### PR TITLE
Delayed GC of dartdoc files.

### DIFF
--- a/app/lib/dartdoc/backend.dart
+++ b/app/lib/dartdoc/backend.dart
@@ -47,6 +47,11 @@ class DartdocBackend {
   final DatastoreDB _db;
   final Bucket _storage;
   final VersionedJsonStorage _sdkStorage;
+
+  /// If the server crashed, the pending GC tasks will disappear. This is
+  /// acceptable, as - eventually - new dartdoc will be generated in the future,
+  /// which will trigger another GC for the package/version, and hopefully
+  /// we'll catch up on these files.
   final _gcTasks = <_GCTask>{};
 
   DartdocBackend(this._db, this._storage)
@@ -267,7 +272,10 @@ class DartdocBackend {
   }
 
   /// Schedules the garbage collection of the [package] and [version].
-  /// The wait queue is in-memory, it is not persisted.
+  ///
+  /// The wait queue is in-memory, it is not persisted, and only only works as a
+  /// best-effort method to clean up obsolete files.
+  /// TODO: implement weekly cleanup process outside of the job processing
   void scheduleGC(String package, String version) {
     _gcTasks.add(_GCTask(package, version));
   }

--- a/app/lib/dartdoc/backend.dart
+++ b/app/lib/dartdoc/backend.dart
@@ -47,6 +47,7 @@ class DartdocBackend {
   final DatastoreDB _db;
   final Bucket _storage;
   final VersionedJsonStorage _sdkStorage;
+  final _gcTasks = <_GCTask>{};
 
   DartdocBackend(this._db, this._storage)
       : _sdkStorage = VersionedJsonStorage(
@@ -265,8 +266,35 @@ class DartdocBackend {
     await _deleteAllWithPrefix(prefix, concurrency: concurrency);
   }
 
+  /// Schedules the garbage collection of the [package] and [version].
+  /// The wait queue is in-memory, it is not persisted.
+  void scheduleGC(String package, String version) {
+    _gcTasks.add(_GCTask(package, version));
+  }
+
+  /// Runs obsolete GC of old dartdoc files with low overhead (concurrency = 1).
+  ///
+  /// The function never returns.
+  Future<void> processScheduledGCTasks() async {
+    for (;;) {
+      if (_gcTasks.isEmpty) {
+        await Future.delayed(Duration(seconds: 30));
+        continue;
+      }
+      final task = _gcTasks.first;
+      _gcTasks.remove(task);
+      try {
+        await _removeObsolete(task.package, task.version, concurrency: 1);
+      } catch (e, st) {
+        _logger.warning(
+            'Unable to GC files of ${task.package} ${task.version}.', e, st);
+      }
+    }
+  }
+
   /// Removes incomplete uploads and old outputs from the bucket.
-  Future<void> removeObsolete(String package, String version) async {
+  Future<void> _removeObsolete(String package, String version,
+      {int concurrency}) async {
     final List<DartdocEntry> completedList =
         await _listEntries(storage_path.entryPrefix(package, version));
     final List<DartdocEntry> inProgressList =
@@ -279,7 +307,7 @@ class DartdocBackend {
         await deleteFromBucket(_storage, entry.inProgressObjectName);
       } else {
         if (entry.age > _obsoleteDeleteThreshold) {
-          await _deleteAll(entry);
+          await _deleteAll(entry, concurrency: concurrency);
           await deleteFromBucket(_storage, entry.inProgressObjectName);
         }
       }
@@ -334,7 +362,7 @@ class DartdocBackend {
     // delete everything else
     for (var entry in completedList) {
       if (entry.age > _obsoleteDeleteThreshold) {
-        await _deleteAll(entry);
+        await _deleteAll(entry, concurrency: concurrency);
       }
     }
   }
@@ -363,8 +391,8 @@ class DartdocBackend {
     );
   }
 
-  Future<void> _deleteAll(DartdocEntry entry) async {
-    await _deleteAllWithPrefix(entry.contentPrefix);
+  Future<void> _deleteAll(DartdocEntry entry, {int concurrency}) async {
+    await _deleteAllWithPrefix(entry.contentPrefix, concurrency: concurrency);
     await deleteFromBucket(_storage, entry.entryObjectName);
   }
 
@@ -392,4 +420,22 @@ class DartdocBackend {
     sw.stop();
     _logger.info('$prefix: $count files deleted in ${sw.elapsed}.');
   }
+}
+
+class _GCTask {
+  final String package;
+  final String version;
+
+  _GCTask(this.package, this.version);
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is _GCTask &&
+          runtimeType == other.runtimeType &&
+          package == other.package &&
+          version == other.version;
+
+  @override
+  int get hashCode => package.hashCode ^ version.hashCode;
 }

--- a/app/lib/dartdoc/dartdoc_runner.dart
+++ b/app/lib/dartdoc/dartdoc_runner.dart
@@ -313,8 +313,6 @@ class DartdocJobProcessor extends JobProcessor {
         ));
     await scoreCardBackend.updateScoreCard(job.packageName, job.packageVersion);
 
-    await dartdocBackend.removeObsolete(job.packageName, job.packageVersion);
-
     if (abortLog != null) {
       return JobStatus.aborted;
     } else {
@@ -326,7 +324,7 @@ class DartdocJobProcessor extends JobProcessor {
     await scoreCardBackend.updateReport(
         job.packageName, job.packageVersion, report);
     await scoreCardBackend.updateScoreCard(job.packageName, job.packageVersion);
-    await dartdocBackend.removeObsolete(job.packageName, job.packageVersion);
+    dartdocBackend.scheduleGC(job.packageName, job.packageVersion);
   }
 
   Future<bool> _resolveDependencies(

--- a/app/lib/service/entrypoint/dartdoc.dart
+++ b/app/lib/service/entrypoint/dartdoc.dart
@@ -91,9 +91,15 @@ Future _workerMain(WorkerEntryMessage message) async {
 
     dartdocBackend.scheduleOldDataGC();
 
-    // Run GC in the next 6-12 hours (randomized wait to reduce race).
+    // Run Job entity GC in the next 6-12 hours (randomized wait to reduce race).
     Timer(Duration(minutes: 360 + _random.nextInt(360)), () {
       jobBackend.deleteOldEntries();
+    });
+
+    // Start dartdoc file GC in the next 6-12 hours (randomized wait to reduce race).
+    // The delay is useful here so that a new deployment is not slowed down with GCs.
+    Timer(Duration(minutes: 360 + _random.nextInt(360)), () {
+      dartdocBackend.processScheduledGCTasks();
     });
 
     await jobMaintenance.run();


### PR DESCRIPTION
- The delayed start of the GC helps new deployments to produce the required files earlier.
- The lower concurrency reduces the rate limit pressure on the storage bucket.
- We'll have an increased risk that the cleanup takes much longer, and may never complete for some unlucky package versions, but as we are planning to restructure the dartdoc buckets and their storage anyway, this may be acceptable now. (We can also increase the concurrency if we wanted to.)
