### PR TITLE
Sort control on publisher- and my-packages.

### DIFF
--- a/app/lib/frontend/templates/admin.dart
+++ b/app/lib/frontend/templates/admin.dart
@@ -89,8 +89,12 @@ String renderAccountPackagesPage({
   final packageListHtml = packages.isEmpty ? '' : renderPackageList(packages);
   final paginationHtml = renderPagination(pageLinks);
 
-  final tabContent =
-      [resultCountHtml, packageListHtml, paginationHtml].join('\n');
+  final tabContent = [
+    renderSortControl(searchQuery),
+    resultCountHtml,
+    packageListHtml,
+    paginationHtml,
+  ].join('\n');
   final content = renderDetailPage(
     headerHtml: _accountDetailHeader(user),
     tabs: [

--- a/app/lib/frontend/templates/listing.dart
+++ b/app/lib/frontend/templates/listing.dart
@@ -91,13 +91,8 @@ String renderPkgIndexPage(
   final isSearch = searchQuery != null && searchQuery.hasQuery;
   final unsupportedQualifier =
       isSearch && (searchQuery.parsedQuery.text?.contains(':') ?? false);
-  final String sortValue = serializeSearchOrder(searchQuery?.order) ??
-      (isSearch ? 'search_relevance' : 'listing_relevance');
-  final SortDict sortDict = getSortDict(sortValue);
   final values = {
-    'sort_value': sortValue,
-    'sort_name': sortDict.label,
-    'ranking_tooltip_html': sortDict.tooltip,
+    'sort_control_html': renderSortControl(searchQuery),
     'is_search': isSearch,
     'unsupported_qualifier': unsupportedQualifier,
     'title': platformDict.topPlatformPackages,
@@ -125,6 +120,19 @@ String renderPkgIndexPage(
     searchQuery: searchQuery,
     noIndex: true,
   );
+}
+
+/// Renders the `views/shared/sort_control.mustache` template.
+String renderSortControl(SearchQuery query) {
+  final isSearch = query != null && query.hasQuery;
+  final sortValue = serializeSearchOrder(query?.order) ??
+      (isSearch ? 'search_relevance' : 'listing_relevance');
+  final sortDict = getSortDict(sortValue);
+  return templateCache.renderTemplate('shared/sort_control', {
+    'sort_value': sortValue,
+    'sort_name': sortDict.label,
+    'ranking_tooltip_html': sortDict.tooltip,
+  });
 }
 
 class PageLinks {

--- a/app/lib/frontend/templates/publisher.dart
+++ b/app/lib/frontend/templates/publisher.dart
@@ -109,8 +109,12 @@ String renderPublisherPackagesPage({
   final packageListHtml = packages.isEmpty ? '' : renderPackageList(packages);
   final paginationHtml = renderPagination(pageLinks);
 
-  final tabContent =
-      [resultCountHtml, packageListHtml, paginationHtml].join('\n');
+  final tabContent = [
+    renderSortControl(searchQuery),
+    resultCountHtml,
+    packageListHtml,
+    paginationHtml,
+  ].join('\n');
 
   final tabs = <Tab>[
     Tab.withContent(

--- a/app/lib/frontend/templates/views/layout.mustache
+++ b/app/lib/frontend/templates/views/layout.mustache
@@ -110,6 +110,7 @@
       <div class="small-banner">
         <form class="search-bar" action="{{& search_form_url}}">
           <input class="input" name="q" placeholder="{{search_query_placeholder}}" autocomplete="on" autofocus="autofocus"{{#search_query_html}} value="{{& search_query_html}}"{{/search_query_html}}/>
+          {{#search_sort_param}}<input type="hidden" name="sort" value="{{search_sort_param}}"/>{{/search_sort_param}}
           <button class="icon"></button>
         </form>
       </div>

--- a/app/lib/frontend/templates/views/pkg/index.mustache
+++ b/app/lib/frontend/templates/views/pkg/index.mustache
@@ -2,15 +2,7 @@
     for details. All rights reserved. Use of this source code is governed by a
     BSD-style license that can be found in the LICENSE file. }}
 
-<div class="listing-sort-header">
-  <div class="tooltip-base hoverable">
-    <span class="tooltip-dotted">Sorted by:</span>
-    <span id="sort-control" data-sort="{{sort_value}}">{{sort_name}}</span>
-    <div class="tooltip-content tooltip-bottom-left">
-      {{& ranking_tooltip_html }}
-    </div>
-  </div>
-</div>
+{{& sort_control_html}}
 
 {{^is_search}}
 <h2 class="listing-page-title">{{title}}</h2>

--- a/app/lib/frontend/templates/views/shared/sort_control.mustache
+++ b/app/lib/frontend/templates/views/shared/sort_control.mustache
@@ -1,0 +1,13 @@
+{{! Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+    for details. All rights reserved. Use of this source code is governed by a
+    BSD-style license that can be found in the LICENSE file. }}
+
+<div class="listing-sort-header">
+  <div class="tooltip-base hoverable">
+    <span class="tooltip-dotted">Sorted by:</span>
+    <span id="sort-control" data-sort="{{sort_value}}">{{sort_name}}</span>
+    <div class="tooltip-content tooltip-bottom-left">
+      {{& ranking_tooltip_html }}
+    </div>
+  </div>
+</div>

--- a/app/test/frontend/golden/my_packages.html
+++ b/app/test/frontend/golden/my_packages.html
@@ -94,7 +94,19 @@
           </ul>
           <div class="main detail-tabs-content">
             <section class="tab-content -active" data-name="-packages-tab-">
-      You own 2 package(s).
+              <div class="listing-sort-header">
+                <div class="tooltip-base hoverable">
+                  <span class="tooltip-dotted">Sorted by:</span>
+                  <span id="sort-control" data-sort="listing_relevance">listing relevance</span>
+                  <div class="tooltip-content tooltip-bottom-left">
+      Packages are sorted by the combination of their overall score and their specificity to the selected platform. More information on 
+                    <a href="/help#ranking">ranking</a>.
+    
+                  </div>
+                </div>
+              </div>
+
+You own 2 package(s).
 
 
               <ul class="package-list">

--- a/app/test/frontend/golden/publisher_packages_page.html
+++ b/app/test/frontend/golden/publisher_packages_page.html
@@ -96,7 +96,19 @@
           </ul>
           <div class="main detail-tabs-content">
             <section class="tab-content -active" data-name="-packages-tab-">
-      2 package(s) owned by 
+              <div class="listing-sort-header">
+                <div class="tooltip-base hoverable">
+                  <span class="tooltip-dotted">Sorted by:</span>
+                  <span id="sort-control" data-sort="listing_relevance">listing relevance</span>
+                  <div class="tooltip-content tooltip-bottom-left">
+      Packages are sorted by the combination of their overall score and their specificity to the selected platform. More information on 
+                    <a href="/help#ranking">ranking</a>.
+    
+                  </div>
+                </div>
+              </div>
+
+2 package(s) owned by 
               <code>example.com</code>.
 
 

--- a/pkg/web_css/lib/src/_home.scss
+++ b/pkg/web_css/lib/src/_home.scss
@@ -18,7 +18,6 @@
 .listing-sort-header {
   float: right;
   margin: 0 0.5em 0.5em 0.5em;
-  max-width: 30%;
   text-align: right;
 }
 


### PR DESCRIPTION
I've removed the `max-width` from the CSS style, as it was breaking it into two lines on the "My packages" page. In practice this does not affect the layout much, even with long search queries.