### PR TITLE
Secondary tabs on SDK-based search.

### DIFF
--- a/app/lib/frontend/templates/views/shared/search_banner.mustache
+++ b/app/lib/frontend/templates/views/shared/search_banner.mustache
@@ -16,13 +16,19 @@
         {{#search_sort_param}}<input type="hidden" name="sort" value="{{search_sort_param}}"/>{{/search_sort_param}}
         <input id="search-legacy-field" type="hidden" name="legacy" value="1"{{^legacy_search_enabled}} disabled="disabled"{{/legacy_search_enabled}} />
         {{/show_details}}
+        {{#hidden_inputs}}
+        <input type="hidden" name="{{name}}" value="{{value}}" />
+        {{/hidden_inputs}}
       </form>
       {{#show_details}}
       <div class="search-bar-details">
         {{& search_tabs_html }}
         <div class="search-bar-options">
+          {{#show_legacy_checkbox}}
           <input id="search-legacy-checkbox" type="checkbox" name="legacy" valye="1" {{#legacy_search_enabled}} checked="checked"{{/legacy_search_enabled}} />
           <label for="search-legacy-checkbox">Include Dart 1.x results</label>
+          {{/show_legacy_checkbox}}
+          {{& secondary_tabs_html }}
         </div>
       </div>
       {{/show_details}}

--- a/app/lib/search/search_service.dart
+++ b/app/lib/search/search_service.dart
@@ -519,7 +519,7 @@ class TagsPredicate {
   TagsPredicate removePrefix(String prefix) {
     final p = TagsPredicate();
     _values.entries.forEach((e) {
-      if (e.key.startsWith(prefix)) {
+      if (!e.key.startsWith(prefix)) {
         p._values[e.key] = e.value;
       }
     });

--- a/app/lib/shared/tags.dart
+++ b/app/lib/shared/tags.dart
@@ -44,3 +44,10 @@ abstract class DartSdkRuntimeValue {
   static const String native = 'native';
   static const String web = 'web';
 }
+
+/// Collection of Flutter SDK runtime values.
+abstract class FlutterSdkRuntimeValue {
+  static const String android = 'android';
+  static const String ios = 'ios';
+  static const String web = 'web';
+}

--- a/pkg/web_css/lib/src/_list.scss
+++ b/pkg/web_css/lib/src/_list.scss
@@ -195,26 +195,34 @@
   margin: 16px 0;
   border: 1px solid $color-searchbar-dark-border;
   border-radius: 3px;
-}
 
-.list-filters > .filter {
-  background: transparent;
-  border-right: 1px solid $color-searchbar-dark-border;
-  color: $color-searchbar-dark-input-fg;
-  text-transform: uppercase;
-  font-size: 14px;
-  font-weight: 500;
-  padding: 4px 24px;
-  cursor: pointer;
+  > .filter {
+    background: transparent;
+    border-right: 1px solid $color-searchbar-dark-border;
+    color: $color-searchbar-dark-input-fg;
+    text-transform: uppercase;
+    font-size: 14px;
+    font-weight: 500;
+    padding: 4px 24px;
+    cursor: pointer;
 
-  &:hover {
-    background: rgba(255, 255, 255, 0.10);
+    &:hover {
+      background: rgba(255, 255, 255, 0.10);
+    }
+
+    &.-active {
+      color: $color-searchbar-dark-input-fg;
+      background: $color-searchbar-dark-link;
+    }
   }
-}
 
-.list-filters > .filter.-active {
-  color: $color-searchbar-dark-input-fg;
-  background: $color-searchbar-dark-link;
+  // Overrides for secondary tabs.
+  .search-bar-options & {
+    margin-top: 0px;
+    > .filter.-active {
+      background: $color-searchbar-secondary-link;
+    }
+  }
 }
 
 .package-count {

--- a/pkg/web_css/lib/src/_variables.scss
+++ b/pkg/web_css/lib/src/_variables.scss
@@ -7,6 +7,7 @@ $color-searchbar-dark-input-bg: #35404d;
 $color-searchbar-dark-input-fg: #ffffff;
 $color-searchbar-dark-border: #1e2a38;
 $color-searchbar-dark-link: #38bffc;
+$color-searchbar-secondary-link: #388f8c;
 
 $color-input-primary: #0175C2;
 $color-input-danger: #ff4242;


### PR DESCRIPTION
- secondary tabs are visible only on sdk:dart or sdk:flutter
- needed to add hidden input to preserve other search-form-related behavior
- different color (see below)
- mobile view wraps nicely (below the sdk-based tabs)
- however, I've omitted the "Runtimes:" and the "Platforms:" label for now, as it screwed the mobile view a bit, and we can easily add them later
- also fixed `TagsPredicate.remove` bug

<img width="678" alt="Screen Shot 2019-12-03 at 14 21 42" src="https://user-images.githubusercontent.com/4778111/70054734-659b0980-15d8-11ea-8cb6-da80c98bb464.png">
