### PR TITLE
Fix: search URLs

### DIFF
--- a/app/lib/shared/urls.dart
+++ b/app/lib/shared/urls.dart
@@ -83,8 +83,16 @@ String searchUrl({
   List<String> platforms,
   String q,
   int page,
-}) =>
-    SearchQuery.parse(platform: platform, query: q).toSearchLink(page: page);
+}) {
+  final query = SearchQuery.parse(
+    platform: platform,
+    sdk: sdk,
+    runtimes: runtimes,
+    platforms: platforms,
+    query: q,
+  );
+  return query.toSearchLink(page: page);
+}
 
 String dartSdkMainUrl(String version) {
   final isDev = version.contains('dev');

--- a/app/test/shared/urls_test.dart
+++ b/app/test/shared/urls_test.dart
@@ -178,4 +178,31 @@ void main() {
           repo);
     });
   });
+
+  group('search urls', () {
+    test('sdk:*', () {
+      expect(searchUrl(), '/packages');
+      expect(searchUrl(q: 'abc'), '/packages?q=abc');
+    });
+
+    test('sdk:dart', () {
+      expect(searchUrl(sdk: 'dart'), '/dart/packages');
+      expect(searchUrl(sdk: 'dart', q: 'abc'), '/dart/packages?q=abc');
+    });
+
+    test('sdk:dart runtime:native', () {
+      expect(searchUrl(sdk: 'dart', runtimes: ['native']),
+          '/dart/packages?runtime=native');
+    });
+
+    test('sdk:flutter', () {
+      expect(searchUrl(sdk: 'flutter'), '/flutter/packages');
+      expect(searchUrl(sdk: 'flutter', q: 'abc'), '/flutter/packages?q=abc');
+    });
+
+    test('sdk:flutter platform:android+ios', () {
+      expect(searchUrl(sdk: 'flutter', platforms: ['android', 'ios']),
+          '/flutter/packages?platform=android+ios');
+    });
+  });
 }


### PR DESCRIPTION
The `searchUrl` had the related parameters, but ignored them. 