### PR TITLE
Hash for more assets.

### DIFF
--- a/app/lib/dartdoc/customization.dart
+++ b/app/lib/dartdoc/customization.dart
@@ -8,6 +8,7 @@ import 'dart:io';
 import 'package:html/dom.dart';
 import 'package:html/parser.dart' as html_parser;
 
+import '../frontend/static_files.dart';
 import '../shared/urls.dart';
 
 class DartdocCustomizer {
@@ -119,7 +120,7 @@ class DartdocCustomizer {
       final linkElement = Element.tag('link')
         ..attributes['rel'] = 'stylesheet'
         ..attributes['type'] = 'text/css'
-        ..attributes['href'] = '/static/css/github-markdown.css';
+        ..attributes['href'] = staticUrls.githubMarkdownCss;
       head.insertBefore(linkElement, firstLink);
     }
   }
@@ -143,7 +144,7 @@ class DartdocCustomizer {
       ..className = 'hidden-xs'
       ..attributes['href'] = '/';
     final imgRef = Element.tag('img')
-      ..attributes['src'] = '/static/img/dart-logo.svg'
+      ..attributes['src'] = staticUrls.dartLogoSvg
       ..attributes['style'] = 'height: 30px; margin-right: 1em;';
     logoLink.append(imgRef);
     parent.insertBefore(logoLink, breadcrumbs);

--- a/app/lib/frontend/static_files.dart
+++ b/app/lib/frontend/static_files.dart
@@ -164,6 +164,12 @@ class StaticUrls {
   }
 
   /// A hashed version of the static assets.
+  ///
+  /// For each file like /static/img/logo.gif we create a key and value of:
+  /// `img__logo_gif => /static/img/logo.gif?hash=etag_hash`
+  ///
+  /// The /static/ prefix is stripped from the start of the key in order to
+  /// reduce the length of the mostly used files in the mustache templates.
   Map<String, String> get assets {
     if (_assets == null) {
       _assets = <String, String>{};

--- a/app/lib/frontend/static_files.dart
+++ b/app/lib/frontend/static_files.dart
@@ -21,7 +21,7 @@ StaticUrls _staticUrls;
 StaticFileCache get staticFileCache =>
     _cache ??= StaticFileCache.withDefaults();
 
-StaticUrls get staticUrls => _staticUrls ??= StaticUrls();
+StaticUrls get staticUrls => _staticUrls ??= StaticUrls._();
 
 /// Register the static file cache.
 void registerStaticFileCacheForTest(StaticFileCache cache) {
@@ -139,7 +139,7 @@ class StaticUrls {
   Map _versionsTableIcons;
   Map<String, String> _assets;
 
-  StaticUrls()
+  StaticUrls._()
       : smallDartFavicon = _getCacheableStaticUrl('/favicon.ico'),
         dartLogoSvg =
             _getCacheableStaticUrl('$_defaultStaticPath/img/dart-logo.svg'),

--- a/app/lib/frontend/static_files.dart
+++ b/app/lib/frontend/static_files.dart
@@ -135,6 +135,7 @@ class StaticUrls {
   final String documentationIcon;
   final String downloadIcon;
   final String pubDevLogo2xPng;
+  final String githubMarkdownCss;
   Map _versionsTableIcons;
   Map<String, String> _assets;
 
@@ -149,7 +150,9 @@ class StaticUrls {
         downloadIcon = _getCacheableStaticUrl(
             '$_defaultStaticPath/img/ic_get_app_black_24dp.svg'),
         pubDevLogo2xPng = _getCacheableStaticUrl(
-            '$_defaultStaticPath/img/pub-dev-logo-2x.png');
+            '$_defaultStaticPath/img/pub-dev-logo-2x.png'),
+        githubMarkdownCss = _getCacheableStaticUrl(
+            '$_defaultStaticPath/css/github-markdown.css');
 
   Map get versionsTableIcons {
     return _versionsTableIcons ??= {

--- a/app/lib/frontend/static_files.dart
+++ b/app/lib/frontend/static_files.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:crypto/crypto.dart' as crypto;
+import 'package:meta/meta.dart';
 import 'package:mime/mime.dart' as mime;
 import 'package:pana/pana.dart' show runProc;
 import 'package:path/path.dart' as path;
@@ -101,6 +102,7 @@ class StaticFileCache {
     ).forEach(addFile);
   }
 
+  @visibleForTesting
   void addFile(StaticFile file) {
     _files[file.requestPath] = file;
   }

--- a/app/test/dartdoc/golden/pana_0.12.2_index.out.html
+++ b/app/test/dartdoc/golden/pana_0.12.2_index.out.html
@@ -11,7 +11,7 @@
     <title>pana - Dart API docs</title>
     <link rel="alternate" href="/documentation/pana/latest/"/>
     <link rel="canonical" href="https://pub.dartlang.org/documentation/pana/0.12.2/"/>
-    <link rel="stylesheet" type="text/css" href="/static/css/github-markdown.css"/>
+    <link rel="stylesheet" type="text/css" href="/static/css/github-markdown.css?hash=t2ti0tfkd3q7dsh5njovil42c3bnhf5s"/>
     <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet"/>
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet"/>
     <link rel="stylesheet" href="static-assets/github.css"/>
@@ -23,7 +23,7 @@
     <header id="title">
       <button id="sidenav-left-toggle" type="button"></button>
       <a class="hidden-xs" href="/">
-        <img src="/static/img/dart-logo.svg" style="height: 30px; margin-right: 1em;"/>
+        <img src="/static/img/dart-logo.svg?hash=gqea88bp2ii6tqf5rn5p8jtg22mma809" style="height: 30px; margin-right: 1em;"/>
       </a>
       <ol class="breadcrumbs gt-separated dark hidden-xs">
         <li>

--- a/app/test/dartdoc/golden/pana_0.12.2_license_file_class.out.html
+++ b/app/test/dartdoc/golden/pana_0.12.2_license_file_class.out.html
@@ -23,7 +23,7 @@
     <header id="title">
       <button id="sidenav-left-toggle" type="button"></button>
       <a class="hidden-xs" href="/">
-        <img src="/static/img/dart-logo.svg" style="height: 30px; margin-right: 1em;"/>
+        <img src="/static/img/dart-logo.svg?hash=gqea88bp2ii6tqf5rn5p8jtg22mma809" style="height: 30px; margin-right: 1em;"/>
       </a>
       <ol class="breadcrumbs gt-separated dark hidden-xs">
         <li>

--- a/app/test/dartdoc/golden/pana_0.12.2_license_file_constructor.out.html
+++ b/app/test/dartdoc/golden/pana_0.12.2_license_file_constructor.out.html
@@ -23,7 +23,7 @@
     <header id="title">
       <button id="sidenav-left-toggle" type="button"></button>
       <a class="hidden-xs" href="/">
-        <img src="/static/img/dart-logo.svg" style="height: 30px; margin-right: 1em;"/>
+        <img src="/static/img/dart-logo.svg?hash=gqea88bp2ii6tqf5rn5p8jtg22mma809" style="height: 30px; margin-right: 1em;"/>
       </a>
       <ol class="breadcrumbs gt-separated dark hidden-xs">
         <li>

--- a/app/test/dartdoc/golden/pana_0.12.2_license_file_name_field.out.html
+++ b/app/test/dartdoc/golden/pana_0.12.2_license_file_name_field.out.html
@@ -23,7 +23,7 @@
     <header id="title">
       <button id="sidenav-left-toggle" type="button"></button>
       <a class="hidden-xs" href="/">
-        <img src="/static/img/dart-logo.svg" style="height: 30px; margin-right: 1em;"/>
+        <img src="/static/img/dart-logo.svg?hash=gqea88bp2ii6tqf5rn5p8jtg22mma809" style="height: 30px; margin-right: 1em;"/>
       </a>
       <ol class="breadcrumbs gt-separated dark hidden-xs">
         <li>

--- a/app/test/dartdoc/golden/pana_0.12.2_pretty_json.out.html
+++ b/app/test/dartdoc/golden/pana_0.12.2_pretty_json.out.html
@@ -23,7 +23,7 @@
     <header id="title">
       <button id="sidenav-left-toggle" type="button"></button>
       <a class="hidden-xs" href="/">
-        <img src="/static/img/dart-logo.svg" style="height: 30px; margin-right: 1em;"/>
+        <img src="/static/img/dart-logo.svg?hash=gqea88bp2ii6tqf5rn5p8jtg22mma809" style="height: 30px; margin-right: 1em;"/>
       </a>
       <ol class="breadcrumbs gt-separated dark hidden-xs">
         <li>

--- a/app/test/frontend/golden/authorized_page.html
+++ b/app/test/frontend/golden/authorized_page.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
   <head>
     <script async="async" src="https://www.googletagmanager.com/gtag/js?id=UA-26406144-13"></script>
-    <script src="/static/js/gtag.js?hash=mocked_hash_673383334"></script>
+    <script src="/static/js/gtag.js?hash=mocked_hash_221832925"></script>
     <meta charset="utf-8"/>
     <meta http-equiv="x-ua-compatible" content="ie=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
@@ -12,16 +12,16 @@
     <title>Pub Authorized Successfully</title>
     <meta property="og:title" content="Pub Authorized Successfully"/>
     <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet"/>
-    <meta itemprop="image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_1042064956"/>
-    <meta property="og:image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_1042064956"/>
-    <link rel="shortcut icon" href="/favicon.ico"/>
+    <meta itemprop="image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <meta property="og:image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
     <meta name="description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
-    <link href="/static/highlight/github.css?hash=mocked_hash_737193633" rel="stylesheet"/>
-    <link href="/static/css/github-markdown.css?hash=mocked_hash_244413523" rel="stylesheet" type="text/css"/>
-    <link href="/static/css/style.css?hash=mocked_hash_714113458" rel="stylesheet" type="text/css"/>
-    <script src="/static/js/script.dart.js?hash=mocked_hash_918742474" defer="defer"></script>
+    <link href="/static/highlight/github.css?hash=mocked_hash_145446167" rel="stylesheet"/>
+    <link href="/static/css/github-markdown.css?hash=mocked_hash_488759485" rel="stylesheet" type="text/css"/>
+    <link href="/static/css/style.css?hash=mocked_hash_537099079" rel="stylesheet" type="text/css"/>
+    <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
   </head>
   <body class="">
     <header class="site-header-row">
@@ -32,7 +32,7 @@
         <div class="nav-wrap">
           <div class="nav-header">
             <a class="logo" href="/">
-              <img src="/static/img/pub-dev-logo-2x.png?hash=mocked_hash_929871536" alt="dart pub logo"/>
+              <img src="/static/img/pub-dev-logo-2x.png?hash=mocked_hash_685890546" alt="dart pub logo"/>
             </a>
             <div class="_flex-space"></div>
             <button class="close"></button>
@@ -81,11 +81,11 @@
       <a class="link" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link" href="/help">Help</a>
       <a class="link" href="/feed.atom">
-        <img src="/static/img/atom-feed-icon-32x32.png?hash=mocked_hash_418851796" class="inline-icon"/>
+        <img src="/static/img/atom-feed-icon-32x32.png?hash=mocked_hash_251226050" class="inline-icon"/>
       </a>
       <a class="link github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">Report an issue with this site</a>
     </footer>
-    <script src="/static/highlight/highlight.pack.js?hash=mocked_hash_918449443"></script>
-    <script src="/static/highlight/init.js?hash=mocked_hash_851568549"></script>
+    <script src="/static/highlight/highlight.pack.js?hash=mocked_hash_252154265"></script>
+    <script src="/static/highlight/init.js?hash=mocked_hash_180963889"></script>
   </body>
 </html>

--- a/app/test/frontend/golden/error_page.html
+++ b/app/test/frontend/golden/error_page.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
   <head>
     <script async="async" src="https://www.googletagmanager.com/gtag/js?id=UA-26406144-13"></script>
-    <script src="/static/js/gtag.js?hash=mocked_hash_673383334"></script>
+    <script src="/static/js/gtag.js?hash=mocked_hash_221832925"></script>
     <meta charset="utf-8"/>
     <meta http-equiv="x-ua-compatible" content="ie=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
@@ -12,16 +12,16 @@
     <title>error_title</title>
     <meta property="og:title" content="error_title"/>
     <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet"/>
-    <meta itemprop="image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_1042064956"/>
-    <meta property="og:image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_1042064956"/>
-    <link rel="shortcut icon" href="/favicon.ico"/>
+    <meta itemprop="image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <meta property="og:image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
     <meta name="description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
-    <link href="/static/highlight/github.css?hash=mocked_hash_737193633" rel="stylesheet"/>
-    <link href="/static/css/github-markdown.css?hash=mocked_hash_244413523" rel="stylesheet" type="text/css"/>
-    <link href="/static/css/style.css?hash=mocked_hash_714113458" rel="stylesheet" type="text/css"/>
-    <script src="/static/js/script.dart.js?hash=mocked_hash_918742474" defer="defer"></script>
+    <link href="/static/highlight/github.css?hash=mocked_hash_145446167" rel="stylesheet"/>
+    <link href="/static/css/github-markdown.css?hash=mocked_hash_488759485" rel="stylesheet" type="text/css"/>
+    <link href="/static/css/style.css?hash=mocked_hash_537099079" rel="stylesheet" type="text/css"/>
+    <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
   </head>
   <body class="">
     <header class="site-header-row">
@@ -32,7 +32,7 @@
         <div class="nav-wrap">
           <div class="nav-header">
             <a class="logo" href="/">
-              <img src="/static/img/pub-dev-logo-2x.png?hash=mocked_hash_929871536" alt="dart pub logo"/>
+              <img src="/static/img/pub-dev-logo-2x.png?hash=mocked_hash_685890546" alt="dart pub logo"/>
             </a>
             <div class="_flex-space"></div>
             <button class="close"></button>
@@ -92,11 +92,11 @@
       <a class="link" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link" href="/help">Help</a>
       <a class="link" href="/feed.atom">
-        <img src="/static/img/atom-feed-icon-32x32.png?hash=mocked_hash_418851796" class="inline-icon"/>
+        <img src="/static/img/atom-feed-icon-32x32.png?hash=mocked_hash_251226050" class="inline-icon"/>
       </a>
       <a class="link github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">Report an issue with this site</a>
     </footer>
-    <script src="/static/highlight/highlight.pack.js?hash=mocked_hash_918449443"></script>
-    <script src="/static/highlight/init.js?hash=mocked_hash_851568549"></script>
+    <script src="/static/highlight/highlight.pack.js?hash=mocked_hash_252154265"></script>
+    <script src="/static/highlight/init.js?hash=mocked_hash_180963889"></script>
   </body>
 </html>

--- a/app/test/frontend/golden/flutter_landing_page.html
+++ b/app/test/frontend/golden/flutter_landing_page.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
   <head>
     <script async="async" src="https://www.googletagmanager.com/gtag/js?id=UA-26406144-13"></script>
-    <script src="/static/js/gtag.js?hash=mocked_hash_673383334"></script>
+    <script src="/static/js/gtag.js?hash=mocked_hash_221832925"></script>
     <meta charset="utf-8"/>
     <meta http-equiv="x-ua-compatible" content="ie=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
@@ -12,16 +12,16 @@
     <title>Flutter packages</title>
     <meta property="og:title" content="Flutter packages"/>
     <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet"/>
-    <meta itemprop="image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_1042064956"/>
-    <meta property="og:image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_1042064956"/>
-    <link rel="shortcut icon" href="/favicon.ico"/>
+    <meta itemprop="image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <meta property="og:image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
     <meta name="description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
-    <link href="/static/highlight/github.css?hash=mocked_hash_737193633" rel="stylesheet"/>
-    <link href="/static/css/github-markdown.css?hash=mocked_hash_244413523" rel="stylesheet" type="text/css"/>
-    <link href="/static/css/style.css?hash=mocked_hash_714113458" rel="stylesheet" type="text/css"/>
-    <script src="/static/js/script.dart.js?hash=mocked_hash_918742474" defer="defer"></script>
+    <link href="/static/highlight/github.css?hash=mocked_hash_145446167" rel="stylesheet"/>
+    <link href="/static/css/github-markdown.css?hash=mocked_hash_488759485" rel="stylesheet" type="text/css"/>
+    <link href="/static/css/style.css?hash=mocked_hash_537099079" rel="stylesheet" type="text/css"/>
+    <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
     <script async="async" defer="defer" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
   </head>
   <body class="">
@@ -33,7 +33,7 @@
         <div class="nav-wrap">
           <div class="nav-header">
             <a class="logo" href="/">
-              <img src="/static/img/pub-dev-logo-2x.png?hash=mocked_hash_929871536" alt="dart pub logo"/>
+              <img src="/static/img/pub-dev-logo-2x.png?hash=mocked_hash_685890546" alt="dart pub logo"/>
             </a>
             <div class="_flex-space"></div>
             <button class="close"></button>
@@ -62,7 +62,7 @@
     <div class="_banner-bg">
       <main class="home-banner">
         <h2 class="_visuallyhidden">Dart package manager</h2>
-        <img class="logo" src="/static/img/flutter-packages-white.png?hash=mocked_hash_527847154" alt="Flutter packages"/>
+        <img class="logo" src="/static/img/flutter-packages-white.png?hash=mocked_hash_276594719" alt="Flutter packages"/>
         <form class="search-bar" action="/flutter/packages">
           <input class="input" name="q" placeholder="Search Flutter-compatible packages" autocomplete="on" autofocus="autofocus"/>
           <button class="icon"></button>
@@ -117,7 +117,7 @@
       <a class="link" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link" href="/help">Help</a>
       <a class="link" href="/feed.atom">
-        <img src="/static/img/atom-feed-icon-32x32.png?hash=mocked_hash_418851796" class="inline-icon"/>
+        <img src="/static/img/atom-feed-icon-32x32.png?hash=mocked_hash_251226050" class="inline-icon"/>
       </a>
       <a class="link github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">Report an issue with this site</a>
     </footer>

--- a/app/test/frontend/golden/index_page.html
+++ b/app/test/frontend/golden/index_page.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
   <head>
     <script async="async" src="https://www.googletagmanager.com/gtag/js?id=UA-26406144-13"></script>
-    <script src="/static/js/gtag.js?hash=mocked_hash_673383334"></script>
+    <script src="/static/js/gtag.js?hash=mocked_hash_221832925"></script>
     <meta charset="utf-8"/>
     <meta http-equiv="x-ua-compatible" content="ie=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
@@ -12,16 +12,16 @@
     <title>Dart packages</title>
     <meta property="og:title" content="Dart packages"/>
     <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet"/>
-    <meta itemprop="image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_1042064956"/>
-    <meta property="og:image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_1042064956"/>
-    <link rel="shortcut icon" href="/favicon.ico"/>
+    <meta itemprop="image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <meta property="og:image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
     <meta name="description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
-    <link href="/static/highlight/github.css?hash=mocked_hash_737193633" rel="stylesheet"/>
-    <link href="/static/css/github-markdown.css?hash=mocked_hash_244413523" rel="stylesheet" type="text/css"/>
-    <link href="/static/css/style.css?hash=mocked_hash_714113458" rel="stylesheet" type="text/css"/>
-    <script src="/static/js/script.dart.js?hash=mocked_hash_918742474" defer="defer"></script>
+    <link href="/static/highlight/github.css?hash=mocked_hash_145446167" rel="stylesheet"/>
+    <link href="/static/css/github-markdown.css?hash=mocked_hash_488759485" rel="stylesheet" type="text/css"/>
+    <link href="/static/css/style.css?hash=mocked_hash_537099079" rel="stylesheet" type="text/css"/>
+    <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
     <script async="async" defer="defer" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
   </head>
   <body class="">
@@ -33,7 +33,7 @@
         <div class="nav-wrap">
           <div class="nav-header">
             <a class="logo" href="/">
-              <img src="/static/img/pub-dev-logo-2x.png?hash=mocked_hash_929871536" alt="dart pub logo"/>
+              <img src="/static/img/pub-dev-logo-2x.png?hash=mocked_hash_685890546" alt="dart pub logo"/>
             </a>
             <div class="_flex-space"></div>
             <button class="close"></button>
@@ -62,7 +62,7 @@
     <div class="_banner-bg">
       <main class="home-banner">
         <h2 class="_visuallyhidden">Dart package manager</h2>
-        <img class="logo" src="/static/img/dart-packages-white.png?hash=mocked_hash_527535581" alt="Dart packages"/>
+        <img class="logo" src="/static/img/dart-packages-white.png?hash=mocked_hash_308431268" alt="Dart packages"/>
         <form class="search-bar" action="/packages">
           <input class="input" name="q" placeholder="Search Dart packages" autocomplete="on" autofocus="autofocus"/>
           <button class="icon"></button>
@@ -113,7 +113,7 @@
       <a class="link" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link" href="/help">Help</a>
       <a class="link" href="/feed.atom">
-        <img src="/static/img/atom-feed-icon-32x32.png?hash=mocked_hash_418851796" class="inline-icon"/>
+        <img src="/static/img/atom-feed-icon-32x32.png?hash=mocked_hash_251226050" class="inline-icon"/>
       </a>
       <a class="link github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">Report an issue with this site</a>
     </footer>

--- a/app/test/frontend/golden/pkg_index_page.html
+++ b/app/test/frontend/golden/pkg_index_page.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
   <head>
     <script async="async" src="https://www.googletagmanager.com/gtag/js?id=UA-26406144-13"></script>
-    <script src="/static/js/gtag.js?hash=mocked_hash_673383334"></script>
+    <script src="/static/js/gtag.js?hash=mocked_hash_221832925"></script>
     <meta charset="utf-8"/>
     <meta http-equiv="x-ua-compatible" content="ie=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
@@ -13,16 +13,16 @@
     <title>Top Dart packages</title>
     <meta property="og:title" content="Top Dart packages"/>
     <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet"/>
-    <meta itemprop="image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_1042064956"/>
-    <meta property="og:image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_1042064956"/>
-    <link rel="shortcut icon" href="/favicon.ico"/>
+    <meta itemprop="image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <meta property="og:image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
     <meta name="description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
-    <link href="/static/highlight/github.css?hash=mocked_hash_737193633" rel="stylesheet"/>
-    <link href="/static/css/github-markdown.css?hash=mocked_hash_244413523" rel="stylesheet" type="text/css"/>
-    <link href="/static/css/style.css?hash=mocked_hash_714113458" rel="stylesheet" type="text/css"/>
-    <script src="/static/js/script.dart.js?hash=mocked_hash_918742474" defer="defer"></script>
+    <link href="/static/highlight/github.css?hash=mocked_hash_145446167" rel="stylesheet"/>
+    <link href="/static/css/github-markdown.css?hash=mocked_hash_488759485" rel="stylesheet" type="text/css"/>
+    <link href="/static/css/style.css?hash=mocked_hash_537099079" rel="stylesheet" type="text/css"/>
+    <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
     <script async="async" defer="defer" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
   </head>
   <body class="">
@@ -34,7 +34,7 @@
         <div class="nav-wrap">
           <div class="nav-header">
             <a class="logo" href="/">
-              <img src="/static/img/pub-dev-logo-2x.png?hash=mocked_hash_929871536" alt="dart pub logo"/>
+              <img src="/static/img/pub-dev-logo-2x.png?hash=mocked_hash_685890546" alt="dart pub logo"/>
             </a>
             <div class="_flex-space"></div>
             <button class="close"></button>
@@ -162,7 +162,7 @@
       <a class="link" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link" href="/help">Help</a>
       <a class="link" href="/feed.atom">
-        <img src="/static/img/atom-feed-icon-32x32.png?hash=mocked_hash_418851796" class="inline-icon"/>
+        <img src="/static/img/atom-feed-icon-32x32.png?hash=mocked_hash_251226050" class="inline-icon"/>
       </a>
       <a class="link github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">Report an issue with this site</a>
     </footer>

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
   <head>
     <script async="async" src="https://www.googletagmanager.com/gtag/js?id=UA-26406144-13"></script>
-    <script src="/static/js/gtag.js?hash=mocked_hash_673383334"></script>
+    <script src="/static/js/gtag.js?hash=mocked_hash_221832925"></script>
     <meta charset="utf-8"/>
     <meta http-equiv="x-ua-compatible" content="ie=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
@@ -12,16 +12,16 @@
     <title>foobar_pkg | Dart Package</title>
     <meta property="og:title" content="foobar_pkg | Dart Package"/>
     <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet"/>
-    <meta itemprop="image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_1042064956"/>
-    <meta property="og:image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_1042064956"/>
-    <link rel="shortcut icon" href="/favicon.ico"/>
+    <meta itemprop="image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <meta property="og:image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
     <meta name="description" content="my package description"/>
     <meta property="og:description" content="my package description"/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
-    <link href="/static/highlight/github.css?hash=mocked_hash_737193633" rel="stylesheet"/>
-    <link href="/static/css/github-markdown.css?hash=mocked_hash_244413523" rel="stylesheet" type="text/css"/>
-    <link href="/static/css/style.css?hash=mocked_hash_714113458" rel="stylesheet" type="text/css"/>
-    <script src="/static/js/script.dart.js?hash=mocked_hash_918742474" defer="defer"></script>
+    <link href="/static/highlight/github.css?hash=mocked_hash_145446167" rel="stylesheet"/>
+    <link href="/static/css/github-markdown.css?hash=mocked_hash_488759485" rel="stylesheet" type="text/css"/>
+    <link href="/static/css/style.css?hash=mocked_hash_537099079" rel="stylesheet" type="text/css"/>
+    <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
     <script async="async" defer="defer" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
   </head>
   <body class="">
@@ -33,7 +33,7 @@
         <div class="nav-wrap">
           <div class="nav-header">
             <a class="logo" href="/">
-              <img src="/static/img/pub-dev-logo-2x.png?hash=mocked_hash_929871536" alt="dart pub logo"/>
+              <img src="/static/img/pub-dev-logo-2x.png?hash=mocked_hash_685890546" alt="dart pub logo"/>
             </a>
             <div class="_flex-space"></div>
             <button class="close"></button>
@@ -184,12 +184,12 @@ import 'package:foobar_pkg/foolib.dart';
                   <td>Jan 1, 2014</td>
                   <td class="documentation">
                     <a href="/documentation/foobar_pkg/0.1.1+5/" rel="nofollow" title="Go to the documentation of foobar_pkg 0.1.1+5">
-                      <img src="/static/img/ic_drive_document_black_24dp.svg" alt="Go to the documentation of foobar_pkg 0.1.1+5"/>
+                      <img src="/static/img/ic_drive_document_black_24dp.svg?hash=mocked_hash_663394799" alt="Go to the documentation of foobar_pkg 0.1.1+5"/>
                     </a>
                   </td>
                   <td class="archive">
                     <a href="http://dart-example.com/" title="Download foobar_pkg 0.1.1+5 archive">
-                      <img src="/static/img/ic_get_app_black_24dp.svg" alt="Download foobar_pkg 0.1.1+5 archive"/>
+                      <img src="/static/img/ic_get_app_black_24dp.svg?hash=mocked_hash_341543596" alt="Download foobar_pkg 0.1.1+5 archive"/>
                     </a>
                   </td>
                 </tr>
@@ -394,11 +394,11 @@ import 'package:foobar_pkg/foolib.dart';
       <a class="link" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link" href="/help">Help</a>
       <a class="link" href="/feed.atom">
-        <img src="/static/img/atom-feed-icon-32x32.png?hash=mocked_hash_418851796" class="inline-icon"/>
+        <img src="/static/img/atom-feed-icon-32x32.png?hash=mocked_hash_251226050" class="inline-icon"/>
       </a>
       <a class="link github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">Report an issue with this site</a>
     </footer>
-    <script src="/static/highlight/highlight.pack.js?hash=mocked_hash_918449443"></script>
-    <script src="/static/highlight/init.js?hash=mocked_hash_851568549"></script>
+    <script src="/static/highlight/highlight.pack.js?hash=mocked_hash_252154265"></script>
+    <script src="/static/highlight/init.js?hash=mocked_hash_180963889"></script>
   </body>
 </html>

--- a/app/test/frontend/golden/pkg_show_page_discontinued.html
+++ b/app/test/frontend/golden/pkg_show_page_discontinued.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
   <head>
     <script async="async" src="https://www.googletagmanager.com/gtag/js?id=UA-26406144-13"></script>
-    <script src="/static/js/gtag.js?hash=mocked_hash_673383334"></script>
+    <script src="/static/js/gtag.js?hash=mocked_hash_221832925"></script>
     <meta charset="utf-8"/>
     <meta http-equiv="x-ua-compatible" content="ie=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
@@ -13,16 +13,16 @@
     <title>foobar_pkg | Dart Package</title>
     <meta property="og:title" content="foobar_pkg | Dart Package"/>
     <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet"/>
-    <meta itemprop="image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_1042064956"/>
-    <meta property="og:image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_1042064956"/>
-    <link rel="shortcut icon" href="/favicon.ico"/>
+    <meta itemprop="image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <meta property="og:image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
     <meta name="description" content="my package description"/>
     <meta property="og:description" content="my package description"/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
-    <link href="/static/highlight/github.css?hash=mocked_hash_737193633" rel="stylesheet"/>
-    <link href="/static/css/github-markdown.css?hash=mocked_hash_244413523" rel="stylesheet" type="text/css"/>
-    <link href="/static/css/style.css?hash=mocked_hash_714113458" rel="stylesheet" type="text/css"/>
-    <script src="/static/js/script.dart.js?hash=mocked_hash_918742474" defer="defer"></script>
+    <link href="/static/highlight/github.css?hash=mocked_hash_145446167" rel="stylesheet"/>
+    <link href="/static/css/github-markdown.css?hash=mocked_hash_488759485" rel="stylesheet" type="text/css"/>
+    <link href="/static/css/style.css?hash=mocked_hash_537099079" rel="stylesheet" type="text/css"/>
+    <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
     <script async="async" defer="defer" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
   </head>
   <body class="">
@@ -34,7 +34,7 @@
         <div class="nav-wrap">
           <div class="nav-header">
             <a class="logo" href="/">
-              <img src="/static/img/pub-dev-logo-2x.png?hash=mocked_hash_929871536" alt="dart pub logo"/>
+              <img src="/static/img/pub-dev-logo-2x.png?hash=mocked_hash_685890546" alt="dart pub logo"/>
             </a>
             <div class="_flex-space"></div>
             <button class="close"></button>
@@ -175,12 +175,12 @@ import 'package:foobar_pkg/foolib.dart';
                   <td>Jan 1, 2014</td>
                   <td class="documentation">
                     <a href="/documentation/foobar_pkg/0.1.1+5/" rel="nofollow" title="Go to the documentation of foobar_pkg 0.1.1+5">
-                      <img src="/static/img/ic_drive_document_black_24dp.svg" alt="Go to the documentation of foobar_pkg 0.1.1+5"/>
+                      <img src="/static/img/ic_drive_document_black_24dp.svg?hash=mocked_hash_663394799" alt="Go to the documentation of foobar_pkg 0.1.1+5"/>
                     </a>
                   </td>
                   <td class="archive">
                     <a href="http://dart-example.com/" title="Download foobar_pkg 0.1.1+5 archive">
-                      <img src="/static/img/ic_get_app_black_24dp.svg" alt="Download foobar_pkg 0.1.1+5 archive"/>
+                      <img src="/static/img/ic_get_app_black_24dp.svg?hash=mocked_hash_341543596" alt="Download foobar_pkg 0.1.1+5 archive"/>
                     </a>
                   </td>
                 </tr>
@@ -334,11 +334,11 @@ import 'package:foobar_pkg/foolib.dart';
       <a class="link" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link" href="/help">Help</a>
       <a class="link" href="/feed.atom">
-        <img src="/static/img/atom-feed-icon-32x32.png?hash=mocked_hash_418851796" class="inline-icon"/>
+        <img src="/static/img/atom-feed-icon-32x32.png?hash=mocked_hash_251226050" class="inline-icon"/>
       </a>
       <a class="link github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">Report an issue with this site</a>
     </footer>
-    <script src="/static/highlight/highlight.pack.js?hash=mocked_hash_918449443"></script>
-    <script src="/static/highlight/init.js?hash=mocked_hash_851568549"></script>
+    <script src="/static/highlight/highlight.pack.js?hash=mocked_hash_252154265"></script>
+    <script src="/static/highlight/init.js?hash=mocked_hash_180963889"></script>
   </body>
 </html>

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
   <head>
     <script async="async" src="https://www.googletagmanager.com/gtag/js?id=UA-26406144-13"></script>
-    <script src="/static/js/gtag.js?hash=mocked_hash_673383334"></script>
+    <script src="/static/js/gtag.js?hash=mocked_hash_221832925"></script>
     <meta charset="utf-8"/>
     <meta http-equiv="x-ua-compatible" content="ie=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
@@ -12,16 +12,16 @@
     <title>foobar_pkg | Flutter Package</title>
     <meta property="og:title" content="foobar_pkg | Flutter Package"/>
     <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet"/>
-    <meta itemprop="image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_1042064956"/>
-    <meta property="og:image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_1042064956"/>
-    <link rel="shortcut icon" href="/static/img/flutter-logo-32x32.png"/>
+    <meta itemprop="image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <meta property="og:image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <link rel="shortcut icon" href="/static/img/flutter-logo-32x32.png?hash=mocked_hash_318836230"/>
     <meta name="description" content="my package description"/>
     <meta property="og:description" content="my package description"/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
-    <link href="/static/highlight/github.css?hash=mocked_hash_737193633" rel="stylesheet"/>
-    <link href="/static/css/github-markdown.css?hash=mocked_hash_244413523" rel="stylesheet" type="text/css"/>
-    <link href="/static/css/style.css?hash=mocked_hash_714113458" rel="stylesheet" type="text/css"/>
-    <script src="/static/js/script.dart.js?hash=mocked_hash_918742474" defer="defer"></script>
+    <link href="/static/highlight/github.css?hash=mocked_hash_145446167" rel="stylesheet"/>
+    <link href="/static/css/github-markdown.css?hash=mocked_hash_488759485" rel="stylesheet" type="text/css"/>
+    <link href="/static/css/style.css?hash=mocked_hash_537099079" rel="stylesheet" type="text/css"/>
+    <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
     <script async="async" defer="defer" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
   </head>
   <body class="">
@@ -33,7 +33,7 @@
         <div class="nav-wrap">
           <div class="nav-header">
             <a class="logo" href="/">
-              <img src="/static/img/pub-dev-logo-2x.png?hash=mocked_hash_929871536" alt="dart pub logo"/>
+              <img src="/static/img/pub-dev-logo-2x.png?hash=mocked_hash_685890546" alt="dart pub logo"/>
             </a>
             <div class="_flex-space"></div>
             <button class="close"></button>
@@ -162,12 +162,12 @@ import 'package:foobar_pkg/foolib.dart';
                   <td>Jan 1, 2015</td>
                   <td class="documentation">
                     <a href="/documentation/foobar_pkg/0.1.1+5/" rel="nofollow" title="Go to the documentation of foobar_pkg 0.1.1+5">
-                      <img src="/static/img/ic_drive_document_black_24dp.svg" alt="Go to the documentation of foobar_pkg 0.1.1+5"/>
+                      <img src="/static/img/ic_drive_document_black_24dp.svg?hash=mocked_hash_663394799" alt="Go to the documentation of foobar_pkg 0.1.1+5"/>
                     </a>
                   </td>
                   <td class="archive">
                     <a href="http://dart-example.com/" title="Download foobar_pkg 0.1.1+5 archive">
-                      <img src="/static/img/ic_get_app_black_24dp.svg" alt="Download foobar_pkg 0.1.1+5 archive"/>
+                      <img src="/static/img/ic_get_app_black_24dp.svg?hash=mocked_hash_341543596" alt="Download foobar_pkg 0.1.1+5 archive"/>
                     </a>
                   </td>
                 </tr>
@@ -334,11 +334,11 @@ import 'package:foobar_pkg/foolib.dart';
       <a class="link" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link" href="/help">Help</a>
       <a class="link" href="/feed.atom">
-        <img src="/static/img/atom-feed-icon-32x32.png?hash=mocked_hash_418851796" class="inline-icon"/>
+        <img src="/static/img/atom-feed-icon-32x32.png?hash=mocked_hash_251226050" class="inline-icon"/>
       </a>
       <a class="link github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">Report an issue with this site</a>
     </footer>
-    <script src="/static/highlight/highlight.pack.js?hash=mocked_hash_918449443"></script>
-    <script src="/static/highlight/init.js?hash=mocked_hash_851568549"></script>
+    <script src="/static/highlight/highlight.pack.js?hash=mocked_hash_252154265"></script>
+    <script src="/static/highlight/init.js?hash=mocked_hash_180963889"></script>
   </body>
 </html>

--- a/app/test/frontend/golden/pkg_show_page_legacy.html
+++ b/app/test/frontend/golden/pkg_show_page_legacy.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
   <head>
     <script async="async" src="https://www.googletagmanager.com/gtag/js?id=UA-26406144-13"></script>
-    <script src="/static/js/gtag.js?hash=mocked_hash_673383334"></script>
+    <script src="/static/js/gtag.js?hash=mocked_hash_221832925"></script>
     <meta charset="utf-8"/>
     <meta http-equiv="x-ua-compatible" content="ie=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
@@ -13,18 +13,18 @@
     <title>foobar_pkg 0.1.1+5 | Dart Package</title>
     <meta property="og:title" content="foobar_pkg 0.1.1+5 | Dart Package"/>
     <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet"/>
-    <meta itemprop="image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_1042064956"/>
-    <meta property="og:image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_1042064956"/>
-    <link rel="shortcut icon" href="/favicon.ico"/>
+    <meta itemprop="image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <meta property="og:image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
     <link rel="canonical" href="https://pub.dev/packages/foobar_pkg"/>
     <meta property="og:url" content="https://pub.dev/packages/foobar_pkg"/>
     <meta name="description" content="my package description"/>
     <meta property="og:description" content="my package description"/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
-    <link href="/static/highlight/github.css?hash=mocked_hash_737193633" rel="stylesheet"/>
-    <link href="/static/css/github-markdown.css?hash=mocked_hash_244413523" rel="stylesheet" type="text/css"/>
-    <link href="/static/css/style.css?hash=mocked_hash_714113458" rel="stylesheet" type="text/css"/>
-    <script src="/static/js/script.dart.js?hash=mocked_hash_918742474" defer="defer"></script>
+    <link href="/static/highlight/github.css?hash=mocked_hash_145446167" rel="stylesheet"/>
+    <link href="/static/css/github-markdown.css?hash=mocked_hash_488759485" rel="stylesheet" type="text/css"/>
+    <link href="/static/css/style.css?hash=mocked_hash_537099079" rel="stylesheet" type="text/css"/>
+    <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
     <script async="async" defer="defer" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
   </head>
   <body class="">
@@ -36,7 +36,7 @@
         <div class="nav-wrap">
           <div class="nav-header">
             <a class="logo" href="/">
-              <img src="/static/img/pub-dev-logo-2x.png?hash=mocked_hash_929871536" alt="dart pub logo"/>
+              <img src="/static/img/pub-dev-logo-2x.png?hash=mocked_hash_685890546" alt="dart pub logo"/>
             </a>
             <div class="_flex-space"></div>
             <button class="close"></button>
@@ -177,12 +177,12 @@ import 'package:foobar_pkg/foolib.dart';
                   <td>Jan 1, 2014</td>
                   <td class="documentation">
                     <a href="/documentation/foobar_pkg/0.1.1+5/" rel="nofollow" title="Go to the documentation of foobar_pkg 0.1.1+5">
-                      <img src="/static/img/ic_drive_document_black_24dp.svg" alt="Go to the documentation of foobar_pkg 0.1.1+5"/>
+                      <img src="/static/img/ic_drive_document_black_24dp.svg?hash=mocked_hash_663394799" alt="Go to the documentation of foobar_pkg 0.1.1+5"/>
                     </a>
                   </td>
                   <td class="archive">
                     <a href="http://dart-example.com/" title="Download foobar_pkg 0.1.1+5 archive">
-                      <img src="/static/img/ic_get_app_black_24dp.svg" alt="Download foobar_pkg 0.1.1+5 archive"/>
+                      <img src="/static/img/ic_get_app_black_24dp.svg?hash=mocked_hash_341543596" alt="Download foobar_pkg 0.1.1+5 archive"/>
                     </a>
                   </td>
                 </tr>
@@ -354,11 +354,11 @@ import 'package:foobar_pkg/foolib.dart';
       <a class="link" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link" href="/help">Help</a>
       <a class="link" href="/feed.atom">
-        <img src="/static/img/atom-feed-icon-32x32.png?hash=mocked_hash_418851796" class="inline-icon"/>
+        <img src="/static/img/atom-feed-icon-32x32.png?hash=mocked_hash_251226050" class="inline-icon"/>
       </a>
       <a class="link github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">Report an issue with this site</a>
     </footer>
-    <script src="/static/highlight/highlight.pack.js?hash=mocked_hash_918449443"></script>
-    <script src="/static/highlight/init.js?hash=mocked_hash_851568549"></script>
+    <script src="/static/highlight/highlight.pack.js?hash=mocked_hash_252154265"></script>
+    <script src="/static/highlight/init.js?hash=mocked_hash_180963889"></script>
   </body>
 </html>

--- a/app/test/frontend/golden/pkg_show_page_outdated.html
+++ b/app/test/frontend/golden/pkg_show_page_outdated.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
   <head>
     <script async="async" src="https://www.googletagmanager.com/gtag/js?id=UA-26406144-13"></script>
-    <script src="/static/js/gtag.js?hash=mocked_hash_673383334"></script>
+    <script src="/static/js/gtag.js?hash=mocked_hash_221832925"></script>
     <meta charset="utf-8"/>
     <meta http-equiv="x-ua-compatible" content="ie=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
@@ -13,18 +13,18 @@
     <title>foobar_pkg 0.1.1+5 | Dart Package</title>
     <meta property="og:title" content="foobar_pkg 0.1.1+5 | Dart Package"/>
     <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet"/>
-    <meta itemprop="image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_1042064956"/>
-    <meta property="og:image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_1042064956"/>
-    <link rel="shortcut icon" href="/favicon.ico"/>
+    <meta itemprop="image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <meta property="og:image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
     <link rel="canonical" href="https://pub.dev/packages/foobar_pkg"/>
     <meta property="og:url" content="https://pub.dev/packages/foobar_pkg"/>
     <meta name="description" content="my package description"/>
     <meta property="og:description" content="my package description"/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
-    <link href="/static/highlight/github.css?hash=mocked_hash_737193633" rel="stylesheet"/>
-    <link href="/static/css/github-markdown.css?hash=mocked_hash_244413523" rel="stylesheet" type="text/css"/>
-    <link href="/static/css/style.css?hash=mocked_hash_714113458" rel="stylesheet" type="text/css"/>
-    <script src="/static/js/script.dart.js?hash=mocked_hash_918742474" defer="defer"></script>
+    <link href="/static/highlight/github.css?hash=mocked_hash_145446167" rel="stylesheet"/>
+    <link href="/static/css/github-markdown.css?hash=mocked_hash_488759485" rel="stylesheet" type="text/css"/>
+    <link href="/static/css/style.css?hash=mocked_hash_537099079" rel="stylesheet" type="text/css"/>
+    <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
     <script async="async" defer="defer" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
   </head>
   <body class="">
@@ -36,7 +36,7 @@
         <div class="nav-wrap">
           <div class="nav-header">
             <a class="logo" href="/">
-              <img src="/static/img/pub-dev-logo-2x.png?hash=mocked_hash_929871536" alt="dart pub logo"/>
+              <img src="/static/img/pub-dev-logo-2x.png?hash=mocked_hash_685890546" alt="dart pub logo"/>
             </a>
             <div class="_flex-space"></div>
             <button class="close"></button>
@@ -177,12 +177,12 @@ import 'package:foobar_pkg/foolib.dart';
                   <td>Jan 1, 2014</td>
                   <td class="documentation">
                     <a href="/documentation/foobar_pkg/0.1.1+5/" rel="nofollow" title="Go to the documentation of foobar_pkg 0.1.1+5">
-                      <img src="/static/img/ic_drive_document_black_24dp.svg" alt="Go to the documentation of foobar_pkg 0.1.1+5"/>
+                      <img src="/static/img/ic_drive_document_black_24dp.svg?hash=mocked_hash_663394799" alt="Go to the documentation of foobar_pkg 0.1.1+5"/>
                     </a>
                   </td>
                   <td class="archive">
                     <a href="http://dart-example.com/" title="Download foobar_pkg 0.1.1+5 archive">
-                      <img src="/static/img/ic_get_app_black_24dp.svg" alt="Download foobar_pkg 0.1.1+5 archive"/>
+                      <img src="/static/img/ic_get_app_black_24dp.svg?hash=mocked_hash_341543596" alt="Download foobar_pkg 0.1.1+5 archive"/>
                     </a>
                   </td>
                 </tr>
@@ -341,11 +341,11 @@ import 'package:foobar_pkg/foolib.dart';
       <a class="link" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link" href="/help">Help</a>
       <a class="link" href="/feed.atom">
-        <img src="/static/img/atom-feed-icon-32x32.png?hash=mocked_hash_418851796" class="inline-icon"/>
+        <img src="/static/img/atom-feed-icon-32x32.png?hash=mocked_hash_251226050" class="inline-icon"/>
       </a>
       <a class="link github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">Report an issue with this site</a>
     </footer>
-    <script src="/static/highlight/highlight.pack.js?hash=mocked_hash_918449443"></script>
-    <script src="/static/highlight/init.js?hash=mocked_hash_851568549"></script>
+    <script src="/static/highlight/highlight.pack.js?hash=mocked_hash_252154265"></script>
+    <script src="/static/highlight/init.js?hash=mocked_hash_180963889"></script>
   </body>
 </html>

--- a/app/test/frontend/golden/pkg_show_version_page.html
+++ b/app/test/frontend/golden/pkg_show_version_page.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
   <head>
     <script async="async" src="https://www.googletagmanager.com/gtag/js?id=UA-26406144-13"></script>
-    <script src="/static/js/gtag.js?hash=mocked_hash_673383334"></script>
+    <script src="/static/js/gtag.js?hash=mocked_hash_221832925"></script>
     <meta charset="utf-8"/>
     <meta http-equiv="x-ua-compatible" content="ie=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
@@ -12,18 +12,18 @@
     <title>foobar_pkg 0.1.1+5 | Dart Package</title>
     <meta property="og:title" content="foobar_pkg 0.1.1+5 | Dart Package"/>
     <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet"/>
-    <meta itemprop="image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_1042064956"/>
-    <meta property="og:image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_1042064956"/>
-    <link rel="shortcut icon" href="/favicon.ico"/>
+    <meta itemprop="image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <meta property="og:image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
     <link rel="canonical" href="https://pub.dev/packages/foobar_pkg"/>
     <meta property="og:url" content="https://pub.dev/packages/foobar_pkg"/>
     <meta name="description" content="my package description"/>
     <meta property="og:description" content="my package description"/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
-    <link href="/static/highlight/github.css?hash=mocked_hash_737193633" rel="stylesheet"/>
-    <link href="/static/css/github-markdown.css?hash=mocked_hash_244413523" rel="stylesheet" type="text/css"/>
-    <link href="/static/css/style.css?hash=mocked_hash_714113458" rel="stylesheet" type="text/css"/>
-    <script src="/static/js/script.dart.js?hash=mocked_hash_918742474" defer="defer"></script>
+    <link href="/static/highlight/github.css?hash=mocked_hash_145446167" rel="stylesheet"/>
+    <link href="/static/css/github-markdown.css?hash=mocked_hash_488759485" rel="stylesheet" type="text/css"/>
+    <link href="/static/css/style.css?hash=mocked_hash_537099079" rel="stylesheet" type="text/css"/>
+    <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
     <script async="async" defer="defer" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
   </head>
   <body class="">
@@ -35,7 +35,7 @@
         <div class="nav-wrap">
           <div class="nav-header">
             <a class="logo" href="/">
-              <img src="/static/img/pub-dev-logo-2x.png?hash=mocked_hash_929871536" alt="dart pub logo"/>
+              <img src="/static/img/pub-dev-logo-2x.png?hash=mocked_hash_685890546" alt="dart pub logo"/>
             </a>
             <div class="_flex-space"></div>
             <button class="close"></button>
@@ -186,12 +186,12 @@ import 'package:foobar_pkg/foolib.dart';
                   <td>Jan 1, 2014</td>
                   <td class="documentation">
                     <a href="/documentation/foobar_pkg/0.1.1+5/" rel="nofollow" title="Go to the documentation of foobar_pkg 0.1.1+5">
-                      <img src="/static/img/ic_drive_document_black_24dp.svg" alt="Go to the documentation of foobar_pkg 0.1.1+5"/>
+                      <img src="/static/img/ic_drive_document_black_24dp.svg?hash=mocked_hash_663394799" alt="Go to the documentation of foobar_pkg 0.1.1+5"/>
                     </a>
                   </td>
                   <td class="archive">
                     <a href="http://dart-example.com/" title="Download foobar_pkg 0.1.1+5 archive">
-                      <img src="/static/img/ic_get_app_black_24dp.svg" alt="Download foobar_pkg 0.1.1+5 archive"/>
+                      <img src="/static/img/ic_get_app_black_24dp.svg?hash=mocked_hash_341543596" alt="Download foobar_pkg 0.1.1+5 archive"/>
                     </a>
                   </td>
                 </tr>
@@ -396,11 +396,11 @@ import 'package:foobar_pkg/foolib.dart';
       <a class="link" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link" href="/help">Help</a>
       <a class="link" href="/feed.atom">
-        <img src="/static/img/atom-feed-icon-32x32.png?hash=mocked_hash_418851796" class="inline-icon"/>
+        <img src="/static/img/atom-feed-icon-32x32.png?hash=mocked_hash_251226050" class="inline-icon"/>
       </a>
       <a class="link github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">Report an issue with this site</a>
     </footer>
-    <script src="/static/highlight/highlight.pack.js?hash=mocked_hash_918449443"></script>
-    <script src="/static/highlight/init.js?hash=mocked_hash_851568549"></script>
+    <script src="/static/highlight/highlight.pack.js?hash=mocked_hash_252154265"></script>
+    <script src="/static/highlight/init.js?hash=mocked_hash_180963889"></script>
   </body>
 </html>

--- a/app/test/frontend/golden/pkg_versions_page.html
+++ b/app/test/frontend/golden/pkg_versions_page.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
   <head>
     <script async="async" src="https://www.googletagmanager.com/gtag/js?id=UA-26406144-13"></script>
-    <script src="/static/js/gtag.js?hash=mocked_hash_673383334"></script>
+    <script src="/static/js/gtag.js?hash=mocked_hash_221832925"></script>
     <meta charset="utf-8"/>
     <meta http-equiv="x-ua-compatible" content="ie=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
@@ -12,18 +12,18 @@
     <title>foobar package - All Versions</title>
     <meta property="og:title" content="foobar package - All Versions"/>
     <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet"/>
-    <meta itemprop="image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_1042064956"/>
-    <meta property="og:image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_1042064956"/>
-    <link rel="shortcut icon" href="/favicon.ico"/>
+    <meta itemprop="image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <meta property="og:image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
     <link rel="canonical" href="https://pub.dev/packages/foobar"/>
     <meta property="og:url" content="https://pub.dev/packages/foobar"/>
     <meta name="description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
-    <link href="/static/highlight/github.css?hash=mocked_hash_737193633" rel="stylesheet"/>
-    <link href="/static/css/github-markdown.css?hash=mocked_hash_244413523" rel="stylesheet" type="text/css"/>
-    <link href="/static/css/style.css?hash=mocked_hash_714113458" rel="stylesheet" type="text/css"/>
-    <script src="/static/js/script.dart.js?hash=mocked_hash_918742474" defer="defer"></script>
+    <link href="/static/highlight/github.css?hash=mocked_hash_145446167" rel="stylesheet"/>
+    <link href="/static/css/github-markdown.css?hash=mocked_hash_488759485" rel="stylesheet" type="text/css"/>
+    <link href="/static/css/style.css?hash=mocked_hash_537099079" rel="stylesheet" type="text/css"/>
+    <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
     <script async="async" defer="defer" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
   </head>
   <body class="">
@@ -35,7 +35,7 @@
         <div class="nav-wrap">
           <div class="nav-header">
             <a class="logo" href="/">
-              <img src="/static/img/pub-dev-logo-2x.png?hash=mocked_hash_929871536" alt="dart pub logo"/>
+              <img src="/static/img/pub-dev-logo-2x.png?hash=mocked_hash_685890546" alt="dart pub logo"/>
             </a>
             <div class="_flex-space"></div>
             <button class="close"></button>
@@ -93,12 +93,12 @@
             <td>Jan 1, 2014</td>
             <td class="documentation">
               <a href="/documentation/foobar_pkg/0.1.1+5/" rel="nofollow" title="Go to the documentation of foobar_pkg 0.1.1+5">
-                <img src="/static/img/ic_drive_document_black_24dp.svg" alt="Go to the documentation of foobar_pkg 0.1.1+5"/>
+                <img src="/static/img/ic_drive_document_black_24dp.svg?hash=mocked_hash_663394799" alt="Go to the documentation of foobar_pkg 0.1.1+5"/>
               </a>
             </td>
             <td class="archive">
               <a href="https://pub.dartlang.org/mock-download-uri.tar.gz" title="Download foobar_pkg 0.1.1+5 archive">
-                <img src="/static/img/ic_get_app_black_24dp.svg" alt="Download foobar_pkg 0.1.1+5 archive"/>
+                <img src="/static/img/ic_get_app_black_24dp.svg?hash=mocked_hash_341543596" alt="Download foobar_pkg 0.1.1+5 archive"/>
               </a>
             </td>
           </tr>
@@ -124,12 +124,12 @@
             <td>Jan 1, 2014</td>
             <td class="documentation">
               <a href="/documentation/foobar_pkg/0.2.0-dev/" rel="nofollow" title="Go to the documentation of foobar_pkg 0.2.0-dev">
-                <img src="/static/img/ic_drive_document_black_24dp.svg" alt="Go to the documentation of foobar_pkg 0.2.0-dev"/>
+                <img src="/static/img/ic_drive_document_black_24dp.svg?hash=mocked_hash_663394799" alt="Go to the documentation of foobar_pkg 0.2.0-dev"/>
               </a>
             </td>
             <td class="archive">
               <a href="https://pub.dartlang.org/mock-download-uri.tar.gz" title="Download foobar_pkg 0.2.0-dev archive">
-                <img src="/static/img/ic_get_app_black_24dp.svg" alt="Download foobar_pkg 0.2.0-dev archive"/>
+                <img src="/static/img/ic_get_app_black_24dp.svg?hash=mocked_hash_341543596" alt="Download foobar_pkg 0.2.0-dev archive"/>
               </a>
             </td>
           </tr>
@@ -142,11 +142,11 @@
       <a class="link" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link" href="/help">Help</a>
       <a class="link" href="/feed.atom">
-        <img src="/static/img/atom-feed-icon-32x32.png?hash=mocked_hash_418851796" class="inline-icon"/>
+        <img src="/static/img/atom-feed-icon-32x32.png?hash=mocked_hash_251226050" class="inline-icon"/>
       </a>
       <a class="link github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">Report an issue with this site</a>
     </footer>
-    <script src="/static/highlight/highlight.pack.js?hash=mocked_hash_918449443"></script>
-    <script src="/static/highlight/init.js?hash=mocked_hash_851568549"></script>
+    <script src="/static/highlight/highlight.pack.js?hash=mocked_hash_252154265"></script>
+    <script src="/static/highlight/init.js?hash=mocked_hash_180963889"></script>
   </body>
 </html>

--- a/app/test/frontend/golden/search_page.html
+++ b/app/test/frontend/golden/search_page.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
   <head>
     <script async="async" src="https://www.googletagmanager.com/gtag/js?id=UA-26406144-13"></script>
-    <script src="/static/js/gtag.js?hash=mocked_hash_673383334"></script>
+    <script src="/static/js/gtag.js?hash=mocked_hash_221832925"></script>
     <meta charset="utf-8"/>
     <meta http-equiv="x-ua-compatible" content="ie=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
@@ -13,16 +13,16 @@
     <title>Search results for foobar.</title>
     <meta property="og:title" content="Search results for foobar."/>
     <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet"/>
-    <meta itemprop="image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_1042064956"/>
-    <meta property="og:image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_1042064956"/>
-    <link rel="shortcut icon" href="/favicon.ico"/>
+    <meta itemprop="image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <meta property="og:image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
     <meta name="description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
-    <link href="/static/highlight/github.css?hash=mocked_hash_737193633" rel="stylesheet"/>
-    <link href="/static/css/github-markdown.css?hash=mocked_hash_244413523" rel="stylesheet" type="text/css"/>
-    <link href="/static/css/style.css?hash=mocked_hash_714113458" rel="stylesheet" type="text/css"/>
-    <script src="/static/js/script.dart.js?hash=mocked_hash_918742474" defer="defer"></script>
+    <link href="/static/highlight/github.css?hash=mocked_hash_145446167" rel="stylesheet"/>
+    <link href="/static/css/github-markdown.css?hash=mocked_hash_488759485" rel="stylesheet" type="text/css"/>
+    <link href="/static/css/style.css?hash=mocked_hash_537099079" rel="stylesheet" type="text/css"/>
+    <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
     <script async="async" defer="defer" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
   </head>
   <body class="">
@@ -34,7 +34,7 @@
         <div class="nav-wrap">
           <div class="nav-header">
             <a class="logo" href="/">
-              <img src="/static/img/pub-dev-logo-2x.png?hash=mocked_hash_929871536" alt="dart pub logo"/>
+              <img src="/static/img/pub-dev-logo-2x.png?hash=mocked_hash_685890546" alt="dart pub logo"/>
             </a>
             <div class="_flex-space"></div>
             <button class="close"></button>
@@ -201,7 +201,7 @@
       <a class="link" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link" href="/help">Help</a>
       <a class="link" href="/feed.atom">
-        <img src="/static/img/atom-feed-icon-32x32.png?hash=mocked_hash_418851796" class="inline-icon"/>
+        <img src="/static/img/atom-feed-icon-32x32.png?hash=mocked_hash_251226050" class="inline-icon"/>
       </a>
       <a class="link github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">Report an issue with this site</a>
     </footer>

--- a/app/test/frontend/golden/search_supported_qualifier.html
+++ b/app/test/frontend/golden/search_supported_qualifier.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
   <head>
     <script async="async" src="https://www.googletagmanager.com/gtag/js?id=UA-26406144-13"></script>
-    <script src="/static/js/gtag.js?hash=mocked_hash_673383334"></script>
+    <script src="/static/js/gtag.js?hash=mocked_hash_221832925"></script>
     <meta charset="utf-8"/>
     <meta http-equiv="x-ua-compatible" content="ie=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
@@ -13,16 +13,16 @@
     <title>Search results for email:user@domain.com.</title>
     <meta property="og:title" content="Search results for email:user@domain.com."/>
     <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet"/>
-    <meta itemprop="image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_1042064956"/>
-    <meta property="og:image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_1042064956"/>
-    <link rel="shortcut icon" href="/favicon.ico"/>
+    <meta itemprop="image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <meta property="og:image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
     <meta name="description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
-    <link href="/static/highlight/github.css?hash=mocked_hash_737193633" rel="stylesheet"/>
-    <link href="/static/css/github-markdown.css?hash=mocked_hash_244413523" rel="stylesheet" type="text/css"/>
-    <link href="/static/css/style.css?hash=mocked_hash_714113458" rel="stylesheet" type="text/css"/>
-    <script src="/static/js/script.dart.js?hash=mocked_hash_918742474" defer="defer"></script>
+    <link href="/static/highlight/github.css?hash=mocked_hash_145446167" rel="stylesheet"/>
+    <link href="/static/css/github-markdown.css?hash=mocked_hash_488759485" rel="stylesheet" type="text/css"/>
+    <link href="/static/css/style.css?hash=mocked_hash_537099079" rel="stylesheet" type="text/css"/>
+    <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
     <script async="async" defer="defer" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
   </head>
   <body class="">
@@ -34,7 +34,7 @@
         <div class="nav-wrap">
           <div class="nav-header">
             <a class="logo" href="/">
-              <img src="/static/img/pub-dev-logo-2x.png?hash=mocked_hash_929871536" alt="dart pub logo"/>
+              <img src="/static/img/pub-dev-logo-2x.png?hash=mocked_hash_685890546" alt="dart pub logo"/>
             </a>
             <div class="_flex-space"></div>
             <button class="close"></button>
@@ -110,7 +110,7 @@
       <a class="link" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link" href="/help">Help</a>
       <a class="link" href="/feed.atom">
-        <img src="/static/img/atom-feed-icon-32x32.png?hash=mocked_hash_418851796" class="inline-icon"/>
+        <img src="/static/img/atom-feed-icon-32x32.png?hash=mocked_hash_251226050" class="inline-icon"/>
       </a>
       <a class="link github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">Report an issue with this site</a>
     </footer>

--- a/app/test/frontend/golden/search_unsupported_qualifier.html
+++ b/app/test/frontend/golden/search_unsupported_qualifier.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
   <head>
     <script async="async" src="https://www.googletagmanager.com/gtag/js?id=UA-26406144-13"></script>
-    <script src="/static/js/gtag.js?hash=mocked_hash_673383334"></script>
+    <script src="/static/js/gtag.js?hash=mocked_hash_221832925"></script>
     <meta charset="utf-8"/>
     <meta http-equiv="x-ua-compatible" content="ie=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
@@ -13,16 +13,16 @@
     <title>Search results for foo:bar.</title>
     <meta property="og:title" content="Search results for foo:bar."/>
     <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet"/>
-    <meta itemprop="image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_1042064956"/>
-    <meta property="og:image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_1042064956"/>
-    <link rel="shortcut icon" href="/favicon.ico"/>
+    <meta itemprop="image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <meta property="og:image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
     <meta name="description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
-    <link href="/static/highlight/github.css?hash=mocked_hash_737193633" rel="stylesheet"/>
-    <link href="/static/css/github-markdown.css?hash=mocked_hash_244413523" rel="stylesheet" type="text/css"/>
-    <link href="/static/css/style.css?hash=mocked_hash_714113458" rel="stylesheet" type="text/css"/>
-    <script src="/static/js/script.dart.js?hash=mocked_hash_918742474" defer="defer"></script>
+    <link href="/static/highlight/github.css?hash=mocked_hash_145446167" rel="stylesheet"/>
+    <link href="/static/css/github-markdown.css?hash=mocked_hash_488759485" rel="stylesheet" type="text/css"/>
+    <link href="/static/css/style.css?hash=mocked_hash_537099079" rel="stylesheet" type="text/css"/>
+    <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
     <script async="async" defer="defer" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
   </head>
   <body class="">
@@ -34,7 +34,7 @@
         <div class="nav-wrap">
           <div class="nav-header">
             <a class="logo" href="/">
-              <img src="/static/img/pub-dev-logo-2x.png?hash=mocked_hash_929871536" alt="dart pub logo"/>
+              <img src="/static/img/pub-dev-logo-2x.png?hash=mocked_hash_685890546" alt="dart pub logo"/>
             </a>
             <div class="_flex-space"></div>
             <button class="close"></button>
@@ -113,7 +113,7 @@
       <a class="link" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link" href="/help">Help</a>
       <a class="link" href="/feed.atom">
-        <img src="/static/img/atom-feed-icon-32x32.png?hash=mocked_hash_418851796" class="inline-icon"/>
+        <img src="/static/img/atom-feed-icon-32x32.png?hash=mocked_hash_251226050" class="inline-icon"/>
       </a>
       <a class="link github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">Report an issue with this site</a>
     </footer>

--- a/app/test/frontend/golden/uploader_approval_page.html
+++ b/app/test/frontend/golden/uploader_approval_page.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
   <head>
     <script async="async" src="https://www.googletagmanager.com/gtag/js?id=UA-26406144-13"></script>
-    <script src="/static/js/gtag.js?hash=mocked_hash_673383334"></script>
+    <script src="/static/js/gtag.js?hash=mocked_hash_221832925"></script>
     <meta charset="utf-8"/>
     <meta http-equiv="x-ua-compatible" content="ie=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
@@ -12,16 +12,16 @@
     <title>Uploader invitation</title>
     <meta property="og:title" content="Uploader invitation"/>
     <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet"/>
-    <meta itemprop="image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_1042064956"/>
-    <meta property="og:image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_1042064956"/>
-    <link rel="shortcut icon" href="/favicon.ico"/>
+    <meta itemprop="image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <meta property="og:image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
     <meta name="description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
-    <link href="/static/highlight/github.css?hash=mocked_hash_737193633" rel="stylesheet"/>
-    <link href="/static/css/github-markdown.css?hash=mocked_hash_244413523" rel="stylesheet" type="text/css"/>
-    <link href="/static/css/style.css?hash=mocked_hash_714113458" rel="stylesheet" type="text/css"/>
-    <script src="/static/js/script.dart.js?hash=mocked_hash_918742474" defer="defer"></script>
+    <link href="/static/highlight/github.css?hash=mocked_hash_145446167" rel="stylesheet"/>
+    <link href="/static/css/github-markdown.css?hash=mocked_hash_488759485" rel="stylesheet" type="text/css"/>
+    <link href="/static/css/style.css?hash=mocked_hash_537099079" rel="stylesheet" type="text/css"/>
+    <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
   </head>
   <body class="">
     <header class="site-header-row">
@@ -32,7 +32,7 @@
         <div class="nav-wrap">
           <div class="nav-header">
             <a class="logo" href="/">
-              <img src="/static/img/pub-dev-logo-2x.png?hash=mocked_hash_929871536" alt="dart pub logo"/>
+              <img src="/static/img/pub-dev-logo-2x.png?hash=mocked_hash_685890546" alt="dart pub logo"/>
             </a>
             <div class="_flex-space"></div>
             <button class="close"></button>
@@ -98,11 +98,11 @@
       <a class="link" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link" href="/help">Help</a>
       <a class="link" href="/feed.atom">
-        <img src="/static/img/atom-feed-icon-32x32.png?hash=mocked_hash_418851796" class="inline-icon"/>
+        <img src="/static/img/atom-feed-icon-32x32.png?hash=mocked_hash_251226050" class="inline-icon"/>
       </a>
       <a class="link github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">Report an issue with this site</a>
     </footer>
-    <script src="/static/highlight/highlight.pack.js?hash=mocked_hash_918449443"></script>
-    <script src="/static/highlight/init.js?hash=mocked_hash_851568549"></script>
+    <script src="/static/highlight/highlight.pack.js?hash=mocked_hash_252154265"></script>
+    <script src="/static/highlight/init.js?hash=mocked_hash_180963889"></script>
   </body>
 </html>

--- a/app/test/frontend/golden/web_landing_page.html
+++ b/app/test/frontend/golden/web_landing_page.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
   <head>
     <script async="async" src="https://www.googletagmanager.com/gtag/js?id=UA-26406144-13"></script>
-    <script src="/static/js/gtag.js?hash=mocked_hash_673383334"></script>
+    <script src="/static/js/gtag.js?hash=mocked_hash_221832925"></script>
     <meta charset="utf-8"/>
     <meta http-equiv="x-ua-compatible" content="ie=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
@@ -12,16 +12,16 @@
     <title>Dart packages for Web</title>
     <meta property="og:title" content="Dart packages for Web"/>
     <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet"/>
-    <meta itemprop="image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_1042064956"/>
-    <meta property="og:image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_1042064956"/>
-    <link rel="shortcut icon" href="/favicon.ico"/>
+    <meta itemprop="image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <meta property="og:image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
     <meta name="description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
-    <link href="/static/highlight/github.css?hash=mocked_hash_737193633" rel="stylesheet"/>
-    <link href="/static/css/github-markdown.css?hash=mocked_hash_244413523" rel="stylesheet" type="text/css"/>
-    <link href="/static/css/style.css?hash=mocked_hash_714113458" rel="stylesheet" type="text/css"/>
-    <script src="/static/js/script.dart.js?hash=mocked_hash_918742474" defer="defer"></script>
+    <link href="/static/highlight/github.css?hash=mocked_hash_145446167" rel="stylesheet"/>
+    <link href="/static/css/github-markdown.css?hash=mocked_hash_488759485" rel="stylesheet" type="text/css"/>
+    <link href="/static/css/style.css?hash=mocked_hash_537099079" rel="stylesheet" type="text/css"/>
+    <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
     <script async="async" defer="defer" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
   </head>
   <body class="">
@@ -33,7 +33,7 @@
         <div class="nav-wrap">
           <div class="nav-header">
             <a class="logo" href="/">
-              <img src="/static/img/pub-dev-logo-2x.png?hash=mocked_hash_929871536" alt="dart pub logo"/>
+              <img src="/static/img/pub-dev-logo-2x.png?hash=mocked_hash_685890546" alt="dart pub logo"/>
             </a>
             <div class="_flex-space"></div>
             <button class="close"></button>
@@ -62,7 +62,7 @@
     <div class="_banner-bg">
       <main class="home-banner">
         <h2 class="_visuallyhidden">Dart package manager</h2>
-        <img class="logo" src="/static/img/dart-packages-white.png?hash=mocked_hash_527535581" alt="Dart packages"/>
+        <img class="logo" src="/static/img/dart-packages-white.png?hash=mocked_hash_308431268" alt="Dart packages"/>
         <form class="search-bar" action="/web/packages">
           <input class="input" name="q" placeholder="Search web-compatible packages" autocomplete="on" autofocus="autofocus"/>
           <button class="icon"></button>
@@ -116,7 +116,7 @@
       <a class="link" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link" href="/help">Help</a>
       <a class="link" href="/feed.atom">
-        <img src="/static/img/atom-feed-icon-32x32.png?hash=mocked_hash_418851796" class="inline-icon"/>
+        <img src="/static/img/atom-feed-icon-32x32.png?hash=mocked_hash_251226050" class="inline-icon"/>
       </a>
       <a class="link github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">Report an issue with this site</a>
     </footer>

--- a/app/test/frontend/static_files_test.dart
+++ b/app/test/frontend/static_files_test.dart
@@ -40,27 +40,6 @@ void main() {
             '/static/highlight/highlight.pack.js'));
   });
 
-  group('mocked static files', () {
-    test('exists', () {
-      for (String path in hashedFiles) {
-        final file = staticFileCache.getFile('/static/$path');
-        expect(file, isNotNull);
-        expect(file.bytes.length, greaterThan(10));
-        expect(file.etag.contains('mocked_hash'), isFalse);
-      }
-    });
-
-    test('urls populated with hash', () {
-      final assets = staticUrls.assets;
-      expect(assets.length, hashedFiles.length);
-      for (String value in assets.values) {
-        final parts = value.split('?hash=');
-        expect(parts.length, greaterThan(1));
-        expect(parts.last.length, greaterThan(20));
-      }
-    });
-  });
-
   group('default content', () {
     final cache = StaticFileCache.withDefaults();
     final files = [

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -37,14 +37,17 @@ const String goldenDir = 'test/frontend/golden';
 final _regenerateGoldens = false;
 
 void main() {
+  setUpAll(() => updateLocalBuiltFiles());
+
   group('templates', () {
     StaticFileCache oldCache;
 
     setUpAll(() {
+      final properCache = StaticFileCache.withDefaults();
       final cache = StaticFileCache();
-      for (String path in hashedFiles) {
-        final file = StaticFile('${staticUrls.staticPath}/$path', 'text/mock',
-            [], DateTime.now(), 'mocked_hash_${path.hashCode.abs()}');
+      for (String path in properCache.keys) {
+        final file = StaticFile(path, 'text/mock', [], DateTime.now(),
+            'mocked_hash_${path.hashCode.abs()}');
         cache.addFile(file);
       }
       oldCache = staticFileCache;


### PR DESCRIPTION
- #2351
- More `?hash=` urls, e.g. `/favicon.ico?hash=`. As this is outside of /static/, it required to change a few more things, and in effect it also changed the mocked hash codes in tests.
- Removed the list of hashed urls (it was only used in test), it makes the updates of assets simpler.
