### PR TITLE
Don't double-escape the search query text.

### DIFF
--- a/app/lib/frontend/templates/layout.dart
+++ b/app/lib/frontend/templates/layout.dart
@@ -39,7 +39,7 @@ String renderLayoutPage(
 }) {
   final queryText = searchQuery?.query;
   final String escapedSearchQuery =
-      queryText == null ? null : htmlEscape.convert(queryText);
+      queryText == null ? null : htmlAttrEscape.convert(queryText);
   String platformTabs;
   if (type == PageType.landing) {
     platformTabs = renderPlatformTabs(platform: platform, isLanding: true);
@@ -68,7 +68,7 @@ String renderLayoutPage(
     'title': htmlEscape.convert(title),
     'site_logo_url': staticUrls.pubDevLogo2xPng,
     'search_platform': platform,
-    'search_query': escapedSearchQuery,
+    'search_query_html': escapedSearchQuery,
     'search_query_placeholder': platformDict.searchPlatformPackagesLabel,
     'search_sort_param': searchSort,
     'platform_tabs_html': platformTabs,

--- a/app/lib/frontend/templates/views/layout.mustache
+++ b/app/lib/frontend/templates/views/layout.mustache
@@ -93,7 +93,7 @@
   <div class="_banner-bg">
     <main class="package-banner">
       <form class="search-bar" action="/{{#search_platform}}{{search_platform}}/{{/search_platform}}packages">
-        <input class="input" name="q" placeholder="{{search_query_placeholder}}" autocomplete="on" autofocus="autofocus"{{#search_query}} value="{{search_query}}"{{/search_query}}/>
+        <input class="input" name="q" placeholder="{{search_query_placeholder}}" autocomplete="on" autofocus="autofocus"{{#search_query_html}} value="{{& search_query_html}}"{{/search_query_html}}/>
         <button class="icon"></button>
         {{#search_sort_param}}<input type="hidden" name="sort" value="{{search_sort_param}}"/>{{/search_sort_param}}
         <input id="search-legacy-field" type="hidden" name="legacy" value="1"{{^legacy_search_enabled}} disabled="disabled"{{/legacy_search_enabled}} />


### PR DESCRIPTION
Fixes #2423.