### PR TITLE
Integrity checks in tests.

### DIFF
--- a/app/bin/tools/check_integrity.dart
+++ b/app/bin/tools/check_integrity.dart
@@ -2,31 +2,17 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
-import 'dart:io';
-
 import 'package:args/args.dart';
 import 'package:gcloud/db.dart';
-import 'package:pool/pool.dart';
+import 'package:logging/logging.dart';
 
-import 'package:pub_dartlang_org/account/models.dart';
-import 'package:pub_dartlang_org/package/models.dart';
+import 'package:pub_dartlang_org/shared/integrity.dart';
 import 'package:pub_dartlang_org/service/entrypoint/tools.dart';
 
 final _argParser = ArgParser()
   ..addOption('concurrency',
       abbr: 'c', defaultsTo: '1', help: 'Number of concurrent processing.')
   ..addFlag('help', abbr: 'h', defaultsTo: false, help: 'Show help.');
-
-final _problems = <String>[];
-final _userToOauth = <String, String>{};
-final _oauthToUser = <String, String>{};
-final _emailToUser = <String, List<String>>{};
-final _invalidUsers = Set<String>();
-final _packages = <String>{};
-final _packagesWithVersion = <String>{};
-int _packageChecked = 0;
-int _versionChecked = 0;
 
 Future main(List<String> args) async {
   final argv = _argParser.parse(args);
@@ -40,208 +26,17 @@ Future main(List<String> args) async {
 
   final concurrency = int.parse(argv['concurrency'] as String);
 
-  await withProdServices(() async {
-    // check user accounts
-    print('Reading User entries...');
-    await for (User user in dbService.query<User>().run()) {
-      _userToOauth[user.userId] = user.oauthUserId;
-      if (user.email == null ||
-          user.email.isEmpty ||
-          !user.email.contains('@')) {
-        _problems.add('User(${user.userId}) has invalid e-mail: ${user.email}');
-        _invalidUsers.add(user.userId);
-      }
-      if (user.email != null && user.email.isNotEmpty) {
-        _emailToUser.putIfAbsent(user.email, () => []).add(user.userId);
-      }
-      // TODO: check if deleted user has no OAuthUserID entry
-      // TODO: check if deleted user has only the minimal set of attributes
-    }
-    int badEmailToUserMappingCount = 0;
-    _emailToUser.forEach((email, userIds) {
-      if (userIds.length > 1) {
-        badEmailToUserMappingCount++;
-        _problems.add(
-            'E-mail address $email is present at ${userIds.length} User: ${userIds.join(', ')}');
-      }
-    });
-    if (badEmailToUserMappingCount > 0) {
-      _problems.add(
-          '$badEmailToUserMappingCount e-mail addresses have more than one User entity.');
-    }
-
-    print('Reading OAuthUserID entries...');
-    await for (OAuthUserID mapping in dbService.query<OAuthUserID>().run()) {
-      if (mapping.userIdKey == null || mapping.userId == null) {
-        _problems
-            .add('OAuthUserID(${mapping.oauthUserId}) has invalid userId.');
-      }
-      _oauthToUser[mapping.oauthUserId] = mapping.userId;
-    }
-
-    for (String userId in _userToOauth.keys) {
-      final oauthUserId = _userToOauth[userId];
-      // Migrated users without login are OK.
-      if (oauthUserId == null) {
-        continue;
-      }
-      final pointer = _oauthToUser[oauthUserId];
-      if (pointer == null) {
-        _problems.add(
-            'User($userId) points to OAuthUserID($oauthUserId) but has no mapping.');
-      } else if (pointer != userId) {
-        _problems.add(
-            'User($userId) points to OAuthUserID($oauthUserId) but it points to a different one ($pointer).');
-      }
-    }
-
-    for (String oauthUserId in _oauthToUser.keys) {
-      final userId = _oauthToUser[oauthUserId];
-      if (userId == null) {
-        _problems.add('OAuthUserID($oauthUserId) has no user.');
-      }
-      final pointer = _userToOauth[userId];
-      if (pointer == null) {
-        _problems.add(
-            'User($userId) is mapped from OAuthUserID($oauthUserId), but does not have it set.');
-      } else if (pointer != oauthUserId) {
-        _problems.add(
-            'User($userId) is mapped from OAuthUserID($oauthUserId), but points to a different one ($pointer).');
-      }
-    }
-
-    print('Reading Package entries...');
-    final pool = Pool(concurrency);
-    final futures = <Future>[];
-    await for (Package p in dbService.query<Package>().run()) {
-      final f = pool.withResource(() => _checkPackage(p));
-      futures.add(f);
-    }
-    await Future.wait(futures);
-    await pool.close();
-
-    print('Reading PackageVersion entries...');
-    await for (PackageVersion pv in dbService.query<PackageVersion>().run()) {
-      _checkPackageVersion(pv);
-    }
-
-    _packages
-        .where((package) => !_packagesWithVersion.contains(package))
-        .forEach((package) {
-      _problems.add('Package ($package) has no version.');
-    });
-    _packagesWithVersion
-        .where((package) => !_packages.contains(package))
-        .forEach((package) {
-      _problems.add('Package ($package) is missing.');
-    });
+  Logger.root.onRecord.listen((r) {
+    print(
+        '${r.time.toIso8601String()} [${r.level.toString().toUpperCase()}] ${r.message}');
   });
 
-  // TODO: check publishers
-
-  print('\nProblems detected: ${_problems.length}\n');
-  for (String line in _problems) {
-    print(line);
-  }
-
-  // not sure what is hanging
-  exit(0);
-}
-
-Future _checkPackage(Package p) async {
-  _packages.add(p.name);
-  if (p.uploaders == null || p.uploaders.isEmpty) {
-    // TODO: empty uploaders with Publisher is fine
-    // TODO: empty uploaders without Publisher must mark it as discontinued
-    // TODO: empty uploaders with abandoned Publisher must mark it as discontinued
-    _problems.add('Package(${p.name}) has no uploaders.');
-  }
-  for (String userId in p.uploaders) {
-    if (!_userToOauth.containsKey(userId)) {
-      _problems.add('Package(${p.name}) has uploader without User: $userId');
+  await withProdServices(() async {
+    final checker = IntegrityChecker(dbService, concurrency: concurrency);
+    final problems = await checker.check();
+    print('\nProblems detected: ${problems.length}\n');
+    for (String line in problems) {
+      print(line);
     }
-    if (_invalidUsers.contains(userId)) {
-      _problems.add('Package(${p.name}) has invalid uploader: User($userId)');
-    }
-  }
-  final versionKeys = <Key>{};
-  final qualifiedVersionKeys = <QualifiedVersionKey>{};
-  await for (PackageVersion pv
-      in dbService.query<PackageVersion>(ancestorKey: p.key).run()) {
-    versionKeys.add(pv.key);
-    qualifiedVersionKeys.add(pv.qualifiedVersionKey);
-    if (pv.uploader == null) {
-      _problems
-          .add('PackageVersion(${pv.package} ${pv.version}) has no uploader.');
-    }
-    if (!_userToOauth.containsKey(pv.uploader)) {
-      _problems.add(
-          'PackageVersion(${pv.package} ${pv.version}) has uploader without User: ${pv.uploader}');
-    }
-    if (_invalidUsers.contains(pv.uploader)) {
-      _problems.add(
-          'PackageVersion(${pv.package} ${pv.version}) has invalid uploader: User(${pv.uploader})');
-    }
-  }
-  if (p.latestVersionKey != null && !versionKeys.contains(p.latestVersionKey)) {
-    _problems.add(
-        'Package(${p.name}) has missing latestVersionKey: ${p.latestVersionKey.id}');
-  }
-  if (p.latestDevVersionKey != null &&
-      !versionKeys.contains(p.latestDevVersionKey)) {
-    _problems.add(
-        'Package(${p.name}) has missing latestDevVersionKey: ${p.latestDevVersionKey.id}');
-  }
-
-  // Checking if PackageVersionPubspec is referenced by a PackageVersion entity.
-  final pvpQuery = dbService.query<PackageVersionPubspec>()
-    ..filter('package =', p.name);
-  final pvpKeys = <QualifiedVersionKey>{};
-  await for (PackageVersionPubspec pvp in pvpQuery.run()) {
-    final key = pvp.qualifiedVersionKey;
-    pvpKeys.add(key);
-    if (!qualifiedVersionKeys.contains(key)) {
-      _problems.add('PackageVersionPubspec($key) has no PackageVersion.');
-    }
-  }
-  for (QualifiedVersionKey key in qualifiedVersionKeys) {
-    if (!pvpKeys.contains(key)) {
-      _problems.add('PackageVersion($key) has no PackageVersionPubspec.');
-    }
-  }
-
-  // Checking if PackageVersionInfo is referenced by a PackageVersion entity.
-  final pviQuery = dbService.query<PackageVersionInfo>()
-    ..filter('package =', p.name);
-  final pviKeys = <QualifiedVersionKey>{};
-  await for (PackageVersionInfo pvi in pviQuery.run()) {
-    final key = pvi.qualifiedVersionKey;
-    pviKeys.add(key);
-    if (!qualifiedVersionKeys.contains(key)) {
-      _problems.add('PackageVersionInfo($key) has no PackageVersion.');
-    }
-  }
-  for (QualifiedVersionKey key in qualifiedVersionKeys) {
-    if (!pviKeys.contains(key)) {
-      _problems.add('PackageVersion($key) has no PackageVersionInfo.');
-    }
-  }
-
-  _packageChecked++;
-  if (_packageChecked % 200 == 0) {
-    print('  .. $_packageChecked done (${p.name})');
-  }
-}
-
-void _checkPackageVersion(PackageVersion pv) {
-  _packagesWithVersion.add(pv.package);
-
-  if (pv.uploader == null) {
-    _problems.add('PackageVersion(${pv.qualifiedVersionKey}) has no uploader.');
-  }
-
-  _versionChecked++;
-  if (_versionChecked % 5000 == 0) {
-    print('  .. $_versionChecked done (${pv.qualifiedVersionKey})');
-  }
+  });
 }

--- a/app/lib/shared/integrity.dart
+++ b/app/lib/shared/integrity.dart
@@ -1,0 +1,247 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:gcloud/db.dart';
+import 'package:logging/logging.dart';
+import 'package:pool/pool.dart';
+
+import '../account/models.dart';
+import '../package/models.dart';
+
+import 'email.dart' show isValidEmail;
+
+final _logger = Logger('integrity.check');
+
+/// Checks the integrity of the datastore.
+class IntegrityChecker {
+  final DatastoreDB _db;
+  final int _concurrency;
+  final _problems = <String>[];
+
+  final _userToOauth = <String, String>{};
+  final _oauthToUser = <String, String>{};
+  final _emailToUser = <String, List<String>>{};
+  final _invalidUsers = Set<String>();
+  final _packages = <String>{};
+  final _packagesWithVersion = <String>{};
+  int _packageChecked = 0;
+  int _versionChecked = 0;
+
+  IntegrityChecker(this._db, {int concurrency})
+      : _concurrency = concurrency ?? 1;
+
+  /// Runs integrity checks, and reports the list of problems.
+  Future<List<String>> check({bool ignorePackages = false}) async {
+    await _checkUsers();
+    await _checkOAuthUserIDs();
+    if (!ignorePackages) {
+      await _checkPackages();
+      await _checkVersions();
+    }
+    // TODO: check Publishers, PublisherMembers
+    return _problems;
+  }
+
+  Future _checkUsers() async {
+    _logger.info('Scanning Users...');
+    await for (User user in _db.query<User>().run()) {
+      _userToOauth[user.userId] = user.oauthUserId;
+      if (user.email == null ||
+          user.email.isEmpty ||
+          !isValidEmail(user.email)) {
+        _problems.add('User(${user.userId}) has invalid e-mail: ${user.email}');
+        _invalidUsers.add(user.userId);
+      }
+      if (user.email != null && user.email.isNotEmpty) {
+        _emailToUser.putIfAbsent(user.email, () => []).add(user.userId);
+      }
+      // TODO: check if deleted user has no OAuthUserID entry
+      // TODO: check if deleted user has only the minimal set of attributes
+    }
+    int badEmailToUserMappingCount = 0;
+    _emailToUser.forEach((email, userIds) {
+      if (userIds.length > 1) {
+        badEmailToUserMappingCount++;
+        _problems.add(
+            'E-mail address $email is present at ${userIds.length} User: ${userIds.join(', ')}');
+      }
+    });
+    if (badEmailToUserMappingCount > 0) {
+      _problems.add(
+          '$badEmailToUserMappingCount e-mail addresses have more than one User entity.');
+    }
+  }
+
+  Future _checkOAuthUserIDs() async {
+    _logger.info('Scanning OAuthUserIDs...');
+    await for (OAuthUserID mapping in _db.query<OAuthUserID>().run()) {
+      if (mapping.userIdKey == null || mapping.userId == null) {
+        _problems
+            .add('OAuthUserID(${mapping.oauthUserId}) has invalid userId.');
+      }
+      _oauthToUser[mapping.oauthUserId] = mapping.userId;
+    }
+
+    for (String userId in _userToOauth.keys) {
+      final oauthUserId = _userToOauth[userId];
+      // Migrated users without login are OK.
+      if (oauthUserId == null) {
+        continue;
+      }
+      final pointer = _oauthToUser[oauthUserId];
+      if (pointer == null) {
+        _problems.add(
+            'User($userId) points to OAuthUserID($oauthUserId) but has no mapping.');
+      } else if (pointer != userId) {
+        _problems.add(
+            'User($userId) points to OAuthUserID($oauthUserId) but it points to a different one ($pointer).');
+      }
+    }
+
+    for (String oauthUserId in _oauthToUser.keys) {
+      final userId = _oauthToUser[oauthUserId];
+      if (userId == null) {
+        _problems.add('OAuthUserID($oauthUserId) has no user.');
+      }
+      final pointer = _userToOauth[userId];
+      if (pointer == null) {
+        _problems.add(
+            'User($userId) is mapped from OAuthUserID($oauthUserId), but does not have it set.');
+      } else if (pointer != oauthUserId) {
+        _problems.add(
+            'User($userId) is mapped from OAuthUserID($oauthUserId), but points to a different one ($pointer).');
+      }
+    }
+  }
+
+  Future _checkPackages() async {
+    _logger.info('Scanning Packages...');
+    final pool = Pool(_concurrency);
+    final futures = <Future>[];
+    await for (Package p in _db.query<Package>().run()) {
+      final f = pool.withResource(() => _checkPackage(p));
+      futures.add(f);
+    }
+    await Future.wait(futures);
+    await pool.close();
+  }
+
+  Future _checkPackage(Package p) async {
+    _packages.add(p.name);
+    if (p.uploaders == null || p.uploaders.isEmpty) {
+      // TODO: empty uploaders with Publisher is fine
+      // TODO: empty uploaders without Publisher must mark it as discontinued
+      // TODO: empty uploaders with abandoned Publisher must mark it as discontinued
+      _problems.add('Package(${p.name}) has no uploaders.');
+    }
+    for (String userId in p.uploaders) {
+      if (!_userToOauth.containsKey(userId)) {
+        _problems.add('Package(${p.name}) has uploader without User: $userId');
+      }
+      if (_invalidUsers.contains(userId)) {
+        _problems.add('Package(${p.name}) has invalid uploader: User($userId)');
+      }
+    }
+    final versionKeys = <Key>{};
+    final qualifiedVersionKeys = <QualifiedVersionKey>{};
+    await for (PackageVersion pv
+        in _db.query<PackageVersion>(ancestorKey: p.key).run()) {
+      versionKeys.add(pv.key);
+      qualifiedVersionKeys.add(pv.qualifiedVersionKey);
+      if (pv.uploader == null) {
+        _problems.add(
+            'PackageVersion(${pv.package} ${pv.version}) has no uploader.');
+      }
+      if (!_userToOauth.containsKey(pv.uploader)) {
+        _problems.add(
+            'PackageVersion(${pv.package} ${pv.version}) has uploader without User: ${pv.uploader}');
+      }
+      if (_invalidUsers.contains(pv.uploader)) {
+        _problems.add(
+            'PackageVersion(${pv.package} ${pv.version}) has invalid uploader: User(${pv.uploader})');
+      }
+    }
+    if (p.latestVersionKey != null &&
+        !versionKeys.contains(p.latestVersionKey)) {
+      _problems.add(
+          'Package(${p.name}) has missing latestVersionKey: ${p.latestVersionKey.id}');
+    }
+    if (p.latestDevVersionKey != null &&
+        !versionKeys.contains(p.latestDevVersionKey)) {
+      _problems.add(
+          'Package(${p.name}) has missing latestDevVersionKey: ${p.latestDevVersionKey.id}');
+    }
+
+    // Checking if PackageVersionPubspec is referenced by a PackageVersion entity.
+    final pvpQuery = _db.query<PackageVersionPubspec>()
+      ..filter('package =', p.name);
+    final pvpKeys = <QualifiedVersionKey>{};
+    await for (PackageVersionPubspec pvp in pvpQuery.run()) {
+      final key = pvp.qualifiedVersionKey;
+      pvpKeys.add(key);
+      if (!qualifiedVersionKeys.contains(key)) {
+        _problems.add('PackageVersionPubspec($key) has no PackageVersion.');
+      }
+    }
+    for (QualifiedVersionKey key in qualifiedVersionKeys) {
+      if (!pvpKeys.contains(key)) {
+        _problems.add('PackageVersion($key) has no PackageVersionPubspec.');
+      }
+    }
+
+    // Checking if PackageVersionInfo is referenced by a PackageVersion entity.
+    final pviQuery = _db.query<PackageVersionInfo>()
+      ..filter('package =', p.name);
+    final pviKeys = <QualifiedVersionKey>{};
+    await for (PackageVersionInfo pvi in pviQuery.run()) {
+      final key = pvi.qualifiedVersionKey;
+      pviKeys.add(key);
+      if (!qualifiedVersionKeys.contains(key)) {
+        _problems.add('PackageVersionInfo($key) has no PackageVersion.');
+      }
+    }
+    for (QualifiedVersionKey key in qualifiedVersionKeys) {
+      if (!pviKeys.contains(key)) {
+        _problems.add('PackageVersion($key) has no PackageVersionInfo.');
+      }
+    }
+
+    _packageChecked++;
+    if (_packageChecked % 200 == 0) {
+      _logger.info('  .. $_packageChecked done (${p.name})');
+    }
+  }
+
+  Future _checkVersions() async {
+    _logger.info('Scanning PackageVersions...');
+    await for (PackageVersion pv in _db.query<PackageVersion>().run()) {
+      _checkPackageVersion(pv);
+    }
+
+    _packages
+        .where((package) => !_packagesWithVersion.contains(package))
+        .forEach((package) {
+      _problems.add('Package ($package) has no version.');
+    });
+    _packagesWithVersion
+        .where((package) => !_packages.contains(package))
+        .forEach((package) {
+      _problems.add('Package ($package) is missing.');
+    });
+  }
+
+  void _checkPackageVersion(PackageVersion pv) {
+    _packagesWithVersion.add(pv.package);
+
+    if (pv.uploader == null) {
+      _problems
+          .add('PackageVersion(${pv.qualifiedVersionKey}) has no uploader.');
+    }
+
+    _versionChecked++;
+    if (_versionChecked % 5000 == 0) {
+      _logger.info('  .. $_versionChecked done (${pv.qualifiedVersionKey})');
+    }
+  }
+}

--- a/app/test/frontend/golden/pkg_show_page_discontinued.html
+++ b/app/test/frontend/golden/pkg_show_page_discontinued.html
@@ -79,6 +79,16 @@
     Published 
           <span>Jan 1, 2014</span>
           <!-- &bull; Downloads: X -->
+      • Updated:
+      
+          <span>
+            <a href="/packages/foobar_pkg">0.1.1+5</a>
+          </span>
+        /
+        
+          <span>
+            <a href="/packages/foobar_pkg/versions/0.2.0-dev">0.2.0-dev</a>
+          </span>
           <div class="tags">
             <span class="package-tag discontinued" title="Package was discontinued.">[discontinued]</span>
           </div>

--- a/app/test/frontend/handlers/listing_test.dart
+++ b/app/test/frontend/handlers/listing_test.dart
@@ -39,7 +39,7 @@ void main() {
           body: {
             'name': 'foobar_pkg',
             'uploaders': ['hans@juergen.com'],
-            'versions': ['0.1.1+5'],
+            'versions': ['0.2.0-dev', '0.1.1+5'],
           });
     });
   });

