### PR TITLE
Account menu on the top bar.

### DIFF
--- a/app/lib/frontend/templates/views/layout.mustache
+++ b/app/lib/frontend/templates/views/layout.mustache
@@ -44,11 +44,6 @@
 </head>
 <body class="{{& body_class}}">
 <header class="site-header-row">
-  {{#oauth_client_id}}
-  <div class="account-header">
-    <div class="g-signin2"></div>
-  </div>
-  {{/oauth_client_id}}
   <div class="site-header">
     <h1 class="_visuallyhidden">Dart pub</h1>
     <button class="hamburger"></button>
@@ -76,6 +71,9 @@
           </div>
         </div>
       </nav>
+      {{#oauth_client_id}}
+      <div id="account-nav"></div>
+      {{/oauth_client_id}}
     </div>
   </div>
 </header>

--- a/pkg/web_app/lib/src/_dom_helper.dart
+++ b/pkg/web_app/lib/src/_dom_helper.dart
@@ -1,0 +1,40 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:html';
+
+/// Creates a DOM Element.
+Element elem(
+  String tag, {
+  String id,
+  Map<String, String> attrs,
+  Iterable<String> classes,
+  String text,
+  List<Element> children,
+  dynamic Function(MouseEvent event) onClick,
+}) {
+  final elem = Element.tag(tag);
+  if (id != null) {
+    elem.id = id;
+  }
+  if (attrs != null) {
+    elem.attributes.addAll(attrs);
+  }
+  if (classes != null) {
+    elem.classes.addAll(classes);
+  }
+  if (text != null) {
+    elem.text = text;
+  }
+  children?.forEach(elem.append);
+  if (onClick != null) {
+    elem.onClick.listen(onClick);
+  }
+  return elem;
+}
+
+/// Show/hide an element.
+void updateDisplay(Element elem, bool show) {
+  elem.style.display = show ? null : 'none';
+}

--- a/pkg/web_app/lib/src/google_auth_js.dart
+++ b/pkg/web_app/lib/src/google_auth_js.dart
@@ -9,6 +9,11 @@ library google_auth_js;
 
 import 'package:js/js.dart';
 
+/// Initializes the GoogleAuth object. You must call this method before calling
+/// gapi.auth2.GoogleAuth's methods.
+@JS()
+external GoogleAuth init(dynamic params);
+
 /// Returns the auth library's main instance (if initialized).
 @JS()
 external GoogleAuth getAuthInstance();
@@ -22,9 +27,18 @@ abstract class GoogleAuth {
   /// The current user.
   external GoogleAuthCurrentUser get currentUser;
 
+  /// Triggers a sign-in, and returns a Promise that will complete when the
+  /// sign-in is finalized.
+  external dynamic signIn();
+
   /// Triggers a sign-out, and returns a Promise that will complete when the
   /// sign-out is finalized.
   external dynamic signOut();
+
+  /// Calls the onInit function when the GoogleAuth object is fully initialized.
+  /// If an error is raised while initializing, the onError function will be
+  /// called instead.
+  external dynamic then(Function onInit);
 }
 
 @anonymous
@@ -68,6 +82,9 @@ abstract class AuthResponse {
 /// The basic profile data of the user.
 @JS()
 abstract class BasicProfile {
-  /// The e-mail address of the user
+  /// The profile image URL of the user.
+  external String getImageUrl();
+
+  /// The e-mail address of the user.
   external String getEmail();
 }

--- a/pkg/web_app/lib/src/hoverable.dart
+++ b/pkg/web_app/lib/src/hoverable.dart
@@ -8,6 +8,8 @@ void setupHoverable() {
   _setEventForHoverable();
 }
 
+Element _activeHover;
+
 /// Elements with the `hoverable` class provide hover tooltip for both desktop
 /// browsers and touchscreen devices:
 ///   - when clicked, they are added a `hover` class (toggled on repeated clicks)
@@ -17,29 +19,33 @@ void setupHoverable() {
 ///
 ///  Their `:hover` and `.hover` style must match to have the same effect.
 void _setEventForHoverable() {
-  Element activeHover;
-  void deactivateHover(_) {
-    if (activeHover != null) {
-      activeHover.classes.remove('hover');
-      activeHover = null;
-    }
-  }
-
   document.body.onClick.listen(deactivateHover);
-
   for (Element h in document.querySelectorAll('.hoverable')) {
-    h.onClick.listen((e) {
-      if (h != activeHover) {
-        deactivateHover(e);
-        activeHover = h;
-        activeHover.classes.add('hover');
-        e.stopPropagation();
-      }
-    });
-    h.onMouseEnter.listen((e) {
-      if (h != activeHover) {
-        deactivateHover(e);
-      }
-    });
+    registerHoverable(h);
   }
+}
+
+/// Deactivates the active hover (hiding the hovering panel).
+void deactivateHover(_) {
+  if (_activeHover != null) {
+    _activeHover.classes.remove('hover');
+    _activeHover = null;
+  }
+}
+
+/// Registers the given Element to follow hoverable events.
+void registerHoverable(Element h) {
+  h.onClick.listen((e) {
+    if (h != _activeHover) {
+      deactivateHover(e);
+      _activeHover = h;
+      _activeHover.classes.add('hover');
+      e.stopPropagation();
+    }
+  });
+  h.onMouseEnter.listen((e) {
+    if (h != _activeHover) {
+      deactivateHover(e);
+    }
+  });
 }

--- a/pkg/web_css/lib/src/_account.scss
+++ b/pkg/web_css/lib/src/_account.scss
@@ -1,0 +1,9 @@
+#account-nav {
+  min-width: 200px;
+  color: #000;
+
+  .profile-img {
+    width: auto;
+    max-height: 30px;
+  }
+}

--- a/pkg/web_css/lib/src/_base.scss
+++ b/pkg/web_css/lib/src/_base.scss
@@ -117,7 +117,6 @@ pre > code {
   color: $color-header-dark-fg;
 }
 
-.account-header,
 .site-header {
   display: -webkit-box;
   display: -ms-flexbox;

--- a/pkg/web_css/lib/style.scss
+++ b/pkg/web_css/lib/style.scss
@@ -1,6 +1,7 @@
 @import 'src/_variables';
 @import 'src/_base';
 @import 'src/_footer';
+@import 'src/_account';
 @import 'src/_list';
 @import 'src/_home';
 @import 'src/_pkg';


### PR DESCRIPTION
Part of #2316, still behind the experimental cookie.

- removed the Google sign-in button, and with that:
  - need to call goog.auth2.init([options]).then(initCallback)
  - need to call signIn() when triggered
- removed the prior status bar, and using the same hover+dropdown that the nav menu is using
- added some minimal DOM helper methods to build and update the DOM

<img width="1025" alt="Screen Shot 2019-06-14 at 19 14 05" src="https://user-images.githubusercontent.com/4778111/59526727-e9055900-8ed9-11e9-9009-f15025e74f2d.png">

A few unresolved parts for later PRs:
- hoverable dropdown positioned to the right
- profile picture is not entirely centered vertically
- not sure if every google account has a profile image, and what happens then
- mobile menu is still broken with this one