### PR TITLE
Extend word separator list in search text parser.

### DIFF
--- a/app/lib/search/text_utils.dart
+++ b/app/lib/search/text_utils.dart
@@ -6,8 +6,9 @@ import 'package:html/parser.dart';
 
 import '../shared/markdown.dart';
 
-final RegExp _separators =
-    RegExp(r'[_\.,;=\:\(\)\>\<\[\]\{\}\|\?\!\/\+\-\*]|\s');
+final _separatorChars = '_.?!,;:=()<>[]{}~@#\$%&|+-*\\/"\'`';
+final _escapedSeparators = _separatorChars.split('').map((s) => '\\$s').join();
+final _separators = RegExp('[$_escapedSeparators]|\\s');
 final RegExp _nonCharacterRegExp = RegExp('[^a-z0-9]');
 final RegExp _multiWhitespaceRegExp = RegExp('\\s+');
 final RegExp _exactTermRegExp = RegExp(r'"([^"]+)"');

--- a/app/test/search/index_simple_test.dart
+++ b/app/test/search/index_simple_test.dart
@@ -292,6 +292,18 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
       });
     });
 
+    test('exact phrase with dot: "once on demand."', () async {
+      final result =
+          await index.search(SearchQuery.parse(query: '"once on demand."'));
+      expect(json.decode(json.encode(result)), {
+        'indexUpdated': isNotNull,
+        'totalCount': 1,
+        'packages': [
+          {'package': 'async', 'score': closeTo(0.65, 0.01)},
+        ],
+      });
+    });
+
     test('package prefix: chrome', () async {
       final PackageSearchResult result =
           await index.search(SearchQuery.parse(query: 'package:chrome'));


### PR DESCRIPTION
I've found an issue with search while trying to do exact match search for #2002. It probably will improve other search queries too.