### PR TITLE
Accept more search candidates.

### DIFF
--- a/app/lib/search/index_simple.dart
+++ b/app/lib/search/index_simple.dart
@@ -699,6 +699,8 @@ class TokenIndex {
         double candidateWeight = 0.0;
         if (token == candidate) {
           candidateWeight = 1.0;
+        } else if (token.startsWith(candidate) || token.endsWith(candidate)) {
+          candidateWeight = candidate.length / token.length;
         } else {
           final candidateNgrams = ngrams(candidate, _minLength, 6);
           candidateWeight = _ngramSimilarity(tokenNgrams, candidateNgrams);

--- a/app/test/search/stack_trace_test.dart
+++ b/app/test/search/stack_trace_test.dart
@@ -1,0 +1,46 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:test/test.dart';
+
+import 'package:pub_dartlang_org/search/index_simple.dart';
+import 'package:pub_dartlang_org/search/text_utils.dart';
+import 'package:pub_dartlang_org/shared/search_service.dart';
+
+void main() {
+  group('stack_trace', () {
+    SimplePackageIndex index;
+
+    setUpAll(() async {
+      index = SimplePackageIndex();
+      await index.addPackages([
+        PackageDocument(
+          package: 'stack_trace',
+          version: '1.9.3',
+          description: compactDescription(
+              'A package for manipulating stack traces and printing them readably.'),
+        ),
+      ]);
+      await index.merge();
+    });
+
+    // should find full word
+    test('stacktrace', () async {
+      final PackageSearchResult result = await index.search(
+          SearchQuery.parse(query: 'stacktrace', order: SearchOrder.text));
+      expect(json.decode(json.encode(result)), {
+        'indexUpdated': isNotNull,
+        'totalCount': 1,
+        'packages': [
+          {
+            'package': 'stack_trace',
+            'score': closeTo(0.99, 0.01),
+          },
+        ]
+      });
+    });
+  });
+}


### PR DESCRIPTION
Fixes #2123.

Earlier we did found `stack` and `trace` as candidates, but their n-gram similarity score was too low (0.1). Added a test to catch if there is a regression with it.