### PR TITLE
Remove health check migration from this release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ AppEngine version, listed here to ease deployment and troubleshooting.
 
 ## `20190617t112618-all`
 
- * Update project to use split health checks, run:
-   `gcloud app update --split-health-checks --project dartlang-pub`
  * `search` service is using custom liveness and readiness checks.
  * Search results (top packages, listing pages) use local fallbacks.
  * Upgraded `pana` (`0.12.18`), runtime and analysis Dart SDK (`2.3.2`).


### PR DESCRIPTION
See: https://cloud.google.com/appengine/docs/flexible/custom-runtimes/configuring-your-app-with-app-yaml#migrating_to_updated_health_checks

In short we need to move all or nothing, we can't just move the `search` service.