### PR TITLE
Use neat_cache for FileInfo

### DIFF
--- a/app/lib/shared/dartdoc_memcache.dart
+++ b/app/lib/shared/dartdoc_memcache.dart
@@ -24,7 +24,6 @@ DartdocMemcache get dartdocMemcache =>
 
 class DartdocMemcache {
   final SimpleMemcache _entry;
-  final SimpleMemcache _fileInfo;
   final SimpleMemcache _apiSummary;
 
   DartdocMemcache()
@@ -32,11 +31,6 @@ class DartdocMemcache {
           'DartdocMemcache/entry/',
           _logger,
           Duration(hours: 24),
-        ),
-        _fileInfo = SimpleMemcache(
-          'DartdocMemcache/fileInfo/',
-          _logger,
-          Duration(minutes: 60),
         ),
         _apiSummary = SimpleMemcache(
           'DartdocMemcache/apiSummary/',
@@ -56,14 +50,6 @@ class DartdocMemcache {
     final key = _entryKey(entry.packageName, entry.packageVersion);
     final bytes = entry.asBytes();
     await _entry.setBytes(key, bytes);
-  }
-
-  Future<List<int>> getFileInfoBytes(String objectName) {
-    return _fileInfo.getBytes(_fileInfoKey(objectName));
-  }
-
-  Future setFileInfoBytes(String objectName, List<int> bytes) {
-    return _fileInfo.setBytes(_fileInfoKey(objectName), bytes);
   }
 
   Future<Map<String, dynamic>> getApiSummary(String package) async {
@@ -87,6 +73,4 @@ class DartdocMemcache {
   }
 
   String _entryKey(String package, String version) => '/$package/$version';
-
-  String _fileInfoKey(String objectName) => objectName;
 }


### PR DESCRIPTION
I've been wanting to use the `Cache` abstraction like this for a long time.
Ideally, I want to refactor most of our cache usages to get rid of `SimpleCache`.

Note. This doesn't attempt to cleanup the error handling. We really should handle
relevant exceptions, ignore others, print them at a higher level, monitor logs to find them,
handle them specifically and then eventually switch to crashing when they occur.

For now, I'm just logging them.