### PR TITLE
Style consent reject button differently.

### DIFF
--- a/app/lib/frontend/templates/views/consent.mustache
+++ b/app/lib/frontend/templates/views/consent.mustache
@@ -10,7 +10,7 @@
 <p id="-admin-consent-buttons">
   <button
     id="-admin-consent-reject-button"
-    class="mdc-button mdc-button--raised"
+    class="mdc-button mdc-button--raised pub-button-cancel"
     data-mdc-auto-init="MDCRipple">Reject</button>
   <button
     id="-admin-consent-accept-button"

--- a/pkg/web_css/lib/src/_base.scss
+++ b/pkg/web_css/lib/src/_base.scss
@@ -40,6 +40,14 @@ button {
         background-color: darken($color-input-danger, 10%) !important;
       }
     }
+
+    &.pub-button-cancel {
+      background-color: $color-input-cancel !important;
+
+      &:hover {
+        background-color: darken($color-input-cancel, 10%) !important;
+      }
+    }
   }
 
   &.mdc-dialog__button {

--- a/pkg/web_css/lib/src/_variables.scss
+++ b/pkg/web_css/lib/src/_variables.scss
@@ -10,4 +10,5 @@ $color-searchbar-dark-link: #38bffc;
 
 $color-input-primary: #0175C2;
 $color-input-danger: #ff4242;
+$color-input-cancel: #aaaaaa;
 $color-link: $color-input-primary;


### PR DESCRIPTION
- This makes the reject button gray, which is I think better than the green/blue vs red distinction, as described in the original issue. I've also tried the style we are using on the dialog buttons, but that was too light for consent.
- The `-cancel` suffix is probably not the best name, any suggestions?
- Fixes #3013.
