### PR TITLE
Show/hide logic for the 'Admin' tab

### DIFF
--- a/app/lib/frontend/templates/package.dart
+++ b/app/lib/frontend/templates/package.dart
@@ -287,6 +287,7 @@ class Tab {
   final String titleHtml;
   final String contentHtml;
   final bool isMarkdown;
+  final bool isHidden;
   bool isActive = false;
 
   Tab.withContent({
@@ -295,12 +296,14 @@ class Tab {
     String titleHtml,
     @required this.contentHtml,
     this.isMarkdown = false,
+    this.isHidden = false,
   }) : titleHtml = titleHtml ?? htmlEscape.convert(title);
 
   Tab.withLink({
     String title,
     String titleHtml,
     @required String href,
+    this.isHidden = false,
   })  : titleHtml =
             '<a href="$href">${titleHtml ?? htmlEscape.convert(title)}</a>',
         id = null,
@@ -311,6 +314,7 @@ class Tab {
     final titleClasses = <String>[
       contentHtml == null ? 'tab-link' : 'tab-button',
       if (isActive) '-active',
+      if (isHidden) '-hidden',
     ];
     final contentClasses = <String>[
       'tab-content',
@@ -385,6 +389,12 @@ List<Tab> _pkgTabs(
         isSkipped: card?.isSkipped ?? false, isNewPackage: isNewPackage),
     contentHtml: renderAnalysisTab(selectedVersion.package,
         selectedVersion.pubspec.sdkConstraint, card, analysis),
+  ));
+  tabs.add(Tab.withContent(
+    id: 'admin',
+    title: 'Admin',
+    contentHtml: '<h1>Admin</h1>',
+    isHidden: true,
   ));
   return tabs;
 }

--- a/app/lib/frontend/templates/package_versions.dart
+++ b/app/lib/frontend/templates/package_versions.dart
@@ -93,6 +93,11 @@ String renderPkgVersionsPage(
           isSkipped: card?.isSkipped ?? false,
           isNewPackage: package.isNewPackage()),
       href: urls.pkgPageUrl(package.name, fragment: '-analysis-tab-')));
