### PR TITLE
Include host when caching /api/packages endpoint.

### DIFF
--- a/app/lib/frontend/handlers/custom_api.dart
+++ b/app/lib/frontend/handlers/custom_api.dart
@@ -82,11 +82,12 @@ Future<shelf.Response> apiPackagesCompactListHandler(
 
 /// Handles request for /api/packages?page=<num>
 Future<shelf.Response> apiPackagesHandler(shelf.Request request) async {
+  final uri = request.requestedUri;
   final int pageSize = 100;
   final int page = extractPageFromUrlParameters(request.url);
 
   // Check that we're not at last page (abuse -1 as special index in cache)
-  final lastPageCacheEntry = cache.apiPackagesListPage(-1);
+  final lastPageCacheEntry = cache.apiPackagesListPage(uri.host, -1);
   final lastPage = await lastPageCacheEntry.get();
   if (lastPage != null) {
     if (page > (lastPage['page'] as num)) {
@@ -94,7 +95,7 @@ Future<shelf.Response> apiPackagesHandler(shelf.Request request) async {
     }
   }
 
-  final data = await cache.apiPackagesListPage(page).get(() async {
+  final data = await cache.apiPackagesListPage(uri.host, page).get(() async {
     final packages = await backend.latestPackages(
         offset: pageSize * (page - 1), limit: pageSize + 1);
 
@@ -110,7 +111,6 @@ Future<shelf.Response> apiPackagesHandler(shelf.Request request) async {
 
     final packagesJson = [];
 
-    final uri = request.requestedUri;
     for (var version in pageVersions) {
       final versionString = Uri.encodeComponent(version.version);
       final packageString = Uri.encodeComponent(version.package);

--- a/app/lib/shared/redis_cache.dart
+++ b/app/lib/shared/redis_cache.dart
@@ -75,15 +75,16 @@ class CachePatterns {
       .withPrefix('package-data')
       .withTTL(Duration(minutes: 10))['$package'];
 
-  Entry<Map<String, dynamic>> apiPackagesListPage(String host, int page) => _cache
-      .withPrefix('api-packages-list')
-      .withTTL(Duration(minutes: 10))
-      .withCodec(utf8)
-      .withCodec(json)
-      .withCodec(wrapAsCodec(
-        encode: (map) => map,
-        decode: (obj) => obj as Map<String, dynamic>,
-      ))['$host/$page'];
+  Entry<Map<String, dynamic>> apiPackagesListPage(String host, int page) =>
+      _cache
+          .withPrefix('api-packages-list')
+          .withTTL(Duration(minutes: 10))
+          .withCodec(utf8)
+          .withCodec(json)
+          .withCodec(wrapAsCodec(
+            encode: (map) => map,
+            decode: (obj) => obj as Map<String, dynamic>,
+          ))['$host/$page'];
 
   Entry<PackageSearchResult> packageSearchResult(String url) => _cache
       .withPrefix('search-result')

--- a/app/lib/shared/redis_cache.dart
+++ b/app/lib/shared/redis_cache.dart
@@ -75,7 +75,7 @@ class CachePatterns {
       .withPrefix('package-data')
       .withTTL(Duration(minutes: 10))['$package'];
 
-  Entry<Map<String, dynamic>> apiPackagesListPage(int page) => _cache
+  Entry<Map<String, dynamic>> apiPackagesListPage(String host, int page) => _cache
       .withPrefix('api-packages-list')
       .withTTL(Duration(minutes: 10))
       .withCodec(utf8)
@@ -83,7 +83,7 @@ class CachePatterns {
       .withCodec(wrapAsCodec(
         encode: (map) => map,
         decode: (obj) => obj as Map<String, dynamic>,
-      ))['$page'];
+      ))['$host/$page'];
 
   Entry<PackageSearchResult> packageSearchResult(String url) => _cache
       .withPrefix('search-result')


### PR DESCRIPTION
#2646

We can't really restrict the caching to a single host, since Flutter started to call API endpoints on `pub.dev`. `Configuration.productionHosts` started out as a way to control which request we are caching, but maybe the way forward will be to include the host as part of the cache key?