### PR TITLE
PackageVersionAsset

### DIFF
--- a/app/bin/tools/backfill_packageversions.dart
+++ b/app/bin/tools/backfill_packageversions.dart
@@ -66,6 +66,8 @@ Future _backfillPackage(String package) async {
     final pvInfoKey = dbService.emptyKey
         .append(PackageVersionInfo, id: qualifiedKey.qualifiedVersion);
 
+    // TODO: query assets
+    // TODO: extract and store assets
     final items = await dbService.lookup([pvPubspecKey, pvInfoKey]);
     final inserts = <Model>[];
     if (items[0] == null) {
@@ -74,15 +76,11 @@ Future _backfillPackage(String package) async {
         ..pubspec = pv.pubspec
         ..updated = pv.created);
     }
+    // TODO: also check if assetNames need to be updated
     if (items[1] == null) {
       inserts.add(PackageVersionInfo()
         ..initFromKey(qualifiedKey)
-        ..readmeFilename = pv.readmeFilename
-        ..readmeContent = pv.readmeContent
-        ..changelogFilename = pv.changelogFilename
-        ..changelogContent = pv.changelogContent
-        ..exampleFilename = pv.exampleFilename
-        ..exampleContent = pv.exampleContent
+        // TODO: populate assetNames
         ..libraries = pv.libraries
         ..libraryCount = pv.libraries.length
         ..updated = pv.created);

--- a/app/lib/frontend/models.dart
+++ b/app/lib/frontend/models.dart
@@ -278,7 +278,8 @@ class PackageVersionAsset extends db.ExpandoModel {
 
   PackageVersionAsset();
 
-  PackageVersionAsset.from(PackageVersion pv, String name, String path, String content) {
+  PackageVersionAsset.from(
+      PackageVersion pv, String name, String path, String content) {
     parentKey = pv.key;
     id = name;
     package = pv.package;

--- a/app/test/frontend/backend_test.dart
+++ b/app/test/frontend/backend_test.dart
@@ -639,12 +639,15 @@ void main() {
       final dateBeforeTest = DateTime.now().toUtc();
 
       void validateSuccessfullUpdate(List<Model> inserts) {
-        expect(inserts, hasLength(5));
+        expect(inserts, hasLength(8));
         final package = inserts[0] as Package;
         final version = inserts[1] as PackageVersion;
         final versionPubspec = inserts[2] as PackageVersionPubspec;
         final versionInfo = inserts[3] as PackageVersionInfo;
-        final history = inserts[4] as History;
+        final pubspecAsset = inserts[4] as PackageVersionAsset;
+        final readmeAsset = inserts[5] as PackageVersionAsset;
+        final changelogAsset = inserts[6] as PackageVersionAsset;
+        final history = inserts[7] as History;
 
         expect(package.key, testPackage.key);
         expect(package.name, testPackage.name);
@@ -676,12 +679,36 @@ void main() {
         expect(versionInfo.package, testPackage.name);
         expect(versionInfo.version, testPackageVersion.version);
         expect(versionInfo.updated.compareTo(dateBeforeTest) >= 0, isTrue);
-        expect(versionInfo.readmeFilename, 'README.md');
-        expect(versionInfo.readmeContent, testPackageReadme);
-        expect(versionInfo.changelogFilename, 'CHANGELOG.md');
-        expect(versionInfo.changelogContent, testPackageChangelog);
+        expect(versionInfo.assetNames, ['pubspec', 'readme', 'changelog']);
         expect(versionInfo.libraries, ['test_library.dart']);
         expect(versionInfo.libraryCount, 1);
+
+        expect(pubspecAsset.parentKey, testPackageVersion.key);
+        expect(pubspecAsset.id, 'pubspec');
+        expect(pubspecAsset.package, testPackage.name);
+        expect(pubspecAsset.version, testPackageVersion.version);
+        expect(pubspecAsset.name, 'pubspec');
+        expect(pubspecAsset.path, 'pubspec.yaml');
+        expect(pubspecAsset.content, testPackagePubspec);
+        expect(pubspecAsset.contentLength, 175);
+
+        expect(readmeAsset.parentKey, testPackageVersion.key);
+        expect(readmeAsset.id, 'readme');
+        expect(readmeAsset.package, testPackage.name);
+        expect(readmeAsset.version, testPackageVersion.version);
+        expect(readmeAsset.name, 'readme');
+        expect(readmeAsset.path, 'README.md');
+        expect(readmeAsset.content, testPackageReadme);
+        expect(readmeAsset.contentLength, 79);
+
+        expect(changelogAsset.parentKey, testPackageVersion.key);
+        expect(changelogAsset.id, 'changelog');
+        expect(changelogAsset.package, testPackage.name);
+        expect(changelogAsset.version, testPackageVersion.version);
+        expect(changelogAsset.name, 'changelog');
+        expect(changelogAsset.path, 'CHANGELOG.md');
+        expect(changelogAsset.content, testPackageChangelog);
+        expect(changelogAsset.contentLength, 46);
 
         expect(history.packageName, testPackage.name);
         expect(history.packageVersion, testPackageVersion.version);


### PR DESCRIPTION
We've discussed this briefly a few weeks ago, this is the first step of many.
I'm removing the extra fields from `PackageVersionInfo` but keeping an aggregate `assetNames` field.

More to come:
- content/asset extraction from packages
- removal of `PackageVersionPubspec` (I don't think it is worth to keep it separately)
- integrity checks
