### PR TITLE
Publisher metadata (created time) on detail header.

### DIFF
--- a/app/lib/frontend/templates/publisher.dart
+++ b/app/lib/frontend/templates/publisher.dart
@@ -2,12 +2,15 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:convert';
+
 import 'package:client_data/page_data.dart';
 
 import '../../package/models.dart' show PackageView;
 import '../../publisher/models.dart' show Publisher;
 import '../../shared/markdown.dart';
 import '../../shared/urls.dart' as urls;
+import '../../shared/utils.dart' show shortDateFormat;
 
 import '_cache.dart';
 import 'detail_page.dart';
@@ -43,7 +46,7 @@ String renderPublisherPage(Publisher publisher, List<PackageView> packages) {
   ];
 
   final content = renderDetailPage(
-    headerHtml: renderDetailHeader(title: publisher.publisherId),
+    headerHtml: _renderDetailHeader(publisher),
     tabs: tabs,
     infoBoxHtml: _renderPublisherInfoBox(publisher),
   );
@@ -74,7 +77,7 @@ String renderPublisherAboutPage(Publisher publisher) {
   ];
 
   final content = renderDetailPage(
-    headerHtml: renderDetailHeader(title: publisher.publisherId),
+    headerHtml: _renderDetailHeader(publisher),
     tabs: tabs,
     infoBoxHtml: _renderPublisherInfoBox(publisher),
   );
@@ -145,7 +148,7 @@ String renderPublisherAdminPage(Publisher publisher) {
   ];
 
   final content = renderDetailPage(
-    headerHtml: renderDetailHeader(title: publisher.publisherId),
+    headerHtml: _renderDetailHeader(publisher),
     tabs: tabs,
     infoBoxHtml: _renderPublisherInfoBox(publisher),
   );
@@ -159,6 +162,14 @@ String renderPublisherAdminPage(Publisher publisher) {
       ),
     ),
     noIndex: true,
+  );
+}
+
+String _renderDetailHeader(Publisher publisher) {
+  final shortCreated = shortDateFormat.format(publisher.created);
+  return renderDetailHeader(
+    title: publisher.publisherId,
+    metadataHtml: htmlEscape.convert('Publisher registered on $shortCreated.'),
   );
 }
 

--- a/app/test/frontend/golden/publisher_about_page.html
+++ b/app/test/frontend/golden/publisher_about_page.html
@@ -78,6 +78,8 @@
         <div class="detail-header">
           <h2 class="title">example.com</h2>
           <div class="metadata">
+    Publisher registered on Sep 13, 2019.
+    
             <div class="tags"></div>
           </div>
         </div>

--- a/app/test/frontend/golden/publisher_packages_page.html
+++ b/app/test/frontend/golden/publisher_packages_page.html
@@ -78,6 +78,8 @@
         <div class="detail-header">
           <h2 class="title">example.com</h2>
           <div class="metadata">
+    Publisher registered on Sep 13, 2019.
+    
             <div class="tags"></div>
           </div>
         </div>

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -557,7 +557,8 @@ void main() {
             ..contactEmail = 'hello@example.com'
             ..description = 'This is our little software developer shop.\n\n'
                 'We develop full-stack in Dart, and happy about it.'
-            ..websiteUrl = 'https://example.com/',
+            ..websiteUrl = 'https://example.com/'
+            ..created = DateTime(2019, 09, 13),
           [
             PackageView(
               name: 'super_package',
@@ -586,7 +587,8 @@ void main() {
         ..contactEmail = 'hello@example.com'
         ..description = 'This is our little software developer shop.\n\n'
             'We develop full-stack in Dart, and happy about it.'
-        ..websiteUrl = 'https://example.com/');
+        ..websiteUrl = 'https://example.com/'
+        ..created = DateTime(2019, 09, 13));
       expectGoldenFile(html, 'publisher_about_page.html');
     });
 


### PR DESCRIPTION
I've tried a few things, and I think instead of putting 'Publisher:' in the title, putting it in the metadata is better. Also the 'created on' felt like that the domain was registered on that date, not sure if the current registered on feels better, but maybe a little bit.