### PR TITLE
Better template structure in search banner.

### DIFF
--- a/app/lib/frontend/templates/layout.dart
+++ b/app/lib/frontend/templates/layout.dart
@@ -149,11 +149,11 @@ String _renderSearchBanner({
           .map((e) => {'name': e.key, 'value': e.value})
           .toList()
       : null;
-  String searchTabsHtml;
+  String sdkTabsHtml;
   if (type == PageType.landing) {
-    searchTabsHtml = renderSearchTabs();
+    sdkTabsHtml = renderSdkTabs();
   } else if (type == PageType.listing) {
-    searchTabsHtml = renderSearchTabs(searchQuery: searchQuery);
+    sdkTabsHtml = renderSdkTabs(searchQuery: searchQuery);
   }
   String secondaryTabsHtml;
   if (searchQuery?.sdk == SdkTagValue.dart) {
@@ -196,15 +196,15 @@ String _renderSearchBanner({
     );
   }
   return templateCache.renderTemplate('shared/search_banner', {
-    'show_details': type == PageType.listing,
-    'show_landing': type == PageType.landing,
+    'show_details': type == PageType.listing || type == PageType.landing,
+    'show_options': type == PageType.listing,
     'search_form_url': searchFormUrl,
     'search_query_placeholder': searchPlaceholder,
     'search_query_html': escapedSearchQuery,
     'search_sort_param': searchSort,
     'legacy_search_enabled': searchQuery?.includeLegacy ?? false,
     'hidden_inputs': hiddenInputs,
-    'search_tabs_html': searchTabsHtml,
+    'sdk_tabs_html': sdkTabsHtml,
     'show_legacy_checkbox': sp.sdk == null,
     'secondary_tabs_html': secondaryTabsHtml,
   });
@@ -220,7 +220,7 @@ String _landingBannerImage(bool isFlutter) {
       : staticUrls.assets['img__dart-packages-white_png'];
 }
 
-String renderSearchTabs({
+String renderSdkTabs({
   SearchQuery searchQuery,
 }) {
   final sp = _sp(searchQuery);

--- a/app/lib/frontend/templates/views/shared/search_banner.mustache
+++ b/app/lib/frontend/templates/views/shared/search_banner.mustache
@@ -2,7 +2,7 @@
     for details. All rights reserved. Use of this source code is governed by a
     BSD-style license that can be found in the LICENSE file. }}
 
-<form class="search-bar" action="{{& search_form_url}}">
+<form class="search-bar banner-item" action="{{& search_form_url}}">
   <input class="input" name="q" placeholder="{{search_query_placeholder}}" autocomplete="on" autofocus="autofocus"{{#search_query_html}} value="{{& search_query_html}}"{{/search_query_html}}/>
   <button class="icon"></button>
   {{#show_details}}
@@ -14,8 +14,10 @@
   {{/hidden_inputs}}
 </form>
 {{#show_details}}
-<div class="search-bar-details">
-  {{& search_tabs_html }}
+<div class="search-bar-details banner-item">
+  {{& sdk_tabs_html }}
+
+  {{#show_options}}
   <div class="search-bar-options">
     {{#show_legacy_checkbox}}
     <input id="search-legacy-checkbox" type="checkbox" name="legacy" valye="1" {{#legacy_search_enabled}} checked="checked"{{/legacy_search_enabled}} />
@@ -23,8 +25,6 @@
     {{/show_legacy_checkbox}}
     {{& secondary_tabs_html }}
   </div>
+  {{/show_options}}
 </div>
 {{/show_details}}
-{{#show_landing}}
-  {{& search_tabs_html }}
-{{/show_landing}}

--- a/app/test/frontend/golden/authorized_page.html
+++ b/app/test/frontend/golden/authorized_page.html
@@ -71,7 +71,7 @@
     </header>
     <div class="_banner-bg">
       <div class="container">
-        <form class="search-bar" action="/packages">
+        <form class="search-bar banner-item" action="/packages">
           <input class="input" name="q" placeholder="Search packages" autocomplete="on" autofocus="autofocus"/>
           <button class="icon"></button>
         </form>

--- a/app/test/frontend/golden/error_page.html
+++ b/app/test/frontend/golden/error_page.html
@@ -71,7 +71,7 @@
     </header>
     <div class="_banner-bg">
       <div class="container">
-        <form class="search-bar" action="/packages">
+        <form class="search-bar banner-item" action="/packages">
           <input class="input" name="q" placeholder="Search packages" autocomplete="on" autofocus="autofocus"/>
           <button class="icon"></button>
         </form>

--- a/app/test/frontend/golden/landing_page.html
+++ b/app/test/frontend/golden/landing_page.html
@@ -74,14 +74,17 @@
       <div class="container home-banner">
         <h2 class="_visuallyhidden">Dart package manager</h2>
         <img class="logo" src="/static/img/dart-packages-white.png?hash=mocked_hash_308431268" alt="Dart packages"/>
-        <form class="search-bar" action="/packages">
+        <form class="search-bar banner-item" action="/packages">
           <input class="input" name="q" placeholder="Search packages" autocomplete="on" autofocus="autofocus"/>
           <button class="icon"></button>
+          <input id="search-legacy-field" type="hidden" name="legacy" value="1" disabled="disabled"/>
         </form>
-        <div class="list-filters">
-          <a class="filter " href="/dart/packages" title="Packages compatible with the Dart SDK">Dart</a>
-          <a class="filter " href="/flutter/packages" title="Packages compatible with the Flutter SDK">Flutter</a>
-          <a class="filter -active" href="/packages" title="Packages compatible with the any SDK">Any</a>
+        <div class="search-bar-details banner-item">
+          <div class="list-filters">
+            <a class="filter " href="/dart/packages" title="Packages compatible with the Dart SDK">Dart</a>
+            <a class="filter " href="/flutter/packages" title="Packages compatible with the Flutter SDK">Flutter</a>
+            <a class="filter -active" href="/packages" title="Packages compatible with the any SDK">Any</a>
+          </div>
         </div>
         <p class="text">Find and use packages to build 
           <a href="/flutter">Flutter</a> and 

--- a/app/test/frontend/golden/my_liked_packages.html
+++ b/app/test/frontend/golden/my_liked_packages.html
@@ -73,7 +73,7 @@
     </header>
     <div class="_banner-bg">
       <div class="container">
-        <form class="search-bar" action="/my-packages">
+        <form class="search-bar banner-item" action="/my-packages">
           <input class="input" name="q" placeholder="Search your packages" autocomplete="on" autofocus="autofocus"/>
           <button class="icon"></button>
         </form>

--- a/app/test/frontend/golden/my_packages.html
+++ b/app/test/frontend/golden/my_packages.html
@@ -73,7 +73,7 @@
     </header>
     <div class="_banner-bg">
       <div class="container">
-        <form class="search-bar" action="/my-packages">
+        <form class="search-bar banner-item" action="/my-packages">
           <input class="input" name="q" placeholder="Search your packages" autocomplete="on" autofocus="autofocus"/>
           <button class="icon"></button>
         </form>

--- a/app/test/frontend/golden/my_publishers.html
+++ b/app/test/frontend/golden/my_publishers.html
@@ -73,7 +73,7 @@
     </header>
     <div class="_banner-bg">
       <div class="container">
-        <form class="search-bar" action="/my-packages">
+        <form class="search-bar banner-item" action="/my-packages">
           <input class="input" name="q" placeholder="Search your packages" autocomplete="on" autofocus="autofocus"/>
           <button class="icon"></button>
         </form>

--- a/app/test/frontend/golden/pkg_admin_page_outdated.html
+++ b/app/test/frontend/golden/pkg_admin_page_outdated.html
@@ -74,7 +74,7 @@
     </header>
     <div class="_banner-bg">
       <div class="container">
-        <form class="search-bar" action="/packages">
+        <form class="search-bar banner-item" action="/packages">
           <input class="input" name="q" placeholder="Search packages" autocomplete="on" autofocus="autofocus"/>
           <button class="icon"></button>
         </form>

--- a/app/test/frontend/golden/pkg_index_page.html
+++ b/app/test/frontend/golden/pkg_index_page.html
@@ -73,12 +73,12 @@
     </header>
     <div class="_banner-bg">
       <div class="container">
-        <form class="search-bar" action="/packages">
+        <form class="search-bar banner-item" action="/packages">
           <input class="input" name="q" placeholder="Search packages" autocomplete="on" autofocus="autofocus"/>
           <button class="icon"></button>
           <input id="search-legacy-field" type="hidden" name="legacy" value="1" disabled="disabled"/>
         </form>
-        <div class="search-bar-details">
+        <div class="search-bar-details banner-item">
           <div class="list-filters">
             <a class="filter " href="/dart/packages" title="Packages compatible with the Dart SDK">Dart</a>
             <a class="filter " href="/flutter/packages" title="Packages compatible with the Flutter SDK">Flutter</a>

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -73,7 +73,7 @@
     </header>
     <div class="_banner-bg">
       <div class="container">
-        <form class="search-bar" action="/packages">
+        <form class="search-bar banner-item" action="/packages">
           <input class="input" name="q" placeholder="Search packages" autocomplete="on" autofocus="autofocus"/>
           <button class="icon"></button>
         </form>

--- a/app/test/frontend/golden/pkg_show_page_discontinued.html
+++ b/app/test/frontend/golden/pkg_show_page_discontinued.html
@@ -74,7 +74,7 @@
     </header>
     <div class="_banner-bg">
       <div class="container">
-        <form class="search-bar" action="/packages">
+        <form class="search-bar banner-item" action="/packages">
           <input class="input" name="q" placeholder="Search packages" autocomplete="on" autofocus="autofocus"/>
           <button class="icon"></button>
         </form>

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -73,7 +73,7 @@
     </header>
     <div class="_banner-bg">
       <div class="container">
-        <form class="search-bar" action="/packages">
+        <form class="search-bar banner-item" action="/packages">
           <input class="input" name="q" placeholder="Search packages" autocomplete="on" autofocus="autofocus"/>
           <button class="icon"></button>
         </form>

--- a/app/test/frontend/golden/pkg_show_page_legacy.html
+++ b/app/test/frontend/golden/pkg_show_page_legacy.html
@@ -74,7 +74,7 @@
     </header>
     <div class="_banner-bg">
       <div class="container">
-        <form class="search-bar" action="/packages">
+        <form class="search-bar banner-item" action="/packages">
           <input class="input" name="q" placeholder="Search packages" autocomplete="on" autofocus="autofocus"/>
           <button class="icon"></button>
         </form>

--- a/app/test/frontend/golden/pkg_show_page_outdated.html
+++ b/app/test/frontend/golden/pkg_show_page_outdated.html
@@ -74,7 +74,7 @@
     </header>
     <div class="_banner-bg">
       <div class="container">
-        <form class="search-bar" action="/packages">
+        <form class="search-bar banner-item" action="/packages">
           <input class="input" name="q" placeholder="Search packages" autocomplete="on" autofocus="autofocus"/>
           <button class="icon"></button>
         </form>

--- a/app/test/frontend/golden/pkg_show_page_publisher.html
+++ b/app/test/frontend/golden/pkg_show_page_publisher.html
@@ -74,7 +74,7 @@
     </header>
     <div class="_banner-bg">
       <div class="container">
-        <form class="search-bar" action="/packages">
+        <form class="search-bar banner-item" action="/packages">
           <input class="input" name="q" placeholder="Search packages" autocomplete="on" autofocus="autofocus"/>
           <button class="icon"></button>
         </form>

--- a/app/test/frontend/golden/pkg_show_version_page.html
+++ b/app/test/frontend/golden/pkg_show_version_page.html
@@ -75,7 +75,7 @@
     </header>
     <div class="_banner-bg">
       <div class="container">
-        <form class="search-bar" action="/packages">
+        <form class="search-bar banner-item" action="/packages">
           <input class="input" name="q" placeholder="Search packages" autocomplete="on" autofocus="autofocus"/>
           <button class="icon"></button>
         </form>

--- a/app/test/frontend/golden/pkg_versions_page.html
+++ b/app/test/frontend/golden/pkg_versions_page.html
@@ -75,7 +75,7 @@
     </header>
     <div class="_banner-bg">
       <div class="container">
-        <form class="search-bar" action="/packages">
+        <form class="search-bar banner-item" action="/packages">
           <input class="input" name="q" placeholder="Search packages" autocomplete="on" autofocus="autofocus"/>
           <button class="icon"></button>
         </form>

--- a/app/test/frontend/golden/publisher_list_page.html
+++ b/app/test/frontend/golden/publisher_list_page.html
@@ -72,12 +72,12 @@
     </header>
     <div class="_banner-bg">
       <div class="container">
-        <form class="search-bar" action="/packages">
+        <form class="search-bar banner-item" action="/packages">
           <input class="input" name="q" placeholder="Search packages" autocomplete="on" autofocus="autofocus"/>
           <button class="icon"></button>
           <input id="search-legacy-field" type="hidden" name="legacy" value="1" disabled="disabled"/>
         </form>
-        <div class="search-bar-details">
+        <div class="search-bar-details banner-item">
           <div class="list-filters">
             <a class="filter " href="/dart/packages" title="Packages compatible with the Dart SDK">Dart</a>
             <a class="filter " href="/flutter/packages" title="Packages compatible with the Flutter SDK">Flutter</a>

--- a/app/test/frontend/golden/publisher_packages_page.html
+++ b/app/test/frontend/golden/publisher_packages_page.html
@@ -73,7 +73,7 @@
     </header>
     <div class="_banner-bg">
       <div class="container">
-        <form class="search-bar" action="/publishers/example.com/packages">
+        <form class="search-bar banner-item" action="/publishers/example.com/packages">
           <input class="input" name="q" placeholder="Search example.com packages" autocomplete="on" autofocus="autofocus"/>
           <button class="icon"></button>
         </form>

--- a/app/test/frontend/golden/search_page.html
+++ b/app/test/frontend/golden/search_page.html
@@ -73,13 +73,13 @@
     </header>
     <div class="_banner-bg">
       <div class="container">
-        <form class="search-bar" action="/packages">
+        <form class="search-bar banner-item" action="/packages">
           <input class="input" name="q" placeholder="Search packages" autocomplete="on" autofocus="autofocus" value="foobar"/>
           <button class="icon"></button>
           <input type="hidden" name="sort" value="top"/>
           <input id="search-legacy-field" type="hidden" name="legacy" value="1" disabled="disabled"/>
         </form>
-        <div class="search-bar-details">
+        <div class="search-bar-details banner-item">
           <div class="list-filters">
             <a class="filter " href="/dart/packages?q=foobar&amp;sort=top" title="Packages compatible with the Dart SDK">Dart</a>
             <a class="filter " href="/flutter/packages?q=foobar&amp;sort=top" title="Packages compatible with the Flutter SDK">Flutter</a>

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -709,12 +709,12 @@ void main() {
     });
 
     scopedTest('platform tabs: list', () {
-      final String html = renderSearchTabs();
+      final String html = renderSdkTabs();
       expectGoldenFile(html, 'platform_tabs_list.html', isFragment: true);
     });
 
     scopedTest('platform tabs: search', () {
-      final String html = renderSearchTabs(
+      final String html = renderSdkTabs(
           searchQuery: SearchQuery.parse(
         query: 'foo',
         sdk: 'flutter',

--- a/pkg/web_css/lib/src/_home.scss
+++ b/pkg/web_css/lib/src/_home.scss
@@ -68,7 +68,7 @@
     }
   }
 
-  > .search-bar {
+  > .banner-item {
     margin: 0 auto;
   }
 }

--- a/pkg/web_css/lib/src/_search.scss
+++ b/pkg/web_css/lib/src/_search.scss
@@ -3,11 +3,7 @@
 ******************************************************/
 .search-bar {
   border: 1px solid $color-searchbar-dark-border;
-  display: -webkit-box;
-  display: -ms-flexbox;
   display: flex;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
   border-radius: 3px;
   max-width: 650px;
@@ -50,10 +46,8 @@
 
 .search-bar-options {
   font-size: 14px;
-}
 
-@media (min-width: 600px) {
-  .search-bar-options {
+  @media (min-width: 600px) {
     position: absolute;
     top: 16px;
     right: 0px;


### PR DESCRIPTION
- part of #3138
- removes the duplication of `search_tabs_html` inclusion
- `search_tabs_html` renamed to `sdk_tabs_html`
- `banner-item` class decouples it is bit from `home-banner`
- removed really old flex prefixes
