### PR TITLE
Downgrade Flutter to use stable channel

### DIFF
--- a/app/lib/shared/flutter_archive.dart
+++ b/app/lib/shared/flutter_archive.dart
@@ -1,0 +1,80 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:json_annotation/json_annotation.dart';
+import 'package:http/http.dart';
+
+part 'flutter_archive.g.dart';
+
+/// Returns the latest released versions on all Flutter release channels.
+///
+/// See:
+/// - https://flutter.dev/docs/development/tools/sdk/releases?tab=linux
+/// - https://github.com/flutter/flutter/wiki/Flutter-build-release-channels
+Future<FlutterArchive> fetchFlutterArchive() async {
+  final client = Client();
+  final rs = await client.get(
+      'https://storage.googleapis.com/flutter_infra/releases/releases_linux.json');
+  client.close();
+  return FlutterArchive.fromJson(json.decode(rs.body) as Map<String, dynamic>);
+}
+
+/// The latest released versions on all Flutter release channels.
+@JsonSerializable(explicitToJson: true, includeIfNull: false)
+class FlutterArchive {
+  final String baseUrl;
+  @JsonKey(name: 'current_release')
+  final FlutterCurrentRelease currentRelease;
+  final List<FlutterRelease> releases;
+
+  FlutterArchive({this.baseUrl, this.currentRelease, this.releases});
+
+  factory FlutterArchive.fromJson(Map<String, dynamic> json) =>
+      _$FlutterArchiveFromJson(json);
+
+  Map<String, dynamic> toJson() => _$FlutterArchiveToJson(this);
+}
+
+/// The hashes of the current Flutter releases on the different channels.
+@JsonSerializable(explicitToJson: true, includeIfNull: false)
+class FlutterCurrentRelease {
+  final String beta;
+  final String dev;
+  final String stable;
+
+  FlutterCurrentRelease({this.beta, this.dev, this.stable});
+
+  factory FlutterCurrentRelease.fromJson(Map<String, dynamic> json) =>
+      _$FlutterCurrentReleaseFromJson(json);
+
+  Map<String, dynamic> toJson() => _$FlutterCurrentReleaseToJson(this);
+}
+
+/// A single release for Flutter.
+@JsonSerializable(explicitToJson: true, includeIfNull: false)
+class FlutterRelease {
+  final String hash;
+  final String channel;
+  final String version;
+  @JsonKey(name: 'release_date')
+  final DateTime releaseDate;
+  final String archive;
+  final String sha256;
+
+  FlutterRelease({
+    this.hash,
+    this.channel,
+    this.version,
+    this.releaseDate,
+    this.archive,
+    this.sha256,
+  });
+
+  factory FlutterRelease.fromJson(Map<String, dynamic> json) =>
+      _$FlutterReleaseFromJson(json);
+
+  Map<String, dynamic> toJson() => _$FlutterReleaseToJson(this);
+}

--- a/app/lib/shared/flutter_archive.g.dart
+++ b/app/lib/shared/flutter_archive.g.dart
@@ -1,0 +1,91 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'flutter_archive.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+FlutterArchive _$FlutterArchiveFromJson(Map<String, dynamic> json) {
+  return FlutterArchive(
+      baseUrl: json['baseUrl'] as String,
+      currentRelease: json['current_release'] == null
+          ? null
+          : FlutterCurrentRelease.fromJson(
+              json['current_release'] as Map<String, dynamic>),
+      releases: (json['releases'] as List)
+          ?.map((e) => e == null
+              ? null
+              : FlutterRelease.fromJson(e as Map<String, dynamic>))
+          ?.toList());
+}
+
+Map<String, dynamic> _$FlutterArchiveToJson(FlutterArchive instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('baseUrl', instance.baseUrl);
+  writeNotNull('current_release', instance.currentRelease?.toJson());
+  writeNotNull(
+      'releases', instance.releases?.map((e) => e?.toJson())?.toList());
+  return val;
+}
+
+FlutterCurrentRelease _$FlutterCurrentReleaseFromJson(
+    Map<String, dynamic> json) {
+  return FlutterCurrentRelease(
+      beta: json['beta'] as String,
+      dev: json['dev'] as String,
+      stable: json['stable'] as String);
+}
+
+Map<String, dynamic> _$FlutterCurrentReleaseToJson(
+    FlutterCurrentRelease instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('beta', instance.beta);
+  writeNotNull('dev', instance.dev);
+  writeNotNull('stable', instance.stable);
+  return val;
+}
+
+FlutterRelease _$FlutterReleaseFromJson(Map<String, dynamic> json) {
+  return FlutterRelease(
+      hash: json['hash'] as String,
+      channel: json['channel'] as String,
+      version: json['version'] as String,
+      releaseDate: json['release_date'] == null
+          ? null
+          : DateTime.parse(json['release_date'] as String),
+      archive: json['archive'] as String,
+      sha256: json['sha256'] as String);
+}
+
+Map<String, dynamic> _$FlutterReleaseToJson(FlutterRelease instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('hash', instance.hash);
+  writeNotNull('channel', instance.channel);
+  writeNotNull('version', instance.version);
+  writeNotNull('release_date', instance.releaseDate?.toIso8601String());
+  writeNotNull('archive', instance.archive);
+  writeNotNull('sha256', instance.sha256);
+  return val;
+}

