### PR TITLE
Using watcher to update resource files inside the app.

### DIFF
--- a/app/lib/frontend/templates/_cache.dart
+++ b/app/lib/frontend/templates/_cache.dart
@@ -12,13 +12,23 @@ import '../static_files.dart' show resolveAppDir, staticUrls;
 
 final templateCache = TemplateCache();
 
+/// The directory that contains the mustache files.
+final templateViewsDir =
+    path.join(resolveAppDir(), 'lib/frontend/templates/views');
+
 /// Loads, parses, caches and renders mustache templates.
 class TemplateCache {
   /// A cache which keeps all used mustache templates parsed in memory.
-  final Map<String, mustache.Template> _parsedMustacheTemplates = {};
+  final _parsedMustacheTemplates = <String, mustache.Template>{};
 
   TemplateCache() {
-    _loadDirectory(path.join(resolveAppDir(), 'lib/frontend/templates/views'));
+    update();
+  }
+
+  /// Updates all the cached templates by reloading them from disk.
+  void update() {
+    _parsedMustacheTemplates.clear();
+    _loadDirectory(templateViewsDir);
   }
 
   void _loadDirectory(String templateFolder) {

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -91,7 +91,7 @@ packages:
       name: build_daemon
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.3"
   build_resolvers:
     dependency: transitive
     description:
@@ -105,7 +105,7 @@ packages:
       name: build_runner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.2"
+    version: "1.7.3"
   build_runner_core:
     dependency: transitive
     description:
@@ -672,7 +672,7 @@ packages:
       name: stream_transform
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.20"
+    version: "1.1.0"
   string_scanner:
     dependency: transitive
     description:
@@ -744,7 +744,7 @@ packages:
     source: hosted
     version: "2.2.0"
   watcher:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: watcher
       url: "https://pub.dartlang.org"

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -38,7 +38,8 @@ dependencies:
   shelf: '>=0.5.6 <0.8.0'
   shelf_router: ^0.7.0
   stack_trace: ^1.9.2
-  stream_transform: ^0.0.20
+  stream_transform: ^1.1.0
+  watcher: ^0.9.7
   yaml: '^2.1.12'
   # pana version to be pinned
   pana: '0.13.3'

--- a/app/test/frontend/handlers/landing_test.dart
+++ b/app/test/frontend/handlers/landing_test.dart
@@ -13,7 +13,7 @@ import '../../shared/test_services.dart';
 import '_utils.dart';
 
 void main() {
-  setUpAll(() => updateLocalBuiltFiles());
+  setUpAll(() => updateLocalBuiltFilesIfNeeded());
 
   group('ui', () {
     testWithServices('/', () async {

--- a/app/test/frontend/handlers/listing_test.dart
+++ b/app/test/frontend/handlers/listing_test.dart
@@ -19,7 +19,7 @@ import '../../shared/test_services.dart';
 import '_utils.dart';
 
 void main() {
-  setUpAll(() => updateLocalBuiltFiles());
+  setUpAll(() => updateLocalBuiltFilesIfNeeded());
 
   group('old api', () {
     testWithServices('/packages.json', () async {

--- a/app/test/frontend/handlers/package_test.dart
+++ b/app/test/frontend/handlers/package_test.dart
@@ -12,7 +12,7 @@ import '../../shared/test_services.dart';
 import '_utils.dart';
 
 void main() {
-  setUpAll(() => updateLocalBuiltFiles());
+  setUpAll(() => updateLocalBuiltFilesIfNeeded());
 
   group('ui', () {
     testWithServices('/packages/foobar_pkg - found', () async {

--- a/app/test/frontend/handlers/redirects_test.dart
+++ b/app/test/frontend/handlers/redirects_test.dart
@@ -14,7 +14,7 @@ import '../../shared/test_services.dart';
 import '_utils.dart';
 
 void main() {
-  setUpAll(() => updateLocalBuiltFiles());
+  setUpAll(() => updateLocalBuiltFilesIfNeeded());
 
   group('redirects', () {
     testWithServices('pub.dartlang.org', () async {

--- a/app/test/frontend/static_files_test.dart
+++ b/app/test/frontend/static_files_test.dart
@@ -14,7 +14,7 @@ import 'package:test/test.dart';
 import 'package:pub_dev/frontend/static_files.dart';
 
 void main() {
-  setUpAll(() => updateLocalBuiltFiles());
+  setUpAll(() => updateLocalBuiltFilesIfNeeded());
 
   group('dartdoc assets', () {
     Future<void> checkAsset(String url, String path) async {

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -39,7 +39,7 @@ const String goldenDir = 'test/frontend/golden';
 final _regenerateGoldens = false;
 
 void main() {
-  setUpAll(() => updateLocalBuiltFiles());
+  setUpAll(() => updateLocalBuiltFilesIfNeeded());
 
   group('templates', () {
     StaticFileCache oldCache;

--- a/pkg/fake_pub_server/lib/fake_pub_server.dart
+++ b/pkg/fake_pub_server/lib/fake_pub_server.dart
@@ -42,7 +42,7 @@ class FakePubServer {
     @required Configuration configuration,
     shelf.Handler extraHandler,
   }) async {
-    await updateLocalBuiltFiles();
+    await updateLocalBuiltFilesIfNeeded();
     await ss.fork(() async {
       final db = DatastoreDB(_datastore);
       registerDbService(db);

--- a/pkg/fake_pub_server/lib/fake_search_service.dart
+++ b/pkg/fake_pub_server/lib/fake_search_service.dart
@@ -34,7 +34,7 @@ class FakeSearchService {
     int port = 8082,
     @required Configuration configuration,
   }) async {
-    await updateLocalBuiltFiles();
+    await updateLocalBuiltFilesIfNeeded();
     await ss.fork(() async {
       final db = DatastoreDB(_datastore);
       registerDbService(db);


### PR DESCRIPTION
This is for local/dev mode only, but it monitors the following items, and if something changes, it will trigger the update of that specific resource:
- mustache templates (reloads template cache)
- JS script sources (recompiles web_app)
- SCSS files (recompiles web_css)
- static files (reloads static file cache)

I've started out to keep track of file-specific update times for mustache templates, but ended with this more generic solution. I've also done some cleanup in the main isolate initialization block, we could probably do a similar watcher script to update the dart VM itself when a server file changes.