### PR TITLE
Headless Consent entities.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,13 @@ Important changes to data-models, configuration and migrations between each
 AppEngine version, listed here to ease deployment and troubleshooting.
 
 ## Next Release (replace with git tag when deployed)
+ * Refactored `Consent`:
+   * new entities do not have the user in their key
+   * WARNING: user merge on pending old consent entities does not work
 
 ## `20191104t103859-all`
  * Refactored `Consent`:
    * new entities contain `userId` (if it is known upfront)  
-   * new entities do not have the user in their key
-   * WARNING: user merge with pending old consent does not work
  * Search updates:
    * #2968 may increase CPU latencies while serving a query
  * Bumped runtimeVersion to `2019.11.01`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ AppEngine version, listed here to ease deployment and troubleshooting.
 ## `20191104t103859-all`
  * Refactored `Consent`:
    * new entities contain `userId` (if it is known upfront)  
+   * new entities do not have the user in their key
+   * WARNING: user merge with pending old consent does not work
  * Search updates:
    * #2968 may increase CPU latencies while serving a query
  * Bumped runtimeVersion to `2019.11.01`.

--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -751,9 +751,8 @@ class GCloudPackageRepository extends PackageRepository {
       throw GenericProcessingException('Not a valid email: `$uploaderEmail`.');
     }
 
-    final uploader =
-        await accountBackend.lookupOrCreateUserByEmail(uploaderEmail);
-    if (package.containsUploader(uploader.userId)) {
+    final uploader = await accountBackend.lookupUserByEmail(uploaderEmail);
+    if (uploader != null && package.containsUploader(uploader.userId)) {
       // The requested uploaderEmail is already part of the uploaders.
       return;
     }
@@ -766,7 +765,8 @@ class GCloudPackageRepository extends PackageRepository {
     ));
 
     final status = await consentBackend.invite(
-      userId: uploader.userId,
+      userId: uploader?.userId,
+      email: uploaderEmail,
       kind: 'PackageUploader',
       args: [packageName],
     );

--- a/app/test/shared/user_merger_test.dart
+++ b/app/test/shared/user_merger_test.dart
@@ -96,19 +96,22 @@ void main() {
     expect(list[1].userId, adminUser.userId);
   });
 
-  testWithServices('consent', () async {
+  testWithServices('new consent', () async {
     final target1 = Consent.init(
-        parentKey: hansUser.key,
+        userId: hansUser.userId,
+        email: null,
         kind: 'k1',
         args: ['1'],
         fromUserId: adminUser.userId);
     final target2 = Consent.init(
-        parentKey: adminUser.key,
+        userId: adminUser.userId,
+        email: null,
         kind: 'k2',
         args: ['2'],
         fromUserId: hansUser.userId);
     final control = Consent.init(
-        parentKey: adminUser.key,
+        userId: adminUser.userId,
+        email: null,
         kind: 'k3',
         args: ['3'],
         fromUserId: adminUser.userId);
@@ -121,11 +124,11 @@ void main() {
     final updated2 = list.firstWhere((c) => c.id == target2.id);
     final updated3 = list.firstWhere((c) => c.id == control.id);
 
-    expect(updated1.parentKey.id, joeUser.userId);
+    expect(updated1.userId, joeUser.userId);
     expect(updated1.fromUserId, adminUser.userId);
-    expect(updated2.parentKey.id, adminUser.userId);
+    expect(updated2.userId, adminUser.userId);
     expect(updated2.fromUserId, joeUser.userId);
-    expect(updated3.parentKey.id, adminUser.userId);
+    expect(updated3.userId, adminUser.userId);
     expect(updated3.fromUserId, adminUser.userId);
   });
 


### PR DESCRIPTION
- #2971
- dedup id includes further attributes (if they are present)
- `User` entities are now created only at the time of accepting the consent, and not upfront
- ignoring the case of user merges with old pending Consent requests (throws an exception during merge)