--- a/app/test/shared/test_models.dart
+++ b/app/test/shared/test_models.dart
@@ -78,12 +78,11 @@ Package createFoobarPackage({String name, List<User> uploaders}) {
     ..updated = DateTime.utc(2015)
     ..uploaders = uploaders.map((user) => user.userId).toList()
     ..latestVersionKey = foobarStablePVKey
-    ..latestDevVersionKey = foobarStablePVKey
+    ..latestDevVersionKey = foobarDevPVKey
     ..downloads = 0;
 }
 
-final Package foobarPackage = createFoobarPackage()
-  ..latestDevVersionKey = foobarDevPVKey;
+final Package foobarPackage = createFoobarPackage();
 final foobarUploaderEmails = [hansUser.email];
 
 final Package discontinuedPackage = createFoobarPackage()
@@ -95,6 +94,7 @@ final PackageVersion foobarStablePV = PackageVersion()
   ..version = foobarStablePVKey.id as String
   ..packageKey = foobarPkgKey
   ..created = DateTime.utc(2014)
+  ..uploader = hansUser.userId
   ..libraries = ['foolib.dart']
   ..pubspec = Pubspec.fromYaml(foobarStablePubspec)
   ..readmeFilename = 'README.md'
@@ -120,11 +120,13 @@ final PackageVersion foobarDevPV = clonePackageVersion(foobarStablePV)
   ..version = foobarDevPVKey.id as String;
 
 PackageVersion clonePackageVersion(PackageVersion original) => PackageVersion()
