### PR TITLE
Fix NPE in JS on publisher pages.

### DIFF
--- a/pkg/web_app/lib/src/account.dart
+++ b/pkg/web_app/lib/src/account.dart
@@ -422,6 +422,7 @@ class _PublisherAdminWidget {
   }
 
   void update() {
+    if (!isActive) return;
     // only load trigger the loading of the members list once
     if (_isAdmin && membersFuture == null) {
       final publisherId = pageData.publisher.publisherId;


### PR DESCRIPTION
The exception on line 444 happened because we were trying to load the members list on non-admin pages too. Checking the active state of the widget prevents that.