### PR TITLE
Reduce the use of AuthenticatedUser in tests.

### DIFF
--- a/app/test/package/package_publisher_test.dart
+++ b/app/test/package/package_publisher_test.dart
@@ -234,7 +234,7 @@ void _testPublisherAdminAuthIssues(
       () async {
     await dbService.commit(
         deletes: [publisherKey.append(PublisherMember, id: hansUser.userId)]);
-    final client = createPubApiClient(authToken: hansAuthenticated.userId);
+    final client = createPubApiClient(authToken: hansUser.userId);
     final rs = fn(client);
     await expectApiException(rs, status: 403, code: 'InsufficientPermissions');
   });
@@ -245,7 +245,7 @@ void _testPublisherAdminAuthIssues(
     await dbService.commit(inserts: [
       publisherMember(hansUser.userId, 'non-admin', parentKey: publisherKey),
     ]);
-    final client = createPubApiClient(authToken: hansAuthenticated.userId);
+    final client = createPubApiClient(authToken: hansUser.userId);
     final rs = fn(client);
     await expectApiException(rs, status: 403, code: 'InsufficientPermissions');
   });
@@ -253,7 +253,7 @@ void _testPublisherAdminAuthIssues(
 
 void _testNoPackage(Future fn(PubApiClient client)) {
   testWithServices('No puackage with given name', () async {
-    final client = createPubApiClient(authToken: hansAuthenticated.userId);
+    final client = createPubApiClient(authToken: hansUser.userId);
     final rs = fn(client);
     await expectApiException(rs, status: 404, code: 'NotFound');
   });
@@ -261,7 +261,7 @@ void _testNoPackage(Future fn(PubApiClient client)) {
 
 void _testNoPublisher(Future fn(PubApiClient client)) {
   testWithServices('No publisher with given id', () async {
-    final client = createPubApiClient(authToken: hansAuthenticated.userId);
+    final client = createPubApiClient(authToken: hansUser.userId);
     final rs = fn(client);
     await expectApiException(rs, status: 404, code: 'NotFound');
   });

--- a/app/test/publisher/api_test.dart
+++ b/app/test/publisher/api_test.dart
@@ -35,21 +35,21 @@ void main() {
 
     group('Create publisher', () {
       testWithServices('verified.com', () async {
-        final api = createPubApiClient(authToken: hansAuthenticated.userId);
+        final api = createPubApiClient(authToken: hansUser.userId);
 
         // Check that we can create the publisher
         final r1 = await api.createPublisher(
           'verified.com',
           CreatePublisherRequest(accessToken: 'dummy-token-for-testing'),
         );
-        expect(r1.contactEmail, hansAuthenticated.email);
+        expect(r1.contactEmail, hansUser.email);
 
         // Check that creating again idempotently works too
         final r2 = await api.createPublisher(
           'verified.com',
           CreatePublisherRequest(accessToken: 'dummy-token-for-testing'),
         );
-        expect(r2.contactEmail, hansAuthenticated.email);
+        expect(r2.contactEmail, hansUser.email);
 
         // Check that we can update the description
         final r3 = await api.updatePublisher(
@@ -62,12 +62,12 @@ void main() {
         final r4 = await api.publisherInfo('verified.com');
         expect(r4.toJson(), {
           'description': 'hello-world',
-          'contactEmail': hansAuthenticated.email,
+          'contactEmail': hansUser.email,
         });
       });
 
       testWithServices('notverified.com', () async {
-        final api = createPubApiClient(authToken: hansAuthenticated.userId);
+        final api = createPubApiClient(authToken: hansUser.userId);
 
         // Check that we can create the publisher
         final rs = api.createPublisher(
@@ -98,7 +98,7 @@ void main() {
       );
 
       testWithServices('OK', () async {
-        final client = createPubApiClient(authToken: hansAuthenticated.userId);
+        final client = createPubApiClient(authToken: hansUser.userId);
         final rs = await client.updatePublisher(
           'example.com',
           UpdatePublisherRequest(description: 'new description'),
@@ -361,7 +361,7 @@ void main() {
       );
 
       testWithServices('OK', () async {
-        final client = createPubApiClient(authToken: hansAuthenticated.userId);
+        final client = createPubApiClient(authToken: hansUser.userId);
         final rs = await client.listPublisherMembers('example.com');
         expect(_json(rs.toJson()), {
           'members': [
@@ -530,7 +530,7 @@ void _testAdminAuthIssues(Future fn(PubApiClient client)) {
 
   testWithServices('Active user is not a member', () async {
     await dbService.commit(deletes: [exampleComHansAdmin.key]);
-    final client = createPubApiClient(authToken: hansAuthenticated.userId);
+    final client = createPubApiClient(authToken: hansUser.userId);
     final rs = fn(client);
     await expectApiException(rs, status: 403, code: 'InsufficientPermissions');
   });
@@ -539,7 +539,7 @@ void _testAdminAuthIssues(Future fn(PubApiClient client)) {
     await dbService.commit(inserts: [
       publisherMember(hansUser.userId, 'non-admin'),
     ]);
-    final client = createPubApiClient(authToken: hansAuthenticated.userId);
+    final client = createPubApiClient(authToken: hansUser.userId);
     final rs = fn(client);
     await expectApiException(rs, status: 403, code: 'InsufficientPermissions');
   });
@@ -547,7 +547,7 @@ void _testAdminAuthIssues(Future fn(PubApiClient client)) {
 
 void _testNoPublisher(Future fn(PubApiClient client)) {
   testWithServices('No publisher with given id', () async {
-    final client = createPubApiClient(authToken: hansAuthenticated.userId);
+    final client = createPubApiClient(authToken: hansUser.userId);
     final rs = fn(client);
     await expectApiException(rs, status: 404, code: 'NotFound');
   });

--- a/app/test/shared/test_models.dart
+++ b/app/test/shared/test_models.dart
@@ -55,9 +55,9 @@ final testUserA = User()
 final hansAuthenticated =
     AuthenticatedUser('hans-at-juergen-dot-com', 'hans@juergen.com');
 
-Package createFoobarPackage({String name, List<AuthenticatedUser> uploaders}) {
+Package createFoobarPackage({String name, List<User> uploaders}) {
   name ??= foobarPkgKey.id as String;
-  uploaders ??= [hansAuthenticated];
+  uploaders ??= [hansUser];
   return Package()
     ..parentKey = foobarPkgKey.parent
     ..id = name
@@ -72,7 +72,7 @@ Package createFoobarPackage({String name, List<AuthenticatedUser> uploaders}) {
 
 final Package foobarPackage = createFoobarPackage()
   ..latestDevVersionKey = foobarDevPVKey;
-final foobarUploaderEmails = [hansAuthenticated.email];
+final foobarUploaderEmails = [hansUser.email];
 
 final Package discontinuedPackage = createFoobarPackage()
   ..isDiscontinued = true;


### PR DESCRIPTION
This is in preparation for removing `AuthenticatedUser` and using `User` instead of it.