### PR TITLE
Granular admin API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ AppEngine version, listed here to ease deployment and troubleshooting.
    * new entities do not have the user in their key
    * WARNING: user merge on pending old consent entities does not work
  * Removed support for old uploader invites.
+ * Added `backfill_packageisflutterfavorite.dart` to be executed before and
+   after next deployment, in order to backfill the `Package.isFlutterFavorite`
+   property.
 
 ## `20191104t103859-all`
  * Refactored `Consent`:

--- a/app/bin/tools/backfill_packageisflutterfavorite.dart
+++ b/app/bin/tools/backfill_packageisflutterfavorite.dart
@@ -1,0 +1,63 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:appengine/appengine.dart';
+import 'package:args/args.dart';
+import 'package:gcloud/db.dart';
+import 'package:pool/pool.dart';
+import 'package:pub_dartlang_org/package/models.dart';
+import 'package:pub_dartlang_org/service/entrypoint/tools.dart';
+import 'package:pub_dartlang_org/shared/datastore_helper.dart';
+
+final _argParser = ArgParser()
+  ..addOption('concurrency',
+      abbr: 'c', defaultsTo: '10', help: 'Number of concurrent processing.')
+  ..addFlag('help', abbr: 'h', defaultsTo: false, help: 'Show help.');
+
+Future main(List<String> args) async {
+  final argv = _argParser.parse(args);
+  if (argv['help'] as bool == true) {
+    print('Usage: dart backfill_packageisflutterfavorite.dart');
+    print('Ensures Package.isFlutterFavorite is set to a boolean.');
+    print(_argParser.usage);
+    return;
+  }
+
+  final concurrency = int.parse(argv['concurrency'] as String);
+
+  await withProdServices(() async {
+    final pool = Pool(concurrency);
+    final futures = <Future>[];
+
+    useLoggingPackageAdaptor();
+    await for (Package p in dbService.query<Package>().run()) {
+      final f = pool.withResource(() => _backfillPackageIsFlutterFavorite(p));
+      futures.add(f);
+    }
+
+    await Future.wait(futures);
+    await pool.close();
+  });
+}
+
+Future<void> _backfillPackageIsFlutterFavorite(Package p) async {
+  if (p.isFlutterFavorite != null) return;
+  print('Backfilling isFlutterFavorite property on package ${p.name}');
+  try {
+    await withTransaction(dbService, (tx) async {
+      final package = await tx.lookupValue<Package>(p.key, orElse: () => null);
+      if (package == null) {
+        return;
+      }
+      if (package.isFlutterFavorite != null) {
+        return;
+      }
+      package.isFlutterFavorite = false;
+      tx.insert(package);
+      print('Updated isFlutterFavorite property on package ${package.name}.');
+    });
+  } catch (e) {
+    print('Failed to update isFlutterFavorite on package ${p.name}, error $e');
+  }
+}

--- a/app/lib/frontend/handlers/pubapi.client.dart
+++ b/app/lib/frontend/handlers/pubapi.client.dart
@@ -339,4 +339,21 @@ class PubApiClient {
       path: '/api/admin/users/$userId',
     );
   }
+
+  Future<_i6.FlutterFavoriteStatus> adminGetFlutterFavorite(
+      String package) async {
+    return _i6.FlutterFavoriteStatus.fromJson(await _client.requestJson(
+      verb: 'get',
+      path: '/api/admin/packages/$package/flutter-favorite',
+    ));
+  }
+
+  Future<_i6.FlutterFavoriteStatus> adminPutFlutterFavorite(
+      String package, _i6.FlutterFavoriteStatus payload) async {
+    return _i6.FlutterFavoriteStatus.fromJson(await _client.requestJson(
+      verb: 'put',
+      path: '/api/admin/packages/$package/flutter-favorite',
+      body: payload.toJson(),
+    ));
+  }
 }

--- a/app/lib/frontend/handlers/pubapi.dart
+++ b/app/lib/frontend/handlers/pubapi.dart
@@ -336,6 +336,19 @@ class PubApi {
     await adminBackend.removeUser(userId);
     return jsonResponse({'status': 'OK'});
   }
