### PR TITLE
Use fixed tab labels instead of filenames.

### DIFF
--- a/app/lib/frontend/templates/package.dart
+++ b/app/lib/frontend/templates/package.dart
@@ -301,26 +301,21 @@ List<Map<String, String>> _tabsData(
 }) {
   final card = analysis?.card;
 
-  String readmeFilename;
   String renderedReadme;
   final packageLinks = selectedVersion.packageLinks;
   final baseUrl = packageLinks.repositoryUrl ?? packageLinks.homepageUrl;
   if (selectedVersion.readme != null) {
-    readmeFilename = selectedVersion.readme.filename;
     renderedReadme = renderFile(selectedVersion.readme, baseUrl);
   }
 
-  String changelogFilename;
   String renderedChangelog;
   if (selectedVersion.changelog != null) {
-    changelogFilename = selectedVersion.changelog.filename;
     renderedChangelog = renderFile(selectedVersion.changelog, baseUrl);
   }
 
-  String exampleFilename;
   String renderedExample;
   if (selectedVersion.example != null) {
-    exampleFilename = selectedVersion.example.filename;
+    final exampleFilename = selectedVersion.example.filename;
     renderedExample = renderFile(selectedVersion.example, baseUrl);
     if (renderedExample != null) {
       renderedExample = '<p style="font-family: monospace">'
@@ -351,8 +346,8 @@ List<Map<String, String>> _tabsData(
     addTab(id, title: title, content: content, markdown: true);
   }
 
-  addFileTab('readme', readmeFilename, renderedReadme);
-  addFileTab('changelog', changelogFilename, renderedChangelog);
+  addFileTab('readme', 'Readme', renderedReadme);
+  addFileTab('changelog', 'Changelog', renderedChangelog);
   addFileTab('example', 'Example', renderedExample);
 
   addTab('installing',

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -91,8 +91,8 @@
       </div>
       <div class="package-container">
         <ul class="package-tabs js-tabs">
-          <li class="tab -active" data-name="-readme-tab-" role="button">README.md</li>
-          <li class="tab " data-name="-changelog-tab-" role="button">CHANGELOG.md</li>
+          <li class="tab -active" data-name="-readme-tab-" role="button">Readme</li>
+          <li class="tab " data-name="-changelog-tab-" role="button">Changelog</li>
           <li class="tab " data-name="-example-tab-" role="button">Example</li>
           <li class="tab " data-name="-installing-tab-" role="button">Installing</li>
           <li class="tab " data-name="-versions-tab-" role="button">Versions</li>

--- a/app/test/frontend/golden/pkg_show_page_discontinued.html
+++ b/app/test/frontend/golden/pkg_show_page_discontinued.html
@@ -82,8 +82,8 @@
       </div>
       <div class="package-container">
         <ul class="package-tabs js-tabs">
-          <li class="tab -active" data-name="-readme-tab-" role="button">README.md</li>
-          <li class="tab " data-name="-changelog-tab-" role="button">CHANGELOG.md</li>
+          <li class="tab -active" data-name="-readme-tab-" role="button">Readme</li>
+          <li class="tab " data-name="-changelog-tab-" role="button">Changelog</li>
           <li class="tab " data-name="-example-tab-" role="button">Example</li>
           <li class="tab " data-name="-installing-tab-" role="button">Installing</li>
           <li class="tab " data-name="-versions-tab-" role="button">Versions</li>

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -91,8 +91,8 @@
       </div>
       <div class="package-container">
         <ul class="package-tabs js-tabs">
-          <li class="tab -active" data-name="-readme-tab-" role="button">README.md</li>
-          <li class="tab " data-name="-changelog-tab-" role="button">CHANGELOG.md</li>
+          <li class="tab -active" data-name="-readme-tab-" role="button">Readme</li>
+          <li class="tab " data-name="-changelog-tab-" role="button">Changelog</li>
           <li class="tab " data-name="-installing-tab-" role="button">Installing</li>
           <li class="tab " data-name="-versions-tab-" role="button">Versions</li>
           <li class="tab " data-name="-analysis-tab-" role="button">

--- a/app/test/frontend/golden/pkg_show_page_legacy.html
+++ b/app/test/frontend/golden/pkg_show_page_legacy.html
@@ -94,8 +94,8 @@
       </div>
       <div class="package-container">
         <ul class="package-tabs js-tabs">
-          <li class="tab -active" data-name="-readme-tab-" role="button">README.md</li>
-          <li class="tab " data-name="-changelog-tab-" role="button">CHANGELOG.md</li>
+          <li class="tab -active" data-name="-readme-tab-" role="button">Readme</li>
+          <li class="tab " data-name="-changelog-tab-" role="button">Changelog</li>
           <li class="tab " data-name="-example-tab-" role="button">Example</li>
           <li class="tab " data-name="-installing-tab-" role="button">Installing</li>
           <li class="tab " data-name="-versions-tab-" role="button">Versions</li>

--- a/app/test/frontend/golden/pkg_show_page_outdated.html
+++ b/app/test/frontend/golden/pkg_show_page_outdated.html
@@ -94,8 +94,8 @@
       </div>
       <div class="package-container">
         <ul class="package-tabs js-tabs">
-          <li class="tab -active" data-name="-readme-tab-" role="button">README.md</li>
-          <li class="tab " data-name="-changelog-tab-" role="button">CHANGELOG.md</li>
+          <li class="tab -active" data-name="-readme-tab-" role="button">Readme</li>
+          <li class="tab " data-name="-changelog-tab-" role="button">Changelog</li>
           <li class="tab " data-name="-example-tab-" role="button">Example</li>
           <li class="tab " data-name="-installing-tab-" role="button">Installing</li>
           <li class="tab " data-name="-versions-tab-" role="button">Versions</li>

--- a/app/test/frontend/golden/pkg_show_version_page.html
+++ b/app/test/frontend/golden/pkg_show_version_page.html
@@ -93,8 +93,8 @@
       </div>
       <div class="package-container">
         <ul class="package-tabs js-tabs">
-          <li class="tab -active" data-name="-readme-tab-" role="button">README.md</li>
-          <li class="tab " data-name="-changelog-tab-" role="button">CHANGELOG.md</li>
+          <li class="tab -active" data-name="-readme-tab-" role="button">Readme</li>
+          <li class="tab " data-name="-changelog-tab-" role="button">Changelog</li>
           <li class="tab " data-name="-example-tab-" role="button">Example</li>
           <li class="tab " data-name="-installing-tab-" role="button">Installing</li>
           <li class="tab " data-name="-versions-tab-" role="button">Versions</li>


### PR DESCRIPTION
- saves some horizontal space
- once `PackageVersionAsset` is ready, it will be easier to render the links without actually loading the asset content (e.g. a rollup-info need to know only if there is a readme file, no need to know also its name).