### PR TITLE
Copy pana helper methods into pkg/pub_package_reader.

### DIFF
--- a/pkg/pub_package_reader/lib/pub_package_reader.dart
+++ b/pkg/pub_package_reader/lib/pub_package_reader.dart
@@ -3,9 +3,8 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:pubspec_parse/pubspec_parse.dart';
-import 'package:pana/pana.dart'
-    show readmeFileNames, changelogFileNames, exampleFileCandidates;
 
+import 'src/file_names.dart';
 import 'src/names.dart';
 import 'src/tar_utils.dart';
 

--- a/pkg/pub_package_reader/lib/src/file_names.dart
+++ b/pkg/pub_package_reader/lib/src/file_names.dart
@@ -20,15 +20,15 @@ final List<String> readmeFileNames = textFileNameCandidates('readme');
 /// Returns the candidates in priority order to display under the 'Example' tab.
 List<String> exampleFileCandidates(String package) {
   return <String>[
-  ...textFileNameCandidates('example/readme'),
-  ...textFileNameCandidates('example/example'),
-  'example/lib/main.dart',
-  'example/main.dart',
-  'example/lib/$package.dart',
-  'example/$package.dart',
-  'example/lib/${package}_example.dart',
-  'example/${package}_example.dart',
-  'example/lib/example.dart',
-  'example/example.dart',
+    ...textFileNameCandidates('example/readme'),
+    ...textFileNameCandidates('example/example'),
+    'example/lib/main.dart',
+    'example/main.dart',
+    'example/lib/$package.dart',
+    'example/$package.dart',
+    'example/lib/${package}_example.dart',
+    'example/${package}_example.dart',
+    'example/lib/example.dart',
+    'example/example.dart',
   ];
 }

--- a/pkg/pub_package_reader/lib/src/file_names.dart
+++ b/pkg/pub_package_reader/lib/src/file_names.dart
@@ -1,0 +1,34 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// Returns common file name candidates for [base] (specified without any extension).
+List<String> textFileNameCandidates(String base) {
+  return <String>[
+    base,
+    '$base.md',
+    '$base.markdown',
+    '$base.mkdown',
+    '$base.txt',
+  ];
+}
+
+final List<String> changelogFileNames = textFileNameCandidates('changelog');
+
+final List<String> readmeFileNames = textFileNameCandidates('readme');
+
+/// Returns the candidates in priority order to display under the 'Example' tab.
+List<String> exampleFileCandidates(String package) {
+  return <String>[
+  ...textFileNameCandidates('example/readme'),
+  ...textFileNameCandidates('example/example'),
+  'example/lib/main.dart',
+  'example/main.dart',
+  'example/lib/$package.dart',
+  'example/$package.dart',
+  'example/lib/${package}_example.dart',
+  'example/${package}_example.dart',
+  'example/lib/example.dart',
+  'example/example.dart',
+  ];
+}

--- a/pkg/pub_package_reader/lib/src/names.dart
+++ b/pkg/pub_package_reader/lib/src/names.dart
@@ -70,8 +70,10 @@ final invalidHostNames = const <String>[
   'example.com',
   'example.org',
   'example.net',
+  'google.com',
   'www.example.com',
   'www.example.org',
   'www.example.net',
+  'www.google.com',
   'none',
 ];

--- a/pkg/pub_package_reader/pubspec.yaml
+++ b/pkg/pub_package_reader/pubspec.yaml
@@ -7,7 +7,6 @@ environment:
 
 dependencies:
   logging: ^0.11.3
-  pana: ^0.12.18
   pubspec_parse: ^0.1.4
 
 dev_dependencies:


### PR DESCRIPTION
- We don't need to depend on `pana` (and `pana` can depend on this package once it is published).
- Also added `google.com` to list of not useful domain names.