### PR TITLE
Refactor: search banner rendering.

### DIFF
--- a/app/lib/frontend/templates/views/layout.mustache
+++ b/app/lib/frontend/templates/views/layout.mustache
@@ -102,7 +102,21 @@
   </div>
 </header>
 
-{{& search_banner_html}}
+<div class="_banner-bg">
+  <div class="container{{#is_landing}} home-banner{{/is_landing}}">
+
+  {{#is_landing}}
+    <h2 class="_visuallyhidden">Dart package manager</h2>
+    <img class="logo" src="{{{landing_banner_image}}}" alt="{{landing_banner_alt}}" />
+  {{/is_landing}}
+
+  {{& search_banner_html}}
+
+  {{#is_landing}}
+    {{& landing_blurb_html }}
+  {{/is_landing}}
+  </div>
+</div>
 
 <div class="container">
   <main>

--- a/app/lib/frontend/templates/views/shared/search_banner.mustache
+++ b/app/lib/frontend/templates/views/shared/search_banner.mustache
@@ -2,40 +2,29 @@
     for details. All rights reserved. Use of this source code is governed by a
     BSD-style license that can be found in the LICENSE file. }}
 
-<div class="_banner-bg">
-  <div class="container">
-    <div class="{{& banner_class}}">
-      {{#show_landing}}
-      <h2 class="_visuallyhidden">Dart package manager</h2>
-      <img class="logo" src="{{{landing_banner_image}}}" alt="{{landing_banner_alt}}" />
-      {{/show_landing}}
-      <form class="search-bar" action="{{& search_form_url}}">
-        <input class="input" name="q" placeholder="{{search_query_placeholder}}" autocomplete="on" autofocus="autofocus"{{#search_query_html}} value="{{& search_query_html}}"{{/search_query_html}}/>
-        <button class="icon"></button>
-        {{#show_details}}
-        {{#search_sort_param}}<input type="hidden" name="sort" value="{{search_sort_param}}"/>{{/search_sort_param}}
-        <input id="search-legacy-field" type="hidden" name="legacy" value="1"{{^legacy_search_enabled}} disabled="disabled"{{/legacy_search_enabled}} />
-        {{/show_details}}
-        {{#hidden_inputs}}
-        <input type="hidden" name="{{name}}" value="{{value}}" />
-        {{/hidden_inputs}}
-      </form>
-      {{#show_details}}
-      <div class="search-bar-details">
-        {{& search_tabs_html }}
-        <div class="search-bar-options">
-          {{#show_legacy_checkbox}}
-          <input id="search-legacy-checkbox" type="checkbox" name="legacy" valye="1" {{#legacy_search_enabled}} checked="checked"{{/legacy_search_enabled}} />
-          <label for="search-legacy-checkbox">Include Dart 1.x results</label>
-          {{/show_legacy_checkbox}}
-          {{& secondary_tabs_html }}
-        </div>
-      </div>
-      {{/show_details}}
-      {{#show_landing}}
-        {{& search_tabs_html }}
-        {{& landing_blurb_html }}
-      {{/show_landing}}
-    </div>
+<form class="search-bar" action="{{& search_form_url}}">
+  <input class="input" name="q" placeholder="{{search_query_placeholder}}" autocomplete="on" autofocus="autofocus"{{#search_query_html}} value="{{& search_query_html}}"{{/search_query_html}}/>
+  <button class="icon"></button>
+  {{#show_details}}
+  {{#search_sort_param}}<input type="hidden" name="sort" value="{{search_sort_param}}"/>{{/search_sort_param}}
+  <input id="search-legacy-field" type="hidden" name="legacy" value="1"{{^legacy_search_enabled}} disabled="disabled"{{/legacy_search_enabled}} />
+  {{/show_details}}
+  {{#hidden_inputs}}
+  <input type="hidden" name="{{name}}" value="{{value}}" />
+  {{/hidden_inputs}}
+</form>
+{{#show_details}}
+<div class="search-bar-details">
+  {{& search_tabs_html }}
+  <div class="search-bar-options">
+    {{#show_legacy_checkbox}}
+    <input id="search-legacy-checkbox" type="checkbox" name="legacy" valye="1" {{#legacy_search_enabled}} checked="checked"{{/legacy_search_enabled}} />
+    <label for="search-legacy-checkbox">Include Dart 1.x results</label>
+    {{/show_legacy_checkbox}}
+    {{& secondary_tabs_html }}
   </div>
 </div>
+{{/show_details}}
+{{#show_landing}}
+  {{& search_tabs_html }}
+{{/show_landing}}

--- a/app/test/frontend/golden/authorized_page.html
+++ b/app/test/frontend/golden/authorized_page.html
@@ -71,12 +71,10 @@
     </header>
     <div class="_banner-bg">
       <div class="container">
-        <div class="small-banner">
-          <form class="search-bar" action="/packages">
-            <input class="input" name="q" placeholder="Search packages" autocomplete="on" autofocus="autofocus"/>
-            <button class="icon"></button>
-          </form>
-        </div>
+        <form class="search-bar" action="/packages">
+          <input class="input" name="q" placeholder="Search packages" autocomplete="on" autofocus="autofocus"/>
+          <button class="icon"></button>
+        </form>
       </div>
     </div>
     <div class="container">

--- a/app/test/frontend/golden/error_page.html
+++ b/app/test/frontend/golden/error_page.html
@@ -71,12 +71,10 @@
     </header>
     <div class="_banner-bg">
       <div class="container">
-        <div class="small-banner">
-          <form class="search-bar" action="/packages">
-            <input class="input" name="q" placeholder="Search packages" autocomplete="on" autofocus="autofocus"/>
-            <button class="icon"></button>
-          </form>
-        </div>
+        <form class="search-bar" action="/packages">
+          <input class="input" name="q" placeholder="Search packages" autocomplete="on" autofocus="autofocus"/>
+          <button class="icon"></button>
+        </form>
       </div>
     </div>
     <div class="container">

--- a/app/test/frontend/golden/landing_page.html
+++ b/app/test/frontend/golden/landing_page.html
@@ -71,25 +71,23 @@
       </div>
     </header>
     <div class="_banner-bg">
-      <div class="container">
-        <div class="home-banner">
-          <h2 class="_visuallyhidden">Dart package manager</h2>
-          <img class="logo" src="/static/img/dart-packages-white.png?hash=mocked_hash_308431268" alt="Dart packages"/>
-          <form class="search-bar" action="/packages">
-            <input class="input" name="q" placeholder="Search packages" autocomplete="on" autofocus="autofocus"/>
-            <button class="icon"></button>
-          </form>
-          <div class="list-filters">
-            <a class="filter " href="/dart/packages" title="Packages compatible with the Dart SDK">Dart</a>
-            <a class="filter " href="/flutter/packages" title="Packages compatible with the Flutter SDK">Flutter</a>
-            <a class="filter -active" href="/packages" title="Packages compatible with the any SDK">Any</a>
-          </div>
-          <p class="text">Find and use packages to build 
-            <a href="/flutter">Flutter</a> and 
-            <a href="/web">web</a> apps with 
-            <a target="_blank" rel="noopener" href="https://dart.dev">Dart</a>.
-          </p>
+      <div class="container home-banner">
+        <h2 class="_visuallyhidden">Dart package manager</h2>
+        <img class="logo" src="/static/img/dart-packages-white.png?hash=mocked_hash_308431268" alt="Dart packages"/>
+        <form class="search-bar" action="/packages">
+          <input class="input" name="q" placeholder="Search packages" autocomplete="on" autofocus="autofocus"/>
+          <button class="icon"></button>
+        </form>
+        <div class="list-filters">
+          <a class="filter " href="/dart/packages" title="Packages compatible with the Dart SDK">Dart</a>
+          <a class="filter " href="/flutter/packages" title="Packages compatible with the Flutter SDK">Flutter</a>
+          <a class="filter -active" href="/packages" title="Packages compatible with the any SDK">Any</a>
         </div>
+        <p class="text">Find and use packages to build 
+          <a href="/flutter">Flutter</a> and 
+          <a href="/web">web</a> apps with 
+          <a target="_blank" rel="noopener" href="https://dart.dev">Dart</a>.
+        </p>
       </div>
     </div>
     <div class="container">

--- a/app/test/frontend/golden/my_liked_packages.html
+++ b/app/test/frontend/golden/my_liked_packages.html
@@ -73,12 +73,10 @@
     </header>
     <div class="_banner-bg">
       <div class="container">
-        <div class="small-banner">
-          <form class="search-bar" action="/my-packages">
-            <input class="input" name="q" placeholder="Search your packages" autocomplete="on" autofocus="autofocus"/>
-            <button class="icon"></button>
-          </form>
-        </div>
+        <form class="search-bar" action="/my-packages">
+          <input class="input" name="q" placeholder="Search your packages" autocomplete="on" autofocus="autofocus"/>
+          <button class="icon"></button>
+        </form>
       </div>
     </div>
     <div class="container">

--- a/app/test/frontend/golden/my_packages.html
+++ b/app/test/frontend/golden/my_packages.html
@@ -73,12 +73,10 @@
     </header>
     <div class="_banner-bg">
       <div class="container">
-        <div class="small-banner">
-          <form class="search-bar" action="/my-packages">
-            <input class="input" name="q" placeholder="Search your packages" autocomplete="on" autofocus="autofocus"/>
-            <button class="icon"></button>
-          </form>
-        </div>
+        <form class="search-bar" action="/my-packages">
+          <input class="input" name="q" placeholder="Search your packages" autocomplete="on" autofocus="autofocus"/>
+          <button class="icon"></button>
+        </form>
       </div>
     </div>
     <div class="container">

--- a/app/test/frontend/golden/my_publishers.html
+++ b/app/test/frontend/golden/my_publishers.html
@@ -73,12 +73,10 @@
     </header>
     <div class="_banner-bg">
       <div class="container">
-        <div class="small-banner">
-          <form class="search-bar" action="/my-packages">
-            <input class="input" name="q" placeholder="Search your packages" autocomplete="on" autofocus="autofocus"/>
-            <button class="icon"></button>
-          </form>
-        </div>
+        <form class="search-bar" action="/my-packages">
+          <input class="input" name="q" placeholder="Search your packages" autocomplete="on" autofocus="autofocus"/>
+          <button class="icon"></button>
+        </form>
       </div>
     </div>
     <div class="container">

--- a/app/test/frontend/golden/pkg_admin_page_outdated.html
+++ b/app/test/frontend/golden/pkg_admin_page_outdated.html
@@ -74,12 +74,10 @@
     </header>
     <div class="_banner-bg">
       <div class="container">
-        <div class="small-banner">
-          <form class="search-bar" action="/packages">
-            <input class="input" name="q" placeholder="Search packages" autocomplete="on" autofocus="autofocus"/>
-            <button class="icon"></button>
-          </form>
-        </div>
+        <form class="search-bar" action="/packages">
+          <input class="input" name="q" placeholder="Search packages" autocomplete="on" autofocus="autofocus"/>
+          <button class="icon"></button>
+        </form>
       </div>
     </div>
     <div class="container">

--- a/app/test/frontend/golden/pkg_index_page.html
+++ b/app/test/frontend/golden/pkg_index_page.html
@@ -73,22 +73,20 @@
     </header>
     <div class="_banner-bg">
       <div class="container">
-        <div class="medium-banner">
-          <form class="search-bar" action="/packages">
-            <input class="input" name="q" placeholder="Search packages" autocomplete="on" autofocus="autofocus"/>
-            <button class="icon"></button>
-            <input id="search-legacy-field" type="hidden" name="legacy" value="1" disabled="disabled"/>
-          </form>
-          <div class="search-bar-details">
-            <div class="list-filters">
-              <a class="filter " href="/dart/packages" title="Packages compatible with the Dart SDK">Dart</a>
-              <a class="filter " href="/flutter/packages" title="Packages compatible with the Flutter SDK">Flutter</a>
-              <a class="filter -active" href="/packages" title="Packages compatible with the any SDK">Any</a>
-            </div>
-            <div class="search-bar-options">
-              <input id="search-legacy-checkbox" type="checkbox" name="legacy" valye="1"/>
-              <label for="search-legacy-checkbox">Include Dart 1.x results</label>
-            </div>
+        <form class="search-bar" action="/packages">
+          <input class="input" name="q" placeholder="Search packages" autocomplete="on" autofocus="autofocus"/>
+          <button class="icon"></button>
+          <input id="search-legacy-field" type="hidden" name="legacy" value="1" disabled="disabled"/>
+        </form>
+        <div class="search-bar-details">
+          <div class="list-filters">
+            <a class="filter " href="/dart/packages" title="Packages compatible with the Dart SDK">Dart</a>
+            <a class="filter " href="/flutter/packages" title="Packages compatible with the Flutter SDK">Flutter</a>
+            <a class="filter -active" href="/packages" title="Packages compatible with the any SDK">Any</a>
+          </div>
+          <div class="search-bar-options">
+            <input id="search-legacy-checkbox" type="checkbox" name="legacy" valye="1"/>
+            <label for="search-legacy-checkbox">Include Dart 1.x results</label>
           </div>
         </div>
       </div>

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -73,12 +73,10 @@
     </header>
     <div class="_banner-bg">
       <div class="container">
-        <div class="small-banner">
-          <form class="search-bar" action="/packages">
-            <input class="input" name="q" placeholder="Search packages" autocomplete="on" autofocus="autofocus"/>
-            <button class="icon"></button>
-          </form>
-        </div>
+        <form class="search-bar" action="/packages">
+          <input class="input" name="q" placeholder="Search packages" autocomplete="on" autofocus="autofocus"/>
+          <button class="icon"></button>
+        </form>
       </div>
     </div>
     <div class="container">

--- a/app/test/frontend/golden/pkg_show_page_discontinued.html
+++ b/app/test/frontend/golden/pkg_show_page_discontinued.html
@@ -74,12 +74,10 @@
     </header>
     <div class="_banner-bg">
       <div class="container">
-        <div class="small-banner">
-          <form class="search-bar" action="/packages">
-            <input class="input" name="q" placeholder="Search packages" autocomplete="on" autofocus="autofocus"/>
-            <button class="icon"></button>
-          </form>
-        </div>
+        <form class="search-bar" action="/packages">
+          <input class="input" name="q" placeholder="Search packages" autocomplete="on" autofocus="autofocus"/>
+          <button class="icon"></button>
+        </form>
       </div>
     </div>
     <div class="container">

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -73,12 +73,10 @@
     </header>
     <div class="_banner-bg">
       <div class="container">
-        <div class="small-banner">
-          <form class="search-bar" action="/packages">
-            <input class="input" name="q" placeholder="Search packages" autocomplete="on" autofocus="autofocus"/>
-            <button class="icon"></button>
-          </form>
-        </div>
+        <form class="search-bar" action="/packages">
+          <input class="input" name="q" placeholder="Search packages" autocomplete="on" autofocus="autofocus"/>
+          <button class="icon"></button>
+        </form>
       </div>
     </div>
     <div class="container">

--- a/app/test/frontend/golden/pkg_show_page_legacy.html
+++ b/app/test/frontend/golden/pkg_show_page_legacy.html
@@ -74,12 +74,10 @@
     </header>
     <div class="_banner-bg">
       <div class="container">
-        <div class="small-banner">
-          <form class="search-bar" action="/packages">
-            <input class="input" name="q" placeholder="Search packages" autocomplete="on" autofocus="autofocus"/>
-            <button class="icon"></button>
-          </form>
-        </div>
+        <form class="search-bar" action="/packages">
+          <input class="input" name="q" placeholder="Search packages" autocomplete="on" autofocus="autofocus"/>
+          <button class="icon"></button>
+        </form>
       </div>
     </div>
     <div class="container">

--- a/app/test/frontend/golden/pkg_show_page_outdated.html
+++ b/app/test/frontend/golden/pkg_show_page_outdated.html
@@ -74,12 +74,10 @@
     </header>
     <div class="_banner-bg">
       <div class="container">
-        <div class="small-banner">
-          <form class="search-bar" action="/packages">
-            <input class="input" name="q" placeholder="Search packages" autocomplete="on" autofocus="autofocus"/>
-            <button class="icon"></button>
-          </form>
-        </div>
+        <form class="search-bar" action="/packages">
+          <input class="input" name="q" placeholder="Search packages" autocomplete="on" autofocus="autofocus"/>
+          <button class="icon"></button>
+        </form>
       </div>
     </div>
     <div class="container">

--- a/app/test/frontend/golden/pkg_show_page_publisher.html
+++ b/app/test/frontend/golden/pkg_show_page_publisher.html
@@ -74,12 +74,10 @@
     </header>
     <div class="_banner-bg">
       <div class="container">
-        <div class="small-banner">
-          <form class="search-bar" action="/packages">
-            <input class="input" name="q" placeholder="Search packages" autocomplete="on" autofocus="autofocus"/>
-            <button class="icon"></button>
-          </form>
-        </div>
+        <form class="search-bar" action="/packages">
+          <input class="input" name="q" placeholder="Search packages" autocomplete="on" autofocus="autofocus"/>
+          <button class="icon"></button>
+        </form>
       </div>
     </div>
     <div class="container">

--- a/app/test/frontend/golden/pkg_show_version_page.html
+++ b/app/test/frontend/golden/pkg_show_version_page.html
@@ -75,12 +75,10 @@
     </header>
     <div class="_banner-bg">
       <div class="container">
-        <div class="small-banner">
-          <form class="search-bar" action="/packages">
-            <input class="input" name="q" placeholder="Search packages" autocomplete="on" autofocus="autofocus"/>
-            <button class="icon"></button>
-          </form>
-        </div>
+        <form class="search-bar" action="/packages">
+          <input class="input" name="q" placeholder="Search packages" autocomplete="on" autofocus="autofocus"/>
+          <button class="icon"></button>
+        </form>
       </div>
     </div>
     <div class="container">

--- a/app/test/frontend/golden/pkg_versions_page.html
+++ b/app/test/frontend/golden/pkg_versions_page.html
@@ -75,12 +75,10 @@
     </header>
     <div class="_banner-bg">
       <div class="container">
-        <div class="small-banner">
-          <form class="search-bar" action="/packages">
-            <input class="input" name="q" placeholder="Search packages" autocomplete="on" autofocus="autofocus"/>
-            <button class="icon"></button>
-          </form>
-        </div>
+        <form class="search-bar" action="/packages">
+          <input class="input" name="q" placeholder="Search packages" autocomplete="on" autofocus="autofocus"/>
+          <button class="icon"></button>
+        </form>
       </div>
     </div>
     <div class="container">

--- a/app/test/frontend/golden/publisher_list_page.html
+++ b/app/test/frontend/golden/publisher_list_page.html
@@ -72,22 +72,20 @@
     </header>
     <div class="_banner-bg">
       <div class="container">
-        <div class="medium-banner">
-          <form class="search-bar" action="/packages">
-            <input class="input" name="q" placeholder="Search packages" autocomplete="on" autofocus="autofocus"/>
-            <button class="icon"></button>
-            <input id="search-legacy-field" type="hidden" name="legacy" value="1" disabled="disabled"/>
-          </form>
-          <div class="search-bar-details">
-            <div class="list-filters">
-              <a class="filter " href="/dart/packages" title="Packages compatible with the Dart SDK">Dart</a>
-              <a class="filter " href="/flutter/packages" title="Packages compatible with the Flutter SDK">Flutter</a>
-              <a class="filter -active" href="/packages" title="Packages compatible with the any SDK">Any</a>
-            </div>
-            <div class="search-bar-options">
-              <input id="search-legacy-checkbox" type="checkbox" name="legacy" valye="1"/>
-              <label for="search-legacy-checkbox">Include Dart 1.x results</label>
-            </div>
+        <form class="search-bar" action="/packages">
+          <input class="input" name="q" placeholder="Search packages" autocomplete="on" autofocus="autofocus"/>
+          <button class="icon"></button>
+          <input id="search-legacy-field" type="hidden" name="legacy" value="1" disabled="disabled"/>
+        </form>
+        <div class="search-bar-details">
+          <div class="list-filters">
+            <a class="filter " href="/dart/packages" title="Packages compatible with the Dart SDK">Dart</a>
+            <a class="filter " href="/flutter/packages" title="Packages compatible with the Flutter SDK">Flutter</a>
+            <a class="filter -active" href="/packages" title="Packages compatible with the any SDK">Any</a>
+          </div>
+          <div class="search-bar-options">
+            <input id="search-legacy-checkbox" type="checkbox" name="legacy" valye="1"/>
+            <label for="search-legacy-checkbox">Include Dart 1.x results</label>
           </div>
         </div>
       </div>

--- a/app/test/frontend/golden/publisher_packages_page.html
+++ b/app/test/frontend/golden/publisher_packages_page.html
@@ -73,12 +73,10 @@
     </header>
     <div class="_banner-bg">
       <div class="container">
-        <div class="small-banner">
-          <form class="search-bar" action="/publishers/example.com/packages">
-            <input class="input" name="q" placeholder="Search example.com packages" autocomplete="on" autofocus="autofocus"/>
-            <button class="icon"></button>
-          </form>
-        </div>
+        <form class="search-bar" action="/publishers/example.com/packages">
+          <input class="input" name="q" placeholder="Search example.com packages" autocomplete="on" autofocus="autofocus"/>
+          <button class="icon"></button>
+        </form>
       </div>
     </div>
     <div class="container">

--- a/app/test/frontend/golden/search_page.html
+++ b/app/test/frontend/golden/search_page.html
@@ -73,23 +73,21 @@
     </header>
     <div class="_banner-bg">
       <div class="container">
-        <div class="medium-banner">
-          <form class="search-bar" action="/packages">
-            <input class="input" name="q" placeholder="Search packages" autocomplete="on" autofocus="autofocus" value="foobar"/>
-            <button class="icon"></button>
-            <input type="hidden" name="sort" value="top"/>
-            <input id="search-legacy-field" type="hidden" name="legacy" value="1" disabled="disabled"/>
-          </form>
-          <div class="search-bar-details">
-            <div class="list-filters">
-              <a class="filter " href="/dart/packages?q=foobar&amp;sort=top" title="Packages compatible with the Dart SDK">Dart</a>
-              <a class="filter " href="/flutter/packages?q=foobar&amp;sort=top" title="Packages compatible with the Flutter SDK">Flutter</a>
-              <a class="filter -active" href="/packages?q=foobar&amp;sort=top" title="Packages compatible with the any SDK">Any</a>
-            </div>
-            <div class="search-bar-options">
-              <input id="search-legacy-checkbox" type="checkbox" name="legacy" valye="1"/>
-              <label for="search-legacy-checkbox">Include Dart 1.x results</label>
-            </div>
+        <form class="search-bar" action="/packages">
+          <input class="input" name="q" placeholder="Search packages" autocomplete="on" autofocus="autofocus" value="foobar"/>
+          <button class="icon"></button>
+          <input type="hidden" name="sort" value="top"/>
+          <input id="search-legacy-field" type="hidden" name="legacy" value="1" disabled="disabled"/>
+        </form>
+        <div class="search-bar-details">
+          <div class="list-filters">
+            <a class="filter " href="/dart/packages?q=foobar&amp;sort=top" title="Packages compatible with the Dart SDK">Dart</a>
+            <a class="filter " href="/flutter/packages?q=foobar&amp;sort=top" title="Packages compatible with the Flutter SDK">Flutter</a>
+            <a class="filter -active" href="/packages?q=foobar&amp;sort=top" title="Packages compatible with the any SDK">Any</a>
+          </div>
+          <div class="search-bar-options">
+            <input id="search-legacy-checkbox" type="checkbox" name="legacy" valye="1"/>
+            <label for="search-legacy-checkbox">Include Dart 1.x results</label>
           </div>
         </div>
       </div>

--- a/pkg/web_css/lib/src/_base.scss
+++ b/pkg/web_css/lib/src/_base.scss
@@ -192,16 +192,12 @@ pre > code {
   flex: 1;
 }
 
-.small-banner,
-.medium-banner {
-  padding: 10px 0px;
-}
-
 ._banner-bg {
   background: $color-searchbar-dark-bg;
   background-image: url('/static/img/background-pattern-darkblue.jpg?hash=tqigd6sddnrgq97c7crv8d2l6agjtrob');
   background-size: cover;
   color: $color-searchbar-dark-fg;
+  padding: 10px 0px;
 
   a {
     color: $color-searchbar-dark-link;

--- a/pkg/web_css/lib/src/_home.scss
+++ b/pkg/web_css/lib/src/_home.scss
@@ -23,7 +23,7 @@
 
 .home-banner {
   text-align: center;
-  padding: 40px 20px 10px 20px;
+  padding: 30px 20px 0px 20px;
 
   > .logo {
     width: 520px;


### PR DESCRIPTION
- part of #3138
- removed `small-banner` and `medium-banner` styles, merged the padding inside `_banner-bg`
- moved landing page logo and blurb outside of the search control template