### PR TITLE
Use client_data for updating publisher description.

### DIFF
--- a/app/lib/frontend/handlers/pubapi.client.dart
+++ b/app/lib/frontend/handlers/pubapi.client.dart
@@ -5,6 +5,7 @@
 // **************************************************************************
 
 import 'package:api_builder/_client_utils.dart' as _i2;
+import 'package:client_data/publisher_api.dart' as _i3;
 import 'package:http/http.dart' as _i1;
 
 export 'package:api_builder/_client_utils.dart' show RequestException;
@@ -85,11 +86,13 @@ class PubApiClient {
     );
   }
 
-  Future<List<int>> updatePublisher(String publisherId) async {
-    return await _client.requestBytes(
+  Future<_i3.PublisherInfo> updatePublisher(
+      String publisherId, _i3.UpdatePublisherRequest payload) async {
+    return _i3.PublisherInfo.fromJson(await _client.requestJson(
       verb: 'put',
       path: '/api/publisher/$publisherId',
-    );
+      body: payload.toJson(),
+    ));
   }
 
   Future<List<int>> invitePublisherMember(String publisherId) async {

--- a/app/lib/frontend/handlers/pubapi.dart
+++ b/app/lib/frontend/handlers/pubapi.dart
@@ -1,4 +1,5 @@
 import 'package:api_builder/api_builder.dart';
+import 'package:client_data/publisher_api.dart';
 import 'package:shelf/shelf.dart';
 
 import '../../shared/handlers.dart';
@@ -106,8 +107,9 @@ class PubApi {
 
   /// Updates publisher data.
   @EndPoint.put('/api/publisher/<publisherId>')
-  Future<Response> updatePublisher(Request request, String publisherId) =>
-      updatePublisherApiHandler(request, publisherId);
+  Future<PublisherInfo> updatePublisher(
+          Request request, String publisherId, UpdatePublisherRequest update) =>
+      updatePublisherApiHandler(request, publisherId, update);
 
   /// Returns a publisher's member data and role in a JSON form.
   @EndPoint.post('/api/publisher/<publisherId>/invite-member')

--- a/app/lib/frontend/handlers/pubapi.g.dart
+++ b/app/lib/frontend/handlers/pubapi.g.dart
@@ -101,8 +101,13 @@ Router _$PubApiRouter(PubApi service) {
   router.add('PUT', r'/api/publisher/<publisherId>',
       (Request request, String publisherId) async {
     try {
-      final _$result = await service.updatePublisher(request, publisherId);
-      return _$result;
+      final _$result = await service.updatePublisher(
+          request,
+          publisherId,
+          await $utilities.decodeJson<UpdatePublisherRequest>(request, (o) {
+            return UpdatePublisherRequest.fromJson(o);
+          }));
+      return $utilities.jsonResponse(_$result.toJson());
     } on ResponseException catch (e) {
       return e.asResponse();
     }

--- a/app/lib/frontend/handlers/publisher.dart
+++ b/app/lib/frontend/handlers/publisher.dart
@@ -4,8 +4,10 @@
 
 import 'dart:async';
 
+import 'package:client_data/publisher_api.dart';
 import 'package:shelf/shelf.dart' as shelf;
 
+import '../../publisher/backend.dart';
 import '../../shared/handlers.dart';
 
 /// Handles requests for GET /create-publisher
@@ -29,10 +31,14 @@ Future<shelf.Response> getPublisherApiHandler(
 }
 
 /// Handles requests for PUT /api/publisher/<publisherId>
-Future<shelf.Response> updatePublisherApiHandler(
-    shelf.Request request, String publisherId) async {
-  // TODO: implement
-  return notFoundHandler(request);
+Future<PublisherInfo> updatePublisherApiHandler(shelf.Request request,
+    String publisherId, UpdatePublisherRequest update) async {
+  final p = await publisherBackend.updatePublisherData(
+      publisherId, update.description);
+  return PublisherInfo(
+    description: p.description,
+    contact: p.contactEmail,
+  );
 }
 
 /// Handles requests for POST /api/publisher/<publisherId>/invite-member

--- a/app/lib/publisher/backend.dart
+++ b/app/lib/publisher/backend.dart
@@ -57,19 +57,21 @@ class PublisherBackend {
   }
 
   /// Updates the publisher data.
-  Future updatePublisherData(String publisherId, String description) async {
+  Future<Publisher> updatePublisherData(
+      String publisherId, String description) async {
     ArgumentError.checkNotNull(description, 'description');
     if (description.length > 64 * 1024) {
       throw ArgumentError('Description too long.');
     }
-    await _withPublisherAdmin(publisherId, (_) async {
-      await _db.withTransaction((tx) async {
+    return await _withPublisherAdmin(publisherId, (_) async {
+      return await _db.withTransaction((tx) async {
         final key = _db.emptyKey.append(Publisher, id: publisherId);
         final p = (await tx.lookup<Publisher>([key])).single;
         p.description = description;
         tx.queueMutations(inserts: [p]);
         await tx.commit();
-      });
+        return p;
+      }) as Publisher;
     });
   }
 }


### PR DESCRIPTION
I'm not entirely sure that it is worth to keep the `frontend/handlers/publisher.dart` part, maybe we should put everything in the `publisher/backend.dart`?