### PR TITLE
Additional query parameter for search backend.

### DIFF
--- a/app/lib/frontend/handlers/custom_api.dart
+++ b/app/lib/frontend/handlers/custom_api.dart
@@ -224,7 +224,7 @@ Future<shelf.Response> apiHistoryHandler(shelf.Request request) async {
 /// Handles requests for /api/search
 Future<shelf.Response> apiSearchHandler(shelf.Request request) async {
   final searchQuery =
-      parseFrontendSearchQuery(request.requestedUri.queryParameters, null);
+      parseFrontendSearchQuery(request.requestedUri.queryParameters);
   final sr = await searchClient.search(searchQuery);
   final packages = sr.packages.map((ps) => {'package': ps.package}).toList();
   final hasNextPage = sr.totalCount > searchQuery.limit + searchQuery.offset;

--- a/app/lib/frontend/handlers/listing.dart
+++ b/app/lib/frontend/handlers/listing.dart
@@ -45,8 +45,10 @@ Future<shelf.Response> webPackagesHandlerHtml(shelf.Request request) =>
 Future<shelf.Response> _packagesHandlerHtmlCore(
     shelf.Request request, String platform) async {
   // TODO: use search memcache for all results here or remove search memcache
-  final searchQuery =
-      parseFrontendSearchQuery(request.requestedUri.queryParameters, platform);
+  final searchQuery = parseFrontendSearchQuery(
+    request.requestedUri.queryParameters,
+    platform: platform,
+  );
   final sw = Stopwatch()..start();
   final searchResult = await searchService.search(searchQuery);
   final int totalCount = searchResult.totalCount;

--- a/app/lib/search/index_simple.dart
+++ b/app/lib/search/index_simple.dart
@@ -169,10 +169,11 @@ class SimplePackageIndex implements PackageIndex {
     }
 
     // filter on publisher
-    if (query.parsedQuery.publisher != null) {
+    if (query.publisherId != null || query.parsedQuery.publisher != null) {
+      final publisherId = query.publisherId ?? query.parsedQuery.publisher;
       packages.removeWhere((package) {
         final doc = _packages[package];
-        return doc.publisherId != query.parsedQuery.publisher;
+        return doc.publisherId != publisherId;
       });
     }
 

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -752,7 +752,7 @@ void main() {
     scopedTest('PageLinks defaults', () {
       final query = SearchQuery.parse(query: 'web framework');
       final PageLinks links = PageLinks(0, 100, searchQuery: query);
-      expect(links.formatHref(1), '/packages?q=web+framework&page=1');
+      expect(links.formatHref(1), '/packages?q=web+framework');
       expect(links.formatHref(2), '/packages?q=web+framework&page=2');
     });
 
@@ -760,7 +760,7 @@ void main() {
       final query =
           SearchQuery.parse(query: 'some framework', platform: 'flutter');
       final PageLinks links = PageLinks(0, 100, searchQuery: query);
-      expect(links.formatHref(1), '/flutter/packages?q=some+framework&page=1');
+      expect(links.formatHref(1), '/flutter/packages?q=some+framework');
       expect(links.formatHref(2), '/flutter/packages?q=some+framework&page=2');
     });
   });

--- a/app/test/search/search_service_test.dart
+++ b/app/test/search/search_service_test.dart
@@ -163,6 +163,21 @@ void main() {
       expect(query.toSearchLink(), '/flutter/packages');
     });
 
+    test('publisher: example.com', () {
+      final query = SearchQuery.parse(publisherId: 'example.com');
+      expect(query.toSearchLink(), '/publishers/example.com/packages');
+      expect(query.toSearchLink(page: 2),
+          '/publishers/example.com/packages?page=2');
+    });
+
+    test('publisher: example.com with query', () {
+      final query =
+          SearchQuery.parse(publisherId: 'example.com', query: 'json');
+      expect(query.toSearchLink(), '/publishers/example.com/packages?q=json');
+      expect(query.toSearchLink(page: 2),
+          '/publishers/example.com/packages?q=json&page=2');
+    });
+
     test('package prefix: angular', () {
       final query = SearchQuery.parse(query: 'package:angular');
       expect(query.parsedQuery.text, isNull);


### PR DESCRIPTION
Still keeping the `publisher:*` pattern in the parsed query, because that has some value, and we can deal with the conflicting queries later (e.g. searching for `publisher:a` on `/publishers/b/packages`).