### PR TITLE
Search fallbacks on landing and listing pages.

### DIFF
--- a/app/lib/frontend/name_tracker.dart
+++ b/app/lib/frontend/name_tracker.dart
@@ -54,6 +54,13 @@ class NameTracker {
     }
     return _names.toList()..sort();
   }
+
+  /// Should be used in tests only!
+  void markReady() {
+    if (!_firstScanCompleter.isCompleted) {
+      _firstScanCompleter.complete();
+    }
+  }
 }
 
 /// Updates [nameTracker] by polling the Datastore periodically.

--- a/app/lib/frontend/name_tracker.dart
+++ b/app/lib/frontend/name_tracker.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 
 import 'package:logging/logging.dart';
 import 'package:gcloud/db.dart';
+import 'package:meta/meta.dart';
 
 import '../shared/utils.dart';
 
@@ -55,7 +56,8 @@ class NameTracker {
     return _names.toList()..sort();
   }
 
-  /// Should be used in tests only!
+  /// Should be used in tests, indicates that the first scan is completed.
+  @visibleForTesting
   void markReady() {
     if (!_firstScanCompleter.isCompleted) {
       _firstScanCompleter.complete();

--- a/app/lib/frontend/search_service.dart
+++ b/app/lib/frontend/search_service.dart
@@ -50,6 +50,8 @@ class SearchService {
     return _loadResultForPackages(query, result.totalCount, result.packages);
   }
 
+  /// Search over the package names as a fallback, in the absence of the
+  /// `search` service.
   Future<PackageSearchResult> _fallbackSearch(SearchQuery query) async {
     final names =
         await nameTracker.getPackageNames().timeout(Duration(seconds: 5));

--- a/app/lib/frontend/search_service.dart
+++ b/app/lib/frontend/search_service.dart
@@ -30,6 +30,13 @@ void registerSearchService(SearchService s) => ss.register(#_search, s);
 
 /// A wrapper around the Custom Search API, used for searching for pub packages.
 class SearchService {
+
+  /// Performs search using the `search` service and lookup package info and
+  /// score from DatastoreDB.
+  ///
+  /// When the `search` service fails, it falls back to use the name tracker to
+  /// provide package names and perform search in that set. Set [fallbackToNames]
+  /// to false in cases where this is not the desired result.
   Future<SearchResultPage> search(SearchQuery query,
       {bool fallbackToNames = true}) async {
     PackageSearchResult result;

--- a/app/test/frontend/handlers/_utils.dart
+++ b/app/test/frontend/handlers/_utils.dart
@@ -33,12 +33,14 @@ Future<shelf.Response> issueGetUri(Uri uri) async {
   return appHandler(request, null);
 }
 
-Future expectHtmlResponse(shelf.Response response, {int status = 200}) async {
+Future<String> expectHtmlResponse(shelf.Response response,
+    {int status = 200}) async {
   expect(response.statusCode, status);
   expect(response.headers['content-type'], 'text/html; charset="utf-8"');
   final content = await response.readAsString();
   expect(content, contains('<!DOCTYPE html>'));
   expect(content, contains('</html>'));
+  return content;
 }
 
 Future expectAtomXmlResponse(shelf.Response response,

--- a/app/test/frontend/handlers/landing_test.dart
+++ b/app/test/frontend/handlers/landing_test.dart
@@ -9,6 +9,7 @@ import 'package:pub_dartlang_org/frontend/models.dart';
 import 'package:pub_dartlang_org/frontend/search_service.dart';
 import 'package:pub_dartlang_org/frontend/static_files.dart';
 import 'package:pub_dartlang_org/shared/analyzer_client.dart';
+import 'package:pub_dartlang_org/shared/search_client.dart';
 import 'package:pub_dartlang_org/shared/search_service.dart';
 
 import '../mocks.dart';
@@ -43,6 +44,16 @@ void main() {
       registerAnalyzerClient(AnalyzerClientMock());
 
       await expectHtmlResponse(await issueGet('/'));
+    });
+
+    tScopedTest('/ without a working search service', () async {
+      registerSearchClient(null);
+      registerSearchService(SearchService());
+      final rs = await issueGet('/');
+      final content = await expectHtmlResponse(rs);
+      expect(content, contains('/packages/http'));
+      expect(content, contains('/packages/event_bus'));
+      expect(content, contains('lightweight library for parsing'));
     });
 
     tScopedTest('/flutter', () async {

--- a/app/test/frontend/mocks.dart
+++ b/app/test/frontend/mocks.dart
@@ -104,8 +104,8 @@ class BackendMock implements Backend {
   }
 
   @override
-  Future<List<Package>> lookupPackages(Iterable<String> packageNames) {
-    return Future.wait(packageNames.map(lookupPackage));
+  Future<List<Package>> lookupPackages(Iterable<String> packageNames) async {
+    return (await Future.wait(packageNames.map(lookupPackage))).toList();
   }
 
   @override
@@ -179,7 +179,7 @@ class ScoreCardBackendMock implements ScoreCardBackend {
   @override
   Future<ScoreCardData> getScoreCardData(
       String packageName, String packageVersion,
-      {bool onlyCurrent = false}) {
+      {bool onlyCurrent = false}) async {
     return null;
   }
 
@@ -290,7 +290,8 @@ class SearchServiceMock implements SearchService {
   SearchServiceMock(this.searchFun);
 
   @override
-  Future<SearchResultPage> search(SearchQuery query) async {
+  Future<SearchResultPage> search(SearchQuery query,
+      {bool fallbackToNames = true}) async {
     return (await searchFun(query)) as SearchResultPage;
   }
 


### PR DESCRIPTION
- Implemented suggestions from https://github.com/dart-lang/pub-dev/issues/2336#issuecomment-498213612
- Landing page will display a fixed list of popular packages in case the search service is not available.
- Listing page will use the in-memory list of package names (and use exact, prefix and contains matches) if the search service is not available.