### PR TITLE
Refactor search service initialization

### DIFF
--- a/app/bin/service/search.dart
+++ b/app/bin/service/search.dart
@@ -58,28 +58,27 @@ Future _main(FrontendEntryMessage message) async {
     // the dartdoc service produces the required output.
     _updateDartSdkIndex().whenComplete(() {});
 
-    final BatchIndexUpdater batchIndexUpdater = BatchIndexUpdater();
     // Don't block on init, we need to serve liveliness and readiness checks.
     scheduleMicrotask(() async {
       try {
-        await batchIndexUpdater.init();
+        await indexUpdater.init();
       } catch (e, st) {
         _logger.shout('Error initializing search service.', e, st);
         exit(1);
       }
 
       final scheduler = TaskScheduler(
-        batchIndexUpdater,
+        indexUpdater,
         [
           ManualTriggerTaskSource(taskReceivePort.cast<Task>()),
-          IndexUpdateTaskSource(db.dbService, batchIndexUpdater),
+          IndexUpdateTaskSource(db.dbService, indexUpdater),
           DatastoreHeadTaskSource(
             db.dbService,
             TaskSourceModel.scorecard,
             sleep: const Duration(minutes: 10),
             skipHistory: true,
           ),
-          batchIndexUpdater.periodicUpdateTaskSource,
+          indexUpdater.periodicUpdateTaskSource,
         ],
       );
       scheduler.run();

--- a/app/bin/service/search.dart
+++ b/app/bin/service/search.dart
@@ -9,16 +9,13 @@ import 'dart:isolate';
 import 'package:_discoveryapis_commons/_discoveryapis_commons.dart'
     show DetailedApiRequestError;
 import 'package:gcloud/db.dart' as db;
-import 'package:gcloud/storage.dart';
 import 'package:logging/logging.dart';
 
 import 'package:pub_dartlang_org/dartdoc/backend.dart';
-import 'package:pub_dartlang_org/shared/configuration.dart';
 import 'package:pub_dartlang_org/shared/handler_helpers.dart';
 import 'package:pub_dartlang_org/shared/popularity_storage.dart';
 import 'package:pub_dartlang_org/shared/scheduler_stats.dart';
 import 'package:pub_dartlang_org/shared/service_utils.dart';
-import 'package:pub_dartlang_org/shared/storage.dart';
 import 'package:pub_dartlang_org/shared/task_client.dart';
 import 'package:pub_dartlang_org/shared/task_scheduler.dart';
 import 'package:pub_dartlang_org/shared/task_sources.dart';
@@ -49,9 +46,6 @@ Future _main(FrontendEntryMessage message) async {
   await withServices(() async {
     await popularityStorage.init();
 
-    final Bucket snapshotBucket = await getOrCreateBucket(
-        storageService, activeConfiguration.searchSnapshotBucketName);
-    registerSnapshotStorage(SnapshotStorage(snapshotBucket));
     snapshotStorage.scheduleOldDataGC();
 
     final ReceivePort taskReceivePort = ReceivePort();

--- a/app/bin/service/search.dart
+++ b/app/bin/service/search.dart
@@ -14,13 +14,10 @@ import 'package:pub_dartlang_org/shared/scheduler_stats.dart';
 import 'package:pub_dartlang_org/shared/service_utils.dart';
 import 'package:pub_dartlang_org/shared/task_client.dart';
 import 'package:pub_dartlang_org/shared/task_scheduler.dart';
-import 'package:pub_dartlang_org/shared/versions.dart';
-import 'package:pub_dartlang_org/shared/urls.dart';
 import 'package:pub_dartlang_org/shared/services.dart';
 
 import 'package:pub_dartlang_org/search/backend.dart';
 import 'package:pub_dartlang_org/search/handlers.dart';
-import 'package:pub_dartlang_org/search/index_simple.dart';
 import 'package:pub_dartlang_org/search/updater.dart';
 
 final Logger _logger = Logger('pub.search');
@@ -44,9 +41,6 @@ Future _main(FrontendEntryMessage message) async {
     snapshotStorage.scheduleOldDataGC();
 
     final ReceivePort taskReceivePort = ReceivePort();
-    registerDartSdkIndex(
-        SimplePackageIndex.sdk(urlPrefix: dartSdkMainUrl(toolEnvSdkVersion)));
-    registerPackageIndex(SimplePackageIndex());
     registerTaskSendPort(taskReceivePort.sendPort);
 
     indexUpdater.initDartSdkIndex();

--- a/app/bin/service/search.dart
+++ b/app/bin/service/search.dart
@@ -66,7 +66,7 @@ Future _main(FrontendEntryMessage message) async {
         indexUpdater,
         [
           ManualTriggerTaskSource(taskReceivePort.cast<Task>()),
-          IndexUpdateTaskSource(db.dbService, indexUpdater),
+          IndexUpdateTaskSource(db.dbService),
           DatastoreHeadTaskSource(
             db.dbService,
             TaskSourceModel.scorecard,

--- a/app/bin/service/search.dart
+++ b/app/bin/service/search.dart
@@ -6,12 +6,9 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:isolate';
 
-import 'package:_discoveryapis_commons/_discoveryapis_commons.dart'
-    show DetailedApiRequestError;
 import 'package:gcloud/db.dart' as db;
 import 'package:logging/logging.dart';
 
-import 'package:pub_dartlang_org/dartdoc/backend.dart';
 import 'package:pub_dartlang_org/shared/handler_helpers.dart';
 import 'package:pub_dartlang_org/shared/popularity_storage.dart';
 import 'package:pub_dartlang_org/shared/scheduler_stats.dart';
@@ -54,9 +51,7 @@ Future _main(FrontendEntryMessage message) async {
     registerPackageIndex(SimplePackageIndex());
     registerTaskSendPort(taskReceivePort.sendPort);
 
-    // Don't block on SDK index updates, as it may take several minutes before
-    // the dartdoc service produces the required output.
-    _updateDartSdkIndex().whenComplete(() {});
+    indexUpdater.initDartSdkIndex();
 
     // Don't block on init, we need to serve liveliness and readiness checks.
     scheduleMicrotask(() async {
@@ -90,33 +85,4 @@ Future _main(FrontendEntryMessage message) async {
 
     await runHandler(_logger, searchServiceHandler);
   });
-}
-
-Future _updateDartSdkIndex() async {
-  for (int i = 0;; i++) {
-    try {
-      _logger.info('Trying to load SDK index.');
-      final data = await dartdocBackend.getDartSdkDartdocData();
-      if (data != null) {
-        final docs =
-            splitLibraries(data).map((lib) => createSdkDocument(lib)).toList();
-        await dartSdkIndex.addPackages(docs);
-        await dartSdkIndex.merge();
-        _logger.info('Dart SDK index loaded successfully.');
-        return;
-      }
-    } on DetailedApiRequestError catch (e, st) {
-      if (e.status == 404) {
-        _logger.info('Error loading Dart SDK index.', e, st);
-      } else {
-        _logger.warning('Error loading Dart SDK index.', e, st);
-      }
-    } catch (e, st) {
-      _logger.warning('Error loading Dart SDK index.', e, st);
-    }
-    if (i % 10 == 0) {
-      _logger.warning('Unable to load Dart SDK index. Attempt: $i');
-    }
-    await Future.delayed(const Duration(minutes: 1));
-  }
 }

--- a/app/lib/shared/services.dart
+++ b/app/lib/shared/services.dart
@@ -15,6 +15,7 @@ import '../job/backend.dart';
 import '../publisher/backend.dart';
 import '../scorecard/backend.dart';
 import '../search/backend.dart';
+import '../search/index_simple.dart';
 import '../search/updater.dart';
 import '../shared/analyzer_client.dart';
 import '../shared/configuration.dart';
@@ -22,6 +23,8 @@ import '../shared/dartdoc_client.dart';
 import '../shared/popularity_storage.dart';
 import '../shared/search_client.dart';
 import '../shared/storage.dart';
+import '../shared/urls.dart';
+import '../shared/versions.dart';
 
 import 'redis_cache.dart' show withAppEngineAndCache;
 import 'storage_retry.dart' show withStorageRetry;
@@ -53,12 +56,15 @@ Future<void> withPubServices(FutureOr<void> Function() fn) async {
       ),
     );
     registerDartdocClient(DartdocClient());
+    registerDartSdkIndex(
+        SimplePackageIndex.sdk(urlPrefix: dartSdkMainUrl(toolEnvSdkVersion)));
     registerEmailSender(
         EmailSender(dbService, activeConfiguration.blockEmails));
     registerHistoryBackend(HistoryBackend(dbService));
     registerIndexUpdater(IndexUpdater(dbService));
     registerJobBackend(JobBackend(dbService));
     registerNameTracker(NameTracker(dbService));
+    registerPackageIndex(SimplePackageIndex());
     registerPopularityStorage(
       PopularityStorage(await getOrCreateBucket(
           storageService, activeConfiguration.popularityDumpBucketName)),

--- a/app/lib/shared/services.dart
+++ b/app/lib/shared/services.dart
@@ -66,6 +66,8 @@ Future<void> withPubServices(FutureOr<void> Function() fn) async {
     registerSearchBackend(SearchBackend(dbService));
     registerSearchClient(SearchClient());
     registerSearchService(SearchService());
+    registerSnapshotStorage(SnapshotStorage(await getOrCreateBucket(
+        storageService, activeConfiguration.searchSnapshotBucketName)));
     registerTarballStorage(
       TarballStorage(
           storageService,

--- a/app/lib/shared/services.dart
+++ b/app/lib/shared/services.dart
@@ -56,7 +56,7 @@ Future<void> withPubServices(FutureOr<void> Function() fn) async {
     registerEmailSender(
         EmailSender(dbService, activeConfiguration.blockEmails));
     registerHistoryBackend(HistoryBackend(dbService));
-    registerIndexUpdater(IndexUpdater());
+    registerIndexUpdater(IndexUpdater(dbService));
     registerJobBackend(JobBackend(dbService));
     registerNameTracker(NameTracker(dbService));
     registerPopularityStorage(
@@ -81,6 +81,7 @@ Future<void> withPubServices(FutureOr<void> Function() fn) async {
     // depends on previously registered services
     registerBackend(Backend(dbService, tarballStorage));
 
+    registerScopeExitCallback(indexUpdater.close);
     registerScopeExitCallback(accountBackend.close);
     registerScopeExitCallback(dartdocClient.close);
     registerScopeExitCallback(searchClient.close);

--- a/app/lib/shared/services.dart
+++ b/app/lib/shared/services.dart
@@ -15,6 +15,7 @@ import '../job/backend.dart';
 import '../publisher/backend.dart';
 import '../scorecard/backend.dart';
 import '../search/backend.dart';
+import '../search/updater.dart';
 import '../shared/analyzer_client.dart';
 import '../shared/configuration.dart';
 import '../shared/dartdoc_client.dart';
@@ -55,6 +56,7 @@ Future<void> withPubServices(FutureOr<void> Function() fn) async {
     registerEmailSender(
         EmailSender(dbService, activeConfiguration.blockEmails));
     registerHistoryBackend(HistoryBackend(dbService));
+    registerIndexUpdater(IndexUpdater());
     registerJobBackend(JobBackend(dbService));
     registerNameTracker(NameTracker(dbService));
     registerPopularityStorage(

--- a/app/lib/shared/task_sources.dart
+++ b/app/lib/shared/task_sources.dart
@@ -71,15 +71,12 @@ class DatastoreHeadTaskSource implements TaskSource {
     }
   }
 
-  Future dbScanComplete(int count) async {}
-
   Stream<Task> _poll<M extends Model>(
       String field, Task modelToTask(M model)) async* {
     final Query q = _db.query<M>();
     if (_lastTs != null) {
       q.filter('$field >=', _lastTs);
     }
-    int count = 0;
     Timer timer;
     await for (M model in q.run().cast<M>()) {
       timer?.cancel();
@@ -89,12 +86,10 @@ class DatastoreHeadTaskSource implements TaskSource {
       });
       final Task task = modelToTask(model);
       if (task != null) {
-        count++;
         yield task;
       }
     }
     timer?.cancel();
-    await dbScanComplete(count);
   }
 
   Task _packageToTask(Package p) =>

--- a/app/test/shared/test_services.dart
+++ b/app/test/shared/test_services.dart
@@ -76,10 +76,8 @@ void testWithServices(String name, Future fn()) {
           registerAccountBackend(
               AccountBackend(db, authProvider: FakeAuthProvider()));
 
-          registerDartSdkIndex(SimplePackageIndex());
           await dartSdkIndex.merge();
 
-          registerPackageIndex(SimplePackageIndex());
           packageIndex.addPackage(
               await searchBackend.loadDocument(hydrogen.package.name));
           packageIndex.addPackage(


### PR DESCRIPTION
- Removed `Batch` from `IndexUpdater`, as it is no longer using batching.
- Some of the initialization flow can be simplified since we are doing a minimal index building in the `init()` method.
- These are a few steps towards making it more test-friendly. I'm planning to implement a method that would do a single Datastore scan to update the index, in order to manually trigger it in tests.