### PR TITLE
Remove retry that is no longer necessary.

### DIFF
--- a/app/lib/frontend/backend.dart
+++ b/app/lib/frontend/backend.dart
@@ -393,9 +393,7 @@ class GCloudPackageRepository extends PackageRepository {
 
       return withTempDirectory((Directory dir) async {
         final filename = '${dir.absolute.path}/tarball.tar.gz';
-        // TODO: check why this is flaky https://github.com/dart-lang/pub-dartlang-dart/issues/1680
-        await retryAsync(
-            () => _saveTarballToFS(storage.readTempObject(guid), filename));
+        await _saveTarballToFS(storage.readTempObject(guid), filename);
         return _performTarballUpload(user, filename, (package, version) {
           return storage.uploadViaTempObject(guid, package, version);
         }).whenComplete(() async {


### PR DESCRIPTION
- Originally it was introduced to debug #1680, but the root cause was not storage-related.
- Retrying the read should happen at a lower-level library.