### PR TITLE
 Display package header on versions page.

### DIFF
--- a/app/lib/frontend/templates/package_versions.dart
+++ b/app/lib/frontend/templates/package_versions.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import '../../shared/analyzer_client.dart';
 import '../../shared/urls.dart' as urls;
 
 import '../models.dart';
@@ -10,10 +11,16 @@ import '../static_files.dart';
 import '_cache.dart';
 import '_utils.dart';
 import 'layout.dart';
+import 'package.dart';
 
 /// Renders the `views/pkg/versions/index` template.
-String renderPkgVersionsPage(String package, List<PackageVersion> versions,
-    List<Uri> versionDownloadUrls) {
+String renderPkgVersionsPage(
+  Package package,
+  PackageVersion latestVersion,
+  List<PackageVersion> versions,
+  List<Uri> versionDownloadUrls,
+  AnalysisView latestAnalysis,
+) {
   assert(versions.length == versionDownloadUrls.length);
 
   final stableVersionRows = [];
@@ -31,7 +38,9 @@ String renderPkgVersionsPage(String package, List<PackageVersion> versions,
     }
   }
 
-  final htmlBlocks = <String>[];
+  final htmlBlocks = <String>[
+    renderPkgHeader(package, latestVersion, latestAnalysis),
+  ];
   if (stableVersionRows.isNotEmpty && devVersionRows.isNotEmpty) {
     htmlBlocks.add(
         '<p>The latest dev release was <a href="#dev">${latestDevVersion.version}</a> '
@@ -41,7 +50,7 @@ String renderPkgVersionsPage(String package, List<PackageVersion> versions,
     htmlBlocks.add(templateCache.renderTemplate('pkg/versions/index', {
       'id': 'stable',
       'kind': 'Stable',
-      'package': {'name': package},
+      'package': {'name': package.name},
       'version_table_rows': stableVersionRows,
     }));
   }
@@ -49,13 +58,13 @@ String renderPkgVersionsPage(String package, List<PackageVersion> versions,
     htmlBlocks.add(templateCache.renderTemplate('pkg/versions/index', {
       'id': 'dev',
       'kind': 'Dev',
-      'package': {'name': package},
+      'package': {'name': package.name},
       'version_table_rows': devVersionRows,
     }));
   }
   return renderLayoutPage(PageType.package, htmlBlocks.join(),
-      title: '$package package - All Versions',
-      canonicalUrl: urls.pkgPageUrl(package, includeHost: true));
+      title: '${package.name} package - All Versions',
+      canonicalUrl: urls.pkgPageUrl(package.name, includeHost: true));
 }
 
 String renderVersionTableRow(PackageVersion version, String downloadUrl) {

--- a/app/lib/frontend/templates/views/pkg/header.mustache
+++ b/app/lib/frontend/templates/views/pkg/header.mustache
@@ -1,0 +1,19 @@
+{{! Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+    for details. All rights reserved. Use of this source code is governed by a
+    BSD-style license that can be found in the LICENSE file. }}
+<div class="package-header">
+  <h2 class="title">{{name}} {{version}}</h2>
+  <div class="metadata">
+    Published <span>{{short_created}}</span>
+    <!-- &bull; Downloads: X -->
+    {{#latest.show_updated}}
+      &bull; Updated:
+      <span><a href="{{& latest.stable_url}}">{{latest.stable_version}}</a></span>
+      {{#latest.show_dev_version}}
+        /
+        <span><a href="{{& latest.dev_url}}">{{latest.dev_version}}</a></span>
+      {{/latest.show_dev_version}}
+    {{/latest.show_updated}}
+    <div class="tags">{{& tags_html}}</div>
+  </div>
+</div>

--- a/app/lib/frontend/templates/views/pkg/show.mustache
+++ b/app/lib/frontend/templates/views/pkg/show.mustache
@@ -2,22 +2,7 @@
     for details. All rights reserved. Use of this source code is governed by a
     BSD-style license that can be found in the LICENSE file. }}
 
-<div class="package-header">
-  <h2 class="title">{{package.name}} {{package.version}}</h2>
-  <div class="metadata">
-    Published <span>{{package.short_created}}</span>
-    <!-- &bull; Downloads: X -->
-    {{#package.latest.show_updated}}
-      &bull; Updated:
-      <span><a href="{{& package.latest.stable_url}}">{{package.latest.stable_version}}</a></span>
-      {{#package.latest.show_dev_version}}
-        /
-        <span><a href="{{& package.latest.dev_url}}">{{package.latest.dev_version}}</a></span>
-      {{/package.latest.show_dev_version}}
-    {{/package.latest.show_updated}}
-    <div class="tags">{{& package.tags_html}}</div>
-  </div>
-</div>
+{{& header_html}}
 
 <div class="package-container">
   <ul class="package-tabs js-tabs">
@@ -37,5 +22,5 @@
 </div>
 
 <script type="application/ld+json">
-{{& package.schema_org_pkgmeta_json}}
+{{& schema_org_pkgmeta_json}}
 </script>

--- a/app/test/frontend/golden/pkg_versions_page.html
+++ b/app/test/frontend/golden/pkg_versions_page.html
@@ -9,15 +9,15 @@
     <meta name="twitter:card" content="summary"/>
     <meta name="twitter:site" content="@dart_lang"/>
     <meta property="og:site_name" content="Dart packages"/>
-    <title>foobar package - All Versions</title>
-    <meta property="og:title" content="foobar package - All Versions"/>
+    <title>foobar_pkg package - All Versions</title>
+    <meta property="og:title" content="foobar_pkg package - All Versions"/>
     <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet"/>
     <meta itemprop="image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
     <meta property="og:image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
     <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
     <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/osd.xml?hash=mocked_hash_869379763"/>
-    <link rel="canonical" href="https://pub.dev/packages/foobar"/>
-    <meta property="og:url" content="https://pub.dev/packages/foobar"/>
+    <link rel="canonical" href="https://pub.dev/packages/foobar_pkg"/>
+    <meta property="og:url" content="https://pub.dev/packages/foobar_pkg"/>
     <meta name="description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
@@ -71,11 +71,32 @@
       </main>
     </div>
     <main>
+      <div class="package-header">
+        <h2 class="title">foobar_pkg 0.1.1+5</h2>
+        <div class="metadata">
+    Published 
+          <span>Jan 1, 2014</span>
+          <!-- &bull; Downloads: X -->
+      • Updated:
+      
+          <span>
+            <a href="/packages/foobar_pkg">0.1.1+5</a>
+          </span>
+        /
+        
+          <span>
+            <a href="/packages/foobar_pkg/versions/0.2.0-dev">0.2.0-dev</a>
+          </span>
+          <div class="tags">
+            <span class="package-tag missing" title="Analysis should be ready soon.">[awaiting]</span>
+          </div>
+        </div>
+      </div>
       <p>The latest dev release was 
         <a href="#dev">0.2.0-dev</a> on Jan 1, 2014.
       </p>
-      <h2 id="stable">Stable versions of foobar</h2>
-      <table class="version-table" data-package="foobar">
+      <h2 id="stable">Stable versions of foobar_pkg</h2>
+      <table class="version-table" data-package="foobar_pkg">
         <thead>
           <tr>
             <th>Version</th>
@@ -105,8 +126,8 @@
           </tr>
         </tbody>
       </table>
-      <h2 id="dev">Dev versions of foobar</h2>
-      <table class="version-table" data-package="foobar">
+      <h2 id="dev">Dev versions of foobar_pkg</h2>
+      <table class="version-table" data-package="foobar_pkg">
         <thead>
           <tr>
             <th>Version</th>

--- a/app/test/frontend/handlers/package_test.dart
+++ b/app/test/frontend/handlers/package_test.dart
@@ -56,22 +56,28 @@ void main() {
     });
 
     tScopedTest('/packages/foobar_pkg/versions - found', () async {
-      final backend = BackendMock(versionsOfPackageFun: (String package) {
+      final backend = BackendMock(lookupPackageFun: (String package) {
+        expect(package, testPackage.name);
+        return testPackage;
+      }, versionsOfPackageFun: (String package) {
         expect(package, testPackage.name);
         return [testPackageVersion];
       }, downloadUrlFun: (String package, String version) {
         return Uri.parse('http://blobstore/$package/$version');
       });
       registerBackend(backend);
+      registerAnalyzerClient(AnalyzerClientMock());
       registerDartdocClient(DartdocClientMock());
       await expectHtmlResponse(await issueGet('/packages/foobar_pkg/versions'));
     });
 
     tScopedTest('/packages/foobar_pkg/versions - not found', () async {
-      final backend = BackendMock(versionsOfPackageFun: (String package) {
-        expect(package, testPackage.name);
-        return [];
-      });
+      final backend = BackendMock(
+        lookupPackageFun: (String package) {
+          expect(package, testPackage.name);
+          return null;
+        },
+      );
       registerBackend(backend);
       await expectRedirectResponse(
           await issueGet('/packages/foobar_pkg/versions'),

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -34,7 +34,7 @@ import 'utils.dart';
 
 const String goldenDir = 'test/frontend/golden';
 
-final _regenerateGoldens = true;
+final _regenerateGoldens = false;
 
 void main() {
   setUpAll(() => updateLocalBuiltFiles());

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -34,7 +34,7 @@ import 'utils.dart';
 
 const String goldenDir = 'test/frontend/golden';
 
-final _regenerateGoldens = false;
+final _regenerateGoldens = true;
 
 void main() {
   setUpAll(() => updateLocalBuiltFiles());
@@ -517,7 +517,8 @@ void main() {
 
     scopedTest('package versions page', () {
       final String html = renderPkgVersionsPage(
-        'foobar',
+        testPackage,
+        testPackageVersion,
         [
           testPackageVersion,
           devPackageVersion,
@@ -526,6 +527,14 @@ void main() {
           Uri.parse('https://pub.dartlang.org/mock-download-uri.tar.gz'),
           Uri.parse('https://pub.dartlang.org/mock-download-uri.tar.gz'),
         ],
+        AnalysisView(
+          card: ScoreCardData(
+            platformTags: KnownPlatforms.all,
+            maintenanceScore: 0.9,
+            healthScore: 0.9,
+            popularityScore: 0.2,
+          ),
+        ),
       );
       expectGoldenFile(html, 'pkg_versions_page.html');
     });


### PR DESCRIPTION
This is part of the versions page migration: we want to keep the same header as the landing page. This does not affects the tabs yet.

---

New UI for a package without dev versions:

<img width="827" alt="Screen Shot 2019-07-01 at 11 13 36" src="https://user-images.githubusercontent.com/4778111/60424884-9920d480-9bf1-11e9-8f25-713378a94b92.png">

---

New UI for a package with dev versions:

<img width="849" alt="Screen Shot 2019-07-01 at 11 13 43" src="https://user-images.githubusercontent.com/4778111/60424889-9b832e80-9bf1-11e9-8efe-aecaf29e8ccf.png">
