### PR TITLE
Updated Job scheduling and dartdoc processing.

### DIFF
--- a/app/lib/analyzer/pana_runner.dart
+++ b/app/lib/analyzer/pana_runner.dart
@@ -43,6 +43,15 @@ class AnalyzerJobProcessor extends JobProcessor {
       return JobStatus.skipped;
     }
 
+    // We know that pana will fail on this package, no reason to run it.
+    if (packageStatus.isLegacy) {
+      _logger.info('Package is on legacy SDK: $job.');
+      final summary =
+          createPanaSummaryForLegacy(job.packageName, job.packageVersion);
+      await _storeScoreCard(job, summary);
+      return JobStatus.skipped;
+    }
+
     if (packageStatus.isDiscontinued) {
       _logger.info('Package is discontinued: $job.');
       await _storeScoreCard(job, null);
@@ -53,14 +62,6 @@ class AnalyzerJobProcessor extends JobProcessor {
       _logger
           .info('Package is older than two years and has newer release: $job.');
       await _storeScoreCard(job, null);
-      return JobStatus.skipped;
-    }
-
-    if (packageStatus.isLegacy) {
-      _logger.info('Package is on legacy SDK: $job.');
-      final summary =
-          createPanaSummaryForLegacy(job.packageName, job.packageVersion);
-      await _storeScoreCard(job, summary);
       return JobStatus.skipped;
     }
 

--- a/app/lib/analyzer/pana_runner.dart
+++ b/app/lib/analyzer/pana_runner.dart
@@ -38,6 +38,7 @@ class AnalyzerJobProcessor extends JobProcessor {
   Future<JobStatus> process(Job job) async {
     final packageStatus = await scoreCardBackend.getPackageStatus(
         job.packageName, job.packageVersion);
+    // In case the package was deleted between scheduling and the actual delete.
     if (!packageStatus.exists) {
       _logger.info('Package does not exist: $job.');
       return JobStatus.skipped;

--- a/app/lib/dartdoc/dartdoc_runner.dart
+++ b/app/lib/dartdoc/dartdoc_runner.dart
@@ -119,14 +119,35 @@ class DartdocJobProcessor extends JobProcessor {
       version,
       ReportType.dartdoc,
       updatedAfter: updated,
-      includeDiscontinued: true,
-      includeObsolete: true,
-      successThreshold: const Duration(days: 90),
     );
   }
 
   @override
   Future<JobStatus> process(Job job) async {
+    final packageStatus = await scoreCardBackend.getPackageStatus(
+        job.packageName, job.packageVersion);
+    if (!packageStatus.exists) {
+      _logger.info('Package does not exist: $job.');
+      return JobStatus.skipped;
+    }
+
+    // We know that dartdoc will fail on this package, no reason to run it.
+    if (packageStatus.isLegacy) {
+      _logger.info('Package is on legacy SDK: $job.');
+      await _storeScoreCard(job, _emptyReport());
+      return JobStatus.skipped;
+    }
+
+    // Do not check for discontinued status, we still generate documentation for
+    // such packages.
+
+    if (packageStatus.isObsolete) {
+      _logger
+          .info('Package is older than two years and has newer release: $job.');
+      await _storeScoreCard(job, _emptyReport());
+      return JobStatus.skipped;
+    }
+
     final logger =
         Logger('pub.dartdoc.runner/${job.packageName}/${job.packageVersion}');
     final tempDir =
@@ -278,9 +299,8 @@ class DartdocJobProcessor extends JobProcessor {
         score: 10.0,
       ));
     }
-    await scoreCardBackend.updateReport(
-        job.packageName,
-        job.packageVersion,
+    await _storeScoreCard(
+        job,
         DartdocReport(
           reportStatus: reportStatus,
           coverage: coverage?.percent ?? 0.0,
@@ -299,6 +319,13 @@ class DartdocJobProcessor extends JobProcessor {
     } else {
       return hasContent ? JobStatus.success : JobStatus.failed;
     }
+  }
+
+  Future _storeScoreCard(Job job, DartdocReport report) async {
+    await scoreCardBackend.updateReport(
+        job.packageName, job.packageVersion, report);
+    await scoreCardBackend.updateScoreCard(job.packageName, job.packageVersion);
+    await dartdocBackend.removeObsolete(job.packageName, job.packageVersion);
   }
 
   Future<bool> _resolveDependencies(
@@ -515,3 +542,11 @@ String _mergeOutput(ProcessResult pr, {bool compressStdout = false}) {
   }
   return 'exitCode: ${pr.exitCode}\nstdout: $stdout\nstderr: ${pr.stderr}\n';
 }
+
+DartdocReport _emptyReport() => DartdocReport(
+      reportStatus: ReportStatus.aborted,
+      coverage: 0.0,
+      coverageScore: 0.0,
+      healthSuggestions: [],
+      maintenanceSuggestions: [],
+    );

--- a/app/lib/dartdoc/dartdoc_runner.dart
+++ b/app/lib/dartdoc/dartdoc_runner.dart
@@ -126,6 +126,7 @@ class DartdocJobProcessor extends JobProcessor {
   Future<JobStatus> process(Job job) async {
     final packageStatus = await scoreCardBackend.getPackageStatus(
         job.packageName, job.packageVersion);
+    // In case the package was deleted between scheduling and the actual delete.
     if (!packageStatus.exists) {
       _logger.info('Package does not exist: $job.');
       return JobStatus.skipped;


### PR DESCRIPTION
This should address the underlying problem of #3168.

- Updated `ScoreCardBackend.shouldUpdateReport` to be based only on the report's existence or updated time, package status flags are handled in the runners.
- `pana_runner` was already checking for the legacy and obsolete status and created an empty report on it, doing the same for `dartdoc_runner`.
- `pana_runner` also checks for discontinued status, which we don't do for `dartdoc_runner`.
- The legacy block ordering in `pana_runner` is purely aesthetics, I wanted to start the rejection logic with that.
- Lowered `successThreshold` for `dartdoc_runner`, because I think we may schedule old dartdoc results for deletion anyway.