### PR TITLE
Migrate landing tests.

### DIFF
--- a/app/lib/shared/popularity_storage.dart
+++ b/app/lib/shared/popularity_storage.dart
@@ -9,6 +9,7 @@ import 'dart:io';
 import 'package:logging/logging.dart';
 import 'package:gcloud/storage.dart';
 import 'package:gcloud/service_scope.dart' as ss;
+import 'package:meta/meta.dart';
 import 'package:_popularity/popularity.dart';
 
 import '../shared/storage.dart';
@@ -86,6 +87,12 @@ class PopularityStorage {
     _dateRange = '${popularity.dateFirst?.toIso8601String()} - '
         '${popularity.dateLast?.toIso8601String()}';
     _logger.info('Popularity updated for ${popularity.items.length} packages.');
+  }
+
+  // Updates popularity scores to fixed values, useful for testing.
+  @visibleForTesting
+  void updateValues(Map<String, double> values) {
+    _values.addAll(values);
   }
 }
 

--- a/app/lib/shared/search_client.dart
+++ b/app/lib/shared/search_client.dart
@@ -26,7 +26,9 @@ SearchClient get searchClient => ss.lookup(#_searchClient) as SearchClient;
 /// indexed data.
 class SearchClient {
   /// The HTTP client used for making calls to our search service.
-  final http.Client _httpClient = http.Client();
+  final http.Client _httpClient;
+
+  SearchClient([http.Client client]) : _httpClient = client ?? http.Client();
 
   Future<PackageSearchResult> search(SearchQuery query) async {
     final String httpHostPort = activeConfiguration.searchServicePrefix;

--- a/app/lib/shared/utils.dart
+++ b/app/lib/shared/utils.dart
@@ -238,8 +238,6 @@ Future<http.Response> getUrlWithRetry(http.Client client, String url,
         return result;
       }
     } catch (e, st) {
-      print(e);
-      print(st);
       _logger.warning(
           'HTTP GET failed on $url (${retryCount - i} retry left)', e, st);
       if (i == retryCount) rethrow;

--- a/app/lib/shared/utils.dart
+++ b/app/lib/shared/utils.dart
@@ -238,6 +238,8 @@ Future<http.Response> getUrlWithRetry(http.Client client, String url,
         return result;
       }
     } catch (e, st) {
+      print(e);
+      print(st);
       _logger.warning(
           'HTTP GET failed on $url (${retryCount - i} retry left)', e, st);
       if (i == retryCount) rethrow;

--- a/app/test/frontend/handlers/custom_api_test.dart
+++ b/app/test/frontend/handlers/custom_api_test.dart
@@ -40,6 +40,7 @@ void main() {
                 'version': '5.8.6',
                 'pubspec': {
                   'homepage': 'https://example.com/lithium',
+                  'environment': {'sdk': '>=2.4.0 <3.0.0'},
                   'version': '5.8.6',
                   'name': 'lithium',
                   'author': 'hans@juergen.com',
@@ -58,6 +59,7 @@ void main() {
                 'version': '2.0.5',
                 'pubspec': {
                   'homepage': 'https://example.com/helium',
+                  'environment': {'sdk': '>=2.4.0 <3.0.0'},
                   'version': '2.0.5',
                   'name': 'helium',
                   'author': 'hans@juergen.com',
@@ -79,6 +81,7 @@ void main() {
                 'version': '2.0.8',
                 'pubspec': {
                   'homepage': 'https://example.com/hydrogen',
+                  'environment': {'sdk': '>=2.4.0 <3.0.0'},
                   'version': '2.0.8',
                   'name': 'hydrogen',
                   'author': 'hans@juergen.com',

--- a/app/test/frontend/handlers/landing_test.dart
+++ b/app/test/frontend/handlers/landing_test.dart
@@ -9,10 +9,11 @@ import 'package:pub_dartlang_org/frontend/models.dart';
 import 'package:pub_dartlang_org/frontend/search_service.dart';
 import 'package:pub_dartlang_org/frontend/static_files.dart';
 import 'package:pub_dartlang_org/shared/analyzer_client.dart';
+import 'package:pub_dartlang_org/shared/search_client.dart';
 import 'package:pub_dartlang_org/shared/search_service.dart';
 
-import '../../shared/handlers_test_utils.dart';
 import '../../shared/test_models.dart';
+import '../../shared/test_services.dart';
 import '../mocks.dart';
 
 import '_utils.dart';
@@ -21,33 +22,16 @@ void main() {
   setUpAll(() => updateLocalBuiltFiles());
 
   group('ui', () {
-    tScopedTest('/', () async {
-      registerSearchService(SearchServiceMock((SearchQuery query) {
-        expect(query.order, isNull);
-        expect(query.offset, 0);
-        expect(query.limit, topQueryLimit);
-        expect(query.platform, isNull);
-        expect(query.query, isNull);
-        expect(query.isAd, isTrue);
-        return SearchResultPage(
-          query,
-          1,
-          [PackageView.fromModel(version: foobarStablePV)],
-        );
-      }));
-      final backend = BackendMock(latestPackageVersionsFun: ({offset, limit}) {
-        expect(offset, isNull);
-        expect(limit, equals(5));
-        return [foobarStablePV];
-      });
-      registerBackend(backend);
-      registerAnalyzerClient(AnalyzerClientMock());
-
-      await expectHtmlResponse(await issueGet('/'));
+    testWithServices('/', () async {
+      final rs = await issueGet('/');
+      final content = await expectHtmlResponse(rs);
+      expect(content, contains('/packages/helium'));
+      expect(content, contains('/packages/hydrogen'));
+      expect(content, contains('hydrogen is a Dart package'));
     });
 
-    tScopedTest('/ without a working search service', () async {
-      registerSearchService(SearchService());
+    testWithServices('/ without a working search service', () async {
+      registerSearchClient(null);
       final rs = await issueGet('/');
       final content = await expectHtmlResponse(rs);
       expect(content, contains('/packages/http'));
@@ -80,21 +64,13 @@ void main() {
       await expectHtmlResponse(await issueGet('/flutter'));
     });
 
-    tScopedTest('/xxx - not found page', () async {
-      registerSearchService(SearchServiceMock((SearchQuery query) {
-        expect(query.order, isNull);
-        expect(query.offset, 0);
-        expect(query.limit, topQueryLimit);
-        expect(query.platform, isNull);
-        expect(query.query, isNull);
-        expect(query.isAd, isTrue);
-        return SearchResultPage(
-          query,
-          1,
-          [PackageView.fromModel(version: foobarStablePV)],
-        );
-      }));
-      await expectNotFoundResponse(await issueGet('/xxx'));
+    testWithServices('/xxx - not found page', () async {
+      final rs = await issueGet('/xxx');
+      final content = await expectHtmlResponse(rs, status: 404);
+      expect(content, contains('You\'ve stumbled onto a page'));
+      expect(content, contains('/packages/helium'));
+      expect(content, contains('/packages/hydrogen'));
+      expect(content, contains('hydrogen is a Dart package'));
     });
   });
 }

--- a/app/test/frontend/handlers/landing_test.dart
+++ b/app/test/frontend/handlers/landing_test.dart
@@ -4,17 +4,10 @@
 
 import 'package:test/test.dart';
 
-import 'package:pub_dartlang_org/frontend/backend.dart';
-import 'package:pub_dartlang_org/frontend/models.dart';
-import 'package:pub_dartlang_org/frontend/search_service.dart';
 import 'package:pub_dartlang_org/frontend/static_files.dart';
-import 'package:pub_dartlang_org/shared/analyzer_client.dart';
 import 'package:pub_dartlang_org/shared/search_client.dart';
-import 'package:pub_dartlang_org/shared/search_service.dart';
 
-import '../../shared/test_models.dart';
 import '../../shared/test_services.dart';
-import '../mocks.dart';
 
 import '_utils.dart';
 
@@ -57,29 +50,21 @@ void main() {
       );
     });
 
-    tScopedTest('/flutter', () async {
-      registerSearchService(SearchServiceMock((SearchQuery query) {
-        expect(query.order, isNull);
-        expect(query.offset, 0);
-        expect(query.limit, topQueryLimit);
-        expect(query.platform, 'flutter');
-        expect(query.query, isNull);
-        expect(query.isAd, isTrue);
-        return SearchResultPage(
-          query,
-          1,
-          [PackageView.fromModel(version: foobarStablePV)],
-        );
-      }));
-      final backend = BackendMock(latestPackageVersionsFun: ({offset, limit}) {
-        expect(offset, isNull);
-        expect(limit, equals(5));
-        return [foobarStablePV];
-      });
-      registerBackend(backend);
-      registerAnalyzerClient(AnalyzerClientMock());
-
-      await expectHtmlResponse(await issueGet('/flutter'));
+    testWithServices('/flutter', () async {
+      final rs = await issueGet('/flutter');
+      await expectHtmlResponse(
+        rs,
+        present: [
+          '/packages/helium',
+        ],
+        absent: [
+          '/packages/hydrogen',
+          'hydrogen is a Dart package',
+          '/packages/http',
+          '/packages/event_bus',
+          'lightweight library for parsing',
+        ],
+      );
     });
 
     testWithServices('/xxx - not found page', () async {

--- a/app/test/frontend/handlers/landing_test.dart
+++ b/app/test/frontend/handlers/landing_test.dart
@@ -24,19 +24,37 @@ void main() {
   group('ui', () {
     testWithServices('/', () async {
       final rs = await issueGet('/');
-      final content = await expectHtmlResponse(rs);
-      expect(content, contains('/packages/helium'));
-      expect(content, contains('/packages/hydrogen'));
-      expect(content, contains('hydrogen is a Dart package'));
+      await expectHtmlResponse(
+        rs,
+        present: [
+          '/packages/helium',
+          '/packages/hydrogen',
+          'hydrogen is a Dart package',
+        ],
+        absent: [
+          '/packages/http',
+          '/packages/event_bus',
+          'lightweight library for parsing',
+        ],
+      );
     });
 
     testWithServices('/ without a working search service', () async {
       registerSearchClient(null);
       final rs = await issueGet('/');
-      final content = await expectHtmlResponse(rs);
-      expect(content, contains('/packages/http'));
-      expect(content, contains('/packages/event_bus'));
-      expect(content, contains('lightweight library for parsing'));
+      await expectHtmlResponse(
+        rs,
+        present: [
+          '/packages/http',
+          '/packages/event_bus',
+          'lightweight library for parsing',
+        ],
+        absent: [
+          '/packages/helium',
+          '/packages/hydrogen',
+          'hydrogen is a Dart package',
+        ],
+      );
     });
 
     tScopedTest('/flutter', () async {
@@ -66,11 +84,16 @@ void main() {
 
     testWithServices('/xxx - not found page', () async {
       final rs = await issueGet('/xxx');
-      final content = await expectHtmlResponse(rs, status: 404);
-      expect(content, contains('You\'ve stumbled onto a page'));
-      expect(content, contains('/packages/helium'));
-      expect(content, contains('/packages/hydrogen'));
-      expect(content, contains('hydrogen is a Dart package'));
+      await expectHtmlResponse(rs, status: 404, present: [
+        'You\'ve stumbled onto a page',
+        '/packages/helium',
+        '/packages/hydrogen',
+        'hydrogen is a Dart package',
+      ], absent: [
+        '/packages/http',
+        '/packages/event_bus',
+        'lightweight library for parsing',
+      ]);
     });
   });
 }

--- a/app/test/shared/test_models.dart
+++ b/app/test/shared/test_models.dart
@@ -239,6 +239,7 @@ PkgBundle generateBundle(
   String homepage,
   List<User> uploaders,
   String publisherId,
+  String sdkConstraint = '>=2.4.0 <3.0.0',
   String pubspecExtraContent,
 }) {
   description ??= '$name is a Dart package';
@@ -265,6 +266,8 @@ PkgBundle generateBundle(
         'description: ${json.encode(description)}\n'
         'author: ${uploader.email}\n'
         'homepage: $homepage\n'
+        'environment:\n'
+        '  sdk: "$sdkConstraint"\n'
         '${pubspecExtraContent ?? ''}';
 
     final readme = (hash % 99 == 0) ? null : '# $name\n\n$description\n\n';

--- a/app/test/shared/test_models.dart
+++ b/app/test/shared/test_models.dart
@@ -9,9 +9,10 @@ import 'package:pub_semver/pub_semver.dart';
 
 import 'package:pub_dartlang_org/account/backend.dart';
 import 'package:pub_dartlang_org/account/models.dart';
-import 'package:pub_dartlang_org/publisher/models.dart';
 import 'package:pub_dartlang_org/frontend/model_properties.dart';
 import 'package:pub_dartlang_org/frontend/models.dart';
+import 'package:pub_dartlang_org/publisher/models.dart';
+import 'package:pub_dartlang_org/scorecard/models.dart';
 
 // regular package
 final hydrogen = generateBundle('hydrogen', generateVersions(13, increment: 9));
@@ -302,4 +303,21 @@ PkgBundle generateBundle(
   }
 
   return PkgBundle(package, versions);
+}
+
+PanaReport generatePanaReport({List<String> platformTags}) {
+  return PanaReport(
+      timestamp: DateTime.now(),
+      panaRuntimeInfo: PanaRuntimeInfo(),
+      reportStatus: ReportStatus.success,
+      healthScore: 1.0,
+      maintenanceScore: 0.6,
+      platformTags: platformTags,
+      platformReason: 'Set by test.',
+      pkgDependencies: null,
+      licenses: null,
+      panaSuggestions: null,
+      healthSuggestions: null,
+      maintenanceSuggestions: null,
+      flags: null);
 }

--- a/app/test/shared/test_services.dart
+++ b/app/test/shared/test_services.dart
@@ -13,6 +13,7 @@ import 'package:shelf/shelf.dart' as shelf;
 
 import 'package:pub_dartlang_org/account/backend.dart';
 import 'package:pub_dartlang_org/account/testing/fake_auth_provider.dart';
+import 'package:pub_dartlang_org/scorecard/backend.dart';
 import 'package:pub_dartlang_org/search/backend.dart';
 import 'package:pub_dartlang_org/search/handlers.dart';
 import 'package:pub_dartlang_org/search/index_simple.dart';
@@ -59,6 +60,13 @@ void testWithServices(String name, Future fn()) {
           helium.package.name: 1.0,
           lithium.package.name: 0.7,
         });
+
+        await scoreCardBackend.updateReport(
+            helium.package.name,
+            helium.package.latestVersion,
+            generatePanaReport(platformTags: ['flutter']));
+        await scoreCardBackend.updateScoreCard(
+            helium.package.name, helium.package.latestVersion);
 
         await fork(() async {
           registerAccountBackend(


### PR DESCRIPTION
- bridging the search client and the search handlers with mock http client
- fake popularity scores

TBD later: I think we'll need to have a single method that rebuilds the package index and returns. That would be useful both here and later on with the integration tests too.