### PR TITLE
Hide 'API reference' link if package has no valid dartdoc output.

### DIFF
--- a/app/lib/analyzer/analyzer_client.dart
+++ b/app/lib/analyzer/analyzer_client.dart
@@ -65,6 +65,8 @@ class AnalysisView {
   bool get hasAnalysisData => _card != null;
   bool get hasPanaSummary => _pana != null;
   ScoreCardData get card => _card;
+  bool get hasApiDocs =>
+      _dartdoc != null && _dartdoc.reportStatus == ReportStatus.success;
 
   DateTime get timestamp => _pana?.timestamp;
   String get panaReportStatus => _pana?.reportStatus;

--- a/app/lib/frontend/templates/package.dart
+++ b/app/lib/frontend/templates/package.dart
@@ -161,7 +161,9 @@ String renderPkgInfoBox(
       detectServiceProvider: true);
   addLink(packageLinks.issueTrackerUrl, 'View/report issues');
   addLink(documentationUrl, 'Documentation');
-  addLink(dartdocsUrl, 'API reference');
+  if (analysis.hasApiDocs) {
+    addLink(dartdocsUrl, 'API reference');
+  }
 
   return templateCache.renderTemplate('pkg/info_box', {
     'name': package.name,

--- a/app/test/frontend/golden/pkg_admin_page_outdated.html
+++ b/app/test/frontend/golden/pkg_admin_page_outdated.html
@@ -175,8 +175,6 @@ Published
             <p>
               <a class="link" href="http://hans.juergen.com">Homepage</a>
               <br/>
-              <a class="link" href="/documentation/foobar_pkg/latest/">API reference</a>
-              <br/>
             </p>
             <h3 class="title">Uploader</h3>
             <p>

--- a/app/test/frontend/golden/pkg_show_page_discontinued.html
+++ b/app/test/frontend/golden/pkg_show_page_discontinued.html
@@ -289,8 +289,6 @@ import 'package:foobar_pkg/foolib.dart';
             <p>
               <a class="link" href="http://hans.juergen.com">Homepage</a>
               <br/>
-              <a class="link" href="/documentation/foobar_pkg/latest/">API reference</a>
-              <br/>
             </p>
             <h3 class="title">Uploader</h3>
             <p>

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -292,8 +292,6 @@ import 'package:foobar_pkg/foolib.dart';
             <p>
               <a class="link" href="http://hans.juergen.com">Homepage</a>
               <br/>
-              <a class="link" href="/documentation/foobar_pkg/latest/">API reference</a>
-              <br/>
             </p>
             <h3 class="title">Uploader</h3>
             <p>

--- a/app/test/frontend/golden/pkg_show_page_legacy.html
+++ b/app/test/frontend/golden/pkg_show_page_legacy.html
@@ -307,8 +307,6 @@ import 'package:foobar_pkg/foolib.dart';
             <p>
               <a class="link" href="http://hans.juergen.com">Homepage</a>
               <br/>
-              <a class="link" href="/documentation/foobar_pkg/latest/">API reference</a>
-              <br/>
             </p>
             <h3 class="title">Uploaders</h3>
             <p>

--- a/app/test/frontend/golden/pkg_show_page_outdated.html
+++ b/app/test/frontend/golden/pkg_show_page_outdated.html
@@ -294,8 +294,6 @@ import 'package:foobar_pkg/foolib.dart';
             <p>
               <a class="link" href="http://hans.juergen.com">Homepage</a>
               <br/>
-              <a class="link" href="/documentation/foobar_pkg/latest/">API reference</a>
-              <br/>
             </p>
             <h3 class="title">Uploader</h3>
             <p>

--- a/app/test/frontend/golden/pkg_show_page_publisher.html
+++ b/app/test/frontend/golden/pkg_show_page_publisher.html
@@ -308,8 +308,6 @@ import 'package:lithium/lib/lithium.dart';
             <p>
               <a class="link" href="https://example.com/lithium">Homepage</a>
               <br/>
-              <a class="link" href="/documentation/lithium/latest/">API reference</a>
-              <br/>
             </p>
             <h3 class="title">More</h3>
             <p>

--- a/app/test/frontend/golden/pkg_show_version_page.html
+++ b/app/test/frontend/golden/pkg_show_version_page.html
@@ -325,8 +325,6 @@ import 'package:foobar_pkg/foolib.dart';
             <p>
               <a class="link" href="http://hans.juergen.com">Homepage</a>
               <br/>
-              <a class="link" href="/documentation/foobar_pkg/0.2.0-dev/">API reference</a>
-              <br/>
             </p>
             <h3 class="title">Uploader</h3>
             <p>

--- a/app/test/frontend/golden/pkg_versions_page.html
+++ b/app/test/frontend/golden/pkg_versions_page.html
@@ -205,8 +205,6 @@ Published
             <p>
               <a class="link" href="http://hans.juergen.com">Homepage</a>
               <br/>
-              <a class="link" href="/documentation/foobar_pkg/latest/">API reference</a>
-              <br/>
             </p>
             <h3 class="title">Uploader</h3>
             <p>

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -138,7 +138,10 @@ void main() {
         foobarUploaderEmails,
         foobarStablePV,
         AnalysisView(
-          card: ScoreCardData(reportTypes: ['pana'], healthScore: 0.1),
+          card: ScoreCardData(
+            reportTypes: ['pana', 'dartdoc'],
+            healthScore: 0.1,
+          ),
           panaReport: PanaReport(
               timestamp: DateTime(2018, 02, 05),
               panaRuntimeInfo: _panaRuntimeInfo,
@@ -173,7 +176,13 @@ void main() {
               healthSuggestions: null,
               maintenanceSuggestions: null,
               flags: null),
-          dartdocReport: null,
+          dartdocReport: DartdocReport(
+            reportStatus: ReportStatus.success,
+            coverage: 1.0,
+            coverageScore: 1.0,
+            healthSuggestions: [],
+            maintenanceSuggestions: [],
+          ),
         ),
         isAdmin: true,
       );


### PR DESCRIPTION
- Fixes #2610.
- I've update one test so that it contains the link.