### PR TITLE
Fix typecheck of --help argument (and also travis)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ jobs:
       env: PKGS="pkg/client_data"
       script: ./tool/travis.sh dartfmt dartanalyzer_0
     - stage: smoke_test
-      name: "SDK: 2.4.0; PKG: pkg/pub_integration; TASKS: [`dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos --fatal-warnings lib/`]"
+      name: "SDK: 2.4.0; PKG: pkg/pub_integration; TASKS: [`dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos --fatal-warnings bin/ lib/`]"
       dart: "2.4.0"
       env: PKGS="pkg/pub_integration"
       script: ./tool/travis.sh dartfmt dartanalyzer_1

--- a/pkg/pub_integration/bin/pub_integration.dart
+++ b/pkg/pub_integration/bin/pub_integration.dart
@@ -18,7 +18,7 @@ Future main(List<String> args) async {
     ..addOption('credentials-json',
         help: 'The credentials.json to use for uploads and other actions.');
   final argv = _argParser.parse(args);
-  if (argv['help']) {
+  if (argv['help'] as bool) {
     print(_argParser.usage);
     exit(0);
   }

--- a/pkg/pub_integration/mono_pkg.yaml
+++ b/pkg/pub_integration/mono_pkg.yaml
@@ -6,6 +6,6 @@ stages:
   - smoke_test:
     - group:
         - dartfmt
-        - dartanalyzer: --fatal-infos --fatal-warnings lib/
+        - dartanalyzer: --fatal-infos --fatal-warnings bin/ lib/
   - unit_test:
     - test: --run-skipped

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -27,8 +27,8 @@ for PKG in ${PKGS}; do
       dartanalyzer --fatal-infos --fatal-warnings . || EXIT_CODE=$?
       ;;
     dartanalyzer_1)
-      echo 'dartanalyzer --fatal-infos --fatal-warnings lib/'
-      dartanalyzer --fatal-infos --fatal-warnings lib/ || EXIT_CODE=$?
+      echo 'dartanalyzer --fatal-infos --fatal-warnings bin/ lib/'
+      dartanalyzer --fatal-infos --fatal-warnings bin/ lib/ || EXIT_CODE=$?
       ;;
     dartfmt)
       echo 'dartfmt -n --set-exit-if-changed .'


### PR DESCRIPTION
Because the directory contains the package templates used for pub integration, we can't use `dartanalyzer .`, and the `bin/` directory was left out.