### PR TITLE
PackageLinks.baseUrl

### DIFF
--- a/app/lib/frontend/templates/package.dart
+++ b/app/lib/frontend/templates/package.dart
@@ -125,7 +125,6 @@ String renderPkgInfoBox(
   AnalysisView analysis,
 ) {
   final packageLinks = selectedVersion.packageLinks;
-  final baseUrl = packageLinks.repositoryUrl ?? packageLinks.homepageUrl;
 
   String documentationUrl = packageLinks.documentationUrl;
   if (urls.hideUserProvidedDocUrl(documentationUrl)) {
@@ -175,7 +174,7 @@ String renderPkgInfoBox(
     'uploaders_title': uploaderEmails.length > 1 ? 'Uploaders' : 'Uploader',
     'uploaders_html':
         uploaderEmails.isEmpty ? null : _getAuthorsHtml(uploaderEmails),
-    'license_html': _renderLicenses(baseUrl, analysis?.licenses),
+    'license_html': _renderLicenses(packageLinks.baseUrl, analysis?.licenses),
     'dependencies_html': _renderDependencyList(analysis),
     'search_deps_link': urls.searchUrl(q: 'dependency:${package.name}'),
   });
@@ -295,7 +294,7 @@ List<Tab> _pkgTabs(
 
   String renderedReadme;
   final packageLinks = selectedVersion.packageLinks;
-  final baseUrl = packageLinks.repositoryUrl ?? packageLinks.homepageUrl;
+  final baseUrl = packageLinks.baseUrl;
   if (selectedVersion.readme != null) {
     renderedReadme = renderFile(selectedVersion.readme, baseUrl);
   }

--- a/app/lib/package/models.dart
+++ b/app/lib/package/models.dart
@@ -487,16 +487,29 @@ void sortPackageVersionsDesc(List<PackageVersion> versions,
 
 /// The URLs provided by the package's pubspec or inferred from the homepage.
 class PackageLinks {
+  /// `homepage` property in `pubspec.yaml`
   final String homepageUrl;
+
+  /// `documentation` property in `pubspec.yaml`
   final String documentationUrl;
+
+  /// `repository` property in `pubspec.yaml`, or if not specified, an inferred
+  /// URL from [homepageUrl].
   final String repositoryUrl;
+
+  /// `issue_tracker` property in `pubspec.yaml`, or if not specified, an
+  /// inferred URL from [repositoryUrl].
   final String issueTrackerUrl;
 
-  PackageLinks({
+  /// The inferred base URL that can be used to link files from.
+  final String baseUrl;
+
+  PackageLinks._({
     this.homepageUrl,
     this.documentationUrl,
     this.repositoryUrl,
     this.issueTrackerUrl,
+    this.baseUrl,
   });
 
   factory PackageLinks.infer({
@@ -507,11 +520,16 @@ class PackageLinks {
   }) {
     repositoryUrl ??= urls.inferRepositoryUrl(homepageUrl);
     issueTrackerUrl ??= urls.inferIssueTrackerUrl(repositoryUrl);
-    return PackageLinks(
+    final baseUrl = urls.inferBaseUrl(
+      homepageUrl: homepageUrl,
+      repositoryUrl: repositoryUrl,
+    );
+    return PackageLinks._(
       homepageUrl: homepageUrl,
       documentationUrl: documentationUrl,
       repositoryUrl: repositoryUrl,
       issueTrackerUrl: issueTrackerUrl,
+      baseUrl: baseUrl,
     );
   }
 }

--- a/app/lib/shared/urls.dart
+++ b/app/lib/shared/urls.dart
@@ -143,6 +143,19 @@ String inferIssueTrackerUrl(String baseUrl) {
   return null;
 }
 
+/// Infer base URL that can be used to link files from.
+String inferBaseUrl({String homepageUrl, String repositoryUrl}) {
+  String baseUrl = repositoryUrl ?? homepageUrl;
+  // In a few cases people specify only a deep repository URL for their
+  // package (e.g. a monorepo for multiple packages). While we default the
+  // base URL to be the repository URL, this check allows us to use the deep
+  // URL for linking.
+  if (homepageUrl != null && homepageUrl.startsWith(baseUrl)) {
+    baseUrl = homepageUrl;
+  }
+  return baseUrl;
+}
+
 /// Infer the hosting/service provider for a given URL.
 String inferServiceProviderName(String url) {
   if (url == null) {

--- a/app/lib/shared/urls.dart
+++ b/app/lib/shared/urls.dart
@@ -146,6 +146,8 @@ String inferIssueTrackerUrl(String baseUrl) {
 /// Infer base URL that can be used to link files from.
 String inferBaseUrl({String homepageUrl, String repositoryUrl}) {
   String baseUrl = repositoryUrl ?? homepageUrl;
+  if (baseUrl == null) return null;
+
   // In a few cases people specify only a deep repository URL for their
   // package (e.g. a monorepo for multiple packages). While we default the
   // base URL to be the repository URL, this check allows us to use the deep
@@ -153,6 +155,27 @@ String inferBaseUrl({String homepageUrl, String repositoryUrl}) {
   if (homepageUrl != null && homepageUrl.startsWith(baseUrl)) {
     baseUrl = homepageUrl;
   }
+
+  // URL cleanup
+  final prefixReplacements = const <String, String>{
+    'http://github.com/': 'https://github.com/',
+    'http://www.github.com/': 'https://github.com/',
+    'https://www.github.com/': 'https://github.com/',
+    'http://gitlab.com/': 'https://gitlab.com/',
+    'http://www.gitlab.com/': 'https://gitlab.com/',
+    'https://www.gitlab.com/': 'https://gitlab.com/',
+  };
+  for (final prefix in prefixReplacements.keys) {
+    if (baseUrl.startsWith(prefix)) {
+      baseUrl = baseUrl.replaceFirst(prefix, prefixReplacements[prefix]);
+    }
+  }
+  if ((baseUrl.startsWith('https://github.com/') ||
+          baseUrl.startsWith('https://gitlab.com/')) &&
+      baseUrl.endsWith('.git')) {
+    baseUrl = baseUrl.substring(0, baseUrl.length - 4);
+  }
+
   return baseUrl;
 }
 

--- a/app/test/shared/urls_test.dart
+++ b/app/test/shared/urls_test.dart
@@ -118,4 +118,46 @@ void main() {
       expect(inferIssueTrackerUrl('$repo/a/b/c'), tracker);
     });
   });
+
+  group('Infer base URL', () {
+    final repo = 'https://gitlab.com/user/repo';
+
+    test('only homepage is set', () {
+      expect(inferBaseUrl(homepageUrl: repo), repo);
+      expect(
+        inferBaseUrl(homepageUrl: '$repo/tree/master/dir'),
+        '$repo/tree/master/dir',
+      );
+    });
+
+    test('only repository is set', () {
+      expect(inferBaseUrl(repositoryUrl: repo), repo);
+      expect(
+        inferBaseUrl(repositoryUrl: '$repo/tree/master/dir'),
+        '$repo/tree/master/dir',
+      );
+    });
+
+    test('deep homepage, inferred repository', () {
+      final homepage = '$repo/tree/master/dir';
+      expect(
+        inferBaseUrl(
+          homepageUrl: homepage,
+          repositoryUrl: inferRepositoryUrl(homepage),
+        ),
+        '$repo/tree/master/dir',
+      );
+    });
+
+    test('unrelated homepage, simple repository', () {
+      final homepage = 'https://example.com/';
+      expect(
+        inferBaseUrl(
+          homepageUrl: homepage,
+          repositoryUrl: repo,
+        ),
+        repo,
+      );
+    });
+  });
 }

--- a/app/test/shared/urls_test.dart
+++ b/app/test/shared/urls_test.dart
@@ -159,5 +159,23 @@ void main() {
         repo,
       );
     });
+
+    test('URL cleanup', () {
+      expect(
+          inferBaseUrl(
+            homepageUrl: 'http://gitlab.com/user/repo.git',
+          ),
+          repo);
+      expect(
+          inferBaseUrl(
+            homepageUrl: 'http://www.gitlab.com/user/repo.git',
+          ),
+          repo);
+      expect(
+          inferBaseUrl(
+            homepageUrl: 'https://www.gitlab.com/user/repo.git',
+          ),
+          repo);
+    });
   });
 }


### PR DESCRIPTION
- Fixes #2957 (and other places where we are using the wrong URL for deep repositories)
- Fixes #3003
- keeps the `repositoryUrl` separate, so that we treat it as the url of the git repo