### PR TITLE
Migrate account tests to testWithServices.

### DIFF
--- a/app/test/account/backend_test.dart
+++ b/app/test/account/backend_test.dart
@@ -2,82 +2,71 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:fake_gcloud/mem_datastore.dart';
 import 'package:gcloud/db.dart';
 import 'package:test/test.dart';
 
 import 'package:pub_dartlang_org/account/backend.dart';
 import 'package:pub_dartlang_org/account/models.dart';
-import 'package:pub_dartlang_org/account/testing/fake_auth_provider.dart';
+
+import '../shared/test_services.dart';
 
 void main() {
   group('AccountBackend', () {
-    final memDb = MemDatastore();
-    final datastore = DatastoreDB(memDb);
-    final backend = AccountBackend(datastore, authProvider: FakeAuthProvider());
-
-    setUpAll(() async {
-      datastore.commit(inserts: [
-        User()
-          ..parentKey = datastore.emptyKey
-          ..id = 'a-example-com'
-          ..oauthUserId = null
-          ..email = 'a@example.com'
-          ..created = DateTime(2019, 01, 01)
-      ]);
-    });
-
-    test('No user', () async {
-      final email = await backend.getEmailOfUserId('no-user-id');
+    testWithServices('No user', () async {
+      final email = await accountBackend.getEmailOfUserId('no-user-id');
       expect(email, isNull);
     });
 
-    test('Successful lookup', () async {
-      final email = await backend.getEmailOfUserId('a-example-com');
+    testWithServices('Successful lookup', () async {
+      final email = await accountBackend.getEmailOfUserId('a-example-com');
       expect(email, 'a@example.com');
-      final u1 = await backend.lookupUserById('a-example-com');
+      final u1 = await accountBackend.lookupUserById('a-example-com');
       expect(u1.email, 'a@example.com');
       expect(u1.oauthUserId, isNull);
-      final u2 = await backend.lookupOrCreateUserByEmail('a@example.com');
+      final u2 =
+          await accountBackend.lookupOrCreateUserByEmail('a@example.com');
       expect(u2.id, u1.id);
     });
 
-    test('Create missing user', () async {
-      final u = await backend.lookupOrCreateUserByEmail('b@example.com');
+    testWithServices('Create missing user', () async {
+      final oldIds =
+          await dbService.query<User>().run().map((u) => u.userId).toList();
+
+      final u = await accountBackend.lookupOrCreateUserByEmail('b@example.com');
       expect(u.userId, hasLength(36));
       expect(u.oauthUserId, isNull);
       expect(u.email, 'b@example.com');
 
       final ids =
-          await datastore.query<User>().run().map((u) => u.userId).toList();
-      expect(ids.length, 2);
+          await dbService.query<User>().run().map((u) => u.userId).toList();
+      expect(ids.length, oldIds.length + 1);
       expect(ids.contains('a-example-com'), isTrue);
       expect(ids.contains(u.userId), isTrue);
     });
 
-    test('Authenticate: token failure', () async {
-      final u = await backend.authenticateWithAccessToken('x');
+    testWithServices('Authenticate: token failure', () async {
+      final u = await accountBackend.authenticateWithAccessToken('x');
       expect(u, isNull);
     });
 
-    test('Authenticate: pre-created', () async {
-      final ids1 = await datastore
+    testWithServices('Authenticate: pre-created', () async {
+      final ids1 = await dbService
           .query<OAuthUserID>()
           .run()
           .map((u) => u.oauthUserId)
           .toList();
       expect(ids1, isEmpty);
 
-      final u1 =
-          await backend.authenticateWithAccessToken('a-at-example-dot-com');
+      final u1 = await accountBackend
+          .authenticateWithAccessToken('a-at-example-dot-com');
       expect(u1.userId, 'a-example-com');
       expect(u1.email, 'a@example.com');
 
-      final u2 = await backend.lookupUserById('a-example-com');
+      final u2 = await accountBackend.lookupUserById('a-example-com');
       expect(u2.email, 'a@example.com');
       expect(u2.oauthUserId, 'a-example-com');
 
-      final ids2 = await datastore
+      final ids2 = await dbService
           .query<OAuthUserID>()
           .run()
           .map((u) => u.oauthUserId)
@@ -85,30 +74,30 @@ void main() {
       expect(ids2, ['a-example-com']);
     });
 
-    test('Authenticate: new user', () async {
-      final ids1 = await datastore
+    testWithServices('Authenticate: new user', () async {
+      final ids1 = await dbService
           .query<OAuthUserID>()
           .run()
           .map((u) => u.oauthUserId)
           .toList();
-      expect(ids1, ['a-example-com']);
+      expect(ids1, []);
 
-      final u1 =
-          await backend.authenticateWithAccessToken('c-at-example-dot-com');
+      final u1 = await accountBackend
+          .authenticateWithAccessToken('c-at-example-dot-com');
       expect(u1.userId, hasLength(36));
       expect(u1.email, 'c@example.com');
 
-      final u2 = await backend.lookupUserById(u1.userId);
+      final u2 = await accountBackend.lookupUserById(u1.userId);
       expect(u2.email, 'c@example.com');
       expect(u2.oauthUserId, 'c-example-com');
 
-      final ids2 = await datastore
+      final ids2 = await dbService
           .query<OAuthUserID>()
           .run()
           .map((u) => u.oauthUserId)
           .toList();
       ids2.sort();
-      expect(ids2, ['a-example-com', 'c-example-com']);
+      expect(ids2, ['c-example-com']);
     });
   });
 }

--- a/app/test/frontend/handlers/package_test.dart
+++ b/app/test/frontend/handlers/package_test.dart
@@ -7,7 +7,7 @@ import 'package:test/test.dart';
 import 'package:pub_dartlang_org/frontend/static_files.dart';
 
 import '../../shared/handlers_test_utils.dart';
-import '../test_services.dart';
+import '../../shared/test_services.dart';
 
 import '_utils.dart';
 

--- a/app/test/frontend/utils.dart
+++ b/app/test/frontend/utils.dart
@@ -35,10 +35,14 @@ final Key devPackageVersionKey =
 
 final Pubspec testPubspec = Pubspec.fromYaml(testPackagePubspec);
 
-final testUser = User()
+final testUserHans = User()
   ..id = 'hans-at-juergen-dot-com'
   ..email = 'hans@juergen.com'
   ..created = DateTime.utc(2014);
+final testUserA = User()
+  ..id = 'a-example-com'
+  ..email = 'a@example.com'
+  ..created = DateTime(2019, 01, 01);
 
 final testUploaderUser =
     AuthenticatedUser('hans-at-juergen-dot-com', 'hans@juergen.com');

--- a/app/test/shared/test_services.dart
+++ b/app/test/shared/test_services.dart
@@ -15,8 +15,8 @@ import 'package:pub_dartlang_org/shared/analyzer_client.dart';
 import 'package:pub_dartlang_org/shared/configuration.dart';
 import 'package:pub_dartlang_org/shared/redis_cache.dart';
 
+import '../frontend/utils.dart';
 import '../shared/utils.dart';
-import 'utils.dart';
 
 /// Setup scoped services (including fake datastore with pre-populated base data
 /// and fake storage) for tests.
@@ -28,7 +28,8 @@ void testWithServices(String name, Future fn()) {
         testPackage,
         testPackageVersion,
         devPackageVersion,
-        testUser,
+        testUserA,
+        testUserHans,
       ]);
       registerDbService(db);
 


### PR DESCRIPTION
- It is better to have the same test setup in all of the tests.
- Moved `test_services.dart` to `test/shared/`.
- Added new user used in account tests.
- Adjusted account tests to expect the same "clean" state of the database at the beginning of each test.
