### PR TITLE
Expand packages handler test with some sanity checks on the package content

### DIFF
--- a/app/test/frontend/handlers/_utils.dart
+++ b/app/test/frontend/handlers/_utils.dart
@@ -34,12 +34,22 @@ Future<shelf.Response> issueGetUri(Uri uri) async {
 }
 
 Future<String> expectHtmlResponse(shelf.Response response,
-    {int status = 200}) async {
+    {int status = 200, List<Pattern> present, List<Pattern> absent}) async {
   expect(response.statusCode, status);
   expect(response.headers['content-type'], 'text/html; charset="utf-8"');
   final content = await response.readAsString();
   expect(content, contains('<!DOCTYPE html>'));
   expect(content, contains('</html>'));
+  for (Pattern p in present ?? []) {
+    if (p.allMatches(content).isEmpty) {
+      throw Exception('$p is missing from the content.');
+    }
+  }
+  for (Pattern p in absent ?? []) {
+    if (p.allMatches(content).isNotEmpty) {
+      throw Exception('$p is present in the content.');
+    }
+  }
   return content;
 }
 

--- a/app/test/frontend/handlers/_utils.dart
+++ b/app/test/frontend/handlers/_utils.dart
@@ -33,19 +33,23 @@ Future<shelf.Response> issueGetUri(Uri uri) async {
   return createAppHandler(null)(request);
 }
 
-Future<String> expectHtmlResponse(shelf.Response response,
-    {int status = 200, List<Pattern> present, List<Pattern> absent}) async {
+Future<String> expectHtmlResponse(
+  shelf.Response response, {
+  int status = 200,
+  List<Pattern> present = const [],
+  List<Pattern> absent = const [],
+}) async {
   expect(response.statusCode, status);
   expect(response.headers['content-type'], 'text/html; charset="utf-8"');
   final content = await response.readAsString();
   expect(content, contains('<!DOCTYPE html>'));
   expect(content, contains('</html>'));
-  for (Pattern p in present ?? []) {
+  for (Pattern p in present) {
     if (p.allMatches(content).isEmpty) {
       throw Exception('$p is missing from the content.');
     }
   }
-  for (Pattern p in absent ?? []) {
+  for (Pattern p in absent) {
     if (p.allMatches(content).isNotEmpty) {
       throw Exception('$p is present in the content.');
     }

--- a/app/test/frontend/handlers/package_test.dart
+++ b/app/test/frontend/handlers/package_test.dart
@@ -16,7 +16,14 @@ void main() {
 
   group('ui', () {
     testWithServices('/packages/foobar_pkg - found', () async {
-      await expectHtmlResponse(await issueGet('/packages/foobar_pkg'));
+      await expectHtmlResponse(
+        await issueGet('/packages/foobar_pkg'),
+        present: [
+          '<h2 class="title">foobar_pkg 0.1.1+5</h2>',
+          '<a href="/packages/foobar_pkg">0.1.1+5</a>',
+          '<a href="/packages/foobar_pkg/versions/0.2.0-dev">0.2.0-dev</a>',
+        ],
+      );
     });
 
     testWithServices('/packages/foobar_not_found - not found', () async {
@@ -25,7 +32,14 @@ void main() {
     });
 
     testWithServices('/packages/foobar_pkg/versions - found', () async {
-      await expectHtmlResponse(await issueGet('/packages/foobar_pkg/versions'));
+      await expectHtmlResponse(
+        await issueGet('/packages/foobar_pkg/versions'),
+        present: [
+          '<h2 class="title">foobar_pkg 0.1.1+5</h2>',
+          '<a href="/packages/foobar_pkg">0.1.1+5</a>',
+          '<a href="/packages/foobar_pkg/versions/0.2.0-dev">0.2.0-dev</a>',
+        ],
+      );
     });
 
     testWithServices(
@@ -39,7 +53,13 @@ void main() {
 
     testWithServices('/packages/foobar_pkg/versions/0.1.1 - found', () async {
       await expectHtmlResponse(
-          await issueGet('/packages/foobar_pkg/versions/0.1.1+5'));
+        await issueGet('/packages/foobar_pkg/versions/0.1.1+5'),
+        present: [
+          '<h2 class="title">foobar_pkg 0.1.1+5</h2>',
+          '<a href="/packages/foobar_pkg">0.1.1+5</a>',
+          '<a href="/packages/foobar_pkg/versions/0.2.0-dev">0.2.0-dev</a>',
+        ],
+      );
     });
 
     testWithServices(


### PR DESCRIPTION
This is similar to the pub_integration's dev_versions script, but with smaller scope: this doesn't check the alternating display of the versions, only that the page is something like a package page.