### PR TITLE
Harden search service.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ AppEngine version, listed here to ease deployment and troubleshooting.
 
 ## Next Release (replace with git tag when deployed)
 
+ * Update project to use split health checks, run:
+   `gcloud app update --split-health-checks --project dartlang-pub`
+ * `search` service is using custom liveness and readiness checks.
 
 ## `20190529t163905-all`
 

--- a/app/bin/service/search.dart
+++ b/app/bin/service/search.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:io';
 import 'dart:isolate';
 
 import 'package:_discoveryapis_commons/_discoveryapis_commons.dart'
@@ -100,6 +101,7 @@ Future _main(FrontendEntryMessage message) async {
         await batchIndexUpdater.init();
       } catch (e, st) {
         _logger.shout('Error initializing search service.', e, st);
+        exit(1);
       }
 
       final scheduler = TaskScheduler(

--- a/app/lib/search/handlers.dart
+++ b/app/lib/search/handlers.dart
@@ -21,6 +21,8 @@ Future<shelf.Response> searchServiceHandler(shelf.Request request) async {
   final path = request.requestedUri.path;
   final handler = <String, shelf.Handler>{
     '/debug': _debugHandler,
+    '/liveness_check': _livenessCheckHandler,
+    '/readiness_check': _readinessCheckHandler,
     '/search': _searchHandler,
     '/robots.txt': rejectRobotsHandler,
   }[path];
@@ -29,6 +31,20 @@ Future<shelf.Response> searchServiceHandler(shelf.Request request) async {
     return await handler(request);
   } else {
     return notFoundHandler(request);
+  }
+}
+
+/// Handles /liveness_check requests.
+Future<shelf.Response> _livenessCheckHandler(shelf.Request request) async {
+  return htmlResponse('OK');
+}
+
+/// Handles /readiness_check requests.
+Future<shelf.Response> _readinessCheckHandler(shelf.Request request) async {
+  if (packageIndex.isReady) {
+    return htmlResponse('OK');
+  } else {
+    return htmlResponse('Service Unavailable', status: 503);
   }
 }
 

--- a/app/test/search/handlers_test.dart
+++ b/app/test/search/handlers_test.dart
@@ -131,4 +131,9 @@ class MockSearchBackend implements SearchBackend {
       popularity: 0.1,
     );
   }
+
+  @override
+  Stream<PackageDocument> loadMinimumPackageIndex() async* {
+    throw UnimplementedError();
+  }
 }

--- a/search.yaml
+++ b/search.yaml
@@ -14,8 +14,16 @@ resources:
 #  instances: 1
 
 automatic_scaling:
-  min_num_instances: 2
+  min_num_instances: 3
   max_num_instances: 4
 
 skip_files:
 - ^\.git/.*$
+
+liveness_check:
+  path: '/liveness_check'
+
+readiness_check:
+  path: '/readiness_check'
+  check_interval_sec: 15
+  app_start_timeout_sec: 1800


### PR DESCRIPTION
- #2336 
- increased number of instances to reduce the chance of all of them rebooted
- switching to split health checks (instruction in CHANGELOG)
- index updates are tied to the successful initialization
- initialization is done either via snapshot, or a minimal package index