### PR TITLE
Re-adding the -pub-remove-user-button style

### DIFF
--- a/app/lib/frontend/templates/views/publisher/admin_page.mustache
+++ b/app/lib/frontend/templates/views/publisher/admin_page.mustache
@@ -64,7 +64,7 @@
         <td class="mdc-data-table__cell">{{role}}</td>
         <td class="mdc-data-table__cell">
           <button
-            class="pub-button-danger mdc-button mdc-button--raised"
+            class="-pub-remove-user-button pub-button-danger mdc-button mdc-button--raised"
             data-user-id="{{user_id}}"
             data-email="{{email}}"
             data-mdc-auto-init="MDCRipple">Remove</button>


### PR DESCRIPTION
I've removed the style in a previous PR because I thought it was for style only. Apparently it is used by the binding selector.