+
+  @EndPoint.get('/api/admin/packages/<package>/flutter-favorite')
+  Future<FlutterFavoriteStatus> adminGetFlutterFavorite(
+    Request request,
+    String package,
+  ) => adminBackend.handleGetFlutterFavorite(package);
+
+  @EndPoint.put('/api/admin/packages/<package>/flutter-favorite')
+  Future<FlutterFavoriteStatus> adminPutFlutterFavorite(
+    Request request,
+    String package,
+    FlutterFavoriteStatus body,
+  ) => adminBackend.handlePutFlutterFavorite(package, body);
 }
 
 /// Replaces the requested uri with the primary API uri.

--- a/app/lib/frontend/handlers/pubapi.g.dart
+++ b/app/lib/frontend/handlers/pubapi.g.dart
@@ -601,5 +601,35 @@ Router _$PubApiRouter(PubApi service) {
       return $utilities.unhandledError(e, st);
     }
   });
+  router.add('GET', r'/api/admin/packages/<package>/flutter-favorite',
+      (Request request, String package) async {
+    try {
+      final _$result = await service.adminGetFlutterFavorite(
+        request,
+        package,
+      );
+      return $utilities.jsonResponse(_$result.toJson());
+    } on ApiResponseException catch (e) {
+      return e.asApiResponse();
+    } catch (e, st) {
+      return $utilities.unhandledError(e, st);
+    }
+  });
+  router.add('PUT', r'/api/admin/packages/<package>/flutter-favorite',
+      (Request request, String package) async {
+    try {
+      final _$result = await service.adminPutFlutterFavorite(
+        request,
+        package,
+        await $utilities.decodeJson<FlutterFavoriteStatus>(
+            request, (o) => FlutterFavoriteStatus.fromJson(o)),
+      );
+      return $utilities.jsonResponse(_$result.toJson());
+    } on ApiResponseException catch (e) {
+      return e.asApiResponse();
+    } catch (e, st) {
+      return $utilities.unhandledError(e, st);
+    }
+  });
   return router;
 }

--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -900,7 +900,8 @@ models.Package _newPackageFromVersion(
     ..latestVersionKey = version.key
     ..latestDevVersionKey = version.key
     ..uploaders = [userId]
-    ..likes = 0;
+    ..likes = 0
+    ..isFlutterFavorite = false;
 }
 
 class _ValidatedUpload {

--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -115,6 +115,8 @@ class PackageBackend {
   }
 
   /// Looks up a package by name.
+  ///
+  /// Returns `null` if the package doesn't exist.
   Future<models.Package> lookupPackage(String packageName) async {
     final packageKey = db.emptyKey.append(models.Package, id: packageName);
     return (await db.lookup([packageKey])).first as models.Package;

--- a/app/lib/package/models.dart
+++ b/app/lib/package/models.dart
@@ -91,6 +91,9 @@ class Package extends db.ExpandoModel {
     doNotAdvertiseFlag = value;
   }
 
+  @db.BoolProperty()
+  bool isFlutterFavorite;
+
   // Convenience Fields:
 
   String get latestVersion => latestVersionKey.id as String;

--- a/app/lib/shared/configuration.dart
+++ b/app/lib/shared/configuration.dart
@@ -4,6 +4,7 @@
 
 import 'dart:io';
 
+import 'package:collection/collection.dart' show UnmodifiableSetView;
 import 'package:gcloud/service_scope.dart' as ss;
 import 'package:googleapis_auth/auth.dart' as auth;
 import 'package:logging/logging.dart';
@@ -164,7 +165,14 @@ class Configuration {
         AdminId(
           oauthUserId: '111042304059633250784',
           email: 'istvan.soos@gmail.com',
-        ), // isoos
+          permissions: AdminPermission.values,
+        ),
+        AdminId(
+          oauthUserId: '103787640407960242725',
+          email: 'flutter-favorite-manager-test'
+              '@dartlang-pub-dev.iam.gserviceaccount.com',
+          permissions: {AdminPermission.manageFlutterFavorite},
+        )
       ],
     );
   }
@@ -224,7 +232,13 @@ class Configuration {
       productionHosts: ['localhost'],
       primaryApiUri: Uri.parse('http://localhost:$port/'),
       primarySiteUri: Uri.parse('http://localhost:$port/'),
-      admins: [AdminId(oauthUserId: 'admin-pub-dev', email: 'admin@pub.dev')],
+      admins: [
+        AdminId(
+          oauthUserId: 'admin-pub-dev',
+          email: 'admin@pub.dev',
+          permissions: AdminPermission.values,
+        ),
+      ],
     );
   }
 