+  tabs.add(Tab.withLink(
+    title: 'Admin',
+    href: urls.pkgPageUrl(package.name, fragment: '-admin-tab-'),
+    isHidden: true,
+  ));
 
   final values = {
     'header_html': renderPkgHeader(package, latestVersion, latestAnalysis),

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -106,6 +106,7 @@
               <span class="number -rotten" title="Analysis and more details.">3</span>
             </div>
           </li>
+          <li class="tab-button -hidden" data-name="-admin-tab-" role="button">Admin</li>
         </ul>
         <div class="main package-tabs-content">
           <section class="tab-content -active markdown-body" data-name="-readme-tab-">
@@ -311,6 +312,9 @@ import 'package:foobar_pkg/foolib.dart';
                 </tr>
               </table>
             </div>
+          </section>
+          <section class="tab-content" data-name="-admin-tab-">
+            <h1>Admin</h1>
           </section>
         </div>
         <aside class="sidebar sidebar-content">

--- a/app/test/frontend/golden/pkg_show_page_discontinued.html
+++ b/app/test/frontend/golden/pkg_show_page_discontinued.html
@@ -97,6 +97,7 @@
               <span class="number -rotten" title="Analysis and more details.">0</span>
             </div>
           </li>
+          <li class="tab-button -hidden" data-name="-admin-tab-" role="button">Admin</li>
         </ul>
         <div class="main package-tabs-content">
           <section class="tab-content -active markdown-body" data-name="-readme-tab-">
@@ -258,6 +259,9 @@ import 'package:foobar_pkg/foolib.dart';
             </div>
             <hr/>
             <p>This package is not analyzed, because it is discontinued.</p>
+          </section>
+          <section class="tab-content" data-name="-admin-tab-">
+            <h1>Admin</h1>
           </section>
         </div>
         <aside class="sidebar sidebar-content">

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -105,6 +105,7 @@
               <span class="number -good" title="Analysis and more details.">65</span>
             </div>
           </li>
+          <li class="tab-button -hidden" data-name="-admin-tab-" role="button">Admin</li>
         </ul>
         <div class="main package-tabs-content">
           <section class="tab-content -active markdown-body" data-name="-readme-tab-">
@@ -268,6 +269,9 @@ import 'package:foobar_pkg/foolib.dart';
             <h4>Platforms</h4>
             <p>Detected platforms: Flutter</p>
             <blockquote></blockquote>
+          </section>
+          <section class="tab-content" data-name="-admin-tab-">
+            <h1>Admin</h1>
           </section>
         </div>
         <aside class="sidebar sidebar-content">

--- a/app/test/frontend/golden/pkg_show_page_legacy.html
+++ b/app/test/frontend/golden/pkg_show_page_legacy.html
@@ -107,6 +107,7 @@
               <span class="number -rotten" title="Analysis and more details.">25</span>
             </div>
           </li>
+          <li class="tab-button -hidden" data-name="-admin-tab-" role="button">Admin</li>
         </ul>
         <div class="main package-tabs-content">
           <section class="tab-content -active markdown-body" data-name="-readme-tab-">
@@ -286,6 +287,9 @@ import 'package:foobar_pkg/foolib.dart';
                 </p>
               </div>
             </div>
+          </section>
+          <section class="tab-content" data-name="-admin-tab-">
+            <h1>Admin</h1>
           </section>
         </div>
         <aside class="sidebar sidebar-content">

--- a/app/test/frontend/golden/pkg_show_page_outdated.html
+++ b/app/test/frontend/golden/pkg_show_page_outdated.html
@@ -107,6 +107,7 @@
               <span class="number -rotten" title="Analysis and more details.">0</span>
             </div>
           </li>
+          <li class="tab-button -hidden" data-name="-admin-tab-" role="button">Admin</li>
         </ul>
         <div class="main package-tabs-content">
           <section class="tab-content -active markdown-body" data-name="-readme-tab-">
@@ -273,6 +274,9 @@ import 'package:foobar_pkg/foolib.dart';
               <a href="/packages/foobar_pkg#-analysis-tab-">latest stable version</a> for its analysis.
 
             </p>
+          </section>
+          <section class="tab-content" data-name="-admin-tab-">
+            <h1>Admin</h1>
           </section>
         </div>
         <aside class="sidebar sidebar-content">

--- a/app/test/frontend/golden/pkg_show_version_page.html
+++ b/app/test/frontend/golden/pkg_show_version_page.html
@@ -107,6 +107,7 @@
               <span class="number -rotten" title="Analysis and more details.">3</span>
             </div>
           </li>
+          <li class="tab-button -hidden" data-name="-admin-tab-" role="button">Admin</li>
         </ul>
         <div class="main package-tabs-content">
           <section class="tab-content -active markdown-body" data-name="-readme-tab-">
@@ -301,6 +302,9 @@ import 'package:foobar_pkg/foolib.dart';
                 </tr>
               </table>
             </div>
+          </section>
+          <section class="tab-content" data-name="-admin-tab-">
+            <h1>Admin</h1>
           </section>
         </div>
         <aside class="sidebar sidebar-content">

--- a/app/test/frontend/golden/pkg_versions_page.html
+++ b/app/test/frontend/golden/pkg_versions_page.html
@@ -116,6 +116,9 @@
               </div>
             </a>
           </li>
+          <li class="tab-link -hidden" role="button">
+            <a href="/packages/foobar_pkg#-admin-tab-">Admin</a>
+          </li>
         </ul>
         <div class="main package-tabs-content">
           <section class="tab-content -active" data-name="-versions-tab-">

--- a/pkg/web_app/lib/src/account.dart
+++ b/pkg/web_app/lib/src/account.dart
@@ -16,6 +16,7 @@ import 'google_auth_js.dart';
 import 'google_js.dart';
 import 'hoverable.dart';
 import 'page_data.dart';
+import 'tabs.dart';
 
 bool _initialized = false;
 GoogleUser _currentUser;
@@ -190,5 +191,16 @@ class _PkgAdminWidget {
   void update() {
     if (_root == null) return;
     updateDisplay(_root, _initialized && _isPkgUploader);
+    final adminTab = getTabElement('-admin-tab-');
+    if (_initialized && _isPkgUploader) {
+      final removed = adminTab.classes.remove('-hidden');
+      // If this was the first change since the page load or login, and the
+      // active hash is pointing to the tab, let's change it.
+      if (removed && window.location.hash == '#-admin-tab-') {
+        changeTab('-admin-tab-');
+      }
+    } else {
+      adminTab.classes.add('-hidden');
+    }
   }
 }

--- a/pkg/web_app/lib/src/tabs.dart
+++ b/pkg/web_app/lib/src/tabs.dart
@@ -75,13 +75,16 @@ String getTabName(Element elem) {
 }
 
 void changeTab(String name) {
-  final tabOrContentElem = _headerRoot
-      .querySelector('[data-name="${Uri.encodeQueryComponent(name)}"]');
-  if (tabOrContentElem != null) {
+  final tabOrContentElem = getTabElement(name);
+  if (tabOrContentElem != null &&
+      !tabOrContentElem.classes.contains('-hidden')) {
     _headerRoot.children.forEach((node) => _toggle(node, name));
     _contentRoot.children.forEach((node) => _toggle(node, name));
   }
 }
+
+Element getTabElement(String name) => _headerRoot
+    .querySelector('[data-name="${Uri.encodeQueryComponent(name)}"]');
 
 void _toggle(Element node, String name) {
   if (node.dataset['name'] != name) {

--- a/pkg/web_css/lib/src/_pkg.scss
+++ b/pkg/web_css/lib/src/_pkg.scss
@@ -40,6 +40,10 @@
     &:last-child {
       margin-right: 0;
     }
+
+    &.-hidden {
+      display: none;
+    }
   }
 
   > .tab-button,


### PR DESCRIPTION
- #1642
- The 'Admin' tab is now generated in the page's HTML markup, but it is hidden at first.
- As the login status changes, the 'Admin' tab is shown/hidden.
- If the user is not admin of a package, the `#-admin-tab-` hash must not switch to the tab content.
- If the user is admin, coming in on the `#-admin-tab-` hash, once the status is confirmed, it should switch to the 'Admin' tab.

The 'Versions' page does not display it yet (because the `data` property is used for multiple purposes, and I'll need to split that into two, will be done in a separate PR).

It also keeps the current client-side component rendering, the server-provided templates will be done in a follow-up PR.