### PR TITLE
Trust version number provided by package:pana.

### DIFF
--- a/app/lib/shared/versions.dart
+++ b/app/lib/shared/versions.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:pana/pana.dart' as pana;
 import 'package:pub_semver/pub_semver.dart';
 
 import 'utils.dart' show isNewer;
@@ -38,8 +39,8 @@ final blacklistedRuntimeVersions = ['2019.12.05', '2019.12.05+1'];
 final String runtimeSdkVersion = '2.7.0';
 final String toolEnvSdkVersion = '2.7.0';
 
-// keep in-sync with app/pubspec.yaml
-final String panaVersion = '0.13.2';
+// Value comes from package:pana.
+final String panaVersion = pana.packageVersion;
 final Version semanticPanaVersion = Version.parse(panaVersion);
 
 final String flutterVersion = '1.12.13+hotfix.5';

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -41,7 +41,6 @@ dependencies:
   stream_transform: ^0.0.20
   yaml: '^2.1.12'
   # pana version to be pinned
-  # keep in-sync with app/lib/shared/versions.dart
   pana: '0.13.2'
   # 3rd-party packages with pinned versions
   archive: '2.0.11'


### PR DESCRIPTION
One of the `shared/versions_test` will test if this value is the same as the version value in the resolved `pubspec.lock`.