@@ -248,7 +262,13 @@ class Configuration {
       productionHosts: ['localhost'],
       primaryApiUri: Uri.parse('https://pub.dartlang.org/'),
       primarySiteUri: Uri.parse('https://pub.dev/'),
-      admins: [AdminId(oauthUserId: 'admin-pub-dev', email: 'admin@pub.dev')],
+      admins: [
+        AdminId(
+          oauthUserId: 'admin-pub-dev',
+          email: 'admin@pub.dev',
+          permissions: AdminPermission.values,
+        ),
+      ],
     );
   }
 }
@@ -327,8 +347,25 @@ class AdminId {
   final String oauthUserId;
   final String email;
 
+  /// A set of strings that determine what operations the administrator is
+  /// permitted to perform.
+  final Set<AdminPermission> permissions;
+
   AdminId({
     @required this.oauthUserId,
     @required this.email,
-  });
+    @required Iterable<AdminPermission> permissions,
+  }) : permissions = UnmodifiableSetView(Set.from(permissions));
+}
+
+/// Permission that can be granted to administrators.
+enum AdminPermission {
+  /// Permission to list all users.
+  listUsers,
+
+  /// Permission to remove a user account (granted to wipeout).
+  removeUsers,
+
+  /// Permission to get/set Flutter Favorite status through admin API.
+  manageFlutterFavorite,
 }

--- a/app/lib/shared/integrity.dart
+++ b/app/lib/shared/integrity.dart
@@ -205,6 +205,10 @@ class IntegrityChecker {
             'Package(${p.name}) has an anandoned publisher, must be marked discontinued.');
       }
     }
+    if (p.isFlutterFavorite == null || p.isFlutterFavorite is! bool) {
+      _problems.add(
+          'Package(${p.name}) has a `isFlutterFavorite` property which is not a bool.');
+    }
     if (p.likes == null || p.likes is! int || p.likes < 0) {
       _problems.add(
           'Package(${p.name}) has a `likes` property which is not a non-negative integer.');

--- a/app/test/admin/api_test.dart
+++ b/app/test/admin/api_test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:convert';
 
+import 'package:client_data/admin_api.dart';
 import 'package:gcloud/db.dart';
 import 'package:test/test.dart';
 
@@ -189,6 +190,63 @@ void main() {
       // TODO: delete with multiple uploaders
       // TODO: delete with multiple members (contact email not changed)
       // TODO: delete with multiple members (contact email changes)
+    });
+
+    group('get isFlutterFavorite', () {
+      _testNotAdmin((client) => client.adminGetFlutterFavorite('hydrogen'));
+
+      testWithServices('get isFlutterFavorite', () async {
+        final client = createPubApiClient(authToken: adminUser.userId);
+        final status = await client.adminGetFlutterFavorite('hydrogen');
+        expect(status.isFlutterFavorite, isFalse);
+      });
+    });
+
+    group('set isFlutterFavorite', () {
+      _testNotAdmin((client) => client.adminPutFlutterFavorite(
+            'hydrogen',
+            FlutterFavoriteStatus(isFlutterFavorite: true),
+          ));
+
+      testWithServices('set isFlutterFavorite', () async {
+        final client = createPubApiClient(authToken: adminUser.userId);
+
+        // Is false initially
+        final s1 = await client.adminGetFlutterFavorite('hydrogen');
+        expect(s1.isFlutterFavorite, isFalse);
+
+        // Set it false should change anything
+        await client.adminPutFlutterFavorite(
+          'hydrogen',
+          FlutterFavoriteStatus(isFlutterFavorite: false),
+        );
+        final s2 = await client.adminGetFlutterFavorite('hydrogen');
+        expect(s2.isFlutterFavorite, isFalse);
+
+        // Check that we can set it true
+        await client.adminPutFlutterFavorite(
+          'hydrogen',
+          FlutterFavoriteStatus(isFlutterFavorite: true),
+        );
+        final s3 = await client.adminGetFlutterFavorite('hydrogen');
+        expect(s3.isFlutterFavorite, isTrue);
+
+        // Check that we can set it true (again)
+        await client.adminPutFlutterFavorite(
+          'hydrogen',
+          FlutterFavoriteStatus(isFlutterFavorite: true),
+        );
+        final s4 = await client.adminGetFlutterFavorite('hydrogen');
+        expect(s4.isFlutterFavorite, isTrue);
+
+        // Check that we can set it back to false
+        await client.adminPutFlutterFavorite(
+          'hydrogen',
+          FlutterFavoriteStatus(isFlutterFavorite: false),
+        );
+        final s5 = await client.adminGetFlutterFavorite('hydrogen');
+        expect(s5.isFlutterFavorite, isFalse);
+      });
     });
   });
 }

