### PR TITLE
'My publishers' page

### DIFF
--- a/app/lib/frontend/handlers/routes.dart
+++ b/app/lib/frontend/handlers/routes.dart
@@ -201,6 +201,11 @@ class PubSiteService {
   Future<Response> oauthCallback(Request request) async =>
       oauthCallbackHandler(request);
 
+  /// List of the current user's publishers.
+  @Route.get('/account/publishers')
+  Future<Response> accountPublishersPage(Request request) async =>
+      accountPublishersPageHandler(request);
+
   /// Renders the authorization confirmed page.
   @Route.get('/authorized')
   Future<Response> authorizationConfirmed(Request request) async =>

--- a/app/lib/frontend/handlers/routes.g.dart
+++ b/app/lib/frontend/handlers/routes.g.dart
@@ -48,6 +48,7 @@ Router _$PubSiteServiceRouter(PubSiteService service) {
   router.add('GET', r'/static/<path|[^]*>', service.staticAsset);
   router.add('GET', r'/experimental', service.experimental);
   router.add('GET', r'/oauth/callback', service.oauthCallback);
+  router.add('GET', r'/account/publishers', service.accountPublishersPage);
   router.add('GET', r'/authorized', service.authorizationConfirmed);
   router.add('GET', r'/admin/confirm/new-uploader/<package>/<email>/<nonce>',
       service.confirmUploader);

--- a/app/lib/frontend/templates/misc.dart
+++ b/app/lib/frontend/templates/misc.dart
@@ -13,6 +13,19 @@ import '_consts.dart';
 import '_utils.dart';
 import 'layout.dart';
 
+/// Renders a page where the real content is only provided for logged-in users.
+String renderUnauthenticatedPage() {
+  // TODO: add custom message
+  // TODO: add header and more content to explain how to log in
+  final content = 'You need to be logged in to view this page.';
+  return renderLayoutPage(
+    PageType.standalone,
+    content,
+    title: 'Authentication required',
+    noIndex: true,
+  );
+}
+
 /// Renders the `views/help.mustache` template.
 String renderHelpPage() {
   final String content = templateCache.renderTemplate('help', {

--- a/app/lib/frontend/templates/publisher.dart
+++ b/app/lib/frontend/templates/publisher.dart
@@ -31,8 +31,13 @@ String renderCreatePublisherPage() {
 }
 
 /// Renders the `views/publisher/publisher_list.mustache` template
-String renderPublisherListPage(List<Publisher> publishers) {
+String renderPublisherListPage(List<Publisher> publishers,
+    {@required bool isGlobal}) {
   final content = templateCache.renderTemplate('publisher/publisher_list', {
+    'title': isGlobal ? 'Publishers' : 'My publishers',
+    'no_publisher_message': isGlobal
+        ? 'No publisher has been registered.'
+        : 'You have no publisher',
     'has_publishers': publishers.isNotEmpty,
     'publishers': publishers
         .map(

--- a/app/lib/frontend/templates/views/publisher/publisher_list.mustache
+++ b/app/lib/frontend/templates/views/publisher/publisher_list.mustache
@@ -2,7 +2,7 @@
     for details. All rights reserved. Use of this source code is governed by a
     BSD-style license that can be found in the LICENSE file. }}
 
-<h2>Publishers</h2>
+<h2>{{title}}</h2>
 
 {{#has_publishers}}
 <ul class="package-list">
@@ -18,7 +18,7 @@
 {{/has_publishers}}
 
 {{^has_publishers}}
-<p>No publisher has been registered.</p>
+<p>{{no_publisher_message}}</p>
 {{/has_publishers}}
 
 <h3>How to create a new publisher?</h3>

--- a/app/lib/publisher/backend.dart
+++ b/app/lib/publisher/backend.dart
@@ -50,6 +50,19 @@ class PublisherBackend {
     return await query.run().toList();
   }
 
+  /// List all publishers where the [userId] is a member.
+  Future<List<Publisher>> listPublishersForUser(String userId,
+      {int limit = 100}) async {
+    final query = _db.query<PublisherMember>()
+      ..filter('userId =', userId)
+      ..limit(limit);
+    final members = await query.run().toList();
+    final publisherKeys = members.map((pm) => pm.publisherKey).toList();
+    final publishers = await _db.lookup<Publisher>(publisherKeys);
+    publishers.sort((a, b) => a.publisherId.compareTo(b.publisherId));
+    return publishers;
+  }
+
   /// Loads the [PublisherMember] instance for [userId] (or returns null if it does not exists).
   Future<PublisherMember> getPublisherMember(
       String publisherId, String userId) async {

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -551,21 +551,24 @@ void main() {
     });
 
     scopedTest('publisher list page', () {
-      final html = renderPublisherListPage([
-        Publisher()
-          ..id = 'example.com'
-          ..contactEmail = 'hello@example.com'
-          ..description = 'This is our little software developer shop.\n\n'
-              'We develop full-stack in Dart, and happy about it.'
-          ..websiteUrl = 'https://example.com/'
-          ..created = DateTime(2019, 09, 13),
-        Publisher()
-          ..id = 'other-domain.com'
-          ..contactEmail = 'hello@other-domain.com'
-          ..description = 'We do software.'
-          ..websiteUrl = 'https://other-domain.com/'
-          ..created = DateTime(2019, 09, 19),
-      ]);
+      final html = renderPublisherListPage(
+        [
+          Publisher()
+            ..id = 'example.com'
+            ..contactEmail = 'hello@example.com'
+            ..description = 'This is our little software developer shop.\n\n'
+                'We develop full-stack in Dart, and happy about it.'
+            ..websiteUrl = 'https://example.com/'
+            ..created = DateTime(2019, 09, 13),
+          Publisher()
+            ..id = 'other-domain.com'
+            ..contactEmail = 'hello@other-domain.com'
+            ..description = 'We do software.'
+            ..websiteUrl = 'https://other-domain.com/'
+            ..created = DateTime(2019, 09, 19),
+        ],
+        isGlobal: true,
+      );
       expectGoldenFile(html, 'publisher_list_page.html');
     });
 

--- a/pkg/pub_integration/lib/script/publisher.dart
+++ b/pkg/pub_integration/lib/script/publisher.dart
@@ -69,6 +69,8 @@ class PublisherScript {
       // TODO: verify publisher page (after the search index picks up the package)
 
       await _verifyPublisherListPage();
+
+      // TODO: verify my publishers page
     } finally {
       await _temp.delete(recursive: true);
       _pubHttpClient.close();


### PR DESCRIPTION
- the unauthenticated page seems to be useful for all of the similar cases
- reusing the publisher list template, only changing a few labels based on global or user-specific list
