### PR TITLE
Code coverage reporting tool

### DIFF
--- a/app/lib/frontend/static_files.dart
+++ b/app/lib/frontend/static_files.dart
@@ -14,17 +14,19 @@ const String _defaultStaticPath = '/static';
 const _staticRootPaths = <String>['favicon.ico', 'robots.txt'];
 
 StaticFileCache _cache;
+StaticUrls _staticUrls;
 
 /// The static file cache. If no cache was registered before the first access,
 /// the default instance will be created.
 StaticFileCache get staticFileCache =>
     _cache ??= StaticFileCache.withDefaults();
 
+StaticUrls get staticUrls => _staticUrls ?? StaticUrls();
+
 /// Register the static file cache.
-/// Can be called only once, before the static file cache is set.
-void registerStaticFileCache(StaticFileCache cache) {
-  assert(_cache == null);
+void registerStaticFileCacheForTest(StaticFileCache cache) {
   _cache = cache;
+  _staticUrls = null;
 }
 
 /// Returns the path of the `app/` directory.
@@ -121,8 +123,6 @@ class StaticFile {
     this.etag,
   );
 }
-
-final staticUrls = StaticUrls();
 
 /// The static assets that get a ?hash=<hash> in their URL and with that, longer
 /// cached timeouts.

--- a/app/test/frontend/handlers/landing_test.dart
+++ b/app/test/frontend/handlers/landing_test.dart
@@ -16,8 +16,9 @@ import '../utils.dart';
 
 import '_utils.dart';
 
