### PR TITLE
Increase frontend instances.

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -16,8 +16,8 @@ resources:
 #  instances: 1
 
 automatic_scaling:
-  min_num_instances: 2
-  max_num_instances: 4
+  min_num_instances: 4
+  max_num_instances: 8
 
 skip_files:
 - ^\.git/.*$


### PR DESCRIPTION
My suspicion wrt. the load balancer 500s is that it happens when we have both our instances down. Increasing the min instances should reduces the frequency of load-balancer 500s.