### PR TITLE
Rename test model variables.

### DIFF
--- a/app/test/frontend/backend_test_utils.dart
+++ b/app/test/frontend/backend_test_utils.dart
@@ -380,9 +380,9 @@ Future withTestPackage(Future func(List<int> tarball),
     final changelog = File('$tmp/CHANGELOG.md');
     final pubspec = File('$tmp/pubspec.yaml');
 
-    await readme.writeAsString(testPackageReadme);
-    await changelog.writeAsString(testPackageChangelog);
-    await pubspec.writeAsString(pubspecContent ?? testPackagePubspec);
+    await readme.writeAsString(foobarReadmeContent);
+    await changelog.writeAsString(foobarChangelogContent);
+    await pubspec.writeAsString(pubspecContent ?? foobarStablePubspec);
 
     await Directory('$tmp/lib').create();
     File('$tmp/lib/test_library.dart')

--- a/app/test/frontend/handlers/atom_feed_test.dart
+++ b/app/test/frontend/handlers/atom_feed_test.dart
@@ -29,7 +29,7 @@ void main() {
         <entry>
           <id>urn:uuid:ebaa25c2-6b0c-5829-a686-dc55c2bbd8e4</id>
           <title>v0.1.1\\+5 of foobar_pkg</title>
-          <updated>${testPackageVersion.created.toIso8601String()}</updated>
+          <updated>${foobarStablePV.created.toIso8601String()}</updated>
           <author><name>Hans Juergen &lt;hans@juergen.com&gt;</name></author>
           <content type="html">&lt;h1&gt;Test Package&lt;&#47;h1&gt;
 &lt;p&gt;This is a readme file.&lt;&#47;p&gt;

--- a/app/test/frontend/handlers/custom_api_test.dart
+++ b/app/test/frontend/handlers/custom_api_test.dart
@@ -25,7 +25,7 @@ void main() {
               'name': 'foobar_pkg',
               'latest': {
                 'version': '0.1.1+5',
-                'pubspec': loadYaml(testPackagePubspec),
+                'pubspec': loadYaml(foobarStablePubspec),
                 'archive_url': 'https://pub.dartlang.org'
                     '/packages/foobar_pkg/versions/0.1.1%2B5.tar.gz',
                 'package_url': 'https://pub.dartlang.org'

--- a/app/test/frontend/handlers/landing_test.dart
+++ b/app/test/frontend/handlers/landing_test.dart
@@ -32,13 +32,13 @@ void main() {
         return SearchResultPage(
           query,
           1,
-          [PackageView.fromModel(version: testPackageVersion)],
+          [PackageView.fromModel(version: foobarStablePV)],
         );
       }));
       final backend = BackendMock(latestPackageVersionsFun: ({offset, limit}) {
         expect(offset, isNull);
         expect(limit, equals(5));
-        return [testPackageVersion];
+        return [foobarStablePV];
       });
       registerBackend(backend);
       registerAnalyzerClient(AnalyzerClientMock());
@@ -66,13 +66,13 @@ void main() {
         return SearchResultPage(
           query,
           1,
-          [PackageView.fromModel(version: testPackageVersion)],
+          [PackageView.fromModel(version: foobarStablePV)],
         );
       }));
       final backend = BackendMock(latestPackageVersionsFun: ({offset, limit}) {
         expect(offset, isNull);
         expect(limit, equals(5));
-        return [testPackageVersion];
+        return [foobarStablePV];
       });
       registerBackend(backend);
       registerAnalyzerClient(AnalyzerClientMock());
@@ -91,7 +91,7 @@ void main() {
         return SearchResultPage(
           query,
           1,
-          [PackageView.fromModel(version: testPackageVersion)],
+          [PackageView.fromModel(version: foobarStablePV)],
         );
       }));
       await expectNotFoundResponse(await issueGet('/xxx'));

