### PR TITLE
Update Publisher.contactEmail (limited to admin e-mails).

### DIFF
--- a/pkg/client_data/lib/publisher_api.dart
+++ b/pkg/client_data/lib/publisher_api.dart
@@ -40,10 +40,10 @@ class UpdatePublisherRequest {
   /// If left as `null` this field will be ignored.
   /// If changed, the change will not take effect until the confirmation email
   /// have been confirmed by the user.
-  final String contact;
+  final String contactEmail;
 
   // json_serializable boiler-plate
-  UpdatePublisherRequest({this.description, this.contact});
+  UpdatePublisherRequest({this.description, this.contactEmail});
   factory UpdatePublisherRequest.fromJson(Map<String, dynamic> json) =>
       _$UpdatePublisherRequestFromJson(json);
   Map<String, dynamic> toJson() => _$UpdatePublisherRequestToJson(this);
@@ -56,10 +56,10 @@ class PublisherInfo {
   final String description;
 
   /// The currently verified contact email for the publisher.
-  final String contact;
+  final String contactEmail;
 
   // json_serializable boiler-plate
-  PublisherInfo({@required this.description, @required this.contact});
+  PublisherInfo({@required this.description, @required this.contactEmail});
   factory PublisherInfo.fromJson(Map<String, dynamic> json) =>
       _$PublisherInfoFromJson(json);
   Map<String, dynamic> toJson() => _$PublisherInfoToJson(this);

--- a/pkg/client_data/lib/publisher_api.g.dart
+++ b/pkg/client_data/lib/publisher_api.g.dart
@@ -23,7 +23,7 @@ UpdatePublisherRequest _$UpdatePublisherRequestFromJson(
     Map<String, dynamic> json) {
   return UpdatePublisherRequest(
     description: json['description'] as String,
-    contact: json['contact'] as String,
+    contactEmail: json['contactEmail'] as String,
   );
 }
 
@@ -31,20 +31,20 @@ Map<String, dynamic> _$UpdatePublisherRequestToJson(
         UpdatePublisherRequest instance) =>
     <String, dynamic>{
       'description': instance.description,
-      'contact': instance.contact,
+      'contactEmail': instance.contactEmail,
     };
 
 PublisherInfo _$PublisherInfoFromJson(Map<String, dynamic> json) {
   return PublisherInfo(
     description: json['description'] as String,
-    contact: json['contact'] as String,
+    contactEmail: json['contactEmail'] as String,
   );
 }
 
 Map<String, dynamic> _$PublisherInfoToJson(PublisherInfo instance) =>
     <String, dynamic>{
       'description': instance.description,
-      'contact': instance.contact,
+      'contactEmail': instance.contactEmail,
     };
 
 PublisherMembers _$PublisherMembersFromJson(Map<String, dynamic> json) {


### PR DESCRIPTION
- renamed `contact` to `contactEmail` in API
- enabled the update of `contactEmail`, but only the e-mail of an admin can be selected as valid value