### PR TITLE
Remove unnecessary null checks

### DIFF
--- a/app/lib/publisher/backend.dart
+++ b/app/lib/publisher/backend.dart
@@ -172,7 +172,7 @@ class PublisherBackend {
       }
       if (update.role != null && update.role != pm.role) {
         // user is not allowed to update their own role
-        if (userId == authenticatedUser?.userId) {
+        if (userId == authenticatedUser.userId) {
           throw ConflictException.cantUpdateOwnRole();
         }
         // role needs to be from the allowed set of values
@@ -194,10 +194,11 @@ class PublisherBackend {
 
   /// Deletes a publisher's member.
   Future deletePublisherMember(String publisherId, String userId) async {
-    if (userId == authenticatedUser?.userId) {
-      throw ConflictException.cantUpdateSelf();
-    }
     return await _withPublisherAdmin(publisherId, (p) async {
+      if (userId == authenticatedUser.userId) {
+        throw ConflictException.cantUpdateSelf();
+      }
+
       final key = p.key.append(PublisherMember, id: userId);
       final pm = (await _db.lookup<PublisherMember>([key])).single;
       if (pm != null) {


### PR DESCRIPTION
These are actually dangerous.
If we have null checks like this in places where we expect the value never to be null,
then if the value suddenly becomes null because we made a mistake somewhere else we won't get a 500.

If `authenticatedUser` is null in scenarios like this, we absolutely want an NPE.

The case with moving the authorization check inside the authentication check is simply that one should always check authentication first, then check authorization.
Probably, we need to make the authentication in generated code through an annotation.