### PR TITLE
Tab change: don't default on readme.

### DIFF
--- a/app/lib/frontend/templates/views/pkg/show.mustache
+++ b/app/lib/frontend/templates/views/pkg/show.mustache
@@ -5,14 +5,14 @@
 {{& header_html}}
 
 <div class="package-container">
-  <ul class="package-tabs js-tabs">
+  <ul class="package-tabs-header">
     {{#tabs}}
-      <li class="tab {{active}}" data-name="-{{id}}-tab-" role="button">{{& title_html}}</li>
+      <li class="tab-button {{active}}" data-name="-{{id}}-tab-" role="button">{{& title_html}}</li>
     {{/tabs}}
   </ul>
-  <div class="main tabs-content">
+  <div class="main package-tabs-content">
     {{#tabs}}
-      <section class="content {{active}} js-content {{markdown-body}}" data-name="-{{id}}-tab-">
+      <section class="tab-content {{active}} {{markdown-body}}" data-name="-{{id}}-tab-">
         {{& content_html}}
       </section>
     {{/tabs}}

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -91,20 +91,20 @@
         </div>
       </div>
       <div class="package-container">
-        <ul class="package-tabs js-tabs">
-          <li class="tab -active" data-name="-readme-tab-" role="button">Readme</li>
-          <li class="tab " data-name="-changelog-tab-" role="button">Changelog</li>
-          <li class="tab " data-name="-example-tab-" role="button">Example</li>
-          <li class="tab " data-name="-installing-tab-" role="button">Installing</li>
-          <li class="tab " data-name="-versions-tab-" role="button">Versions</li>
-          <li class="tab " data-name="-analysis-tab-" role="button">
+        <ul class="package-tabs-header">
+          <li class="tab-button -active" data-name="-readme-tab-" role="button">Readme</li>
+          <li class="tab-button " data-name="-changelog-tab-" role="button">Changelog</li>
+          <li class="tab-button " data-name="-example-tab-" role="button">Example</li>
+          <li class="tab-button " data-name="-installing-tab-" role="button">Installing</li>
+          <li class="tab-button " data-name="-versions-tab-" role="button">Versions</li>
+          <li class="tab-button " data-name="-analysis-tab-" role="button">
             <div class="score-box">
               <span class="number -rotten" title="Analysis and more details.">3</span>
             </div>
           </li>
         </ul>
-        <div class="main tabs-content">
-          <section class="content -active js-content markdown-body" data-name="-readme-tab-">
+        <div class="main package-tabs-content">
+          <section class="tab-content -active markdown-body" data-name="-readme-tab-">
             <h1 class="hash-header" id="test-package">Test Package 
               <a href="#test-package" class="hash-link">#</a>
             </h1>
@@ -115,13 +115,13 @@
 </code>
             </pre>
           </section>
-          <section class="content  js-content markdown-body" data-name="-changelog-tab-">
+          <section class="tab-content  markdown-body" data-name="-changelog-tab-">
             <h1 class="hash-header" id="changelog">Changelog 
               <a href="#changelog" class="hash-link">#</a>
             </h1>
             <p>0.1.1 - test package</p>
           </section>
-          <section class="content  js-content markdown-body" data-name="-example-tab-">
+          <section class="tab-content  markdown-body" data-name="-example-tab-">
             <p style="font-family: monospace">
               <b>example/lib/main.dart</b>
             </p>
@@ -132,7 +132,7 @@
 </code>
             </pre>
           </section>
-          <section class="content  js-content " data-name="-installing-tab-">
+          <section class="tab-content  " data-name="-installing-tab-">
             <h2>Use this package as a library</h2>
             <h3>1. Depend on it</h3>
             <p>Add this to your package's pubspec.yaml file:</p>
@@ -165,7 +165,7 @@ import 'package:foobar_pkg/foolib.dart';
   </code>
             </pre>
           </section>
-          <section class="content  js-content " data-name="-versions-tab-">
+          <section class="tab-content  " data-name="-versions-tab-">
             <table class="version-table" data-package="foobar_pkg">
               <thead>
                 <tr>
@@ -197,7 +197,7 @@ import 'package:foobar_pkg/foolib.dart';
               </tbody>
             </table>
           </section>
-          <section class="content  js-content " data-name="-analysis-tab-">
+          <section class="tab-content  " data-name="-analysis-tab-">
             <table id='scores-table'>
               <tr>
                 <td class="score-name">

--- a/app/test/frontend/golden/pkg_show_page_discontinued.html
+++ b/app/test/frontend/golden/pkg_show_page_discontinued.html
@@ -82,20 +82,20 @@
         </div>
       </div>
       <div class="package-container">
-        <ul class="package-tabs js-tabs">
-          <li class="tab -active" data-name="-readme-tab-" role="button">Readme</li>
-          <li class="tab " data-name="-changelog-tab-" role="button">Changelog</li>
-          <li class="tab " data-name="-example-tab-" role="button">Example</li>
-          <li class="tab " data-name="-installing-tab-" role="button">Installing</li>
-          <li class="tab " data-name="-versions-tab-" role="button">Versions</li>
-          <li class="tab " data-name="-analysis-tab-" role="button">
+        <ul class="package-tabs-header">
+          <li class="tab-button -active" data-name="-readme-tab-" role="button">Readme</li>
+          <li class="tab-button " data-name="-changelog-tab-" role="button">Changelog</li>
+          <li class="tab-button " data-name="-example-tab-" role="button">Example</li>
+          <li class="tab-button " data-name="-installing-tab-" role="button">Installing</li>
+          <li class="tab-button " data-name="-versions-tab-" role="button">Versions</li>
+          <li class="tab-button " data-name="-analysis-tab-" role="button">
             <div class="score-box">
               <span class="number -rotten" title="Analysis and more details.">0</span>
             </div>
           </li>
         </ul>
-        <div class="main tabs-content">
-          <section class="content -active js-content markdown-body" data-name="-readme-tab-">
+        <div class="main package-tabs-content">
+          <section class="tab-content -active markdown-body" data-name="-readme-tab-">
             <h1 class="hash-header" id="test-package">Test Package 
               <a href="#test-package" class="hash-link">#</a>
             </h1>
@@ -106,13 +106,13 @@
 </code>
             </pre>
           </section>
-          <section class="content  js-content markdown-body" data-name="-changelog-tab-">
+          <section class="tab-content  markdown-body" data-name="-changelog-tab-">
             <h1 class="hash-header" id="changelog">Changelog 
               <a href="#changelog" class="hash-link">#</a>
             </h1>
             <p>0.1.1 - test package</p>
           </section>
-          <section class="content  js-content markdown-body" data-name="-example-tab-">
+          <section class="tab-content  markdown-body" data-name="-example-tab-">
             <p style="font-family: monospace">
               <b>example/lib/main.dart</b>
             </p>
@@ -123,7 +123,7 @@
 </code>
             </pre>
           </section>
-          <section class="content  js-content " data-name="-installing-tab-">
+          <section class="tab-content  " data-name="-installing-tab-">
             <h2>Use this package as a library</h2>
             <h3>1. Depend on it</h3>
             <p>Add this to your package's pubspec.yaml file:</p>
@@ -156,7 +156,7 @@ import 'package:foobar_pkg/foolib.dart';
   </code>
             </pre>
           </section>
-          <section class="content  js-content " data-name="-versions-tab-">
+          <section class="tab-content  " data-name="-versions-tab-">
             <table class="version-table" data-package="foobar_pkg">
               <thead>
                 <tr>
@@ -188,7 +188,7 @@ import 'package:foobar_pkg/foolib.dart';
               </tbody>
             </table>
           </section>
-          <section class="content  js-content " data-name="-analysis-tab-">
+          <section class="tab-content  " data-name="-analysis-tab-">
             <table id='scores-table'>
               <tr>
                 <td class="score-name">

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -91,19 +91,19 @@
         </div>
       </div>
       <div class="package-container">
-        <ul class="package-tabs js-tabs">
-          <li class="tab -active" data-name="-readme-tab-" role="button">Readme</li>
-          <li class="tab " data-name="-changelog-tab-" role="button">Changelog</li>
-          <li class="tab " data-name="-installing-tab-" role="button">Installing</li>
-          <li class="tab " data-name="-versions-tab-" role="button">Versions</li>
-          <li class="tab " data-name="-analysis-tab-" role="button">
+        <ul class="package-tabs-header">
+          <li class="tab-button -active" data-name="-readme-tab-" role="button">Readme</li>
+          <li class="tab-button " data-name="-changelog-tab-" role="button">Changelog</li>
+          <li class="tab-button " data-name="-installing-tab-" role="button">Installing</li>
+          <li class="tab-button " data-name="-versions-tab-" role="button">Versions</li>
+          <li class="tab-button " data-name="-analysis-tab-" role="button">
             <div class="score-box">
               <span class="number -good" title="Analysis and more details.">65</span>
             </div>
           </li>
         </ul>
-        <div class="main tabs-content">
-          <section class="content -active js-content markdown-body" data-name="-readme-tab-">
+        <div class="main package-tabs-content">
+          <section class="tab-content -active markdown-body" data-name="-readme-tab-">
             <h1 class="hash-header" id="test-package">Test Package 
               <a href="#test-package" class="hash-link">#</a>
             </h1>
@@ -114,13 +114,13 @@
 </code>
             </pre>
           </section>
-          <section class="content  js-content markdown-body" data-name="-changelog-tab-">
+          <section class="tab-content  markdown-body" data-name="-changelog-tab-">
             <h1 class="hash-header" id="changelog">Changelog 
               <a href="#changelog" class="hash-link">#</a>
             </h1>
             <p>0.1.1 - test package</p>
           </section>
-          <section class="content  js-content " data-name="-installing-tab-">
+          <section class="tab-content  " data-name="-installing-tab-">
             <h2>Use this package as a library</h2>
             <h3>1. Depend on it</h3>
             <p>Add this to your package's pubspec.yaml file:</p>
@@ -153,7 +153,7 @@ import 'package:foobar_pkg/foolib.dart';
   </code>
             </pre>
           </section>
-          <section class="content  js-content " data-name="-versions-tab-">
+          <section class="tab-content  " data-name="-versions-tab-">
             <table class="version-table" data-package="foobar_pkg">
               <thead>
                 <tr>
@@ -185,7 +185,7 @@ import 'package:foobar_pkg/foolib.dart';
               </tbody>
             </table>
           </section>
-          <section class="content  js-content " data-name="-analysis-tab-">
+          <section class="tab-content  " data-name="-analysis-tab-">
             <table id='scores-table'>
               <tr>
                 <td class="score-name">

--- a/app/test/frontend/golden/pkg_show_page_legacy.html
+++ b/app/test/frontend/golden/pkg_show_page_legacy.html
@@ -92,20 +92,20 @@
         </div>
       </div>
       <div class="package-container">
-        <ul class="package-tabs js-tabs">
-          <li class="tab -active" data-name="-readme-tab-" role="button">Readme</li>
-          <li class="tab " data-name="-changelog-tab-" role="button">Changelog</li>
-          <li class="tab " data-name="-example-tab-" role="button">Example</li>
-          <li class="tab " data-name="-installing-tab-" role="button">Installing</li>
-          <li class="tab " data-name="-versions-tab-" role="button">Versions</li>
-          <li class="tab " data-name="-analysis-tab-" role="button">
+        <ul class="package-tabs-header">
+          <li class="tab-button -active" data-name="-readme-tab-" role="button">Readme</li>
+          <li class="tab-button " data-name="-changelog-tab-" role="button">Changelog</li>
+          <li class="tab-button " data-name="-example-tab-" role="button">Example</li>
+          <li class="tab-button " data-name="-installing-tab-" role="button">Installing</li>
+          <li class="tab-button " data-name="-versions-tab-" role="button">Versions</li>
+          <li class="tab-button " data-name="-analysis-tab-" role="button">
             <div class="score-box">
               <span class="number -rotten" title="Analysis and more details.">25</span>
             </div>
           </li>
         </ul>
-        <div class="main tabs-content">
-          <section class="content -active js-content markdown-body" data-name="-readme-tab-">
+        <div class="main package-tabs-content">
+          <section class="tab-content -active markdown-body" data-name="-readme-tab-">
             <h1 class="hash-header" id="test-package">Test Package 
               <a href="#test-package" class="hash-link">#</a>
             </h1>
@@ -116,13 +116,13 @@
 </code>
             </pre>
           </section>
-          <section class="content  js-content markdown-body" data-name="-changelog-tab-">
+          <section class="tab-content  markdown-body" data-name="-changelog-tab-">
             <h1 class="hash-header" id="changelog">Changelog 
               <a href="#changelog" class="hash-link">#</a>
             </h1>
             <p>0.1.1 - test package</p>
           </section>
-          <section class="content  js-content markdown-body" data-name="-example-tab-">
+          <section class="tab-content  markdown-body" data-name="-example-tab-">
             <p style="font-family: monospace">
               <b>example/lib/main.dart</b>
             </p>
@@ -133,7 +133,7 @@
 </code>
             </pre>
           </section>
-          <section class="content  js-content " data-name="-installing-tab-">
+          <section class="tab-content  " data-name="-installing-tab-">
             <h2>Use this package as a library</h2>
             <h3>1. Depend on it</h3>
             <p>Add this to your package's pubspec.yaml file:</p>
@@ -166,7 +166,7 @@ import 'package:foobar_pkg/foolib.dart';
   </code>
             </pre>
           </section>
-          <section class="content  js-content " data-name="-versions-tab-">
+          <section class="tab-content  " data-name="-versions-tab-">
             <table class="version-table" data-package="foobar_pkg">
               <thead>
                 <tr>
@@ -198,7 +198,7 @@ import 'package:foobar_pkg/foolib.dart';
               </tbody>
             </table>
           </section>
-          <section class="content  js-content " data-name="-analysis-tab-">
+          <section class="tab-content  " data-name="-analysis-tab-">
             <table id='scores-table'>
               <tr>
                 <td class="score-name">

--- a/app/test/frontend/golden/pkg_show_page_outdated.html
+++ b/app/test/frontend/golden/pkg_show_page_outdated.html
@@ -92,20 +92,20 @@
         </div>
       </div>
       <div class="package-container">
-        <ul class="package-tabs js-tabs">
-          <li class="tab -active" data-name="-readme-tab-" role="button">Readme</li>
-          <li class="tab " data-name="-changelog-tab-" role="button">Changelog</li>
-          <li class="tab " data-name="-example-tab-" role="button">Example</li>
-          <li class="tab " data-name="-installing-tab-" role="button">Installing</li>
-          <li class="tab " data-name="-versions-tab-" role="button">Versions</li>
-          <li class="tab " data-name="-analysis-tab-" role="button">
+        <ul class="package-tabs-header">
+          <li class="tab-button -active" data-name="-readme-tab-" role="button">Readme</li>
+          <li class="tab-button " data-name="-changelog-tab-" role="button">Changelog</li>
+          <li class="tab-button " data-name="-example-tab-" role="button">Example</li>
+          <li class="tab-button " data-name="-installing-tab-" role="button">Installing</li>
+          <li class="tab-button " data-name="-versions-tab-" role="button">Versions</li>
+          <li class="tab-button " data-name="-analysis-tab-" role="button">
             <div class="score-box">
               <span class="number -rotten" title="Analysis and more details.">0</span>
             </div>
           </li>
         </ul>
-        <div class="main tabs-content">
-          <section class="content -active js-content markdown-body" data-name="-readme-tab-">
+        <div class="main package-tabs-content">
+          <section class="tab-content -active markdown-body" data-name="-readme-tab-">
             <h1 class="hash-header" id="test-package">Test Package 
               <a href="#test-package" class="hash-link">#</a>
             </h1>
@@ -116,13 +116,13 @@
 </code>
             </pre>
           </section>
-          <section class="content  js-content markdown-body" data-name="-changelog-tab-">
+          <section class="tab-content  markdown-body" data-name="-changelog-tab-">
             <h1 class="hash-header" id="changelog">Changelog 
               <a href="#changelog" class="hash-link">#</a>
             </h1>
             <p>0.1.1 - test package</p>
           </section>
-          <section class="content  js-content markdown-body" data-name="-example-tab-">
+          <section class="tab-content  markdown-body" data-name="-example-tab-">
             <p style="font-family: monospace">
               <b>example/lib/main.dart</b>
             </p>
@@ -133,7 +133,7 @@
 </code>
             </pre>
           </section>
-          <section class="content  js-content " data-name="-installing-tab-">
+          <section class="tab-content  " data-name="-installing-tab-">
             <h2>Use this package as a library</h2>
             <h3>1. Depend on it</h3>
             <p>Add this to your package's pubspec.yaml file:</p>
@@ -166,7 +166,7 @@ import 'package:foobar_pkg/foolib.dart';
   </code>
             </pre>
           </section>
-          <section class="content  js-content " data-name="-versions-tab-">
+          <section class="tab-content  " data-name="-versions-tab-">
             <table class="version-table" data-package="foobar_pkg">
               <thead>
                 <tr>
@@ -198,7 +198,7 @@ import 'package:foobar_pkg/foolib.dart';
               </tbody>
             </table>
           </section>
-          <section class="content  js-content " data-name="-analysis-tab-">
+          <section class="tab-content  " data-name="-analysis-tab-">
             <table id='scores-table'>
               <tr>
                 <td class="score-name">

--- a/app/test/frontend/golden/pkg_show_version_page.html
+++ b/app/test/frontend/golden/pkg_show_version_page.html
@@ -93,19 +93,19 @@
         </div>
       </div>
       <div class="package-container">
-        <ul class="package-tabs js-tabs">
-          <li class="tab -active" data-name="-readme-tab-" role="button">Readme</li>
-          <li class="tab " data-name="-changelog-tab-" role="button">Changelog</li>
-          <li class="tab " data-name="-installing-tab-" role="button">Installing</li>
-          <li class="tab " data-name="-versions-tab-" role="button">Versions</li>
-          <li class="tab " data-name="-analysis-tab-" role="button">
+        <ul class="package-tabs-header">
+          <li class="tab-button -active" data-name="-readme-tab-" role="button">Readme</li>
+          <li class="tab-button " data-name="-changelog-tab-" role="button">Changelog</li>
+          <li class="tab-button " data-name="-installing-tab-" role="button">Installing</li>
+          <li class="tab-button " data-name="-versions-tab-" role="button">Versions</li>
+          <li class="tab-button " data-name="-analysis-tab-" role="button">
             <div class="score-box">
               <span class="number -rotten" title="Analysis and more details.">3</span>
             </div>
           </li>
         </ul>
-        <div class="main tabs-content">
-          <section class="content -active js-content markdown-body" data-name="-readme-tab-">
+        <div class="main package-tabs-content">
+          <section class="tab-content -active markdown-body" data-name="-readme-tab-">
             <h1 class="hash-header" id="test-package">Test Package 
               <a href="#test-package" class="hash-link">#</a>
             </h1>
@@ -116,13 +116,13 @@
 </code>
             </pre>
           </section>
-          <section class="content  js-content markdown-body" data-name="-changelog-tab-">
+          <section class="tab-content  markdown-body" data-name="-changelog-tab-">
             <h1 class="hash-header" id="changelog">Changelog 
               <a href="#changelog" class="hash-link">#</a>
             </h1>
             <p>0.1.1 - test package</p>
           </section>
-          <section class="content  js-content " data-name="-installing-tab-">
+          <section class="tab-content  " data-name="-installing-tab-">
             <h2>Use this package as a library</h2>
             <h3>1. Depend on it</h3>
             <p>Add this to your package's pubspec.yaml file:</p>
@@ -155,7 +155,7 @@ import 'package:foobar_pkg/foolib.dart';
   </code>
             </pre>
           </section>
-          <section class="content  js-content " data-name="-versions-tab-">
+          <section class="tab-content  " data-name="-versions-tab-">
             <table class="version-table" data-package="foobar_pkg">
               <thead>
                 <tr>
@@ -187,7 +187,7 @@ import 'package:foobar_pkg/foolib.dart';
               </tbody>
             </table>
           </section>
-          <section class="content  js-content " data-name="-analysis-tab-">
+          <section class="tab-content  " data-name="-analysis-tab-">
             <table id='scores-table'>
               <tr>
                 <td class="score-name">

--- a/pkg/web_app/lib/src/tabs.dart
+++ b/pkg/web_app/lib/src/tabs.dart
@@ -44,9 +44,15 @@ void _changeTabOnUrlHash() {
     hash = hash.substring(1);
   }
   // Navigating back to a non-hashed package page will result an empty hash.
-  // Displaying the default tab: readme.
+  // Displaying the first tab (with content) by default.
   if (hash.isEmpty) {
-    changeTab('-readme-tab-');
+    final active = tabContents.firstWhere(
+      (e) => e.classes.contains('-active'),
+      orElse: () => null,
+    );
+    if (active == null) {
+      changeTab(tabContents.first.dataset['name']);
+    }
   } else {
     if (hash.startsWith('pub-pkg-tab-')) {
       hash = '-${hash.substring(12)}-tab-';

--- a/pkg/web_app/lib/src/tabs.dart
+++ b/pkg/web_app/lib/src/tabs.dart
@@ -4,12 +4,12 @@
 
 import 'dart:html';
 
-Element tabRoot;
-List<Element> tabContents;
+Element _headerRoot;
+Element _contentRoot;
 
 void setupTabs() {
-  tabRoot = document.querySelector('.js-tabs');
-  tabContents = document.querySelectorAll('.js-content');
+  _headerRoot = document.querySelector('ul.package-tabs-header');
+  _contentRoot = document.querySelector('div.package-tabs-content');
   _setEventsForTabs();
 
   window.onHashChange.listen((_) {
@@ -19,8 +19,8 @@ void setupTabs() {
 }
 
 void _setEventsForTabs() {
-  if (tabRoot != null && tabContents.isNotEmpty) {
-    tabRoot.onClick.listen((e) {
+  if (_headerRoot != null && _contentRoot != null) {
+    _headerRoot.onClick.listen((e) {
       // locate the <li> tag
       Element target = e.target as Element;
       while (target != null &&
@@ -38,7 +38,7 @@ void _setEventsForTabs() {
 
 /// change the tab based on URL hash
 void _changeTabOnUrlHash() {
-  if (tabRoot == null) return;
+  if (_headerRoot == null) return;
   String hash = window.location.hash ?? '';
   if (hash.startsWith('#')) {
     hash = hash.substring(1);
@@ -46,12 +46,12 @@ void _changeTabOnUrlHash() {
   // Navigating back to a non-hashed package page will result an empty hash.
   // Displaying the first tab (with content) by default.
   if (hash.isEmpty) {
-    final active = tabContents.firstWhere(
+    final active = _contentRoot.children.firstWhere(
       (e) => e.classes.contains('-active'),
       orElse: () => null,
     );
     if (active == null) {
-      changeTab(tabContents.first.dataset['name']);
+      changeTab(_contentRoot.children.first.dataset['name']);
     }
   } else {
     if (hash.startsWith('pub-pkg-tab-')) {
@@ -63,8 +63,8 @@ void _changeTabOnUrlHash() {
 }
 
 String getTabName(Element elem) {
-  final isTabContainer =
-      elem.classes.contains('tab') || elem.classes.contains('content');
+  final isTabContainer = elem.classes.contains('tab-button') ||
+      elem.classes.contains('tab-content');
   if (isTabContainer && elem.dataset['name'] != null) {
     return elem.dataset['name'];
   }
@@ -75,24 +75,18 @@ String getTabName(Element elem) {
 }
 
 void changeTab(String name) {
-  final tabOrContentElem =
-      tabRoot.querySelector('[data-name="${Uri.encodeQueryComponent(name)}"]');
+  final tabOrContentElem = _headerRoot
+      .querySelector('[data-name="${Uri.encodeQueryComponent(name)}"]');
   if (tabOrContentElem != null) {
-    // toggle tab highlights
-    tabRoot.children.forEach((node) {
-      if (node.dataset['name'] != name) {
-        node.classes.remove('-active');
-      } else {
-        node.classes.add('-active');
-      }
-    });
-    // toggle content
-    tabContents.forEach((node) {
-      if (node.dataset['name'] != name) {
-        node.classes.remove('-active');
-      } else {
-        node.classes.add('-active');
-      }
-    });
+    _headerRoot.children.forEach((node) => _toggle(node, name));
+    _contentRoot.children.forEach((node) => _toggle(node, name));
+  }
+}
+
+void _toggle(Element node, String name) {
+  if (node.dataset['name'] != name) {
+    node.classes.remove('-active');
+  } else {
+    node.classes.add('-active');
   }
 }

--- a/pkg/web_css/lib/src/_pkg.scss
+++ b/pkg/web_css/lib/src/_pkg.scss
@@ -25,13 +25,13 @@
   }
 }
 
-.package-tabs {
+.package-tabs-header {
   margin: 10px 0 20px;
   padding: 0;
   border-bottom: 1px solid #f0f0f0;
   list-style: none;
 
-  > .tab {
+  > .tab-button {
     color: #666666;
     display: inline-block;
     margin-right: 35px;
@@ -60,8 +60,8 @@
   }
 }
 
-.tabs-content {
-  > .content {
+.package-tabs-content {
+  > .tab-content {
     display: none;
 
     &.-active {


### PR DESCRIPTION
- In the future cases where we have tabs without content (only links), we should not default to the readme tab on initialization, rather: use the one activated from the page, or the first one that has content.
This should allow us to have pages with a few intra-page tabs and extra-page tabs mixed, and won't cause weird initialization result where a link-only tab is shown as active. 

- Also updated the style names we are using (removed the weird `js-tabs` and `js-content`), and made the processing methods a bit shorter and more resilient to later changes.