### PR TITLE
Integration test for dev versions.

### DIFF
--- a/pkg/pub_integration/bin/pub_integration.dart
+++ b/pkg/pub_integration/bin/pub_integration.dart
@@ -59,6 +59,7 @@ Future main(List<String> args) async {
     print('credentials.json must exist');
     exit(1);
   }
+  final credentialsFileContent = await File(credentialsFile).readAsString();
 
   print('');
   print('PUB_HOSTED_URL:   $pubHostedUrl');
@@ -74,7 +75,7 @@ Future main(List<String> args) async {
 
   await verifyPub(
     pubHostedUrl: pubHostedUrl,
-    credentialsFile: credentialsFile,
+    credentialsFileContent: credentialsFileContent,
     invitedEmail: invitedEmail,
     inviteCompleterFn: () async {
       print('******');

--- a/pkg/pub_integration/lib/pub_integration.dart
+++ b/pkg/pub_integration/lib/pub_integration.dart
@@ -10,13 +10,13 @@ import 'src/public_pages_script.dart';
 /// Runs the integration tests on the [pubHostedUrl].
 Future verifyPub({
   @required String pubHostedUrl,
-  @required String credentialsFile,
+  @required String credentialsFileContent,
   @required String invitedEmail,
   @required InviteCompleterFn inviteCompleterFn,
 }) async {
   final pubToolScript = PubToolScript(
     pubHostedUrl,
-    credentialsFile,
+    credentialsFileContent,
     invitedEmail,
     inviteCompleterFn,
   );

--- a/pkg/pub_integration/lib/src/dev_version_script.dart
+++ b/pkg/pub_integration/lib/src/dev_version_script.dart
@@ -1,0 +1,196 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:meta/meta.dart';
+import 'package:path/path.dart' as p;
+
+import 'pub_http_client.dart';
+import 'pub_tool_client.dart';
+import 'test_data.dart';
+
+/// A single object to execute integration script and verification tests
+/// publishing dev and stable version of a package.
+class DevVersionScript {
+  final String pubHostedUrl;
+  final String credentialsFileContent;
+  PubHttpClient _pubHttpClient;
+  PubToolClient _pubToolClient;
+  Directory _temp;
+  Directory _pubCacheDir;
+
+  DevVersionScript({
+    @required this.pubHostedUrl,
+    @required this.credentialsFileContent,
+  });
+
+  /// Publish and verify dev and stable versions.
+  Future verify(bool stableFirst) async {
+    assert(_pubHttpClient == null);
+    _pubHttpClient = PubHttpClient(pubHostedUrl);
+    _pubToolClient = await PubToolClient.create(
+        pubHostedUrl: pubHostedUrl,
+        credentialsFileContent: credentialsFileContent);
+    _temp = await Directory.systemTemp.createTemp();
+    try {
+      _pubCacheDir = Directory(p.join(_temp.path, 'pub-cache'));
+      await _pubCacheDir.create(recursive: true);
+      await File(p.join(_pubCacheDir.path, 'credentials.json'))
+          .writeAsString(credentialsFileContent);
+
+      if (stableFirst) {
+        await _publishVersion('0.9.0');
+        _expectContent(
+          await _pubHttpClient.getLatestVersionPage('_dummy_pkg'),
+          present: [
+            '<h2 class="title">_dummy_pkg 0.9.0</h2>',
+          ],
+          absent: [
+            '<a href="/packages/_dummy_pkg">0.9.0</a>',
+            '<a href="/packages/_dummy_pkg/versions/0.9.0">0.9.0</a>',
+          ],
+        );
+        await _publishVersion('1.0.0-beta');
+      } else {
+        await _publishVersion('1.0.0-beta');
+        _expectContent(
+          await _pubHttpClient.getLatestVersionPage('_dummy_pkg'),
+          present: [
+            '<h2 class="title">_dummy_pkg 1.0.0-beta</h2>',
+          ],
+          absent: [
+            '<a href="/packages/_dummy_pkg">1.0.0-beta</a>',
+            '<a href="/packages/_dummy_pkg/versions/1.0.0-beta">1.0.0-beta</a>',
+          ],
+        );
+        await _publishVersion('0.9.0');
+      }
+
+      // At this point both 0.9.0 and 1.0.0-beta is published.
+      // We display both versions.
+      _expectContent(
+        await _pubHttpClient.getLatestVersionPage('_dummy_pkg'),
+        present: [
+          '<h2 class="title">_dummy_pkg 0.9.0</h2>',
+          '<a href="/packages/_dummy_pkg">0.9.0</a>',
+          '<a href="/packages/_dummy_pkg/versions/1.0.0-beta">1.0.0-beta</a>',
+        ],
+        absent: [
+          '<a href="/packages/_dummy_pkg">1.0.0-beta</a>',
+          '<a href="/packages/_dummy_pkg/versions/0.9.0">0.9.0</a>',
+        ],
+      );
+
+      // Publishing a stable version that is not larger than the dev version
+      // keeps it on the page.
+      await _publishVersion('0.9.1');
+      _expectContent(
+        await _pubHttpClient.getLatestVersionPage('_dummy_pkg'),
+        present: [
+          '<h2 class="title">_dummy_pkg 0.9.1</h2>',
+          '<a href="/packages/_dummy_pkg">0.9.1</a>',
+          '<a href="/packages/_dummy_pkg/versions/1.0.0-beta">1.0.0-beta</a>',
+        ],
+        absent: [
+          '<a href="/packages/_dummy_pkg">0.9.0</a>',
+          '<a href="/packages/_dummy_pkg">1.0.0-beta</a>',
+          '<a href="/packages/_dummy_pkg/versions/0.9.0">0.9.0</a>',
+          '<a href="/packages/_dummy_pkg/versions/1.0.0">0.9.1</a>',
+        ],
+      );
+
+      // Publishing a new dev version updates the dev version link.
+      await _publishVersion('1.0.0-gamma');
+      _expectContent(
+        await _pubHttpClient.getLatestVersionPage('_dummy_pkg'),
+        present: [
+          '<h2 class="title">_dummy_pkg 0.9.1</h2>',
+          '<a href="/packages/_dummy_pkg">0.9.1</a>',
+          '<a href="/packages/_dummy_pkg/versions/1.0.0-gamma">1.0.0-gamma</a>',
+        ],
+        absent: [
+          '<a href="/packages/_dummy_pkg">0.9.0</a>',
+          '<a href="/packages/_dummy_pkg">1.0.0-beta</a>',
+          '<a href="/packages/_dummy_pkg">1.0.0-gamma</a>',
+          '<a href="/packages/_dummy_pkg/versions/0.9.0">0.9.0</a>',
+          '<a href="/packages/_dummy_pkg/versions/1.0.0">0.9.1</a>',
+          '<a href="/packages/_dummy_pkg/versions/1.0.0-beta">1.0.0-beta</a>',
+        ],
+      );
+
+      // Publishing the stable version removes the dev version link.
+      await _publishVersion('1.0.0');
+      _expectContent(
+        await _pubHttpClient.getLatestVersionPage('_dummy_pkg'),
+        present: [
+          '<h2 class="title">_dummy_pkg 1.0.0</h2>',
+        ],
+        absent: [
+          '<a href="/packages/_dummy_pkg">0.9.0</a>',
+          '<a href="/packages/_dummy_pkg">0.9.1</a>',
+          '<a href="/packages/_dummy_pkg">1.0.0</a>',
+          '<a href="/packages/_dummy_pkg">1.0.0-beta</a>',
+          '<a href="/packages/_dummy_pkg">1.0.0-gamma</a>',
+          '<a href="/packages/_dummy_pkg/versions/0.9.0">0.9.0</a>',
+          '<a href="/packages/_dummy_pkg/versions/1.0.0">0.9.1</a>',
+          '<a href="/packages/_dummy_pkg/versions/1.0.0-beta">1.0.0-beta</a>',
+          '<a href="/packages/_dummy_pkg/versions/1.0.0-gamma">1.0.0-gamma</a>',
+        ],
+      );
+
+      // Publishing a new dev version will trigger the re-appear of the dev link.
+      await _publishVersion('1.1.0-dev');
+      _expectContent(
+        await _pubHttpClient.getLatestVersionPage('_dummy_pkg'),
+        present: [
+          '<h2 class="title">_dummy_pkg 1.0.0</h2>',
+          '<a href="/packages/_dummy_pkg">1.0.0</a>',
+          '<a href="/packages/_dummy_pkg/versions/1.1.0-dev">1.1.0-dev</a>',
+        ],
+        absent: [
+          '<a href="/packages/_dummy_pkg">0.9.0</a>',
+          '<a href="/packages/_dummy_pkg">0.9.1</a>',
+          '<a href="/packages/_dummy_pkg">1.0.0-beta</a>',
+          '<a href="/packages/_dummy_pkg">1.0.0-gamma</a>',
+          '<a href="/packages/_dummy_pkg/versions/0.9.0">0.9.0</a>',
+          '<a href="/packages/_dummy_pkg/versions/1.0.0">0.9.1</a>',
+          '<a href="/packages/_dummy_pkg/versions/1.0.0-beta">1.0.0-beta</a>',
+          '<a href="/packages/_dummy_pkg/versions/1.0.0-gamma">1.0.0-gamma</a>',
+        ],
+      );
+    } finally {
+      await _temp.delete(recursive: true);
+      await _pubToolClient.close();
+      _pubToolClient = null;
+      _pubHttpClient.close();
+      _pubHttpClient = null;
+    }
+  }
+
+  Future _publishVersion(String version) async {
+    final dir = await _temp.createTemp();
+    await createDummyPkg(dir.path, version);
+    await _pubToolClient.runProc(
+      'pub',
+      ['publish', '--force'],
+      workingDirectory: dir.path,
+    );
+    await dir.delete(recursive: true);
+  }
+
+  void _expectContent(String content,
+      {List<Pattern> present, List<Pattern> absent}) {
+    for (Pattern p in present ?? []) {
+      if (p.allMatches(content).isEmpty) {
+        throw Exception('$p is missing from the content.');
+      }
+    }
+    for (Pattern p in absent ?? []) {
+      if (p.allMatches(content).isNotEmpty) {
+        throw Exception('$p is present in the content.');
+      }
+    }
+  }
+}

--- a/pkg/pub_integration/lib/src/fake_credentials.dart
+++ b/pkg/pub_integration/lib/src/fake_credentials.dart
@@ -1,0 +1,16 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert';
+
+/// The content of the fake credentials.json that can be used against fake_pub_server.
+String fakeCredentialsFileContent() {
+  return json.encode({
+    'accessToken': 'user-at-example-dot-com',
+    'refreshToken': 'refresh-token',
+    'tokenEndpoint': 'http://localhost:9999/o/oauth2/token',
+    'scopes': ['email', 'openid'],
+    'expiration': 2558512791154,
+  });
+}

--- a/pkg/pub_integration/lib/src/pub_http_client.dart
+++ b/pkg/pub_integration/lib/src/pub_http_client.dart
@@ -7,11 +7,11 @@ import 'dart:convert';
 import 'package:http/http.dart';
 
 /// Simple pub client library.
-class PubClient {
+class PubHttpClient {
   final _http = Client();
   final String pubHostedUrl;
 
-  PubClient(this.pubHostedUrl) {
+  PubHttpClient(this.pubHostedUrl) {
     if (pubHostedUrl == null) {
       throw Exception('pubHostedUrl must be set');
     }

--- a/pkg/pub_integration/lib/src/pub_tool_client.dart
+++ b/pkg/pub_integration/lib/src/pub_tool_client.dart
@@ -1,0 +1,62 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:meta/meta.dart';
+import 'package:path/path.dart' as p;
+
+/// Command line pub interface.
+class PubToolClient {
+  final String _pubHostedUrl;
+  final Directory _tempDir;
+  final Directory _pubCacheDir;
+
+  PubToolClient._(this._pubHostedUrl, this._tempDir, this._pubCacheDir);
+
+  /// Creates a new PubToolClient context with a temporary directory.
+  static Future<PubToolClient> create({
+    @required String pubHostedUrl,
+    @required String credentialsFileContent,
+  }) async {
+    final dir = await Directory.systemTemp.createTemp();
+    final pubCacheDir = Directory(p.join(dir.path, 'pub-cache'));
+    await pubCacheDir.create(recursive: true);
+    await File(p.join(pubCacheDir.path, 'credentials.json'))
+        .writeAsString(credentialsFileContent);
+    return PubToolClient._(pubHostedUrl, dir, pubCacheDir);
+  }
+
+  /// Delete temp resources.
+  Future close() async {
+    await _tempDir?.delete(recursive: true);
+  }
+
+  /// Runs a process.
+  Future<ProcessResult> runProc(
+    String executable,
+    List<String> arguments, {
+    String workingDirectory,
+    Map<String, String> environment,
+    String expectedError,
+  }) async {
+    final cmd = '$executable ${arguments.join(' ')}';
+    print('Running $cmd in $workingDirectory...');
+    environment ??= <String, String>{};
+    environment['PUB_CACHE'] = _pubCacheDir.path;
+    environment['PUB_HOSTED_URL'] = _pubHostedUrl;
+
+    final pr = await Process.run(
+      executable,
+      arguments,
+      workingDirectory: workingDirectory,
+      environment: environment,
+    );
+    if (pr.exitCode == 0) return pr;
+    if (expectedError == pr.stderr.toString().trim()) return pr;
+    throw Exception('$cmd failed with exit code ${pr.exitCode}.\n'
+        'STDOUT: ${pr.stdout}\n'
+        'STDERR: ${pr.stderr}');
+  }
+}

--- a/pkg/pub_integration/lib/src/public_pages_script.dart
+++ b/pkg/pub_integration/lib/src/public_pages_script.dart
@@ -2,20 +2,20 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'pub_client.dart';
+import 'pub_http_client.dart';
 
 /// A single object to execute integration script and verification tests querying
 /// public pages on the pub.dev site (or on a test site).
 class PublicPagesScript {
   final String pubHostedUrl;
-  PubClient _pubClient;
+  PubHttpClient _pubClient;
 
   PublicPagesScript(this.pubHostedUrl);
 
   /// Verify public pages.
   Future verify() async {
     assert(_pubClient == null);
-    _pubClient = PubClient(pubHostedUrl);
+    _pubClient = PubHttpClient(pubHostedUrl);
     try {
       await _landingPage();
       await _flutterLandingPage();

--- a/pkg/pub_integration/test/dev_version_test.dart
+++ b/pkg/pub_integration/test/dev_version_test.dart
@@ -1,0 +1,58 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:http/http.dart' as http;
+import 'package:test/test.dart';
+
+import 'package:pub_integration/src/dev_version_script.dart';
+import 'package:pub_integration/src/fake_credentials.dart';
+import 'package:pub_integration/src/fake_pub_server_process.dart';
+
+void main() {
+  group('devVersion - dev first', () {
+    FakePubServerProcess fakePubServerProcess;
+    final httpClient = http.Client();
+
+    setUpAll(() async {
+      fakePubServerProcess = await FakePubServerProcess.start();
+      await fakePubServerProcess.started;
+    });
+
+    tearDownAll(() async {
+      await fakePubServerProcess?.kill();
+      httpClient.close();
+    });
+
+    test('steps', () async {
+      final script = DevVersionScript(
+        pubHostedUrl: 'http://localhost:${fakePubServerProcess.port}',
+        credentialsFileContent: fakeCredentialsFileContent(),
+      );
+      await script.verify(false);
+    });
+  });
+
+  group('devVersion - stable first', () {
+    FakePubServerProcess fakePubServerProcess;
+    final httpClient = http.Client();
+
+    setUpAll(() async {
+      fakePubServerProcess = await FakePubServerProcess.start();
+      await fakePubServerProcess.started;
+    });
+
+    tearDownAll(() async {
+      await fakePubServerProcess?.kill();
+      httpClient.close();
+    });
+
+    test('steps', () async {
+      final script = DevVersionScript(
+        pubHostedUrl: 'http://localhost:${fakePubServerProcess.port}',
+        credentialsFileContent: fakeCredentialsFileContent(),
+      );
+      await script.verify(true);
+    });
+  });
+}

--- a/pkg/pub_integration/test/fake_pub_server_test.dart
+++ b/pkg/pub_integration/test/fake_pub_server_test.dart
@@ -2,43 +2,25 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:convert';
-import 'dart:io';
-
 import 'package:html/parser.dart' as html_parser;
 import 'package:http/http.dart' as http;
-import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
 import 'package:pub_integration/pub_integration.dart';
+import 'package:pub_integration/src/fake_credentials.dart';
 import 'package:pub_integration/src/fake_pub_server_process.dart';
 
 void main() {
   group('Integration test using pkg/fake_pub_server', () {
-    Directory tempDir;
-    String fakeCredentialsFile;
     FakePubServerProcess fakePubServerProcess;
     final httpClient = http.Client();
 
     setUpAll(() async {
-      tempDir = await Directory.systemTemp.createTemp('fake-pub-server-test');
-
-      // fake credentials.json
-      fakeCredentialsFile = p.join(tempDir.path, 'credentials.json');
-      await File(fakeCredentialsFile).writeAsString(json.encode({
-        'accessToken': 'user-at-example-dot-com',
-        'refreshToken': 'refresh-token',
-        'tokenEndpoint': 'http://localhost:9999/o/oauth2/token',
-        'scopes': ['email', 'openid'],
-        'expiration': 2558512791154,
-      }));
-
       fakePubServerProcess = await FakePubServerProcess.start();
       await fakePubServerProcess.started;
     });
 
     tearDownAll(() async {
-      await tempDir?.delete(recursive: true);
       await fakePubServerProcess?.kill();
       httpClient.close();
     });
@@ -68,7 +50,7 @@ void main() {
 
       await verifyPub(
         pubHostedUrl: 'http://localhost:${fakePubServerProcess.port}',
-        credentialsFile: fakeCredentialsFile,
+        credentialsFileContent: fakeCredentialsFileContent(),
         invitedEmail: 'dev@example.org',
         inviteCompleterFn: inviteCompleterFn,
       );


### PR DESCRIPTION
- Fixes #2442
- Refactored `pkg/pub_integration` a bit to reuse the same code.
- Separate from the core integration script (which is used in pub release testing too), this is only for CI integration tests.