--- a/app/lib/shared/versions.dart
+++ b/app/lib/shared/versions.dart
@@ -16,7 +16,7 @@ final RegExp runtimeVersionPattern = RegExp(r'\d{4}\.\d{2}\.\d{2}');
 /// Increment the version when a change is significant enough to trigger
 /// reprocessing, including: version change in pana, dartdoc, or the SDKs,
 /// or when an feature or bugfix should be picked up by the analysis ASAP.
-const String runtimeVersion = '2019.05.08';
+const String runtimeVersion = '2019.05.17';
 final Version semanticRuntimeVersion = Version.parse(runtimeVersion);
 
 /// The version which marks the earliest version of the data which we'd like to
@@ -40,7 +40,7 @@ final String toolEnvSdkVersion = '2.3.0';
 final String panaVersion = '0.12.15';
 final Version semanticPanaVersion = Version.parse(panaVersion);
 
-final String flutterVersion = '1.5.8';
+final String flutterVersion = '1.5.4-hotfix.2';
 final Version semanticFlutterVersion = Version.parse(flutterVersion);
 
 // keep in-sync with pkg/pub_dartdoc/pubspec.yaml

--- a/app/test/shared/versions_test.dart
+++ b/app/test/shared/versions_test.dart
@@ -8,6 +8,7 @@ import 'package:pubspec_parse/pubspec_parse.dart';
 import 'package:test/test.dart';
 import 'package:yaml/yaml.dart';
 
+import 'package:pub_dartlang_org/shared/flutter_archive.dart';
 import 'package:pub_dartlang_org/shared/versions.dart';
 
 void main() {
@@ -30,7 +31,7 @@ void main() {
     // This test is a reminder that if pana, the SDK or any of the above
     // versions change, we should also adjust the [runtimeVersion]. Before
     // updating the hash value, double-check if it is being updated.
-    expect(hash, 147423433);
+    expect(hash, 633851915);
   });
 
   test('runtime version should be (somewhat) lexicographically ordered', () {
@@ -62,7 +63,7 @@ void main() {
     expect(lock['packages']['pana']['version'], panaVersion);
   });
 
-  test('flutter version should match the tag in setup-flutter.sh', () {
+  test('flutter version should be a dynamic tag in setup-flutter.sh', () {
     final flutterSetupContent =
         File('script/setup-flutter.sh').readAsStringSync();
 
@@ -70,6 +71,14 @@ void main() {
         flutterSetupContent,
         contains('git clone -b \$1 --single-branch '
             'https://github.com/flutter/flutter.git \$FLUTTER_SDK'));
+  });
+
+  test('Flutter is using a version from the stable channel.', () async {
+    final flutterArchive = await fetchFlutterArchive();
+    expect(
+        flutterArchive.releases.any(
+            (fr) => fr.version == 'v$flutterVersion' && fr.channel == 'stable'),
+        isTrue);
   });
 
   test('dartdoc version should match pkg/pub_dartdoc', () async {


### PR DESCRIPTION
Fixes #2283, with additional tests to verify whether the version is in the published stable versions.
I've created the library in the `lib/shared/` in the hope that we can later use it for dynamically upgrading the Flutter SDK used for analysis.