### PR TITLE
Enable publishers.

### DIFF
--- a/app/lib/frontend/handlers/misc.dart
+++ b/app/lib/frontend/handlers/misc.dart
@@ -56,7 +56,7 @@ Future<shelf.Response> robotsTxtHandler(shelf.Request request) async {
       body: [
         'User-agent: *',
         'Sitemap: $sitemapUri',
-        if (requestContext.isExperimental) 'Sitemap: $sitemap2Uri',
+        'Sitemap: $sitemap2Uri',
       ].join('\n'));
 }
 
@@ -81,8 +81,6 @@ Future<shelf.Response> siteMapTxtHandler(shelf.Request request) async {
     '/help',
     '/web',
     '/flutter',
-    if (requestContext.isExperimental) '/publishers',
-    if (requestContext.isExperimental) '/create-publisher',
   ];
   items.addAll(pages.map((page) => uri.replace(path: page).toString()));
 
@@ -107,9 +105,6 @@ Future<shelf.Response> siteMapTxtHandler(shelf.Request request) async {
 Future<shelf.Response> sitemapPublishersTxtHandler(
     shelf.Request request) async {
   if (requestContext.blockRobots) {
-    return notFoundHandler(request);
-  }
-  if (!requestContext.isExperimental) {
     return notFoundHandler(request);
   }
 

--- a/app/lib/frontend/templates/layout.dart
+++ b/app/lib/frontend/templates/layout.dart
@@ -88,9 +88,7 @@ String renderLayoutPage(
     'is_experimental': requestContext.isExperimental,
     'is_logged_in': userSession != null,
     'dart_site_root': urls.dartSiteRoot,
-    'oauth_client_id': requestContext.isExperimental
-        ? activeConfiguration.pubSiteAudience
-        : null,
+    'oauth_client_id': activeConfiguration.pubSiteAudience,
     'user_session': userSession,
     'body_class': bodyClasses.join(' '),
     'no_index': noIndex,

--- a/app/lib/frontend/templates/views/layout.mustache
+++ b/app/lib/frontend/templates/views/layout.mustache
@@ -40,10 +40,8 @@
   {{#include_survey}}
   <script async="async" defer="defer" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
   {{/include_survey}}
-  {{#is_experimental}}
   <meta name="google-signin-client_id" content="{{oauth_client_id}}" />
   <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
-  {{/is_experimental}}
   {{#page_data_encoded}}
   <meta name="pub-page-data" content="{{& page_data_encoded}}"/>
   {{/page_data_encoded}}

--- a/app/test/frontend/golden/authorized_page.html
+++ b/app/test/frontend/golden/authorized_page.html
@@ -25,6 +25,8 @@
     <link href="/static/css/style.css?hash=mocked_hash_537099079" rel="stylesheet" type="text/css"/>
     <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
     <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
+    <meta name="google-signin-client_id" content=""/>
+    <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
   </head>
   <body class="">
     <header class="site-header-row">

--- a/app/test/frontend/golden/error_page.html
+++ b/app/test/frontend/golden/error_page.html
@@ -25,6 +25,8 @@
     <link href="/static/css/style.css?hash=mocked_hash_537099079" rel="stylesheet" type="text/css"/>
     <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
     <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
+    <meta name="google-signin-client_id" content=""/>
+    <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
   </head>
   <body class="">
     <header class="site-header-row">

--- a/app/test/frontend/golden/flutter_landing_page.html
+++ b/app/test/frontend/golden/flutter_landing_page.html
@@ -26,6 +26,8 @@
     <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
     <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
     <script async="async" defer="defer" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
+    <meta name="google-signin-client_id" content=""/>
+    <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
   </head>
   <body class="">
     <header class="site-header-row">

--- a/app/test/frontend/golden/index_page.html
+++ b/app/test/frontend/golden/index_page.html
@@ -26,6 +26,8 @@
     <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
     <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
     <script async="async" defer="defer" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
+    <meta name="google-signin-client_id" content=""/>
+    <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
   </head>
   <body class="">
     <header class="site-header-row">

--- a/app/test/frontend/golden/my_packages.html
+++ b/app/test/frontend/golden/my_packages.html
@@ -27,6 +27,8 @@
     <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
     <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
     <script async="async" defer="defer" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
+    <meta name="google-signin-client_id" content=""/>
+    <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
   </head>
   <body class="">
     <header class="site-header-row">

--- a/app/test/frontend/golden/my_publishers.html
+++ b/app/test/frontend/golden/my_publishers.html
@@ -27,6 +27,8 @@
     <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
     <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
     <script async="async" defer="defer" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
+    <meta name="google-signin-client_id" content=""/>
+    <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
   </head>
   <body class="">
     <header class="site-header-row">

--- a/app/test/frontend/golden/pkg_admin_page_outdated.html
+++ b/app/test/frontend/golden/pkg_admin_page_outdated.html
@@ -27,6 +27,8 @@
     <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
     <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
     <script async="async" defer="defer" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
+    <meta name="google-signin-client_id" content=""/>
+    <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
     <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJmb29iYXJfcGtnIiwidmVyc2lvbiI6IjAuMS4xKzUiLCJpc0Rpc2NvbnRpbnVlZCI6ZmFsc2V9fQ=="/>
   </head>
   <body class="">

--- a/app/test/frontend/golden/pkg_index_page.html
+++ b/app/test/frontend/golden/pkg_index_page.html
@@ -27,6 +27,8 @@
     <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
     <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
     <script async="async" defer="defer" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
+    <meta name="google-signin-client_id" content=""/>
+    <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
   </head>
   <body class="">
     <header class="site-header-row">

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -26,6 +26,8 @@
     <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
     <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
     <script async="async" defer="defer" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
+    <meta name="google-signin-client_id" content=""/>
+    <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
     <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJmb29iYXJfcGtnIiwidmVyc2lvbiI6IjAuMS4xKzUiLCJpc0Rpc2NvbnRpbnVlZCI6ZmFsc2V9fQ=="/>
   </head>
   <body class="">

--- a/app/test/frontend/golden/pkg_show_page_discontinued.html
+++ b/app/test/frontend/golden/pkg_show_page_discontinued.html
@@ -27,6 +27,8 @@
     <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
     <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
     <script async="async" defer="defer" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
+    <meta name="google-signin-client_id" content=""/>
+    <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
     <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJmb29iYXJfcGtnIiwidmVyc2lvbiI6IjAuMS4xKzUiLCJpc0Rpc2NvbnRpbnVlZCI6dHJ1ZX19"/>
   </head>
   <body class="">

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -26,6 +26,8 @@
     <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
     <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
     <script async="async" defer="defer" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
+    <meta name="google-signin-client_id" content=""/>
+    <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
     <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJmb29iYXJfcGtnIiwidmVyc2lvbiI6IjAuMS4xKzUiLCJpc0Rpc2NvbnRpbnVlZCI6ZmFsc2V9fQ=="/>
   </head>
   <body class="">

--- a/app/test/frontend/golden/pkg_show_page_legacy.html
+++ b/app/test/frontend/golden/pkg_show_page_legacy.html
@@ -27,6 +27,8 @@
     <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
     <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
     <script async="async" defer="defer" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
+    <meta name="google-signin-client_id" content=""/>
+    <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
     <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJmb29iYXJfcGtnIiwidmVyc2lvbiI6IjAuMS4xKzUiLCJpc0Rpc2NvbnRpbnVlZCI6ZmFsc2V9fQ=="/>
   </head>
   <body class="">

--- a/app/test/frontend/golden/pkg_show_page_outdated.html
+++ b/app/test/frontend/golden/pkg_show_page_outdated.html
@@ -27,6 +27,8 @@
     <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
     <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
     <script async="async" defer="defer" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
+    <meta name="google-signin-client_id" content=""/>
+    <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
     <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJmb29iYXJfcGtnIiwidmVyc2lvbiI6IjAuMS4xKzUiLCJpc0Rpc2NvbnRpbnVlZCI6ZmFsc2V9fQ=="/>
   </head>
   <body class="">

--- a/app/test/frontend/golden/pkg_show_page_publisher.html
+++ b/app/test/frontend/golden/pkg_show_page_publisher.html
@@ -27,6 +27,8 @@
     <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
     <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
     <script async="async" defer="defer" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
+    <meta name="google-signin-client_id" content=""/>
+    <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
     <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJsaXRoaXVtIiwidmVyc2lvbiI6IjUuOC42IiwicHVibGlzaGVySWQiOiJleGFtcGxlLmNvbSIsImlzRGlzY29udGludWVkIjpmYWxzZX19"/>
   </head>
   <body class="">

--- a/app/test/frontend/golden/pkg_show_version_page.html
+++ b/app/test/frontend/golden/pkg_show_version_page.html
@@ -28,6 +28,8 @@
     <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
     <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
     <script async="async" defer="defer" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
+    <meta name="google-signin-client_id" content=""/>
+    <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
     <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJmb29iYXJfcGtnIiwidmVyc2lvbiI6IjAuMi4wLWRldiIsImlzRGlzY29udGludWVkIjpmYWxzZX19"/>
   </head>
   <body class="">

--- a/app/test/frontend/golden/pkg_versions_page.html
+++ b/app/test/frontend/golden/pkg_versions_page.html
@@ -28,6 +28,8 @@
     <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
     <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
     <script async="async" defer="defer" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
+    <meta name="google-signin-client_id" content=""/>
+    <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
     <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJmb29iYXJfcGtnIiwidmVyc2lvbiI6IjAuMS4xKzUiLCJpc0Rpc2NvbnRpbnVlZCI6ZmFsc2V9fQ=="/>
   </head>
   <body class="">

--- a/app/test/frontend/golden/publisher_list_page.html
+++ b/app/test/frontend/golden/publisher_list_page.html
@@ -26,6 +26,8 @@
     <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
     <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
     <script async="async" defer="defer" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
+    <meta name="google-signin-client_id" content=""/>
+    <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
   </head>
   <body class="">
     <header class="site-header-row">

--- a/app/test/frontend/golden/publisher_packages_page.html
+++ b/app/test/frontend/golden/publisher_packages_page.html
@@ -26,6 +26,8 @@
     <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
     <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
     <script async="async" defer="defer" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
+    <meta name="google-signin-client_id" content=""/>
+    <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
     <meta name="pub-page-data" content="eyJwdWJsaXNoZXIiOnsicHVibGlzaGVySWQiOiJleGFtcGxlLmNvbSJ9fQ=="/>
   </head>
   <body class="">

--- a/app/test/frontend/golden/search_page.html
+++ b/app/test/frontend/golden/search_page.html
@@ -27,6 +27,8 @@
     <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
     <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
     <script async="async" defer="defer" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
+    <meta name="google-signin-client_id" content=""/>
+    <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
   </head>
   <body class="">
     <header class="site-header-row">

--- a/app/test/frontend/golden/search_supported_qualifier.html
+++ b/app/test/frontend/golden/search_supported_qualifier.html
@@ -27,6 +27,8 @@
     <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
     <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
     <script async="async" defer="defer" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
+    <meta name="google-signin-client_id" content=""/>
+    <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
   </head>
   <body class="">
     <header class="site-header-row">

--- a/app/test/frontend/golden/search_unsupported_qualifier.html
+++ b/app/test/frontend/golden/search_unsupported_qualifier.html
@@ -27,6 +27,8 @@
     <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
     <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
     <script async="async" defer="defer" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
+    <meta name="google-signin-client_id" content=""/>
+    <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
   </head>
   <body class="">
     <header class="site-header-row">

--- a/app/test/frontend/golden/uploader_approval_page.html
+++ b/app/test/frontend/golden/uploader_approval_page.html
@@ -25,6 +25,8 @@
     <link href="/static/css/style.css?hash=mocked_hash_537099079" rel="stylesheet" type="text/css"/>
     <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
     <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
+    <meta name="google-signin-client_id" content=""/>
+    <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
   </head>
   <body class="">
     <header class="site-header-row">

--- a/app/test/frontend/golden/web_landing_page.html
+++ b/app/test/frontend/golden/web_landing_page.html
@@ -26,6 +26,8 @@
     <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
     <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
     <script async="async" defer="defer" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
+    <meta name="google-signin-client_id" content=""/>
+    <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
   </head>
   <body class="">
     <header class="site-header-row">

--- a/app/test/shared/utils.dart
+++ b/app/test/shared/utils.dart
@@ -7,6 +7,8 @@ import 'dart:async';
 import 'package:gcloud/service_scope.dart';
 import 'package:test/test.dart';
 
+import 'package:pub_dartlang_org/shared/configuration.dart';
+
 Future scoped(func()) {
   return fork(() async {
     return func();
@@ -16,7 +18,9 @@ Future scoped(func()) {
 void scopedTest(String name, func(), {Timeout timeout}) {
   test(name, () {
     return fork(() async {
-      return func();
+      // double fork to allow further override
+      registerActiveConfiguration(Configuration.test());
+      return await fork(() async => func());
     });
   }, timeout: timeout);
 }


### PR DESCRIPTION
Small functional changes:
- sitemap does not contain `/publishers` (we do allow it, but not promote it)
- sitemap does not contain `/create-publisher` (as you'd need to be logged in for it)
- scoped tests auto-register the configuration object in the scope (because layout rendering needs to access it)

I've also checked and there is not `experimental` style used in our CSS or web_app