### PR TITLE
Fix NPE: modified canonicalizeVersion

### DIFF
--- a/app/lib/frontend/backend.dart
+++ b/app/lib/frontend/backend.dart
@@ -920,6 +920,10 @@ Future<_ValidatedUpload> _parseAndValidateUpload(
   final packageKey = db.emptyKey.append(models.Package, id: pubspec.name);
 
   final versionString = canonicalizeVersion(pubspec.version);
+  if (versionString == null) {
+    throw GenericProcessingException(
+        'Unable to canonicalize the version: ${pubspec.version}');
+  }
 
   final key =
       models.QualifiedVersionKey(package: pubspec.name, version: versionString);

--- a/app/lib/frontend/handlers/package.dart
+++ b/app/lib/frontend/handlers/package.dart
@@ -118,7 +118,7 @@ Future<shelf.Response> packageVersionHandlerHtml(
     final selectedVersion = await backend.lookupPackageVersion(
         packageName, versionName ?? package.latestVersion);
     if (selectedVersion == null) {
-      return redirectResponse(urls.versionsTabUrl(packageName));
+      return redirectResponse(urls.pkgVersionsUrl(packageName));
     }
 
     final Stopwatch serviceSw = Stopwatch()..start();
@@ -156,7 +156,7 @@ Future<shelf.Response> packageAdminHandler(
   final version =
       await backend.lookupPackageVersion(packageName, package.latestVersion);
   if (version == null) {
-    return redirectResponse(urls.versionsTabUrl(packageName));
+    return redirectResponse(urls.pkgVersionsUrl(packageName));
   }
 
   final uploaderEmails =

--- a/app/lib/shared/urls.dart
+++ b/app/lib/shared/urls.dart
@@ -63,9 +63,6 @@ String pkgAdminUrl(String package, {String version}) =>
 
 String pkgVersionsUrl(String package) => pkgPageUrl(package) + '/versions';
 
-String versionsTabUrl(String package) =>
-    pkgPageUrl(package, fragment: '-versions-tab-');
-
 String analysisTabUrl(String package) {
   final String fragment = '-analysis-tab-';
   return package == null

--- a/app/lib/shared/utils.dart
+++ b/app/lib/shared/utils.dart
@@ -47,10 +47,19 @@ Future<T> withTempDirectory<T>(Future<T> func(Directory dir),
   });
 }
 
+/// Returns null if version is invalid or cannot be normalized.
 String canonicalizeVersion(String version) {
+  if (version == null || version.trim().isEmpty) {
+    return null;
+  }
   // NOTE: This is a hack because [semver.Version.parse] does not remove
   // leading zeros for integer fields.
-  final v = semver.Version.parse(version);
+  semver.Version v;
+  try {
+    v = semver.Version.parse(version);
+  } catch (_) {
+    return null;
+  }
   final pre = v.preRelease != null && v.preRelease.isNotEmpty
       ? v.preRelease.join('.')
       : null;
@@ -61,8 +70,7 @@ String canonicalizeVersion(String version) {
       semver.Version(v.major, v.minor, v.patch, pre: pre, build: build);
 
   if (v != canonicalVersion) {
-    throw StateError(
-        'This should never happen: Canonicalization of versions is wrong.');
+    return null;
   }
   return canonicalVersion.toString();
 }

--- a/app/lib/shared/utils.dart
+++ b/app/lib/shared/utils.dart
@@ -57,7 +57,7 @@ String canonicalizeVersion(String version) {
   semver.Version v;
   try {
     v = semver.Version.parse(version);
-  } catch (_) {
+  } on FormatException catch (_) {
     return null;
   }
   final pre = v.preRelease != null && v.preRelease.isNotEmpty

--- a/app/test/frontend/handlers/package_test.dart
+++ b/app/test/frontend/handlers/package_test.dart
@@ -71,7 +71,16 @@ void main() {
       () async {
         await expectRedirectResponse(
             await issueGet('/packages/foobar_pkg/versions/0.1.2'),
-            '/packages/foobar_pkg#-versions-tab-');
+            '/packages/foobar_pkg/versions');
+      },
+    );
+
+    testWithServices(
+      '/packages/foobar_pkg/versions/xyz - bad version',
+      () async {
+        await expectRedirectResponse(
+            await issueGet('/packages/foobar_pkg/versions/xyz'),
+            '/packages/foobar_pkg/versions');
       },
     );
 


### PR DESCRIPTION
- Fixes #2474
- `canonicalizeVersion` now returns null in various failure cases, and the usual lookup afterwards also returns with null. Only the package upload needs to fail hard if the canonicalization fails.
- Also updated redirect url to version page url, removed version tab url.