### PR TITLE
Parse and use tags in user-provided query string.

### DIFF
--- a/app/lib/package/package_tags.dart
+++ b/app/lib/package/package_tags.dart
@@ -12,10 +12,20 @@ abstract class PackageTags {
 
   /// The first version of the package was published less than 30 days ago.
   static const String isRecent = 'is:recent';
+
+  static const $all = <String>[
+    isDiscontinued,
+    isNotAdvertized,
+    isRecent,
+  ];
 }
 
 /// Collection of version-related tags.
 abstract class PackageVersionTags {
   /// PackageVersion supports only legacy (Dart 1) SDK.
   static const String isLegacy = 'is:legacy';
+
+  static const $all = <String>[
+    isLegacy,
+  ];
 }

--- a/app/lib/package/package_tags.dart
+++ b/app/lib/package/package_tags.dart
@@ -12,20 +12,10 @@ abstract class PackageTags {
 
   /// The first version of the package was published less than 30 days ago.
   static const String isRecent = 'is:recent';
-
-  static const $all = <String>[
-    isDiscontinued,
-    isNotAdvertized,
-    isRecent,
-  ];
 }
 
 /// Collection of version-related tags.
 abstract class PackageVersionTags {
   /// PackageVersion supports only legacy (Dart 1) SDK.
   static const String isLegacy = 'is:legacy';
-
-  static const $all = <String>[
-    isLegacy,
-  ];
 }

--- a/app/lib/search/index_simple.dart
+++ b/app/lib/search/index_simple.dart
@@ -148,9 +148,11 @@ class SimplePackageIndex implements PackageIndex {
     }
 
     // filter on tags
-    if (query.tagsPredicate != null) {
+    final combinedTagsPredicate =
+        query.tagsPredicate.appendPredicate(query.parsedQuery.tagsPredicate);
+    if (combinedTagsPredicate.isNotEmpty) {
       packages.retainWhere(
-          (package) => query.tagsPredicate.evaluate(_packages[package].tags));
+          (package) => combinedTagsPredicate.evaluate(_packages[package].tags));
     }
 
     // filter on dependency

--- a/app/lib/search/index_simple.dart
+++ b/app/lib/search/index_simple.dart
@@ -152,7 +152,7 @@ class SimplePackageIndex implements PackageIndex {
         query.tagsPredicate.appendPredicate(query.parsedQuery.tagsPredicate);
     if (combinedTagsPredicate.isNotEmpty) {
       packages.retainWhere(
-          (package) => combinedTagsPredicate.evaluate(_packages[package].tags));
+          (package) => combinedTagsPredicate.matches(_packages[package].tags));
     }
 
     // filter on dependency

