### PR TITLE
Require dart 2.6

### DIFF
--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -2,7 +2,7 @@ name: pub_dartlang_org
 author: Dart Team <misc@dartlang.org>
 description: The pub.dartlang.org website.
 environment:
-  sdk: ">=2.3.0 <3.0.0"
+  sdk: ">=2.6.0 <3.0.0"
 dependencies:
   _popularity:
     path: ../pkg/_popularity

--- a/pkg/_popularity/pubspec.yaml
+++ b/pkg/_popularity/pubspec.yaml
@@ -2,7 +2,7 @@ name: _popularity
 publish_to: none
 
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.6.0 <3.0.0'
 
 dependencies:
   json_annotation: ^3.0.0

--- a/pkg/api_builder/pubspec.yaml
+++ b/pkg/api_builder/pubspec.yaml
@@ -20,4 +20,4 @@ dev_dependencies:
   build_runner: ^1.4.0
   pedantic: ^1.4.0
 environment:
-  sdk: '>=2.4.0 <3.0.0'
+  sdk: '>=2.6.0 <3.0.0'

--- a/pkg/client_data/pubspec.yaml
+++ b/pkg/client_data/pubspec.yaml
@@ -2,7 +2,7 @@ name: client_data
 description: Shared data between server and JS client.
 publish_to: none
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.6.0 <3.0.0'
 
 dependencies:
   json_annotation: '^3.0.0'

--- a/pkg/code_coverage/pubspec.yaml
+++ b/pkg/code_coverage/pubspec.yaml
@@ -2,7 +2,7 @@ name: code_coverage
 publish_to: none  # don't publish yet
 description: Code coverage tools.
 environment:
-  sdk: '>=2.3.0 <3.0.0'
+  sdk: '>=2.6.0 <3.0.0'
 
 dependencies:
   args: ^1.5.0

--- a/pkg/fake_gcloud/pubspec.lock
+++ b/pkg/fake_gcloud/pubspec.lock
@@ -394,4 +394,4 @@ packages:
     source: hosted
     version: "2.2.0"
 sdks:
-  dart: ">=2.3.0 <3.0.0"
+  dart: ">=2.6.0 <3.0.0"

--- a/pkg/fake_gcloud/pubspec.yaml
+++ b/pkg/fake_gcloud/pubspec.yaml
@@ -3,7 +3,7 @@ publish_to: none  # don't publish yet
 description: Fake, in-memory implementation of `package:gcloud` interfaces.
 
 environment:
-  sdk: '>=2.1.0 <3.0.0'
+  sdk: '>=2.6.0 <3.0.0'
 
 dependencies:
   gcloud: '^0.6.0'

--- a/pkg/fake_pub_server/pubspec.yaml
+++ b/pkg/fake_pub_server/pubspec.yaml
@@ -3,7 +3,7 @@ publish_to: none  # don't publish yet
 description: Fake pub server for integration tests.
 
 environment:
-  sdk: '>=2.2.0 <3.0.0'
+  sdk: '>=2.6.0 <3.0.0'
 
 dependencies:
   args: ^1.0.0

--- a/pkg/pub_dartdoc/pubspec.lock
+++ b/pkg/pub_dartdoc/pubspec.lock
@@ -443,4 +443,4 @@ packages:
     source: hosted
     version: "2.2.0"
 sdks:
-  dart: ">=2.3.0 <3.0.0"
+  dart: ">=2.6.0 <3.0.0"

--- a/pkg/pub_dartdoc/pubspec.yaml
+++ b/pkg/pub_dartdoc/pubspec.yaml
@@ -2,7 +2,7 @@ name: pub_dartdoc
 author: Dart Team <misc@dartlang.org>
 description: The customized dartdoc for pub.dartlang.org.
 environment:
-  sdk: ">=2.0.0 <3.0.0"
+  sdk: ">=2.6.0 <3.0.0"
 dependencies:
   path: ^1.6.0
   pub_dartdoc_data:

--- a/pkg/pub_dartdoc_data/pubspec.yaml
+++ b/pkg/pub_dartdoc_data/pubspec.yaml
@@ -2,7 +2,7 @@ name: pub_dartdoc_data
 description: Data structure for the pub-data.json
 publish_to: none
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.6.0 <3.0.0'
 
 dependencies:
   json_annotation: '^3.0.0'

--- a/pkg/pub_integration/pubspec.lock
+++ b/pkg/pub_integration/pubspec.lock
@@ -394,4 +394,4 @@ packages:
     source: hosted
     version: "2.2.0"
 sdks:
-  dart: ">=2.4.0 <3.0.0"
+  dart: ">=2.6.0 <3.0.0"

--- a/pkg/pub_integration/pubspec.yaml
+++ b/pkg/pub_integration/pubspec.yaml
@@ -3,7 +3,7 @@ publish_to: none  # don't publish yet
 description: Tools for integration tests.
 
 environment:
-  sdk: '>=2.3.0 <3.0.0'
+  sdk: '>=2.6.0 <3.0.0'
 
 dependencies:
   args: ^1.5.0

--- a/pkg/pub_package_reader/pubspec.lock
+++ b/pkg/pub_package_reader/pubspec.lock
@@ -394,4 +394,4 @@ packages:
     source: hosted
     version: "2.2.0"
 sdks:
-  dart: ">=2.3.0 <3.0.0"
+  dart: ">=2.6.0 <3.0.0"

--- a/pkg/pub_package_reader/pubspec.yaml
+++ b/pkg/pub_package_reader/pubspec.yaml
@@ -3,7 +3,7 @@ description: Scans the package archive, extracts its main content and checks for
 publish_to: none
 
 environment:
-  sdk: '>=2.3.0 <3.0.0'
+  sdk: '>=2.6.0 <3.0.0'
 
 dependencies:
   logging: ^0.11.3

--- a/pkg/web_app/pubspec.lock
+++ b/pkg/web_app/pubspec.lock
@@ -366,4 +366,4 @@ packages:
     source: hosted
     version: "2.2.0"
 sdks:
-  dart: ">=2.4.0 <3.0.0"
+  dart: ">=2.6.0 <3.0.0"

--- a/pkg/web_app/pubspec.yaml
+++ b/pkg/web_app/pubspec.yaml
@@ -2,7 +2,7 @@ name: web_app
 publish_to: none
 
 environment:
-  sdk: '>=2.3.0 <3.0.0'
+  sdk: '>=2.6.0 <3.0.0'
 
 dependencies:
   mdc_web: ^0.4.1+1

--- a/pkg/web_css/pubspec.yaml
+++ b/pkg/web_css/pubspec.yaml
@@ -2,7 +2,7 @@ name: web_css
 publish_to: none
 
 environment:
-  sdk: '>=2.1.0 <3.0.0'
+  sdk: '>=2.6.0 <3.0.0'
 
 dependencies:
   sass: ^1.19.0


### PR DESCRIPTION
This is probably why we had the downgrade to `0.0.19` because it was possible to run with an old SDK. Which we shouldn't allow.