### PR TITLE
Use access_token during login.

### DIFF
--- a/app/lib/account/backend.dart
+++ b/app/lib/account/backend.dart
@@ -258,16 +258,17 @@ class AccountBackend {
   Future<String> siteAuthCodeToAccessToken(String redirectUrl, String code) =>
       _authProvider.authCodeToAccessToken(redirectUrl, code);
 
-  /// Verifies that the access token is matching the current active `User`.
+  /// Verifies that the access token belongs to the [owner].
   ///
   /// Throws [AuthenticationException] if token cannot be authenticated or the
-  /// OAuth userId differs from the current active user.
-  Future<void> verifyAccessToken(String accessToken) async {
+  /// OAuth userId differs from [owner].
+  Future<void> verifyAccessTokenOwnership(
+      String accessToken, User owner) async {
     final auth = await _authProvider.tryAuthenticate(accessToken);
     if (auth == null) {
       throw AuthenticationException.accessTokenInvalid();
     }
-    if (_authenticatedUser?.oauthUserId != auth.oauthUserId) {
+    if (owner.oauthUserId != auth.oauthUserId) {
       throw AuthenticationException.accessTokenMissmatch();
     }
   }

--- a/app/lib/account/backend.dart
+++ b/app/lib/account/backend.dart
@@ -258,8 +258,21 @@ class AccountBackend {
   Future<String> siteAuthCodeToAccessToken(String redirectUrl, String code) =>
       _authProvider.authCodeToAccessToken(redirectUrl, code);
 
-  /// Authenticates with bearer [token] and returns an `AuthenticatedUser`
-  /// object.
+  /// Verifies that the access token is matching the current active `User`.
+  ///
+  /// Throws [AuthenticationException] if token cannot be authenticated or the
+  /// OAuth userId differs from the current active user.
+  Future<void> verifyAccessToken(String accessToken) async {
+    final auth = await _authProvider.tryAuthenticate(accessToken);
+    if (auth == null) {
+      throw AuthenticationException.accessTokenInvalid();
+    }
+    if (_authenticatedUser?.oauthUserId != auth.oauthUserId) {
+      throw AuthenticationException.accessTokenMissmatch();
+    }
+  }
+
+  /// Authenticates with bearer [token] and returns an `User` object.
   ///
   /// The method returns null if [token] is invalid.
   ///

--- a/app/lib/frontend/handlers/account.dart
+++ b/app/lib/frontend/handlers/account.dart
@@ -30,7 +30,7 @@ Future<shelf.Response> updateSessionHandler(
   final user = await requireAuthenticatedUser();
 
   InvalidInputException.checkNotNull(body.accessToken, 'accessToken');
-  await accountBackend.verifyAccessToken(body.accessToken);
+  await accountBackend.verifyAccessTokenOwnership(body.accessToken, user);
 
   // Only allow creation of sessions on the primary site host.
   // Exposing session on other domains is a security concern.

--- a/app/lib/frontend/handlers/account.dart
+++ b/app/lib/frontend/handlers/account.dart
@@ -26,10 +26,11 @@ shelf.Response authorizedHandler(_) => htmlResponse(renderAuthorizedPage());
 
 /// Handles POST /api/account/session
 Future<shelf.Response> updateSessionHandler(
-  shelf.Request request, {
-  ClientSessionData clientSessionData,
-}) async {
+    shelf.Request request, ClientSessionRequest body) async {
   final user = await requireAuthenticatedUser();
+
+  InvalidInputException.checkNotNull(body.accessToken, 'accessToken');
+  await accountBackend.verifyAccessToken(body.accessToken);
 
   // Only allow creation of sessions on the primary site host.
   // Exposing session on other domains is a security concern.
@@ -45,7 +46,7 @@ Future<shelf.Response> updateSessionHandler(
   if (userSessionData != null &&
       userSessionData.userId == user.userId &&
       userSessionData.email == user.email &&
-      userSessionData.imageUrl == clientSessionData.imageUrl) {
+      userSessionData.imageUrl == body.imageUrl) {
     final status = ClientSessionStatus(
       changed: false,
       expires: userSessionData.expires,
@@ -53,8 +54,8 @@ Future<shelf.Response> updateSessionHandler(
     return jsonResponse(status.toJson());
   }
 
-  final newSession = await accountBackend.createNewSession(
-      imageUrl: clientSessionData.imageUrl);
+  final newSession =
+      await accountBackend.createNewSession(imageUrl: body.imageUrl);
 
   return jsonResponse(
     ClientSessionStatus(

--- a/app/lib/frontend/handlers/pubapi.client.dart
+++ b/app/lib/frontend/handlers/pubapi.client.dart
@@ -157,7 +157,7 @@ class PubApiClient {
     ));
   }
 
-  Future<List<int>> updateSession(_i4.ClientSessionData payload) async {
+  Future<List<int>> updateSession(_i4.ClientSessionRequest payload) async {
     return await _client.requestBytes(
       verb: 'post',
       path: '/api/account/session',

--- a/app/lib/frontend/handlers/pubapi.dart
+++ b/app/lib/frontend/handlers/pubapi.dart
@@ -192,9 +192,8 @@ class PubApi {
   /// The response header will contain the updated session cookie, and the body
   /// is a [ClientSessionStatus].
   @EndPoint.post('/api/account/session')
-  Future<Response> updateSession(
-          Request request, ClientSessionData sessionData) =>
-      updateSessionHandler(request, clientSessionData: sessionData);
+  Future<Response> updateSession(Request request, ClientSessionRequest body) =>
+      updateSessionHandler(request, body);
 
   /// Removes the user session.
   ///

--- a/app/lib/frontend/handlers/pubapi.g.dart
+++ b/app/lib/frontend/handlers/pubapi.g.dart
@@ -278,8 +278,8 @@ Router _$PubApiRouter(PubApi service) {
     try {
       final _$result = await service.updateSession(
         request,
-        await $utilities.decodeJson<ClientSessionData>(
-            request, (o) => ClientSessionData.fromJson(o)),
+        await $utilities.decodeJson<ClientSessionRequest>(
+            request, (o) => ClientSessionRequest.fromJson(o)),
       );
       return _$result;
     } on ApiResponseException catch (e) {

--- a/app/lib/publisher/backend.dart
+++ b/app/lib/publisher/backend.dart
@@ -111,6 +111,7 @@ class PublisherBackend {
       minimum: 1,
       maximum: 4096,
     );
+    await accountBackend.verifyAccessToken(body.accessToken);
 
     // Verify ownership of domain.
     final isOwner = await domainVerifier.verifyDomainOwnership(

--- a/app/lib/publisher/backend.dart
+++ b/app/lib/publisher/backend.dart
@@ -111,7 +111,7 @@ class PublisherBackend {
       minimum: 1,
       maximum: 4096,
     );
-    await accountBackend.verifyAccessToken(body.accessToken);
+    await accountBackend.verifyAccessTokenOwnership(body.accessToken, user);
 
     // Verify ownership of domain.
     final isOwner = await domainVerifier.verifyDomainOwnership(

--- a/app/lib/shared/exceptions.dart
+++ b/app/lib/shared/exceptions.dart
@@ -185,8 +185,16 @@ class AuthenticationException extends ResponseException
   /// Signaling that `authorization` header was missing.
   factory AuthenticationException.authenticationRequired() =>
       AuthenticationException._(
-        'authenication is required, please add `authorization` header.',
-      );
+          'Authenication is required, please add `authorization` header.');
+
+  /// Signaling that `accessToken` payload was missing or could not be authenticated.
+  factory AuthenticationException.accessTokenInvalid() =>
+      AuthenticationException._('Invalid `accessToken`.');
+
+  /// Signaling that `accessToken` resolved to a different OAuth `userId`.
+  factory AuthenticationException.accessTokenMissmatch() =>
+      AuthenticationException._(
+          '`accessToken` does not match current active user.');
 
   @override
   String toString() => '$code: $message'; // used by package:pub_server

--- a/app/test/publisher/api_test.dart
+++ b/app/test/publisher/api_test.dart
@@ -40,14 +40,14 @@ void main() {
         // Check that we can create the publisher
         final r1 = await api.createPublisher(
           'verified.com',
-          CreatePublisherRequest(accessToken: 'dummy-token-for-testing'),
+          CreatePublisherRequest(accessToken: hansUser.userId),
         );
         expect(r1.contactEmail, hansUser.email);
 
         // Check that creating again idempotently works too
         final r2 = await api.createPublisher(
           'verified.com',
-          CreatePublisherRequest(accessToken: 'dummy-token-for-testing'),
+          CreatePublisherRequest(accessToken: hansUser.userId),
         );
         expect(r2.contactEmail, hansUser.email);
 
@@ -73,7 +73,7 @@ void main() {
         // Check that we can create the publisher
         final rs = api.createPublisher(
           'notverified.com',
-          CreatePublisherRequest(accessToken: 'dummy-token-for-testing'),
+          CreatePublisherRequest(accessToken: hansUser.userId),
         );
         await expectApiException(
           rs,

--- a/pkg/client_data/lib/account_api.dart
+++ b/pkg/client_data/lib/account_api.dart
@@ -9,19 +9,29 @@ import 'package:meta/meta.dart';
 
 part 'account_api.g.dart';
 
-/// Session data to be cached from the authenticated client.
+/// A session request to be processed on the server.
 @JsonSerializable()
-class ClientSessionData {
+class ClientSessionRequest {
+  /// The OAuth2 `access_token` to be used when accessing profile data like
+  /// image URL.
+  ///
+  /// This must:
+  ///  * be valid at the time of the request,
+  ///  * obtained from the OAuth2 flow used on the pub.dev website.
+  final String accessToken;
+
+  /// TODO: remove after we can get this information on the server side.
   final String imageUrl;
 
-  ClientSessionData({
+  ClientSessionRequest({
+    @required this.accessToken,
     @required this.imageUrl,
   });
 
-  factory ClientSessionData.fromJson(Map<String, dynamic> json) =>
-      _$ClientSessionDataFromJson(json);
+  factory ClientSessionRequest.fromJson(Map<String, dynamic> json) =>
+      _$ClientSessionRequestFromJson(json);
 
-  Map<String, dynamic> toJson() => _$ClientSessionDataToJson(this);
+  Map<String, dynamic> toJson() => _$ClientSessionRequestToJson(this);
 }
 
 /// The server-provided status of the current session.

--- a/pkg/client_data/lib/account_api.g.dart
+++ b/pkg/client_data/lib/account_api.g.dart
@@ -6,14 +6,17 @@ part of 'account_api.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-ClientSessionData _$ClientSessionDataFromJson(Map<String, dynamic> json) {
-  return ClientSessionData(
+ClientSessionRequest _$ClientSessionRequestFromJson(Map<String, dynamic> json) {
+  return ClientSessionRequest(
+    accessToken: json['accessToken'] as String,
     imageUrl: json['imageUrl'] as String,
   );
 }
 
-Map<String, dynamic> _$ClientSessionDataToJson(ClientSessionData instance) =>
+Map<String, dynamic> _$ClientSessionRequestToJson(
+        ClientSessionRequest instance) =>
     <String, dynamic>{
+      'accessToken': instance.accessToken,
       'imageUrl': instance.imageUrl,
     };
 

--- a/pkg/pub_integration/lib/script/publisher.dart
+++ b/pkg/pub_integration/lib/script/publisher.dart
@@ -51,7 +51,7 @@ class PublisherScript {
       await _pubHttpClient.createPublisher(
         authToken: 'user-at-example-dot-com',
         publisherId: 'example.com',
-        accessToken: 'access-at-example-dot-com',
+        accessToken: 'user-at-example-dot-com',
       );
       await _pubHttpClient.setPackagePublisher(
         authToken: 'user-at-example-dot-com',

--- a/pkg/web_app/lib/src/account.dart
+++ b/pkg/web_app/lib/src/account.dart
@@ -146,13 +146,14 @@ Future _updateUser(GoogleUser user) async {
       }
     }
   } else {
-    final st1 = ClientSessionStatus.fromBytes(await client.updateSession(
-      ClientSessionData(imageUrl: user.getBasicProfile().getImageUrl()),
-    ));
+    final body = ClientSessionRequest(
+      accessToken: currentUser.getAuthResponse(true).access_token,
+      imageUrl: user.getBasicProfile().getImageUrl(),
+    );
+    final st1 = ClientSessionStatus.fromBytes(await client.updateSession(body));
     if (st1.changed) {
-      final st2 = ClientSessionStatus.fromBytes(await client.updateSession(
-        ClientSessionData(imageUrl: user.getBasicProfile().getImageUrl()),
-      ));
+      final st2 =
+          ClientSessionStatus.fromBytes(await client.updateSession(body));
       // If creating the session a second time changed anything then maybe the
       // client has disabled cookies. We should NOT reload to avoid degrading
       // into an infinite reload loop. We could show a message, but we have no

--- a/pkg/web_app/lib/src/pubapi.client.dart
+++ b/pkg/web_app/lib/src/pubapi.client.dart
@@ -157,7 +157,7 @@ class PubApiClient {
     ));
   }
 
-  Future<List<int>> updateSession(_i4.ClientSessionData payload) async {
+  Future<List<int>> updateSession(_i4.ClientSessionRequest payload) async {
     return await _client.requestBytes(
       verb: 'post',
       path: '/api/account/session',


### PR DESCRIPTION
- Strengthen the sign-in process with extra verification of the `access_token`.
- Same verification is applied when creating new publisher.
- The `imageUrl` remains client-provided, as I couldn't figure out which API to use to access it. I suspect that we may extend `package:googleapis` to also include userinfo with the `picture` field, but I'm not sure if that is the best way to do it.
- #2830