--- a/app/lib/search/search_service.dart
+++ b/app/lib/search/search_service.dart
@@ -466,7 +466,7 @@ class TagsPredicate {
 
   /// Evaluate this predicate against the list of supplied [tags].
   /// Returns true if the predicate matches the [tags], false otherwise.
-  bool evaluate(List<String> tags) {
+  bool matches(List<String> tags) {
     tags ??= const <String>[];
     for (String tag in _values.keys) {
       final present = tags.contains(tag);

--- a/app/lib/search/search_service.dart
+++ b/app/lib/search/search_service.dart
@@ -454,7 +454,9 @@ class TagsPredicate {
 
   /// Appends [other] predicate to the current set of tags, and returns a new
   /// [TagsPredicate] instance.
-  /// The appended flags take precedence over the current ones.
+  ///
+  /// If there are conflicting tag predicates, the [other] takes precedence over
+  /// this [TagsPredicate].
   TagsPredicate appendPredicate(TagsPredicate other) {
     final p = TagsPredicate();
     p._values.addAll(_values);

--- a/app/lib/search/search_service.dart
+++ b/app/lib/search/search_service.dart
@@ -452,18 +452,6 @@ class TagsPredicate {
     return p;
   }
 
-  /// Appends [requiredTags] and [prohibitedTags] to the current set of tags,
-  /// and returns a new [TagsPredicate] instance.
-  /// The appended flags take precedence over the current ones.
-  TagsPredicate append(
-      {List<String> requiredTags, List<String> prohibitedTags}) {
-    final p = TagsPredicate();
-    p._values.addAll(_values);
-    requiredTags?.forEach((tag) => _values[tag] = true);
-    prohibitedTags?.forEach((tag) => _values[tag] = false);
-    return p;
-  }
-
   /// Appends [other] predicate to the current set of tags, and returns a new
   /// [TagsPredicate] instance.
   /// The appended flags take precedence over the current ones.

--- a/app/lib/search/search_service.dart
+++ b/app/lib/search/search_service.dart
@@ -7,8 +7,6 @@ import 'dart:math' show max;
 
 import 'package:json_annotation/json_annotation.dart';
 
-import '../package/package_tags.dart';
-
 part 'search_service.g.dart';
 
 const int _minSearchLimit = 10;
@@ -22,10 +20,9 @@ const int resultsPerPage = 10;
 /// links from page 5 to page 15.
 const int maxPages = 10;
 
-/// The tags that we can detect in the user-provided search query.
-final _detectedTags = <String>{
-  ...PackageTags.$all.expand((s) => [s, '-$s', '+$s']),
-  ...PackageVersionTags.$all.expand((s) => [s, '-$s', '+$s']),
+/// The tag prefixes that we can detect in the user-provided search query.
+final _detectedTagPrefixes = <String>{
+  ...['is:'].expand((s) => [s, '-$s', '+$s']),
 };
 
 /// Package search index and lookup.
@@ -546,7 +543,7 @@ class ParsedQuery {
 
     final tagValues = extractRegExp(
       _tagRegExp,
-      where: (tag) => _detectedTags.contains(tag),
+      where: (tag) => _detectedTagPrefixes.any((p) => tag.startsWith(p)),
     );
     final tagsPredicate = TagsPredicate.parseQueryValues(tagValues);
 

--- a/app/test/search/search_service_test.dart
+++ b/app/test/search/search_service_test.dart
@@ -94,6 +94,28 @@ void main() {
       expect(query.parsedQuery.emails, ['user@domain.com']);
     });
 
+    test('known tag', () {
+      final query = SearchQuery.parse(query: 'is:legacy');
+      expect(query.parsedQuery.text, isNull);
+      expect(
+          query.parsedQuery.tagsPredicate.toQueryParameters(), ['is:legacy']);
+    });
+
+    test('forbidden known tag', () {
+      final query = SearchQuery.parse(query: '-is:legacy');
+      expect(query.parsedQuery.text, isNull);
+      expect(
+          query.parsedQuery.tagsPredicate.toQueryParameters(), ['-is:legacy']);
+    });
+
+    test('known tag + package prefix + search text', () {
+      final query = SearchQuery.parse(query: 'json is:legacy package:foo_');
+      expect(query.parsedQuery.text, 'json');
+      expect(
+          query.parsedQuery.tagsPredicate.toQueryParameters(), ['is:legacy']);
+      expect(query.parsedQuery.packagePrefix, 'foo_');
+    });
+
     test('publisher + email + text + dependency', () {
       final query = SearchQuery.parse(
           query:

--- a/app/test/search/tags_test.dart
+++ b/app/test/search/tags_test.dart
@@ -142,14 +142,12 @@ void main() {
 
     test('User-supplied queried tags #1', () async {
       final index = SimplePackageIndex();
-      await index.addPackage(
-          PackageDocument(package: 'pkg1', tags: ['is:recent', 'is:legacy']));
       await index
-          .addPackage(PackageDocument(package: 'pkg2', tags: ['is:legacy']));
+          .addPackage(PackageDocument(package: 'pkg1', tags: ['is:a', 'is:b']));
+      await index.addPackage(PackageDocument(package: 'pkg2', tags: ['is:b']));
       await index.merge();
 
-      final rs =
-          await index.search(SearchQuery.parse(query: 'is:legacy -is:recent'));
+      final rs = await index.search(SearchQuery.parse(query: 'is:b -is:a'));
       expect(json.decode(json.encode(rs.toJson())), {
         'indexUpdated': isNotEmpty,
         'totalCount': 1,
@@ -161,15 +159,14 @@ void main() {
 
     test('User-supplied queried tags #2', () async {
       final index = SimplePackageIndex();
-      await index.addPackage(
-          PackageDocument(package: 'pkg1', tags: ['is:recent', 'is:legacy']));
       await index
-          .addPackage(PackageDocument(package: 'pkg2', tags: ['is:recent']));
+          .addPackage(PackageDocument(package: 'pkg1', tags: ['is:a', 'is:b']));
+      await index.addPackage(PackageDocument(package: 'pkg2', tags: ['is:a']));
       await index.merge();
 
       final rs = await index.search(SearchQuery.parse(
-          tagsPredicate: TagsPredicate(prohibitedTags: ['is:legacy']),
-          query: 'is:recent is:legacy'));
+          tagsPredicate: TagsPredicate(prohibitedTags: ['is:b']),
+          query: 'is:a is:b'));
       expect(json.decode(json.encode(rs.toJson())), {
         'indexUpdated': isNotEmpty,
         'totalCount': 1,


### PR DESCRIPTION
- non-null `tagsPredicate` in both `SearchQuery` (which we control and configure) and `ParsedQuery` (which the user sends as the query string and we parse).
- The combiner function is simple: the user-provided query overrides the search query's settings. (we may change it later if needed)
- I kept `TagsPredicate` construction with `requiredTags` and (renamed) `prohibitedTags`, but the internal data is using a map, as it is much easier to implement `append` with it.
