### PR TITLE
Rename: package/SearchService -> SearchAdapter

### DIFF
--- a/app/lib/frontend/handlers/account.dart
+++ b/app/lib/frontend/handlers/account.dart
@@ -9,7 +9,7 @@ import '../../account/backend.dart';
 import '../../account/consent_backend.dart';
 import '../../account/session_cookie.dart' as session_cookie;
 import '../../package/backend.dart';
-import '../../package/search_service.dart';
+import '../../package/search_adapter.dart';
 import '../../publisher/backend.dart';
 import '../../publisher/models.dart';
 import '../../search/search_service.dart';
@@ -192,7 +192,7 @@ Future<shelf.Response> accountPackagesPageHandler(shelf.Request request) async {
     ],
   );
 
-  final searchResult = await searchService.search(searchQuery);
+  final searchResult = await searchAdapter.search(searchQuery);
   final int totalCount = searchResult.totalCount;
   final links =
       PageLinks(searchQuery.offset, totalCount, searchQuery: searchQuery);

--- a/app/lib/frontend/handlers/landing.dart
+++ b/app/lib/frontend/handlers/landing.dart
@@ -6,7 +6,7 @@ import 'dart:async';
 
 import 'package:shelf/shelf.dart' as shelf;
 
-import '../../package/search_service.dart';
+import '../../package/search_adapter.dart';
 import '../../shared/handlers.dart';
 import '../../shared/platform.dart';
 import '../../shared/redis_cache.dart' show cache;

--- a/app/lib/frontend/handlers/listing.dart
+++ b/app/lib/frontend/handlers/listing.dart
@@ -9,7 +9,7 @@ import 'package:shelf/shelf.dart' as shelf;
 import '../../package/backend.dart';
 import '../../package/models.dart';
 import '../../package/overrides.dart';
-import '../../package/search_service.dart';
+import '../../package/search_adapter.dart';
 import '../../search/search_service.dart';
 import '../../shared/handlers.dart';
 import '../../shared/platform.dart';
@@ -50,7 +50,7 @@ Future<shelf.Response> _packagesHandlerHtmlCore(
     platform: platform,
   );
   final sw = Stopwatch()..start();
-  final searchResult = await searchService.search(searchQuery);
+  final searchResult = await searchAdapter.search(searchQuery);
   final int totalCount = searchResult.totalCount;
 
   final links =

--- a/app/lib/frontend/handlers/misc.dart
+++ b/app/lib/frontend/handlers/misc.dart
@@ -13,7 +13,7 @@ import 'package:shelf/shelf.dart' as shelf;
 import '../../package/backend.dart';
 import '../../package/name_tracker.dart';
 import '../../package/overrides.dart';
-import '../../package/search_service.dart';
+import '../../package/search_adapter.dart';
 import '../../publisher/backend.dart';
 import '../../shared/handlers.dart';
 import '../../shared/urls.dart' as urls;

--- a/app/lib/frontend/handlers/publisher.dart
+++ b/app/lib/frontend/handlers/publisher.dart
@@ -7,7 +7,7 @@ import 'dart:async';
 import 'package:shelf/shelf.dart' as shelf;
 
 import '../../account/backend.dart';
-import '../../package/search_service.dart';
+import '../../package/search_adapter.dart';
 import '../../publisher/backend.dart';
 import '../../search/search_service.dart';
 import '../../shared/handlers.dart';
@@ -77,7 +77,7 @@ Future<shelf.Response> publisherPackagesPageHandler(
     return formattedNotFoundHandler(request);
   }
 
-  final searchResult = await searchService.search(searchQuery);
+  final searchResult = await searchAdapter.search(searchQuery);
   final int totalCount = searchResult.totalCount;
   final links =
       PageLinks(searchQuery.offset, totalCount, searchQuery: searchQuery);

--- a/app/lib/package/search_adapter.dart
+++ b/app/lib/package/search_adapter.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library pub_dartlang_org.search_service;
-
 import 'dart:async';
 
 import 'package:gcloud/service_scope.dart' as ss;
