### PR TITLE
Random sample of search results.

### DIFF
--- a/app/lib/search/search_service.dart
+++ b/app/lib/search/search_service.dart
@@ -248,6 +248,11 @@ class SearchQuery {
   /// True, if packages which only support dart 1.x should be included.
   final bool includeLegacy;
 
+  /// True, if the result list should be a random sample of packages matching
+  /// this [SearchQuery]. The range, method and weights of the random sampling
+  /// is up to the index implementation.
+  final bool randomize;
+
   SearchQuery._({
     this.query,
     String platform,
@@ -258,6 +263,7 @@ class SearchQuery {
     this.offset,
     this.limit,
     this.includeLegacy,
+    this.randomize,
   })  : parsedQuery = ParsedQuery._parse(query),
         platform = _stringToNull(platform),
         tagsPredicate = tagsPredicate ?? TagsPredicate(),
@@ -274,6 +280,7 @@ class SearchQuery {
     int offset = 0,
     int limit = 10,
     bool includeLegacy = false,
+    bool randomize = false,
   }) {
     final q = _stringToNull(query?.trim());
     return SearchQuery._(
@@ -286,6 +293,7 @@ class SearchQuery {
       offset: offset,
       limit: limit,
       includeLegacy: includeLegacy,
+      randomize: randomize,
     );
   }
 
@@ -312,6 +320,7 @@ class SearchQuery {
       offset: max(0, offset),
       limit: max(_minSearchLimit, limit),
       includeLegacy: uri.queryParameters['legacy'] == '1',
+      randomize: uri.queryParameters['randomize'] == '1',
     );
   }
 
@@ -325,9 +334,8 @@ class SearchQuery {
     SearchOrder order,
     int offset,
     int limit,
-    bool isAd,
-    bool apiEnabled,
     bool includeLegacy,
+    bool randomize,
   }) {
     return SearchQuery._(
       query: query ?? this.query,
@@ -339,6 +347,7 @@ class SearchQuery {
       offset: offset ?? this.offset,
       limit: limit ?? this.limit,
       includeLegacy: includeLegacy ?? this.includeLegacy,
+      randomize: randomize ?? this.randomize,
     );
   }
 
@@ -353,6 +362,7 @@ class SearchQuery {
       'limit': limit?.toString(),
       'order': serializeSearchOrder(order),
       'legacy': includeLegacy ? '1' : null,
+      'randomize': randomize ? '1' : null,
     };
     map.removeWhere((k, v) => v == null);
     return map;
@@ -670,6 +680,8 @@ class PackageScore {
       apiPages: apiPages ?? this.apiPages,
     );
   }
+
+  PackageScore onlyPackageName() => PackageScore(package: package);
 
   bool get isExternal => url != null && version != null && description != null;
 

--- a/app/test/search/index_simple_test.dart
+++ b/app/test/search/index_simple_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:convert';
+import 'dart:math';
 
 import 'package:test/test.dart';
 
@@ -615,6 +616,47 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
           {'package': 'http', 'score': closeTo(0.65, 0.01)},
         ],
       });
+    });
+  });
+
+  group('SimplePackageIndex + randomize', () {
+    final index = SimplePackageIndex(random: Random(12345));
+
+    setUpAll(() async {
+      for (int i = 0; i < 1000; i++) {
+        await index
+            .addPackage(PackageDocument(package: 'd$i', popularity: i / 1000));
+      }
+    });
+
+    test('random1', () async {
+      final results =
+          await index.search(SearchQuery.parse(randomize: true, limit: 3));
+      // should not contain d899 or below
+      expect(results.packages.map((sr) => sr.package).toList(), [
+        'd909',
+        'd982',
+        'd925',
+        'd993',
+        'd989',
+        'd915',
+        'd992',
+        'd902',
+        'd984',
+        'd901',
+      ]);
+    });
+
+    // uses the same index, the Random object is on its second use
+    test('random2', () async {
+      final results =
+          await index.search(SearchQuery.parse(randomize: true, limit: 20));
+      // could contain d899 or below
+      expect(results.packages.map((sr) => sr.package).take(3).toList(), [
+        'd857',
+        'd969',
+        'd809',
+      ]);
     });
   });
 }


### PR DESCRIPTION
Should be useful for random sampling of a subset of packages (e.g. matching a given tag).