### PR TITLE
Migration atom_feed_test.dart to use fake_gcloud.

### DIFF
--- a/app/test/frontend/handlers/atom_feed_test.dart
+++ b/app/test/frontend/handlers/atom_feed_test.dart
@@ -2,26 +2,22 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:fake_gcloud/mem_datastore.dart';
+import 'package:gcloud/db.dart';
 import 'package:test/test.dart';
 
 import 'package:pub_dartlang_org/frontend/backend.dart';
 
-import '../mocks.dart';
 import '../utils.dart';
 
 import '_utils.dart';
 
 void main() {
-  final pageSize = 10;
-
   group('feeds', () {
     tScopedTest('/feed.atom', () async {
-      final backend = BackendMock(latestPackageVersionsFun: ({offset, limit}) {
-        expect(offset, 0);
-        expect(limit, pageSize);
-        return [testPackageVersion];
-      });
-      registerBackend(backend);
+      final db = DatastoreDB(MemDatastore());
+      await db.commit(inserts: [testPackage, testPackageVersion]);
+      registerBackend(Backend(db, null));
       await expectAtomXmlResponse(await issueGet('/feed.atom'), regexp: '''
 <\\?xml version="1.0" encoding="UTF-8"\\?>
 <feed xmlns="http://www.w3.org/2005/Atom">

--- a/app/test/frontend/utils.dart
+++ b/app/test/frontend/utils.dart
@@ -47,7 +47,8 @@ Package createTestPackage({List<AuthenticatedUser> uploaders}) {
     ..updated = DateTime.utc(2015)
     ..uploaders = uploaders.map((user) => user.userId).toList()
     ..latestVersionKey = testPackageVersionKey
-    ..latestDevVersionKey = testPackageVersionKey;
+    ..latestDevVersionKey = testPackageVersionKey
+    ..downloads = 0;
 }
 
 final Package testPackage = createTestPackage()
@@ -71,7 +72,8 @@ final PackageVersion testPackageVersion = PackageVersion()
   ..changelogContent = testPackageChangelog
   ..exampleFilename = 'example/lib/main.dart'
   ..exampleContent = testPackageExample
-  ..sortOrder = -1;
+  ..sortOrder = -1
+  ..downloads = 0;
 
 final PackageVersion flutterPackageVersion =
     clonePackageVersion(testPackageVersion)

--- a/pkg/fake_gcloud/lib/mem_datastore.dart
+++ b/pkg/fake_gcloud/lib/mem_datastore.dart
@@ -118,7 +118,7 @@ class MemDatastore implements Datastore {
     if (query.offset != null && query.offset > 0) {
       items = items.skip(query.offset).toList();
     }
-    if (query.limit != null && query.limit > items.length) {
+    if (query.limit != null && query.limit < items.length) {
       items = items.sublist(0, query.limit);
     }
     return _Page(items, 0, 100);


### PR DESCRIPTION
- #1595
- also fixes a bug in `fake_gcloud` and updates the test package models with the required field.