### PR TITLE
Migrate uploader invites to Consent: sending the e-mail.

### DIFF
--- a/app/lib/frontend/handlers/routes.dart
+++ b/app/lib/frontend/handlers/routes.dart
@@ -217,6 +217,7 @@ class PubSiteService {
       authorizedHandler(request);
 
   /// Renders the page that initiates the confirmation and then finalizes the uploader.
+  /// TODO: remove after all new invites are on the consent URL
   @Route.get('/admin/confirm/new-uploader/<package>/<email>/<nonce>')
   Future<Response> confirmUploader(
           Request request, String package, String email, String nonce) =>

--- a/app/lib/publisher/backend.dart
+++ b/app/lib/publisher/backend.dart
@@ -441,12 +441,6 @@ class PublisherBackend {
     await purgePublisherCache(publisherId: publisherId);
   }
 
-  /// A callback from consent backend, when a consent is not granted, or expired.
-  /// Note: this will be retried when transaction fails due race conditions.
-  Future inviteDeleted(String publisherId, String userId) async {
-    // nothing to do
-  }
-
   Future<api.PublisherMember> _asPublisherMember(PublisherMember pm) async {
     return api.PublisherMember(
       userId: pm.userId,

--- a/app/lib/shared/email.dart
+++ b/app/lib/shared/email.dart
@@ -138,35 +138,6 @@ With appreciation, the Dart package site admin
   return EmailMessage(_defaultFrom, authorizedUploaders, subject, bodyText);
 }
 
-/// Creates the [EmailMessage] that will be sent to the new uploader for confirmation.
-EmailMessage createUploaderConfirmationEmail({
-  @required String packageName,
-  @required String activeAccountEmail,
-  @required String addedUploaderEmail,
-  @required String confirmationUrl,
-}) {
-  final pkgUrl = pkgPageUrl(packageName, includeHost: true);
-  final subject = 'Uploader invitation for package: $packageName';
-  final bodyText = '''Dear package maintainer,
-
-$activeAccountEmail has invited you to become an uploader of the $packageName package. If you accept this invitation, you’ll be able to upload new versions of the package to the Dart package site ($primaryHost), and you’ll be listed as an uploader at $pkgUrl
-
-To accept this invitation, visit the following URL:
-$confirmationUrl
-
-
-If you don’t want to be an uploader, simply ignore this email.
-
-If you have any concerns about this invitation, file an issue at https://github.com/dart-lang/pub-dev/issues
-
-Thanks for your contributions to the Dart community!
-
-With appreciation, the Dart package site admin
-''';
-  return EmailMessage(_defaultFrom, [EmailAddress(null, addedUploaderEmail)],
-      subject, bodyText);
-}
-
 /// Creates the [EmailMessage] that will be sent to users about new invitations
 /// they need to confirm.
 EmailMessage createInviteEmail({

--- a/app/lib/shared/urls.dart
+++ b/app/lib/shared/urls.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 
 import 'package:pub_dartlang_org/package/overrides.dart';
@@ -88,19 +87,6 @@ String searchUrl({String platform, String q, int page}) {
   return Uri(
     path: packagesPath,
     queryParameters: params.isEmpty ? null : params,
-  ).toString();
-}
-
-String pkgInviteUrl({
-  @required String type,
-  @required String package,
-  @required String email,
-  @required String urlNonce,
-}) {
-  return Uri(
-    scheme: 'https',
-    host: primaryHost,
-    path: p.join('/admin/confirm', type, package, email, urlNonce),
   ).toString();
 }
 

--- a/app/test/package/backend_test.dart
+++ b/app/test/package/backend_test.dart
@@ -228,8 +228,12 @@ void main() {
         expect(fakeEmailSender.sentMessages, hasLength(1));
         final email = fakeEmailSender.sentMessages.single;
         expect(email.recipients.single.email, 'somebody@example.com');
-        expect(email.subject, 'Uploader invitation for package: hydrogen');
-        expect(email.bodyText, contains('https://pub.dev/packages/hydrogen\n'));
+        expect(
+            email.subject, 'You have a new invitation to confirm on pub.dev');
+        expect(
+            email.bodyText,
+            contains(
+                'hans@juergen.com has invited you to be an uploader of the package\nhydrogen.\n'));
 
         // TODO: check consent (after migrating to consent API)
       });

--- a/app/test/shared/email_test.dart
+++ b/app/test/shared/email_test.dart
@@ -155,27 +155,4 @@ void main() {
           contains('https://pub.dev/packages/pkg_foo/versions/1.0.0'));
     });
   });
-
-  group('Uploaders', () {
-    test('uploader confirmation', () {
-      final message = createUploaderConfirmationEmail(
-        packageName: 'pkg_foo',
-        activeAccountEmail: 'active@example.com',
-        addedUploaderEmail: 'uploader@example.com',
-        confirmationUrl:
-            'https://pub.dev/confirmation/add-uploader/abcdef1234567890',
-      );
-      expect(message.from.toString(), contains('<pub@dartlang.org>'));
-      expect(message.recipients.map((e) => e.toString()).toList(),
-          ['uploader@example.com']);
-      expect(message.subject, contains('pkg_foo'));
-      expect(message.bodyText, contains('active@example.com'));
-      expect(message.bodyText, contains('pkg_foo'));
-      expect(message.bodyText, contains('https://pub.dev/packages/pkg_foo'));
-      expect(
-          message.bodyText,
-          contains(
-              'https://pub.dev/confirmation/add-uploader/abcdef1234567890'));
-    });
-  });
 }

--- a/app/test/shared/urls_test.dart
+++ b/app/test/shared/urls_test.dart
@@ -118,17 +118,4 @@ void main() {
       expect(inferIssueTrackerUrl('$repo/a/b/c'), tracker);
     });
   });
-
-  group('Invite urls', () {
-    test('new uploader invite', () {
-      expect(
-          pkgInviteUrl(
-            type: 'new-uploader',
-            package: 'pkg_foo',
-            email: 'uploader@example.com',
-            urlNonce: 'abcdefghijklmnop1234567890',
-          ),
-          'https://pub.dev/admin/confirm/new-uploader/pkg_foo/uploader@example.com/abcdefghijklmnop1234567890');
-    });
-  });
 }


### PR DESCRIPTION
- #2945
- I think it would be not too hard to modify `Consent` to use non-parented `Key`, so that we can delay `User` creation.