@@ -19,16 +17,18 @@ import 'backend.dart';
 import 'models.dart';
 import 'name_tracker.dart';
 
-final _logger = Logger('frontend.search_service');
+final _logger = Logger('frontend.search_adapter');
 
-/// The [SearchService] registered in the current service scope.
-SearchService get searchService => ss.lookup(#_search) as SearchService;
+/// The `SearchAdapter` registered in the current service scope.
+SearchAdapter get searchAdapter => ss.lookup(#_search) as SearchAdapter;
 
-/// Register a new [SearchService] in the current service scope.
-void registerSearchService(SearchService s) => ss.register(#_search, s);
+/// Register a new [SearchAdapter] in the current service scope.
+void registerSearchAdapter(SearchAdapter s) => ss.register(#_search, s);
 
-/// A wrapper around the Custom Search API, used for searching for pub packages.
-class SearchService {
+/// Uses the HTTP-based `search` service client to execute a search query and
+/// processes its results, extending the search results with up-to-date package
+/// data.
+class SearchAdapter {
   /// Performs search using the `search` service and lookup package info and
   /// score from DatastoreDB.
   ///
@@ -203,7 +203,7 @@ Future<List<PackageView>> topFeaturedPackages(
     {String platform, int count = 15}) async {
   // TODO: store top packages in memcache
   try {
-    final result = await searchService.search(
+    final result = await searchAdapter.search(
       SearchQuery.parse(
         platform: platform,
         limit: count,

--- a/app/lib/package/search_adapter.dart
+++ b/app/lib/package/search_adapter.dart
@@ -72,8 +72,6 @@ class SearchAdapter {
     return PackageSearchResult(packages: scores, totalCount: totalCount);
   }
 
-  Future close() async {}
-
   /// Returns the [PackageView] instance for [package] on its latest stable version.
   ///
   /// Returns null if the package does not exists.

--- a/app/lib/service/services.dart
+++ b/app/lib/service/services.dart
@@ -99,7 +99,6 @@ Future<void> withPubServices(FutureOr<void> Function() fn) async {
     registerScopeExitCallback(accountBackend.close);
     registerScopeExitCallback(dartdocClient.close);
     registerScopeExitCallback(searchClient.close);
-    registerScopeExitCallback(searchAdapter.close);
 
     return await withCache(fn);
   });

--- a/app/lib/service/services.dart
+++ b/app/lib/service/services.dart
@@ -16,7 +16,7 @@ import '../history/backend.dart';
 import '../job/backend.dart';
 import '../package/backend.dart';
 import '../package/name_tracker.dart';
-import '../package/search_service.dart';
+import '../package/search_adapter.dart';
 import '../publisher/backend.dart';
 import '../publisher/domain_verifier.dart';
 import '../scorecard/backend.dart';
@@ -80,7 +80,7 @@ Future<void> withPubServices(FutureOr<void> Function() fn) async {
     registerScoreCardBackend(ScoreCardBackend(dbService));
     registerSearchBackend(SearchBackend(dbService));
     registerSearchClient(SearchClient());
-    registerSearchService(SearchService());
+    registerSearchAdapter(SearchAdapter());
     registerSecretBackend(SecretBackend(dbService));
     registerSnapshotStorage(SnapshotStorage(await getOrCreateBucket(
         storageService, activeConfiguration.searchSnapshotBucketName)));
@@ -99,7 +99,7 @@ Future<void> withPubServices(FutureOr<void> Function() fn) async {
     registerScopeExitCallback(accountBackend.close);
     registerScopeExitCallback(dartdocClient.close);
     registerScopeExitCallback(searchClient.close);
-    registerScopeExitCallback(searchService.close);
+    registerScopeExitCallback(searchAdapter.close);
 
     return await withCache(fn);
   });


### PR DESCRIPTION
We have two classes called `SearchService`, this one was one the first historically, but its role clearly changed over time.