### PR TITLE
Consent page with session data.

### DIFF
--- a/app/lib/account/consent_backend.dart
+++ b/app/lib/account/consent_backend.dart
@@ -38,8 +38,8 @@ class ConsentBackend {
   ConsentBackend(this._db);
 
   /// Returns the consent details.
-  Future<api.Consent> getConsent(String consentId) async {
-    final user = await requireAuthenticatedUser();
+  Future<api.Consent> getConsent(String consentId, {User user}) async {
+    user ??= await requireAuthenticatedUser();
     final key = _db.emptyKey
         .append(User, id: user.userId)
         .append(Consent, id: consentId);

--- a/app/lib/account/consent_backend.dart
+++ b/app/lib/account/consent_backend.dart
@@ -38,11 +38,9 @@ class ConsentBackend {
   ConsentBackend(this._db);
 
   /// Returns the consent details.
-  Future<api.Consent> getConsent(String consentId, {User user}) async {
-    user ??= await requireAuthenticatedUser();
-    final key = _db.emptyKey
-        .append(User, id: user.userId)
-        .append(Consent, id: consentId);
+  Future<api.Consent> getConsent(String userId, String consentId) async {
+    final key =
+        _db.emptyKey.append(User, id: userId).append(Consent, id: consentId);
     final c = (await _db.lookup<Consent>([key])).single;
     if (c == null) {
       throw NotFoundException.resource('consent: $consentId');
@@ -54,6 +52,12 @@ class ConsentBackend {
       titleText: action.renderInviteTitleText(activeAccountEmail, c.args),
       descriptionHtml: action.renderInviteHtml(activeAccountEmail, c.args),
     );
+  }
+
+  /// Returns the consent details for API calls.
+  Future<api.Consent> handleGetConsent(String consentId) async {
+    final user = await requireAuthenticatedUser();
+    return getConsent(user.userId, consentId);
   }
 
   /// Resolves the consent.

--- a/app/lib/frontend/handlers/account.dart
+++ b/app/lib/frontend/handlers/account.dart
@@ -92,8 +92,8 @@ Future<shelf.Response> consentPageHandler(
     throw NotFoundException('Missing consent id.');
   }
 
-  final user = await accountBackend.lookupUserById(userSessionData.userId);
-  final consent = await consentBackend.getConsent(consentId, user: user);
+  final consent =
+      await consentBackend.getConsent(userSessionData.userId, consentId);
   // If consent does not exists (or does not belong to the user), the `getConsent`
   // call above will throw, and the generic error page will be shown.
   // TODO: handle missing/expired consent gracefully

--- a/app/lib/frontend/handlers/pubapi.dart
+++ b/app/lib/frontend/handlers/pubapi.dart
@@ -175,7 +175,7 @@ class PubApi {
   /// Returns the consent request details.
   @EndPoint.get('/api/account/consent/<consentId>')
   Future<Consent> consentInfo(Request request, String consentId) =>
-      consentBackend.getConsent(consentId);
+      consentBackend.handleGetConsent(consentId);
 
   /// Accepts or declines the consent.
   @EndPoint.put('/api/account/consent/<consentId>')

--- a/app/lib/frontend/templates/admin.dart
+++ b/app/lib/frontend/templates/admin.dart
@@ -43,8 +43,15 @@ String renderUploaderApprovalPage(
 }
 
 /// Renders the `views/consent.mustache` template.
-String renderConsentPage(String consentId) {
-  final content = templateCache.renderTemplate('consent', {});
+String renderConsentPage({
+  @required String consentId,
+  @required String title,
+  @required String descriptionHtml,
+}) {
+  final content = templateCache.renderTemplate('consent', {
+    'title': title,
+    'description_html': descriptionHtml,
+  });
   return renderLayoutPage(
     PageType.standalone,
     content,

--- a/app/lib/frontend/templates/views/consent.mustache
+++ b/app/lib/frontend/templates/views/consent.mustache
@@ -2,12 +2,18 @@
     for details. All rights reserved. Use of this source code is governed by a
     BSD-style license that can be found in the LICENSE file. }}
 
-<h1 id="-admin-consent-title">Consent request</h1>
+<h1 id="-admin-consent-title">{{title}}</h1>
 
 <div id="-admin-consent-content">
-  <p>Loading consent details...</p>
+{{& description_html}}
 </div>
 <p id="-admin-consent-buttons">
-  <button id="-admin-consent-reject-button" class="pub-button">Reject</button>
-  <button id="-admin-consent-accept-button" class="pub-button">Accept</button>
+  <button
+    id="-admin-consent-reject-button"
+    class="mdc-button mdc-button--raised"
+    data-mdc-auto-init="MDCRipple">Reject</button>
+  <button
+    id="-admin-consent-accept-button"
+    class="mdc-button mdc-button--raised"
+    data-mdc-auto-init="MDCRipple">Accept</button>
 </p>

--- a/pkg/web_app/lib/src/account.dart
+++ b/pkg/web_app/lib/src/account.dart
@@ -162,7 +162,6 @@ void _updateUi() {
   _pkgAdminWidget.update();
   _createPublisherWidget.update();
   _publisherAdminWidget.update();
-  _consentWidget.update();
 }
 
 /// Active on /packages/<package>/admin page.
@@ -390,16 +389,10 @@ class _PublisherAdminWidget {
 }
 
 class _ConsentWidget {
-  Element _title;
-  Element _content;
   Element _buttons;
-  Future<Consent> _consentFuture;
-  bool _loaded = false;
 
   void init() {
     if (!pageData.isConsentPage) return;
-    _title = document.getElementById('-admin-consent-title');
-    _content = document.getElementById('-admin-consent-content');
     _buttons = document.getElementById('-admin-consent-buttons');
     document
         .getElementById('-admin-consent-accept-button')
@@ -409,35 +402,6 @@ class _ConsentWidget {
         .getElementById('-admin-consent-reject-button')
         .onClick
         .listen((_) => _reject());
-  }
-
-  void update() {
-    if (!pageData.isConsentPage) return;
-
-    updateDisplay(_buttons, _loaded);
-
-    if (isSignedIn && _consentFuture == null) {
-      _consentFuture = client.consentInfo(pageData.consentId);
-      _consentFuture.then((consent) {
-        _title.innerText = consent.titleText;
-        _content.replaceWith(Element.div()
-          ..children = [
-            Element.div()..innerHtml = consent.descriptionHtml,
-          ]);
-        _loaded = true;
-        update();
-      }).catchError((e) {
-        String text = 'Error: $e';
-        if (e is RequestException) {
-          if (e.status == 404) {
-            text = 'Consent request `${pageData.consentId}` has expired.';
-          } else {
-            text = (e.bodyAsJson()['message'] as String) ?? text;
-          }
-        }
-        _content.replaceWith(Element.div()..text = text);
-      });
-    }
   }
 
   void _updateButtons(bool granted) {
@@ -466,8 +430,6 @@ class _ConsentWidget {
       _updateButtons(rs.granted);
     });
   }
-
-  bool get isActive => _content != null && _buttons != null;
 }
 
 Future<R> _rpc<R>(Future<R> fn()) async {


### PR DESCRIPTION
- In `consent_backend.dart`, mixing the API serving with regular backend seems to be non-ideal in this case, however, the separate API method would be almost identical with the non-API one.