### PR TITLE
Move service internals

### DIFF
--- a/app/lib/service/entrypoint/_gae_setup.dart
+++ b/app/lib/service/entrypoint/_gae_setup.dart
@@ -8,8 +8,8 @@ import 'dart:io';
 import 'package:logging/logging.dart';
 import 'package:pana/pana.dart' show runProc;
 
-import '../shared/configuration.dart';
-import '../shared/versions.dart';
+import '../../shared/configuration.dart';
+import '../../shared/versions.dart';
 
 /// Runs the setup-flutter.sh script in a GAE machine.
 Future initFlutterSdk(Logger logger) async {

--- a/app/lib/service/entrypoint/_isolate.dart
+++ b/app/lib/service/entrypoint/_isolate.dart
@@ -10,11 +10,11 @@ import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
 import 'package:stack_trace/stack_trace.dart';
 
-import '../shared/configuration.dart';
-import '../shared/scheduler_stats.dart';
-import '../shared/utils.dart' show trackEventLoopLatency;
+import '../../shared/configuration.dart';
+import '../../shared/scheduler_stats.dart';
+import '../../shared/utils.dart' show trackEventLoopLatency;
 
-import 'services.dart';
+import '../services.dart';
 
 class FrontendEntryMessage {
   final int frontendIndex;

--- a/app/lib/service/entrypoint/analyzer.dart
+++ b/app/lib/service/entrypoint/analyzer.dart
@@ -18,9 +18,10 @@ import '../../shared/handler_helpers.dart';
 import '../../shared/popularity_storage.dart';
 import '../../shared/scheduler_stats.dart';
 
-import '../gae_setup.dart';
-import '../isolate.dart';
 import '../services.dart';
+
+import '_gae_setup.dart';
+import '_isolate.dart';
 
 final Logger logger = Logger('pub.analyzer');
 final _random = math.Random.secure();

--- a/app/lib/service/entrypoint/dartdoc.dart
+++ b/app/lib/service/entrypoint/dartdoc.dart
@@ -17,9 +17,10 @@ import '../../shared/handler_helpers.dart';
 import '../../shared/popularity_storage.dart';
 import '../../shared/scheduler_stats.dart';
 
-import '../gae_setup.dart';
-import '../isolate.dart';
 import '../services.dart';
+
+import '_gae_setup.dart';
+import '_isolate.dart';
 
 final Logger logger = Logger('pub.dartdoc');
 

--- a/app/lib/service/entrypoint/frontend.dart
+++ b/app/lib/service/entrypoint/frontend.dart
@@ -28,8 +28,9 @@ import '../../shared/handler_helpers.dart';
 import '../../shared/popularity_storage.dart';
 import '../../shared/storage.dart';
 
-import '../isolate.dart';
 import '../services.dart';
+
+import '_isolate.dart';
 
 final Logger _logger = Logger('pub');
 final _random = Random.secure();

--- a/app/lib/service/entrypoint/search.dart
+++ b/app/lib/service/entrypoint/search.dart
@@ -17,8 +17,9 @@ import '../../shared/scheduler_stats.dart';
 import '../../shared/task_client.dart';
 import '../../shared/task_scheduler.dart';
 
-import '../isolate.dart';
 import '../services.dart';
+
+import '_isolate.dart';
 
 final Logger _logger = Logger('pub.search');
 


### PR DESCRIPTION
These are not used by non-entrypoint libraries, and we can use the `lib/service/` namespace for other libraries too (e.g. planning to do `lib/service/email`, `lib/service/cache`)