### PR TITLE
Use search service in integration tests.

### DIFF
--- a/app/lib/shared/configuration.dart
+++ b/app/lib/shared/configuration.dart
@@ -205,7 +205,8 @@ class Configuration {
 
   /// Configuration for pkg/fake_pub_server.
   factory Configuration.fakePubServer({
-    @required int port,
+    @required int frontendPort,
+    @required int searchPort,
     @required String storageBaseUrl,
   }) {
     return Configuration(
@@ -215,7 +216,7 @@ class Configuration {
       popularityDumpBucketName: 'fake-bucket-popularity',
       searchSnapshotBucketName: 'fake-bucket-search',
       backupSnapshotBucketName: 'fake-bucket-backup',
-      searchServicePrefix: 'http://localhost:$port',
+      searchServicePrefix: 'http://localhost:$searchPort',
       storageBaseUrl: storageBaseUrl,
       pubClientAudience: null,
       pubSiteAudience: null,
@@ -223,8 +224,8 @@ class Configuration {
       blockEmails: true,
       blockRobots: true,
       productionHosts: ['localhost'],
-      primaryApiUri: Uri.parse('http://localhost:$port/'),
-      primarySiteUri: Uri.parse('http://localhost:$port/'),
+      primaryApiUri: Uri.parse('http://localhost:$frontendPort/'),
+      primarySiteUri: Uri.parse('http://localhost:$frontendPort/'),
       admins: [
         AdminId(
           oauthUserId: 'admin-pub-dev',

--- a/pkg/fake_pub_server/bin/fake_pub_server.dart
+++ b/pkg/fake_pub_server/bin/fake_pub_server.dart
@@ -1,20 +1,31 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'package:args/args.dart';
+import 'package:http/http.dart';
 import 'package:logging/logging.dart';
 
+import 'package:fake_gcloud/mem_datastore.dart';
 import 'package:fake_gcloud/mem_storage.dart';
 import 'package:fake_pub_server/fake_pub_server.dart';
+import 'package:fake_pub_server/fake_search_service.dart';
 import 'package:fake_pub_server/fake_storage_server.dart';
+import 'package:pub_dev/shared/configuration.dart';
 
 final _argParser = ArgParser()
   ..addOption('port',
       defaultsTo: '8080', help: 'The HTTP port of the fake pub server.')
   ..addOption('storage-port',
-      defaultsTo: '8081', help: 'The HTTP port for the fake storage server.');
+      defaultsTo: '8081', help: 'The HTTP port for the fake storage server.')
+  ..addOption('search-port',
+      defaultsTo: '8082', help: 'The HTTP port for the fake search service.');
 
 Future main(List<String> args) async {
   final argv = _argParser.parse(args);
   final port = int.parse(argv['port'] as String);
   final storagePort = int.parse(argv['storage-port'] as String);
+  final searchPort = int.parse(argv['search-port'] as String);
 
   Logger.root.onRecord.listen((r) {
     print([
@@ -25,16 +36,38 @@ Future main(List<String> args) async {
     ].where((e) => e != null).join(' '));
   });
 
+  final datastore = MemDatastore();
   final storage = MemStorage();
 
   final storageServer = FakeStorageServer(storage);
-  final pubServer = FakePubServer(storage);
+  final pubServer = FakePubServer(datastore, storage);
+  final searchService = FakeSearchService(datastore, storage);
+
+  final configuration = Configuration.fakePubServer(
+    frontendPort: port,
+    storageBaseUrl: 'http://localhost:$storagePort',
+    searchPort: searchPort,
+  );
+
+  // On each non-read request, we trigger an update of the search index in
+  // `fake_search_service`.
+  Future<void> onHttpFn(String method, Uri uri) async {
+    if (method == 'HEAD' || method == 'GET') return;
+    await post('http://localhost:$searchPort/fake-update-all');
+  }
 
   await Future.wait(
     [
       storageServer.run(port: storagePort),
       pubServer.run(
-          port: port, storageBaseUrl: 'http://localhost:$storagePort'),
+        port: port,
+        configuration: configuration,
+        onHttpFn: onHttpFn,
+      ),
+      searchService.run(
+        port: searchPort,
+        configuration: configuration,
+      ),
     ],
     eagerError: true,
   );

--- a/pkg/fake_pub_server/lib/fake_search_service.dart
+++ b/pkg/fake_pub_server/lib/fake_search_service.dart
@@ -1,0 +1,69 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:fake_gcloud/mem_datastore.dart';
+import 'package:fake_gcloud/mem_storage.dart';
+import 'package:gcloud/db.dart';
+import 'package:gcloud/service_scope.dart' as ss;
+import 'package:gcloud/storage.dart';
+import 'package:logging/logging.dart';
+import 'package:meta/meta.dart';
+import 'package:shelf/shelf.dart' as shelf;
+import 'package:shelf/shelf_io.dart';
+
+import 'package:pub_dev/frontend/static_files.dart';
+import 'package:pub_dev/search/handlers.dart';
+import 'package:pub_dev/search/updater.dart';
+import 'package:pub_dev/shared/configuration.dart';
+import 'package:pub_dev/shared/handler_helpers.dart';
+import 'package:pub_dev/service/services.dart';
+
+final _logger = Logger('fake_search_service');
+
+class FakeSearchService {
+  final MemDatastore _datastore;
+  final MemStorage _storage;
+
+  FakeSearchService(this._datastore, this._storage);
+
+  Future<void> run({
+    int port = 8082,
+    @required Configuration configuration,
+  }) async {
+    await updateLocalBuiltFiles();
+    await ss.fork(() async {
+      final db = DatastoreDB(_datastore);
+      registerDbService(db);
+      registerStorageService(_storage);
+      registerActiveConfiguration(configuration);
+
+      await withPubServices(() async {
+        await ss.fork(() async {
+          final handler = wrapHandler(_logger, searchServiceHandler);
+          final server = await IOServer.bind('localhost', port);
+          serveRequests(server.server, (request) async {
+            return await ss.fork(() async {
+              if (request.requestedUri.path == '/fake-update-all') {
+                // ignore: invalid_use_of_visible_for_testing_member
+                await indexUpdater.updateAllPackages();
+                return shelf.Response.ok('');
+              }
+              return await handler(request);
+            }) as shelf.Response;
+          });
+          _logger.info('fake_search_service running on port $port');
+
+          await ProcessSignal.sigterm.watch().first;
+
+          _logger.info('fake_search_service shutting down');
+          await server.close();
+          _logger.info('closing');
+        });
+      });
+    });
+  }
+}

--- a/pkg/fake_pub_server/lib/fake_storage_server.dart
+++ b/pkg/fake_pub_server/lib/fake_storage_server.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/pkg/fake_pub_server/pubspec.lock
+++ b/pkg/fake_pub_server/pubspec.lock
@@ -35,7 +35,7 @@ packages:
       name: appengine
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.1"
+    version: "0.10.4"
   archive:
     dependency: transitive
     description:
@@ -239,6 +239,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.2.11"
+  grpc:
+    dependency: transitive
+    description:
+      name: grpc
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.3"
   html:
     dependency: transitive
     description:
@@ -462,7 +469,7 @@ packages:
       name: protobuf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.1"
+    version: "1.0.1"
   pub_dartdoc_data:
     dependency: transitive
     description:

--- a/pkg/fake_pub_server/pubspec.lock
+++ b/pkg/fake_pub_server/pubspec.lock
@@ -35,7 +35,7 @@ packages:
       name: appengine
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.10.3"
+    version: "0.6.1"
   archive:
     dependency: transitive
     description:
@@ -239,13 +239,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.2.11"
-  grpc:
-    dependency: transitive
-    description:
-      name: grpc
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.1.3"
   html:
     dependency: transitive
     description:
@@ -441,7 +434,7 @@ packages:
       name: pana
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.1+4"
+    version: "0.13.2"
   path:
     dependency: transitive
     description:
@@ -469,7 +462,7 @@ packages:
       name: protobuf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "0.9.1"
   pub_dartdoc_data:
     dependency: transitive
     description:

--- a/pkg/pub_integration/lib/script/publisher.dart
+++ b/pkg/pub_integration/lib/script/publisher.dart
@@ -70,7 +70,8 @@ class PublisherScript {
       await Future.delayed(Duration(seconds: 1));
       await _verifyDummyPkg(version: '2.0.0', publisherId: 'example.com');
 
-      // TODO: verify publisher page (after the search index picks up the package)
+      await _pubHttpClient.forceSearchUpdate();
+      await _verifyPublisherPackageListPage();
 
       await _verifyPublisherListPage();
 
@@ -158,6 +159,13 @@ class PublisherScript {
       if (!pageHtml.contains('href="/publishers/$publisherId"')) {
         throw Exception('Publisher link not found on the package page.');
       }
+    }
+  }
+
+  Future<void> _verifyPublisherPackageListPage() async {
+    final html = await _pubHttpClient.getPublisherPage('example.com');
+    if (!html.contains('href="/packages/_dummy_pkg"')) {
+      throw Exception('Does not contain link to package.');
     }
   }
 

--- a/pkg/pub_integration/lib/src/fake_pub_server_process.dart
+++ b/pkg/pub_integration/lib/src/fake_pub_server_process.dart
@@ -25,6 +25,7 @@ class FakePubServerProcess {
     String pkgDir,
     int port,
     int storagePort,
+    int searchPort,
   }) async {
     final vmArgs = (Platform.environment['FAKE_PUB_SERVER_VM_ARGS'] ?? '')
         .split(' ')
@@ -34,6 +35,7 @@ class FakePubServerProcess {
     // TODO: check for free port
     port ??= 20000 + _random.nextInt(990);
     storagePort ??= port + 1;
+    searchPort ??= port + 2;
 
     final pr1 = await Process.run('pub', ['get'], workingDirectory: pkgDir);
     if (pr1.exitCode != 0) {
@@ -46,6 +48,7 @@ class FakePubServerProcess {
         'bin/fake_pub_server.dart',
         '--port=$port',
         '--storage-port=$storagePort',
+        '--search-port=$searchPort',
       ],
       workingDirectory: pkgDir,
     );

--- a/pkg/pub_integration/lib/src/pub_http_client.dart
+++ b/pkg/pub_integration/lib/src/pub_http_client.dart
@@ -20,6 +20,10 @@ class PubHttpClient {
   }
 
   /// Forces the search index to update.
+  ///
+  /// This works only with the local fake_pub_server instance, because the
+  /// current implementation is blocking the search instance, and we don't want
+  /// to expose such functionality in production.
   Future<void> forceSearchUpdate() async {
     final url = '$pubHostedUrl/fake-update-search';
     final rs = await _http.post(url);

--- a/pkg/pub_integration/lib/src/pub_http_client.dart
+++ b/pkg/pub_integration/lib/src/pub_http_client.dart
@@ -19,6 +19,17 @@ class PubHttpClient {
     }
   }
 
+  /// Forces the search index to update.
+  Future<void> forceSearchUpdate() async {
+    final url = '$pubHostedUrl/fake-update-search';
+    final rs = await _http.post(url);
+    if (rs.statusCode == 200) {
+      return;
+    }
+    throw UnsupportedError(
+        'Forced search update is supported only on fake pub server.');
+  }
+
   /// Get the latest version name of a package.
   Future<String> getLatestVersionName(String package) async {
     final url = '$pubHostedUrl/api/packages/$package';

--- a/pkg/pub_integration/test/browser_test.dart
+++ b/pkg/pub_integration/test/browser_test.dart
@@ -58,5 +58,5 @@ void main() {
         },
       );
     });
-  }, timeout: Timeout.factor(2));
+  }, timeout: Timeout.factor(3));
 }

--- a/pkg/pub_integration/test/dev_version_test.dart
+++ b/pkg/pub_integration/test/dev_version_test.dart
@@ -54,5 +54,5 @@ void main() {
       );
       await script.verify(true);
     });
-  }, timeout: Timeout.factor(2));
+  }, timeout: Timeout.factor(3));
 }

--- a/pkg/pub_integration/test/pub_integration_test.dart
+++ b/pkg/pub_integration/test/pub_integration_test.dart
@@ -66,5 +66,5 @@ void main() {
         inviteCompleterFn: inviteCompleterFn,
       );
     });
-  }, timeout: Timeout.factor(2));
+  }, timeout: Timeout.factor(3));
 }

--- a/pkg/pub_integration/test/publisher_test.dart
+++ b/pkg/pub_integration/test/publisher_test.dart
@@ -68,5 +68,5 @@ void main() {
       );
       await script.verify();
     });
-  }, timeout: Timeout.factor(2));
+  }, timeout: Timeout.factor(3));
 }


### PR DESCRIPTION
To make the test reasonable (*), I've added a callback mechanism that triggers a search index update after a non-read HTTP request to the frontend server.

(*) Otherwise we'll need to trigger it in some other way, e.g. HTTP request, which would then be filtered out from tests against staging or prod.