### PR TITLE
Parse source maps + JS/CSS code coverage.

### DIFF
--- a/pkg/code_coverage/build.sh
+++ b/pkg/code_coverage/build.sh
@@ -66,5 +66,8 @@ ls -1 "${PUB_INTEGRATION_DIR}/test" | grep .dart$ | xargs -n 1 -I ZZZ dart \
 
 ## Processing coverage
 
+echo "Converting browser coverages to LCOV"
+dart lib/source_map_coverage.dart
+
 echo "Generating report..."
 dart lib/format_lcov.dart

--- a/pkg/code_coverage/lib/source_map_coverage.dart
+++ b/pkg/code_coverage/lib/source_map_coverage.dart
@@ -1,0 +1,127 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:meta/meta.dart';
+import 'package:path/path.dart';
+import 'package:source_maps/parser.dart';
+
+Future<void> main() async {
+  await _process(
+    resourceUri: '/static/js/script.dart.js',
+    coveragePath: 'build/browser/js-coverage.json',
+    outputPath: 'build/lcov/js-coverage.json.info',
+  );
+
+  await _process(
+    resourceUri: '/static/css/style.css',
+    coveragePath: 'build/browser/css-coverage.json',
+    outputPath: 'build/lcov/css-coverage.json.info',
+  );
+}
+
+Future<void> _process({
+  @required Pattern resourceUri,
+  String compiledPath,
+  String mapPath,
+  @required String coveragePath,
+  @required String outputPath,
+}) async {
+  compiledPath ??= '../..$resourceUri';
+  mapPath ??= '$compiledPath.map';
+
+  final sm = parse(File(mapPath).readAsStringSync()) as SingleMapping;
+
+  // Initialize line counts with 0 for all the known lines.
+  final sourceCoverage = <String, Map<int, int>>{};
+  for (final e in sm.lines.expand((l) => l.entries)) {
+    if (e.sourceUrlId == null) continue;
+    final sourceUrl = sm.urls[e.sourceUrlId];
+    if (sourceUrl.startsWith('org-dartlang-sdk:')) continue;
+    final counts = sourceCoverage.putIfAbsent(sourceUrl, () => <int, int>{});
+    counts[e.sourceLine] = 0;
+  }
+
+  // Returns the source map location for [line] and [column] in the compiled file.
+  // [line] and [column] is starting from 1
+
+  // Returns `null` if the position is invalid or if there is no mapping.
+  TargetEntry _sourceLines(int line, int column) {
+    try {
+      final entries = sm.lines[line - 1].entries;
+      // TargetEntry.column is 0-indexed
+      return entries.lastWhere((e) => e.column < column, orElse: () => null);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  final compiled = File(compiledPath).readAsStringSync();
+  final compiledLines = compiled.split('\n');
+
+  // Returns the compiled code source position for [offset].
+  _Position _compiledPosition(int offset) {
+    int line = 0;
+    while (line < compiledLines.length && offset > compiledLines[line].length) {
+      offset -= compiledLines[line].length + 1;
+      line++;
+    }
+    return _Position(line + 1, offset + 1);
+  }
+
+  // load coverages
+  final coverageRoot = json.decode(File(coveragePath).readAsStringSync())
+      as Map<String, dynamic>;
+  final coverageKey = coverageRoot.keys
+      .firstWhere((key) => resourceUri.allMatches(key).isNotEmpty);
+  final coverage = coverageRoot[coverageKey] as Map<String, dynamic>;
+  final rangesList = (coverage['ranges'] as List).cast<Map<String, dynamic>>();
+
+  // process coverages
+  rangesList
+      .map((r) => _Range(r['start'] as int, r['end'] as int))
+      .expand((r) => List<int>.generate(r.end - r.start, (i) => i + r.start))
+      .map(_compiledPosition)
+      .map((s) => _sourceLines(s.line, s.column))
+      .where((e) => e != null && e.sourceUrlId != null)
+      .forEach(
+    (e) {
+      final sourceUrl = sm.urls[e.sourceUrlId];
+      if (sourceUrl.startsWith('org-dartlang-sdk:')) return;
+      final counts = sourceCoverage.putIfAbsent(sourceUrl, () => <int, int>{});
+      counts[e.sourceLine] = 1;
+    },
+  );
+
+  // format results in the LCOV block format
+  final sources = sourceCoverage.keys.toList()..sort();
+  String _lcovSource(String source) {
+    final relativeFileName = relative(source, from: '../..');
+    final counts = sourceCoverage[source];
+    final lines = counts.keys.toList()..sort();
+    return [
+      'SF:$relativeFileName',
+      ...lines.map((line) => 'DA:$line,${counts[line]}'),
+      'end_of_record\n',
+    ].join('\n');
+  }
+
+  File(outputPath).writeAsStringSync(sources.map(_lcovSource).join());
+}
+
+class _Range {
+  final int start;
+  final int end;
+
+  _Range(this.start, this.end);
+}
+
+class _Position {
+  final int line;
+  final int column;
+
+  _Position(this.line, this.column);
+}

--- a/pkg/code_coverage/lib/source_map_coverage.dart
+++ b/pkg/code_coverage/lib/source_map_coverage.dart
@@ -9,6 +9,8 @@ import 'package:meta/meta.dart';
 import 'package:path/path.dart';
 import 'package:source_maps/parser.dart';
 
+/// Converts the browser-provided JS and CSS coverage information (using the
+/// compiled source maps) into LCOV format.
 Future<void> main() async {
   await _process(
     resourceUri: '/static/js/script.dart.js',

--- a/pkg/code_coverage/pubspec.lock
+++ b/pkg/code_coverage/pubspec.lock
@@ -275,7 +275,7 @@ packages:
     source: hosted
     version: "1.1.5"
   source_maps:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: source_maps
       url: "https://pub.dartlang.org"

--- a/pkg/code_coverage/pubspec.yaml
+++ b/pkg/code_coverage/pubspec.yaml
@@ -9,6 +9,7 @@ dependencies:
   coverage: ^0.13.0
   lcov: ^5.3.0
   path: ^1.0.0
+  source_maps: ^0.10.8
 
 dev_dependencies:
   test: ^1.5.1


### PR DESCRIPTION
- It seems that the JS code coverage is does not have all the original source lines, probably because some inlining happens.
- The mapping and coverage calculation is inefficient, but it is good enough that I don't think it would be worth to optimize it.
- `web_app` - 34.4%
-  `web_css` - 28.5%

