### PR TITLE
Remove ambiguous 'web' from landing blurb.

### DIFF
--- a/app/lib/frontend/templates/_consts.dart
+++ b/app/lib/frontend/templates/_consts.dart
@@ -42,8 +42,8 @@ SdkDict getSdkDict(String sdk) {
 }
 
 final defaultLandingBlurbHtml =
-    '<p class="text">Find and use packages to build <a href="/flutter">Flutter</a> and '
-    '<a href="/web">web</a> apps with <a target="_blank" rel="noopener" href="${urls.dartSiteRoot}">Dart</a>.</p>';
+    '<p class="text">Find and use packages to build <a href="/dart">Dart</a> and '
+    '<a href="/flutter">Flutter</a> and apps.</p>';
 
 final flutterLandingBlurbHtml =
     '<p class="text"><a target="_blank" rel="noopener" href="https://flutter.dev/">Flutter<sup><small>↗</small></sup></a> '

--- a/app/lib/frontend/templates/_consts.dart
+++ b/app/lib/frontend/templates/_consts.dart
@@ -43,7 +43,7 @@ SdkDict getSdkDict(String sdk) {
 
 final defaultLandingBlurbHtml =
     '<p class="text">Find and use packages to build <a href="/dart">Dart</a> and '
-    '<a href="/flutter">Flutter</a> and apps.</p>';
+    '<a href="/flutter">Flutter</a> apps.</p>';
 
 final flutterLandingBlurbHtml =
     '<p class="text"><a target="_blank" rel="noopener" href="https://flutter.dev/">Flutter<sup><small>↗</small></sup></a> '

--- a/app/test/frontend/golden/landing_page.html
+++ b/app/test/frontend/golden/landing_page.html
@@ -87,9 +87,8 @@
           </div>
         </div>
         <p class="text">Find and use packages to build 
-          <a href="/flutter">Flutter</a> and 
-          <a href="/web">web</a> apps with 
-          <a target="_blank" rel="noopener" href="https://dart.dev">Dart</a>.
+          <a href="/dart">Dart</a> and 
+          <a href="/flutter">Flutter</a> and apps.
         </p>
       </div>
     </div>

--- a/app/test/frontend/golden/landing_page.html
+++ b/app/test/frontend/golden/landing_page.html
@@ -88,7 +88,7 @@
         </div>
         <p class="text">Find and use packages to build 
           <a href="/dart">Dart</a> and 
-          <a href="/flutter">Flutter</a> and apps.
+          <a href="/flutter">Flutter</a> apps.
         </p>
       </div>
     </div>


### PR DESCRIPTION
Fixes #3224.

<img width="677" alt="Screen Shot 2020-01-09 at 11 34 19" src="https://user-images.githubusercontent.com/4778111/72060402-2f862f00-32d4-11ea-9768-12c09b726deb.png">

/cc @mit-mit 