### PR TITLE
Extract: package list template.

### DIFF
--- a/app/lib/frontend/templates/listing.dart
+++ b/app/lib/frontend/templates/listing.dart
@@ -22,10 +22,8 @@ String renderPagination(PageLinks pageLinks) {
   return templateCache.renderTemplate('pagination', values);
 }
 
-/// Renders the `views/pkg/show.mustache` template.
-String renderPkgIndexPage(
-    List<PackageView> packages, PageLinks links, String currentPlatform,
-    {SearchQuery searchQuery, int totalCount}) {
+/// Renders the `views/pkg/package_list.mustache` template.
+String renderPackageList(List<PackageView> packages) {
   final packagesJson = [];
   for (int i = 0; i < packages.length; i++) {
     final view = packages[i];
@@ -77,7 +75,15 @@ String renderPkgIndexPage(
           ?.toList(),
     });
   }
+  return templateCache.renderTemplate('pkg/package_list', {
+    'packages': packagesJson,
+  });
+}
 
+/// Renders the `views/pkg/index.mustache` template.
+String renderPkgIndexPage(
+    List<PackageView> packages, PageLinks links, String currentPlatform,
+    {SearchQuery searchQuery, int totalCount}) {
   final PlatformDict platformDict = getPlatformDict(currentPlatform);
   final isSearch = searchQuery != null && searchQuery.hasQuery;
   final unsupportedQualifier =
@@ -92,7 +98,7 @@ String renderPkgIndexPage(
     'is_search': isSearch,
     'unsupported_qualifier': unsupportedQualifier,
     'title': platformDict.topPlatformPackages,
-    'packages': packagesJson,
+    'package_list_html': renderPackageList(packages),
     'has_packages': packages.isNotEmpty,
     'pagination': renderPagination(links),
     'search_query': searchQuery?.query,

--- a/app/lib/frontend/templates/views/pkg/index.mustache
+++ b/app/lib/frontend/templates/views/pkg/index.mustache
@@ -22,36 +22,7 @@
   {{/unsupported_qualifier}}
 {{/is_search}}
 
-<ul class="package-list">
-  {{#packages}}
-    <li class="list-item -full">
-      {{& score_box_html }}
-      <h3 class="title"><a href="{{& url}}">{{name}}</a></h3>
-      <p class="description">{{desc}}</p>
-      {{#is_external}}
-        <p class="metadata">v {{version}} • {{external_type}}</p>
-      {{/is_external}}
-      {{#show_metadata}}
-      <p class="metadata">
-        v <a href="{{& url}}">{{version}}</a>
-        {{#show_dev_version}} / <a href="{{& dev_version_url}}">{{dev_version}}</a>{{/show_dev_version}}
-        • Updated: <span>{{last_uploaded}}</span>
-        {{& tags_html}}
-      </p>
-      {{/show_metadata}}
-      {{#has_api_pages}}
-      <div class="api_pages">
-        API results:
-        <ul>
-        {{#api_pages}}
-          <li><a href="{{& href}}">{{title}}</a></li>
-        {{/api_pages}}
-        </ul>
-      </div>
-      {{/has_api_pages}}
-    </li>
-  {{/packages}}
-</ul>
+{{& package_list_html}}
 
 {{#has_packages}}
   {{{pagination}}}

--- a/app/lib/frontend/templates/views/pkg/package_list.mustache
+++ b/app/lib/frontend/templates/views/pkg/package_list.mustache
@@ -1,0 +1,34 @@
+{{! Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+    for details. All rights reserved. Use of this source code is governed by a
+    BSD-style license that can be found in the LICENSE file. }}
+
+<ul class="package-list">
+  {{#packages}}
+    <li class="list-item -full">
+      {{& score_box_html }}
+      <h3 class="title"><a href="{{& url}}">{{name}}</a></h3>
+      <p class="description">{{desc}}</p>
+      {{#is_external}}
+        <p class="metadata">v {{version}} • {{external_type}}</p>
+      {{/is_external}}
+      {{#show_metadata}}
+      <p class="metadata">
+        v <a href="{{& url}}">{{version}}</a>
+        {{#show_dev_version}} / <a href="{{& dev_version_url}}">{{dev_version}}</a>{{/show_dev_version}}
+        • Updated: <span>{{last_uploaded}}</span>
+        {{& tags_html}}
+      </p>
+      {{/show_metadata}}
+      {{#has_api_pages}}
+      <div class="api_pages">
+        API results:
+        <ul>
+        {{#api_pages}}
+          <li><a href="{{& href}}">{{title}}</a></li>
+        {{/api_pages}}
+        </ul>
+      </div>
+      {{/has_api_pages}}
+    </li>
+  {{/packages}}
+</ul>


### PR DESCRIPTION
In order to use the same template on the publisher's package listing. (no change in template)