### PR TITLE
Set and clear session cookie on login/logout.

### DIFF
--- a/app/lib/account/backend.dart
+++ b/app/lib/account/backend.dart
@@ -279,12 +279,12 @@ class AccountBackend {
   }
 
   /// Creates a new session for the current authenticated user and returns the
-  /// new `sessionId`.
+  /// new session data.
   ///
-  /// The `sessionId` is a secret that will be stored in a secure cookie.
-  /// Presence of this `sessionId` in a cookie, can only be used to authorize
-  /// user specific content to be embedded in HTML pages (such pages must have
-  /// `Cache-Control: private`, and may not be cached in server-side).
+  /// The [UserSessionData.sessionId] is a secret that will be stored in a
+  /// secure cookie. Presence of this `sessionId` in a cookie, can only be used
+  /// to authorize user specific content to be embedded in HTML pages (such pages
+  /// must have `Cache-Control: private`, and may not be cached in server-side).
   /// JSON APIs whether fetching data or updating data cannot be authorized with
   /// a cookie carrying the `sessionId`.
   Future<UserSessionData> createNewSession({@required String imageUrl}) async {

--- a/app/lib/account/models.dart
+++ b/app/lib/account/models.dart
@@ -67,6 +67,7 @@ class OAuthUserID extends db.ExpandoModel {
 }
 
 /// Maps the session id (from cookie) to User.id and cached profile properties.
+@db.Kind(name: 'UserSession', idType: db.IdType.String)
 class UserSession extends db.ExpandoModel {
   /// Same as [id].
   /// This is a v4 (random) UUID String.

--- a/app/lib/frontend/handlers/pubapi.client.dart
+++ b/app/lib/frontend/handlers/pubapi.client.dart
@@ -157,6 +157,21 @@ class PubApiClient {
     ));
   }
 
