### PR TITLE
Searchable publisher packages page.

### DIFF
--- a/app/lib/frontend/handlers/routes.dart
+++ b/app/lib/frontend/handlers/routes.dart
@@ -147,6 +147,11 @@ class PubSiteService {
   Future<Response> publisherAboutPage(Request request, String publisherId) =>
       publisherAboutPageHandler(request, publisherId);
 
+  /// Renders the publisher's packages page.
+  @Route.get('/publishers/<publisherId>/packages')
+  Future<Response> publisherPackagesPage(Request request, String publisherId) =>
+      publisherPackagesPageHandler(request, publisherId);
+
   /// Renders the publisher's admin page.
   @Route.get('/publishers/<publisherId>/admin')
   Future<Response> publisherAdminPage(Request request, String publisherId) =>

--- a/app/lib/frontend/handlers/routes.g.dart
+++ b/app/lib/frontend/handlers/routes.g.dart
@@ -36,6 +36,8 @@ Router _$PubSiteServiceRouter(PubSiteService service) {
   router.add('GET', r'/publishers/<publisherId>', service.publisherPage);
   router.add(
       'GET', r'/publishers/<publisherId>/about', service.publisherAboutPage);
+  router.add('GET', r'/publishers/<publisherId>/packages',
+      service.publisherPackagesPage);
   router.add(
       'GET', r'/publishers/<publisherId>/admin', service.publisherAdminPage);
   router.add('GET', r'/feed.atom', service.atomFeed);

--- a/app/lib/frontend/templates/layout.dart
+++ b/app/lib/frontend/templates/layout.dart
@@ -37,6 +37,7 @@ String renderLayoutPage(
   String faviconUrl,
   String canonicalUrl,
   String platform,
+  String publisherId,
   SearchQuery searchQuery,
   bool includeSurvey = true,
   bool noIndex = false,
@@ -64,7 +65,12 @@ String renderLayoutPage(
     if (type == PageType.standalone) 'page-standalone',
     if (requestContext.isExperimental) 'experimental',
   ];
-  final searchFormUrl = SearchQuery.parse(platform: platform).toSearchLink();
+  final searchFormUrl =
+      SearchQuery.parse(platform: platform, publisherId: publisherId)
+          .toSearchLink();
+  final searchPlaceholder = publisherId != null
+      ? 'Search $publisherId packages'
+      : platformDict.searchPlatformPackagesLabel;
   final values = {
     'dart_site_root': urls.dartSiteRoot,
     'oauth_client_id': requestContext.isExperimental
@@ -82,7 +88,7 @@ String renderLayoutPage(
     'site_logo_url': staticUrls.pubDevLogo2xPng,
     'search_form_url': searchFormUrl,
     'search_query_html': escapedSearchQuery,
-    'search_query_placeholder': platformDict.searchPlatformPackagesLabel,
+    'search_query_placeholder': searchPlaceholder,
     'search_sort_param': searchSort,
     'platform_tabs_html': platformTabs,
     'legacy_search_enabled': searchQuery?.includeLegacy ?? false,

--- a/app/lib/frontend/templates/views/layout.mustache
+++ b/app/lib/frontend/templates/views/layout.mustache
@@ -107,7 +107,7 @@
     <div class="container">
       <div class="small-banner">
         <form class="search-bar" action="{{& search_form_url}}">
-          <input class="input" name="q" placeholder="{{search_query_placeholder}}" autocomplete="on" autofocus="autofocus" />
+          <input class="input" name="q" placeholder="{{search_query_placeholder}}" autocomplete="on" autofocus="autofocus"{{#search_query_html}} value="{{& search_query_html}}"{{/search_query_html}}/>
           <button class="icon"></button>
         </form>
       </div>

--- a/app/lib/search/index_simple.dart
+++ b/app/lib/search/index_simple.dart
@@ -241,7 +241,8 @@ class SimplePackageIndex implements PackageIndex {
             : (_packages[queryText] ?? _packages[queryText.toLowerCase()]);
         if (matchingPackage != null &&
             matchingPackage.maintenance != null &&
-            matchingPackage.maintenance > 0.0) {
+            matchingPackage.maintenance > 0.0 &&
+            packages.contains(matchingPackage.package)) {
           final double maxValue = overallScore.getMaxValue();
           final map = Map<String, double>.from(
               overallScore.map((key, value) => value * 0.99)._values);

--- a/app/lib/search/search_service.dart
+++ b/app/lib/search/search_service.dart
@@ -590,6 +590,7 @@ SearchQuery parseFrontendSearchQuery(
   return SearchQuery.parse(
     query: queryText,
     platform: platform,
+    publisherId: publisherId,
     order: sortOrder,
     offset: offset,
     limit: resultsPerPage,

--- a/app/lib/shared/urls.dart
+++ b/app/lib/shared/urls.dart
@@ -73,6 +73,8 @@ String analysisTabUrl(String package) {
 String publisherUrl(String publisherId) => '/publishers/$publisherId';
 String publisherAboutUrl(String publisherId) =>
     '/publishers/$publisherId/about';
+String publisherPackagesUrl(String publisherId) =>
+    '/publishers/$publisherId/packages';
 String publisherAdminUrl(String publisherId) =>
     '/publishers/$publisherId/admin';
 

--- a/app/test/frontend/golden/publisher_landing_page.html
+++ b/app/test/frontend/golden/publisher_landing_page.html
@@ -9,8 +9,8 @@
     <meta name="twitter:card" content="summary"/>
     <meta name="twitter:site" content="@dart_lang"/>
     <meta property="og:site_name" content="Dart packages"/>
-    <title>Packages of publisher example.com</title>
-    <meta property="og:title" content="Packages of publisher example.com"/>
+    <title>Publisher: example.com</title>
+    <meta property="og:title" content="Publisher: example.com"/>
     <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet"/>
     <meta itemprop="image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
     <meta property="og:image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
@@ -66,8 +66,8 @@
     <div class="_banner-bg">
       <div class="container">
         <div class="small-banner">
-          <form class="search-bar" action="/publishers/example.com/packages">
-            <input class="input" name="q" placeholder="Search example.com packages" autocomplete="on" autofocus="autofocus"/>
+          <form class="search-bar" action="/packages">
+            <input class="input" name="q" placeholder="Search Dart packages" autocomplete="on" autofocus="autofocus"/>
             <button class="icon"></button>
           </form>
         </div>
@@ -85,17 +85,16 @@
         </div>
         <div class="detail-container">
           <ul class="detail-tabs-header">
-            <li class="tab-button -active" data-name="-packages-tab-" role="button">Packages</li>
+            <li class="tab-button -active" data-name="-packages-tab-" role="button">Top Packages</li>
+            <li class="tab-link" data-name="-about-tab-" role="button">
+              <a href="/publishers/example.com/about">About</a>
+            </li>
             <li class="tab-link -hidden" data-name="-admin-tab-" role="button">
               <a href="/publishers/example.com/admin">Admin</a>
             </li>
           </ul>
           <div class="main detail-tabs-content">
             <section class="tab-content -active" data-name="-packages-tab-">
-      2 
-              <code>example.com</code> packages.
-
-
               <ul class="package-list">
                 <li class="list-item -full">
                   <a href="/packages/super_package#-analysis-tab-">
@@ -135,23 +134,6 @@
                     <span>30 Mar 2019</span>
                     <a class="package-tag" href="/flutter/packages" title="Compatible with the Flutter platform.">Flutter</a>
                   </p>
-                </li>
-              </ul>
-              <ul class="pagination">
-                <li class="-disabled">
-                  <a href="">
-                    <span>«</span>
-                  </a>
-                </li>
-                <li class="-active">
-                  <a href="">
-                    <span>1</span>
-                  </a>
-                </li>
-                <li class="-disabled">
-                  <a href="">
-                    <span>»</span>
-                  </a>
                 </li>
               </ul>
             </section>

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -569,7 +569,7 @@ void main() {
       expectGoldenFile(html, 'publisher_list_page.html');
     });
 
-    scopedTest('publisher packages page', () {
+    scopedTest('publisher landing page', () {
       final html = renderPublisherPage(
           Publisher()
             ..id = 'example.com'
@@ -597,6 +597,42 @@ void main() {
               overallScore: 0.90,
             ),
           ]);
+      expectGoldenFile(html, 'publisher_landing_page.html');
+    });
+
+    scopedTest('publisher packages page', () {
+      final searchQuery = SearchQuery.parse(publisherId: 'example.com');
+      final html = renderPublisherPackagesPage(
+        publisher: Publisher()
+          ..id = 'example.com'
+          ..contactEmail = 'hello@example.com'
+          ..description = 'This is our little software developer shop.\n\n'
+              'We develop full-stack in Dart, and happy about it.'
+          ..websiteUrl = 'https://example.com/'
+          ..created = DateTime(2019, 09, 13),
+        packages: [
+          PackageView(
+            name: 'super_package',
+            version: '1.0.0',
+            ellipsizedDescription: 'A great web UI library.',
+            shortUpdated: '3 Jan 2019',
+            platforms: ['web'],
+            overallScore: 0.97,
+          ),
+          PackageView(
+            name: 'another_package',
+            version: '2.0.0',
+            devVersion: '3.0.0-beta2',
+            ellipsizedDescription: 'Camera plugin.',
+            shortUpdated: '30 Mar 2019',
+            platforms: ['flutter'],
+            overallScore: 0.90,
+          ),
+        ],
+        totalCount: 2,
+        searchQuery: searchQuery,
+        pageLinks: PageLinks(0, 10, searchQuery: searchQuery),
+      );
       expectGoldenFile(html, 'publisher_packages_page.html');
     });
 


### PR DESCRIPTION
- tabs are not fully done yet (e.g. haven't removed the old ones, no redirect)
- search and pagination is working, tested it with relaxing the publisher filter
- search is working when started from the admin page too
- search index needed adjustment, exact name match is shown only when other filters don't remove it
- deployed to staging
