### PR TITLE
Timeout for triggers after upload.

### DIFF
--- a/app/lib/analyzer/analyzer_client.dart
+++ b/app/lib/analyzer/analyzer_client.dart
@@ -5,7 +5,6 @@
 import 'dart:async';
 
 import 'package:gcloud/service_scope.dart' as ss;
-import 'package:logging/logging.dart';
 import 'package:pana/pana.dart';
 
 import '../job/backend.dart';
@@ -21,8 +20,6 @@ void registerAnalyzerClient(AnalyzerClient client) =>
 /// The active analyzer client.
 AnalyzerClient get analyzerClient =>
     ss.lookup(#_analyzerClient) as AnalyzerClient;
-
-final Logger _logger = Logger('pub.analyzer_client');
 
 /// Client methods that access the analyzer service and the internals of the
 /// analysis data. This keeps the interface narrow over the raw analysis data.
@@ -44,10 +41,6 @@ class AnalyzerClient {
 
   Future triggerAnalysis(
       String package, String version, Set<String> dependentPackages) async {
-    if (jobBackend == null) {
-      _logger.warning('Job backend is not initialized!');
-      return;
-    }
     await jobBackend.trigger(JobService.analyzer, package, version);
     for (final String package in dependentPackages) {
       await jobBackend.trigger(JobService.analyzer, package);

--- a/app/lib/dartdoc/dartdoc_client.dart
+++ b/app/lib/dartdoc/dartdoc_client.dart
@@ -36,10 +36,6 @@ class DartdocClient {
 
   Future triggerDartdoc(
       String package, String version, Set<String> dependentPackages) async {
-    if (jobBackend == null) {
-      _logger.warning('Job backend is not initialized!');
-      return;
-    }
     await jobBackend.trigger(JobService.dartdoc, package, version);
     for (final String package in dependentPackages) {
       await jobBackend.trigger(JobService.dartdoc, package);

--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -712,7 +712,11 @@ class GCloudPackageRepository extends PackageRepository {
       final triggerDartdoc = dartdocClient
           .triggerDartdoc(newVersion.package, newVersion.version, <String>{});
 
-      await Future.wait([email, triggerAnalysis, triggerDartdoc]);
+      // Let's not block the upload response on these. In case of a timeout, the
+      // underlying operations still go ahead, but the `Future.wait` call below
+      // is not blocked on it.
+      await Future.wait([email, triggerAnalysis, triggerDartdoc])
+          .timeout(Duration(seconds: 10));
     } catch (e, st) {
       final v = newVersion.qualifiedVersionKey;
       _logger.severe('Error post-processing package upload $v', e, st);


### PR DESCRIPTION
As we'll be retrying the triggers, it is better to have a reasonable timeout on this operation, so that the CLI tool gets an answer in time.