### PR TITLE
My packages page + search index with owners.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ AppEngine version, listed here to ease deployment and troubleshooting.
 
  * Upgraded to Dart `2.5.0`.
  * Upgraded `package:markdown` to `2.1.0`.
+ * Search index contains `publisherId` and `owners` fields, the first startup
+   needs to have a 1-2 hours before all the packages get re-indexed with them.
+   After that they will be part of the index snapshot, and will be available
+   as other parts of the index.
 
 ## `20190910t122708-all`
 

--- a/app/lib/frontend/handlers/account.dart
+++ b/app/lib/frontend/handlers/account.dart
@@ -121,7 +121,7 @@ Future<shelf.Response> accountPackagesPageHandler(shelf.Request request) async {
       await publisherBackend.listPublishersForUser(userSessionData.userId);
   final searchQuery = parseFrontendSearchQuery(
     request.requestedUri.queryParameters,
-    owners: [
+    uploaderOrPublishers: [
       userSessionData.email,
       ...publishers.map((p) => p.publisherId),
     ],

--- a/app/lib/frontend/handlers/routes.dart
+++ b/app/lib/frontend/handlers/routes.dart
@@ -201,6 +201,11 @@ class PubSiteService {
   Future<Response> oauthCallback(Request request) async =>
       oauthCallbackHandler(request);
 
+  /// List of the current user's packages.
+  @Route.get('/account/packages')
+  Future<Response> accountPackagesPage(Request request) async =>
+      accountPackagesPageHandler(request);
+
   /// List of the current user's publishers.
   @Route.get('/account/publishers')
   Future<Response> accountPublishersPage(Request request) async =>

--- a/app/lib/frontend/handlers/routes.g.dart
+++ b/app/lib/frontend/handlers/routes.g.dart
@@ -48,6 +48,7 @@ Router _$PubSiteServiceRouter(PubSiteService service) {
   router.add('GET', r'/static/<path|[^]*>', service.staticAsset);
   router.add('GET', r'/experimental', service.experimental);
   router.add('GET', r'/oauth/callback', service.oauthCallback);
+  router.add('GET', r'/account/packages', service.accountPackagesPage);
   router.add('GET', r'/account/publishers', service.accountPublishersPage);
   router.add('GET', r'/authorized', service.authorizationConfirmed);
   router.add('GET', r'/admin/confirm/new-uploader/<package>/<email>/<nonce>',

--- a/app/lib/frontend/templates/admin.dart
+++ b/app/lib/frontend/templates/admin.dart
@@ -2,12 +2,18 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:client_data/page_data.dart';
+import 'dart:convert';
 
+import 'package:client_data/page_data.dart';
+import 'package:meta/meta.dart';
+
+import '../../package/models.dart' show PackageView;
+import '../../search/search_service.dart' show SearchQuery;
 import '../../shared/urls.dart';
 
 import '_cache.dart';
 import 'layout.dart';
+import 'listing.dart';
 
 /// Renders the `views/authorized.mustache` template.
 String renderAuthorizedPage() {
@@ -40,5 +46,41 @@ String renderConsentPage(String consentId) {
     title: 'Consent',
     pageData: PageData(consentId: consentId),
     includeSurvey: false,
+  );
+}
+
+/// Renders the search results on the current user's packages page.
+String renderAccountPackagesPage({
+  @required List<PackageView> packages,
+  @required PageLinks pageLinks,
+  @required SearchQuery searchQuery,
+  @required int totalCount,
+}) {
+  final isSearch = searchQuery.hasQuery;
+  String title = 'My packages';
+  if (isSearch && pageLinks.currentPage > 1) {
+    title += ' | Page ${pageLinks.currentPage}';
+  }
+
+  String resultCountHtml;
+  if (isSearch) {
+    resultCountHtml =
+        '$totalCount packages for <code>${htmlEscape.convert(searchQuery.query)}</code>';
+  } else {
+    resultCountHtml =
+        totalCount > 0 ? '$totalCount packages.' : 'You have no packages.';
+  }
+
+  final packageListHtml = packages.isEmpty ? '' : renderPackageList(packages);
+  final paginationHtml = renderPagination(pageLinks);
+
+  final content = [resultCountHtml, packageListHtml, paginationHtml].join('\n');
+
+  return renderLayoutPage(
+    PageType.listing,
+    content,
+    title: title,
+    searchQuery: searchQuery,
+    noIndex: true,
   );
 }

--- a/app/lib/frontend/templates/layout.dart
+++ b/app/lib/frontend/templates/layout.dart
@@ -66,7 +66,7 @@ String renderLayoutPage(
     if (type == PageType.standalone) 'page-standalone',
     if (requestContext.isExperimental) 'experimental',
   ];
-  final searchFormUrl =
+  final searchFormUrl = searchQuery?.toSearchFormPath() ??
       SearchQuery.parse(platform: platform, publisherId: publisherId)
           .toSearchLink();
   final searchPlaceholder = publisherId != null

--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -131,6 +131,20 @@ class PackageBackend {
         .cast();
   }
 
+  /// List packages for the specified uploader (user id).
+  Future<List<models.Package>> listPackagesByUploaderId(String userId) async {
+    final query = db.query<models.Package>()..filter('uploaders =', userId);
+    return await query.run().toList();
+  }
+
+  /// List packages for the specified [publisherId].
+  Future<List<models.Package>> listPackagesByPublisherId(
+      String publisherId) async {
+    final query = db.query<models.Package>()
+      ..filter('publisherId =', publisherId);
+    return await query.run().toList();
+  }
+
   /// Looks up a specific package version.
   ///
   /// Returns null if the version is not a semantic version or if the version

--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -131,20 +131,6 @@ class PackageBackend {
         .cast();
   }
 
-  /// List packages for the specified uploader (user id).
-  Future<List<models.Package>> listPackagesByUploaderId(String userId) async {
-    final query = db.query<models.Package>()..filter('uploaders =', userId);
-    return await query.run().toList();
-  }
-
-  /// List packages for the specified [publisherId].
-  Future<List<models.Package>> listPackagesByPublisherId(
-      String publisherId) async {
-    final query = db.query<models.Package>()
-      ..filter('publisherId =', publisherId);
-    return await query.run().toList();
-  }
-
   /// Looks up a specific package version.
   ///
   /// Returns null if the version is not a semantic version or if the version

--- a/app/lib/search/backend.dart
+++ b/app/lib/search/backend.dart
@@ -114,7 +114,7 @@ class SearchBackend {
       dependencies: _buildDependencies(analysisView),
       publisherId: p.publisherId,
       emails: await _buildEmails(p, pv),
-      owners: await _buildOwners(p),
+      uploaderEmails: await _buildUploaderEmails(p),
       apiDocPages: apiDocPages,
       timestamp: DateTime.now().toUtc(),
     );
@@ -140,13 +140,13 @@ class SearchBackend {
     return emails.toList()..sort();
   }
 
-  Future<List<String>> _buildOwners(Package p) async {
-    if (p.publisherId != null) {
-      return [p.publisherId];
-    } else {
+  Future<List<String>> _buildUploaderEmails(Package p) async {
+    if (p.publisherId == null) {
       final owners = await accountBackend.getEmailsOfUserIds(p.uploaders);
       owners.sort();
       return owners;
+    } else {
+      return <String>[];
     }
   }
 
@@ -174,7 +174,7 @@ class SearchBackend {
         maintenance: 0.0,
         publisherId: p.publisherId,
         emails: await _buildEmails(p, null),
-        owners: await _buildOwners(p),
+        uploaderEmails: await _buildUploaderEmails(p),
         timestamp: DateTime.now().toUtc(),
       );
     }

--- a/app/lib/search/backend.dart
+++ b/app/lib/search/backend.dart
@@ -114,6 +114,7 @@ class SearchBackend {
       dependencies: _buildDependencies(analysisView),
       publisherId: p.publisherId,
       emails: await _buildEmails(p, pv),
+      owners: await _buildOwners(p),
       apiDocPages: apiDocPages,
       timestamp: DateTime.now().toUtc(),
     );
@@ -137,6 +138,16 @@ class SearchBackend {
       emails.add(author.email);
     }
     return emails.toList()..sort();
+  }
+
+  Future<List<String>> _buildOwners(Package p) async {
+    if (p.publisherId != null) {
+      return [p.publisherId];
+    } else {
+      final owners = await accountBackend.getEmailsOfUserIds(p.uploaders);
+      owners.sort();
+      return owners;
+    }
   }
 
   List<ApiDocPage> _apiDocPagesFromPubDataText(String text) {
@@ -163,6 +174,7 @@ class SearchBackend {
         maintenance: 0.0,
         publisherId: p.publisherId,
         emails: await _buildEmails(p, null),
+        owners: await _buildOwners(p),
         timestamp: DateTime.now().toUtc(),
       );
     }

--- a/app/lib/search/backend.dart
+++ b/app/lib/search/backend.dart
@@ -141,13 +141,12 @@ class SearchBackend {
   }
 
   Future<List<String>> _buildUploaderEmails(Package p) async {
-    if (p.publisherId == null) {
-      final owners = await accountBackend.getEmailsOfUserIds(p.uploaders);
-      owners.sort();
-      return owners;
-    } else {
+    if (p.publisherId != null) {
       return <String>[];
     }
+    final uploaders = await accountBackend.getEmailsOfUserIds(p.uploaders);
+    uploaders.sort();
+    return uploaders;
   }
 
   List<ApiDocPage> _apiDocPagesFromPubDataText(String text) {

--- a/app/lib/search/index_simple.dart
+++ b/app/lib/search/index_simple.dart
@@ -168,6 +168,17 @@ class SimplePackageIndex implements PackageIndex {
       });
     }
 
+    // filter on owners
+    if (query.owners != null && query.owners.isNotEmpty) {
+      packages.removeWhere((package) {
+        final doc = _packages[package];
+        for (String owner in query.owners) {
+          if (doc.owners.contains(owner)) return false;
+        }
+        return true;
+      });
+    }
+
     // filter on publisher
     if (query.publisherId != null || query.parsedQuery.publisher != null) {
       final publisherId = query.publisherId ?? query.parsedQuery.publisher;

--- a/app/lib/search/index_simple.dart
+++ b/app/lib/search/index_simple.dart
@@ -173,7 +173,13 @@ class SimplePackageIndex implements PackageIndex {
       packages.removeWhere((package) {
         final doc = _packages[package];
         for (String owner in query.owners) {
-          if (doc.owners.contains(owner)) return false;
+          if (doc.publisherId == owner) {
+            return false;
+          }
+          if (doc.uploaderEmails != null &&
+              doc.uploaderEmails.contains(owner)) {
+            return false;
+          }
         }
         return true;
       });

--- a/app/lib/search/index_simple.dart
+++ b/app/lib/search/index_simple.dart
@@ -169,20 +169,18 @@ class SimplePackageIndex implements PackageIndex {
     }
 
     // filter on owners
-    if (query.uploaderOrPublishers != null &&
-        query.uploaderOrPublishers.isNotEmpty) {
+    if (query.uploaderOrPublishers != null) {
+      assert(query.uploaderOrPublishers.isNotEmpty);
+
       packages.removeWhere((package) {
         final doc = _packages[package];
-        for (String owner in query.uploaderOrPublishers) {
-          if (doc.publisherId == owner) {
-            return false;
-          }
-          if (doc.uploaderEmails != null &&
-              doc.uploaderEmails.contains(owner)) {
-            return false;
-          }
+        if (doc.publisherId != null) {
+          return !query.uploaderOrPublishers.contains(doc.publisherId);
         }
-        return true;
+        if (doc.uploaderEmails == null) {
+          return true; // turn this into an error in the future.
+        }
+        return !query.uploaderOrPublishers.any(doc.uploaderEmails.contains);
       });
     }
 

--- a/app/lib/search/index_simple.dart
+++ b/app/lib/search/index_simple.dart
@@ -169,10 +169,11 @@ class SimplePackageIndex implements PackageIndex {
     }
 
     // filter on owners
-    if (query.owners != null && query.owners.isNotEmpty) {
+    if (query.uploaderOrPublishers != null &&
+        query.uploaderOrPublishers.isNotEmpty) {
       packages.removeWhere((package) {
         final doc = _packages[package];
-        for (String owner in query.owners) {
+        for (String owner in query.uploaderOrPublishers) {
           if (doc.publisherId == owner) {
             return false;
           }

--- a/app/lib/search/search_service.dart
+++ b/app/lib/search/search_service.dart
@@ -232,8 +232,9 @@ class SearchQuery {
   /// The query will match packages where the owners of the package have
   /// non-empty intersection with the provided list of owners.
   ///
-  /// Values of this list can be email addresses or publisher ids.
-  final List<String> owners;
+  /// Values of this list can be email addresses (usually a single on) or
+  /// publisher ids (may be multiple).
+  final List<String> uploaderOrPublishers;
 
   final String publisherId;
   final SearchOrder order;
@@ -248,7 +249,7 @@ class SearchQuery {
   SearchQuery._({
     this.query,
     String platform,
-    List<String> owners,
+    List<String> uploaderOrPublishers,
     String publisherId,
     this.order,
     this.offset,
@@ -258,14 +259,17 @@ class SearchQuery {
     this.includeLegacy,
   })  : parsedQuery = ParsedQuery._parse(query),
         platform = (platform == null || platform.isEmpty) ? null : platform,
-        owners = (owners == null || owners.isEmpty) ? null : owners,
+        uploaderOrPublishers =
+            (uploaderOrPublishers == null || uploaderOrPublishers.isEmpty)
+                ? null
+                : uploaderOrPublishers,
         publisherId =
             (publisherId == null || publisherId.isEmpty) ? null : publisherId;
 
   factory SearchQuery.parse({
     String query,
     String platform,
-    List<String> owners,
+    List<String> uploaderOrPublishers,
     String publisherId,
     SearchOrder order,
     int offset = 0,
@@ -279,7 +283,7 @@ class SearchQuery {
     return SearchQuery._(
       query: q,
       platform: platform,
-      owners: owners,
+      uploaderOrPublishers: uploaderOrPublishers,
       publisherId: publisherId,
       order: order,
       offset: offset,
@@ -294,7 +298,7 @@ class SearchQuery {
     final String q = uri.queryParameters['q'];
     final String platform =
         uri.queryParameters['platform'] ?? uri.queryParameters['platforms'];
-    final owners = uri.queryParametersAll['owners'];
+    final uploaderOrPublishers = uri.queryParametersAll['uploaderOrPublishers'];
     final publisherId = uri.queryParameters['publisherId'];
     final String orderValue = uri.queryParameters['order'];
     final SearchOrder order = parseSearchOrder(orderValue);
@@ -305,7 +309,7 @@ class SearchQuery {
     return SearchQuery.parse(
       query: q,
       platform: platform,
-      owners: owners,
+      uploaderOrPublishers: uploaderOrPublishers,
       publisherId: publisherId,
       order: order,
       offset: max(0, offset),
@@ -319,7 +323,7 @@ class SearchQuery {
   SearchQuery change({
     String query,
     String platform,
-    List<String> owners,
+    List<String> uploaderOrPublishers,
     String publisherId,
     SearchOrder order,
     int offset,
@@ -331,7 +335,7 @@ class SearchQuery {
     return SearchQuery._(
       query: query ?? this.query,
       platform: platform ?? this.platform,
-      owners: owners ?? this.owners,
+      uploaderOrPublishers: uploaderOrPublishers ?? this.uploaderOrPublishers,
       publisherId: publisherId ?? this.publisherId,
       order: order ?? this.order,
       offset: offset ?? this.offset,
@@ -346,7 +350,7 @@ class SearchQuery {
     final map = <String, dynamic>{
       'q': query,
       'platform': platform,
-      'owners': owners,
+      'uploaderOrPublishers': uploaderOrPublishers,
       'publisherId': publisherId,
       'offset': offset?.toString(),
       'limit': limit?.toString(),
@@ -386,7 +390,7 @@ class SearchQuery {
     if (publisherId != null && publisherId.isNotEmpty) {
       path = '/publishers/$publisherId/packages';
     }
-    if (owners != null && owners.isNotEmpty) {
+    if (uploaderOrPublishers != null && uploaderOrPublishers.isNotEmpty) {
       path = '/account/packages';
     }
     return path;
@@ -618,7 +622,7 @@ int extractPageFromUrlParameters(Map<String, String> queryParameters) {
 SearchQuery parseFrontendSearchQuery(
   Map<String, String> queryParameters, {
   String platform,
-  List<String> owners,
+  List<String> uploaderOrPublishers,
   String publisherId,
 }) {
   final int page = extractPageFromUrlParameters(queryParameters);
@@ -630,7 +634,7 @@ SearchQuery parseFrontendSearchQuery(
   return SearchQuery.parse(
     query: queryText,
     platform: platform,
-    owners: owners,
+    uploaderOrPublishers: uploaderOrPublishers,
     publisherId: publisherId,
     order: sortOrder,
     offset: offset,

--- a/app/lib/search/search_service.dart
+++ b/app/lib/search/search_service.dart
@@ -66,8 +66,8 @@ class PackageDocument {
   /// release, and the e-mail addresses in the `pubspec.authors` block.
   final List<String> emails;
 
-  /// The publisher id, or the current uploader emails of the package.
-  final List<String> owners;
+  /// The current uploader emails of the package.
+  final List<String> uploaderEmails;
 
   final List<ApiDocPage> apiDocPages;
 
@@ -92,7 +92,7 @@ class PackageDocument {
     this.dependencies = const {},
     this.publisherId,
     this.emails = const [],
-    this.owners = const [],
+    this.uploaderEmails = const [],
     this.apiDocPages = const [],
     DateTime timestamp,
   }) : timestamp = timestamp ?? DateTime.now();
@@ -125,7 +125,7 @@ class PackageDocument {
             ),
       publisherId: internFn(publisherId),
       emails: emails?.map(internFn)?.toList(),
-      owners: owners?.map(internFn)?.toList(),
+      uploaderEmails: uploaderEmails?.map(internFn)?.toList(),
       apiDocPages: apiDocPages?.map((p) => p.intern(internFn))?.toList(),
       timestamp: timestamp,
     );

--- a/app/lib/search/search_service.dart
+++ b/app/lib/search/search_service.dart
@@ -228,7 +228,13 @@ class SearchQuery {
   final String query;
   final ParsedQuery parsedQuery;
   final String platform;
+
+  /// The query will match packages where the owners of the package have
+  /// non-empty intersection with the provided list of owners.
+  ///
+  /// Values of this list can be email addresses or publisher ids.
   final List<String> owners;
+
   final String publisherId;
   final SearchOrder order;
   final int offset;

--- a/app/lib/search/search_service.dart
+++ b/app/lib/search/search_service.dart
@@ -58,8 +58,15 @@ class PackageDocument {
   final double maintenance;
 
   final Map<String, String> dependencies;
+
+  /// The publisher id of the package
   final String publisherId;
+
+  /// The current uploaders of the package, the uploader of the latest stable
+  /// release, and the e-mail addresses in the `pubspec.authors` block.
   final List<String> emails;
+
+  /// The publisher id, or the current uploader emails of the package.
   final List<String> owners;
 
   final List<ApiDocPage> apiDocPages;
@@ -363,6 +370,8 @@ class SearchQuery {
   }
 
   // TODO: move this to shared/urls.dart after simplifying platformPredicate
+  /// Converts the query to a user-facing link that the search form can use as
+  /// the base path of its `action` parameter.
   String toSearchFormPath() {
     String path = '/packages';
     if (platform != null && platform.isNotEmpty) {
@@ -377,6 +386,9 @@ class SearchQuery {
     return path;
   }
 
+  // TODO: move this to shared/urls.dart after simplifying platformPredicate
+  /// Converts the query to a user-facing link that (after frontend parsing) will
+  /// re-create an identical search query object.
   String toSearchLink({int page}) {
     final Map<String, String> params = {};
     if (query != null && query.isNotEmpty) {

--- a/app/lib/search/search_service.g.dart
+++ b/app/lib/search/search_service.g.dart
@@ -31,6 +31,7 @@ PackageDocument _$PackageDocumentFromJson(Map<String, dynamic> json) {
     ),
     publisherId: json['publisherId'] as String,
     emails: (json['emails'] as List)?.map((e) => e as String)?.toList(),
+    owners: (json['owners'] as List)?.map((e) => e as String)?.toList(),
     apiDocPages: (json['apiDocPages'] as List)
         ?.map((e) =>
             e == null ? null : ApiDocPage.fromJson(e as Map<String, dynamic>))
@@ -60,6 +61,7 @@ Map<String, dynamic> _$PackageDocumentToJson(PackageDocument instance) =>
       'dependencies': instance.dependencies,
       'publisherId': instance.publisherId,
       'emails': instance.emails,
+      'owners': instance.owners,
       'apiDocPages': instance.apiDocPages,
       'timestamp': instance.timestamp?.toIso8601String(),
     };

--- a/app/lib/search/search_service.g.dart
+++ b/app/lib/search/search_service.g.dart
@@ -31,7 +31,8 @@ PackageDocument _$PackageDocumentFromJson(Map<String, dynamic> json) {
     ),
     publisherId: json['publisherId'] as String,
     emails: (json['emails'] as List)?.map((e) => e as String)?.toList(),
-    owners: (json['owners'] as List)?.map((e) => e as String)?.toList(),
+    uploaderEmails:
+        (json['uploaderEmails'] as List)?.map((e) => e as String)?.toList(),
     apiDocPages: (json['apiDocPages'] as List)
         ?.map((e) =>
             e == null ? null : ApiDocPage.fromJson(e as Map<String, dynamic>))
@@ -61,7 +62,7 @@ Map<String, dynamic> _$PackageDocumentToJson(PackageDocument instance) =>
       'dependencies': instance.dependencies,
       'publisherId': instance.publisherId,
       'emails': instance.emails,
-      'owners': instance.owners,
+      'uploaderEmails': instance.uploaderEmails,
       'apiDocPages': instance.apiDocPages,
       'timestamp': instance.timestamp?.toIso8601String(),
     };

--- a/app/test/frontend/golden/account_packages.html
+++ b/app/test/frontend/golden/account_packages.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html lang="en-us">
+  <head>
+    <script async="async" src="https://www.googletagmanager.com/gtag/js?id=UA-26406144-13"></script>
+    <script src="/static/js/gtag.js?hash=mocked_hash_221832925"></script>
+    <meta charset="utf-8"/>
+    <meta http-equiv="x-ua-compatible" content="ie=edge"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <meta name="robots" content="noindex"/>
+    <meta name="twitter:card" content="summary"/>
+    <meta name="twitter:site" content="@dart_lang"/>
+    <meta property="og:site_name" content="Dart packages"/>
+    <title>My packages</title>
+    <meta property="og:title" content="My packages"/>
+    <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet"/>
+    <meta itemprop="image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <meta property="og:image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
+    <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/osd.xml?hash=mocked_hash_869379763"/>
+    <meta name="description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
+    <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
+    <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
+    <link href="/static/highlight/github.css?hash=mocked_hash_145446167" rel="stylesheet"/>
+    <link href="/static/css/github-markdown.css?hash=mocked_hash_488759485" rel="stylesheet" type="text/css"/>
+    <link href="/static/css/style.css?hash=mocked_hash_537099079" rel="stylesheet" type="text/css"/>
+    <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
+    <script async="async" defer="defer" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
+  </head>
+  <body class="">
+    <header class="site-header-row">
+      <div class="container site-header">
+        <h1 class="_visuallyhidden">Dart pub</h1>
+        <button class="hamburger"></button>
+        <div class="mask"></div>
+        <div class="nav-wrap">
+          <div class="nav-header">
+            <a class="logo" href="/">
+              <img src="/static/img/pub-dev-logo-2x.png?hash=mocked_hash_685890546" alt="dart pub logo"/>
+            </a>
+            <div class="_flex-space"></div>
+            <button class="close"></button>
+          </div>
+          <nav class="site-nav">
+            <span>Getting Started:</span>
+            <div class="sub-wrap hoverable">
+              <button class="button">Flutter</button>
+              <div class="sub-nav">
+                <a class="link" target="_blank" rel="noopener" href="https://flutter.io/using-packages/">Using packages</a>
+                <a class="link" target="_blank" rel="noopener" href="https://flutter.io/developing-packages/">Developing packages and plugins</a>
+                <a class="link" target="_blank" rel="noopener" href="https://dart.dev/tools/pub/publishing">Publishing a package</a>
+                <a class="link" target="_blank" rel="noopener" href="https://dart.dev/tools/pub">Pub tool</a>
+              </div>
+            </div>
+            <div class="sub-wrap hoverable">
+              <button class="button">Web &amp; Server</button>
+              <div class="sub-nav">
+                <a class="link" target="_blank" rel="noopener" href="https://dart.dev/tools/pub/get-started">Using packages</a>
+                <a class="link" target="_blank" rel="noopener" href="https://dart.dev/tools/pub/publishing">Publishing a package</a>
+                <a class="link" target="_blank" rel="noopener" href="https://dart.dev/tools/pub">Pub tool</a>
+              </div>
+            </div>
+          </nav>
+        </div>
+      </div>
+    </header>
+    <div class="_banner-bg">
+      <div class="container">
+        <div class="medium-banner">
+          <form class="search-bar" action="/account/packages">
+            <input class="input" name="q" placeholder="Search Dart packages" autocomplete="on" autofocus="autofocus"/>
+            <button class="icon"></button>
+            <input id="search-legacy-field" type="hidden" name="legacy" value="1" disabled="disabled"/>
+            <input id="search-api-field" type="hidden" name="api" value="0" disabled="disabled"/>
+          </form>
+          <div class="search-bar-details">
+            <div class="list-filters">
+              <a class="filter " href="/account/packages">Flutter</a>
+              <a class="filter " href="/account/packages">Web</a>
+              <a class="filter -active" href="/account/packages">All</a>
+            </div>
+            <div class="search-bar-options">
+              <input id="search-legacy-checkbox" type="checkbox" name="legacy" valye="1"/>
+              <label for="search-legacy-checkbox">Include Dart 1.x results</label>
+              <input id="search-api-checkbox" type="checkbox" name="api" checked="checked"/>
+              <label for="search-api-checkbox"> Include API results</label>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="container">
+      <main>
+    2 packages.
+
+
+        <ul class="package-list">
+          <li class="list-item -full">
+            <a href="/packages/super_package#-analysis-tab-">
+              <div class="score-box">
+                <span class="number -solid" title="Analysis and more details.">97</span>
+              </div>
+            </a>
+            <h3 class="title">
+              <a href="/packages/super_package">super_package</a>
+            </h3>
+            <p class="description">A great web UI library.</p>
+            <p class="metadata">
+        v 
+              <a href="/packages/super_package">1.0.0</a>
+        
+        • updated: 
+              <span>3 Jan 2019</span>
+              <a class="package-tag" href="/web/packages" title="Compatible with the web platform.">web</a>
+            </p>
+          </li>
+          <li class="list-item -full">
+            <a href="/packages/another_package#-analysis-tab-">
+              <div class="score-box">
+                <span class="number -solid" title="Analysis and more details.">90</span>
+              </div>
+            </a>
+            <h3 class="title">
+              <a href="/packages/another_package">another_package</a>
+            </h3>
+            <p class="description">Camera plugin.</p>
+            <p class="metadata">
+        v 
+              <a href="/packages/another_package">2.0.0</a>
+         / 
+              <a href="/packages/another_package/versions/3.0.0-beta2">3.0.0-beta2</a>
+        • updated: 
+              <span>30 Mar 2019</span>
+              <a class="package-tag" href="/flutter/packages" title="Compatible with the Flutter platform.">Flutter</a>
+            </p>
+          </li>
+        </ul>
+        <ul class="pagination">
+          <li class="-disabled">
+            <a href="">
+              <span>«</span>
+            </a>
+          </li>
+          <li class="-active">
+            <a href="">
+              <span>1</span>
+            </a>
+          </li>
+          <li class="-disabled">
+            <a href="">
+              <span>»</span>
+            </a>
+          </li>
+        </ul>
+      </main>
+    </div>
+    <footer class="site-footer">
+      <a class="link" href="https://dart.dev/">Dart language</a>
+      <a class="link" href="https://www.google.com/intl/en/policies/terms/">Terms</a>
+      <a class="link" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
+      <a class="link" href="/help">Help</a>
+      <a class="link" href="/security">Security</a>
+      <a class="link" href="/feed.atom">
+        <img src="/static/img/atom-feed-icon-32x32.png?hash=mocked_hash_251226050" class="inline-icon"/>
+      </a>
+      <a class="link github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">Report an issue with this site</a>
+    </footer>
+  </body>
+</html>

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -609,7 +609,8 @@ void main() {
     });
 
     scopedTest('account packages page', () {
-      final searchQuery = SearchQuery.parse(owners: [hansUser.email]);
+      final searchQuery =
+          SearchQuery.parse(uploaderOrPublishers: [hansUser.email]);
       final String html = renderAccountPackagesPage(
         packages: [
           PackageView(

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -608,6 +608,35 @@ void main() {
       expectGoldenFile(html, 'publisher_packages_page.html');
     });
 
+    scopedTest('account packages page', () {
+      final searchQuery = SearchQuery.parse(owners: [hansUser.email]);
+      final String html = renderAccountPackagesPage(
+        packages: [
+          PackageView(
+            name: 'super_package',
+            version: '1.0.0',
+            ellipsizedDescription: 'A great web UI library.',
+            shortUpdated: '3 Jan 2019',
+            platforms: ['web'],
+            overallScore: 0.97,
+          ),
+          PackageView(
+            name: 'another_package',
+            version: '2.0.0',
+            devVersion: '3.0.0-beta2',
+            ellipsizedDescription: 'Camera plugin.',
+            shortUpdated: '30 Mar 2019',
+            platforms: ['flutter'],
+            overallScore: 0.90,
+          ),
+        ],
+        pageLinks: PageLinks(0, 10, searchQuery: searchQuery),
+        searchQuery: searchQuery,
+        totalCount: 2,
+      );
+      expectGoldenFile(html, 'account_packages.html');
+    });
+
     scopedTest('authorized page', () {
       final String html = renderAuthorizedPage();
       expectGoldenFile(html, 'authorized_page.html');

--- a/app/test/search/index_simple_test.dart
+++ b/app/test/search/index_simple_test.dart
@@ -514,8 +514,8 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
     });
 
     test('no results via owners', () async {
-      final PackageSearchResult result =
-          await index.search(SearchQuery.parse(owners: ['other-domain.com']));
+      final PackageSearchResult result = await index.search(
+          SearchQuery.parse(uploaderOrPublishers: ['other-domain.com']));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
         'totalCount': 0,
@@ -524,8 +524,8 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
     });
 
     test('filter by a single owner', () async {
-      final PackageSearchResult result =
-          await index.search(SearchQuery.parse(owners: ['dart.dev']));
+      final PackageSearchResult result = await index
+          .search(SearchQuery.parse(uploaderOrPublishers: ['dart.dev']));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
         'totalCount': 1,
@@ -537,7 +537,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
 
     test('filter by multiple owners', () async {
       final PackageSearchResult result =
-          await index.search(SearchQuery.parse(owners: [
+          await index.search(SearchQuery.parse(uploaderOrPublishers: [
         'dart.dev',
         'user1@example.com',
       ]));

--- a/app/test/search/index_simple_test.dart
+++ b/app/test/search/index_simple_test.dart
@@ -146,6 +146,7 @@ void main() {
         maintenance: 1.0,
         dependencies: {'async': 'direct', 'test': 'dev', 'foo': 'transitive'},
         emails: ['user1@example.com'],
+        owners: ['user1@example.com'],
       ));
       await index.addPackage(PackageDocument(
         package: 'async',
@@ -168,6 +169,7 @@ The delegating wrapper classes allow users to easily add functionality on top of
         dependencies: {'test': 'dev'},
         publisherId: 'dart.dev',
         emails: ['user1@example.com'],
+        owners: ['dart.dev'],
       ));
       await index.addPackage(PackageDocument(
         package: 'chrome_net',
@@ -508,6 +510,44 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'totalCount': 1,
         'packages': [
           {'package': 'async', 'score': closeTo(0.930, 0.001)},
+        ],
+      });
+    });
+
+    test('no results via owners', () async {
+      final PackageSearchResult result =
+          await index.search(SearchQuery.parse(owners: ['other-domain.com']));
+      expect(json.decode(json.encode(result)), {
+        'indexUpdated': isNotNull,
+        'totalCount': 0,
+        'packages': [],
+      });
+    });
+
+    test('filter by a single owner', () async {
+      final PackageSearchResult result =
+          await index.search(SearchQuery.parse(owners: ['dart.dev']));
+      expect(json.decode(json.encode(result)), {
+        'indexUpdated': isNotNull,
+        'totalCount': 1,
+        'packages': [
+          {'package': 'async', 'score': closeTo(0.930, 0.001)},
+        ],
+      });
+    });
+
+    test('filter by multiple owners', () async {
+      final PackageSearchResult result =
+          await index.search(SearchQuery.parse(owners: [
+        'dart.dev',
+        'user1@example.com',
+      ]));
+      expect(json.decode(json.encode(result)), {
+        'indexUpdated': isNotNull,
+        'totalCount': 2,
+        'packages': [
+          {'package': 'async', 'score': closeTo(0.930, 0.001)},
+          {'package': 'http', 'score': closeTo(0.895, 0.001)},
         ],
       });
     });

--- a/app/test/search/index_simple_test.dart
+++ b/app/test/search/index_simple_test.dart
@@ -146,7 +146,7 @@ void main() {
         maintenance: 1.0,
         dependencies: {'async': 'direct', 'test': 'dev', 'foo': 'transitive'},
         emails: ['user1@example.com'],
-        owners: ['user1@example.com'],
+        uploaderEmails: ['user1@example.com'],
       ));
       await index.addPackage(PackageDocument(
         package: 'async',
@@ -169,7 +169,6 @@ The delegating wrapper classes allow users to easily add functionality on top of
         dependencies: {'test': 'dev'},
         publisherId: 'dart.dev',
         emails: ['user1@example.com'],
-        owners: ['dart.dev'],
       ));
       await index.addPackage(PackageDocument(
         package: 'chrome_net',


### PR DESCRIPTION
- This is similar (both in behaviour and in layout) to `/packages` and `/publishers/<id>/packages`, only with the narrow scope for the current account's email + its publishers
- I think the layout could be improved if we had tabs similar to publisher (just with "My packages" and "My publishers"), but deferring to a subsequent PR.