### PR TITLE
HTML-safe shared page data.

### DIFF
--- a/app/lib/frontend/templates/layout.dart
+++ b/app/lib/frontend/templates/layout.dart
@@ -54,9 +54,9 @@ String renderLayoutPage(
       : serializeSearchOrder(searchQuery.order);
   final platformDict = getPlatformDict(platform);
   final isRoot = type == PageType.landing && platform == null;
-  final pageDataJson = pageData == null
+  final pageDataEncoded = pageData == null
       ? null
-      : json.encode({'@context': 'https://pub.dev', 'data': pageData.toJson()});
+      : htmlAttrEscape.convert(pageDataJsonCodec.encode(pageData.toJson()));
   final values = {
     'dart_site_root': urls.dartSiteRoot,
     'oauth_client_id': requestContext.isExperimental
@@ -92,7 +92,7 @@ String renderLayoutPage(
     'package_banner': type == PageType.package,
     'schema_org_searchaction_json':
         isRoot ? encodeScriptSafeJson(_schemaOrgSearchAction) : null,
-    'page_data_json': pageDataJson,
+    'page_data_encoded': pageDataEncoded,
   };
   return templateCache.renderTemplate('layout', values);
 }

--- a/app/lib/frontend/templates/views/layout.mustache
+++ b/app/lib/frontend/templates/views/layout.mustache
@@ -42,6 +42,9 @@
   <meta name="google-signin-client_id" content="{{oauth_client_id}}" />
   <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
   {{/oauth_client_id}}
+  {{#page_data_encoded}}
+  <meta name="pub-page-data" content="{{& page_data_encoded}}"/>
+  {{/page_data_encoded}}
 </head>
 <body class="{{& body_class}}">
 <header class="site-header-row">
@@ -160,11 +163,5 @@
 {{& schema_org_searchaction_json}}
 </script>
 {{/schema_org_searchaction_json}}
-
-{{#page_data_json}}
-<script type="application/ld+json">
-{{& page_data_json}}
-</script>
-{{/page_data_json}}
 </body>
 </html>

--- a/app/test/frontend/golden/pkg_admin_page_outdated.html
+++ b/app/test/frontend/golden/pkg_admin_page_outdated.html
@@ -25,6 +25,7 @@
     <link href="/static/css/style.css?hash=mocked_hash_537099079" rel="stylesheet" type="text/css"/>
     <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
     <script async="async" defer="defer" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
+    <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJmb29iYXJfcGtnIiwidmVyc2lvbiI6IjAuMS4xKzUiLCJpc0Rpc2NvbnRpbnVlZCI6ZmFsc2V9fQ=="/>
   </head>
   <body class="">
     <header class="site-header-row">
@@ -194,8 +195,5 @@
     </footer>
     <script src="/static/highlight/highlight.pack.js?hash=mocked_hash_252154265"></script>
     <script src="/static/highlight/init.js?hash=mocked_hash_180963889"></script>
-    <script type="application/ld+json">
-{"@context":"https://pub.dev","data":{"pkgData":{"package":"foobar_pkg","version":"0.1.1+5","isDiscontinued":false}}}
-</script>
   </body>
 </html>

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -24,6 +24,7 @@
     <link href="/static/css/style.css?hash=mocked_hash_537099079" rel="stylesheet" type="text/css"/>
     <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
     <script async="async" defer="defer" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
+    <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJmb29iYXJfcGtnIiwidmVyc2lvbiI6IjAuMS4xKzUiLCJpc0Rpc2NvbnRpbnVlZCI6ZmFsc2V9fQ=="/>
   </head>
   <body class="">
     <header class="site-header-row">
@@ -376,8 +377,5 @@ import 'package:foobar_pkg/foolib.dart';
     </footer>
     <script src="/static/highlight/highlight.pack.js?hash=mocked_hash_252154265"></script>
     <script src="/static/highlight/init.js?hash=mocked_hash_180963889"></script>
-    <script type="application/ld+json">
-{"@context":"https://pub.dev","data":{"pkgData":{"package":"foobar_pkg","version":"0.1.1+5","isDiscontinued":false}}}
-</script>
   </body>
 </html>

--- a/app/test/frontend/golden/pkg_show_page_discontinued.html
+++ b/app/test/frontend/golden/pkg_show_page_discontinued.html
@@ -25,6 +25,7 @@
     <link href="/static/css/style.css?hash=mocked_hash_537099079" rel="stylesheet" type="text/css"/>
     <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
     <script async="async" defer="defer" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
+    <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJmb29iYXJfcGtnIiwidmVyc2lvbiI6IjAuMS4xKzUiLCJpc0Rpc2NvbnRpbnVlZCI6dHJ1ZX19"/>
   </head>
   <body class="">
     <header class="site-header-row">
@@ -316,8 +317,5 @@ import 'package:foobar_pkg/foolib.dart';
     </footer>
     <script src="/static/highlight/highlight.pack.js?hash=mocked_hash_252154265"></script>
     <script src="/static/highlight/init.js?hash=mocked_hash_180963889"></script>
-    <script type="application/ld+json">
-{"@context":"https://pub.dev","data":{"pkgData":{"package":"foobar_pkg","version":"0.1.1+5","isDiscontinued":true}}}
-</script>
   </body>
 </html>

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -24,6 +24,7 @@
     <link href="/static/css/style.css?hash=mocked_hash_537099079" rel="stylesheet" type="text/css"/>
     <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
     <script async="async" defer="defer" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
+    <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJmb29iYXJfcGtnIiwidmVyc2lvbiI6IjAuMS4xKzUiLCJpc0Rpc2NvbnRpbnVlZCI6ZmFsc2V9fQ=="/>
   </head>
   <body class="">
     <header class="site-header-row">
@@ -326,8 +327,5 @@ import 'package:foobar_pkg/foolib.dart';
     </footer>
     <script src="/static/highlight/highlight.pack.js?hash=mocked_hash_252154265"></script>
     <script src="/static/highlight/init.js?hash=mocked_hash_180963889"></script>
-    <script type="application/ld+json">
-{"@context":"https://pub.dev","data":{"pkgData":{"package":"foobar_pkg","version":"0.1.1+5","isDiscontinued":false}}}
-</script>
   </body>
 </html>

--- a/app/test/frontend/golden/pkg_show_page_legacy.html
+++ b/app/test/frontend/golden/pkg_show_page_legacy.html
@@ -25,6 +25,7 @@
     <link href="/static/css/style.css?hash=mocked_hash_537099079" rel="stylesheet" type="text/css"/>
     <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
     <script async="async" defer="defer" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
+    <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJmb29iYXJfcGtnIiwidmVyc2lvbiI6IjAuMS4xKzUiLCJpc0Rpc2NvbnRpbnVlZCI6ZmFsc2V9fQ=="/>
   </head>
   <body class="">
     <header class="site-header-row">
@@ -344,8 +345,5 @@ import 'package:foobar_pkg/foolib.dart';
     </footer>
     <script src="/static/highlight/highlight.pack.js?hash=mocked_hash_252154265"></script>
     <script src="/static/highlight/init.js?hash=mocked_hash_180963889"></script>
-    <script type="application/ld+json">
-{"@context":"https://pub.dev","data":{"pkgData":{"package":"foobar_pkg","version":"0.1.1+5","isDiscontinued":false}}}
-</script>
   </body>
 </html>

--- a/app/test/frontend/golden/pkg_show_page_outdated.html
+++ b/app/test/frontend/golden/pkg_show_page_outdated.html
@@ -25,6 +25,7 @@
     <link href="/static/css/style.css?hash=mocked_hash_537099079" rel="stylesheet" type="text/css"/>
     <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
     <script async="async" defer="defer" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
+    <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJmb29iYXJfcGtnIiwidmVyc2lvbiI6IjAuMS4xKzUiLCJpc0Rpc2NvbnRpbnVlZCI6ZmFsc2V9fQ=="/>
   </head>
   <body class="">
     <header class="site-header-row">
@@ -331,8 +332,5 @@ import 'package:foobar_pkg/foolib.dart';
     </footer>
     <script src="/static/highlight/highlight.pack.js?hash=mocked_hash_252154265"></script>
     <script src="/static/highlight/init.js?hash=mocked_hash_180963889"></script>
-    <script type="application/ld+json">
-{"@context":"https://pub.dev","data":{"pkgData":{"package":"foobar_pkg","version":"0.1.1+5","isDiscontinued":false}}}
-</script>
   </body>
 </html>

--- a/app/test/frontend/golden/pkg_show_version_page.html
+++ b/app/test/frontend/golden/pkg_show_version_page.html
@@ -26,6 +26,7 @@
     <link href="/static/css/style.css?hash=mocked_hash_537099079" rel="stylesheet" type="text/css"/>
     <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
     <script async="async" defer="defer" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
+    <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJmb29iYXJfcGtnIiwidmVyc2lvbiI6IjAuMi4wLWRldiIsImlzRGlzY29udGludWVkIjpmYWxzZX19"/>
   </head>
   <body class="">
     <header class="site-header-row">
@@ -366,8 +367,5 @@ import 'package:foobar_pkg/foolib.dart';
     </footer>
     <script src="/static/highlight/highlight.pack.js?hash=mocked_hash_252154265"></script>
     <script src="/static/highlight/init.js?hash=mocked_hash_180963889"></script>
-    <script type="application/ld+json">
-{"@context":"https://pub.dev","data":{"pkgData":{"package":"foobar_pkg","version":"0.2.0-dev","isDiscontinued":false}}}
-</script>
   </body>
 </html>

--- a/app/test/frontend/golden/pkg_versions_page.html
+++ b/app/test/frontend/golden/pkg_versions_page.html
@@ -26,6 +26,7 @@
     <link href="/static/css/style.css?hash=mocked_hash_537099079" rel="stylesheet" type="text/css"/>
     <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
     <script async="async" defer="defer" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
+    <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJmb29iYXJfcGtnIiwidmVyc2lvbiI6IjAuMS4xKzUiLCJpc0Rpc2NvbnRpbnVlZCI6ZmFsc2V9fQ=="/>
   </head>
   <body class="">
     <header class="site-header-row">
@@ -239,8 +240,5 @@
     </footer>
     <script src="/static/highlight/highlight.pack.js?hash=mocked_hash_252154265"></script>
     <script src="/static/highlight/init.js?hash=mocked_hash_180963889"></script>
-    <script type="application/ld+json">
-{"@context":"https://pub.dev","data":{"pkgData":{"package":"foobar_pkg","version":"0.1.1+5","isDiscontinued":false}}}
-</script>
   </body>
 </html>

--- a/pkg/client_data/lib/page_data.dart
+++ b/pkg/client_data/lib/page_data.dart
@@ -2,10 +2,15 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:convert';
+
 import 'package:json_annotation/json_annotation.dart';
 import 'package:meta/meta.dart';
 
 part 'page_data.g.dart';
+
+/// Codec to serialize the [PageData] JSON content on the HTML page.
+final pageDataJsonCodec = json.fuse(utf8).fuse(base64);
 
 /// The server-provided config/data for the current page.
 ///

--- a/pkg/web_app/lib/src/page_data.dart
+++ b/pkg/web_app/lib/src/page_data.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:convert';
 import 'dart:html';
 
 import 'package:client_data/page_data.dart';
@@ -11,24 +10,20 @@ PageData _data;
 
 /// The server-provided config/data for the current page.
 ///
-/// This is the `application/ld+json` data embedded in the page with
-/// `"@context":"https://pub.dev"`.
+/// This is the <meta name="pub-page-data" content="[json-data]"> embedded in
+/// the `head` section of the HTML page.
 PageData get pageData {
   return _data ??= _extractData() ?? PageData();
 }
 
 PageData _extractData() {
-  final scripts = document.body.children
-      .where((e) => e.tagName.toLowerCase() == 'script')
-      .where((e) => e.attributes['type'] == 'application/ld+json');
-  for (final script in scripts) {
+  final meta = document.head.querySelector('meta[name="pub-page-data"]');
+  if (meta != null) {
     try {
-      final map = json.decode(script.text) as Map<String, dynamic>;
+      final text = meta.attributes['content'];
+      final map = pageDataJsonCodec.decode(text) as Map<String, dynamic>;
       print(map);
-      if (map['@context'] == 'https://pub.dev') {
-        final json = map['data'] as Map<String, dynamic>;
-        return PageData.fromJson(json);
-      }
+      return PageData.fromJson(map);
     } catch (_) {
       // ignore exception
     }


### PR DESCRIPTION
- Fixes #2663.
- The `meta` header felt a little but better than our previous discussion with the `body` attribute, but it can be easily changed to that.