### PR TITLE
API endpoint for account's publisher options.

### DIFF
--- a/app/lib/frontend/handlers/pubapi.client.dart
+++ b/app/lib/frontend/handlers/pubapi.client.dart
@@ -157,11 +157,19 @@ class PubApiClient {
     ));
   }
 
-  Future<List<int>> accountPackageOptions(String package) async {
-    return await _client.requestBytes(
+  Future<_i4.AccountPkgOptions> accountPackageOptions(String package) async {
+    return _i4.AccountPkgOptions.fromJson(await _client.requestJson(
       verb: 'get',
       path: '/api/account/options/packages/$package',
-    );
+    ));
+  }
+
+  Future<_i4.AccountPublisherOptions> accountPublisherOptions(
+      String publisherId) async {
+    return _i4.AccountPublisherOptions.fromJson(await _client.requestJson(
+      verb: 'get',
+      path: '/api/account/options/publishers/$publisherId',
+    ));
   }
 
   Future<List<int>> documentation(String package) async {

--- a/app/lib/frontend/handlers/pubapi.dart
+++ b/app/lib/frontend/handlers/pubapi.dart
@@ -188,8 +188,14 @@ class PubApi {
   // ****
 
   @EndPoint.get('/api/account/options/packages/<package>')
-  Future<Response> accountPackageOptions(Request request, String package) =>
+  Future<AccountPkgOptions> accountPackageOptions(
+          Request request, String package) =>
       accountPkgOptionsHandler(request, package);
+
+  @EndPoint.get('/api/account/options/publishers/<publisherId>')
+  Future<AccountPublisherOptions> accountPublisherOptions(
+          Request request, String publisherId) =>
+      accountPublisherOptionsHandler(request, publisherId);
 
   @EndPoint.get('/api/documentation/<package>')
   Future<Response> documentation(Request request, String package) =>

--- a/app/lib/frontend/handlers/pubapi.g.dart
+++ b/app/lib/frontend/handlers/pubapi.g.dart
@@ -281,7 +281,21 @@ Router _$PubApiRouter(PubApi service) {
         request,
         package,
       );
-      return _$result;
+      return $utilities.jsonResponse(_$result.toJson());
+    } on ApiResponseException catch (e) {
+      return e.asApiResponse();
+    } catch (e, st) {
+      return $utilities.unhandledError(e, st);
+    }
+  });
+  router.add('GET', r'/api/account/options/publishers/<publisherId>',
+      (Request request, String publisherId) async {
+    try {
+      final _$result = await service.accountPublisherOptions(
+        request,
+        publisherId,
+      );
+      return $utilities.jsonResponse(_$result.toJson());
     } on ApiResponseException catch (e) {
       return e.asApiResponse();
     } catch (e, st) {

--- a/app/lib/publisher/backend.dart
+++ b/app/lib/publisher/backend.dart
@@ -37,8 +37,20 @@ class PublisherBackend {
 
   /// Loads a publisher (or returns null if it does not exists).
   Future<Publisher> getPublisher(String publisherId) async {
+    ArgumentError.checkNotNull(publisherId, 'publisherId');
     final pKey = _db.emptyKey.append(Publisher, id: publisherId);
     return (await _db.lookup<Publisher>([pKey])).single;
+  }
+
+  /// Loads the [PublisherMember] instance for [userId] (or returns null if it does not exists).
+  Future<PublisherMember> getPublisherMember(
+      String publisherId, String userId) async {
+    ArgumentError.checkNotNull(publisherId, 'publisherId');
+    ArgumentError.checkNotNull(userId, 'userId');
+    final mKey = _db.emptyKey
+        .append(Publisher, id: publisherId)
+        .append(PublisherMember, id: userId);
+    return (await _db.lookup<PublisherMember>([mKey])).single;
   }
 
   /// Create publisher.

--- a/app/test/account/options_test.dart
+++ b/app/test/account/options_test.dart
@@ -1,0 +1,61 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test/test.dart';
+
+import '../shared/handlers_test_utils.dart';
+import '../shared/test_models.dart';
+import '../shared/test_services.dart';
+
+void main() {
+  group('/api/account/options', () {
+    testWithServices('package - no user', () async {
+      final client = createPubApiClient();
+      final rs = client.accountPackageOptions('hydrogen');
+      await expectApiException(rs, status: 401);
+    });
+
+    testWithServices('package - no package', () async {
+      final client = createPubApiClient(authToken: joeUser.userId);
+      final rs = client.accountPackageOptions('no_package');
+      await expectApiException(rs, status: 404);
+    });
+
+    testWithServices('package - not admin', () async {
+      final client = createPubApiClient(authToken: joeUser.userId);
+      final rs = await client.accountPackageOptions('hydrogen');
+      expect(rs.isAdmin, isFalse);
+    });
+
+    testWithServices('package - admin', () async {
+      final client = createPubApiClient(authToken: hansUser.userId);
+      final rs = await client.accountPackageOptions('hydrogen');
+      expect(rs.isAdmin, isTrue);
+    });
+
+    testWithServices('publisher - no user', () async {
+      final client = createPubApiClient();
+      final rs = client.accountPublisherOptions('hydrogen');
+      await expectApiException(rs, status: 401);
+    });
+
+    testWithServices('publisher - no publisher', () async {
+      final client = createPubApiClient(authToken: joeUser.userId);
+      final rs = await client.accountPublisherOptions('no-domain.com');
+      expect(rs.isAdmin, isFalse);
+    });
+
+    testWithServices('publisher - not admin', () async {
+      final client = createPubApiClient(authToken: joeUser.userId);
+      final rs = await client.accountPublisherOptions('example.com');
+      expect(rs.isAdmin, isFalse);
+    });
+
+    testWithServices('publisher - admin', () async {
+      final client = createPubApiClient(authToken: hansUser.userId);
+      final rs = await client.accountPublisherOptions('example.com');
+      expect(rs.isAdmin, isTrue);
+    });
+  });
+}

--- a/pkg/client_data/lib/account_api.dart
+++ b/pkg/client_data/lib/account_api.dart
@@ -22,6 +22,21 @@ class AccountPkgOptions {
   Map<String, dynamic> toJson() => _$AccountPkgOptionsToJson(this);
 }
 
+/// Account-specific information about a publisher.
+@JsonSerializable()
+class AccountPublisherOptions {
+  final bool isAdmin;
+
+  AccountPublisherOptions({
+    @required this.isAdmin,
+  });
+
+  factory AccountPublisherOptions.fromJson(Map<String, dynamic> json) =>
+      _$AccountPublisherOptionsFromJson(json);
+
+  Map<String, dynamic> toJson() => _$AccountPublisherOptionsToJson(this);
+}
+
 @JsonSerializable(nullable: false)
 class Consent {
   /// The description of the consent request, in HTML format.

--- a/pkg/client_data/lib/account_api.g.dart
+++ b/pkg/client_data/lib/account_api.g.dart
@@ -17,6 +17,19 @@ Map<String, dynamic> _$AccountPkgOptionsToJson(AccountPkgOptions instance) =>
       'isAdmin': instance.isAdmin,
     };
 
+AccountPublisherOptions _$AccountPublisherOptionsFromJson(
+    Map<String, dynamic> json) {
+  return AccountPublisherOptions(
+    isAdmin: json['isAdmin'] as bool,
+  );
+}
+
+Map<String, dynamic> _$AccountPublisherOptionsToJson(
+        AccountPublisherOptions instance) =>
+    <String, dynamic>{
+      'isAdmin': instance.isAdmin,
+    };
+
 Consent _$ConsentFromJson(Map<String, dynamic> json) {
   return Consent(
     descriptionHtml: json['descriptionHtml'] as String,

--- a/pkg/web_app/lib/src/account.dart
+++ b/pkg/web_app/lib/src/account.dart
@@ -97,12 +97,11 @@ Future _updateOnCredChange() async {
         _isAdmin = options.isAdmin ?? false;
         _updateUi();
       } else if (pageData.isPublisherPage) {
-        // This is a temporary solution for checking if the current use is the
-        // admin of the package.
-        // TODO: introduce a special service endpoint for this
-        final rs = await client
-            .get('/api/publishers/${pageData.publisher.publisherId}/members');
-        _isAdmin = rs.statusCode == 200;
+        final rs = await client.get(
+            '/api/account/options/publishers/${pageData.publisher.publisherId}');
+        final map = json.decode(rs.body) as Map<String, dynamic>;
+        final options = AccountPublisherOptions.fromJson(map);
+        _isAdmin = options.isAdmin ?? false;
         _updateUi();
       }
     } catch (e) {


### PR DESCRIPTION
- Also updated package options + tests.
- Publisher options API endpoint has one difference compared to the package options: it does not throw 404 on non-existent publisher, rather returns a non-admin status. I think this difference is not too bad, as it allows us faster response time, and in practice it doesn't do much difference.
