### PR TITLE
Cleanup tab classes.

### DIFF
--- a/app/lib/frontend/templates/package.dart
+++ b/app/lib/frontend/templates/package.dart
@@ -270,15 +270,14 @@ String renderPkgShowPage(Package package, List<String> uploaderEmails,
 
 /// Renders the `views/pkg/tabs.mustache` template.
 String renderPkgTabs(List<Tab> tabs) {
-  final tabsData = tabs.map((t) => t.toMustacheData()).toList();
   // active: the first one with content
-  for (int i = 0; i < tabs.length; i++) {
-    if (tabs[i].contentHtml != null) {
-      tabsData[i]['active'] = '-active';
+  for (Tab tab in tabs) {
+    if (tab.contentHtml != null) {
+      tab.isActive = true;
       break;
     }
   }
-  final values = {'tabs': tabsData};
+  final values = {'tabs': tabs.map((t) => t.toMustacheData()).toList()};
   return templateCache.renderTemplate('pkg/tabs', values);
 }
 
@@ -288,6 +287,7 @@ class Tab {
   final String titleHtml;
   final String contentHtml;
   final bool isMarkdown;
+  bool isActive = false;
 
   Tab.withContent({
     @required this.id,
@@ -307,13 +307,25 @@ class Tab {
         contentHtml = null,
         isMarkdown = false;
 
-  Map toMustacheData() => <String, dynamic>{
-        'id': id,
-        'title_html': titleHtml,
-        'content_html': contentHtml,
-        'markdown-body': isMarkdown ? 'markdown-body' : null,
-        'is_link': contentHtml == null,
-      };
+  Map toMustacheData() {
+    final titleClasses = <String>[
+      contentHtml == null ? 'tab-link' : 'tab-button',
+      if (isActive) '-active',
+    ];
+    final contentClasses = <String>[
+      'tab-content',
+      if (isActive) '-active',
+      if (isMarkdown) 'markdown-body',
+    ];
+    return <String, dynamic>{
+      'id': id,
+      'title_classes': titleClasses.join(' '),
+      'title_html': titleHtml,
+      'content_classes': contentClasses.join(' '),
+      'content_html': contentHtml,
+      'has_content': contentHtml != null,
+    };
+  }
 }
 
 List<Tab> _pkgTabs(

--- a/app/lib/frontend/templates/views/pkg/tabs.mustache
+++ b/app/lib/frontend/templates/views/pkg/tabs.mustache
@@ -3,18 +3,15 @@
     BSD-style license that can be found in the LICENSE file. }}
 <ul class="package-tabs-header">
   {{#tabs}}
-    {{^is_link}}
-    <li class="tab-button {{active}}" data-name="-{{id}}-tab-" role="button">{{& title_html}}</li>
-    {{/is_link}}
-    {{#is_link}}
-      <li class="tab-link {{active}}" role="button">{{& title_html}}</li>
-    {{/is_link}}
+    <li class="{{title_classes}}"{{#has_content}} data-name="-{{id}}-tab-"{{/has_content}} role="button">{{& title_html}}</li>
   {{/tabs}}
 </ul>
 <div class="main package-tabs-content">
   {{#tabs}}
-    <section class="tab-content {{active}} {{markdown-body}}" data-name="-{{id}}-tab-">
+    {{#has_content}}
+    <section class="{{content_classes}}" data-name="-{{id}}-tab-">
       {{& content_html}}
     </section>
+    {{/has_content}}
   {{/tabs}}
 </div>

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -95,13 +95,13 @@
       <div class="package-container">
         <ul class="package-tabs-header">
           <li class="tab-button -active" data-name="-readme-tab-" role="button">Readme</li>
-          <li class="tab-button " data-name="-changelog-tab-" role="button">Changelog</li>
-          <li class="tab-button " data-name="-example-tab-" role="button">Example</li>
-          <li class="tab-button " data-name="-installing-tab-" role="button">Installing</li>
-          <li class="tab-link " role="button">
+          <li class="tab-button" data-name="-changelog-tab-" role="button">Changelog</li>
+          <li class="tab-button" data-name="-example-tab-" role="button">Example</li>
+          <li class="tab-button" data-name="-installing-tab-" role="button">Installing</li>
+          <li class="tab-link" role="button">
             <a href="/packages/foobar_pkg/versions">Versions</a>
           </li>
-          <li class="tab-button " data-name="-analysis-tab-" role="button">
+          <li class="tab-button" data-name="-analysis-tab-" role="button">
             <div class="score-box">
               <span class="number -rotten" title="Analysis and more details.">3</span>
             </div>
@@ -119,13 +119,13 @@
 </code>
             </pre>
           </section>
-          <section class="tab-content  markdown-body" data-name="-changelog-tab-">
+          <section class="tab-content markdown-body" data-name="-changelog-tab-">
             <h1 class="hash-header" id="changelog">Changelog 
               <a href="#changelog" class="hash-link">#</a>
             </h1>
             <p>0.1.1 - test package</p>
           </section>
-          <section class="tab-content  markdown-body" data-name="-example-tab-">
+          <section class="tab-content markdown-body" data-name="-example-tab-">
             <p style="font-family: monospace">
               <b>example/lib/main.dart</b>
             </p>
@@ -136,7 +136,7 @@
 </code>
             </pre>
           </section>
-          <section class="tab-content  " data-name="-installing-tab-">
+          <section class="tab-content" data-name="-installing-tab-">
             <h2>Use this package as a library</h2>
             <h3>1. Depend on it</h3>
             <p>Add this to your package's pubspec.yaml file:</p>
@@ -169,8 +169,7 @@ import 'package:foobar_pkg/foolib.dart';
   </code>
             </pre>
           </section>
-          <section class="tab-content  " data-name="--tab-"></section>
-          <section class="tab-content  " data-name="-analysis-tab-">
+          <section class="tab-content" data-name="-analysis-tab-">
             <table id='scores-table'>
               <tr>
                 <td class="score-name">

--- a/app/test/frontend/golden/pkg_show_page_discontinued.html
+++ b/app/test/frontend/golden/pkg_show_page_discontinued.html
@@ -86,13 +86,13 @@
       <div class="package-container">
         <ul class="package-tabs-header">
           <li class="tab-button -active" data-name="-readme-tab-" role="button">Readme</li>
-          <li class="tab-button " data-name="-changelog-tab-" role="button">Changelog</li>
-          <li class="tab-button " data-name="-example-tab-" role="button">Example</li>
-          <li class="tab-button " data-name="-installing-tab-" role="button">Installing</li>
-          <li class="tab-link " role="button">
+          <li class="tab-button" data-name="-changelog-tab-" role="button">Changelog</li>
+          <li class="tab-button" data-name="-example-tab-" role="button">Example</li>
+          <li class="tab-button" data-name="-installing-tab-" role="button">Installing</li>
+          <li class="tab-link" role="button">
             <a href="/packages/foobar_pkg/versions">Versions</a>
           </li>
-          <li class="tab-button " data-name="-analysis-tab-" role="button">
+          <li class="tab-button" data-name="-analysis-tab-" role="button">
             <div class="score-box">
               <span class="number -rotten" title="Analysis and more details.">0</span>
             </div>
@@ -110,13 +110,13 @@
 </code>
             </pre>
           </section>
-          <section class="tab-content  markdown-body" data-name="-changelog-tab-">
+          <section class="tab-content markdown-body" data-name="-changelog-tab-">
             <h1 class="hash-header" id="changelog">Changelog 
               <a href="#changelog" class="hash-link">#</a>
             </h1>
             <p>0.1.1 - test package</p>
           </section>
-          <section class="tab-content  markdown-body" data-name="-example-tab-">
+          <section class="tab-content markdown-body" data-name="-example-tab-">
             <p style="font-family: monospace">
               <b>example/lib/main.dart</b>
             </p>
@@ -127,7 +127,7 @@
 </code>
             </pre>
           </section>
-          <section class="tab-content  " data-name="-installing-tab-">
+          <section class="tab-content" data-name="-installing-tab-">
             <h2>Use this package as a library</h2>
             <h3>1. Depend on it</h3>
             <p>Add this to your package's pubspec.yaml file:</p>
@@ -160,8 +160,7 @@ import 'package:foobar_pkg/foolib.dart';
   </code>
             </pre>
           </section>
-          <section class="tab-content  " data-name="--tab-"></section>
-          <section class="tab-content  " data-name="-analysis-tab-">
+          <section class="tab-content" data-name="-analysis-tab-">
             <table id='scores-table'>
               <tr>
                 <td class="score-name">

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -95,12 +95,12 @@
       <div class="package-container">
         <ul class="package-tabs-header">
           <li class="tab-button -active" data-name="-readme-tab-" role="button">Readme</li>
-          <li class="tab-button " data-name="-changelog-tab-" role="button">Changelog</li>
-          <li class="tab-button " data-name="-installing-tab-" role="button">Installing</li>
-          <li class="tab-link " role="button">
+          <li class="tab-button" data-name="-changelog-tab-" role="button">Changelog</li>
+          <li class="tab-button" data-name="-installing-tab-" role="button">Installing</li>
+          <li class="tab-link" role="button">
             <a href="/packages/foobar_pkg/versions">Versions</a>
           </li>
-          <li class="tab-button " data-name="-analysis-tab-" role="button">
+          <li class="tab-button" data-name="-analysis-tab-" role="button">
             <div class="score-box">
               <span class="number -good" title="Analysis and more details.">65</span>
             </div>
@@ -118,13 +118,13 @@
 </code>
             </pre>
           </section>
-          <section class="tab-content  markdown-body" data-name="-changelog-tab-">
+          <section class="tab-content markdown-body" data-name="-changelog-tab-">
             <h1 class="hash-header" id="changelog">Changelog 
               <a href="#changelog" class="hash-link">#</a>
             </h1>
             <p>0.1.1 - test package</p>
           </section>
-          <section class="tab-content  " data-name="-installing-tab-">
+          <section class="tab-content" data-name="-installing-tab-">
             <h2>Use this package as a library</h2>
             <h3>1. Depend on it</h3>
             <p>Add this to your package's pubspec.yaml file:</p>
@@ -157,8 +157,7 @@ import 'package:foobar_pkg/foolib.dart';
   </code>
             </pre>
           </section>
-          <section class="tab-content  " data-name="--tab-"></section>
-          <section class="tab-content  " data-name="-analysis-tab-">
+          <section class="tab-content" data-name="-analysis-tab-">
             <table id='scores-table'>
               <tr>
                 <td class="score-name">

--- a/app/test/frontend/golden/pkg_show_page_legacy.html
+++ b/app/test/frontend/golden/pkg_show_page_legacy.html
@@ -96,13 +96,13 @@
       <div class="package-container">
         <ul class="package-tabs-header">
           <li class="tab-button -active" data-name="-readme-tab-" role="button">Readme</li>
-          <li class="tab-button " data-name="-changelog-tab-" role="button">Changelog</li>
-          <li class="tab-button " data-name="-example-tab-" role="button">Example</li>
-          <li class="tab-button " data-name="-installing-tab-" role="button">Installing</li>
-          <li class="tab-link " role="button">
+          <li class="tab-button" data-name="-changelog-tab-" role="button">Changelog</li>
+          <li class="tab-button" data-name="-example-tab-" role="button">Example</li>
+          <li class="tab-button" data-name="-installing-tab-" role="button">Installing</li>
+          <li class="tab-link" role="button">
             <a href="/packages/foobar_pkg/versions">Versions</a>
           </li>
-          <li class="tab-button " data-name="-analysis-tab-" role="button">
+          <li class="tab-button" data-name="-analysis-tab-" role="button">
             <div class="score-box">
               <span class="number -rotten" title="Analysis and more details.">25</span>
             </div>
@@ -120,13 +120,13 @@
 </code>
             </pre>
           </section>
-          <section class="tab-content  markdown-body" data-name="-changelog-tab-">
+          <section class="tab-content markdown-body" data-name="-changelog-tab-">
             <h1 class="hash-header" id="changelog">Changelog 
               <a href="#changelog" class="hash-link">#</a>
             </h1>
             <p>0.1.1 - test package</p>
           </section>
-          <section class="tab-content  markdown-body" data-name="-example-tab-">
+          <section class="tab-content markdown-body" data-name="-example-tab-">
             <p style="font-family: monospace">
               <b>example/lib/main.dart</b>
             </p>
@@ -137,7 +137,7 @@
 </code>
             </pre>
           </section>
-          <section class="tab-content  " data-name="-installing-tab-">
+          <section class="tab-content" data-name="-installing-tab-">
             <h2>Use this package as a library</h2>
             <h3>1. Depend on it</h3>
             <p>Add this to your package's pubspec.yaml file:</p>
@@ -170,8 +170,7 @@ import 'package:foobar_pkg/foolib.dart';
   </code>
             </pre>
           </section>
-          <section class="tab-content  " data-name="--tab-"></section>
-          <section class="tab-content  " data-name="-analysis-tab-">
+          <section class="tab-content" data-name="-analysis-tab-">
             <table id='scores-table'>
               <tr>
                 <td class="score-name">

--- a/app/test/frontend/golden/pkg_show_page_outdated.html
+++ b/app/test/frontend/golden/pkg_show_page_outdated.html
@@ -96,13 +96,13 @@
       <div class="package-container">
         <ul class="package-tabs-header">
           <li class="tab-button -active" data-name="-readme-tab-" role="button">Readme</li>
-          <li class="tab-button " data-name="-changelog-tab-" role="button">Changelog</li>
-          <li class="tab-button " data-name="-example-tab-" role="button">Example</li>
-          <li class="tab-button " data-name="-installing-tab-" role="button">Installing</li>
-          <li class="tab-link " role="button">
+          <li class="tab-button" data-name="-changelog-tab-" role="button">Changelog</li>
+          <li class="tab-button" data-name="-example-tab-" role="button">Example</li>
+          <li class="tab-button" data-name="-installing-tab-" role="button">Installing</li>
+          <li class="tab-link" role="button">
             <a href="/packages/foobar_pkg/versions">Versions</a>
           </li>
-          <li class="tab-button " data-name="-analysis-tab-" role="button">
+          <li class="tab-button" data-name="-analysis-tab-" role="button">
             <div class="score-box">
               <span class="number -rotten" title="Analysis and more details.">0</span>
             </div>
@@ -120,13 +120,13 @@
 </code>
             </pre>
           </section>
-          <section class="tab-content  markdown-body" data-name="-changelog-tab-">
+          <section class="tab-content markdown-body" data-name="-changelog-tab-">
             <h1 class="hash-header" id="changelog">Changelog 
               <a href="#changelog" class="hash-link">#</a>
             </h1>
             <p>0.1.1 - test package</p>
           </section>
-          <section class="tab-content  markdown-body" data-name="-example-tab-">
+          <section class="tab-content markdown-body" data-name="-example-tab-">
             <p style="font-family: monospace">
               <b>example/lib/main.dart</b>
             </p>
@@ -137,7 +137,7 @@
 </code>
             </pre>
           </section>
-          <section class="tab-content  " data-name="-installing-tab-">
+          <section class="tab-content" data-name="-installing-tab-">
             <h2>Use this package as a library</h2>
             <h3>1. Depend on it</h3>
             <p>Add this to your package's pubspec.yaml file:</p>
@@ -170,8 +170,7 @@ import 'package:foobar_pkg/foolib.dart';
   </code>
             </pre>
           </section>
-          <section class="tab-content  " data-name="--tab-"></section>
-          <section class="tab-content  " data-name="-analysis-tab-">
+          <section class="tab-content" data-name="-analysis-tab-">
             <table id='scores-table'>
               <tr>
                 <td class="score-name">

--- a/app/test/frontend/golden/pkg_show_version_page.html
+++ b/app/test/frontend/golden/pkg_show_version_page.html
@@ -97,12 +97,12 @@
       <div class="package-container">
         <ul class="package-tabs-header">
           <li class="tab-button -active" data-name="-readme-tab-" role="button">Readme</li>
-          <li class="tab-button " data-name="-changelog-tab-" role="button">Changelog</li>
-          <li class="tab-button " data-name="-installing-tab-" role="button">Installing</li>
-          <li class="tab-link " role="button">
+          <li class="tab-button" data-name="-changelog-tab-" role="button">Changelog</li>
+          <li class="tab-button" data-name="-installing-tab-" role="button">Installing</li>
+          <li class="tab-link" role="button">
             <a href="/packages/foobar_pkg/versions">Versions</a>
           </li>
-          <li class="tab-button " data-name="-analysis-tab-" role="button">
+          <li class="tab-button" data-name="-analysis-tab-" role="button">
             <div class="score-box">
               <span class="number -rotten" title="Analysis and more details.">3</span>
             </div>
@@ -120,13 +120,13 @@
 </code>
             </pre>
           </section>
-          <section class="tab-content  markdown-body" data-name="-changelog-tab-">
+          <section class="tab-content markdown-body" data-name="-changelog-tab-">
             <h1 class="hash-header" id="changelog">Changelog 
               <a href="#changelog" class="hash-link">#</a>
             </h1>
             <p>0.1.1 - test package</p>
           </section>
-          <section class="tab-content  " data-name="-installing-tab-">
+          <section class="tab-content" data-name="-installing-tab-">
             <h2>Use this package as a library</h2>
             <h3>1. Depend on it</h3>
             <p>Add this to your package's pubspec.yaml file:</p>
@@ -159,8 +159,7 @@ import 'package:foobar_pkg/foolib.dart';
   </code>
             </pre>
           </section>
-          <section class="tab-content  " data-name="--tab-"></section>
-          <section class="tab-content  " data-name="-analysis-tab-">
+          <section class="tab-content" data-name="-analysis-tab-">
             <table id='scores-table'>
               <tr>
                 <td class="score-name">

--- a/app/test/frontend/golden/pkg_versions_page.html
+++ b/app/test/frontend/golden/pkg_versions_page.html
@@ -96,20 +96,20 @@
       </div>
       <div class="package-container">
         <ul class="package-tabs-header">
-          <li class="tab-link " role="button">
+          <li class="tab-link" role="button">
             <a href="/packages/foobar_pkg#-readme-tab-">Readme</a>
           </li>
-          <li class="tab-link " role="button">
+          <li class="tab-link" role="button">
             <a href="/packages/foobar_pkg#-changelog-tab-">Changelog</a>
           </li>
-          <li class="tab-link " role="button">
+          <li class="tab-link" role="button">
             <a href="/packages/foobar_pkg#-example-tab-">Example</a>
           </li>
-          <li class="tab-link " role="button">
+          <li class="tab-link" role="button">
             <a href="/packages/foobar_pkg#-installing-tab-">Installing</a>
           </li>
           <li class="tab-button -active" data-name="-versions-tab-" role="button">Versions</li>
-          <li class="tab-link " role="button">
+          <li class="tab-link" role="button">
             <a href="/packages/foobar_pkg#-analysis-tab-">
               <div class="score-box">
                 <span class="number -good" title="Analysis and more details.">55</span>
@@ -118,11 +118,7 @@
           </li>
         </ul>
         <div class="main package-tabs-content">
-          <section class="tab-content  " data-name="--tab-"></section>
-          <section class="tab-content  " data-name="--tab-"></section>
-          <section class="tab-content  " data-name="--tab-"></section>
-          <section class="tab-content  " data-name="--tab-"></section>
-          <section class="tab-content -active " data-name="-versions-tab-">
+          <section class="tab-content -active" data-name="-versions-tab-">
             <p>The latest dev release was 
               <a href="#dev">0.2.0-dev</a> on Jan 1, 2014.
             </p>
@@ -189,7 +185,6 @@
               </tbody>
             </table>
           </section>
-          <section class="tab-content  " data-name="--tab-"></section>
         </div>
         <aside class="sidebar sidebar-content">
           <h3 class="title">About</h3>


### PR DESCRIPTION
- Explicit separation of the title and content styles.
- Removed extra whitespaces.
- Removed no-content lines like `<section class="tab-content  " data-name="--tab-"></section>`.
- Prepares the change of the new "Admin" tab: it would add an extra style to its title classes.