### PR TITLE
Edit publisher description.

### DIFF
--- a/app/lib/publisher/backend.dart
+++ b/app/lib/publisher/backend.dart
@@ -35,6 +35,7 @@ class PublisherBackend {
 
   /// Checks whether the current authenticated user has admin role of the
   /// publisher, and executes [fn] if it does.
+  /// Otherwise, it throws [UnauthorizedAccessException].
   Future<R> _withPublisherAdmin<R>(
       String publisherId, Future<R> fn(Publisher p)) async {
     return await withAuthenticatedUser((user) async {
@@ -58,10 +59,10 @@ class PublisherBackend {
   /// Updates the publisher data.
   Future updatePublisherData(String publisherId, String description) async {
     if (description == null) {
-      throw Exception('Description must not be null.');
+      throw ArgumentError.notNull('description');
     }
     if (description.length > 64 * 1024) {
-      throw Exception('Description too long.');
+      throw ArgumentError('Description too long.');
     }
     await _withPublisherAdmin(publisherId, (_) async {
       await _db.withTransaction((tx) async {

--- a/app/lib/publisher/backend.dart
+++ b/app/lib/publisher/backend.dart
@@ -1,0 +1,76 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:gcloud/db.dart';
+import 'package:gcloud/service_scope.dart' as ss;
+import 'package:logging/logging.dart';
+import 'package:pub_server/repository.dart' show UnauthorizedAccessException;
+
+import '../account/backend.dart';
+
+import 'models.dart';
+
+final _logger = Logger('pub.publisher.backend');
+
+/// Sets the publisher backend service.
+void registerPublisherBackend(PublisherBackend backend) =>
+    ss.register(#_publisherBackend, backend);
+
+/// The active publisher backend service.
+PublisherBackend get publisherBackend =>
+    ss.lookup(#_publisherBackend) as PublisherBackend;
+
+/// Represents the backend for the publisher handling and related utilities.
+class PublisherBackend {
+  final DatastoreDB _db;
+
+  PublisherBackend(this._db);
+
+  /// Loads a publisher (or returns null if it does not exists).
+  Future<Publisher> getPublisher(String publisherId) async {
+    final pKey = _db.emptyKey.append(Publisher, id: publisherId);
+    return (await _db.lookup<Publisher>([pKey])).single;
+  }
+
+  /// Checks whether the current authenticated user has admin role of the
+  /// publisher, and executes [fn] if it does.
+  Future<R> _withPublisherAdmin<R>(
+      String publisherId, Future<R> fn(Publisher p)) async {
+    return await withAuthenticatedUser((user) async {
+      final p = await getPublisher(publisherId);
+      if (p == null) {
+        throw Exception('Publisher does not exists.');
+      }
+
+      final member = (await _db.lookup<PublisherMember>(
+              [p.key.append(PublisherMember, id: user.userId)]))
+          .single;
+      if (member == null || member.role != PublisherMemberRole.admin) {
+        _logger.info(
+            'Unauthorized access of Publisher($publisherId) from ${user.email}.');
+        throw UnauthorizedAccessException('User is not an admin.');
+      }
+      return await fn(p);
+    });
+  }
+
+  /// Updates the publisher data.
+  Future updatePublisherData(String publisherId, String description) async {
+    if (description == null) {
+      throw Exception('Description must not be null.');
+    }
+    if (description.length > 64 * 1024) {
+      throw Exception('Description too long.');
+    }
+    await _withPublisherAdmin(publisherId, (_) async {
+      await _db.withTransaction((tx) async {
+        final key = _db.emptyKey.append(Publisher, id: publisherId);
+        final p = (await tx.lookup<Publisher>([key])).single;
+        p.description = description;
+        tx.queueMutations(inserts: [p]);
+        await tx.commit();
+      });
+    });
+  }
+}

--- a/app/lib/publisher/backend.dart
+++ b/app/lib/publisher/backend.dart
@@ -58,9 +58,7 @@ class PublisherBackend {
 
   /// Updates the publisher data.
   Future updatePublisherData(String publisherId, String description) async {
-    if (description == null) {
-      throw ArgumentError.notNull('description');
-    }
+    ArgumentError.checkNotNull(description, 'description');
     if (description.length > 64 * 1024) {
       throw ArgumentError('Description too long.');
     }

--- a/app/test/frontend/backend_test.dart
+++ b/app/test/frontend/backend_test.dart
@@ -303,7 +303,7 @@ void main() {
         final repo = GCloudPackageRepository(db, tarballStorage);
 
         final pkg = testPackage.name;
-        registerAuthenticatedUser(testUploaderUser);
+        registerAuthenticatedUser(testAuthenticatedUserHans);
         final f = repo.addUploader(pkg, 'a@b.com');
         await f.catchError(expectAsync2((e, _) {
           expect(e.toString(), 'Package "null" does not exist');
@@ -427,7 +427,7 @@ void main() {
         final repo = GCloudPackageRepository(db, tarballStorage);
 
         final pkg = testPackage.name;
-        registerAuthenticatedUser(testUploaderUser);
+        registerAuthenticatedUser(testAuthenticatedUserHans);
         final f = repo.removeUploader(pkg, 'a@b.com');
         await f.catchError(expectAsync2((e, _) {
           expect('$e', equals('Package "null" does not exist'));
@@ -448,11 +448,11 @@ void main() {
         final repo = GCloudPackageRepository(db, tarballStorage);
 
         final pkg = testPackage.name;
-        registerAuthenticatedUser(testUploaderUser);
-        registerAccountBackend(
-            AccountBackendMock(authenticatedUsers: [testUploaderUser]));
+        registerAuthenticatedUser(testAuthenticatedUserHans);
+        registerAccountBackend(AccountBackendMock(
+            authenticatedUsers: [testAuthenticatedUserHans]));
         await repo
-            .removeUploader(pkg, testUploaderUser.email)
+            .removeUploader(pkg, testAuthenticatedUserHans.email)
             .catchError(expectAsync2((e, _) {
           expect(e is pub_server.LastUploaderRemoveException, isTrue);
         }));
@@ -471,7 +471,7 @@ void main() {
         final repo = GCloudPackageRepository(db, tarballStorage);
 
         final pkg = testPackage.name;
-        registerAuthenticatedUser(testUploaderUser);
+        registerAuthenticatedUser(testAuthenticatedUserHans);
         registerAccountBackend(AccountBackendMock());
         await repo
             .removeUploader(pkg, 'foo2@bar.com')
@@ -751,7 +751,7 @@ void main() {
             return expectedUploadInfo;
           });
           registerUploadSigner(uploadSignerMock);
-          registerAuthenticatedUser(testUploaderUser);
+          registerAuthenticatedUser(testAuthenticatedUserHans);
           final uploadInfo = await repo.startAsyncUpload(redirectUri);
           expect(identical(uploadInfo, expectedUploadInfo), isTrue);
         });
@@ -779,7 +779,7 @@ void main() {
           final transactionMock = TransactionMock();
           final db = DatastoreDBMock(transactionMock: transactionMock);
           final repo = GCloudPackageRepository(db, tarballStorage);
-          registerAuthenticatedUser(testUploaderUser);
+          registerAuthenticatedUser(testAuthenticatedUserHans);
           final historyBackendMock = HistoryBackendMock();
           registerHistoryBackend(historyBackendMock);
           final Future result = repo.finishAsyncUpload(redirectUri);
@@ -830,9 +830,9 @@ void main() {
                 queryMock: queryMock);
             final db = DatastoreDBMock(transactionMock: transactionMock);
             final repo = GCloudPackageRepository(db, tarballStorage);
-            registerAuthenticatedUser(testUploaderUser);
-            registerAccountBackend(
-                AccountBackendMock(authenticatedUsers: [testUploaderUser]));
+            registerAuthenticatedUser(testAuthenticatedUserHans);
+            registerAccountBackend(AccountBackendMock(
+                authenticatedUsers: [testAuthenticatedUserHans]));
             final emailSenderMock = EmailSenderMock();
             registerEmailSender(emailSenderMock);
             registerHistoryBackend(HistoryBackendMock());
@@ -922,7 +922,7 @@ void main() {
           final transactionMock = TransactionMock();
           final db = DatastoreDBMock(transactionMock: transactionMock);
           final repo = GCloudPackageRepository(db, tarballStorage);
-          registerAuthenticatedUser(testUploaderUser);
+          registerAuthenticatedUser(testAuthenticatedUserHans);
           registerNameTracker(NameTracker(null));
           nameTracker.add('foobar_pkg');
 
@@ -964,7 +964,7 @@ void main() {
           final transactionMock = TransactionMock();
           final db = DatastoreDBMock(transactionMock: transactionMock);
           final repo = GCloudPackageRepository(db, tarballStorage);
-          registerAuthenticatedUser(testUploaderUser);
+          registerAuthenticatedUser(testAuthenticatedUserHans);
           registerAnalyzerClient(AnalyzerClientMock());
           registerDartdocClient(DartdocClientMock());
           final historyBackendMock = HistoryBackendMock();
@@ -1026,11 +1026,11 @@ void main() {
 
             final db = DatastoreDBMock(transactionMock: transactionMock);
             final repo = GCloudPackageRepository(db, tarballStorage);
-            registerAuthenticatedUser(testUploaderUser);
+            registerAuthenticatedUser(testAuthenticatedUserHans);
             registerAnalyzerClient(AnalyzerClientMock());
             registerDartdocClient(DartdocClientMock());
-            registerAccountBackend(
-                AccountBackendMock(authenticatedUsers: [testUploaderUser]));
+            registerAccountBackend(AccountBackendMock(
+                authenticatedUsers: [testAuthenticatedUserHans]));
             registerHistoryBackend(HistoryBackendMock());
             final emailSenderMock = EmailSenderMock();
             registerEmailSender(emailSenderMock);

--- a/app/test/frontend/utils.dart
+++ b/app/test/frontend/utils.dart
@@ -44,11 +44,11 @@ final testUserA = User()
   ..email = 'a@example.com'
   ..created = DateTime(2019, 01, 01);
 
-final testUploaderUser =
+final testAuthenticatedUserHans =
     AuthenticatedUser('hans-at-juergen-dot-com', 'hans@juergen.com');
 
 Package createTestPackage({List<AuthenticatedUser> uploaders}) {
-  uploaders ??= [testUploaderUser];
+  uploaders ??= [testAuthenticatedUserHans];
   return Package()
     ..parentKey = testPackageKey.parent
     ..id = testPackageKey.id
@@ -63,10 +63,10 @@ Package createTestPackage({List<AuthenticatedUser> uploaders}) {
 
 final Package testPackage = createTestPackage()
   ..latestDevVersionKey = devPackageVersionKey;
-final testPackageUploaderEmails = [testUploaderUser.email];
+final testPackageUploaderEmails = [testAuthenticatedUserHans.email];
 
 final Package discontinuedPackage = createTestPackage()..isDiscontinued = true;
-final discontinuedPackageUploaderEmails = [testUploaderUser.email];
+final discontinuedPackageUploaderEmails = [testAuthenticatedUserHans.email];
 
 final PackageVersion testPackageVersion = PackageVersion()
   ..parentKey = testPackageVersionKey.parent

--- a/app/test/publisher/backend_test.dart
+++ b/app/test/publisher/backend_test.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:gcloud/db.dart';
-import 'package:pub_server/repository.dart' show UnauthorizedAccessException;
 import 'package:test/test.dart';
 
 import 'package:pub_dartlang_org/account/backend.dart';

--- a/app/test/publisher/backend_test.dart
+++ b/app/test/publisher/backend_test.dart
@@ -1,0 +1,90 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:gcloud/db.dart';
+import 'package:test/test.dart';
+
+import 'package:pub_dartlang_org/account/backend.dart';
+import 'package:pub_dartlang_org/publisher/backend.dart';
+import 'package:pub_dartlang_org/publisher/models.dart';
+
+import '../frontend/utils.dart';
+import '../shared/test_services.dart';
+
+void main() {
+  group('PublisherBackend', () {
+    group('Update description', () {
+      testWithServices('No active user', () async {
+        await publisherBackend
+            .updatePublisherData('example.com', 'new description')
+            .catchError(expectAsync1((e) {
+          expect('$e', 'UnauthorizedAccess: No active user.');
+        }));
+        final p = await publisherBackend.getPublisher('example.com');
+        expect(p, isNull);
+      });
+
+      testWithServices('No publisher with given id', () async {
+        registerAuthenticatedUser(testAuthenticatedUserHans);
+        await publisherBackend
+            .updatePublisherData('example.com', 'new description')
+            .catchError(expectAsync1((e) {
+          expect('$e', 'Exception: Publisher does not exists.');
+        }));
+        final p = await publisherBackend.getPublisher('example.com');
+        expect(p, isNull);
+      });
+
+      testWithServices('Not a member', () async {
+        await dbService.commit(inserts: [testPublisher]);
+        registerAuthenticatedUser(testAuthenticatedUserHans);
+        await publisherBackend
+            .updatePublisherData('example.com', 'new description')
+            .catchError(expectAsync1((e) {
+          expect('$e', 'UnauthorizedAccess: User is not an admin.');
+        }));
+        final p = await publisherBackend.getPublisher('example.com');
+        expect(p.description, testPublisher.description);
+      });
+
+      testWithServices('Not an admin yet', () async {
+        await dbService.commit(inserts: [
+          testPublisher,
+          testMember(testUserHans.userId, PublisherMemberRole.pending),
+        ]);
+        registerAuthenticatedUser(testAuthenticatedUserHans);
+        await publisherBackend
+            .updatePublisherData('example.com', 'new description')
+            .catchError(expectAsync1((e) {
+          expect('$e', 'UnauthorizedAccess: User is not an admin.');
+        }));
+        final p = await publisherBackend.getPublisher('example.com');
+        expect(p.description, testPublisher.description);
+      });
+
+      testWithServices('OK', () async {
+        await dbService.commit(inserts: [
+          testPublisher,
+          testMember(testUserHans.userId, PublisherMemberRole.admin),
+        ]);
+        registerAuthenticatedUser(testAuthenticatedUserHans);
+        await publisherBackend.updatePublisherData(
+            'example.com', 'new description');
+        final p = await publisherBackend.getPublisher('example.com');
+        expect(p.description, 'new description');
+      });
+    });
+  });
+}
+
+final testPublisher = Publisher()
+  ..id = 'example.com'
+  ..description = 'This is us!'
+  ..created = DateTime(2019, 07, 15)
+  ..updated = DateTime(2019, 07, 16);
+
+PublisherMember testMember(String userId, String role) => PublisherMember()
+  ..parentKey = testPublisher.key
+  ..id = userId
+  ..role = role;

--- a/app/test/shared/test_services.dart
+++ b/app/test/shared/test_services.dart
@@ -11,6 +11,7 @@ import 'package:pub_dartlang_org/account/backend.dart';
 import 'package:pub_dartlang_org/account/testing/fake_auth_provider.dart';
 import 'package:pub_dartlang_org/dartdoc/backend.dart';
 import 'package:pub_dartlang_org/frontend/backend.dart';
+import 'package:pub_dartlang_org/publisher/backend.dart';
 import 'package:pub_dartlang_org/scorecard/backend.dart';
 import 'package:pub_dartlang_org/shared/analyzer_client.dart';
 import 'package:pub_dartlang_org/shared/configuration.dart';
@@ -50,6 +51,7 @@ void testWithServices(String name, Future fn()) {
       registerBackend(
           Backend(db, TarballStorage(storage, tarballBucket, null)));
       registerDartdocBackend(DartdocBackend(db, storage.bucket('dartdoc')));
+      registerPublisherBackend(PublisherBackend(db));
       registerScoreCardBackend(ScoreCardBackend(db));
 
       await fn();


### PR DESCRIPTION
- #1518
- This is also to create some initial infrastructure (backend registration, test with fake_gcloud).
- TBD:
  - API endpoint
  - `websiteUrl` (should we delete the field or rather update it in the same operation as the description).