### PR TITLE
Ensure atomicity around user Entity creation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ AppEngine version, listed here to ease deployment and troubleshooting.
  * Force account selection on login.
  * Bumped runtimeVersion to `2019.10.22`.
  * Upgraded dartdoc to `0.28.8` (upgraded analyzer).
+ * Fixed race condition in user creation flow.
 
 ## `20191015t141342-all`
  * Minor fixes to publisher texts.

--- a/app/lib/account/backend.dart
+++ b/app/lib/account/backend.dart
@@ -335,7 +335,7 @@ class AccountBackend {
           await tx.lookupOrNull<OAuthUserID>(oauthUserIdKey);
       if (oauthUserMapping != null) {
         // If the user does exist we can just return it.
-        return await _db.lookupValue<User>(
+        return await tx.lookupValue<User>(
           oauthUserMapping.userIdKey,
           orElse: () => throw StateError(
             'Incomplete OAuth userId mapping missing '
@@ -376,7 +376,6 @@ class AccountBackend {
           );
           return user;
         }
-        // We have a user with the same userId, this is not ideal.
         _logger.info(
           'Reusing email from User(${user.userId}) as user has a different oauth2 user_id',
         );

--- a/app/lib/account/backend.dart
+++ b/app/lib/account/backend.dart
@@ -321,7 +321,7 @@ class AccountBackend {
     // transaction.
     final user = await _lookupUserByOauthUserId(auth.oauthUserId);
     if (user != null) {
-      return null;
+      return user;
     }
 
     return withRetryTransaction<User>(_db, (tx) async {

--- a/app/lib/account/backend.dart
+++ b/app/lib/account/backend.dart
@@ -11,7 +11,6 @@ import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
 import 'package:neat_cache/neat_cache.dart';
 import 'package:pub_dartlang_org/package/models.dart';
-import 'package:retry/retry.dart';
 import 'package:uuid/uuid.dart';
 
 import '../shared/configuration.dart';

--- a/app/lib/shared/datastore_helper.dart
+++ b/app/lib/shared/datastore_helper.dart
@@ -1,0 +1,62 @@
+import 'package:gcloud/db.dart';
+import 'package:retry/retry.dart';
+
+class TransactionWrapper {
+  final Transaction _tx;
+  bool _mutated = false;
+
+  TransactionWrapper._(this._tx);
+
+  Future<List<T>> lookup<T extends Model>(List<Key> keys) =>
+      _tx.lookup<T>(keys);
+
+  Future<T> lookupOrNull<T extends Model>(Key key) =>
+      _tx.lookupValue<T>(key, orElse: () => null);
+
+  Future<T> lookupValue<T extends Model>(Key key, {T orElse()}) =>
+      _tx.lookupValue<T>(key, orElse: orElse);
+
+  Query<T> query<T extends Model>(Key ancestorKey, {Partition partition}) =>
+      _tx.query<T>(ancestorKey, partition: partition);
+
+  void insert(Model entity) => queueMutations(inserts: [entity]);
+
+  void delete(Key key) => queueMutations(deletes: [key]);
+
+  void queueMutations({List<Model> inserts, List<Key> deletes}) {
+    _mutated = true;
+    _tx.queueMutations(inserts: inserts, deletes: deletes);
+  }
+}
+
+/// Call [fn] with a [TransactionWrapper] that is either committed or
+/// rolled back when [fn] returns.
+Future<T> withTransaction<T>(
+  DatastoreDB db,
+  Future<T> Function(TransactionWrapper) fn,
+) async {
+  return db.withTransaction<T>((tx) async {
+    bool done = false;
+    try {
+      final wrapper = TransactionWrapper._(tx);
+      final retval = await fn(wrapper);
+      if (wrapper._mutated) {
+        await tx.commit();
+        done = true;
+      }
+      return retval;
+    } finally {
+      if (!done) {
+        await tx.rollback();
+      }
+    }
+  });
+}
+
+/// Call [fn] with a [TransactionWrapper] that is either committed or
+/// rolled back when [fn] returns, and retried if [fn] fails.
+Future<T> withRetryTransaction<T>(
+  DatastoreDB db,
+  Future<T> Function(TransactionWrapper) fn,
+) =>
+    retry<T>(() => withTransaction<T>(db, fn));

--- a/app/lib/shared/datastore_helper.dart
+++ b/app/lib/shared/datastore_helper.dart
@@ -1,28 +1,41 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'package:gcloud/db.dart';
 import 'package:retry/retry.dart';
 
+/// Wrap [Transaction] to avoid exposing [Transaction.commit] and
+/// [Transaction.rollback].
 class TransactionWrapper {
   final Transaction _tx;
   bool _mutated = false;
 
   TransactionWrapper._(this._tx);
 
+  /// See [Transaction.lookup].
   Future<List<T>> lookup<T extends Model>(List<Key> keys) =>
       _tx.lookup<T>(keys);
 
+  /// [lookupValue] or return `null`.
   Future<T> lookupOrNull<T extends Model>(Key key) =>
       _tx.lookupValue<T>(key, orElse: () => null);
 
+  /// See [Transaction.lookupValue].
   Future<T> lookupValue<T extends Model>(Key key, {T orElse()}) =>
       _tx.lookupValue<T>(key, orElse: orElse);
 
+  /// See [Transaction.query].
   Query<T> query<T extends Model>(Key ancestorKey, {Partition partition}) =>
       _tx.query<T>(ancestorKey, partition: partition);
 
+  /// Insert [entity] in this transaction.
   void insert(Model entity) => queueMutations(inserts: [entity]);
 
+  /// Delete entity at [key] in this transaction.
   void delete(Key key) => queueMutations(deletes: [key]);
 
+  /// See [Transaction.queueMutations].
   void queueMutations({List<Model> inserts, List<Key> deletes}) {
     _mutated = true;
     _tx.queueMutations(inserts: inserts, deletes: deletes);

--- a/app/lib/shared/datastore_helper.dart
+++ b/app/lib/shared/datastore_helper.dart
@@ -46,7 +46,7 @@ class TransactionWrapper {
 /// rolled back when [fn] returns.
 Future<T> withTransaction<T>(
   DatastoreDB db,
-  Future<T> Function(TransactionWrapper) fn,
+  Future<T> Function(TransactionWrapper tx) fn,
 ) async {
   return db.withTransaction<T>((tx) async {
     bool done = false;
@@ -70,6 +70,6 @@ Future<T> withTransaction<T>(
 /// rolled back when [fn] returns, and retried if [fn] fails.
 Future<T> withRetryTransaction<T>(
   DatastoreDB db,
-  Future<T> Function(TransactionWrapper) fn,
+  Future<T> Function(TransactionWrapper tx) fn,
 ) =>
     retry<T>(() => withTransaction<T>(db, fn));


### PR DESCRIPTION
From reading about datastore transactions I understand that a transaction
will see a consistent snapshot of the datastore.

Hence, if we try to read an entity and see that it doesn't exist before writing it,
then another transaction can't also do the same thing. As each transaction should see
serializable snapshots of the datastore. I think the problem before was that we
weren't reading the entity in the same transaction that we created it in.

We still have an issue with the email lookups, this only works if user entity was
created a while ago. Hence, we should work to remove all the cases where we create
a user entity from an email without an oauth user_id.

https://cloud.google.com/datastore/docs/concepts/transactions#isolation_and_consistency