### PR TITLE
Fix mobile view issues of the landing page.

### DIFF
--- a/pkg/web_css/lib/src/_search.scss
+++ b/pkg/web_css/lib/src/_search.scss
@@ -11,14 +11,14 @@
   align-items: center;
   border-radius: 3px;
   max-width: 650px;
-  background: #fff;
+  background: transparent;
 }
 
 .search-bar > .input {
   font-size: 16px;
   padding: 0.8em 1em;
   border: none;
-  width: 250px;
+  width: 150px;
   -webkit-box-flex: 1;
   -ms-flex-positive: 1;
   flex-grow: 1;


### PR DESCRIPTION
- Fixes #2263 
- The white background was showing through Safari's rendering, but it was just a leftover of the old style.
- The input width is a minimal width, as the `flex-grow` will make it use the available space (up to a maximum width). Lowering it provides a nicer view on mobile displays (verified with Safari responsive design view).