### PR TITLE
Small cleanup in search URL construction.

### DIFF
--- a/app/lib/search/search_service.dart
+++ b/app/lib/search/search_service.dart
@@ -373,7 +373,6 @@ class SearchQuery {
     return hasText || hasNonTextOrdering;
   }
 
-  // TODO: move this to shared/urls.dart after simplifying platformPredicate
   /// Converts the query to a user-facing link that the search form can use as
   /// the base path of its `action` parameter.
   String toSearchFormPath() {
@@ -390,7 +389,6 @@ class SearchQuery {
     return path;
   }
 
-  // TODO: move this to shared/urls.dart after simplifying platformPredicate
   /// Converts the query to a user-facing link that (after frontend parsing) will
   /// re-create an identical search query object.
   String toSearchLink({int page}) {

--- a/app/lib/shared/urls.dart
+++ b/app/lib/shared/urls.dart
@@ -4,7 +4,8 @@
 
 import 'package:path/path.dart' as p;
 
-import 'package:pub_dartlang_org/package/overrides.dart';
+import '../package/overrides.dart';
+import '../search/search_service.dart' show SearchQuery;
 import 'versions.dart';
 
 const primaryHost = 'pub.dev';
@@ -71,24 +72,12 @@ String analysisTabUrl(String package) {
 
 String publisherUrl(String publisherId) => '/publishers/$publisherId';
 String publisherPackagesUrl(String publisherId) =>
-    '/publishers/$publisherId/packages';
+    SearchQuery.parse(publisherId: publisherId).toSearchLink();
 String publisherAdminUrl(String publisherId) =>
     '/publishers/$publisherId/admin';
 
-String searchUrl({String platform, String q, int page}) {
-  final packagesPath = platform == null ? '/packages' : '/$platform/packages';
-  final params = <String, String>{};
-  if (q != null && q.isNotEmpty) {
-    params['q'] = q;
-  }
-  if (page != null && page > 1) {
-    params['page'] = page.toString();
-  }
-  return Uri(
-    path: packagesPath,
-    queryParameters: params.isEmpty ? null : params,
-  ).toString();
-}
+String searchUrl({String platform, String q, int page}) =>
+    SearchQuery.parse(platform: platform, query: q).toSearchLink(page: page);
 
 String dartSdkMainUrl(String version) {
   final isDev = version.contains('dev');


### PR DESCRIPTION
I did consider moving these methods to `shared/urls.dart` but given we have an ever-increasing complexity in the URL, it seems rather better to leave it with the `SearchQuery`.