### PR TITLE
Fixed broken JS on site, because mdc was not available

### DIFF
--- a/app/lib/frontend/templates/views/layout.mustache
+++ b/app/lib/frontend/templates/views/layout.mustache
@@ -31,15 +31,11 @@
   <meta name="description" content="{{& pageDescription}}" />
   <meta property="og:description" content="{{& pageDescription}}" />
   <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom" />
-  {{#is_experimental}}
   <link href="{{{static_assets.material__material-components-web_min_css}}}" rel="stylesheet" type="text/css" />
-  {{/is_experimental}}
   <link href="{{{static_assets.highlight__github_css}}}" rel="stylesheet" />
   <link href="{{{static_assets.css__github-markdown_css}}}" rel="stylesheet" type="text/css" />
   <link href="{{{static_assets.css__style_css}}}" rel="stylesheet" type="text/css" />
-  {{#is_experimental}}
   <script src="{{{static_assets.material__material-components-web_min_js}}}" defer="defer"></script>
-  {{/is_experimental}}
   <script src="{{{static_assets.js__script_dart_js}}}" defer="defer"></script>
   {{#include_survey}}
   <script async="async" defer="defer" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>

--- a/app/test/frontend/golden/authorized_page.html
+++ b/app/test/frontend/golden/authorized_page.html
@@ -19,9 +19,11 @@
     <meta name="description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
+    <link href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842" rel="stylesheet" type="text/css"/>
     <link href="/static/highlight/github.css?hash=mocked_hash_145446167" rel="stylesheet"/>
     <link href="/static/css/github-markdown.css?hash=mocked_hash_488759485" rel="stylesheet" type="text/css"/>
     <link href="/static/css/style.css?hash=mocked_hash_537099079" rel="stylesheet" type="text/css"/>
+    <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
     <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
   </head>
   <body class="">

--- a/app/test/frontend/golden/error_page.html
+++ b/app/test/frontend/golden/error_page.html
@@ -19,9 +19,11 @@
     <meta name="description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
+    <link href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842" rel="stylesheet" type="text/css"/>
     <link href="/static/highlight/github.css?hash=mocked_hash_145446167" rel="stylesheet"/>
     <link href="/static/css/github-markdown.css?hash=mocked_hash_488759485" rel="stylesheet" type="text/css"/>
     <link href="/static/css/style.css?hash=mocked_hash_537099079" rel="stylesheet" type="text/css"/>
+    <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
     <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
   </head>
   <body class="">

--- a/app/test/frontend/golden/flutter_landing_page.html
+++ b/app/test/frontend/golden/flutter_landing_page.html
@@ -19,9 +19,11 @@
     <meta name="description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
+    <link href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842" rel="stylesheet" type="text/css"/>
     <link href="/static/highlight/github.css?hash=mocked_hash_145446167" rel="stylesheet"/>
     <link href="/static/css/github-markdown.css?hash=mocked_hash_488759485" rel="stylesheet" type="text/css"/>
     <link href="/static/css/style.css?hash=mocked_hash_537099079" rel="stylesheet" type="text/css"/>
+    <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
     <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
     <script async="async" defer="defer" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
   </head>

--- a/app/test/frontend/golden/index_page.html
+++ b/app/test/frontend/golden/index_page.html
@@ -19,9 +19,11 @@
     <meta name="description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
+    <link href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842" rel="stylesheet" type="text/css"/>
     <link href="/static/highlight/github.css?hash=mocked_hash_145446167" rel="stylesheet"/>
     <link href="/static/css/github-markdown.css?hash=mocked_hash_488759485" rel="stylesheet" type="text/css"/>
     <link href="/static/css/style.css?hash=mocked_hash_537099079" rel="stylesheet" type="text/css"/>
+    <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
     <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
     <script async="async" defer="defer" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
   </head>

--- a/app/test/frontend/golden/my_packages.html
+++ b/app/test/frontend/golden/my_packages.html
@@ -20,9 +20,11 @@
     <meta name="description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
+    <link href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842" rel="stylesheet" type="text/css"/>
     <link href="/static/highlight/github.css?hash=mocked_hash_145446167" rel="stylesheet"/>
     <link href="/static/css/github-markdown.css?hash=mocked_hash_488759485" rel="stylesheet" type="text/css"/>
     <link href="/static/css/style.css?hash=mocked_hash_537099079" rel="stylesheet" type="text/css"/>
+    <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
     <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
     <script async="async" defer="defer" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
   </head>

--- a/app/test/frontend/golden/my_publishers.html
+++ b/app/test/frontend/golden/my_publishers.html
@@ -20,9 +20,11 @@
     <meta name="description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
+    <link href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842" rel="stylesheet" type="text/css"/>
     <link href="/static/highlight/github.css?hash=mocked_hash_145446167" rel="stylesheet"/>
     <link href="/static/css/github-markdown.css?hash=mocked_hash_488759485" rel="stylesheet" type="text/css"/>
     <link href="/static/css/style.css?hash=mocked_hash_537099079" rel="stylesheet" type="text/css"/>
+    <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
     <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
     <script async="async" defer="defer" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
   </head>

--- a/app/test/frontend/golden/pkg_admin_page_outdated.html
+++ b/app/test/frontend/golden/pkg_admin_page_outdated.html
@@ -20,9 +20,11 @@
     <meta name="description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
+    <link href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842" rel="stylesheet" type="text/css"/>
     <link href="/static/highlight/github.css?hash=mocked_hash_145446167" rel="stylesheet"/>
     <link href="/static/css/github-markdown.css?hash=mocked_hash_488759485" rel="stylesheet" type="text/css"/>
     <link href="/static/css/style.css?hash=mocked_hash_537099079" rel="stylesheet" type="text/css"/>
+    <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
     <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
     <script async="async" defer="defer" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
     <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJmb29iYXJfcGtnIiwidmVyc2lvbiI6IjAuMS4xKzUiLCJpc0Rpc2NvbnRpbnVlZCI6ZmFsc2V9fQ=="/>

--- a/app/test/frontend/golden/pkg_index_page.html
+++ b/app/test/frontend/golden/pkg_index_page.html
@@ -20,9 +20,11 @@
     <meta name="description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
+    <link href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842" rel="stylesheet" type="text/css"/>
     <link href="/static/highlight/github.css?hash=mocked_hash_145446167" rel="stylesheet"/>
     <link href="/static/css/github-markdown.css?hash=mocked_hash_488759485" rel="stylesheet" type="text/css"/>
     <link href="/static/css/style.css?hash=mocked_hash_537099079" rel="stylesheet" type="text/css"/>
+    <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
     <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
     <script async="async" defer="defer" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
   </head>

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -19,9 +19,11 @@
     <meta name="description" content="my package description"/>
     <meta property="og:description" content="my package description"/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
+    <link href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842" rel="stylesheet" type="text/css"/>
     <link href="/static/highlight/github.css?hash=mocked_hash_145446167" rel="stylesheet"/>
     <link href="/static/css/github-markdown.css?hash=mocked_hash_488759485" rel="stylesheet" type="text/css"/>
     <link href="/static/css/style.css?hash=mocked_hash_537099079" rel="stylesheet" type="text/css"/>
+    <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
     <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
     <script async="async" defer="defer" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
     <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJmb29iYXJfcGtnIiwidmVyc2lvbiI6IjAuMS4xKzUiLCJpc0Rpc2NvbnRpbnVlZCI6ZmFsc2V9fQ=="/>

--- a/app/test/frontend/golden/pkg_show_page_discontinued.html
+++ b/app/test/frontend/golden/pkg_show_page_discontinued.html
@@ -20,9 +20,11 @@
     <meta name="description" content="my package description"/>
     <meta property="og:description" content="my package description"/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
+    <link href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842" rel="stylesheet" type="text/css"/>
     <link href="/static/highlight/github.css?hash=mocked_hash_145446167" rel="stylesheet"/>
     <link href="/static/css/github-markdown.css?hash=mocked_hash_488759485" rel="stylesheet" type="text/css"/>
     <link href="/static/css/style.css?hash=mocked_hash_537099079" rel="stylesheet" type="text/css"/>
+    <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
     <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
     <script async="async" defer="defer" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
     <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJmb29iYXJfcGtnIiwidmVyc2lvbiI6IjAuMS4xKzUiLCJpc0Rpc2NvbnRpbnVlZCI6dHJ1ZX19"/>

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -19,9 +19,11 @@
     <meta name="description" content="my package description"/>
     <meta property="og:description" content="my package description"/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
+    <link href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842" rel="stylesheet" type="text/css"/>
     <link href="/static/highlight/github.css?hash=mocked_hash_145446167" rel="stylesheet"/>
     <link href="/static/css/github-markdown.css?hash=mocked_hash_488759485" rel="stylesheet" type="text/css"/>
     <link href="/static/css/style.css?hash=mocked_hash_537099079" rel="stylesheet" type="text/css"/>
+    <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
     <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
     <script async="async" defer="defer" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
     <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJmb29iYXJfcGtnIiwidmVyc2lvbiI6IjAuMS4xKzUiLCJpc0Rpc2NvbnRpbnVlZCI6ZmFsc2V9fQ=="/>

--- a/app/test/frontend/golden/pkg_show_page_legacy.html
+++ b/app/test/frontend/golden/pkg_show_page_legacy.html
@@ -20,9 +20,11 @@
     <meta name="description" content="my package description"/>
     <meta property="og:description" content="my package description"/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
+    <link href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842" rel="stylesheet" type="text/css"/>
     <link href="/static/highlight/github.css?hash=mocked_hash_145446167" rel="stylesheet"/>
     <link href="/static/css/github-markdown.css?hash=mocked_hash_488759485" rel="stylesheet" type="text/css"/>
     <link href="/static/css/style.css?hash=mocked_hash_537099079" rel="stylesheet" type="text/css"/>
+    <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
     <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
     <script async="async" defer="defer" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
     <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJmb29iYXJfcGtnIiwidmVyc2lvbiI6IjAuMS4xKzUiLCJpc0Rpc2NvbnRpbnVlZCI6ZmFsc2V9fQ=="/>

--- a/app/test/frontend/golden/pkg_show_page_outdated.html
+++ b/app/test/frontend/golden/pkg_show_page_outdated.html
@@ -20,9 +20,11 @@
     <meta name="description" content="my package description"/>
     <meta property="og:description" content="my package description"/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
+    <link href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842" rel="stylesheet" type="text/css"/>
     <link href="/static/highlight/github.css?hash=mocked_hash_145446167" rel="stylesheet"/>
     <link href="/static/css/github-markdown.css?hash=mocked_hash_488759485" rel="stylesheet" type="text/css"/>
     <link href="/static/css/style.css?hash=mocked_hash_537099079" rel="stylesheet" type="text/css"/>
+    <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
     <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
     <script async="async" defer="defer" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
     <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJmb29iYXJfcGtnIiwidmVyc2lvbiI6IjAuMS4xKzUiLCJpc0Rpc2NvbnRpbnVlZCI6ZmFsc2V9fQ=="/>

--- a/app/test/frontend/golden/pkg_show_page_publisher.html
+++ b/app/test/frontend/golden/pkg_show_page_publisher.html
@@ -20,9 +20,11 @@
     <meta name="description" content="lithium is a Dart package"/>
     <meta property="og:description" content="lithium is a Dart package"/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
+    <link href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842" rel="stylesheet" type="text/css"/>
     <link href="/static/highlight/github.css?hash=mocked_hash_145446167" rel="stylesheet"/>
     <link href="/static/css/github-markdown.css?hash=mocked_hash_488759485" rel="stylesheet" type="text/css"/>
     <link href="/static/css/style.css?hash=mocked_hash_537099079" rel="stylesheet" type="text/css"/>
+    <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
     <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
     <script async="async" defer="defer" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
     <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJsaXRoaXVtIiwidmVyc2lvbiI6IjUuOC42IiwicHVibGlzaGVySWQiOiJleGFtcGxlLmNvbSIsImlzRGlzY29udGludWVkIjpmYWxzZX19"/>

--- a/app/test/frontend/golden/pkg_show_version_page.html
+++ b/app/test/frontend/golden/pkg_show_version_page.html
@@ -21,9 +21,11 @@
     <meta name="description" content="my package description"/>
     <meta property="og:description" content="my package description"/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
+    <link href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842" rel="stylesheet" type="text/css"/>
     <link href="/static/highlight/github.css?hash=mocked_hash_145446167" rel="stylesheet"/>
     <link href="/static/css/github-markdown.css?hash=mocked_hash_488759485" rel="stylesheet" type="text/css"/>
     <link href="/static/css/style.css?hash=mocked_hash_537099079" rel="stylesheet" type="text/css"/>
+    <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
     <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
     <script async="async" defer="defer" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
     <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJmb29iYXJfcGtnIiwidmVyc2lvbiI6IjAuMi4wLWRldiIsImlzRGlzY29udGludWVkIjpmYWxzZX19"/>

--- a/app/test/frontend/golden/pkg_versions_page.html
+++ b/app/test/frontend/golden/pkg_versions_page.html
@@ -21,9 +21,11 @@
     <meta name="description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
+    <link href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842" rel="stylesheet" type="text/css"/>
     <link href="/static/highlight/github.css?hash=mocked_hash_145446167" rel="stylesheet"/>
     <link href="/static/css/github-markdown.css?hash=mocked_hash_488759485" rel="stylesheet" type="text/css"/>
     <link href="/static/css/style.css?hash=mocked_hash_537099079" rel="stylesheet" type="text/css"/>
+    <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
     <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
     <script async="async" defer="defer" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
     <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJmb29iYXJfcGtnIiwidmVyc2lvbiI6IjAuMS4xKzUiLCJpc0Rpc2NvbnRpbnVlZCI6ZmFsc2V9fQ=="/>

--- a/app/test/frontend/golden/publisher_list_page.html
+++ b/app/test/frontend/golden/publisher_list_page.html
@@ -19,9 +19,11 @@
     <meta name="description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
+    <link href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842" rel="stylesheet" type="text/css"/>
     <link href="/static/highlight/github.css?hash=mocked_hash_145446167" rel="stylesheet"/>
     <link href="/static/css/github-markdown.css?hash=mocked_hash_488759485" rel="stylesheet" type="text/css"/>
     <link href="/static/css/style.css?hash=mocked_hash_537099079" rel="stylesheet" type="text/css"/>
+    <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
     <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
     <script async="async" defer="defer" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
   </head>

--- a/app/test/frontend/golden/publisher_packages_page.html
+++ b/app/test/frontend/golden/publisher_packages_page.html
@@ -19,9 +19,11 @@
     <meta name="description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
+    <link href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842" rel="stylesheet" type="text/css"/>
     <link href="/static/highlight/github.css?hash=mocked_hash_145446167" rel="stylesheet"/>
     <link href="/static/css/github-markdown.css?hash=mocked_hash_488759485" rel="stylesheet" type="text/css"/>
     <link href="/static/css/style.css?hash=mocked_hash_537099079" rel="stylesheet" type="text/css"/>
+    <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
     <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
     <script async="async" defer="defer" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
     <meta name="pub-page-data" content="eyJwdWJsaXNoZXIiOnsicHVibGlzaGVySWQiOiJleGFtcGxlLmNvbSJ9fQ=="/>

--- a/app/test/frontend/golden/search_page.html
+++ b/app/test/frontend/golden/search_page.html
@@ -20,9 +20,11 @@
     <meta name="description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
+    <link href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842" rel="stylesheet" type="text/css"/>
     <link href="/static/highlight/github.css?hash=mocked_hash_145446167" rel="stylesheet"/>
     <link href="/static/css/github-markdown.css?hash=mocked_hash_488759485" rel="stylesheet" type="text/css"/>
     <link href="/static/css/style.css?hash=mocked_hash_537099079" rel="stylesheet" type="text/css"/>
+    <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
     <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
     <script async="async" defer="defer" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
   </head>

--- a/app/test/frontend/golden/search_supported_qualifier.html
+++ b/app/test/frontend/golden/search_supported_qualifier.html
@@ -20,9 +20,11 @@
     <meta name="description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
+    <link href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842" rel="stylesheet" type="text/css"/>
     <link href="/static/highlight/github.css?hash=mocked_hash_145446167" rel="stylesheet"/>
     <link href="/static/css/github-markdown.css?hash=mocked_hash_488759485" rel="stylesheet" type="text/css"/>
     <link href="/static/css/style.css?hash=mocked_hash_537099079" rel="stylesheet" type="text/css"/>
+    <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
     <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
     <script async="async" defer="defer" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
   </head>

--- a/app/test/frontend/golden/search_unsupported_qualifier.html
+++ b/app/test/frontend/golden/search_unsupported_qualifier.html
@@ -20,9 +20,11 @@
     <meta name="description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
+    <link href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842" rel="stylesheet" type="text/css"/>
     <link href="/static/highlight/github.css?hash=mocked_hash_145446167" rel="stylesheet"/>
     <link href="/static/css/github-markdown.css?hash=mocked_hash_488759485" rel="stylesheet" type="text/css"/>
     <link href="/static/css/style.css?hash=mocked_hash_537099079" rel="stylesheet" type="text/css"/>
+    <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
     <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
     <script async="async" defer="defer" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
   </head>

--- a/app/test/frontend/golden/uploader_approval_page.html
+++ b/app/test/frontend/golden/uploader_approval_page.html
@@ -19,9 +19,11 @@
     <meta name="description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
+    <link href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842" rel="stylesheet" type="text/css"/>
     <link href="/static/highlight/github.css?hash=mocked_hash_145446167" rel="stylesheet"/>
     <link href="/static/css/github-markdown.css?hash=mocked_hash_488759485" rel="stylesheet" type="text/css"/>
     <link href="/static/css/style.css?hash=mocked_hash_537099079" rel="stylesheet" type="text/css"/>
+    <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
     <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
   </head>
   <body class="">

--- a/app/test/frontend/golden/web_landing_page.html
+++ b/app/test/frontend/golden/web_landing_page.html
@@ -19,9 +19,11 @@
     <meta name="description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
+    <link href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842" rel="stylesheet" type="text/css"/>
     <link href="/static/highlight/github.css?hash=mocked_hash_145446167" rel="stylesheet"/>
     <link href="/static/css/github-markdown.css?hash=mocked_hash_488759485" rel="stylesheet" type="text/css"/>
     <link href="/static/css/style.css?hash=mocked_hash_537099079" rel="stylesheet" type="text/css"/>
+    <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
     <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
     <script async="async" defer="defer" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
   </head>


### PR DESCRIPTION
I know we have to update the golden templates.
But not in this PR, as it would conflict with the other pending PR.
So let's just do that when we merge.