### PR TITLE
Put publisher entries 3-per-row

### DIFF
--- a/app/lib/frontend/templates/views/publisher/publisher_list.mustache
+++ b/app/lib/frontend/templates/views/publisher/publisher_list.mustache
@@ -7,7 +7,7 @@
 {{/title}}
 
 {{#has_publishers}}
-<ul class="package-list">
+<ul class="publisher-list">
   {{#publishers}}
   <li class="list-item">
     <h3 class="title"><a href="{{& url}}">{{publisher_id}}</a></h3>

--- a/app/test/frontend/golden/my_publishers.html
+++ b/app/test/frontend/golden/my_publishers.html
@@ -96,7 +96,7 @@
           </ul>
           <div class="main detail-tabs-content">
             <section class="tab-content -active" data-name="-publishers-tab-">
-              <ul class="package-list">
+              <ul class="publisher-list">
                 <li class="list-item">
                   <h3 class="title">
                     <a href="/publishers/example.com">example.com</a>

--- a/app/test/frontend/golden/publisher_list_page.html
+++ b/app/test/frontend/golden/publisher_list_page.html
@@ -94,7 +94,7 @@
     <div class="container">
       <main>
         <h2>Publishers</h2>
-        <ul class="package-list">
+        <ul class="publisher-list">
           <li class="list-item">
             <h3 class="title">
               <a href="/publishers/example.com">example.com</a>

--- a/pkg/web_css/lib/src/_list.scss
+++ b/pkg/web_css/lib/src/_list.scss
@@ -1,11 +1,21 @@
 /******************************************************
   package list
 ******************************************************/
-.package-list {
+.package-list, .publisher-list {
   clear: both;
   padding: 0;
   margin: 0;
   list-style: none;
+}
+
+.publisher-list {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.publisher-list > li {
+  /* Ensures 3 items per row */
+  flex: 1 1 26%;
 }
 
 .list-item {


### PR DESCRIPTION
Looks a lot nicer IMHO

Compare to https://pub.dev/publishers/
<img width="1019" alt="Screen Shot 2019-10-19 at 10 44 49 PM" src="https://user-images.githubusercontent.com/17034/67155351-22a00380-f2c2-11e9-96f9-73af8438c908.png">
