### PR TITLE
Perf optimizations in N-gram similarity calculation.

### DIFF
--- a/app/lib/search/index_simple.dart
+++ b/app/lib/search/index_simple.dart
@@ -725,8 +725,14 @@ class TokenIndex {
     final intersection = a.intersection(b);
     if (intersection.isEmpty) return 0.0;
 
-    double sumFn(double sum, String str) =>
-        sum + math.min<double>(100.0, math.pow(str.length, 1.5).toDouble());
+    double sumFn(double sum, String str) {
+      final len = str.length;
+      if (len < _ngramSimilarityWeights.length) {
+        return sum + _ngramSimilarityWeights[len];
+      } else {
+        return sum + _ngramSimilarityWeights.last;
+      }
+    }
 
     final intersectionWeight = intersection.fold<double>(0, sumFn);
     final supersetWeight = a.fold<double>(0, sumFn) +
@@ -773,3 +779,7 @@ class TokenIndex {
     return scoreDocs(lookupTokens(text));
   }
 }
+
+/// Pre-calculated weight list for ngram similarity.
+final _ngramSimilarityWeights =
+    List<double>.generate(20, (i) => math.pow(i, 1.5).toDouble());

--- a/app/lib/search/index_simple.dart
+++ b/app/lib/search/index_simple.dart
@@ -722,9 +722,6 @@ class TokenIndex {
 
   // Weighted Jaccard-similarity metric of sets of strings.
   double _ngramSimilarity(Set<String> a, Set<String> b) {
-    final intersection = a.intersection(b);
-    if (intersection.isEmpty) return 0.0;
-
     double sumFn(double sum, String str) {
       final len = str.length;
       if (len < _ngramSimilarityWeights.length) {
@@ -734,7 +731,11 @@ class TokenIndex {
       }
     }
 
-    final intersectionWeight = intersection.fold<double>(0, sumFn);
+    // We are not calling `Set.intersection()` here, because that will also build a
+    // new `Set`, which we don't need.
+    final intersectionWeight = a.where((b.contains)).fold<double>(0, sumFn);
+    if (intersectionWeight == 0.0) return 0.0;
+
     final supersetWeight = a.fold<double>(0, sumFn) +
         b.fold<double>(0, sumFn) -
         intersectionWeight;


### PR DESCRIPTION
- #2705
- Pre-calculated math.pow for ngram similarity: reduces the method's time from 57% to 49% of the token lookup time. (exact measurements varied too much)
- Using `contains` instead of `Set.intersection` to spare time on building a new `Set`.
- Pre-calculating the folded value of the token N-grams.