### PR TITLE
Fix: input placeholder color in Chrome 78

### DIFF
--- a/pkg/web_css/lib/src/_search.scss
+++ b/pkg/web_css/lib/src/_search.scss
@@ -24,6 +24,10 @@
   flex-grow: 1;
   background: $color-searchbar-dark-input-bg;
   color: $color-searchbar-dark-input-fg;
+
+  &::placeholder {
+    color: #888;
+  }
 }
 
 .search-bar > .icon {


### PR DESCRIPTION
Fixes #2797

It looks like that Chrome 78 changed the default color of `input::placeholder` CSS style, and now defaults to something close to black, which reduced the visibility in our dark grey input field. Setting it explicitly will fix that.
