### PR TITLE
Extended Consent entity and its handling.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Important changes to data-models, configuration and migrations between each
 AppEngine version, listed here to ease deployment and troubleshooting.
 
 ## Next Release (replace with git tag when deployed)
+ * Refactored `Consent`:
+   * new entities contain `userId` (if it is known upfront)  
 
 ## `20191028t120414-all`
  * Run `app/bin/tools/backfill_packagelikes.dart` to backfill `Package`

--- a/app/lib/account/models.dart
+++ b/app/lib/account/models.dart
@@ -179,7 +179,15 @@ class Consent extends db.Model {
   String get consentId => id as String;
 
   /// The user that this consent is for.
-  String get userId => parentKey.id as String;
+  String get userId => userIdField ?? parentKey.id as String;
+
+  /// The user that this consent is for.
+  /// TODO: rename to userId once we migrated off of User-derived consents.
+  @db.StringProperty(propertyName: 'userId')
+  String userIdField;
+
+  @db.StringProperty()
+  String email;
 
   /// A [Uri.path]-like concatenation of identifiers from [kind] and [args].
   /// It should be used to query the Datastore for duplicate detection.
@@ -218,6 +226,7 @@ class Consent extends db.Model {
   }) {
     this.parentKey = parentKey;
     this.id = Ulid().toString();
+    userIdField = parentKey.id as String;
     dedupId = consentDedupId(kind, args);
     created = DateTime.now().toUtc();
     notificationCount = 0;
@@ -241,6 +250,8 @@ class Consent extends db.Model {
     return Consent()
       ..parentKey = parentKey.parent.append(User, id: userId)
       ..id = id
+      ..userIdField = userId
+      ..email = email
       ..dedupId = dedupId
       ..kind = kind
       ..args = args

--- a/app/lib/frontend/handlers/account.dart
+++ b/app/lib/frontend/handlers/account.dart
@@ -92,8 +92,8 @@ Future<shelf.Response> consentPageHandler(
     throw NotFoundException('Missing consent id.');
   }
 
-  final consent =
-      await consentBackend.getConsent(userSessionData.userId, consentId);
+  final user = await accountBackend.lookupUserById(userSessionData.userId);
+  final consent = await consentBackend.getConsent(consentId, user);
   // If consent does not exists (or does not belong to the user), the `getConsent`
   // call above will throw, and the generic error page will be shown.
   // TODO: handle missing/expired consent gracefully


### PR DESCRIPTION
#2971

This PR does not change the parent of the `Consent` yet, but it adds `userId` and `email` to it, and we can check against them when we load the consent via id. The change in parent would be in a follow-up PR.