### PR TITLE
Update to pkg/code_coverage

### DIFF
--- a/pkg/code_coverage/lib/format_lcov.dart
+++ b/pkg/code_coverage/lib/format_lcov.dart
@@ -21,8 +21,7 @@ Future main() async {
     for (final record in report.records) {
       final path = record.sourceFile;
       final partOfPubDev = path.startsWith('app/') || path.startsWith('pkg/');
-      final partOfTest = path.contains('/test/');
-      if (partOfPubDev && !partOfTest) {
+      if (partOfPubDev) {
         final counts = _lineExecCounts.putIfAbsent(path, () => <int, int>{});
         for (final lineData in record.lines.data) {
           counts[lineData.lineNumber] =

--- a/pkg/code_coverage/pubspec.lock
+++ b/pkg/code_coverage/pubspec.lock
@@ -394,4 +394,4 @@ packages:
     source: hosted
     version: "2.2.0"
 sdks:
-  dart: ">=2.4.0 <3.0.0"
+  dart: ">=2.6.0 <3.0.0"


### PR DESCRIPTION
- better env variable names
- `_all_test.dart` for `pkg/pub_integration`
- include `test/` in report.txt (useful to track helper classes in tests that are no longer used)
