### PR TITLE
Deep repository URLs.

### DIFF
--- a/app/lib/shared/urls.dart
+++ b/app/lib/shared/urls.dart
@@ -102,12 +102,17 @@ String inferRepositoryUrl(String baseUrl) {
     return null;
   }
   if (uri.host == 'github.com' || uri.host == 'gitlab.com') {
-    final segments = uri.pathSegments.take(2).toList();
-    if (segments.length != 2) {
+    if (uri.pathSegments.length < 2) {
       return null;
     }
-    return Uri(scheme: uri.scheme, host: uri.host, pathSegments: segments)
-        .toString();
+    if (uri.pathSegments.length >= 4 &&
+        uri.pathSegments[2] == 'tree' &&
+        uri.pathSegments[3] == 'master') {
+      return uri.toString();
+    } else {
+      final segments = uri.pathSegments.take(2).toList();
+      return uri.replace(pathSegments: segments).toString();
+    }
   }
   return null;
 }

--- a/app/test/shared/urls_test.dart
+++ b/app/test/shared/urls_test.dart
@@ -74,6 +74,9 @@ void main() {
       expect(inferRepositoryUrl('$repo/'), repo);
       expect(inferRepositoryUrl('$repo/a'), repo);
       expect(inferRepositoryUrl('$repo/a/b/c'), repo);
+      expect(inferRepositoryUrl('$repo/tree/master'), '$repo/tree/master');
+      expect(
+          inferRepositoryUrl('$repo/tree/master/dir'), '$repo/tree/master/dir');
     });
 
     test('gitlab', () {
@@ -82,6 +85,9 @@ void main() {
       expect(inferRepositoryUrl('$repo/'), repo);
       expect(inferRepositoryUrl('$repo/a'), repo);
       expect(inferRepositoryUrl('$repo/a/b/c'), repo);
+      expect(inferRepositoryUrl('$repo/tree/master'), '$repo/tree/master');
+      expect(
+          inferRepositoryUrl('$repo/tree/master/dir'), '$repo/tree/master/dir');
     });
   });
 


### PR DESCRIPTION
- When inferring the repository URLs, we stopped at `/user/repo` level, however in many cases, especially in Flutter plugins, we have deep URLs set as `homepage`. We should keep these deep URLs and not shorten them. (Maybe we should always-keep for GitHub and GitLab URLs, not yet sure).
- Also fixes #2957.
