### PR TITLE
New Admin tab

### DIFF
--- a/app/lib/frontend/handlers/package.dart
+++ b/app/lib/frontend/handlers/package.dart
@@ -146,16 +146,15 @@ Future<shelf.Response> packageVersionHandlerHtml(
 /// Handles requests for /packages/<package>/admin
 /// Handles requests for /packages/<package>/versions/<version>/admin
 Future<shelf.Response> packageAdminHandler(
-    shelf.Request request, String packageName,
-    {String versionName}) async {
+    shelf.Request request, String packageName) async {
   if (redirectPackagePages.containsKey(packageName)) {
     return redirectResponse(redirectPackagePages[packageName]);
   }
   final package = await backend.lookupPackage(packageName);
   if (package == null) return redirectToSearch(packageName);
 
-  final version = await backend.lookupPackageVersion(
-      packageName, versionName ?? package.latestVersion);
+  final version =
+      await backend.lookupPackageVersion(packageName, package.latestVersion);
   if (version == null) {
     return redirectResponse(urls.versionsTabUrl(packageName));
   }

--- a/app/lib/frontend/handlers/package.dart
+++ b/app/lib/frontend/handlers/package.dart
@@ -18,6 +18,7 @@ import '../backend.dart';
 import '../models.dart';
 import '../request_context.dart';
 import '../templates/package.dart';
+import '../templates/package_admin.dart';
 import '../templates/package_versions.dart';
 
 import 'misc.dart' show formattedNotFoundHandler;
@@ -140,4 +141,30 @@ Future<shelf.Response> packageVersionHandlerHtml(
   }
 
   return htmlResponse(cachedPage);
+}
+
+/// Handles requests for /packages/<package>/admin
+/// Handles requests for /packages/<package>/versions/<version>/admin
+Future<shelf.Response> packageAdminHandler(
+    shelf.Request request, String packageName,
+    {String versionName}) async {
+  if (redirectPackagePages.containsKey(packageName)) {
+    return redirectResponse(redirectPackagePages[packageName]);
+  }
+  final package = await backend.lookupPackage(packageName);
+  if (package == null) return redirectToSearch(packageName);
+
+  final version = await backend.lookupPackageVersion(
+      packageName, versionName ?? package.latestVersion);
+  if (version == null) {
+    return redirectResponse(urls.versionsTabUrl(packageName));
+  }
+
+  final uploaderEmails =
+      await accountBackend.getEmailsOfUserIds(package.uploaders);
+  final analysis =
+      await analyzerClient.getAnalysisView(version.package, version.version);
+
+  return htmlResponse(
+      renderPkgAdminPage(package, uploaderEmails, version, analysis));
 }

--- a/app/lib/frontend/handlers/routes.dart
+++ b/app/lib/frontend/handlers/routes.dart
@@ -138,11 +138,6 @@ class PubSiteService {
   // **** Packages
   // ****
 
-  @Route.get('/packages/<package>/versions/<version>/admin')
-  Future<Response> packageVersionAdmin(
-          Request request, String package, String version) =>
-      packageAdminHandler(request, package, versionName: version);
-
   @Route.get('/packages/<package>/versions/<version>')
   Future<Response> packageVersion(
           Request request, String package, String version) =>

--- a/app/lib/frontend/handlers/routes.dart
+++ b/app/lib/frontend/handlers/routes.dart
@@ -138,10 +138,19 @@ class PubSiteService {
   // **** Packages
   // ****
 
+  @Route.get('/packages/<package>/versions/<version>/admin')
+  Future<Response> packageVersionAdmin(
+          Request request, String package, String version) =>
+      packageAdminHandler(request, package, versionName: version);
+
   @Route.get('/packages/<package>/versions/<version>')
   Future<Response> packageVersion(
           Request request, String package, String version) =>
       packageVersionHandlerHtml(request, package, versionName: version);
+
+  @Route.get('/packages/<package>/admin')
+  Future<Response> packageAdmin(Request request, String package) =>
+      packageAdminHandler(request, package);
 
   @Route.get('/packages/<package>/versions')
   Future<Response> packageVersionsJson(Request request, String package) =>

--- a/app/lib/frontend/handlers/routes.g.dart
+++ b/app/lib/frontend/handlers/routes.g.dart
@@ -29,8 +29,11 @@ Router _$PubSiteServiceRouter(PubSiteService service) {
   router.add('GET', '/packages', service.packages);
   router.add('GET', '/flutter/packages', service.flutterPackages);
   router.add('GET', '/web/packages', service.webPackages);
+  router.add('GET', '/packages/<package>/versions/<version>/admin',
+      service.packageVersionAdmin);
   router.add(
       'GET', '/packages/<package>/versions/<version>', service.packageVersion);
+  router.add('GET', '/packages/<package>/admin', service.packageAdmin);
   router.add(
       'GET', '/packages/<package>/versions', service.packageVersionsJson);
   router.add('GET', '/packages/<package>.json', service.packageJson);

--- a/app/lib/frontend/handlers/routes.g.dart
+++ b/app/lib/frontend/handlers/routes.g.dart
@@ -29,8 +29,6 @@ Router _$PubSiteServiceRouter(PubSiteService service) {
   router.add('GET', '/packages', service.packages);
   router.add('GET', '/flutter/packages', service.flutterPackages);
   router.add('GET', '/web/packages', service.webPackages);
-  router.add('GET', '/packages/<package>/versions/<version>/admin',
-      service.packageVersionAdmin);
   router.add(
       'GET', '/packages/<package>/versions/<version>', service.packageVersion);
   router.add('GET', '/packages/<package>/admin', service.packageAdmin);

--- a/app/lib/frontend/templates/package.dart
+++ b/app/lib/frontend/templates/package.dart
@@ -394,12 +394,7 @@ List<Tab> _pkgTabs(
   tabs.add(Tab.withLink(
     id: 'admin',
     title: 'Admin',
-    href: urls.pkgAdminUrl(
-      selectedVersion.package,
-      version: selectedVersion.version == package.latestVersion
-          ? null
-          : selectedVersion.version,
-    ),
+    href: urls.pkgAdminUrl(selectedVersion.package),
     isHidden: true,
   ));
   return tabs;

--- a/app/lib/frontend/templates/package.dart
+++ b/app/lib/frontend/templates/package.dart
@@ -220,12 +220,7 @@ String renderPkgHeader(
 String renderPkgShowPage(Package package, List<String> uploaderEmails,
     PackageVersion selectedVersion, AnalysisView analysis) {
   final card = analysis?.card;
-
-  final tabs = _pkgTabs(
-    selectedVersion,
-    analysis,
-    isNewPackage: package.isNewPackage(),
-  );
+  final tabs = _pkgTabs(package, selectedVersion, analysis);
 
   final values = {
     'header_html': renderPkgHeader(package, selectedVersion, analysis),
@@ -258,12 +253,16 @@ String renderPkgShowPage(Package package, List<String> uploaderEmails,
     canonicalUrl: canonicalUrl,
     platform: card?.asSinglePlatform,
     noIndex: noIndex,
-    pageData: PageData(
-      pkgData: PkgData(
-        package: package.name,
-        version: selectedVersion.version,
-        isDiscontinued: package.isDiscontinued == true,
-      ),
+    pageData: pkgPageData(package, selectedVersion),
+  );
+}
+
+PageData pkgPageData(Package package, PackageVersion selectedVersion) {
+  return PageData(
+    pkgData: PkgData(
+      package: package.name,
+      version: selectedVersion.version,
+      isDiscontinued: package.isDiscontinued == true,
     ),
   );
 }
@@ -300,13 +299,13 @@ class Tab {
   }) : titleHtml = titleHtml ?? htmlEscape.convert(title);
 
   Tab.withLink({
+    @required this.id,
     String title,
     String titleHtml,
     @required String href,
     this.isHidden = false,
   })  : titleHtml =
             '<a href="$href">${titleHtml ?? htmlEscape.convert(title)}</a>',
-        id = null,
         contentHtml = null,
         isMarkdown = false;
 
@@ -333,10 +332,10 @@ class Tab {
 }
 
 List<Tab> _pkgTabs(
+  Package package,
   PackageVersion selectedVersion,
-  AnalysisView analysis, {
-  @required bool isNewPackage,
-}) {
+  AnalysisView analysis,
+) {
   final card = analysis?.card;
 
   String renderedReadme;
@@ -380,20 +379,27 @@ List<Tab> _pkgTabs(
       title: 'Installing',
       contentHtml: _renderInstallTab(selectedVersion, analysis?.platforms)));
   tabs.add(Tab.withLink(
+    id: 'versions',
     title: 'Versions',
     href: urls.pkgVersionsUrl(selectedVersion.package),
   ));
   tabs.add(Tab.withContent(
     id: 'analysis',
     titleHtml: renderScoreBox(card?.overallScore,
-        isSkipped: card?.isSkipped ?? false, isNewPackage: isNewPackage),
+        isSkipped: card?.isSkipped ?? false,
+        isNewPackage: package.isNewPackage()),
     contentHtml: renderAnalysisTab(selectedVersion.package,
         selectedVersion.pubspec.sdkConstraint, card, analysis),
   ));
-  tabs.add(Tab.withContent(
+  tabs.add(Tab.withLink(
     id: 'admin',
     title: 'Admin',
-    contentHtml: '<h1>Admin</h1>',
+    href: urls.pkgAdminUrl(
+      selectedVersion.package,
+      version: selectedVersion.version == package.latestVersion
+          ? null
+          : selectedVersion.version,
+    ),
     isHidden: true,
   ));
   return tabs;

--- a/app/lib/frontend/templates/package_admin.dart
+++ b/app/lib/frontend/templates/package_admin.dart
@@ -1,0 +1,95 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import '../../shared/analyzer_client.dart';
+import '../../shared/urls.dart' as urls;
+
+import '../models.dart';
+import '../static_files.dart';
+
+import '_cache.dart';
+import 'layout.dart';
+import 'misc.dart';
+import 'package.dart';
+
+/// Renders the `views/pkg/admin_page` template.
+String renderPkgAdminPage(
+  Package package,
+  List<String> uploaderEmails,
+  PackageVersion version,
+  AnalysisView analysis,
+) {
+  final card = analysis?.card;
+  final versionSegment =
+      package.latestVersion == version.version ? null : version.version;
+
+  final tabs = <Tab>[];
+  if (version.readme != null) {
+    tabs.add(Tab.withLink(
+      id: 'readme',
+      title: 'Readme',
+      href: urls.pkgPageUrl(package.name,
+          version: versionSegment, fragment: '-readme-tab-'),
+    ));
+  }
+  if (version.changelog != null) {
+    tabs.add(Tab.withLink(
+      id: 'changelog',
+      title: 'Changelog',
+      href: urls.pkgPageUrl(package.name,
+          version: versionSegment, fragment: '-changelog-tab-'),
+    ));
+  }
+  if (version.example != null) {
+    tabs.add(Tab.withLink(
+      id: 'example',
+      title: 'Example',
+      href: urls.pkgPageUrl(package.name,
+          version: versionSegment, fragment: '-example-tab-'),
+    ));
+  }
+  tabs.add(Tab.withLink(
+    id: 'installing',
+    title: 'Installing',
+    href: urls.pkgPageUrl(package.name,
+        version: versionSegment, fragment: '-installing-tab-'),
+  ));
+  tabs.add(Tab.withLink(
+    id: 'versions',
+    title: 'Versions',
+    href: urls.pkgVersionsUrl(package.name),
+  ));
+  tabs.add(Tab.withLink(
+      id: 'analysis',
+      titleHtml: renderScoreBox(card?.overallScore,
+          isSkipped: card?.isSkipped ?? false,
+          isNewPackage: package.isNewPackage()),
+      href: urls.pkgPageUrl(package.name,
+          version: versionSegment, fragment: '-analysis-tab-')));
+  tabs.add(Tab.withContent(
+    id: 'admin',
+    title: 'Admin',
+    contentHtml: templateCache.renderTemplate('pkg/admin_page', {
+      'is_discontinued': package.isDiscontinued == true,
+    }),
+  ));
+
+  final values = {
+    'header_html': renderPkgHeader(package, version, analysis),
+    'tabs_html': renderPkgTabs(tabs),
+    'icons': staticUrls.versionsTableIcons,
+    'sidebar_html':
+        renderPkgSidebar(package, version, uploaderEmails, analysis),
+    // TODO: render schema_org_pkgmeta_json
+  };
+  final content = templateCache.renderTemplate('pkg/show', values);
+
+  return renderLayoutPage(
+    PageType.package,
+    content,
+    title: '${package.name} package - Admin',
+    pageData: pkgPageData(package, version),
+    noIndex: true,
+  );
+}

--- a/app/lib/frontend/templates/package_admin.dart
+++ b/app/lib/frontend/templates/package_admin.dart
@@ -21,39 +21,33 @@ String renderPkgAdminPage(
   AnalysisView analysis,
 ) {
   final card = analysis?.card;
-  final versionSegment =
-      package.latestVersion == version.version ? null : version.version;
 
   final tabs = <Tab>[];
   if (version.readme != null) {
     tabs.add(Tab.withLink(
       id: 'readme',
       title: 'Readme',
-      href: urls.pkgPageUrl(package.name,
-          version: versionSegment, fragment: '-readme-tab-'),
+      href: urls.pkgPageUrl(package.name, fragment: '-readme-tab-'),
     ));
   }
   if (version.changelog != null) {
     tabs.add(Tab.withLink(
       id: 'changelog',
       title: 'Changelog',
-      href: urls.pkgPageUrl(package.name,
-          version: versionSegment, fragment: '-changelog-tab-'),
+      href: urls.pkgPageUrl(package.name, fragment: '-changelog-tab-'),
     ));
   }
   if (version.example != null) {
     tabs.add(Tab.withLink(
       id: 'example',
       title: 'Example',
-      href: urls.pkgPageUrl(package.name,
-          version: versionSegment, fragment: '-example-tab-'),
+      href: urls.pkgPageUrl(package.name, fragment: '-example-tab-'),
     ));
   }
   tabs.add(Tab.withLink(
     id: 'installing',
     title: 'Installing',
-    href: urls.pkgPageUrl(package.name,
-        version: versionSegment, fragment: '-installing-tab-'),
+    href: urls.pkgPageUrl(package.name, fragment: '-installing-tab-'),
   ));
   tabs.add(Tab.withLink(
     id: 'versions',
@@ -65,8 +59,7 @@ String renderPkgAdminPage(
       titleHtml: renderScoreBox(card?.overallScore,
           isSkipped: card?.isSkipped ?? false,
           isNewPackage: package.isNewPackage()),
-      href: urls.pkgPageUrl(package.name,
-          version: versionSegment, fragment: '-analysis-tab-')));
+      href: urls.pkgPageUrl(package.name, fragment: '-analysis-tab-')));
   tabs.add(Tab.withContent(
     id: 'admin',
     title: 'Admin',

--- a/app/lib/frontend/templates/package_versions.dart
+++ b/app/lib/frontend/templates/package_versions.dart
@@ -67,20 +67,24 @@ String renderPkgVersionsPage(
   final tabs = <Tab>[];
   if (latestVersion.readme != null) {
     tabs.add(Tab.withLink(
+        id: 'readme',
         title: 'Readme',
         href: urls.pkgPageUrl(package.name, fragment: '-readme-tab-')));
   }
   if (latestVersion.changelog != null) {
     tabs.add(Tab.withLink(
+        id: 'changelog',
         title: 'Changelog',
         href: urls.pkgPageUrl(package.name, fragment: '-changelog-tab-')));
   }
   if (latestVersion.example != null) {
     tabs.add(Tab.withLink(
+        id: 'example',
         title: 'Example',
         href: urls.pkgPageUrl(package.name, fragment: '-example-tab-')));
   }
   tabs.add(Tab.withLink(
+      id: 'installing',
       title: 'Installing',
       href: urls.pkgPageUrl(package.name, fragment: '-installing-tab-')));
   tabs.add(Tab.withContent(
@@ -89,13 +93,15 @@ String renderPkgVersionsPage(
     contentHtml: htmlBlocks.join(),
   ));
   tabs.add(Tab.withLink(
+      id: 'analysis',
       titleHtml: renderScoreBox(card?.overallScore,
           isSkipped: card?.isSkipped ?? false,
           isNewPackage: package.isNewPackage()),
       href: urls.pkgPageUrl(package.name, fragment: '-analysis-tab-')));
   tabs.add(Tab.withLink(
+    id: 'admin',
     title: 'Admin',
-    href: urls.pkgPageUrl(package.name, fragment: '-admin-tab-'),
+    href: urls.pkgAdminUrl(package.name),
     isHidden: true,
   ));
 
@@ -109,9 +115,13 @@ String renderPkgVersionsPage(
   };
   final content = templateCache.renderTemplate('pkg/show', values);
 
-  return renderLayoutPage(PageType.package, content,
-      title: '${package.name} package - All Versions',
-      canonicalUrl: urls.pkgPageUrl(package.name, includeHost: true));
+  return renderLayoutPage(
+    PageType.package,
+    content,
+    title: '${package.name} package - All Versions',
+    canonicalUrl: urls.pkgPageUrl(package.name, includeHost: true),
+    pageData: pkgPageData(package, latestVersion),
+  );
 }
 
 String renderVersionTableRow(PackageVersion version, String downloadUrl) {

--- a/app/lib/frontend/templates/views/pkg/admin_page.mustache
+++ b/app/lib/frontend/templates/views/pkg/admin_page.mustache
@@ -1,0 +1,40 @@
+{{! Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+    for details. All rights reserved. Use of this source code is governed by a
+    BSD-style license that can be found in the LICENSE file. }}
+
+<div id="-admin-unauthenticated">
+  <p>
+    Package administration is for signed-in users only.
+  </p>
+</div>
+
+<div id="-admin-unauthorized">
+  <p>You are not admin of this package.</p>
+</div>
+
+<div id="-admin-authorized">
+  <h2>Admin package</h2>
+
+    {{^is_discontinued}}
+    <div>
+      <p>
+        If you are no longer developing the package, you can mark it as discontinued.
+        Pub site won't run analysis on it, and we won't display it in search results.
+      </p>
+      <ul>
+        <li><a class="-admin-is-discontinued-toggle">Mark as "discontinued".</a></li>
+      </ul>
+    </div>
+    {{/is_discontinued}}
+    {{#is_discontinued}}
+    <div>
+      <p>
+        If you want to continue developing the package, you can remove its discontinued
+        status. Pub site will run analysis on it again, and we will include it in search results.
+      </p>
+      <ul>
+        <li><a class="-admin-is-discontinued-toggle">Remove "discontinued".</a></li>
+      </ul>
+    </div>
+    {{/is_discontinued}}
+</div>

--- a/app/lib/frontend/templates/views/pkg/sidebar.mustache
+++ b/app/lib/frontend/templates/views/pkg/sidebar.mustache
@@ -30,6 +30,4 @@
 
   <h3 class="title">More</h3>
   <p><a href="{{{search_deps_link}}}" rel="nofollow">Packages that depend on {{name}}</a></p>
-
-  <div id="-pub-pkg-admin"></div>
 </aside>

--- a/app/lib/frontend/templates/views/pkg/tabs.mustache
+++ b/app/lib/frontend/templates/views/pkg/tabs.mustache
@@ -3,7 +3,7 @@
     BSD-style license that can be found in the LICENSE file. }}
 <ul class="package-tabs-header">
   {{#tabs}}
-    <li class="{{title_classes}}"{{#has_content}} data-name="-{{id}}-tab-"{{/has_content}} role="button">{{& title_html}}</li>
+    <li class="{{title_classes}}" data-name="-{{id}}-tab-" role="button">{{& title_html}}</li>
   {{/tabs}}
 </ul>
 <div class="main package-tabs-content">

--- a/app/lib/shared/urls.dart
+++ b/app/lib/shared/urls.dart
@@ -58,6 +58,9 @@ String pkgDocUrl(
   return url;
 }
 
+String pkgAdminUrl(String package, {String version}) =>
+    pkgPageUrl(package, version: version) + '/admin';
+
 String pkgVersionsUrl(String package) => pkgPageUrl(package) + '/versions';
 
 String versionsTabUrl(String package) =>

--- a/app/test/frontend/golden/pkg_admin_page_outdated.html
+++ b/app/test/frontend/golden/pkg_admin_page_outdated.html
@@ -6,18 +6,17 @@
     <meta charset="utf-8"/>
     <meta http-equiv="x-ua-compatible" content="ie=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <meta name="robots" content="noindex"/>
     <meta name="twitter:card" content="summary"/>
     <meta name="twitter:site" content="@dart_lang"/>
     <meta property="og:site_name" content="Dart packages"/>
-    <title>foobar_pkg package - All Versions</title>
-    <meta property="og:title" content="foobar_pkg package - All Versions"/>
+    <title>foobar_pkg package - Admin</title>
+    <meta property="og:title" content="foobar_pkg package - Admin"/>
     <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet"/>
     <meta itemprop="image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
     <meta property="og:image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
     <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
     <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/osd.xml?hash=mocked_hash_869379763"/>
-    <link rel="canonical" href="https://pub.dev/packages/foobar_pkg"/>
-    <meta property="og:url" content="https://pub.dev/packages/foobar_pkg"/>
     <meta name="description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
@@ -90,7 +89,7 @@
             <a href="/packages/foobar_pkg/versions/0.2.0-dev">0.2.0-dev</a>
           </span>
           <div class="tags">
-            <span class="package-tag missing" title="Analysis should be ready soon.">[awaiting]</span>
+            <span class="package-tag missing" title="Package version too old, check latest stable.">[outdated]</span>
           </div>
         </div>
       </div>
@@ -108,85 +107,42 @@
           <li class="tab-link" data-name="-installing-tab-" role="button">
             <a href="/packages/foobar_pkg#-installing-tab-">Installing</a>
           </li>
-          <li class="tab-button -active" data-name="-versions-tab-" role="button">Versions</li>
+          <li class="tab-link" data-name="-versions-tab-" role="button">
+            <a href="/packages/foobar_pkg/versions">Versions</a>
+          </li>
           <li class="tab-link" data-name="-analysis-tab-" role="button">
             <a href="/packages/foobar_pkg#-analysis-tab-">
               <div class="score-box">
-                <span class="number -good" title="Analysis and more details.">55</span>
+                <span class="number -rotten" title="Analysis and more details.">0</span>
               </div>
             </a>
           </li>
-          <li class="tab-link -hidden" data-name="-admin-tab-" role="button">
-            <a href="/packages/foobar_pkg/admin">Admin</a>
-          </li>
+          <li class="tab-button -active" data-name="-admin-tab-" role="button">Admin</li>
         </ul>
         <div class="main package-tabs-content">
-          <section class="tab-content -active" data-name="-versions-tab-">
-            <p>The latest dev release was 
-              <a href="#dev">0.2.0-dev</a> on Jan 1, 2014.
-            </p>
-            <h2 id="stable">Stable versions of foobar_pkg</h2>
-            <table class="version-table" data-package="foobar_pkg">
-              <thead>
-                <tr>
-                  <th>Version</th>
-                  <th>Uploaded</th>
-                  <th class="documentation" width="80">Documentation</th>
-                  <th class="archive" width="80">Archive</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr data-version="0.1.1+5">
-                  <td>
-                    <strong>
-                      <a href="/packages/foobar_pkg/versions/0.1.1+5">0.1.1+5</a>
-                    </strong>
-                  </td>
-                  <td>Jan 1, 2014</td>
-                  <td class="documentation">
-                    <a href="/documentation/foobar_pkg/0.1.1+5/" rel="nofollow" title="Go to the documentation of foobar_pkg 0.1.1+5">
-                      <img src="/static/img/ic_drive_document_black_24dp.svg?hash=mocked_hash_663394799" alt="Go to the documentation of foobar_pkg 0.1.1+5"/>
-                    </a>
-                  </td>
-                  <td class="archive">
-                    <a href="https://pub.dartlang.org/mock-download-uri.tar.gz" title="Download foobar_pkg 0.1.1+5 archive">
-                      <img src="/static/img/ic_get_app_black_24dp.svg?hash=mocked_hash_341543596" alt="Download foobar_pkg 0.1.1+5 archive"/>
-                    </a>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-            <h2 id="dev">Dev versions of foobar_pkg</h2>
-            <table class="version-table" data-package="foobar_pkg">
-              <thead>
-                <tr>
-                  <th>Version</th>
-                  <th>Uploaded</th>
-                  <th class="documentation" width="80">Documentation</th>
-                  <th class="archive" width="80">Archive</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr data-version="0.2.0-dev">
-                  <td>
-                    <strong>
-                      <a href="/packages/foobar_pkg/versions/0.2.0-dev">0.2.0-dev</a>
-                    </strong>
-                  </td>
-                  <td>Jan 1, 2014</td>
-                  <td class="documentation">
-                    <a href="/documentation/foobar_pkg/0.2.0-dev/" rel="nofollow" title="Go to the documentation of foobar_pkg 0.2.0-dev">
-                      <img src="/static/img/ic_drive_document_black_24dp.svg?hash=mocked_hash_663394799" alt="Go to the documentation of foobar_pkg 0.2.0-dev"/>
-                    </a>
-                  </td>
-                  <td class="archive">
-                    <a href="https://pub.dartlang.org/mock-download-uri.tar.gz" title="Download foobar_pkg 0.2.0-dev archive">
-                      <img src="/static/img/ic_get_app_black_24dp.svg?hash=mocked_hash_341543596" alt="Download foobar_pkg 0.2.0-dev archive"/>
-                    </a>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
+          <section class="tab-content -active" data-name="-admin-tab-">
+            <div id="-admin-unauthenticated">
+              <p>
+    Package administration is for signed-in users only.
+  </p>
+            </div>
+            <div id="-admin-unauthorized">
+              <p>You are not admin of this package.</p>
+            </div>
+            <div id="-admin-authorized">
+              <h2>Admin package</h2>
+              <div>
+                <p>
+        If you are no longer developing the package, you can mark it as discontinued.
+        Pub site won't run analysis on it, and we won't display it in search results.
+      </p>
+                <ul>
+                  <li>
+                    <a class="-admin-is-discontinued-toggle">Mark as "discontinued".</a>
+                  </li>
+                </ul>
+              </div>
+            </div>
           </section>
         </div>
         <aside class="sidebar sidebar-content">

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -98,7 +98,7 @@
           <li class="tab-button" data-name="-changelog-tab-" role="button">Changelog</li>
           <li class="tab-button" data-name="-example-tab-" role="button">Example</li>
           <li class="tab-button" data-name="-installing-tab-" role="button">Installing</li>
-          <li class="tab-link" role="button">
+          <li class="tab-link" data-name="-versions-tab-" role="button">
             <a href="/packages/foobar_pkg/versions">Versions</a>
           </li>
           <li class="tab-button" data-name="-analysis-tab-" role="button">
@@ -106,7 +106,9 @@
               <span class="number -rotten" title="Analysis and more details.">3</span>
             </div>
           </li>
-          <li class="tab-button -hidden" data-name="-admin-tab-" role="button">Admin</li>
+          <li class="tab-link -hidden" data-name="-admin-tab-" role="button">
+            <a href="/packages/foobar_pkg/admin">Admin</a>
+          </li>
         </ul>
         <div class="main package-tabs-content">
           <section class="tab-content -active markdown-body" data-name="-readme-tab-">
@@ -313,9 +315,6 @@ import 'package:foobar_pkg/foolib.dart';
               </table>
             </div>
           </section>
-          <section class="tab-content" data-name="-admin-tab-">
-            <h1>Admin</h1>
-          </section>
         </div>
         <aside class="sidebar sidebar-content">
           <h3 class="title">About</h3>
@@ -359,7 +358,6 @@ import 'package:foobar_pkg/foolib.dart';
           <p>
             <a href="/packages?q=dependency%3Afoobar_pkg" rel="nofollow">Packages that depend on foobar_pkg</a>
           </p>
-          <div id="-pub-pkg-admin"></div>
         </aside>
       </div>
       <script type="application/ld+json">

--- a/app/test/frontend/golden/pkg_show_page_discontinued.html
+++ b/app/test/frontend/golden/pkg_show_page_discontinued.html
@@ -89,7 +89,7 @@
           <li class="tab-button" data-name="-changelog-tab-" role="button">Changelog</li>
           <li class="tab-button" data-name="-example-tab-" role="button">Example</li>
           <li class="tab-button" data-name="-installing-tab-" role="button">Installing</li>
-          <li class="tab-link" role="button">
+          <li class="tab-link" data-name="-versions-tab-" role="button">
             <a href="/packages/foobar_pkg/versions">Versions</a>
           </li>
           <li class="tab-button" data-name="-analysis-tab-" role="button">
@@ -97,7 +97,9 @@
               <span class="number -rotten" title="Analysis and more details.">0</span>
             </div>
           </li>
-          <li class="tab-button -hidden" data-name="-admin-tab-" role="button">Admin</li>
+          <li class="tab-link -hidden" data-name="-admin-tab-" role="button">
+            <a href="/packages/foobar_pkg/admin">Admin</a>
+          </li>
         </ul>
         <div class="main package-tabs-content">
           <section class="tab-content -active markdown-body" data-name="-readme-tab-">
@@ -260,9 +262,6 @@ import 'package:foobar_pkg/foolib.dart';
             <hr/>
             <p>This package is not analyzed, because it is discontinued.</p>
           </section>
-          <section class="tab-content" data-name="-admin-tab-">
-            <h1>Admin</h1>
-          </section>
         </div>
         <aside class="sidebar sidebar-content">
           <h3 class="title">About</h3>
@@ -299,7 +298,6 @@ import 'package:foobar_pkg/foolib.dart';
           <p>
             <a href="/packages?q=dependency%3Afoobar_pkg" rel="nofollow">Packages that depend on foobar_pkg</a>
           </p>
-          <div id="-pub-pkg-admin"></div>
         </aside>
       </div>
       <script type="application/ld+json">

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -97,7 +97,7 @@
           <li class="tab-button -active" data-name="-readme-tab-" role="button">Readme</li>
           <li class="tab-button" data-name="-changelog-tab-" role="button">Changelog</li>
           <li class="tab-button" data-name="-installing-tab-" role="button">Installing</li>
-          <li class="tab-link" role="button">
+          <li class="tab-link" data-name="-versions-tab-" role="button">
             <a href="/packages/foobar_pkg/versions">Versions</a>
           </li>
           <li class="tab-button" data-name="-analysis-tab-" role="button">
@@ -105,7 +105,9 @@
               <span class="number -good" title="Analysis and more details.">65</span>
             </div>
           </li>
-          <li class="tab-button -hidden" data-name="-admin-tab-" role="button">Admin</li>
+          <li class="tab-link -hidden" data-name="-admin-tab-" role="button">
+            <a href="/packages/foobar_pkg/admin">Admin</a>
+          </li>
         </ul>
         <div class="main package-tabs-content">
           <section class="tab-content -active markdown-body" data-name="-readme-tab-">
@@ -270,9 +272,6 @@ import 'package:foobar_pkg/foolib.dart';
             <p>Detected platforms: Flutter</p>
             <blockquote></blockquote>
           </section>
-          <section class="tab-content" data-name="-admin-tab-">
-            <h1>Admin</h1>
-          </section>
         </div>
         <aside class="sidebar sidebar-content">
           <h3 class="title">About</h3>
@@ -309,7 +308,6 @@ import 'package:foobar_pkg/foolib.dart';
           <p>
             <a href="/packages?q=dependency%3Afoobar_pkg" rel="nofollow">Packages that depend on foobar_pkg</a>
           </p>
-          <div id="-pub-pkg-admin"></div>
         </aside>
       </div>
       <script type="application/ld+json">

--- a/app/test/frontend/golden/pkg_show_page_legacy.html
+++ b/app/test/frontend/golden/pkg_show_page_legacy.html
@@ -99,7 +99,7 @@
           <li class="tab-button" data-name="-changelog-tab-" role="button">Changelog</li>
           <li class="tab-button" data-name="-example-tab-" role="button">Example</li>
           <li class="tab-button" data-name="-installing-tab-" role="button">Installing</li>
-          <li class="tab-link" role="button">
+          <li class="tab-link" data-name="-versions-tab-" role="button">
             <a href="/packages/foobar_pkg/versions">Versions</a>
           </li>
           <li class="tab-button" data-name="-analysis-tab-" role="button">
@@ -107,7 +107,9 @@
               <span class="number -rotten" title="Analysis and more details.">25</span>
             </div>
           </li>
-          <li class="tab-button -hidden" data-name="-admin-tab-" role="button">Admin</li>
+          <li class="tab-link -hidden" data-name="-admin-tab-" role="button">
+            <a href="/packages/foobar_pkg/admin">Admin</a>
+          </li>
         </ul>
         <div class="main package-tabs-content">
           <section class="tab-content -active markdown-body" data-name="-readme-tab-">
@@ -288,9 +290,6 @@ import 'package:foobar_pkg/foolib.dart';
               </div>
             </div>
           </section>
-          <section class="tab-content" data-name="-admin-tab-">
-            <h1>Admin</h1>
-          </section>
         </div>
         <aside class="sidebar sidebar-content">
           <h3 class="title">About</h3>
@@ -327,7 +326,6 @@ import 'package:foobar_pkg/foolib.dart';
           <p>
             <a href="/packages?q=dependency%3Afoobar_pkg" rel="nofollow">Packages that depend on foobar_pkg</a>
           </p>
-          <div id="-pub-pkg-admin"></div>
         </aside>
       </div>
       <script type="application/ld+json">

--- a/app/test/frontend/golden/pkg_show_page_outdated.html
+++ b/app/test/frontend/golden/pkg_show_page_outdated.html
@@ -99,7 +99,7 @@
           <li class="tab-button" data-name="-changelog-tab-" role="button">Changelog</li>
           <li class="tab-button" data-name="-example-tab-" role="button">Example</li>
           <li class="tab-button" data-name="-installing-tab-" role="button">Installing</li>
-          <li class="tab-link" role="button">
+          <li class="tab-link" data-name="-versions-tab-" role="button">
             <a href="/packages/foobar_pkg/versions">Versions</a>
           </li>
           <li class="tab-button" data-name="-analysis-tab-" role="button">
@@ -107,7 +107,9 @@
               <span class="number -rotten" title="Analysis and more details.">0</span>
             </div>
           </li>
-          <li class="tab-button -hidden" data-name="-admin-tab-" role="button">Admin</li>
+          <li class="tab-link -hidden" data-name="-admin-tab-" role="button">
+            <a href="/packages/foobar_pkg/admin">Admin</a>
+          </li>
         </ul>
         <div class="main package-tabs-content">
           <section class="tab-content -active markdown-body" data-name="-readme-tab-">
@@ -275,9 +277,6 @@ import 'package:foobar_pkg/foolib.dart';
 
             </p>
           </section>
-          <section class="tab-content" data-name="-admin-tab-">
-            <h1>Admin</h1>
-          </section>
         </div>
         <aside class="sidebar sidebar-content">
           <h3 class="title">About</h3>
@@ -314,7 +313,6 @@ import 'package:foobar_pkg/foolib.dart';
           <p>
             <a href="/packages?q=dependency%3Afoobar_pkg" rel="nofollow">Packages that depend on foobar_pkg</a>
           </p>
-          <div id="-pub-pkg-admin"></div>
         </aside>
       </div>
       <script type="application/ld+json">

--- a/app/test/frontend/golden/pkg_show_version_page.html
+++ b/app/test/frontend/golden/pkg_show_version_page.html
@@ -99,7 +99,7 @@
           <li class="tab-button -active" data-name="-readme-tab-" role="button">Readme</li>
           <li class="tab-button" data-name="-changelog-tab-" role="button">Changelog</li>
           <li class="tab-button" data-name="-installing-tab-" role="button">Installing</li>
-          <li class="tab-link" role="button">
+          <li class="tab-link" data-name="-versions-tab-" role="button">
             <a href="/packages/foobar_pkg/versions">Versions</a>
           </li>
           <li class="tab-button" data-name="-analysis-tab-" role="button">
@@ -107,7 +107,9 @@
               <span class="number -rotten" title="Analysis and more details.">3</span>
             </div>
           </li>
-          <li class="tab-button -hidden" data-name="-admin-tab-" role="button">Admin</li>
+          <li class="tab-link -hidden" data-name="-admin-tab-" role="button">
+            <a href="/packages/foobar_pkg/versions/0.2.0-dev/admin">Admin</a>
+          </li>
         </ul>
         <div class="main package-tabs-content">
           <section class="tab-content -active markdown-body" data-name="-readme-tab-">
@@ -303,9 +305,6 @@ import 'package:foobar_pkg/foolib.dart';
               </table>
             </div>
           </section>
-          <section class="tab-content" data-name="-admin-tab-">
-            <h1>Admin</h1>
-          </section>
         </div>
         <aside class="sidebar sidebar-content">
           <h3 class="title">About</h3>
@@ -349,7 +348,6 @@ import 'package:foobar_pkg/foolib.dart';
           <p>
             <a href="/packages?q=dependency%3Afoobar_pkg" rel="nofollow">Packages that depend on foobar_pkg</a>
           </p>
-          <div id="-pub-pkg-admin"></div>
         </aside>
       </div>
       <script type="application/ld+json">

--- a/app/test/frontend/golden/pkg_show_version_page.html
+++ b/app/test/frontend/golden/pkg_show_version_page.html
@@ -108,7 +108,7 @@
             </div>
           </li>
           <li class="tab-link -hidden" data-name="-admin-tab-" role="button">
-            <a href="/packages/foobar_pkg/versions/0.2.0-dev/admin">Admin</a>
+            <a href="/packages/foobar_pkg/admin">Admin</a>
           </li>
         </ul>
         <div class="main package-tabs-content">

--- a/app/test/frontend/handlers/package_test.dart
+++ b/app/test/frontend/handlers/package_test.dart
@@ -22,6 +22,10 @@ void main() {
           '<h2 class="title">foobar_pkg 0.1.1+5</h2>',
           '<a href="/packages/foobar_pkg">0.1.1+5</a>',
           '<a href="/packages/foobar_pkg/versions/0.2.0-dev">0.2.0-dev</a>',
+          '<li class="tab-link -hidden" data-name="-admin-tab-" role="button">',
+        ],
+        absent: [
+          '<li class="tab-button -active" data-name="-admin-tab-" role="button">',
         ],
       );
     });
@@ -68,6 +72,36 @@ void main() {
         await expectRedirectResponse(
             await issueGet('/packages/foobar_pkg/versions/0.1.2'),
             '/packages/foobar_pkg#-versions-tab-');
+      },
+    );
+
+    testWithServices(
+      '/packages/foobar_pkg/admin',
+      () async {
+        await expectHtmlResponse(
+          await issueGet('/packages/foobar_pkg/admin'),
+          present: [
+            '<li class="tab-button -active" data-name="-admin-tab-" role="button">',
+          ],
+          absent: [
+            '<li class="tab-link -hidden" data-name="-admin-tab-" role="button">',
+          ],
+        );
+      },
+    );
+
+    testWithServices(
+      '/packages/foobar_pkg/versions/0.1.1+5/admin',
+      () async {
+        await expectHtmlResponse(
+          await issueGet('/packages/foobar_pkg/versions/0.1.1+5/admin'),
+          present: [
+            '<li class="tab-button -active" data-name="-admin-tab-" role="button">',
+          ],
+          absent: [
+            '<li class="tab-link -hidden" data-name="-admin-tab-" role="button">',
+          ],
+        );
       },
     );
   });

--- a/app/test/frontend/handlers/package_test.dart
+++ b/app/test/frontend/handlers/package_test.dart
@@ -89,20 +89,5 @@ void main() {
         );
       },
     );
-
-    testWithServices(
-      '/packages/foobar_pkg/versions/0.1.1+5/admin',
-      () async {
-        await expectHtmlResponse(
-          await issueGet('/packages/foobar_pkg/versions/0.1.1+5/admin'),
-          present: [
-            '<li class="tab-button -active" data-name="-admin-tab-" role="button">',
-          ],
-          absent: [
-            '<li class="tab-link -hidden" data-name="-admin-tab-" role="button">',
-          ],
-        );
-      },
-    );
   });
 }

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -25,6 +25,7 @@ import 'package:pub_dartlang_org/frontend/templates/layout.dart';
 import 'package:pub_dartlang_org/frontend/templates/listing.dart';
 import 'package:pub_dartlang_org/frontend/templates/misc.dart';
 import 'package:pub_dartlang_org/frontend/templates/package.dart';
+import 'package:pub_dartlang_org/frontend/templates/package_admin.dart';
 import 'package:pub_dartlang_org/frontend/templates/package_analysis.dart';
 import 'package:pub_dartlang_org/frontend/templates/package_versions.dart';
 
@@ -415,6 +416,21 @@ void main() {
             ),
           ));
       expectGoldenFile(html, 'analysis_tab_outdated.html', isFragment: true);
+    });
+
+    scopedTest('package admin page with outdated version', () {
+      final String html = renderPkgAdminPage(
+          testPackage,
+          testPackageUploaderEmails,
+          testPackageVersion,
+          AnalysisView(
+            card: ScoreCardData(
+              flags: [PackageFlags.isObsolete],
+              updated: DateTime(2018, 02, 05),
+            ),
+          ));
+
+      expectGoldenFile(html, 'pkg_admin_page_outdated.html');
     });
 
     scopedTest('package index page', () {

--- a/pkg/web_app/lib/src/_dom_helper.dart
+++ b/pkg/web_app/lib/src/_dom_helper.dart
@@ -35,6 +35,6 @@ Element elem(
 }
 
 /// Show/hide an element.
-void updateDisplay(Element elem, bool show) {
-  elem.style.display = show ? null : 'none';
+void updateDisplay(Element elem, bool show, {String display}) {
+  elem.style.display = show ? display : 'none';
 }

--- a/pkg/web_app/lib/src/tabs.dart
+++ b/pkg/web_app/lib/src/tabs.dart
@@ -77,6 +77,7 @@ String getTabName(Element elem) {
 void changeTab(String name) {
   final tabOrContentElem = getTabElement(name);
   if (tabOrContentElem != null &&
+      tabOrContentElem.classes.contains('tab-button') &&
       !tabOrContentElem.classes.contains('-hidden')) {
     _headerRoot.children.forEach((node) => _toggle(node, name));
     _contentRoot.children.forEach((node) => _toggle(node, name));
@@ -85,6 +86,9 @@ void changeTab(String name) {
 
 Element getTabElement(String name) => _headerRoot
     .querySelector('[data-name="${Uri.encodeQueryComponent(name)}"]');
+
+bool hasContentTab(String name) =>
+    _contentRoot.children.any((e) => e.dataset['name'] == name);
 
 void _toggle(Element node, String name) {
   if (node.dataset['name'] != name) {

--- a/pkg/web_css/lib/src/_admin.scss
+++ b/pkg/web_css/lib/src/_admin.scss
@@ -1,0 +1,7 @@
+#-admin-unauthorized {
+  display: none;
+}
+
+#-admin-authorized {
+  display: none;
+}

--- a/pkg/web_css/lib/style.scss
+++ b/pkg/web_css/lib/style.scss
@@ -2,6 +2,7 @@
 @import 'src/_base';
 @import 'src/_footer';
 @import 'src/_account';
+@import 'src/_admin';
 @import 'src/_list';
 @import 'src/_home';
 @import 'src/_pkg';


### PR DESCRIPTION
- #1519

- New page on `/packages/<pkg>/admin`.

- The admin tab has new visibility rules:
  - always visible on the admin page
  - becomes visible on other pages if the user has admin rights

- The content of the admin tab has now three blocks:
  - (A): it describes login is needed (default)
  - if the JS code block has authenticated the user, it switches to (B)
  - (B): it describes that the user needs admin rights to access the admin tab
  - if the JS code block has authorized the user, it switches to (C)
  - (C): it has the pre-build HTML blocks of the commands.
- The client-side script will change the visibility of the above blocks, and also hooks-up the event listeners.

- Removed the part which extended the sidebar with the admin command.

- Added a browser-based confirmation that the user really wants to change the status.

- Postponed to a later PR:
  - button-like action button
  - when switch back from discontinued to normal, the analysis is still the old one, we should rather have awaiting status

