### PR TITLE
New sitemap for publishers.

### DIFF
--- a/app/lib/frontend/handlers/misc.dart
+++ b/app/lib/frontend/handlers/misc.dart
@@ -99,10 +99,15 @@ Future<shelf.Response> siteMapTxtHandler(shelf.Request request) async {
   return shelf.Response.ok(items.join('\n'));
 }
 
-/// Handles requests for /sitemap/publishers.txt
+/// Handles requests for /sitemap-2.txt
 Future<shelf.Response> sitemapPublishersTxtHandler(
     shelf.Request request) async {
   if (requestContext.blockRobots) {
+    return notFoundHandler(request);
+  }
+  if (!requestContext.isExperimental) {
+    // TODO: add the following line to robots.txt
+    // Sitemap: https://pub.dev/sitemap-2.txt
     return notFoundHandler(request);
   }
 

--- a/app/lib/frontend/handlers/routes.dart
+++ b/app/lib/frontend/handlers/routes.dart
@@ -177,8 +177,8 @@ class PubSiteService {
   @Route.get('/sitemap.txt')
   Future<Response> sitemapTxt(Request request) => siteMapTxtHandler(request);
 
-  /// Renders the /sitemap.txt page
-  @Route.get('/sitemap/publishers.txt')
+  /// Renders the /sitemap-2.txt page
+  @Route.get('/sitemap-2.txt')
   Future<Response> sitemapPublishersTxt(Request request) =>
       sitemapPublishersTxtHandler(request);
 

--- a/app/lib/frontend/handlers/routes.dart
+++ b/app/lib/frontend/handlers/routes.dart
@@ -177,6 +177,11 @@ class PubSiteService {
   @Route.get('/sitemap.txt')
   Future<Response> sitemapTxt(Request request) => siteMapTxtHandler(request);
 
+  /// Renders the /sitemap.txt page
+  @Route.get('/sitemap/publishers.txt')
+  Future<Response> sitemapPublishersTxt(Request request) =>
+      sitemapPublishersTxtHandler(request);
+
   /// Renders static assets
   @Route.get('/favicon.ico')
   @Route.get('/static/<path|[^]*>')

--- a/app/lib/frontend/handlers/routes.g.dart
+++ b/app/lib/frontend/handlers/routes.g.dart
@@ -43,7 +43,7 @@ Router _$PubSiteServiceRouter(PubSiteService service) {
   router.add('GET', r'/robots.txt', service.robotsTxt);
   router.add('GET', r'/security', service.securityPage);
   router.add('GET', r'/sitemap.txt', service.sitemapTxt);
-  router.add('GET', r'/sitemap/publishers.txt', service.sitemapPublishersTxt);
+  router.add('GET', r'/sitemap-2.txt', service.sitemapPublishersTxt);
   router.add('GET', r'/favicon.ico', service.staticAsset);
   router.add('GET', r'/static/<path|[^]*>', service.staticAsset);
   router.add('GET', r'/experimental', service.experimental);

--- a/app/lib/frontend/handlers/routes.g.dart
+++ b/app/lib/frontend/handlers/routes.g.dart
@@ -43,6 +43,7 @@ Router _$PubSiteServiceRouter(PubSiteService service) {
   router.add('GET', r'/robots.txt', service.robotsTxt);
   router.add('GET', r'/security', service.securityPage);
   router.add('GET', r'/sitemap.txt', service.sitemapTxt);
+  router.add('GET', r'/sitemap/publishers.txt', service.sitemapPublishersTxt);
   router.add('GET', r'/favicon.ico', service.staticAsset);
   router.add('GET', r'/static/<path|[^]*>', service.staticAsset);
   router.add('GET', r'/experimental', service.experimental);

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,5 +1,3 @@
 User-agent: *
 Disallow: /experimental/
 Sitemap: https://pub.dev/sitemap.txt
-# TODO: enable this after publishers are launched
-# Sitemap: https://pub.dev/sitemap/publishers.txt

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,3 +1,5 @@
 User-agent: *
 Disallow: /experimental/
 Sitemap: https://pub.dev/sitemap.txt
+# TODO: enable this after publishers are launched
+# Sitemap: https://pub.dev/sitemap/publishers.txt


### PR DESCRIPTION
- Future plans:
  - one-hour caching for both sitemaps
  - moving packages to `/sitemap/packages.txt` (may keep only static pages in the `/sitemap.txt`, maybe moving that too inside `/sitemap/` directory).
  - maybe sharding (with some kind of `packages-[postfix].txt`