--- a/app/test/shared/test_models.dart
+++ b/app/test/shared/test_models.dart
@@ -80,7 +80,8 @@ Package createFoobarPackage({String name, List<User> uploaders}) {
     ..latestVersionKey = foobarStablePVKey
     ..latestDevVersionKey = foobarDevPVKey
     ..downloads = 0
-    ..likes = 0;
+    ..likes = 0
+    ..isFlutterFavorite = false;
 }
 
 final Package foobarPackage = createFoobarPackage();
@@ -309,6 +310,7 @@ PkgBundle generateBundle(
     ..name = name
     ..downloads = 0
     ..likes = 0
+    ..isFlutterFavorite = false
     ..publisherId = publisherId
     ..uploaders =
         publisherId != null ? [] : uploaders.map((u) => u.userId).toList();

--- a/pkg/client_data/lib/admin_api.dart
+++ b/pkg/client_data/lib/admin_api.dart
@@ -58,3 +58,16 @@ class AdminUserEntry {
       _$AdminUserEntryFromJson(json);
   Map<String, dynamic> toJson() => _$AdminUserEntryToJson(this);
 }
+
+/// Flutter favorite status which can be get/set.
+@JsonSerializable()
+class FlutterFavoriteStatus {
+  /// True, if the package is a Flutter Favorite package.
+  final bool isFlutterFavorite;
+
+  // json_serializable boiler-plate
+  FlutterFavoriteStatus({@required this.isFlutterFavorite});
+  factory FlutterFavoriteStatus.fromJson(Map<String, dynamic> json) =>
+      _$FlutterFavoriteStatusFromJson(json);
+  Map<String, dynamic> toJson() => _$FlutterFavoriteStatusToJson(this);
+}

--- a/pkg/client_data/lib/admin_api.g.dart
+++ b/pkg/client_data/lib/admin_api.g.dart
@@ -39,3 +39,16 @@ Map<String, dynamic> _$AdminUserEntryToJson(AdminUserEntry instance) =>
       'oauthUserId': instance.oauthUserId,
       'email': instance.email,
     };
+
+FlutterFavoriteStatus _$FlutterFavoriteStatusFromJson(
+    Map<String, dynamic> json) {
+  return FlutterFavoriteStatus(
+    isFlutterFavorite: json['isFlutterFavorite'] as bool,
+  );
+}
+
+Map<String, dynamic> _$FlutterFavoriteStatusToJson(
+        FlutterFavoriteStatus instance) =>
+    <String, dynamic>{
+      'isFlutterFavorite': instance.isFlutterFavorite,
+    };

--- a/pkg/web_app/lib/src/pubapi.client.dart
+++ b/pkg/web_app/lib/src/pubapi.client.dart
@@ -339,4 +339,21 @@ class PubApiClient {
       path: '/api/admin/users/$userId',
     );
   }
+
+  Future<_i6.FlutterFavoriteStatus> adminGetFlutterFavorite(
+      String package) async {
+    return _i6.FlutterFavoriteStatus.fromJson(await _client.requestJson(
+      verb: 'get',
+      path: '/api/admin/packages/$package/flutter-favorite',
+    ));
+  }
+
+  Future<_i6.FlutterFavoriteStatus> adminPutFlutterFavorite(
+      String package, _i6.FlutterFavoriteStatus payload) async {
+    return _i6.FlutterFavoriteStatus.fromJson(await _client.requestJson(
+      verb: 'put',
+      path: '/api/admin/packages/$package/flutter-favorite',
+      body: payload.toJson(),
+    ));
+  }
 }


### PR DESCRIPTION
API for managing ff and data model update, along with backfill, etc.

Also introduce a concept of admin permissions, because we really should segregate what
service accounts can access what resources.

In practice I don't think we'll be adding individual adminstrators in our configuration.
It takes a long time for us to update this configration as it's effectively hardcoded into the application.
Thus, we need to do a full deployment to add/remove admin permissions.

Instead we'll grant admin permissions to a service account, and use IAM in GCP Console
grant individual users permission to impersonate the service account. This makes calling with
admin credentials slightly complicated as an administrator will have to call the IAM API to
obtain a token impersonating the service account listed as administrator.
On the other hand this is very flexible. And once we have the setup for specifying which
service we'll be impersonating, it's pretty easy to call this way.