### PR TITLE
Fix fuzzy search for 1-edit differences.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ AppEngine version, listed here to ease deployment and troubleshooting.
 ## Next Release (replace with git tag when deployed)
  * Refactored `Consent`:
    * new entities contain `userId` (if it is known upfront)  
+ * Search updates:
+   * #2968 may increase CPU latencies while serving a query
 
 ## `20191028t120414-all`
  * Run `app/bin/tools/backfill_packagelikes.dart` to backfill `Package`

--- a/app/lib/search/index_simple.dart
+++ b/app/lib/search/index_simple.dart
@@ -714,6 +714,9 @@ class TokenIndex {
     for (String token in tokens.keys) {
       final candidates = Set<String>();
       candidates.add(token);
+      if (_lookupCandidates.containsKey(token)) {
+        candidates.addAll(_lookupCandidates[token]);
+      }
       for (String reduced in deriveLookupCandidates(token)) {
         final set = _lookupCandidates[reduced];
         if (set != null) {
@@ -728,6 +731,8 @@ class TokenIndex {
           candidateWeight = 1.0;
         } else if (token.startsWith(candidate) || token.endsWith(candidate)) {
           candidateWeight = candidate.length / token.length;
+        } else if (candidate.startsWith(token) || candidate.endsWith(token)) {
+          candidateWeight = token.length / candidate.length;
         } else {
           final candidateNgrams = ngrams(candidate, _minLength, 6);
           tokenWeightSum ??= tokenNgrams.fold<double>(0.0, _ngramWeightSum);

--- a/app/test/search/api_doc_page_test.dart
+++ b/app/test/search/api_doc_page_test.dart
@@ -116,7 +116,7 @@ void main() {
           SearchQuery.parse(query: 'web page', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
-        'totalCount': 1,
+        'totalCount': 2,
         'packages': [
           {
             'package': 'foo',
@@ -125,7 +125,13 @@ void main() {
               {'title': null, 'path': 'generator.html'},
             ],
           },
-          // serveWebPages get low score
+          {
+            'package': 'other_with_api',
+            'score': closeTo(0.045, 0.001), // find serveWebPages (low score)
+            'apiPages': [
+              {'title': null, 'path': 'serve.html'},
+            ],
+          },
           // should not contain `other_without_api`
         ],
       });

--- a/app/test/search/index_simple_test.dart
+++ b/app/test/search/index_simple_test.dart
@@ -98,8 +98,16 @@ void main() {
       // location should be the top value, everything else should be lower
       expect(match.tokenWeights, {
         'location': 1.0,
-        'geolocation': closeTo(0.588, 0.001),
+        'geolocation': closeTo(0.727, 0.001),
       });
+    });
+
+    test('short words: lookup for app', () {
+      final index = TokenIndex(minLength: 2);
+      index.add('app', 'app');
+      index.add('apps', 'apps');
+      final match = index.lookupTokens('app');
+      expect(match.tokenWeights, {'app': 1.0, 'apps': 0.75});
     });
   });
 


### PR DESCRIPTION
Previously `12345` had a lookup candidate of `1234` (among others), and we have found `12345` when searching for `1234x`. However, when searching for `1234` we only considered lookup candidates like `123` and not `1234` itself.

With this fix `app` lookup will yield both `app` and `apps`, while only slightly increases query time, it does not change the memory requirement. Fixes #2813.
