### PR TITLE
Generic exception handler wrappers.

### DIFF
--- a/app/lib/frontend/request_context.dart
+++ b/app/lib/frontend/request_context.dart
@@ -14,6 +14,9 @@ RequestContext get requestContext =>
 
 /// Holds flags for request context.
 class RequestContext {
+  /// Whether the handler is expected to emit a JSON response.
+  final bool emitsJsonResponse;
+
   /// Whether the JSON responses should be indented.
   final bool indentJson;
 
@@ -28,6 +31,7 @@ class RequestContext {
   final bool uiCacheEnabled;
 
   const RequestContext({
+    this.emitsJsonResponse = false,
     this.indentJson = false,
     this.isExperimental = false,
     this.blockRobots = true,

--- a/app/lib/frontend/request_context.dart
+++ b/app/lib/frontend/request_context.dart
@@ -14,9 +14,6 @@ RequestContext get requestContext =>
 
 /// Holds flags for request context.
 class RequestContext {
-  /// Whether the handler is expected to emit a JSON response.
-  final bool emitsJsonResponse;
-
   /// Whether the JSON responses should be indented.
   final bool indentJson;
 
@@ -31,7 +28,6 @@ class RequestContext {
   final bool uiCacheEnabled;
 
   const RequestContext({
-    this.emitsJsonResponse = false,
     this.indentJson = false,
     this.isExperimental = false,
     this.blockRobots = true,

--- a/app/lib/shared/handler_helpers.dart
+++ b/app/lib/shared/handler_helpers.dart
@@ -87,12 +87,7 @@ shelf.Handler _requestContextWrapper(shelf.Handler handler) {
         (!activeConfiguration.blockRobots && isProductionHost);
     final uiCacheEnabled = isPrimaryHost && !hasExperimentalCookie;
 
-    final path = request.requestedUri.path;
-    final isApi = path.startsWith('/api/') && !path.endsWith('.tar.gz');
-    final emitsJsonResponse = isApi || path.endsWith('.json');
-
     registerRequestContext(RequestContext(
-      emitsJsonResponse: emitsJsonResponse,
       indentJson: indentJson,
       isExperimental: isExperimental,
       blockRobots: !enableRobots,
@@ -141,7 +136,9 @@ shelf.Handler _logRequestWrapper(Logger logger, shelf.Handler handler) {
 
 shelf.Handler _exceptionHandlerWrapper(Logger logger, shelf.Handler handler) {
   return (shelf.Request request) async {
-    if (requestContext.emitsJsonResponse) {
+    final acceptHeader = request.headers['accept'];
+    final isJson = acceptHeader != null && acceptHeader.contains('application/json');
+    if (isJson) {
       try {
         return await handler(request);
       } on UnauthorizedAccessException catch (_) {

--- a/app/lib/shared/handler_helpers.dart
+++ b/app/lib/shared/handler_helpers.dart
@@ -137,7 +137,8 @@ shelf.Handler _logRequestWrapper(Logger logger, shelf.Handler handler) {
 shelf.Handler _exceptionHandlerWrapper(Logger logger, shelf.Handler handler) {
   return (shelf.Request request) async {
     final acceptHeader = request.headers['accept'];
-    final isJson = acceptHeader != null && acceptHeader.contains('application/json');
+    final isJson =
+        acceptHeader != null && acceptHeader.contains('application/json');
     if (isJson) {
       try {
         return await handler(request);


### PR DESCRIPTION
Not entirely sure if the current `emitsJsonResponse` flag handles everything, but we can fix it as we go ahead with the handler-level tests.