### PR TITLE
Increase timeout for fake-pub-server startup

### DIFF
--- a/pkg/pub_integration/lib/src/fake_pub_server_process.dart
+++ b/pkg/pub_integration/lib/src/fake_pub_server_process.dart
@@ -73,7 +73,7 @@ class FakePubServerProcess {
         }
       },
     );
-    Timer(Duration(seconds: 30), () {
+    Timer(Duration(seconds: 60), () {
       if (!_startedCompleter.isCompleted) {
         _startedCompleter.completeError('Timout starting fake_pub_server');
       }


### PR DESCRIPTION
We've increased the test timeouts a while back, but this value still limits it to 30 seconds.