### PR TITLE
Non-complete derived tags.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Important changes to data-models, configuration and migrations between each
 AppEngine version, listed here to ease deployment and troubleshooting.
 
 ## Next Release (replace with git tag when deployed)
+ * Bumped runtimeVersion to `2019.11.29`.
 
 ## `20191127t111711-all`
  * Added 'my liked packages' page behind experimental flag.

--- a/app/lib/analyzer/pana_runner.dart
+++ b/app/lib/analyzer/pana_runner.dart
@@ -254,7 +254,7 @@ List<String> _deriveTags(List<String> platformTags) {
       ];
     }
   }
-  return null;
+  return <String>[];
 }
 
 Summary createPanaSummaryForLegacy(String packageName, String packageVersion) {

--- a/app/lib/analyzer/pana_runner.dart
+++ b/app/lib/analyzer/pana_runner.dart
@@ -190,6 +190,9 @@ class AnalyzerJobProcessor extends JobProcessor {
 PanaReport panaReportFromSummary(Summary summary, {List<String> flags}) {
   final reportStatus =
       summary == null ? ReportStatus.aborted : ReportStatus.success;
+  final platformTags = indexDartPlatform(summary?.platform);
+  // TODO: use summary.tags instead, once pana gets a release with it
+  final derivedTags = _deriveTags(platformTags);
   return PanaReport(
     timestamp: DateTime.now().toUtc(),
     panaRuntimeInfo: summary?.runtimeInfo,
@@ -197,9 +200,9 @@ PanaReport panaReportFromSummary(Summary summary, {List<String> flags}) {
     healthScore: summary?.health?.healthScore ?? 0.0,
     maintenanceScore:
         summary == null ? 0.0 : calculateMaintenanceScore(summary.maintenance),
-    platformTags: indexDartPlatform(summary?.platform),
+    platformTags: platformTags,
     platformReason: summary?.platform?.reason,
-    derivedTags: null,
+    derivedTags: derivedTags,
     pkgDependencies: summary?.pkgResolution?.dependencies,
     panaSuggestions: summary?.suggestions,
     healthSuggestions: summary?.health?.suggestions,
@@ -207,6 +210,51 @@ PanaReport panaReportFromSummary(Summary summary, {List<String> flags}) {
     licenses: summary?.licenses,
     flags: flags,
   );
+}
+
+/// This derivative method populates the ScoreCard and the search index with
+/// correct, but incomplete data.
+List<String> _deriveTags(List<String> platformTags) {
+  if (platformTags != null && platformTags.isNotEmpty) {
+    if (KnownPlatforms.all.every(platformTags.contains)) {
+      return <String>[
+        'sdk:dart',
+        'sdk:flutter',
+        'platform:android',
+        'platform:ios',
+        'runtime:native',
+        'runtime:web',
+      ];
+    } else if (platformTags.length == 1 &&
+        platformTags.single == KnownPlatforms.flutter) {
+      return <String>[
+        'sdk:flutter',
+      ];
+    } else if (platformTags.length == 1 &&
+        platformTags.single == KnownPlatforms.web) {
+      return <String>[
+        'sdk:dart',
+        'runtime:web',
+      ];
+    } else if (platformTags.length == 1 &&
+        platformTags.single == KnownPlatforms.other) {
+      return <String>[
+        'sdk:dart',
+        'runtime:native',
+      ];
+    } else if (platformTags.length == 2 &&
+        platformTags.contains(KnownPlatforms.flutter) &&
+        platformTags.contains(KnownPlatforms.other)) {
+      return <String>[
+        'sdk:dart',
+        'sdk:flutter',
+        'platform:android',
+        'platform:ios',
+        'runtime:native',
+      ];
+    }
+  }
+  return null;
 }
 
 Summary createPanaSummaryForLegacy(String packageName, String packageVersion) {

--- a/app/lib/shared/versions.dart
+++ b/app/lib/shared/versions.dart
@@ -16,7 +16,7 @@ final RegExp runtimeVersionPattern = RegExp(r'\d{4}\.\d{2}\.\d{2}');
 /// Increment the version when a change is significant enough to trigger
 /// reprocessing, including: version change in pana, dartdoc, or the SDKs,
 /// or when an feature or bugfix should be picked up by the analysis ASAP.
-const String runtimeVersion = '2019.11.12';
+const String runtimeVersion = '2019.11.29';
 final Version semanticRuntimeVersion = Version.parse(runtimeVersion);
 
 /// The version which marks the earliest version of the data which we'd like to
@@ -25,12 +25,12 @@ final Version semanticRuntimeVersion = Version.parse(runtimeVersion);
 ///
 /// Make sure that at least two versions are kept here as the next candidates
 /// when the version switch happens:
+/// - 2019.11.29
 /// - 2019.11.12
 /// - 2019.11.01
 /// - 2019.10.22
 /// - 2019.10.07
-/// - 2019.09.10
-final String gcBeforeRuntimeVersion = '2019.09.10';
+final String gcBeforeRuntimeVersion = '2019.10.07';
 
 // keep in-sync with SDK version in .travis.yml, .mono_repo.yml and Dockerfile
 final String runtimeSdkVersion = '2.6.0';

--- a/app/test/shared/versions_test.dart
+++ b/app/test/shared/versions_test.dart
@@ -31,7 +31,7 @@ void main() {
     // This test is a reminder that if pana, the SDK or any of the above
     // versions change, we should also adjust the [runtimeVersion]. Before
     // updating the hash value, double-check if it is being updated.
-    expect(hash, 920695121);
+    expect(hash, 439757776);
   });
 
   test('runtime version should be (somewhat) lexicographically ordered', () {


### PR DESCRIPTION
I'd use this in staging, so that we are not blocked on `pana` and have some data to work with. Once `pana` is released, we could remove the `_deriveTags` method and use `summary.tags`.

Bumped the `runtimeVersion` in order to separate this data from the current stack.