### PR TITLE
Remove Platforms block on analysis tab.

### DIFF
--- a/app/lib/frontend/templates/package_analysis.dart
+++ b/app/lib/frontend/templates/package_analysis.dart
@@ -66,8 +66,6 @@ String renderAnalysisTab(String package, String sdkConstraint,
     'dart_sdk_version': analysis.dartSdkVersion,
     'pana_version': analysis.panaVersion,
     'flutter_version': analysis.flutterVersion,
-    'platforms_html': analysis.platforms?.join(', ') ?? '<i>unsure</i>',
-    'platforms_reason_html': markdownToHtml(analysis.platformsReason, null),
     'analysis_suggestions_html':
         _renderSuggestionBlockHtml('Analysis', analysis.panaSuggestions),
     'health_suggestions_html':

--- a/app/lib/frontend/templates/views/pkg/analysis_tab.mustache
+++ b/app/lib/frontend/templates/views/pkg/analysis_tab.mustache
@@ -84,11 +84,6 @@
   <li>pana: {{pana_version}}</li>
 {{#flutter_version}}<li>Flutter: {{flutter_version}}</li>{{/flutter_version}}
 </ul>
-
-<h4>Platforms</h4>
-
-<p>Detected platforms: {{& platforms_html}}</p>
-<blockquote>{{& platforms_reason_html}}</blockquote>
 {{/show_analysis}}
 
 {{& analysis_suggestions_html}}

--- a/app/test/frontend/golden/analysis_tab_aborted.html
+++ b/app/test/frontend/golden/analysis_tab_aborted.html
@@ -105,9 +105,4 @@
     <li>Dart: 2.0.0-dev.7.0</li>
     <li>pana: 0.6.2</li>
   </ul>
-  <h4>Platforms</h4>
-  <p>Detected platforms: 
-    <i>unsure</i>
-  </p>
-  <blockquote></blockquote>
 </fragment>

--- a/app/test/frontend/golden/analysis_tab_http.html
+++ b/app/test/frontend/golden/analysis_tab_http.html
@@ -105,13 +105,6 @@
     <li>Dart: 2.1.0</li>
     <li>pana: 0.12.6</li>
   </ul>
-  <h4>Platforms</h4>
-  <p>Detected platforms: flutter, web, other</p>
-  <blockquote>
-    <p>No platform restriction found in primary library 
-      <code>package:http/http.dart</code>.
-    </p>
-  </blockquote>
   <h4>Maintenance suggestions</h4>
   <div class="suggestion-row">
     <div class="suggestion-title">

--- a/app/test/frontend/golden/analysis_tab_mock.html
+++ b/app/test/frontend/golden/analysis_tab_mock.html
@@ -105,11 +105,6 @@
     <li>Dart: 2.0.0-dev.7.0</li>
     <li>pana: 0.6.2</li>
   </ul>
-  <h4>Platforms</h4>
-  <p>Detected platforms: web</p>
-  <blockquote>
-    <p>All libraries agree.</p>
-  </blockquote>
   <h4>Health issues and suggestions</h4>
   <div class="suggestion-row">
     <div class="suggestion-title">

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -301,11 +301,6 @@ import 'package:foobar_pkg/foolib.dart';
                 <li>Dart: 2.0.0-dev.7.0</li>
                 <li>pana: 0.6.2</li>
               </ul>
-              <h4>Platforms</h4>
-              <p>Detected platforms: 
-                <i>unsure</i>
-              </p>
-              <blockquote></blockquote>
               <h4>Dependencies</h4>
               <div class="overflow-x">
                 <table class="dependency-table">

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -293,9 +293,6 @@ import 'package:foobar_pkg/foolib.dart';
                 <li>pana: 0.6.2</li>
                 <li>Flutter: 0.0.18</li>
               </ul>
-              <h4>Platforms</h4>
-              <p>Detected platforms: flutter</p>
-              <blockquote></blockquote>
             </section>
           </div>
           <aside class="detail-info-box">

--- a/app/test/frontend/golden/pkg_show_page_publisher.html
+++ b/app/test/frontend/golden/pkg_show_page_publisher.html
@@ -278,11 +278,6 @@ import 'package:lithium/lib/lithium.dart';
                 <li>Dart: </li>
                 <li>pana: </li>
               </ul>
-              <h4>Platforms</h4>
-              <p>Detected platforms: 
-                <i>unsure</i>
-              </p>
-              <blockquote></blockquote>
               <h4>Dependencies</h4>
               <div class="overflow-x">
                 <table class="dependency-table">

--- a/app/test/frontend/golden/pkg_show_version_page.html
+++ b/app/test/frontend/golden/pkg_show_version_page.html
@@ -291,11 +291,6 @@ import 'package:foobar_pkg/foolib.dart';
                 <li>Dart: 2.0.0-dev.7.0</li>
                 <li>pana: 0.6.2</li>
               </ul>
-              <h4>Platforms</h4>
-              <p>Detected platforms: 
-                <i>unsure</i>
-              </p>
-              <blockquote></blockquote>
               <h4>Dependencies</h4>
               <div class="overflow-x">
                 <table class="dependency-table">


### PR DESCRIPTION
- The list of the `platformTags` is no longer relevant.
- The resolution reason may be helpful in some cases, but traditionally only for us, developers probably need a different structure in the analysis.