-  ..packageKey = original.parentKey
+  ..parentKey = original.parentKey
   ..id = original.id
   ..version = original.version
   ..packageKey = original.packageKey
   ..created = original.created
+  ..publisherId = original.publisherId
+  ..uploader = original.uploader
   ..libraries = original.libraries
   ..pubspec = original.pubspec
   ..readmeFilename = original.readmeFilename

--- a/app/test/shared/test_services.dart
+++ b/app/test/shared/test_services.dart
@@ -31,6 +31,7 @@ import 'package:pub_dartlang_org/shared/email.dart';
 import 'package:pub_dartlang_org/shared/exceptions.dart'
     show AuthorizationException;
 import 'package:pub_dartlang_org/shared/handler_helpers.dart';
+import 'package:pub_dartlang_org/shared/integrity.dart';
 import 'package:pub_dartlang_org/shared/popularity_storage.dart';
 import 'package:pub_dartlang_org/shared/redis_cache.dart';
 import 'package:pub_dartlang_org/search/search_client.dart';
@@ -100,6 +101,13 @@ void testWithServices(String name, Future fn()) {
 
           await fork(() async {
             await fn();
+            // post-test integrity check
+            final problems =
+                await IntegrityChecker(dbService).check(ignorePackages: true);
+            if (problems.isNotEmpty) {
+              throw Exception(
+                  '${problems.length} integrity problems detected. First: ${problems.first}');
+            }
           });
         });
       });


### PR DESCRIPTION
Moved the script to shared (no changes, except for one: e-mail verification is using a bit more checks than before (which was only to check for `@`).

At the moment only the `User` / `OAuthUserID` checks are enabled in tests, because package and versions tests require a bit more preparation in the test setups (e.g. to include derived content). I'll do that in a follow-up PR.