--- a/app/test/frontend/handlers/listing_test.dart
+++ b/app/test/frontend/handlers/listing_test.dart
@@ -32,11 +32,11 @@ void main() {
           BackendMock(latestPackagesFun: ({offset, limit, detectedType}) {
         expect(offset, 0);
         expect(limit, greaterThan(pageSize));
-        return [testPackage];
+        return [foobarPackage];
       }, lookupLatestVersionsFun: (List<Package> packages) {
         expect(packages.length, 1);
-        expect(packages.first, testPackage);
-        return [testPackageVersion];
+        expect(packages.first, foobarPackage);
+        return [foobarStablePV];
       });
       registerBackend(backend);
       await expectJsonResponse(await issueGet('/packages.json'), body: {
@@ -48,10 +48,10 @@ void main() {
     tScopedTest('/packages/foobar_pkg.json', () async {
       final backend = BackendMock(lookupPackageFun: (String package) {
         expect(package, 'foobar_pkg');
-        return testPackage;
+        return foobarPackage;
       }, versionsOfPackageFun: (String package) {
         expect(package, 'foobar_pkg');
-        return [testPackageVersion];
+        return [foobarStablePV];
       });
       registerAccountBackend(AccountBackendMock(users: [
         User()
@@ -78,20 +78,20 @@ void main() {
           expect(query.isAd, isFalse);
           return SearchResultPage(query, 1, [
             PackageView.fromModel(
-                package: testPackage,
-                version: testPackageVersion,
+                package: foobarPackage,
+                version: foobarStablePV,
                 scoreCard: null)
           ]);
         },
       ));
       final backend = BackendMock(
         lookupPackageFun: (packageName) {
-          return packageName == testPackage.name ? testPackage : null;
+          return packageName == foobarPackage.name ? foobarPackage : null;
         },
         lookupLatestVersionsFun: (List<Package> packages) {
           expect(packages.length, 1);
-          expect(packages.first, testPackage);
-          return [testPackageVersion];
+          expect(packages.first, foobarPackage);
+          return [foobarStablePV];
         },
       );
       registerBackend(backend);
@@ -109,20 +109,20 @@ void main() {
           expect(query.isAd, isFalse);
           return SearchResultPage(query, 1, [
             PackageView.fromModel(
-                package: testPackage,
-                version: testPackageVersion,
+                package: foobarPackage,
+                version: foobarStablePV,
                 scoreCard: null)
           ]);
         },
       ));
       final backend = BackendMock(
         lookupPackageFun: (packageName) {
-          return packageName == testPackage.name ? testPackage : null;
+          return packageName == foobarPackage.name ? foobarPackage : null;
         },
         lookupLatestVersionsFun: (List<Package> packages) {
           expect(packages.length, 1);
-          expect(packages.first, testPackage);
-          return [testPackageVersion];
+          expect(packages.first, foobarPackage);
+          return [foobarStablePV];
         },
       );
       registerBackend(backend);
@@ -137,12 +137,12 @@ void main() {
       nameTracker.markReady();
       final backend = BackendMock(
         lookupPackageFun: (packageName) {
-          return packageName == testPackage.name ? testPackage : null;
+          return packageName == foobarPackage.name ? foobarPackage : null;
         },
         lookupLatestVersionsFun: (List<Package> packages) {
           expect(packages.length, 1);
-          expect(packages.first, testPackage);
-          return [testPackageVersion];
+          expect(packages.first, foobarPackage);
+          return [foobarStablePV];
         },
       );
       registerBackend(backend);
@@ -162,20 +162,20 @@ void main() {
           expect(query.isAd, isFalse);
           return SearchResultPage(query, 1, [
             PackageView.fromModel(
-                package: testPackage,
-                version: testPackageVersion,
+                package: foobarPackage,
+                version: foobarStablePV,
                 scoreCard: null)
           ]);
         },
       ));
       final backend = BackendMock(
         lookupPackageFun: (packageName) {
-          return packageName == testPackage.name ? testPackage : null;
+          return packageName == foobarPackage.name ? foobarPackage : null;
         },
         lookupLatestVersionsFun: (List<Package> packages) {
           expect(packages.length, 1);
-          expect(packages.first, testPackage);
-          return [testPackageVersion];
+          expect(packages.first, foobarPackage);
+          return [foobarStablePV];
         },
       );
       registerBackend(backend);
@@ -192,20 +192,20 @@ void main() {
           expect(query.isAd, isFalse);
           return SearchResultPage(query, 1, [
             PackageView.fromModel(
-                package: testPackage,
-                version: testPackageVersion,
+                package: foobarPackage,
+                version: foobarStablePV,
                 scoreCard: null)
           ]);
         },
       ));
       final backend = BackendMock(
         lookupPackageFun: (packageName) {
-          return packageName == testPackage.name ? testPackage : null;
+          return packageName == foobarPackage.name ? foobarPackage : null;
         },
         lookupLatestVersionsFun: (List<Package> packages) {
           expect(packages.length, 1);
-          expect(packages.first, testPackage);
-          return [testPackageVersion];
+          expect(packages.first, foobarPackage);
+          return [foobarStablePV];
         },
       );
       registerBackend(backend);
@@ -222,20 +222,20 @@ void main() {
           expect(query.isAd, isFalse);
           return SearchResultPage(query, 1, [
             PackageView.fromModel(
-                package: testPackage,
-                version: testPackageVersion,
+                package: foobarPackage,
+                version: foobarStablePV,
                 scoreCard: null)
           ]);
         },
       ));
       final backend = BackendMock(
         lookupPackageFun: (packageName) {
-          return packageName == testPackage.name ? testPackage : null;
+          return packageName == foobarPackage.name ? foobarPackage : null;
         },
         lookupLatestVersionsFun: (List<Package> packages) {
           expect(packages.length, 1);
-          expect(packages.first, testPackage);
-          return [testPackageVersion];
+          expect(packages.first, foobarPackage);
+          return [foobarStablePV];
         },
       );
       registerBackend(backend);

