### PR TITLE
Shared content header for packages and publishers.

### DIFF
--- a/app/lib/frontend/templates/misc.dart
+++ b/app/lib/frontend/templates/misc.dart
@@ -178,3 +178,16 @@ String _classifyScore(double value) {
   if (value <= 0.7) return 'good';
   return 'solid';
 }
+
+/// Renders the `shared/content_header.mustache` template
+String renderContentHeader({
+  @required String title,
+  String metadataHtml,
+  String tagsHtml,
+}) {
+  return templateCache.renderTemplate('shared/content_header', {
+    'title': title,
+    'metadata_html': metadataHtml,
+    'tags_html': tagsHtml,
+  });
+}

--- a/app/lib/frontend/templates/package.dart
+++ b/app/lib/frontend/templates/package.dart
@@ -182,7 +182,8 @@ String renderPkgSidebar(
   });
 }
 
-/// Renders the `views/pkg/header.mustache` template.
+/// Renders the `views/pkg/header.mustache` template for header metadata and
+/// wraps it with content-header.
 String renderPkgHeader(
     Package package, PackageVersion selectedVersion, AnalysisView analysis) {
   final card = analysis?.card;
@@ -202,8 +203,6 @@ String renderPkgHeader(
           (!card.isSkipped && !analysis.hasPanaSummary);
 
   final values = {
-    'name': package.name,
-    'version': selectedVersion.id,
     'latest': {
       'show_updated': showUpdated,
       'show_dev_version': showDevVersion,
@@ -213,16 +212,20 @@ String renderPkgHeader(
           urls.pkgPageUrl(package.name, version: package.latestDevVersion),
       'dev_version': package.latestDevVersion,
     },
-    'tags_html': renderTags(
+    'short_created': selectedVersion.shortCreated,
+  };
+  final metadataHtml = templateCache.renderTemplate('pkg/header', values);
+  return renderContentHeader(
+    title: '${package.name} ${selectedVersion.version}',
+    metadataHtml: metadataHtml,
+    tagsHtml: renderTags(
       analysis?.platforms,
       isAwaiting: isAwaiting,
       isDiscontinued: package.isDiscontinued ?? false,
       isLegacy: card?.isLegacy ?? false,
       isObsolete: card?.isObsolete ?? false,
     ),
-    'short_created': selectedVersion.shortCreated,
-  };
-  return templateCache.renderTemplate('pkg/header', values);
+  );
 }
 
 /// Renders the `views/pkg/show.mustache` template.

--- a/app/lib/frontend/templates/publisher.dart
+++ b/app/lib/frontend/templates/publisher.dart
@@ -9,6 +9,7 @@ import '../../shared/markdown.dart';
 
 import '_cache.dart';
 import 'layout.dart';
+import 'misc.dart' show renderContentHeader;
 
 /// Renders the `views/publisher/create.mustache` template.
 String renderCreatePublisherPage() {
@@ -20,6 +21,7 @@ String renderCreatePublisherPage() {
 /// Renders the `views/publisher/show.mustache` template.
 String renderPublisherPage(Publisher publisher) {
   final String content = templateCache.renderTemplate('publisher/show', {
+    'header_html': renderContentHeader(title: publisher.publisherId),
     'publisher_id': publisher.publisherId,
     'description_html': markdownToHtml(publisher.description, null),
   });
@@ -37,6 +39,7 @@ String renderPublisherPage(Publisher publisher) {
 /// Renders the `views/publisher/admin_page.mustache` template.
 String renderPublisherAdminPage(Publisher publisher) {
   final String content = templateCache.renderTemplate('publisher/admin_page', {
+    'header_html': renderContentHeader(title: publisher.publisherId),
     'publisher_id': publisher.publisherId,
     'description': publisher.description,
   });

--- a/app/lib/frontend/templates/views/pkg/header.mustache
+++ b/app/lib/frontend/templates/views/pkg/header.mustache
@@ -1,19 +1,14 @@
 {{! Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
     for details. All rights reserved. Use of this source code is governed by a
     BSD-style license that can be found in the LICENSE file. }}
-<div class="package-header">
-  <h2 class="title">{{name}} {{version}}</h2>
-  <div class="metadata">
-    Published <span>{{short_created}}</span>
-    <!-- &bull; Downloads: X -->
-    {{#latest.show_updated}}
-      &bull; Updated:
-      <span><a href="{{& latest.stable_url}}">{{latest.stable_version}}</a></span>
-      {{#latest.show_dev_version}}
-        /
-        <span><a href="{{& latest.dev_url}}">{{latest.dev_version}}</a></span>
-      {{/latest.show_dev_version}}
-    {{/latest.show_updated}}
-    <div class="tags">{{& tags_html}}</div>
-  </div>
-</div>
+
+Published <span>{{short_created}}</span>
+<!-- &bull; Downloads: X -->
+{{#latest.show_updated}}
+  &bull; Updated:
+  <span><a href="{{& latest.stable_url}}">{{latest.stable_version}}</a></span>
+  {{#latest.show_dev_version}}
+    /
+    <span><a href="{{& latest.dev_url}}">{{latest.dev_version}}</a></span>
+  {{/latest.show_dev_version}}
+{{/latest.show_updated}}

--- a/app/lib/frontend/templates/views/publisher/admin_page.mustache
+++ b/app/lib/frontend/templates/views/publisher/admin_page.mustache
@@ -2,6 +2,8 @@
     for details. All rights reserved. Use of this source code is governed by a
     BSD-style license that can be found in the LICENSE file. }}
 
+{{& header_html}}
+
 <div id="-admin-unauthenticated">
   <p>
     Publisher administration is for signed-in users only.
@@ -13,7 +15,6 @@
 </div>
 
 <div id="-admin-authorized">
-  <h2>Admin publisher: {{publisher_id}}</h2>
   <h4>Description</h4>
   <p>
     <textarea id="-publisher-description" class="pub-input" rows="16">{{description}}</textarea>

--- a/app/lib/frontend/templates/views/shared/content_header.mustache
+++ b/app/lib/frontend/templates/views/shared/content_header.mustache
@@ -2,8 +2,10 @@
     for details. All rights reserved. Use of this source code is governed by a
     BSD-style license that can be found in the LICENSE file. }}
 
-{{& header_html}}
-
-<div class="publisher-container">
-{{& description_html}}
+<div class="content-header">
+  <h2 class="title">{{title}}</h2>
+  <div class="metadata">
+    {{& metadata_html}}
+    <div class="tags">{{& tags_html}}</div>
+  </div>
 </div>

--- a/app/test/frontend/golden/pkg_admin_page_outdated.html
+++ b/app/test/frontend/golden/pkg_admin_page_outdated.html
@@ -76,19 +76,20 @@
     </div>
     <div class="container">
       <main>
-        <div class="package-header">
+        <div class="content-header">
           <h2 class="title">foobar_pkg 0.1.1+5</h2>
           <div class="metadata">
-    Published 
+    
+Published 
             <span>Jan 1, 2014</span>
             <!-- &bull; Downloads: X -->
-      • Updated:
-      
+  • Updated:
+  
             <span>
               <a href="/packages/foobar_pkg">0.1.1+5</a>
             </span>
-        /
-        
+    /
+    
             <span>
               <a href="/packages/foobar_pkg/versions/0.2.0-dev">0.2.0-dev</a>
             </span>

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -75,19 +75,20 @@
     </div>
     <div class="container">
       <main>
-        <div class="package-header">
+        <div class="content-header">
           <h2 class="title">foobar_pkg 0.1.1+5</h2>
           <div class="metadata">
-    Published 
+    
+Published 
             <span>Jan 1, 2014</span>
             <!-- &bull; Downloads: X -->
-      • Updated:
-      
+  • Updated:
+  
             <span>
               <a href="/packages/foobar_pkg">0.1.1+5</a>
             </span>
-        /
-        
+    /
+    
             <span>
               <a href="/packages/foobar_pkg/versions/0.2.0-dev">0.2.0-dev</a>
             </span>

--- a/app/test/frontend/golden/pkg_show_page_discontinued.html
+++ b/app/test/frontend/golden/pkg_show_page_discontinued.html
@@ -76,19 +76,20 @@
     </div>
     <div class="container">
       <main>
-        <div class="package-header">
+        <div class="content-header">
           <h2 class="title">foobar_pkg 0.1.1+5</h2>
           <div class="metadata">
-    Published 
+    
+Published 
             <span>Jan 1, 2014</span>
             <!-- &bull; Downloads: X -->
-      • Updated:
-      
+  • Updated:
+  
             <span>
               <a href="/packages/foobar_pkg">0.1.1+5</a>
             </span>
-        /
-        
+    /
+    
             <span>
               <a href="/packages/foobar_pkg/versions/0.2.0-dev">0.2.0-dev</a>
             </span>

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -75,19 +75,20 @@
     </div>
     <div class="container">
       <main>
-        <div class="package-header">
+        <div class="content-header">
           <h2 class="title">foobar_pkg 0.1.1+5</h2>
           <div class="metadata">
-    Published 
+    
+Published 
             <span>Jan 1, 2015</span>
             <!-- &bull; Downloads: X -->
-      • Updated:
-      
+  • Updated:
+  
             <span>
               <a href="/packages/foobar_pkg">0.1.1+5</a>
             </span>
-        /
-        
+    /
+    
             <span>
               <a href="/packages/foobar_pkg/versions/0.2.0-dev">0.2.0-dev</a>
             </span>

--- a/app/test/frontend/golden/pkg_show_page_legacy.html
+++ b/app/test/frontend/golden/pkg_show_page_legacy.html
@@ -76,19 +76,20 @@
     </div>
     <div class="container">
       <main>
-        <div class="package-header">
+        <div class="content-header">
           <h2 class="title">foobar_pkg 0.1.1+5</h2>
           <div class="metadata">
-    Published 
+    
+Published 
             <span>Jan 1, 2014</span>
             <!-- &bull; Downloads: X -->
-      • Updated:
-      
+  • Updated:
+  
             <span>
               <a href="/packages/foobar_pkg">0.1.1+5</a>
             </span>
-        /
-        
+    /
+    
             <span>
               <a href="/packages/foobar_pkg/versions/0.2.0-dev">0.2.0-dev</a>
             </span>

--- a/app/test/frontend/golden/pkg_show_page_outdated.html
+++ b/app/test/frontend/golden/pkg_show_page_outdated.html
@@ -76,19 +76,20 @@
     </div>
     <div class="container">
       <main>
-        <div class="package-header">
+        <div class="content-header">
           <h2 class="title">foobar_pkg 0.1.1+5</h2>
           <div class="metadata">
-    Published 
+    
+Published 
             <span>Jan 1, 2014</span>
             <!-- &bull; Downloads: X -->
-      • Updated:
-      
+  • Updated:
+  
             <span>
               <a href="/packages/foobar_pkg">0.1.1+5</a>
             </span>
-        /
-        
+    /
+    
             <span>
               <a href="/packages/foobar_pkg/versions/0.2.0-dev">0.2.0-dev</a>
             </span>

--- a/app/test/frontend/golden/pkg_show_page_publisher.html
+++ b/app/test/frontend/golden/pkg_show_page_publisher.html
@@ -76,10 +76,11 @@
     </div>
     <div class="container">
       <main>
-        <div class="package-header">
+        <div class="content-header">
           <h2 class="title">lithium 5.8.6</h2>
           <div class="metadata">
-    Published 
+    
+Published 
             <span>Mar 5, 2014</span>
             <!-- &bull; Downloads: X -->
             <div class="tags">

--- a/app/test/frontend/golden/pkg_show_version_page.html
+++ b/app/test/frontend/golden/pkg_show_version_page.html
@@ -77,19 +77,20 @@
     </div>
     <div class="container">
       <main>
-        <div class="package-header">
+        <div class="content-header">
           <h2 class="title">foobar_pkg 0.2.0-dev</h2>
           <div class="metadata">
-    Published 
+    
+Published 
             <span>Jan 1, 2014</span>
             <!-- &bull; Downloads: X -->
-      • Updated:
-      
+  • Updated:
+  
             <span>
               <a href="/packages/foobar_pkg">0.1.1+5</a>
             </span>
-        /
-        
+    /
+    
             <span>
               <a href="/packages/foobar_pkg/versions/0.2.0-dev">0.2.0-dev</a>
             </span>

--- a/app/test/frontend/golden/pkg_versions_page.html
+++ b/app/test/frontend/golden/pkg_versions_page.html
@@ -77,19 +77,20 @@
     </div>
     <div class="container">
       <main>
-        <div class="package-header">
+        <div class="content-header">
           <h2 class="title">foobar_pkg 0.1.1+5</h2>
           <div class="metadata">
-    Published 
+    
+Published 
             <span>Jan 1, 2014</span>
             <!-- &bull; Downloads: X -->
-      • Updated:
-      
+  • Updated:
+  
             <span>
               <a href="/packages/foobar_pkg">0.1.1+5</a>
             </span>
-        /
-        
+    /
+    
             <span>
               <a href="/packages/foobar_pkg/versions/0.2.0-dev">0.2.0-dev</a>
             </span>

--- a/app/test/frontend/golden/publisher_show_page.html
+++ b/app/test/frontend/golden/publisher_show_page.html
@@ -75,7 +75,12 @@
     </div>
     <div class="container">
       <main>
-        <h1>Publisher: example.com</h1>
+        <div class="content-header">
+          <h2 class="title">example.com</h2>
+          <div class="metadata">
+            <div class="tags"></div>
+          </div>
+        </div>
         <div class="publisher-container">
           <p>This is our little software developer shop.</p>
           <p>We develop full-stack in Dart, and happy about it.</p>

--- a/pkg/web_css/lib/src/_content.scss
+++ b/pkg/web_css/lib/src/_content.scss
@@ -1,0 +1,19 @@
+.content-header {
+  margin: 30px 0 10px;
+
+  > .title {
+    font-size: 32px;
+    font-weight: 600;
+    margin: 0;
+  }
+
+  > .metadata {
+    font-size: 14px;
+    color: #555;
+
+    > .tags {
+      display: inline-block;
+      margin-left: 20px;
+    }
+  }
+}

--- a/pkg/web_css/lib/src/_pkg.scss
+++ b/pkg/web_css/lib/src/_pkg.scss
@@ -2,26 +2,6 @@
   package page
 ******************************************************/
 
-.package-header {
-  margin: 30px 0 10px;
-
-  > .title {
-    font-size: 32px;
-    font-weight: 600;
-    margin: 0;
-  }
-
-  > .metadata {
-    font-size: 14px;
-    color: #555;
-
-    > .tags {
-      display: inline-block;
-      margin-left: 20px;
-    }
-  }
-}
-
 .package-container {
   > .main {
     display: inline-block;

--- a/pkg/web_css/lib/style.scss
+++ b/pkg/web_css/lib/style.scss
@@ -1,5 +1,6 @@
 @import 'src/_variables';
 @import 'src/_base';
+@import 'src/_content';
 @import 'src/_footer';
 @import 'src/_account';
 @import 'src/_admin';


### PR DESCRIPTION
As we will have very similar layout structure for publishers and packages, I'm extracting this template and its styles out of package rendering. A similar refactor will happen with the sidebar positioning.