### PR TITLE
Display SDK and secondary tags.

### DIFF
--- a/app/lib/frontend/templates/admin.dart
+++ b/app/lib/frontend/templates/admin.dart
@@ -72,7 +72,12 @@ String renderAccountPackagesPage({
             '<a href="https://dart.dev/tools/pub/publishing">publishing packages</a>.';
   }
 
-  final packageListHtml = packages.isEmpty ? '' : renderPackageList(packages);
+  final packageListHtml = packages.isEmpty
+      ? ''
+      : renderPackageList(
+          packages,
+          searchQuery: searchQuery,
+        );
   final paginationHtml = renderPagination(pageLinks);
 
   final tabContent = [

--- a/app/lib/frontend/templates/listing.dart
+++ b/app/lib/frontend/templates/listing.dart
@@ -26,7 +26,10 @@ String renderPagination(PageLinks pageLinks) {
 }
 
 /// Renders the `views/pkg/package_list.mustache` template.
-String renderPackageList(List<PackageView> packages) {
+String renderPackageList(
+  List<PackageView> packages, {
+  SearchQuery searchQuery,
+}) {
   final packagesJson = [];
   for (int i = 0; i < packages.length; i++) {
     final view = packages[i];
@@ -63,6 +66,8 @@ String renderPackageList(List<PackageView> packages) {
           view.publisherId == null ? null : urls.publisherUrl(view.publisherId),
       'tags_html': renderTags(
         view.platforms,
+        searchQuery: searchQuery,
+        tags: view.tags,
         isAwaiting: view.isAwaiting,
         isDiscontinued: view.isDiscontinued,
         isLegacy: view.isLegacy,
@@ -120,7 +125,7 @@ String renderPkgIndexPage(
     'sort_control_html': renderSortControl(searchQuery),
     'is_search': isSearch,
     'title': topPackages,
-    'package_list_html': renderPackageList(packages),
+    'package_list_html': renderPackageList(packages, searchQuery: searchQuery),
     'has_packages': packages.isNotEmpty,
     'pagination': renderPagination(links),
     'search_query': searchQuery?.query,

--- a/app/lib/frontend/templates/misc.dart
+++ b/app/lib/frontend/templates/misc.dart
@@ -5,8 +5,11 @@
 import 'package:meta/meta.dart';
 
 import '../../package/models.dart';
+import '../../search/search_service.dart' show SearchQuery;
 import '../../shared/markdown.dart';
+import '../../shared/tags.dart';
 import '../../shared/urls.dart' as urls;
+import '../request_context.dart';
 
 import '_cache.dart';
 import '_consts.dart';
@@ -92,6 +95,8 @@ String renderMiniList(List<PackageView> packages) {
         'ellipsized_description': package.ellipsizedDescription,
         'tags_html': renderTags(
           package.platforms,
+          searchQuery: null,
+          tags: package.tags,
           isAwaiting: package.isAwaiting,
           isDiscontinued: package.isDiscontinued,
           isLegacy: package.isLegacy,
@@ -107,39 +112,77 @@ String renderMiniList(List<PackageView> packages) {
 /// Renders the tags using the pkg/tags template.
 String renderTags(
   List<String> platforms, {
+  @required SearchQuery searchQuery,
+  @required List<String> tags,
   @required bool isAwaiting,
   @required bool isDiscontinued,
   @required bool isLegacy,
   @required bool isObsolete,
   String packageName,
 }) {
-  final List<Map> tags = <Map>[];
+  final List<Map> tabValues = <Map>[];
   if (isAwaiting) {
-    tags.add({
+    tabValues.add({
       'status': 'missing',
       'text': '[awaiting]',
       'title': 'Analysis should be ready soon.',
     });
   } else if (isDiscontinued) {
-    tags.add({
+    tabValues.add({
       'status': 'discontinued',
       'text': '[discontinued]',
       'title': 'Package was discontinued.',
     });
   } else if (isObsolete) {
-    tags.add({
+    tabValues.add({
       'status': 'missing',
       'text': '[outdated]',
       'title': 'Package version too old, check latest stable.',
     });
   } else if (isLegacy) {
-    tags.add({
+    tabValues.add({
       'status': 'legacy',
       'text': 'Dart 2 incompatible',
       'title': 'Package does not support Dart 2.',
     });
+  } else if (requestContext.isExperimental) {
+    if (searchQuery?.sdk == null) {
+      tabValues.addAll(
+        tags.where((s) => s.startsWith('sdk:')).map(
+          (tag) {
+            final value = tag.split(':').last;
+            return {
+              'text': value,
+              'href': urls.searchUrl(sdk: value),
+              'title': tag,
+            };
+          },
+        ),
+      );
+    } else {
+      String prefix;
+      if (searchQuery.sdk == SdkTagValue.dart) {
+        prefix = 'runtime:';
+      } else if (searchQuery.sdk == SdkTagValue.flutter) {
+        prefix = 'platform:';
+      }
+      if (prefix != null) {
+        tabValues.addAll(
+          tags.where((s) => s.startsWith(prefix)).map(
+            (tag) {
+              final value = tag.split(':').last;
+              return {
+                'text': value,
+                // TODO: link to platform/runtime-based search
+                'title': tag,
+              };
+            },
+          ),
+        );
+      }
+    }
   } else if (platforms != null && platforms.isNotEmpty) {
-    tags.addAll(platforms.map((platform) {
+    tabValues.addAll(platforms.map((platform) {
       final platformDict = getPlatformDict(platform, nullIfMissing: true);
       return {
         'text': platformDict?.name ?? platform,
@@ -148,14 +191,14 @@ String renderTags(
       };
     }));
   } else {
-    tags.add({
+    tabValues.add({
       'status': 'unidentified',
       'text': '[unidentified]',
       'title': 'Check the analysis tab for further details.',
       'href': urls.analysisTabUrl(packageName),
     });
   }
-  return templateCache.renderTemplate('pkg/tags', {'tags': tags});
+  return templateCache.renderTemplate('pkg/tags', {'tags': tabValues});
 }
 
 /// Renders the simplified version of the circle with 'sdk' text content instead

--- a/app/lib/frontend/templates/misc.dart
+++ b/app/lib/frontend/templates/misc.dart
@@ -148,6 +148,7 @@ String renderTags(
   } else if (requestContext.isExperimental) {
     if (searchQuery?.sdk == null) {
       tabValues.addAll(
+        // TODO: sort tags
         tags.where((s) => s.startsWith('sdk:')).map(
           (tag) {
             final value = tag.split(':').last;
@@ -168,6 +169,7 @@ String renderTags(
       }
       if (prefix != null) {
         tabValues.addAll(
+          // TODO: sort tags
           tags.where((s) => s.startsWith(prefix)).map(
             (tag) {
               final value = tag.split(':').last;

--- a/app/lib/frontend/templates/package.dart
+++ b/app/lib/frontend/templates/package.dart
@@ -226,6 +226,8 @@ String renderPkgHeader(Package package, PackageVersion selectedVersion,
     metadataHtml: metadataHtml,
     tagsHtml: renderTags(
       analysis?.platforms,
+      searchQuery: null,
+      tags: analysis?.derivedTags,
       isAwaiting: isAwaiting,
       isDiscontinued: package.isDiscontinued,
       isLegacy: card?.isLegacy ?? false,

--- a/app/lib/frontend/templates/publisher.dart
+++ b/app/lib/frontend/templates/publisher.dart
@@ -107,7 +107,9 @@ String renderPublisherPackagesPage({
         : '<code>${publisher.publisherId}</code> has no packages.';
   }
 
-  final packageListHtml = packages.isEmpty ? '' : renderPackageList(packages);
+  final packageListHtml = packages.isEmpty
+      ? ''
+      : renderPackageList(packages, searchQuery: searchQuery);
   final paginationHtml = renderPagination(pageLinks);
 
   final tabContent = [

--- a/app/lib/package/models.dart
+++ b/app/lib/package/models.dart
@@ -399,6 +399,7 @@ class PackageView extends Object with FlagMixin {
   final bool isAwaiting;
   final double overallScore;
   final List<String> platforms;
+  final List<String> tags;
   final bool isNewPackage;
   final List<ApiPageRef> apiPages;
 
@@ -415,6 +416,7 @@ class PackageView extends Object with FlagMixin {
     this.isAwaiting = false,
     this.overallScore,
     this.platforms,
+    this.tags,
     this.isNewPackage,
     this.apiPages,
   });
@@ -447,6 +449,7 @@ class PackageView extends Object with FlagMixin {
       isAwaiting: isAwaiting,
       overallScore: scoreCard?.overallScore,
       platforms: scoreCard?.platformTags,
+      tags: scoreCard?.derivedTags,
       isNewPackage: package?.isNewPackage(),
       apiPages: apiPages,
     );
@@ -466,6 +469,7 @@ class PackageView extends Object with FlagMixin {
       isAwaiting: isAwaiting,
       overallScore: overallScore,
       platforms: platforms,
+      tags: tags,
       isNewPackage: isNewPackage,
       apiPages: apiPages ?? this.apiPages,
     );

--- a/app/lib/package/models.g.dart
+++ b/app/lib/package/models.g.dart
@@ -20,6 +20,7 @@ PackageView _$PackageViewFromJson(Map<String, dynamic> json) {
     isAwaiting: json['isAwaiting'] as bool,
     overallScore: (json['overallScore'] as num)?.toDouble(),
     platforms: (json['platforms'] as List)?.map((e) => e as String)?.toList(),
+    tags: (json['tags'] as List)?.map((e) => e as String)?.toList(),
     isNewPackage: json['isNewPackage'] as bool,
     apiPages: (json['apiPages'] as List)
         ?.map((e) =>
@@ -49,6 +50,7 @@ Map<String, dynamic> _$PackageViewToJson(PackageView instance) {
   writeNotNull('isAwaiting', instance.isAwaiting);
   writeNotNull('overallScore', instance.overallScore);
   writeNotNull('platforms', instance.platforms);
+  writeNotNull('tags', instance.tags);
   writeNotNull('isNewPackage', instance.isNewPackage);
   writeNotNull('apiPages', instance.apiPages);
   return val;


### PR DESCRIPTION
- sdk:X tags are displayed with a link (to `/X/packages`)
- platform:Y and runtime:Y tags are displayed only as text (Y)
- all of these will have a title="prefix:value"