--- a/app/test/frontend/models_test.dart
+++ b/app/test/frontend/models_test.dart
@@ -13,13 +13,12 @@ void main() {
   group('models', () {
     group('Package', () {
       test('only dev version', () {
-        final devVersion =
-            testPackageKey.append(PackageVersion, id: '0.0.1-dev');
+        final devVersion = foobarPkgKey.append(PackageVersion, id: '0.0.1-dev');
         final Package p = Package()
           ..latestVersionKey = devVersion
           ..latestDevVersionKey = devVersion;
         p.updateVersion(PackageVersion()
-          ..parentKey = testPackageKey
+          ..parentKey = foobarPkgKey
           ..id = '0.2.0-dev'
           ..version = '0.2.0-dev');
         expect(p.latestVersion, '0.2.0-dev');
@@ -27,13 +26,12 @@ void main() {
       });
 
       test('update old with only dev version', () {
-        final devVersion =
-            testPackageKey.append(PackageVersion, id: '1.0.0-dev');
+        final devVersion = foobarPkgKey.append(PackageVersion, id: '1.0.0-dev');
         final Package p = Package()
           ..latestVersionKey = devVersion
           ..latestDevVersionKey = devVersion;
         p.updateVersion(PackageVersion()
-          ..parentKey = testPackageKey
+          ..parentKey = foobarPkgKey
           ..id = '0.2.1-dev'
           ..version = '0.2.1-dev');
         expect(p.latestVersion, '1.0.0-dev');
@@ -41,13 +39,12 @@ void main() {
       });
 
       test('stable after dev', () {
-        final devVersion =
-            testPackageKey.append(PackageVersion, id: '1.0.0-dev');
+        final devVersion = foobarPkgKey.append(PackageVersion, id: '1.0.0-dev');
         final Package p = Package()
           ..latestVersionKey = devVersion
           ..latestDevVersionKey = devVersion;
         p.updateVersion(PackageVersion()
-          ..parentKey = testPackageKey
+          ..parentKey = foobarPkgKey
           ..id = '0.2.0'
           ..version = '0.2.0');
         expect(p.latestVersion, '0.2.0');
@@ -56,11 +53,11 @@ void main() {
 
       test('new stable version', () {
         final Package p = Package()
-          ..latestVersionKey = testPackageVersionKey
-          ..latestDevVersionKey = testPackageVersionKey;
+          ..latestVersionKey = foobarStablePVKey
+          ..latestDevVersionKey = foobarStablePVKey;
         expect(p.latestVersion, '0.1.1+5');
         p.updateVersion(PackageVersion()
-          ..parentKey = testPackageKey
+          ..parentKey = foobarPkgKey
           ..id = '0.2.0'
           ..version = '0.2.0');
         expect(p.latestVersion, '0.2.0');
@@ -69,11 +66,11 @@ void main() {
 
       test('update old stable version', () {
         final Package p = Package()
-          ..latestVersionKey = testPackageVersionKey
-          ..latestDevVersionKey = testPackageVersionKey;
+          ..latestVersionKey = foobarStablePVKey
+          ..latestDevVersionKey = foobarStablePVKey;
         expect(p.latestVersion, '0.1.1+5');
         p.updateVersion(PackageVersion()
-          ..parentKey = testPackageKey
+          ..parentKey = foobarPkgKey
           ..id = '0.1.0'
           ..version = '0.1.0');
         expect(p.latestVersion, '0.1.1+5');
@@ -82,11 +79,11 @@ void main() {
 
       test('new dev version', () {
         final Package p = Package()
-          ..latestVersionKey = testPackageVersionKey
-          ..latestDevVersionKey = testPackageVersionKey;
+          ..latestVersionKey = foobarStablePVKey
+          ..latestDevVersionKey = foobarStablePVKey;
         expect(p.latestVersion, '0.1.1+5');
         p.updateVersion(PackageVersion()
-          ..parentKey = testPackageKey
+          ..parentKey = foobarPkgKey
           ..id = '1.0.0-dev'
           ..version = '1.0.0-dev');
         expect(p.latestVersion, '0.1.1+5');
@@ -95,19 +92,19 @@ void main() {
 
       test('new dev version, then a stable patch', () {
         final Package p = Package()
-          ..latestVersionKey = testPackageVersionKey
-          ..latestDevVersionKey = testPackageVersionKey;
+          ..latestVersionKey = foobarStablePVKey
+          ..latestDevVersionKey = foobarStablePVKey;
         expect(p.latestVersion, '0.1.1+5');
 
         p.updateVersion(PackageVersion()
-          ..parentKey = testPackageKey
+          ..parentKey = foobarPkgKey
           ..id = '1.0.0-dev'
           ..version = '1.0.0-dev');
         expect(p.latestVersion, '0.1.1+5');
         expect(p.latestDevVersion, '1.0.0-dev');
 
         p.updateVersion(PackageVersion()
-          ..parentKey = testPackageKey
+          ..parentKey = foobarPkgKey
           ..id = '0.2.0'
           ..version = '0.2.0');
         expect(p.latestVersion, '0.2.0');

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -88,8 +88,8 @@ void main() {
     scopedTest('index page', () {
       final popularHtml = renderMiniList([
         PackageView.fromModel(
-          package: testPackage,
-          version: testPackageVersion,
+          package: foobarPackage,
+          version: foobarStablePV,
           scoreCard: ScoreCardData(
             platformTags: ['web'],
             reportTypes: ['pana'],
@@ -103,8 +103,8 @@ void main() {
     scopedTest('landing page flutter', () {
       final popularHtml = renderMiniList([
         PackageView.fromModel(
-          package: testPackage,
-          version: testPackageVersion,
+          package: foobarPackage,
+          version: foobarStablePV,
           scoreCard: ScoreCardData(
             platformTags: ['flutter'],
             reportTypes: ['pana'],
@@ -118,8 +118,8 @@ void main() {
     scopedTest('landing page web', () {
       final popularHtml = renderMiniList([
         PackageView.fromModel(
-          package: testPackage,
-          version: testPackageVersion,
+          package: foobarPackage,
+          version: foobarStablePV,
           scoreCard: ScoreCardData(
             platformTags: ['web'],
             reportTypes: ['pana'],
@@ -132,9 +132,9 @@ void main() {
 
     scopedTest('package show page', () {
       final String html = renderPkgShowPage(
-          testPackage,
-          testPackageUploaderEmails,
-          testPackageVersion,
+          foobarPackage,
+          foobarUploaderEmails,
+          foobarStablePV,
           AnalysisView(
             card: ScoreCardData(reportTypes: ['pana'], healthScore: 0.1),
             panaReport: PanaReport(
@@ -178,9 +178,9 @@ void main() {
 
     scopedTest('package show page - with version', () {
       final String html = renderPkgShowPage(
-          testPackage,
-          testPackageUploaderEmails,
-          devPackageVersion,
+          foobarPackage,
+          foobarUploaderEmails,
+          foobarDevPV,
           AnalysisView(
             card: ScoreCardData(reportTypes: ['pana'], healthScore: 0.1),
             panaReport: PanaReport(
@@ -223,8 +223,8 @@ void main() {
 
     scopedTest('package show page with flutter_plugin', () {
       final String html = renderPkgShowPage(
-        testPackage,
-        testPackageUploaderEmails,
+        foobarPackage,
+        foobarUploaderEmails,
         flutterPackageVersion,
         AnalysisView(
           card: ScoreCardData(
@@ -256,9 +256,9 @@ void main() {
 
     scopedTest('package show page with outdated version', () {
       final String html = renderPkgShowPage(
-          testPackage,
-          testPackageUploaderEmails,
-          testPackageVersion,
+          foobarPackage,
+          foobarUploaderEmails,
+          foobarStablePV,
           AnalysisView(
             card: ScoreCardData(
               flags: [PackageFlags.isObsolete],
@@ -272,8 +272,8 @@ void main() {
     scopedTest('package show page with discontinued version', () {
       final String html = renderPkgShowPage(
           discontinuedPackage,
-          discontinuedPackageUploaderEmails,
-          testPackageVersion,
+          foobarUploaderEmails,
+          foobarStablePV,
           AnalysisView(
             card: ScoreCardData(
               flags: [PackageFlags.isDiscontinued],
@@ -286,11 +286,11 @@ void main() {
 
     scopedTest('package show page with legacy version', () {
       final summary = createPanaSummaryForLegacy(
-          testPackageVersion.package, testPackageVersion.version);
+          foobarStablePV.package, foobarStablePV.version);
       final String html = renderPkgShowPage(
-          testPackage,
-          testPackageUploaderEmails,
-          testPackageVersion,
+          foobarPackage,
+          foobarUploaderEmails,
+          foobarStablePV,
           AnalysisView(
             card: ScoreCardData(
               popularityScore: 0.5,
@@ -420,9 +420,9 @@ void main() {
 
     scopedTest('package admin page with outdated version', () {
       final String html = renderPkgAdminPage(
-          testPackage,
-          testPackageUploaderEmails,
-          testPackageVersion,
+          foobarPackage,
+          foobarUploaderEmails,
+          foobarStablePV,
           AnalysisView(
             card: ScoreCardData(
               flags: [PackageFlags.isObsolete],
@@ -436,12 +436,12 @@ void main() {
     scopedTest('package index page', () {
       final String html = renderPkgIndexPage([
         PackageView.fromModel(
-          package: testPackage,
-          version: testPackageVersion,
+          package: foobarPackage,
+          version: foobarStablePV,
           scoreCard: ScoreCardData(),
         ),
         PackageView.fromModel(
-          package: testPackage,
+          package: foobarPackage,
           version: flutterPackageVersion,
           scoreCard: ScoreCardData(
             platformTags: ['flutter'],
@@ -458,8 +458,8 @@ void main() {
       final String html = renderPkgIndexPage(
         [
           PackageView.fromModel(
-            package: testPackage,
-            version: testPackageVersion,
+            package: foobarPackage,
+            version: foobarStablePV,
             scoreCard: ScoreCardData(),
             apiPages: [
               ApiPageRef(path: 'some/some-library.html'),
@@ -467,7 +467,7 @@ void main() {
             ],
           ),
           PackageView.fromModel(
-            package: testPackage,
+            package: foobarPackage,
             version: flutterPackageVersion,
             scoreCard: ScoreCardData(
               platformTags: ['flutter'],
@@ -509,12 +509,12 @@ void main() {
 
     scopedTest('package versions page', () {
       final String html = renderPkgVersionsPage(
-        testPackage,
-        testPackageUploaderEmails,
-        testPackageVersion,
+        foobarPackage,
+        foobarUploaderEmails,
+        foobarStablePV,
         [
-          testPackageVersion,
-          devPackageVersion,
+          foobarStablePV,
+          foobarDevPV,
         ],
         [
           Uri.parse('https://pub.dartlang.org/mock-download-uri.tar.gz'),

--- a/app/test/publisher/backend_test.dart
+++ b/app/test/publisher/backend_test.dart
@@ -27,7 +27,7 @@ void main() {
       });
 
       testWithServices('No publisher with given id', () async {
-        registerAuthenticatedUser(testAuthenticatedUserHans);
+        registerAuthenticatedUser(hansAuthenticated);
         await expectLater(
           publisherBackend.updatePublisherData(
               'example.com', 'new description'),
@@ -39,8 +39,8 @@ void main() {
       });
 
       testWithServices('Not a member', () async {
-        await dbService.commit(inserts: [testPublisher]);
-        registerAuthenticatedUser(testAuthenticatedUserHans);
+        await dbService.commit(inserts: [exampleComPublisher]);
+        registerAuthenticatedUser(hansAuthenticated);
         await expectLater(
           publisherBackend.updatePublisherData(
               'example.com', 'new description'),
@@ -48,15 +48,15 @@ void main() {
               'UnauthorizedAccess: User is not an admin.')),
         );
         final p = await publisherBackend.getPublisher('example.com');
-        expect(p.description, testPublisher.description);
+        expect(p.description, exampleComPublisher.description);
       });
 
       testWithServices('Not an admin yet', () async {
         await dbService.commit(inserts: [
-          testPublisher,
-          testPublisherMember(testUserHans.userId, PublisherMemberRole.pending),
+          exampleComPublisher,
+          publisherMember(hansUser.userId, PublisherMemberRole.pending),
         ]);
-        registerAuthenticatedUser(testAuthenticatedUserHans);
+        registerAuthenticatedUser(hansAuthenticated);
         await expectLater(
           publisherBackend.updatePublisherData(
               'example.com', 'new description'),
@@ -64,15 +64,15 @@ void main() {
               'UnauthorizedAccess: User is not an admin.')),
         );
         final p = await publisherBackend.getPublisher('example.com');
-        expect(p.description, testPublisher.description);
+        expect(p.description, exampleComPublisher.description);
       });
 
       testWithServices('OK', () async {
         await dbService.commit(inserts: [
-          testPublisher,
-          testPublisherMember(testUserHans.userId, PublisherMemberRole.admin),
+          exampleComPublisher,
+          publisherMember(hansUser.userId, PublisherMemberRole.admin),
         ]);
-        registerAuthenticatedUser(testAuthenticatedUserHans);
+        registerAuthenticatedUser(hansAuthenticated);
         await publisherBackend.updatePublisherData(
             'example.com', 'new description');
         final p = await publisherBackend.getPublisher('example.com');

--- a/app/test/shared/test_models.dart
+++ b/app/test/shared/test_models.dart
@@ -10,17 +10,14 @@ import 'package:pub_dartlang_org/publisher/models.dart';
 import 'package:pub_dartlang_org/frontend/model_properties.dart';
 import 'package:pub_dartlang_org/frontend/models.dart';
 
-final Key testPackageKey =
+final Key foobarPkgKey =
     Key.emptyKey(Partition(null)).append(Package, id: 'foobar_pkg');
 
-final Key testPackageVersionKey =
-    testPackageKey.append(PackageVersion, id: '0.1.1+5');
-final Key devPackageVersionKey =
-    testPackageKey.append(PackageVersion, id: '0.2.0-dev');
+final Key foobarStablePVKey =
+    foobarPkgKey.append(PackageVersion, id: '0.1.1+5');
+final Key foobarDevPVKey = foobarPkgKey.append(PackageVersion, id: '0.2.0-dev');
 
-final Pubspec testPubspec = Pubspec.fromYaml(testPackagePubspec);
-
-final testUserHans = User()
+final hansUser = User()
   ..id = 'hans-at-juergen-dot-com'
   ..email = 'hans@juergen.com'
   ..created = DateTime.utc(2014);
@@ -29,61 +26,60 @@ final testUserA = User()
   ..email = 'a@example.com'
   ..created = DateTime(2019, 01, 01);
 
-final testAuthenticatedUserHans =
+final hansAuthenticated =
     AuthenticatedUser('hans-at-juergen-dot-com', 'hans@juergen.com');
 
-Package createTestPackage({String name, List<AuthenticatedUser> uploaders}) {
-  name ??= testPackageKey.id as String;
-  uploaders ??= [testAuthenticatedUserHans];
+Package createFoobarPackage({String name, List<AuthenticatedUser> uploaders}) {
+  name ??= foobarPkgKey.id as String;
+  uploaders ??= [hansAuthenticated];
   return Package()
-    ..parentKey = testPackageKey.parent
+    ..parentKey = foobarPkgKey.parent
     ..id = name
     ..name = name
     ..created = DateTime.utc(2014)
     ..updated = DateTime.utc(2015)
     ..uploaders = uploaders.map((user) => user.userId).toList()
-    ..latestVersionKey = testPackageVersionKey
-    ..latestDevVersionKey = testPackageVersionKey
+    ..latestVersionKey = foobarStablePVKey
+    ..latestDevVersionKey = foobarStablePVKey
     ..downloads = 0;
 }
 
-final Package testPackage = createTestPackage()
-  ..latestDevVersionKey = devPackageVersionKey;
-final testPackageUploaderEmails = [testAuthenticatedUserHans.email];
+final Package foobarPackage = createFoobarPackage()
+  ..latestDevVersionKey = foobarDevPVKey;
+final foobarUploaderEmails = [hansAuthenticated.email];
 
-final Package discontinuedPackage = createTestPackage()..isDiscontinued = true;
-final discontinuedPackageUploaderEmails = [testAuthenticatedUserHans.email];
+final Package discontinuedPackage = createFoobarPackage()
+  ..isDiscontinued = true;
 
-final PackageVersion testPackageVersion = PackageVersion()
-  ..parentKey = testPackageVersionKey.parent
-  ..id = testPackageVersionKey.id
-  ..version = testPackageVersionKey.id as String
-  ..packageKey = testPackageKey
+final PackageVersion foobarStablePV = PackageVersion()
+  ..parentKey = foobarStablePVKey.parent
+  ..id = foobarStablePVKey.id
+  ..version = foobarStablePVKey.id as String
+  ..packageKey = foobarPkgKey
   ..created = DateTime.utc(2014)
   ..libraries = ['foolib.dart']
-  ..pubspec = testPubspec
+  ..pubspec = Pubspec.fromYaml(foobarStablePubspec)
   ..readmeFilename = 'README.md'
-  ..readmeContent = testPackageReadme
+  ..readmeContent = foobarReadmeContent
   ..changelogFilename = 'CHANGELOG.md'
-  ..changelogContent = testPackageChangelog
+  ..changelogContent = foobarChangelogContent
   ..exampleFilename = 'example/lib/main.dart'
-  ..exampleContent = testPackageExample
+  ..exampleContent = foobarExampleContent
   ..sortOrder = -1
   ..downloads = 0;
 
-final PackageVersion flutterPackageVersion =
-    clonePackageVersion(testPackageVersion)
-      ..created = DateTime.utc(2015)
-      ..pubspec = Pubspec.fromYaml(testPackagePubspec +
-          '''
+final PackageVersion flutterPackageVersion = clonePackageVersion(foobarStablePV)
+  ..created = DateTime.utc(2015)
+  ..pubspec = Pubspec.fromYaml(foobarStablePubspec +
+      '''
 flutter:
   plugin:
     class: SomeClass
   ''');
 
-final PackageVersion devPackageVersion = clonePackageVersion(testPackageVersion)
-  ..id = devPackageVersionKey.id
-  ..version = devPackageVersionKey.id as String;
+final PackageVersion foobarDevPV = clonePackageVersion(foobarStablePV)
+  ..id = foobarDevPVKey.id
+  ..version = foobarDevPVKey.id as String;
 
 PackageVersion clonePackageVersion(PackageVersion original) => PackageVersion()
   ..packageKey = original.parentKey
@@ -100,7 +96,7 @@ PackageVersion clonePackageVersion(PackageVersion original) => PackageVersion()
   ..sortOrder = original.sortOrder
   ..downloads = original.downloads;
 
-final String testPackageReadme = '''
+final String foobarReadmeContent = '''
 Test Package
 ============
 
@@ -112,7 +108,7 @@ void main() {
 ```
 ''';
 
-final String testPackageChangelog = '''
+final String foobarChangelogContent = '''
 Changelog
 ============
 
@@ -120,13 +116,13 @@ Changelog
 
 ''';
 
-final String testPackageExample = '''
+final String foobarExampleContent = '''
 main() {
   print('Hello world!');
 }
 ''';
 
-final String testPackagePubspec = '''
+final String foobarStablePubspec = '''
 name: foobar_pkg
 version: 0.1.1+5
 author: Hans Juergen <hans@juergen.com>
@@ -137,14 +133,14 @@ dependencies:
   gcloud: any
 ''';
 
-final testPublisher = Publisher()
+final exampleComPublisher = Publisher()
   ..id = 'example.com'
   ..description = 'This is us!'
   ..created = DateTime(2019, 07, 15)
   ..updated = DateTime(2019, 07, 16);
 
-PublisherMember testPublisherMember(String userId, String role) =>
+PublisherMember publisherMember(String userId, String role, {Key parentKey}) =>
     PublisherMember()
-      ..parentKey = testPublisher.key
+      ..parentKey = parentKey ?? exampleComPublisher.key
       ..id = userId
       ..role = role;

--- a/app/test/shared/test_services.dart
+++ b/app/test/shared/test_services.dart
@@ -30,11 +30,11 @@ void testWithServices(String name, Future fn()) {
     await withCache(() async {
       final db = DatastoreDB(MemDatastore());
       await db.commit(inserts: [
-        testPackage,
-        testPackageVersion,
-        devPackageVersion,
+        foobarPackage,
+        foobarStablePV,
+        foobarDevPV,
         testUserA,
-        testUserHans,
+        hansUser,
       ]);
       registerDbService(db);
       registerStorageService(MemStorage());


### PR DESCRIPTION
I'd like to introduce more packages, versions and users as I migrate the test, and a first step is to make the naming less confusing for a multi-example setup.