+  Future<List<int>> updateSession(_i4.ClientSessionData payload) async {
+    return await _client.requestBytes(
+      verb: 'post',
+      path: '/api/account/session',
+      body: payload.toJson(),
+    );
+  }
+
+  Future<List<int>> invalidateSession() async {
+    return await _client.requestBytes(
+      verb: 'delete',
+      path: '/api/account/session',
+    );
+  }
+
   Future<_i4.AccountPkgOptions> accountPackageOptions(String package) async {
     return _i4.AccountPkgOptions.fromJson(await _client.requestJson(
       verb: 'get',

--- a/app/lib/frontend/handlers/pubapi.dart
+++ b/app/lib/frontend/handlers/pubapi.dart
@@ -183,6 +183,30 @@ class PubApi {
           Request request, String consentId, ConsentResult result) =>
       consentBackend.resolveConsent(consentId, result);
 
+  /// Registers (or extends) a user session.
+  ///
+  /// This endpoint should be called after an explicit login action or when the
+  /// client-side auth library receives an updated GoogleUser object
+  /// (automatic updates).
+  ///
+  /// The response header will contain the updated session cookie, and the body
+  /// is a [ClientSessionStatus].
+  @EndPoint.post('/api/account/session')
+  Future<Response> updateSession(
+          Request request, ClientSessionData sessionData) =>
+      updateSessionHandler(request, clientSessionData: sessionData);
+
+  /// Registers (or extends) a user session.
+  ///
+  /// This endpoint should be called after an explicit logout action or when the
+  /// client-side auth library logs out the current session.
+  ///
+  /// The response header will contain the session cookie with an immediate
+  /// expiration, and the body is a [ClientSessionStatus].
+  @EndPoint.delete('/api/account/session')
+  Future<Response> invalidateSession(Request request) =>
+      invalidateSessionHandler(request);
+
   // ****
   // **** Custom API
   // ****

--- a/app/lib/frontend/handlers/pubapi.dart
+++ b/app/lib/frontend/handlers/pubapi.dart
@@ -196,13 +196,13 @@ class PubApi {
           Request request, ClientSessionData sessionData) =>
       updateSessionHandler(request, clientSessionData: sessionData);
 
-  /// Registers (or extends) a user session.
+  /// Removes the user session.
   ///
   /// This endpoint should be called after an explicit logout action or when the
   /// client-side auth library logs out the current session.
   ///
   /// The response header will contain the session cookie with an immediate
-  /// expiration, and the body is a [ClientSessionStatus].
+  /// expiration (clearing the cookie), and the body is a [ClientSessionStatus].
   @EndPoint.delete('/api/account/session')
   Future<Response> invalidateSession(Request request) =>
       invalidateSessionHandler(request);

--- a/app/lib/frontend/handlers/pubapi.g.dart
+++ b/app/lib/frontend/handlers/pubapi.g.dart
@@ -274,6 +274,32 @@ Router _$PubApiRouter(PubApi service) {
       return $utilities.unhandledError(e, st);
     }
   });
+  router.add('POST', r'/api/account/session', (Request request) async {
+    try {
+      final _$result = await service.updateSession(
+        request,
+        await $utilities.decodeJson<ClientSessionData>(
+            request, (o) => ClientSessionData.fromJson(o)),
+      );
+      return _$result;
+    } on ApiResponseException catch (e) {
+      return e.asApiResponse();
+    } catch (e, st) {
+      return $utilities.unhandledError(e, st);
+    }
+  });
+  router.add('DELETE', r'/api/account/session', (Request request) async {
+    try {
+      final _$result = await service.invalidateSession(
+        request,
+      );
+      return _$result;
+    } on ApiResponseException catch (e) {
+      return e.asApiResponse();
+    } catch (e, st) {
+      return $utilities.unhandledError(e, st);
+    }
+  });
   router.add('GET', r'/api/account/options/packages/<package>',
       (Request request, String package) async {
     try {

--- a/app/lib/frontend/handlers/routes.dart
+++ b/app/lib/frontend/handlers/routes.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:client_data/account_api.dart';
 import 'package:shelf/shelf.dart';
 import 'package:shelf_router/shelf_router.dart';
 

--- a/app/lib/frontend/handlers/routes.dart
+++ b/app/lib/frontend/handlers/routes.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:client_data/account_api.dart';
 import 'package:shelf/shelf.dart';
 import 'package:shelf_router/shelf_router.dart';
 

--- a/app/lib/shared/handler_helpers.dart
+++ b/app/lib/shared/handler_helpers.dart
@@ -228,7 +228,7 @@ shelf.Handler _userSessionWrapper(shelf.Handler handler) {
   return (shelf.Request request) async {
     final cookies =
         parseCookieHeader(request.headers[HttpHeaders.cookieHeader]);
-    final sessionId = cookies['pub_sid'];
+    final sessionId = cookies[pubSessionCookieName];
     if (sessionId != null) {
       final sessionData = await accountBackend.lookupSession(sessionId);
       if (sessionData != null) {

--- a/app/lib/shared/handler_helpers.dart
+++ b/app/lib/shared/handler_helpers.dart
@@ -229,7 +229,7 @@ shelf.Handler _userSessionWrapper(shelf.Handler handler) {
     final cookies =
         parseCookieHeader(request.headers[HttpHeaders.cookieHeader]);
     final sessionId = cookies[pubSessionCookieName];
-    if (sessionId != null) {
+    if (sessionId != null && sessionId.isNotEmpty) {
       final sessionData = await accountBackend.lookupSession(sessionId);
       if (sessionData != null) {
         registerUserSessionData(sessionData);

--- a/app/lib/shared/handlers.dart
+++ b/app/lib/shared/handlers.dart
@@ -44,10 +44,15 @@ shelf.Response jsonResponse(
   final String body = (indentJson || requestContext.indentJson)
       ? _prettyJson.convert(map)
       : json.encode(map);
-  headers ??= <String, String>{};
-  headers['content-type'] = 'application/json; charset="utf-8"';
-  headers['x-content-type-options'] = 'nosniff';
-  return shelf.Response(status, body: body, headers: headers);
+  return shelf.Response(
+    status,
+    body: body,
+    headers: {
+      if (headers != null) ...headers,
+      'content-type': 'application/json; charset="utf-8"',
+      'x-content-type-options': 'nosniff',
+    },
+  );
 }
 
 final _none = <String>["'none'"];

--- a/app/lib/shared/handlers.dart
+++ b/app/lib/shared/handlers.dart
@@ -35,19 +35,19 @@ shelf.Response redirectToSearch(String query) {
   return redirectResponse(urls.searchUrl(q: query));
 }
 
-shelf.Response jsonResponse(Map map,
-    {int status = 200, bool indentJson = false}) {
+shelf.Response jsonResponse(
+  Map map, {
+  int status = 200,
+  bool indentJson = false,
+  Map<String, String> headers,
+}) {
   final String body = (indentJson || requestContext.indentJson)
       ? _prettyJson.convert(map)
       : json.encode(map);
-  return shelf.Response(
-    status,
-    body: body,
-    headers: {
-      'content-type': 'application/json; charset="utf-8"',
-      'x-content-type-options': 'nosniff',
-    },
-  );
+  headers ??= <String, String>{};
+  headers['content-type'] = 'application/json; charset="utf-8"';
+  headers['x-content-type-options'] = 'nosniff';
+  return shelf.Response(status, body: body, headers: headers);
 }
 
 final _none = <String>["'none'"];

--- a/pkg/client_data/lib/account_api.dart
+++ b/pkg/client_data/lib/account_api.dart
@@ -2,10 +2,50 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:convert';
+
 import 'package:json_annotation/json_annotation.dart';
 import 'package:meta/meta.dart';
 
 part 'account_api.g.dart';
+
+/// Session data to be cached from the authenticated client.
+@JsonSerializable()
+class ClientSessionData {
+  final String imageUrl;
+
+  ClientSessionData({
+    @required this.imageUrl,
+  });
+
+  factory ClientSessionData.fromJson(Map<String, dynamic> json) =>
+      _$ClientSessionDataFromJson(json);
+
+  Map<String, dynamic> toJson() => _$ClientSessionDataToJson(this);
+}
+
+/// The server-provided status of the current session.
+@JsonSerializable()
+class ClientSessionStatus {
+  final bool changed;
+  final DateTime expires;
+
+  ClientSessionStatus({
+    @required this.changed,
+    @required this.expires,
+  });
+
+  factory ClientSessionStatus.fromJson(Map<String, dynamic> json) =>
+      _$ClientSessionStatusFromJson(json);
+
+  factory ClientSessionStatus.fromBytes(List<int> bytes) =>
+      ClientSessionStatus.fromJson(
+          json.decode(utf8.decode(bytes)) as Map<String, dynamic>);
+
+  Map<String, dynamic> toJson() => _$ClientSessionStatusToJson(this);
+
+  bool get isValid => expires != null && DateTime.now().isBefore(expires);
+}
 
 /// Account-specific information about a package.
 @JsonSerializable()

--- a/pkg/client_data/lib/account_api.dart
+++ b/pkg/client_data/lib/account_api.dart
@@ -27,6 +27,8 @@ class ClientSessionData {
 /// The server-provided status of the current session.
 @JsonSerializable()
 class ClientSessionStatus {
+  /// True, if the user session has been updated and the current page should be
+  /// reloaded.
   final bool changed;
   final DateTime expires;
 

--- a/pkg/client_data/lib/account_api.g.dart
+++ b/pkg/client_data/lib/account_api.g.dart
@@ -6,6 +6,33 @@ part of 'account_api.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
+ClientSessionData _$ClientSessionDataFromJson(Map<String, dynamic> json) {
+  return ClientSessionData(
+    imageUrl: json['imageUrl'] as String,
+  );
+}
+
+Map<String, dynamic> _$ClientSessionDataToJson(ClientSessionData instance) =>
+    <String, dynamic>{
+      'imageUrl': instance.imageUrl,
+    };
+
+ClientSessionStatus _$ClientSessionStatusFromJson(Map<String, dynamic> json) {
+  return ClientSessionStatus(
+    changed: json['changed'] as bool,
+    expires: json['expires'] == null
+        ? null
+        : DateTime.parse(json['expires'] as String),
+  );
+}
+
+Map<String, dynamic> _$ClientSessionStatusToJson(
+        ClientSessionStatus instance) =>
+    <String, dynamic>{
+      'changed': instance.changed,
+      'expires': instance.expires?.toIso8601String(),
+    };
+
 AccountPkgOptions _$AccountPkgOptionsFromJson(Map<String, dynamic> json) {
   return AccountPkgOptions(
     isAdmin: json['isAdmin'] as bool,

--- a/pkg/web_app/lib/src/pubapi.client.dart
+++ b/pkg/web_app/lib/src/pubapi.client.dart
@@ -157,6 +157,21 @@ class PubApiClient {
     ));
   }
 
+  Future<List<int>> updateSession(_i4.ClientSessionData payload) async {
+    return await _client.requestBytes(
+      verb: 'post',
+      path: '/api/account/session',
+      body: payload.toJson(),
+    );
+  }
+
+  Future<List<int>> invalidateSession() async {
+    return await _client.requestBytes(
+      verb: 'delete',
+      path: '/api/account/session',
+    );
+  }
+
   Future<_i4.AccountPkgOptions> accountPackageOptions(String package) async {
     return _i4.AccountPkgOptions.fromJson(await _client.requestJson(
       verb: 'get',


### PR DESCRIPTION
- The set and clear action is on an API endpoint, which makes it simpler (single place, one operation to test for), but it requires a page reload if the cookie has changed (otherwise the background action is a no-op). The reload should happen only on explicit login and logout actions.
- The javascript code does not have access to the cookie (it is http-only).
- The endpoint result contains the flag whether the method call changed the cookie state, and reload happens based on that. It also contains the expiry, which we can use later for displaying a warning before automatic logout or something like that.
- The auth initialization flow is not yet complete, (you can see it on staging, there is still a flicker of "Login" displayed), I'll fix that as a subsequent PR. 