### PR TITLE
Better cleanup of obsolete Job data.

### DIFF
--- a/app/lib/service/entrypoint/analyzer.dart
+++ b/app/lib/service/entrypoint/analyzer.dart
@@ -85,12 +85,12 @@ Future _workerMain(WorkerEntryMessage message) async {
       message.statsSendPort.send(await jobBackend.stats(JobService.analyzer));
     });
 
-    // Run ScoreCard GC in the next 6 hours (randomized wait to reduce race).
-    Timer(Duration(minutes: _random.nextInt(360)), () {
+    // Run GC in the next 6-12 hours (randomized wait to reduce race).
+    Timer(Duration(minutes: 360 + _random.nextInt(360)), () {
       scoreCardBackend.deleteOldEntries();
+      jobBackend.deleteOldEntries();
     });
 
-    jobBackend.scheduleOldDataGC();
     await jobMaintenance.run();
   });
 }


### PR DESCRIPTION
I've noticed older entries in the `Job` table on staging, tracked down the reason: we have kept entities that were on old runtimeVersion, if they haven't reached the locked timeout yet.

The PR also increases the GC startup delay, so that new releases are not interrupted right away with a potential cleanup due to the low random number.