### PR TITLE
Remove obsolete email field from search data.

### DIFF
--- a/app/lib/search/backend.dart
+++ b/app/lib/search/backend.dart
@@ -112,7 +112,6 @@ class SearchBackend {
       maintenance: analysisView.maintenanceScore,
       dependencies: _buildDependencies(analysisView),
       publisherId: p.publisherId,
-      emails: await _buildEmails(p, pv),
       uploaderEmails: await _buildUploaderEmails(p),
       apiDocPages: apiDocPages,
       timestamp: DateTime.now().toUtc(),
@@ -125,13 +124,6 @@ class SearchBackend {
       dependencies[pd.package] = pd.dependencyType;
     });
     return dependencies;
-  }
-
-  Future<List<String>> _buildEmails(Package p, PackageVersion pv) async {
-    final Set<String> emails = Set<String>();
-    final uploaderEmails = await accountBackend.getEmailsOfUserIds(p.uploaders);
-    emails.addAll(uploaderEmails.where((email) => email != null));
-    return emails.toList()..sort();
   }
 
   Future<List<String>> _buildUploaderEmails(Package p) async {
@@ -166,7 +158,6 @@ class SearchBackend {
         popularity: popularity,
         maintenance: 0.0,
         publisherId: p.publisherId,
-        emails: await _buildEmails(p, null),
         uploaderEmails: await _buildUploaderEmails(p),
         timestamp: DateTime.now().toUtc(),
       );

--- a/app/lib/search/index_simple.dart
+++ b/app/lib/search/index_simple.dart
@@ -197,13 +197,13 @@ class SimplePackageIndex implements PackageIndex {
     if (query.parsedQuery.emails.isNotEmpty) {
       packages.removeWhere((package) {
         final doc = _packages[package];
-        if (doc?.emails == null) {
+        if (doc?.uploaderEmails == null) {
           return true;
         }
         for (String email in query.parsedQuery.emails) {
           final isDomainMatch = email.startsWith('@') &&
-              doc.emails.where((e) => e.endsWith(email)).isNotEmpty;
-          if (isDomainMatch || doc.emails.contains(email)) {
+              doc.uploaderEmails.where((e) => e.endsWith(email)).isNotEmpty;
+          if (isDomainMatch || doc.uploaderEmails.contains(email)) {
             return false;
           }
         }

--- a/app/lib/search/search_service.dart
+++ b/app/lib/search/search_service.dart
@@ -62,10 +62,6 @@ class PackageDocument {
   /// The publisher id of the package
   final String publisherId;
 
-  /// The current uploaders of the package.
-  /// TODO: remove and use only [uploaderEmails]
-  final List<String> emails;
-
   /// The current uploader emails of the package.
   final List<String> uploaderEmails;
 
@@ -91,7 +87,6 @@ class PackageDocument {
     this.maintenance = 0,
     this.dependencies = const {},
     this.publisherId,
-    this.emails = const [],
     this.uploaderEmails = const [],
     this.apiDocPages = const [],
     DateTime timestamp,
@@ -124,7 +119,6 @@ class PackageDocument {
               value: (key) => internFn(dependencies[key]),
             ),
       publisherId: internFn(publisherId),
-      emails: emails?.map(internFn)?.toList(),
       uploaderEmails: uploaderEmails?.map(internFn)?.toList(),
       apiDocPages: apiDocPages?.map((p) => p.intern(internFn))?.toList(),
       timestamp: timestamp,

--- a/app/lib/search/search_service.g.dart
+++ b/app/lib/search/search_service.g.dart
@@ -30,7 +30,6 @@ PackageDocument _$PackageDocumentFromJson(Map<String, dynamic> json) {
       (k, e) => MapEntry(k, e as String),
     ),
     publisherId: json['publisherId'] as String,
-    emails: (json['emails'] as List)?.map((e) => e as String)?.toList(),
     uploaderEmails:
         (json['uploaderEmails'] as List)?.map((e) => e as String)?.toList(),
     apiDocPages: (json['apiDocPages'] as List)
@@ -61,7 +60,6 @@ Map<String, dynamic> _$PackageDocumentToJson(PackageDocument instance) =>
       'maintenance': instance.maintenance,
       'dependencies': instance.dependencies,
       'publisherId': instance.publisherId,
-      'emails': instance.emails,
       'uploaderEmails': instance.uploaderEmails,
       'apiDocPages': instance.apiDocPages,
       'timestamp': instance.timestamp?.toIso8601String(),

--- a/app/test/search/index_simple_test.dart
+++ b/app/test/search/index_simple_test.dart
@@ -145,7 +145,6 @@ void main() {
         health: 1.0,
         maintenance: 1.0,
         dependencies: {'async': 'direct', 'test': 'dev', 'foo': 'transitive'},
-        emails: ['user1@example.com'],
         uploaderEmails: ['user1@example.com'],
       ));
       await index.addPackage(PackageDocument(
@@ -168,7 +167,7 @@ The delegating wrapper classes allow users to easily add functionality on top of
         maintenance: 1.0,
         dependencies: {'test': 'dev'},
         publisherId: 'dart.dev',
-        emails: ['user1@example.com'],
+        uploaderEmails: ['user1@example.com'],
       ));
       await index.addPackage(PackageDocument(
         package: 'chrome_net',

--- a/app/test/search/result_combiner_test.dart
+++ b/app/test/search/result_combiner_test.dart
@@ -27,7 +27,7 @@ void main() {
         popularity: 0.4,
         health: 1.0,
         maintenance: 1.0,
-        emails: ['foo@example.com'],
+        uploaderEmails: ['foo@example.com'],
       ));
       await dartSdkIndex.addPackage(PackageDocument(
         package: 'dart:core',


### PR DESCRIPTION
`uploaderEmails` is populated since the previous release, so it is safe to just fall back using it.