-Future main() async {
-  await updateLocalBuiltFiles();
+void main() {
+  test('init', () => updateLocalBuiltFiles(),
+      timeout: Timeout(Duration(minutes: 10)));
 
   group('ui', () {
     tScopedTest('/', () async {

--- a/app/test/frontend/handlers/landing_test.dart
+++ b/app/test/frontend/handlers/landing_test.dart
@@ -17,8 +17,7 @@ import '../utils.dart';
 import '_utils.dart';
 
 void main() {
-  test('init', () => updateLocalBuiltFiles(),
-      timeout: Timeout(Duration(minutes: 10)));
+  setUpAll(() => updateLocalBuiltFiles());
 
   group('ui', () {
     tScopedTest('/', () async {

--- a/app/test/frontend/handlers/listing_test.dart
+++ b/app/test/frontend/handlers/listing_test.dart
@@ -22,8 +22,7 @@ import '../utils.dart';
 import '_utils.dart';
 
 void main() {
-  test('init', () => updateLocalBuiltFiles(),
-      timeout: Timeout(Duration(minutes: 10)));
+  setUpAll(() => updateLocalBuiltFiles());
 
   group('old api', () {
     scopedTest('/packages.json', () async {

--- a/app/test/frontend/handlers/listing_test.dart
+++ b/app/test/frontend/handlers/listing_test.dart
@@ -21,8 +21,9 @@ import '../utils.dart';
 
 import '_utils.dart';
 
-Future main() async {
-  await updateLocalBuiltFiles();
+void main() {
+  test('init', () => updateLocalBuiltFiles(),
+      timeout: Timeout(Duration(minutes: 10)));
 
   group('old api', () {
     scopedTest('/packages.json', () async {

--- a/app/test/frontend/handlers/misc_handlers_test.dart
+++ b/app/test/frontend/handlers/misc_handlers_test.dart
@@ -2,10 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library pub_dartlang_org.handlers_test;
-
-import 'dart:async';
-
 import 'package:test/test.dart';
 
 import 'package:pub_dartlang_org/frontend/models.dart';
@@ -19,8 +15,9 @@ import '../utils.dart';
 
 import '_utils.dart';
 
-Future main() async {
-  await updateLocalBuiltFiles();
+void main() {
+  test('init', () => updateLocalBuiltFiles(),
+      timeout: Timeout(Duration(minutes: 10)));
 
   group('handlers', () {
     group('not found', () {

--- a/app/test/frontend/handlers/misc_handlers_test.dart
+++ b/app/test/frontend/handlers/misc_handlers_test.dart
@@ -16,8 +16,7 @@ import '../utils.dart';
 import '_utils.dart';
 
 void main() {
-  test('init', () => updateLocalBuiltFiles(),
-      timeout: Timeout(Duration(minutes: 10)));
+  setUpAll(() => updateLocalBuiltFiles());
 
   group('handlers', () {
     group('not found', () {

--- a/app/test/frontend/handlers/package_test.dart
+++ b/app/test/frontend/handlers/package_test.dart
@@ -20,8 +20,7 @@ import '../utils.dart';
 import '_utils.dart';
 
 void main() {
-  test('init', () => updateLocalBuiltFiles(),
-      timeout: Timeout(Duration(minutes: 10)));
+  setUpAll(() => updateLocalBuiltFiles());
 
   group('ui', () {
     tScopedTest('/packages/foobar_pkg - found', () async {

--- a/app/test/frontend/handlers/package_test.dart
+++ b/app/test/frontend/handlers/package_test.dart
@@ -19,8 +19,9 @@ import '../utils.dart';
 
 import '_utils.dart';
 
-Future main() async {
-  await updateLocalBuiltFiles();
+void main() {
+  test('init', () => updateLocalBuiltFiles(),
+      timeout: Timeout(Duration(minutes: 10)));
 
   group('ui', () {
     tScopedTest('/packages/foobar_pkg - found', () async {

--- a/app/test/frontend/static_files_test.dart
+++ b/app/test/frontend/static_files_test.dart
@@ -12,8 +12,9 @@ import 'package:test/test.dart';
 
 import 'package:pub_dartlang_org/frontend/static_files.dart';
 
-Future main() async {
-  await updateLocalBuiltFiles();
+void main() {
+  test('init', () => updateLocalBuiltFiles(),
+      timeout: Timeout(Duration(minutes: 10)));
 
   group('dartdoc assets', () {
     Future checkAsset(String url, String path) async {

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -38,6 +38,8 @@ final _regenerateGoldens = false;
 
 void main() {
   group('templates', () {
+    StaticFileCache oldCache;
+
     setUpAll(() {
       final cache = StaticFileCache();
       for (String path in hashedFiles) {
@@ -45,7 +47,12 @@ void main() {
             [], DateTime.now(), 'mocked_hash_${path.hashCode.abs()}');
         cache.addFile(file);
       }
-      registerStaticFileCache(cache);
+      oldCache = staticFileCache;
+      registerStaticFileCacheForTest(cache);
+    });
+
+    tearDownAll(() {
+      registerStaticFileCacheForTest(oldCache);
     });
 
     void expectGoldenFile(String content, String fileName,

--- a/app/test/search/handlers_test.dart
+++ b/app/test/search/handlers_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library pub_dartlang_org.handlers_test;
-
 import 'dart:async';
 
 import 'package:pub_dartlang_org/shared/search_service.dart';

--- a/pkg/code_coverage/README.md
+++ b/pkg/code_coverage/README.md
@@ -1,0 +1,3 @@
+This package is a separate tool tool to run tests with code coverage and generate report.
+
+Run `build.sh` to run all tests and generate the report, the results will be in `build/report.txt`.

--- a/pkg/code_coverage/build.sh
+++ b/pkg/code_coverage/build.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+CODE_COVERAGE_DIR="${SCRIPT_DIR}"
+PROJECT_DIR="$( cd ${CODE_COVERAGE_DIR}/../.. && pwd )"
+APP_DIR="${PROJECT_DIR}/app"
+APP_TEST_NAME="_all_tests.dart"
+APP_TEST_PATH="${APP_DIR}/test/${APP_TEST_NAME}"
+
+OUTPUT_DIR="${CODE_COVERAGE_DIR}/build"
+
+rm -rf ${OUTPUT_DIR}
+mkdir -p "${OUTPUT_DIR}/raw"
+
+cd "${CODE_COVERAGE_DIR}"
+pub get
+
+echo "Generate ${APP_TEST_PATH}..."
+dart lib/generate_all_tests.dart \
+  --dir "${APP_DIR}/test" \
+  --name ${APP_TEST_NAME}
+
+pub run coverage:collect_coverage \
+  --uri=http://localhost:20202 \
+  -o "${OUTPUT_DIR}/raw/app_unit.json" \
+  --wait-paused \
+  --resume-isolates &
+COVERAGE_PID=$!
+
+cd "${APP_DIR}"
+dart \
+  --pause-isolates-on-exit \
+  --enable-vm-service=20202 \
+  --disable-service-auth-codes \
+  ${APP_TEST_PATH}
+
+echo "Delete ${APP_TEST_PATH}..."
+rm ${APP_TEST_PATH}
+
+# wait on coverage collection to complete
+echo "Waiting for code coverage to complete..."
+wait ${COVERAGE_PID}
+
+cd "${CODE_COVERAGE_DIR}"
+echo "Exporting to LCOV"
+pub run coverage:format_coverage \
+  --packages "${APP_DIR}/.packages" \
+  -i "${OUTPUT_DIR}/raw/app_unit.json" \
+  --base-directory "${PROJECT_DIR}" \
+  --lcov \
+  --out "${OUTPUT_DIR}/lcov.info"
+
+echo "Generating report..."
+dart lib/format_lcov.dart

--- a/pkg/code_coverage/lib/format_lcov.dart
+++ b/pkg/code_coverage/lib/format_lcov.dart
@@ -1,0 +1,56 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:lcov/lcov.dart';
+
+Future main() async {
+  final coverage = await File('build/lcov.info').readAsString();
+  final report = Report.fromCoverage(coverage);
+
+  for (final record in report.records) {
+    if (record.sourceFile.startsWith('app/') ||
+        record.sourceFile.startsWith('pkg/')) {
+      _add(record.sourceFile, record.lines.found, record.lines.hit);
+    }
+  }
+
+  final output = StringBuffer();
+
+  final keys = _tree.keys.toList()..sort();
+  for (String key in keys) {
+    final entry = _tree[key];
+    final pct = entry.total == 0 ? 0.0 : entry.covered * 100.0 / entry.total;
+    final pctStr = pct.toStringAsFixed(1);
+    final sb = StringBuffer();
+    sb.write('   ' * entry.depth);
+    sb.write('${entry.leaf} - $pctStr% - ${entry.covered}/${entry.total}');
+    output.writeln(sb);
+  }
+
+  await File('build/report.txt').writeAsString(output.toString());
+}
+
+final _tree = <String, Entry>{};
+
+void _add(String path, int total, int covered) {
+  final segments = path.split('/');
+  for (int i = 0; i < segments.length; i++) {
+    final key = segments.take(i + 1).join('/');
+    final entry = _tree.putIfAbsent(key, () => Entry());
+    entry.depth = i;
+    entry.leaf = segments[i];
+    entry.total += total;
+    entry.covered += covered;
+  }
+}
+
+class Entry {
+  int depth = 0;
+  String leaf;
+  int total = 0;
+  int covered = 0;
+}

--- a/pkg/code_coverage/lib/generate_all_tests.dart
+++ b/pkg/code_coverage/lib/generate_all_tests.dart
@@ -1,0 +1,52 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:args/args.dart';
+import 'package:path/path.dart' as p;
+
+final _parser = ArgParser()
+  ..addOption('dir', defaultsTo: 'test', help: 'The test directory.')
+  ..addOption('name',
+      defaultsTo: '_all_tests.dart',
+      help: 'The file name to use for all tests.');
+
+/// Generates test/_all_tests.dart that includes reference to all tests.
+Future main(List<String> args) async {
+  final argv = _parser.parse(args);
+  final name = argv['name'] as String;
+  final dir = Directory(argv['dir'] as String);
+
+  final files = await dir
+      .list(recursive: true)
+      .where((fse) => fse is File && fse.path.endsWith('_test.dart'))
+      .map((fse) => p.relative(fse.path, from: dir.path))
+      .toList();
+  files.sort();
+
+  final content = _generateTestContent(files);
+  final output = File(p.join(dir.path, name));
+  await output.writeAsString(content);
+}
+
+String _generateTestContent(List<String> files) {
+  final imports = <String>[];
+  final calls = <String>[];
+
+  for (String file in files) {
+    final alias = file.substring(0, file.length - 10).replaceAll('/', '_');
+    imports.add("import '$file' as $alias;");
+    calls.add("  group('$file', $alias.main);");
+  }
+
+  return '''import 'package:test/test.dart';
+
+${imports.join('\n')}
+
+void main() {
+${calls.join('\n')}
+}
+''';
+}

--- a/pkg/code_coverage/pubspec.yaml
+++ b/pkg/code_coverage/pubspec.yaml
@@ -1,0 +1,14 @@
+name: code_coverage
+publish_to: none  # don't publish yet
+description: Code coverage tools.
+environment:
+  sdk: '>=2.3.0 <3.0.0'
+
+dependencies:
+  args: ^1.5.0
+  coverage: ^0.12.0
+  lcov: ^5.3.0
+  path: ^1.0.0
+
+dev_dependencies:
+  test: ^1.5.1


### PR DESCRIPTION
- only the unit tests are included at the moment, the integration tests seems to require a mechanism to finish the program without calling `exit` or `SIGKILL` signal.
- I've created a tool that scans the unit tests and creates a single test suite that includes all of the tests. This tool may be published as a separate package later.
- As they are now executed in a single isolate, some of the tests needed adjustments, e.g. static files-related test update the global state.
- I've also create a tool to create a formatted tree report. The current coverage for `app/lib` is about 50%.