### PR TITLE
Publisher admin: websiteUrl and contactEmail

### DIFF
--- a/app/lib/frontend/templates/publisher.dart
+++ b/app/lib/frontend/templates/publisher.dart
@@ -39,6 +39,8 @@ String renderPublisherAdminPage(Publisher publisher) {
   final String content = templateCache.renderTemplate('publisher/admin_page', {
     'publisher_id': publisher.publisherId,
     'description': publisher.description,
+    'website_url': publisher.websiteUrl,
+    'contact_email': publisher.contactEmail,
   });
   return renderLayoutPage(
     PageType.publisher,

--- a/app/lib/frontend/templates/views/publisher/admin_page.mustache
+++ b/app/lib/frontend/templates/views/publisher/admin_page.mustache
@@ -15,9 +15,17 @@
 <div id="-admin-authorized">
   <h2>Admin publisher: {{publisher_id}}</h2>
   <h4>Description</h4>
-  <p>
+  <div>
     <textarea id="-publisher-description" class="pub-input" rows="16">{{description}}</textarea>
-  </p>
+  </div>
+  <h4>Website URL</h4>
+  <div>
+    <input id="-publisher-website-url" class="pub-input" value="{{website_url}}" />
+  </div>
+  <h4>Contact e-mail</h4>
+  <div>
+    <input id="-publisher-contact-email" class="pub-input" value="{{contact_email}}" />
+  </div>
   <p>
       <button id="-publisher-update-button" class="pub-button">Update</button>
   </p>

--- a/app/lib/publisher/backend.dart
+++ b/app/lib/publisher/backend.dart
@@ -100,7 +100,7 @@ class PublisherBackend {
             p.updated.isBefore(now.subtract(Duration(minutes: 10))) ||
             p.contactEmail != authenticatedUser.email ||
             p.description != '' ||
-            p.websiteUrl != 'https://$publisherId') {
+            p.websiteUrl != _publisherWebsite(publisherId)) {
           throw ConflictException.publisherAlreadyExists(publisherId);
         }
         // Avoid creating the same publisher again, this end-point is idempotent
@@ -117,7 +117,7 @@ class PublisherBackend {
           ..description = ''
           ..contactEmail = authenticatedUser.email
           ..updated = now
-          ..websiteUrl = 'https://$publisherId'
+          ..websiteUrl = _publisherWebsite(publisherId)
           ..isAbandoned = false,
         PublisherMember()
           ..parentKey = _db.emptyKey.append(Publisher, id: publisherId)
@@ -160,6 +160,18 @@ class PublisherBackend {
       final key = _db.emptyKey.append(Publisher, id: publisherId);
       final p = (await tx.lookup<Publisher>([key])).single;
 
+      if (update.websiteUrl != null && p.websiteUrl != update.websiteUrl) {
+        final parsedUrl = Uri.tryParse(update.websiteUrl);
+        final isValid = parsedUrl != null &&
+            parsedUrl.isAbsolute &&
+            parsedUrl.toString() == update.websiteUrl;
+        InvalidInputException.check(isValid, 'Not a valid URL.');
+
+        final pw = _publisherWebsite(publisherId);
+        InvalidInputException.check(update.websiteUrl.startsWith(pw),
+            'Only pages under "$pw" are accepted.');
+      }
+
       if (update.contactEmail != null &&
           p.contactEmail != update.contactEmail) {
         final user =
@@ -174,6 +186,7 @@ class PublisherBackend {
       }
 
       p.description = update.description ?? p.description;
+      p.websiteUrl = update.websiteUrl ?? p.websiteUrl;
       p.contactEmail = update.contactEmail ?? p.contactEmail;
       p.updated = DateTime.now().toUtc();
 
@@ -336,8 +349,11 @@ class PublisherBackend {
   }
 }
 
-api.PublisherInfo _asPublisherInfo(Publisher p) =>
-    api.PublisherInfo(description: p.description, contactEmail: p.contactEmail);
+api.PublisherInfo _asPublisherInfo(Publisher p) => api.PublisherInfo(
+      description: p.description,
+      websiteUrl: p.websiteUrl,
+      contactEmail: p.contactEmail,
+    );
 
 /// Loads [publisherId], returns its [Publisher] instance, and also checks if
 /// [userId] is an admin of the publisher.
@@ -367,3 +383,5 @@ Future<Publisher> requirePublisherAdmin(
 Future purgePublisherCache(String publisherId) async {
   await cache.uiPublisherPage(publisherId).purge();
 }
+
+String _publisherWebsite(String domain) => 'https://$domain/';

--- a/app/test/shared/test_models.dart
+++ b/app/test/shared/test_models.dart
@@ -204,6 +204,7 @@ Publisher publisher(String domain) => Publisher()
   ..parentKey = Key.emptyKey(Partition(null))
   ..id = domain
   ..description = 'This is us!'
+  ..websiteUrl = 'https://$domain/'
   ..contactEmail = 'contact@$domain'
   ..created = DateTime(2019, 07, 15)
   ..updated = DateTime(2019, 07, 16)

--- a/pkg/client_data/lib/publisher_api.dart
+++ b/pkg/client_data/lib/publisher_api.dart
@@ -35,6 +35,12 @@ class UpdatePublisherRequest {
   /// publisher will not be changed.
   final String description;
 
+  /// A valid URL that points to the publisher's website.
+  ///
+  /// If left as `null` this field will be ignored, and the website URL of the
+  /// publisher will not be changed.
+  final String websiteUrl;
+
   /// Email to be set as contact email for the publisher.
   ///
   /// If left as `null` this field will be ignored.
@@ -43,7 +49,12 @@ class UpdatePublisherRequest {
   final String contactEmail;
 
   // json_serializable boiler-plate
-  UpdatePublisherRequest({this.description, this.contactEmail});
+  UpdatePublisherRequest({
+    this.description,
+    this.websiteUrl,
+    this.contactEmail,
+  });
+
   factory UpdatePublisherRequest.fromJson(Map<String, dynamic> json) =>
       _$UpdatePublisherRequestFromJson(json);
   Map<String, dynamic> toJson() => _$UpdatePublisherRequestToJson(this);
@@ -55,11 +66,19 @@ class PublisherInfo {
   /// A human readable description in markdown.
   final String description;
 
+  /// The website URL of the publisher.
+  final String websiteUrl;
+
   /// The currently verified contact email for the publisher.
   final String contactEmail;
 
   // json_serializable boiler-plate
-  PublisherInfo({@required this.description, @required this.contactEmail});
+  PublisherInfo({
+    @required this.description,
+    @required this.websiteUrl,
+    @required this.contactEmail,
+  });
+
   factory PublisherInfo.fromJson(Map<String, dynamic> json) =>
       _$PublisherInfoFromJson(json);
   Map<String, dynamic> toJson() => _$PublisherInfoToJson(this);

--- a/pkg/client_data/lib/publisher_api.g.dart
+++ b/pkg/client_data/lib/publisher_api.g.dart
@@ -23,6 +23,7 @@ UpdatePublisherRequest _$UpdatePublisherRequestFromJson(
     Map<String, dynamic> json) {
   return UpdatePublisherRequest(
     description: json['description'] as String,
+    websiteUrl: json['websiteUrl'] as String,
     contactEmail: json['contactEmail'] as String,
   );
 }
@@ -31,12 +32,14 @@ Map<String, dynamic> _$UpdatePublisherRequestToJson(
         UpdatePublisherRequest instance) =>
     <String, dynamic>{
       'description': instance.description,
+      'websiteUrl': instance.websiteUrl,
       'contactEmail': instance.contactEmail,
     };
 
 PublisherInfo _$PublisherInfoFromJson(Map<String, dynamic> json) {
   return PublisherInfo(
     description: json['description'] as String,
+    websiteUrl: json['websiteUrl'] as String,
     contactEmail: json['contactEmail'] as String,
   );
 }
@@ -44,6 +47,7 @@ PublisherInfo _$PublisherInfoFromJson(Map<String, dynamic> json) {
 Map<String, dynamic> _$PublisherInfoToJson(PublisherInfo instance) =>
     <String, dynamic>{
       'description': instance.description,
+      'websiteUrl': instance.websiteUrl,
       'contactEmail': instance.contactEmail,
     };
 

--- a/pkg/web_app/lib/src/account.dart
+++ b/pkg/web_app/lib/src/account.dart
@@ -344,6 +344,8 @@ class _CreatePublisherWidget {
 class _PublisherAdminWidget {
   Element _updateButton;
   TextAreaElement _descriptionTextArea;
+  InputElement _websiteUrlInput;
+  InputElement _contactEmailInput;
   InputElement _inviteMemberInput;
   Element _inviteMemberButton;
   Future<PublisherMembers> membersFuture;
@@ -353,6 +355,10 @@ class _PublisherAdminWidget {
     _updateButton = document.getElementById('-publisher-update-button');
     _descriptionTextArea =
         document.getElementById('-publisher-description') as TextAreaElement;
+    _websiteUrlInput =
+        document.getElementById('-publisher-website-url') as InputElement;
+    _contactEmailInput =
+        document.getElementById('-publisher-contact-email') as InputElement;
     _inviteMemberInput =
         document.getElementById('-admin-invite-member-input') as InputElement;
     _inviteMemberButton =
@@ -365,8 +371,11 @@ class _PublisherAdminWidget {
   }
 
   Future _updatePublisher() async {
-    final payload =
-        UpdatePublisherRequest(description: _descriptionTextArea.value);
+    final payload = UpdatePublisherRequest(
+      description: _descriptionTextArea.value,
+      websiteUrl: _websiteUrlInput.value,
+      contactEmail: _contactEmailInput.value,
+    );
     try {
       await client.updatePublisher(pageData.publisher.publisherId, payload);
       window.location.pathname =
@@ -439,6 +448,8 @@ class _PublisherAdminWidget {
 
   bool get isActive =>
       _descriptionTextArea != null &&
+      _websiteUrlInput != null &&
+      _contactEmailInput != null &&
       _updateButton != null &&
       _inviteMemberInput != null &&
       _inviteMemberButton != null;


### PR DESCRIPTION
- added new fields on the UI
- added `websiteUrl` to API objects
- handling `websiteUrl` in creation and update. (requiring `https://[domain]/` prefix for changes)