### PR TITLE
Search index and queries with publisher

### DIFF
--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -294,6 +294,7 @@ class PackageBackend {
       latestVersion = p.latestVersion;
       await checkPackageAdmin(p, user.userId);
       p.isDiscontinued = options.isDiscontinued ?? p.isDiscontinued;
+      p.updated = DateTime.now().toUtc();
       _logger.info('Updating $package options: '
           'isDiscontinued: ${p.isDiscontinued} '
           'doNotAdvertise: ${p.doNotAdvertise}');
@@ -361,6 +362,7 @@ class PackageBackend {
       final package = (await db.lookup<models.Package>([key])).single;
       package.publisherId = request.publisherId;
       package.uploaders.clear();
+      package.updated = DateTime.now().toUtc();
       tx.queueMutations(inserts: [package]);
       await tx.commit();
       return _asPackagePublisherInfo(package);
@@ -385,6 +387,7 @@ class PackageBackend {
 //      final package = (await db.lookup<models.Package>([key])).single;
 //      package.publisherId = null;
 //      package.uploaders = [user.userId];
+//      package.updated = DateTime.now().toUtc();
 //      tx.queueMutations(inserts: [package]);
 //      await tx.commit();
 //      return _asPackagePublisherInfo(package);
@@ -628,11 +631,9 @@ class GCloudPackageRepository extends PackageRepository {
       // Store the publisher of the package at the time of the upload.
       newVersion.publisherId = package.publisherId;
 
-      // Update the date when the package was last updated.
-      package.updated = newVersion.created;
-
       // Keep the latest version in the package object up-to-date.
       package.updateVersion(newVersion);
+      package.updated = DateTime.now().toUtc();
 
       try {
         _logger.info('Trying to upload tarball to cloud storage.');
@@ -840,6 +841,7 @@ class GCloudPackageRepository extends PackageRepository {
 
       // Add [uploaderEmail] to uploaders and commit.
       package.addUploader(uploader.userId);
+      package.updated = DateTime.now().toUtc();
 
       final inserts = <Model>[package];
       if (historyBackend.isEnabled) {
@@ -909,6 +911,7 @@ class GCloudPackageRepository extends PackageRepository {
 
       // Remove the uploader from the list.
       package.removeUploader(uploader.userId);
+      package.updated = DateTime.now().toUtc();
 
       final inserts = <Model>[package];
       if (historyBackend.isEnabled) {

--- a/app/lib/search/backend.dart
+++ b/app/lib/search/backend.dart
@@ -112,6 +112,7 @@ class SearchBackend {
       popularity: popularity,
       maintenance: analysisView.maintenanceScore,
       dependencies: _buildDependencies(analysisView),
+      publisherId: p.publisherId,
       emails: await _buildEmails(p, pv),
       apiDocPages: apiDocPages,
       timestamp: DateTime.now().toUtc(),
@@ -160,6 +161,7 @@ class SearchBackend {
         health: 0.0,
         popularity: popularity,
         maintenance: 0.0,
+        publisherId: p.publisherId,
         emails: await _buildEmails(p, null),
         timestamp: DateTime.now().toUtc(),
       );

--- a/app/lib/search/index_simple.dart
+++ b/app/lib/search/index_simple.dart
@@ -168,6 +168,14 @@ class SimplePackageIndex implements PackageIndex {
       });
     }
 
+    // filter on publisher
+    if (query.parsedQuery.publisher != null) {
+      packages.removeWhere((package) {
+        final doc = _packages[package];
+        return doc.publisherId != query.parsedQuery.publisher;
+      });
+    }
+
     // filter on email
     if (query.parsedQuery.emails.isNotEmpty) {
       packages.removeWhere((package) {

--- a/app/lib/search/search_service.dart
+++ b/app/lib/search/search_service.dart
@@ -58,6 +58,7 @@ class PackageDocument {
   final double maintenance;
 
   final Map<String, String> dependencies;
+  final String publisherId;
   final List<String> emails;
 
   final List<ApiDocPage> apiDocPages;
@@ -81,6 +82,7 @@ class PackageDocument {
     this.popularity = 0,
     this.maintenance = 0,
     this.dependencies = const {},
+    this.publisherId,
     this.emails = const [],
     this.apiDocPages = const [],
     DateTime timestamp,
@@ -112,6 +114,7 @@ class PackageDocument {
               key: (key) => internFn(key as String),
               value: (key) => internFn(dependencies[key]),
             ),
+      publisherId: internFn(publisherId),
       emails: emails?.map(internFn)?.toList(),
       apiDocPages: apiDocPages?.map((p) => p.intern(internFn))?.toList(),
       timestamp: timestamp,
@@ -202,6 +205,8 @@ String serializeSearchOrder(SearchOrder order) {
 final RegExp _whitespacesRegExp = RegExp(r'\s+');
 final RegExp _packageRegexp =
     RegExp('package:([_a-z0-9]+)', caseSensitive: false);
+final RegExp _publisherRegexp =
+    RegExp(r'publisher:([_a-z0-9\.]+)', caseSensitive: false);
 final RegExp _emailRegexp =
     RegExp(r'email:([_a-z0-9\@\-\.\+]+)', caseSensitive: false);
 final RegExp _refDependencyRegExp =
@@ -374,6 +379,9 @@ class ParsedQuery {
   /// Dependency match for all dependencies, including transitive ones.
   final List<String> allDependencies;
 
+  /// Match the publisher of the package.
+  final String publisher;
+
   /// Match authors and uploaders.
   final List<String> emails;
 
@@ -385,6 +393,7 @@ class ParsedQuery {
     this.packagePrefix,
     this.refDependencies,
     this.allDependencies,
+    this.publisher,
     this.emails,
     this.isApiEnabled,
   );
@@ -411,6 +420,8 @@ class ParsedQuery {
     final List<String> dependencies = extractRegExp(_refDependencyRegExp);
     final List<String> allDependencies = extractRegExp(_allDependencyRegExp);
     final List<String> emails = extractRegExp(_emailRegexp);
+    final allPublishers = extractRegExp(_publisherRegexp);
+    final publisher = allPublishers.isEmpty ? null : allPublishers.first;
 
     final bool isApiEnabled = queryText.contains(' !!api ');
     if (isApiEnabled) {
@@ -427,6 +438,7 @@ class ParsedQuery {
       packagePrefix,
       dependencies,
       allDependencies,
+      publisher,
       emails,
       isApiEnabled,
     );

--- a/app/lib/search/search_service.g.dart
+++ b/app/lib/search/search_service.g.dart
@@ -29,6 +29,7 @@ PackageDocument _$PackageDocumentFromJson(Map<String, dynamic> json) {
     dependencies: (json['dependencies'] as Map<String, dynamic>)?.map(
       (k, e) => MapEntry(k, e as String),
     ),
+    publisherId: json['publisherId'] as String,
     emails: (json['emails'] as List)?.map((e) => e as String)?.toList(),
     apiDocPages: (json['apiDocPages'] as List)
         ?.map((e) =>
@@ -57,6 +58,7 @@ Map<String, dynamic> _$PackageDocumentToJson(PackageDocument instance) =>
       'popularity': instance.popularity,
       'maintenance': instance.maintenance,
       'dependencies': instance.dependencies,
+      'publisherId': instance.publisherId,
       'emails': instance.emails,
       'apiDocPages': instance.apiDocPages,
       'timestamp': instance.timestamp?.toIso8601String(),

--- a/app/lib/search/updater.dart
+++ b/app/lib/search/updater.dart
@@ -107,7 +107,7 @@ class IndexUpdater implements TaskRunner {
         DatastoreHeadTaskSource(
           _db,
           TaskSourceModel.package,
-          sleep: const Duration(minutes: 30),
+          sleep: const Duration(minutes: 10),
         ),
         DatastoreHeadTaskSource(
           _db,

--- a/app/test/search/index_simple_test.dart
+++ b/app/test/search/index_simple_test.dart
@@ -166,6 +166,7 @@ The delegating wrapper classes allow users to easily add functionality on top of
         health: 1.0,
         maintenance: 1.0,
         dependencies: {'test': 'dev'},
+        publisherId: 'dart.dev',
         emails: ['user1@example.com'],
       ));
       await index.addPackage(PackageDocument(
@@ -485,6 +486,28 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'totalCount': 1,
         'packages': [
           {'package': 'http', 'score': closeTo(0.895, 0.001)},
+        ],
+      });
+    });
+
+    test('no results via publisher', () async {
+      final PackageSearchResult result = await index
+          .search(SearchQuery.parse(query: 'publisher:other-domain.com'));
+      expect(json.decode(json.encode(result)), {
+        'indexUpdated': isNotNull,
+        'totalCount': 0,
+        'packages': [],
+      });
+    });
+
+    test('filter by publisher', () async {
+      final PackageSearchResult result =
+          await index.search(SearchQuery.parse(query: 'publisher:dart.dev'));
+      expect(json.decode(json.encode(result)), {
+        'indexUpdated': isNotNull,
+        'totalCount': 1,
+        'packages': [
+          {'package': 'async', 'score': closeTo(0.930, 0.001)},
         ],
       });
     });

--- a/app/test/search/search_service_test.dart
+++ b/app/test/search/search_service_test.dart
@@ -82,18 +82,26 @@ void main() {
       expect(query.parsedQuery.hasAnyDependency, isTrue);
     });
 
+    test('only publisher', () {
+      final query = SearchQuery.parse(query: 'publisher:example.com');
+      expect(query.parsedQuery.text, isNull);
+      expect(query.parsedQuery.publisher, 'example.com');
+    });
+
     test('only email', () {
       final query = SearchQuery.parse(query: 'email:user@domain.com');
       expect(query.parsedQuery.text, isNull);
       expect(query.parsedQuery.emails, ['user@domain.com']);
     });
 
-    test('email + text + dependency', () {
+    test('publisher + email + text + dependency', () {
       final query = SearchQuery.parse(
-          query: 'email:user@domain.com text dependency:pkg1');
+          query:
+              'publisher:example.com email:user@domain.com text dependency:pkg1');
       expect(query.parsedQuery.text, 'text');
       expect(query.parsedQuery.refDependencies, ['pkg1']);
       expect(query.parsedQuery.allDependencies, []);
+      expect(query.parsedQuery.publisher, 'example.com');
       expect(query.parsedQuery.emails, ['user@domain.com']);
     });
   });


### PR DESCRIPTION
- update `Package.updated` on metadata-changes: discontinued change, publisher change, uploader add/remove
- more frequent polling in search for `Package.updated`
- storing `PackageDocument.publisherId` (in search index and snapshot)
- filter on `publisher:<publisherId>` in search queries