### PR TITLE
Cloud Build setup for deploying to staging

### DIFF
--- a/tool/.deploy-staging.sh
+++ b/tool/.deploy-staging.sh
@@ -1,0 +1,53 @@
+#!/bin/bash -e
+
+# This script is used by .deploy-staging.yaml
+# Do NOT use this script for any other purposes.
+
+# This only works on cloud-build
+if [[ "$PROJECT_ID" != 'dartlang-pub-dev' ]]; then 
+  echo 'This script is only intended for use on cloud-build, only for staging'
+  exit 1;
+fi
+
+if [[ "$BRANCH_NAME" != 'staging' ]]; then 
+  echo 'This script is only intended for use on staging branch (for now)'
+  exit 1;
+fi
+
+# Disable interactive gcloud prompts
+export CLOUDSDK_CORE_DISABLE_PROMPTS=1
+
+# This script will build image:
+IMAGE="gcr.io/dartlang-pub-dev/branch-$BRANCH_NAME-image"
+
+echo "### Building docker image: $IMAGE"
+time -p gcloud --project "$PROJECT_ID" builds submit -t "$IMAGE"
+
+APP_VERSION="$BRANCH_NAME"
+
+echo "### Start deploying search.yaml (version: $APP_VERSION)"
+time -p gcloud --project 'dartlang-pub-dev' app deploy --no-promote -v "$APP_VERSION" --image-url "$IMAGE" 'search.yaml' &
+SEARCH_PID=$!
+
+echo "### Start deploying dartdoc.yaml (version: $APP_VERSION)"
+time -p gcloud --project 'dartlang-pub-dev' app deploy --no-promote -v "$APP_VERSION" --image-url "$IMAGE" 'dartdoc.yaml' &
+DARTDOC_PID=$!
+
+echo "### Start deploying analyzer.yaml (version: $APP_VERSION)"
+time -p gcloud --project 'dartlang-pub-dev' app deploy --no-promote -v "$APP_VERSION" --image-url "$IMAGE" 'analyzer.yaml' &
+ANALYZER_PID=$!
+
+echo "### Start deploying app.yaml (version: $APP_VERSION)"
+time -p gcloud --project 'dartlang-pub-dev' app deploy --no-promote -v "$APP_VERSION" --image-url "$IMAGE" 'app.yaml'
+echo "### app.yaml deployed"
+
+wait $SEARCH_PID
+echo "### search.yaml deployed"
+wait $DARTDOC_PID
+echo "### dartdoc.yaml deployed"
+wait $ANALYZER_PID
+echo "### analyzer.yaml deployed"
+
+echo ''
+echo '### Staging site updated, see:'
+echo "https://$APP_VERSION-dot-dartlang-pub-dev.appspot.com/"

--- a/tool/.deploy-staging.yaml
+++ b/tool/.deploy-staging.yaml
@@ -1,0 +1,16 @@
+# Configuration for Google Cloud Build
+#
+# Triggers in the staging project kicks off a cloud build task based on the
+# configuration in this file. Permissions granted to this task is configured
+# by granting permissions to the service account:
+#   <project-id>@cloudbuild.gserviceaccount.com
+#
+# Reference: https://cloud.google.com/cloud-build/docs/build-config
+steps:
+- name: 'gcr.io/cloud-builders/gcloud'
+  entrypoint: '/bin/bash'
+  args: ['tool/.deploy-staging.sh']
+  env:
+    - 'PROJECT_ID=$PROJECT_ID'
+    - 'BRANCH_NAME=$BRANCH_NAME'
+timeout: '1600s'


### PR DESCRIPTION
On push to the `staging` branch, we now have that `tool/.deploy-staging.yaml` gets triggered on cloud-build in the staging project.

It can only do appengine deploys and cloud builds, but we could give it more permissions if needed.
However, I think this is fine for now.

Maybe next time we augment the datastore we give this script permissions deploy the `index.yaml` file... and add this to the deployment script.