### PR TITLE
Remove: API search option

### DIFF
--- a/app/lib/frontend/templates/layout.dart
+++ b/app/lib/frontend/templates/layout.dart
@@ -148,7 +148,6 @@ String _renderSearchBanner({
     'search_query_html': escapedSearchQuery,
     'search_sort_param': searchSort,
     'legacy_search_enabled': searchQuery?.includeLegacy ?? false,
-    'api_search_enabled': searchQuery?.isApiEnabled ?? true,
     'platform_tabs_html': platformTabs,
     'landing_banner_image': _landingBannerImage(platform == 'flutter'),
     'landing_banner_alt':

--- a/app/lib/frontend/templates/views/shared/search_banner.mustache
+++ b/app/lib/frontend/templates/views/shared/search_banner.mustache
@@ -15,7 +15,6 @@
         {{#show_details}}
         {{#search_sort_param}}<input type="hidden" name="sort" value="{{search_sort_param}}"/>{{/search_sort_param}}
         <input id="search-legacy-field" type="hidden" name="legacy" value="1"{{^legacy_search_enabled}} disabled="disabled"{{/legacy_search_enabled}} />
-        <input id="search-api-field" type="hidden" name="api" value="0"{{#api_search_enabled}} disabled="disabled"{{/api_search_enabled}} />
         {{/show_details}}
       </form>
       {{#show_details}}
@@ -24,8 +23,6 @@
         <div class="search-bar-options">
           <input id="search-legacy-checkbox" type="checkbox" name="legacy" valye="1" {{#legacy_search_enabled}} checked="checked"{{/legacy_search_enabled}} />
           <label for="search-legacy-checkbox">Include Dart 1.x results</label>
-          <input id="search-api-checkbox" type="checkbox" name="api"{{#api_search_enabled}} checked="checked"{{/api_search_enabled}} />
-          <label for="search-api-checkbox"> Include API results</label>
         </div>
       </div>
       {{/show_details}}

--- a/app/lib/search/search_service.dart
+++ b/app/lib/search/search_service.dart
@@ -244,7 +244,6 @@ class SearchQuery {
   final SearchOrder order;
   final int offset;
   final int limit;
-  final bool isApiEnabled;
 
   /// True, if packages which only support dart 1.x should be included.
   final bool includeLegacy;
@@ -258,7 +257,6 @@ class SearchQuery {
     this.order,
     this.offset,
     this.limit,
-    this.isApiEnabled,
     this.includeLegacy,
   })  : parsedQuery = ParsedQuery._parse(query),
         platform = _stringToNull(platform),
@@ -275,7 +273,6 @@ class SearchQuery {
     SearchOrder order,
     int offset = 0,
     int limit = 10,
-    bool apiEnabled = true,
     bool includeLegacy = false,
   }) {
     final q = _stringToNull(query?.trim());
@@ -288,7 +285,6 @@ class SearchQuery {
       order: order,
       offset: offset,
       limit: limit,
-      isApiEnabled: apiEnabled,
       includeLegacy: includeLegacy,
     );
   }
@@ -315,7 +311,6 @@ class SearchQuery {
       order: order,
       offset: max(0, offset),
       limit: max(_minSearchLimit, limit),
-      apiEnabled: uri.queryParameters['api'] != '0',
       includeLegacy: uri.queryParameters['legacy'] == '1',
     );
   }
@@ -343,7 +338,6 @@ class SearchQuery {
       order: order ?? this.order,
       offset: offset ?? this.offset,
       limit: limit ?? this.limit,
-      isApiEnabled: apiEnabled ?? this.isApiEnabled,
       includeLegacy: includeLegacy ?? this.includeLegacy,
     );
   }
@@ -358,7 +352,6 @@ class SearchQuery {
       'offset': offset?.toString(),
       'limit': limit?.toString(),
       'order': serializeSearchOrder(order),
-      'api': isApiEnabled ? null : '0',
       'legacy': includeLegacy ? '1' : null,
     };
     map.removeWhere((k, v) => v == null);
@@ -404,9 +397,6 @@ class SearchQuery {
     if (order != null) {
       final String paramName = 'sort';
       params[paramName] = serializeSearchOrder(order);
-    }
-    if (!isApiEnabled) {
-      params['api'] = '0';
     }
     if (includeLegacy) {
       params['legacy'] = '1';
@@ -544,9 +534,6 @@ class ParsedQuery {
   /// Detected tags in the user-provided query.
   TagsPredicate tagsPredicate;
 
-  /// Enable experimental API search.
-  final bool isApiEnabled;
-
   ParsedQuery._(
     this.text,
     this.packagePrefix,
@@ -555,7 +542,6 @@ class ParsedQuery {
     this.publisher,
     this.emails,
     this.tagsPredicate,
-    this.isApiEnabled,
   );
 
   factory ParsedQuery._parse(String q) {
@@ -592,11 +578,6 @@ class ParsedQuery {
     );
     final tagsPredicate = TagsPredicate.parseQueryValues(tagValues);
 
-    final bool isApiEnabled = queryText.contains(' !!api ');
-    if (isApiEnabled) {
-      queryText = queryText.replaceFirst(' !!api ', ' ');
-    }
-
     queryText = queryText.replaceAll(_whitespacesRegExp, ' ').trim();
     if (queryText.isEmpty) {
       queryText = null;
@@ -610,7 +591,6 @@ class ParsedQuery {
       publisher,
       emails,
       tagsPredicate,
-      isApiEnabled,
     );
   }
 
@@ -746,7 +726,6 @@ SearchQuery parseFrontendSearchQuery(
   final String queryText = queryParameters['q'] ?? '';
   final String sortParam = queryParameters['sort'];
   final SearchOrder sortOrder = parseSearchOrder(sortParam);
-  final isApiEnabled = queryParameters['api'] != '0';
   final requiredTags = <String>[];
   if (sdk != null) {
     requiredTags.add('sdk:$sdk');
@@ -775,7 +754,6 @@ SearchQuery parseFrontendSearchQuery(
     order: sortOrder,
     offset: offset,
     limit: resultsPerPage,
-    apiEnabled: isApiEnabled,
     includeLegacy: includeLegacy || queryParameters['legacy'] == '1',
     tagsPredicate: tagsPredicate,
   );

--- a/app/test/frontend/golden/pkg_index_page.html
+++ b/app/test/frontend/golden/pkg_index_page.html
@@ -78,7 +78,6 @@
             <input class="input" name="q" placeholder="Search Dart packages" autocomplete="on" autofocus="autofocus"/>
             <button class="icon"></button>
             <input id="search-legacy-field" type="hidden" name="legacy" value="1" disabled="disabled"/>
-            <input id="search-api-field" type="hidden" name="api" value="0" disabled="disabled"/>
           </form>
           <div class="search-bar-details">
             <div class="list-filters">
@@ -89,8 +88,6 @@
             <div class="search-bar-options">
               <input id="search-legacy-checkbox" type="checkbox" name="legacy" valye="1"/>
               <label for="search-legacy-checkbox">Include Dart 1.x results</label>
-              <input id="search-api-checkbox" type="checkbox" name="api" checked="checked"/>
-              <label for="search-api-checkbox"> Include API results</label>
             </div>
           </div>
         </div>

--- a/app/test/frontend/golden/publisher_list_page.html
+++ b/app/test/frontend/golden/publisher_list_page.html
@@ -77,7 +77,6 @@
             <input class="input" name="q" placeholder="Search Dart packages" autocomplete="on" autofocus="autofocus"/>
             <button class="icon"></button>
             <input id="search-legacy-field" type="hidden" name="legacy" value="1" disabled="disabled"/>
-            <input id="search-api-field" type="hidden" name="api" value="0" disabled="disabled"/>
           </form>
           <div class="search-bar-details">
             <div class="list-filters">
@@ -88,8 +87,6 @@
             <div class="search-bar-options">
               <input id="search-legacy-checkbox" type="checkbox" name="legacy" valye="1"/>
               <label for="search-legacy-checkbox">Include Dart 1.x results</label>
-              <input id="search-api-checkbox" type="checkbox" name="api" checked="checked"/>
-              <label for="search-api-checkbox"> Include API results</label>
             </div>
           </div>
         </div>

--- a/app/test/frontend/golden/search_page.html
+++ b/app/test/frontend/golden/search_page.html
@@ -79,7 +79,6 @@
             <button class="icon"></button>
             <input type="hidden" name="sort" value="top"/>
             <input id="search-legacy-field" type="hidden" name="legacy" value="1" disabled="disabled"/>
-            <input id="search-api-field" type="hidden" name="api" value="0" disabled="disabled"/>
           </form>
           <div class="search-bar-details">
             <div class="list-filters">
@@ -90,8 +89,6 @@
             <div class="search-bar-options">
               <input id="search-legacy-checkbox" type="checkbox" name="legacy" valye="1"/>
               <label for="search-legacy-checkbox">Include Dart 1.x results</label>
-              <input id="search-api-checkbox" type="checkbox" name="api" checked="checked"/>
-              <label for="search-api-checkbox"> Include API results</label>
             </div>
           </div>
         </div>

--- a/app/test/search/search_service_test.dart
+++ b/app/test/search/search_service_test.dart
@@ -27,17 +27,6 @@ void main() {
       expect(SearchQuery.parse(query: 'text').parsedQuery.text, 'text');
       expect(SearchQuery.parse(query: ' text ').query, 'text');
       expect(SearchQuery.parse(query: ' text ').parsedQuery.text, 'text');
-      expect(
-          SearchQuery.parse(query: ' text ').parsedQuery.isApiEnabled, isFalse);
-    });
-
-    test('experimental API search', () {
-      expect(
-          SearchQuery.parse(query: '!!api').parsedQuery.isApiEnabled, isTrue);
-      expect(SearchQuery.parse(query: 'text !!api').parsedQuery.isApiEnabled,
-          isTrue);
-      expect(SearchQuery.parse(query: '!!api text').parsedQuery.isApiEnabled,
-          isTrue);
     });
 
     test('no dependency', () {

--- a/pkg/web_app/lib/src/search.dart
+++ b/pkg/web_app/lib/src/search.dart
@@ -60,19 +60,6 @@ void _setEventForSortControl() {
 }
 
 void _setEventForCheckboxChanges() {
-  final hiddenApiField =
-      document.getElementById('search-api-field') as InputElement;
-  final visibleApiCheckbox =
-      document.getElementById('search-api-checkbox') as CheckboxInputElement;
-  if (hiddenApiField != null && visibleApiCheckbox != null) {
-    final formElement = hiddenApiField.form;
-    visibleApiCheckbox.onChange.listen((_) {
-      hiddenApiField.disabled = visibleApiCheckbox.checked;
-      // TODO: instead of submitting, compose the URL here (also removing the single `?`)
-      formElement.submit();
-    });
-  }
-
   final hiddenLegacyField =
       document.getElementById('search-legacy-field') as InputElement;
   final visibleLegacyCheckbox =


### PR DESCRIPTION
We've discussed a few days ago that it seems to be stable and it is useful to keep it on as default, we can remove it from the UI and make the related processing simpler.