### PR TITLE
Label update for SDK-based listing page.

### DIFF
--- a/app/lib/frontend/handlers/listing.dart
+++ b/app/lib/frontend/handlers/listing.dart
@@ -87,7 +87,8 @@ Future<shelf.Response> _packagesHandlerHtmlCore(shelf.Request request,
   final result = htmlResponse(renderPkgIndexPage(
     searchResult.packages,
     links,
-    platform,
+    platform: platform,
+    sdk: sdk,
     searchQuery: searchQuery,
     totalCount: totalCount,
   ));

--- a/app/lib/frontend/templates/_consts.dart
+++ b/app/lib/frontend/templates/_consts.dart
@@ -6,7 +6,33 @@ import 'package:meta/meta.dart';
 import 'package:pana/models.dart' show SuggestionCode;
 
 import '../../shared/platform.dart' show KnownPlatforms;
+import '../../shared/tags.dart' show SdkTagValue;
 import '../../shared/urls.dart' as urls;
+
+class SdkDict {
+  final String topSdkPackages;
+
+  const SdkDict({
+    @required this.topSdkPackages,
+  });
+
+  const SdkDict.any() : topSdkPackages = 'Top packages';
+
+  const SdkDict.dart() : topSdkPackages = 'Top Dart packages';
+
+  const SdkDict.flutter() : topSdkPackages = 'Top Flutter packages';
+}
+
+/// Returns the dictionary spec for [sdk].
+SdkDict getSdkDict(String sdk) {
+  if (sdk == SdkTagValue.dart) {
+    return SdkDict.dart();
+  } else if (sdk == SdkTagValue.flutter) {
+    return SdkDict.flutter();
+  } else {
+    return SdkDict.any();
+  }
+}
 
 class PlatformDict {
   final String name;

--- a/app/lib/frontend/templates/listing.dart
+++ b/app/lib/frontend/templates/listing.dart
@@ -103,14 +103,23 @@ String renderMyLikedPackagesList(List<LikeData> likes) {
 
 /// Renders the `views/pkg/index.mustache` template.
 String renderPkgIndexPage(
-    List<PackageView> packages, PageLinks links, String currentPlatform,
-    {SearchQuery searchQuery, int totalCount}) {
-  final PlatformDict platformDict = getPlatformDict(currentPlatform);
+  List<PackageView> packages,
+  PageLinks links, {
+  String platform,
+  String sdk,
+  SearchQuery searchQuery,
+  int totalCount,
+}) {
+  String topPackages;
+  if (sdk != null) {
+    topPackages = getSdkDict(sdk).topSdkPackages;
+  }
+  topPackages ??= getPlatformDict(platform).topPlatformPackages;
   final isSearch = searchQuery != null && searchQuery.hasQuery;
   final values = {
     'sort_control_html': renderSortControl(searchQuery),
     'is_search': isSearch,
-    'title': platformDict.topPlatformPackages,
+    'title': topPackages,
     'package_list_html': renderPackageList(packages),
     'has_packages': packages.isNotEmpty,
     'pagination': renderPagination(links),
@@ -119,7 +128,7 @@ String renderPkgIndexPage(
   };
   final content = templateCache.renderTemplate('pkg/index', values);
 
-  String pageTitle = platformDict.topPlatformPackages;
+  String pageTitle = topPackages;
   if (isSearch) {
     pageTitle = 'Search results for ${searchQuery.query}.';
   } else {
@@ -131,7 +140,7 @@ String renderPkgIndexPage(
     PageType.listing,
     content,
     title: pageTitle,
-    platform: currentPlatform,
+    platform: platform,
     searchQuery: searchQuery,
     noIndex: true,
   );

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -504,7 +504,7 @@ void main() {
             reportTypes: ['pana'],
           ),
         ),
-      ], PageLinks.empty(), null);
+      ], PageLinks.empty());
       expectGoldenFile(html, 'pkg_index_page.html');
     });
 
@@ -532,7 +532,6 @@ void main() {
           ),
         ],
         PageLinks(0, 50, searchQuery: searchQuery),
-        null,
         searchQuery: searchQuery,
         totalCount: 2,
       );


### PR DESCRIPTION
We'll eventually have an `SdkDict`-like structure (and remove `PlatformDict`), adding it to the search page rendering is the simplest start for it.