### PR TITLE
Publisher admin page.

### DIFF
--- a/app/lib/frontend/handlers/publisher.dart
+++ b/app/lib/frontend/handlers/publisher.dart
@@ -28,3 +28,15 @@ Future<shelf.Response> publisherPageHandler(
   }
   return htmlResponse(renderPublisherPage(publisher));
 }
+
+/// Handles requests for GET /publishers/<publisherId>/admin
+Future<shelf.Response> publisherAdminPageHandler(
+    shelf.Request request, String publisherId) async {
+  final publisher = await publisherBackend.getPublisher(publisherId);
+  if (publisher == null) {
+    // We may introduce search for publishers (e.g. somebody just mistyped a
+    // domain name), but now we just have a formatted error page.
+    return formattedNotFoundHandler(request);
+  }
+  return htmlResponse(renderPublisherAdminPage(publisher));
+}

--- a/app/lib/frontend/handlers/routes.dart
+++ b/app/lib/frontend/handlers/routes.dart
@@ -137,6 +137,11 @@ class PubSiteService {
   Future<Response> publisherPage(Request request, String publisherId) =>
       publisherPageHandler(request, publisherId);
 
+  /// Renders the publisher page.
+  @Route.get('/publishers/<publisherId>/admin')
+  Future<Response> publisherAdminPage(Request request, String publisherId) =>
+      publisherAdminPageHandler(request, publisherId);
+
   // ****
   // **** Site content and metadata
   // ****

--- a/app/lib/frontend/handlers/routes.g.dart
+++ b/app/lib/frontend/handlers/routes.g.dart
@@ -33,6 +33,8 @@ Router _$PubSiteServiceRouter(PubSiteService service) {
   router.add('GET', '/documentation/<package>/', service.documentationLatest);
   router.add('GET', '/create-publisher', service.createPublisherPage);
   router.add('GET', '/publishers/<publisherId>', service.publisherPage);
+  router.add(
+      'GET', '/publishers/<publisherId>/admin', service.publisherAdminPage);
   router.add('GET', '/feed.atom', service.atomFeed);
   router.add('GET', '/help', service.helpPage);
   router.add('GET', '/robots.txt', service.robotsTxt);

--- a/app/lib/frontend/templates/publisher.dart
+++ b/app/lib/frontend/templates/publisher.dart
@@ -33,3 +33,21 @@ String renderPublisherPage(Publisher publisher) {
     )),
   );
 }
+
+/// Renders the `views/publisher/admin_page.mustache` template.
+String renderPublisherAdminPage(Publisher publisher) {
+  final String content = templateCache.renderTemplate('publisher/admin_page', {
+    'publisher_id': publisher.publisherId,
+    'description': publisher.description,
+  });
+  return renderLayoutPage(
+    PageType.publisher,
+    content,
+    title: 'Publisher: ${publisher.publisherId}',
+    pageData: PageData(
+      publisher: PublisherData(
+        publisherId: publisher.publisherId,
+      ),
+    ),
+  );
+}

--- a/app/lib/frontend/templates/views/publisher/admin_page.mustache
+++ b/app/lib/frontend/templates/views/publisher/admin_page.mustache
@@ -1,0 +1,24 @@
+{{! Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+    for details. All rights reserved. Use of this source code is governed by a
+    BSD-style license that can be found in the LICENSE file. }}
+
+<div id="-admin-unauthenticated">
+  <p>
+    Publisher administration is for signed-in users only.
+  </p>
+</div>
+
+<div id="-admin-unauthorized">
+  <p>You are not admin of this publisher.</p>
+</div>
+
+<div id="-admin-authorized">
+  <h2>Admin publisher: {{publisher_id}}</h2>
+  <h4>Description</h4>
+  <p>
+    <textarea id="-publisher-description" class="pub-input" rows="16">{{description}}</textarea>
+  </p>
+  <p>
+      <button id="-publisher-update-button" class="pub-button">Update</button>
+  </p>
+</div>

--- a/pkg/web_app/lib/src/account.dart
+++ b/pkg/web_app/lib/src/account.dart
@@ -124,6 +124,7 @@ void _updateUi() {
   _publisherAdminWidget.update();
 }
 
+/// Active on all pages.
 class _AccountNavWidget {
   Element _login;
   Element _profile;
@@ -157,6 +158,7 @@ class _AccountNavWidget {
   }
 }
 
+/// Active on multiple pages, including package and publisher admin pages.
 class _AuthorizationWidget {
   Element _unauthenticatedRoot;
   Element _unauthorizedRoot;
@@ -198,6 +200,7 @@ class _AuthorizationWidget {
   }
 }
 
+/// Active on /packages/<package>/admin page.
 class _PkgAdminWidget {
   Element _toggleDiscontinuedButton;
 
@@ -251,6 +254,7 @@ class _PkgAdminWidget {
   bool get isActive => _toggleDiscontinuedButton != null;
 }
 
+/// Active on the /create-publisher page.
 class _CreatePublisherWidget {
   Element _publisherIdInput;
   Element _createButton;
@@ -311,6 +315,7 @@ class _CreatePublisherWidget {
   bool get isActive => _publisherIdInput != null && _createButton != null;
 }
 
+/// Active on the /publishers/<publisherId>/admin page.
 class _PublisherAdminWidget {
   Element _updateButton;
   TextAreaElement _descriptionTextArea;

--- a/pkg/web_css/lib/src/_base.scss
+++ b/pkg/web_css/lib/src/_base.scss
@@ -49,6 +49,13 @@ input.pub-input {
   padding: 12px 24px;
 }
 
+textarea.pub-input {
+  width: 100%;
+  font-size: 13px;
+  margin: 20px 0px;
+  padding: 12px;
+}
+
 a {
   text-decoration: none;
   color: $color-link;


### PR DESCRIPTION
- #1518
- only the barebones for the admin page (description field-only, lame layout)
- we'll need a similar endpoint that we have for packages (which tells us that the current user is an admin for the publisher), using the `.../members` listing endpoint for now.
- refactored UI widgets a bit: the decision to display the authorized/unathorized content seems to be the same across the widgets, let's not repeat that
