### PR TITLE
Fix sitemap hostname in robots.txt

### DIFF
--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,3 +1,3 @@
 User-agent: *
 Disallow: /experimental/
-sitemap: https://pub.dartlang.org/sitemap.txt
+Sitemap: https://pub.dev/sitemap.txt


### PR DESCRIPTION
It is redirected, but why do the extra request there...