### PR TITLE
Misc CSS updates

### DIFF
--- a/pkg/web_css/lib/src/_base.scss
+++ b/pkg/web_css/lib/src/_base.scss
@@ -29,7 +29,7 @@ button {
 
 button.pub-button {
   font-size: 13px;
-  margin: 20px;
+  margin: 20px 20px 20px 0px;
   padding: 12px 24px;
   font-weight: 500;
   color: white;
@@ -43,17 +43,12 @@ button.pub-button {
   }
 }
 
-input.pub-input {
-  font-size: 13px;
-  margin: 20px;
-  padding: 12px 24px;
-}
-
+input.pub-input,
 textarea.pub-input {
-  width: 100%;
   font-size: 13px;
-  margin: 20px 0px;
   padding: 12px;
+  margin: 0 -24px 0 0;
+  width: 100%;
 }
 
 a {

--- a/pkg/web_css/lib/src/_detail_page.scss
+++ b/pkg/web_css/lib/src/_detail_page.scss
@@ -13,10 +13,29 @@
     -ms-flex: 0 0 270px;
     flex: 0 0 270px;
     width: 270px;
-    padding: 20px;
+    padding: 10px 20px 22px 20px;
     background: #F8F8F8;
     border: 1px solid #DDD;
     position: relative;
+    font-size: 14px;
+
+    > .title {
+      font-size: 14px;
+      margin: 12px 0 0 0;
+    }
+
+    > p {
+      margin: 0;
+    }
+
+    > .link {
+      text-overflow: ellipsis;
+      overflow: hidden;
+      white-space: nowrap;
+      max-width: 100%;
+      display: inline-block;
+      line-height: 1.2em;
+    }
   }
 }
 
@@ -118,31 +137,5 @@
     &.-active {
       display: block;
     }
-  }
-}
-
-.detail-info-box {
-  font-size: 14px;
-
-  > .title {
-    font-size: 14px;
-    margin: 12px 0 0 0;
-  }
-
-  &:not(:first-child) {
-    margin-top: 12px;
-  }
-
-  > p {
-    margin: 0;
-  }
-
-  > .link {
-    text-overflow: ellipsis;
-    overflow: hidden;
-    white-space: nowrap;
-    max-width: 100%;
-    display: inline-block;
-    line-height: 1.2em;
   }
 }


### PR DESCRIPTION
- `input` and `textarea` will take up the full width (while also having a padding and not taking up more horizontal space than their enclosing element)
- buttons are now positioned to the left, having extra margin on the right
- removed unnecessary extra top margin from the top of info-box, and also added extra bottom padding to make it symmetrical with the usual titles which do have a top margin
- merged info-box rules because they were in two places and it got confusing a bit