### PR TITLE
Fix 500s related to URL parsing.

### DIFF
--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -132,6 +132,9 @@ class PackageBackend {
   }
 
   /// Looks up a specific package version.
+  ///
+  /// Returns null if the version is not a semantic version or if the version
+  /// entity does not exists in the datastore.
   Future<models.PackageVersion> lookupPackageVersion(
       String package, String version) async {
     version = canonicalizeVersion(version);
@@ -474,6 +477,8 @@ class GCloudPackageRepository extends PackageRepository {
         PackageVersion(package, model.version, model.pubspec.jsonString));
   }
 
+  /// Returns null if the version is not a semantic version or if the version
+  /// entity does not exists in the datastore.
   @override
   Future<PackageVersion> lookupVersion(String package, String version) async {
     version = canonicalizeVersion(version);

--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -135,6 +135,7 @@ class PackageBackend {
   Future<models.PackageVersion> lookupPackageVersion(
       String package, String version) async {
     version = canonicalizeVersion(version);
+    if (version == null) return null;
     final packageVersionKey = db.emptyKey
         .append(models.Package, id: package)
         .append(models.PackageVersion, id: version);
@@ -476,6 +477,7 @@ class GCloudPackageRepository extends PackageRepository {
   @override
   Future<PackageVersion> lookupVersion(String package, String version) async {
     version = canonicalizeVersion(version);
+    if (version == null) return null;
 
     final packageVersionKey = db.emptyKey
         .append(models.Package, id: package)

--- a/app/lib/shared/handler_helpers.dart
+++ b/app/lib/shared/handler_helpers.dart
@@ -246,10 +246,10 @@ shelf.Handler _httpsWrapper(shelf.Handler handler) {
 
 shelf.Request _sanitizeRequestedUri(shelf.Request request) {
   final uri = request.requestedUri;
-  final resource = uri.path;
+  final resource = Uri.decodeFull(uri.path);
   final normalizedResource = path.normalize(resource);
 
-  if (resource == normalizedResource) {
+  if (uri.path == normalizedResource) {
     return request;
   } else {
     // With the new flex VMs we can get requests from the load balancer which

--- a/app/test/frontend/handlers/_utils.dart
+++ b/app/test/frontend/handlers/_utils.dart
@@ -6,10 +6,13 @@ library pub_dartlang_org.frontend.handlers_test;
 
 import 'dart:async';
 
+import 'package:gcloud/service_scope.dart' as ss;
+import 'package:logging/logging.dart';
 import 'package:shelf/shelf.dart' as shelf;
 import 'package:test/test.dart';
 
 import 'package:pub_dartlang_org/frontend/handlers.dart';
+import 'package:pub_dartlang_org/shared/handler_helpers.dart';
 import 'package:pub_dartlang_org/shared/urls.dart';
 
 import '../../shared/utils.dart';
@@ -27,7 +30,10 @@ Future<shelf.Response> issueGet(String path, {String host}) async {
   final uri = host == null ? '$siteRoot$path' : 'https://$host$path';
   final request = shelf.Request('GET', Uri.parse(uri));
   final handler = createAppHandler(null);
-  return await handler(request);
+  final wrapped = wrapHandler(Logger('test'), handler, sanitize: true);
+  return await ss.fork(() async {
+    return await wrapped(request);
+  }) as shelf.Response;
 }
 
 Future<String> expectHtmlResponse(

--- a/app/test/frontend/handlers/package_test.dart
+++ b/app/test/frontend/handlers/package_test.dart
@@ -55,9 +55,20 @@ void main() {
       },
     );
 
-    testWithServices('/packages/foobar_pkg/versions/0.1.1 - found', () async {
+    testWithServices('/packages/foobar_pkg/versions/0.1.1+5 - found', () async {
       await expectHtmlResponse(
         await issueGet('/packages/foobar_pkg/versions/0.1.1+5'),
+        present: [
+          '<h2 class="title">foobar_pkg 0.1.1+5</h2>',
+          '<a href="/packages/foobar_pkg">0.1.1+5</a>',
+          '<a href="/packages/foobar_pkg/versions/0.2.0-dev">0.2.0-dev</a>',
+        ],
+      );
+    });
+
+    testWithServices('/packages/foobar_pkg/versions/0.1.1%2B5 - found', () async {
+      await expectHtmlResponse(
+        await issueGet('/packages/foobar_pkg/versions/0.1.1%2B5'),
         present: [
           '<h2 class="title">foobar_pkg 0.1.1+5</h2>',
           '<a href="/packages/foobar_pkg">0.1.1+5</a>',

--- a/app/test/frontend/handlers/package_test.dart
+++ b/app/test/frontend/handlers/package_test.dart
@@ -66,7 +66,8 @@ void main() {
       );
     });
 
-    testWithServices('/packages/foobar_pkg/versions/0.1.1%2B5 - found', () async {
+    testWithServices('/packages/foobar_pkg/versions/0.1.1%2B5 - found',
+        () async {
       await expectHtmlResponse(
         await issueGet('/packages/foobar_pkg/versions/0.1.1%2B5'),
         present: [

--- a/app/test/frontend/handlers/redirects_test.dart
+++ b/app/test/frontend/handlers/redirects_test.dart
@@ -5,12 +5,11 @@
 import 'package:test/test.dart';
 
 import 'package:pub_dartlang_org/frontend/handlers/redirects.dart';
-import 'package:pub_dartlang_org/package/search_service.dart';
 import 'package:pub_dartlang_org/frontend/static_files.dart';
-import 'package:pub_dartlang_org/search/search_service.dart';
 import 'package:pub_dartlang_org/shared/urls.dart';
 
 import '../../shared/handlers_test_utils.dart';
+import '../../shared/test_services.dart';
 
 import '_utils.dart';
 
@@ -18,7 +17,7 @@ void main() {
   setUpAll(() => updateLocalBuiltFiles());
 
   group('redirects', () {
-    test('pub.dartlang.org', () async {
+    testWithServices('pub.dartlang.org', () async {
       Future testRedirect(String path) async {
         expectRedirectResponse(
             await issueGet(path, host: 'pub.dartlang.org'), '$siteRoot$path');
@@ -31,22 +30,21 @@ void main() {
       testRedirect('/web');
     });
 
-    test('dartdocs.org redirect', () async {
+    testWithServices('dartdocs.org redirect', () async {
       expectRedirectResponse(
         await issueGet('/documentation/pkg/latest/', host: 'dartdocs.org'),
-        '$siteRoot/documentation/pkg/latest/',
+        '$siteRoot/documentation/pkg/latest',
       );
     });
 
-    test('www.dartdocs.org redirect', () async {
+    testWithServices('www.dartdocs.org redirect', () async {
       expectRedirectResponse(
         await issueGet('/documentation/pkg/latest/', host: 'www.dartdocs.org'),
-        '$siteRoot/documentation/pkg/latest/',
+        '$siteRoot/documentation/pkg/latest',
       );
     });
 
-    tScopedTest('/doc', () async {
-      registerSearchService(SearchServiceMock());
+    testWithServices('/doc', () async {
       for (var path in redirectPaths.keys) {
         final redirectUrl = 'https://dart.dev/tools/pub/${redirectPaths[path]}';
         expectNotFoundResponse(await issueGet(path));
@@ -56,83 +54,64 @@ void main() {
     });
 
     // making sure /doc does not catches /documentation request
-    tScopedTest('/documentation', () async {
+    testWithServices('/documentation', () async {
       expectRedirectResponse(await issueGet('/documentation/pana/'),
           '/documentation/pana/latest/');
     });
 
-    tScopedTest('/flutter/plugins', () async {
-      registerSearchService(SearchServiceMock());
+    testWithServices('/flutter/plugins', () async {
       expectRedirectResponse(
           await issueGet('/flutter/plugins', host: 'pub.dartlang.org'),
           'https://pub.dev/flutter/packages');
       expectNotFoundResponse(await issueGet('/flutter/plugins'));
     });
 
-    tScopedTest('/search?q=foobar', () async {
-      registerSearchService(SearchServiceMock());
+    testWithServices('/search?q=foobar', () async {
       expectRedirectResponse(
           await issueGet('/search?q=foobar', host: 'pub.dartlang.org'),
           '$siteRoot/packages?q=foobar');
       expectNotFoundResponse(await issueGet('/search?q=foobar'));
     });
 
-    tScopedTest('/search?q=foobar&page=2', () async {
-      registerSearchService(SearchServiceMock());
+    testWithServices('/search?q=foobar&page=2', () async {
       expectRedirectResponse(
           await issueGet('/search?q=foobar&page=2', host: 'pub.dartlang.org'),
           '$siteRoot/packages?q=foobar&page=2');
       expectNotFoundResponse(await issueGet('/search?q=foobar&page=2'));
     });
 
-    tScopedTest('/server', () async {
-      registerSearchService(SearchServiceMock());
+    testWithServices('/server', () async {
       expectRedirectResponse(
           await issueGet('/server', host: 'pub.dartlang.org'), '$siteRoot/');
       expectNotFoundResponse(await issueGet('/server'));
     });
 
-    tScopedTest('/server/packages with parameters', () async {
-      registerSearchService(SearchServiceMock());
+    testWithServices('/server/packages with parameters', () async {
       expectRedirectResponse(
           await issueGet('/server/packages?sort=top', host: 'pub.dartlang.org'),
           '$siteRoot/packages?sort=top');
       expectNotFoundResponse(await issueGet('/server/packages?sort=top'));
     });
 
-    tScopedTest('/server/packages', () async {
-      registerSearchService(SearchServiceMock());
+    testWithServices('/server/packages', () async {
       expectRedirectResponse(
           await issueGet('/server/packages', host: 'pub.dartlang.org'),
           '$siteRoot/packages');
       expectNotFoundResponse(await issueGet('/server/packages'));
     });
 
-    tScopedTest('/packages/flutter - redirect', () async {
+    testWithServices('/packages/flutter - redirect', () async {
       expectRedirectResponse(
         await issueGet('/packages/flutter'),
         '$siteRoot/flutter',
       );
     });
 
-    tScopedTest('/packages/flutter/versions/* - redirect', () async {
+    testWithServices('/packages/flutter/versions/* - redirect', () async {
       expectRedirectResponse(
         await issueGet('/packages/flutter/versions/0.20'),
         '$siteRoot/flutter',
       );
     });
   });
-}
-
-class SearchServiceMock implements SearchService {
-  @override
-  Future<SearchResultPage> search(SearchQuery query,
-      {bool fallbackToNames = true}) async {
-    return SearchResultPage.empty(query);
-  }
-
-  @override
-  Future close() async {
-    return null;
-  }
 }

--- a/pkg/fake_gcloud/lib/mem_datastore.dart
+++ b/pkg/fake_gcloud/lib/mem_datastore.dart
@@ -47,6 +47,9 @@ class MemDatastore implements Datastore {
 
   @override
   Future<List<Entity>> lookup(List<Key> keys, {Transaction transaction}) async {
+    if (keys.any((k) => k.elements.any((e) => e.id == null))) {
+      throw ArgumentError('Key contains null.');
+    }
     return keys.map((key) => _entities[key]).toList();
   }
 


### PR DESCRIPTION
- `canonicalizeVersion` returns `null` when the version is not a valid versions string (e.g. `README` or `null`). In such cases the backend should return `null`, otherwise the Datastore lookup fails with an exception. (also added change to our fake datastore to match this behaviour).
- percent-decoding the Uri.path at the time of url sanitization.
- I've changed tests to use the wrappers and other sanitization in order to test the full processing chain at all times (at least for most frontend handler tests).