### PR TITLE
Remove isPending from publisher member data.

### DIFF
--- a/app/lib/publisher/models.dart
+++ b/app/lib/publisher/models.dart
@@ -75,13 +75,10 @@ class PublisherMember extends db.ExpandoModel {
   String get userId => id as String;
 
   @db.DateTimeProperty()
-  DateTime invited;
+  DateTime created;
 
   @db.DateTimeProperty()
-  DateTime accepted;
-
-  @db.BoolProperty(required: true)
-  bool isPending;
+  DateTime updated;
 
   /// One of [PublisherMemberRole].
   @db.StringProperty()

--- a/app/lib/shared/exceptions.dart
+++ b/app/lib/shared/exceptions.dart
@@ -59,6 +59,12 @@ class InvalidInputException extends ResponseException {
     }
   }
 
+  /// Throw [InvalidInputException] if [value] is not `null`.
+  static void checkNull(dynamic value, String name) {
+    assert(name != null, '"name" must not be `null`');
+    _check(value == null, () => '"$name" cannot be `null`');
+  }
+
   /// Throw [InvalidInputException] if [value] is `null`.
   static void checkNotNull(dynamic value, String name) {
     assert(name != null, '"name" must not be `null`');
@@ -217,10 +223,6 @@ class ConflictException extends ResponseException {
   /// The active user can't update their own role.
   factory ConflictException.cantUpdateOwnRole() =>
       ConflictException._('User can\'t update their own role.');
-
-  /// Can't update or modify an entity, because a related invite is pending.
-  factory ConflictException.invitePending() =>
-      ConflictException._('Invite is pending.');
 }
 
 /// Thrown when the analysis for a package is not done yet.

--- a/app/test/shared/test_models.dart
+++ b/app/test/shared/test_models.dart
@@ -170,14 +170,12 @@ final exampleComPublisher = Publisher()
 final exampleComHansAdmin =
     publisherMember(hansUser.userId, PublisherMemberRole.admin);
 
-PublisherMember publisherMember(String userId, String role,
-        {bool isPending = false, Key parentKey}) =>
+PublisherMember publisherMember(String userId, String role, {Key parentKey}) =>
     PublisherMember()
       ..parentKey = parentKey ?? exampleComPublisher.key
       ..id = userId
-      ..invited = DateTime(2019, 07, 16)
-      ..accepted = isPending ? DateTime(2019, 07, 31) : null
-      ..isPending = isPending
+      ..created = DateTime(2019, 07, 16)
+      ..updated = DateTime(2019, 07, 16)
       ..role = role;
 
 class PkgBundle {

--- a/pkg/client_data/lib/publisher_api.dart
+++ b/pkg/client_data/lib/publisher_api.dart
@@ -84,9 +84,6 @@ class PublisherMember {
   /// Unqiue user identifier, specific to `pub.dev`.
   final String userId;
 
-  /// Whether the role is still pending and the user needs to confirm it.
-  final bool isPending;
-
   /// The role or access-level of for this user in the given publisher.
   ///
   /// Allowed values are:
@@ -101,7 +98,6 @@ class PublisherMember {
   // json_serializable boiler-plate
   PublisherMember({
     @required this.userId,
-    @required this.isPending,
     @required this.role,
     @required this.email,
   });

--- a/pkg/client_data/lib/publisher_api.g.dart
+++ b/pkg/client_data/lib/publisher_api.g.dart
@@ -65,7 +65,6 @@ Map<String, dynamic> _$PublisherMembersToJson(PublisherMembers instance) =>
 PublisherMember _$PublisherMemberFromJson(Map<String, dynamic> json) {
   return PublisherMember(
     userId: json['userId'] as String,
-    isPending: json['isPending'] as bool,
     role: json['role'] as String,
     email: json['email'] as String,
   );
@@ -74,7 +73,6 @@ PublisherMember _$PublisherMemberFromJson(Map<String, dynamic> json) {
 Map<String, dynamic> _$PublisherMemberToJson(PublisherMember instance) =>
     <String, dynamic>{
       'userId': instance.userId,
-      'isPending': instance.isPending,
       'role': instance.role,
       'email': instance.email,
     };


### PR DESCRIPTION
- removed `isPending` field from API and from Datastore, also updated with created/updated fields on the stored model
- we are no longer creating the `PublisherMember` entity at the time of the invite, only when it was accepted
- updated tests, removed ones that are no longer relevant or became duplicate