### PR TITLE
Optimize+limit text search.

### DIFF
--- a/app/lib/search/handlers.dart
+++ b/app/lib/search/handlers.dart
@@ -70,7 +70,7 @@ Future<shelf.Response> _searchHandler(shelf.Request request) async {
   final Duration elapsed = sw.elapsed;
   if (elapsed > _slowSearchThreshold) {
     _logger.info(
-        'Slow search: handler exceeded ${_slowSearchThreshold.inMilliseconds}ms: '
+        '[pub-slow-search-query] Slow search: handler exceeded ${_slowSearchThreshold.inMilliseconds} ms: '
         '${query.toServiceQueryParameters()}');
   }
 

--- a/app/lib/search/index_simple.dart
+++ b/app/lib/search/index_simple.dart
@@ -400,7 +400,7 @@ class SimplePackageIndex implements PackageIndex {
 
       for (String word in words) {
         if (packages.isEmpty) break;
-        if (pkgScores.length > 5 && sw.elapsedMilliseconds > 500) {
+        if (sw.elapsedMilliseconds > 500) {
           aborted = true;
           _logger.info(
               'Aborted word lookup after ${pkgScores.length} words and ${sw.elapsedMilliseconds} ms.');

--- a/app/lib/search/index_simple.dart
+++ b/app/lib/search/index_simple.dart
@@ -403,7 +403,7 @@ class SimplePackageIndex implements PackageIndex {
         if (sw.elapsedMilliseconds > 500) {
           aborted = true;
           _logger.info(
-              'Aborted word lookup after ${pkgScores.length} words and ${sw.elapsedMilliseconds} ms.');
+              '[pub-aborted-search-query] Aborted word lookup after ${pkgScores.length} words and ${sw.elapsedMilliseconds} ms.');
           break;
         }
 

--- a/app/lib/search/index_simple.dart
+++ b/app/lib/search/index_simple.dart
@@ -384,7 +384,6 @@ class SimplePackageIndex implements PackageIndex {
     final sw = Stopwatch()..start();
     if (text != null && text.isNotEmpty) {
       final words = splitForIndexing(text).toSet().toList();
-      final wordCount = words.length;
 
       // lookup longer words first, as it may restrict the result set better
       words.sort((a, b) => -a.length.compareTo(b.length));
@@ -394,6 +393,7 @@ class SimplePackageIndex implements PackageIndex {
         words.removeRange(20, words.length);
       }
 
+      final wordCount = words.length;
       final pkgScores = <Score>[];
       final apiPagesScores = <Score>[];
       bool aborted = false;

--- a/app/lib/search/index_simple.dart
+++ b/app/lib/search/index_simple.dart
@@ -412,11 +412,11 @@ class SimplePackageIndex implements PackageIndex {
         final readmeTokens = _readmeIndex.lookupTokens(word);
 
         final name = Score(_nameIndex.scoreDocs(nameTokens,
-            weight: 1.00, wordCount: wordCount, ids: packages));
+            weight: 1.00, wordCount: wordCount, limitToIds: packages));
         final descr = Score(_descrIndex.scoreDocs(descrTokens,
-            weight: 0.90, wordCount: wordCount, ids: packages));
+            weight: 0.90, wordCount: wordCount, limitToIds: packages));
         final readme = Score(_readmeIndex.scoreDocs(readmeTokens,
-            weight: 0.75, wordCount: wordCount, ids: packages));
+            weight: 0.75, wordCount: wordCount, limitToIds: packages));
 
         final apiSymbolTokens = _apiSymbolIndex.lookupTokens(word);
         final apiDartdocTokens = _apiDartdocIndex.lookupTokens(word);
@@ -796,16 +796,18 @@ class TokenIndex {
 
   /// Returns an {id: score} map of the documents stored in the [TokenIndex].
   /// The tokens in [tokenMatch] will be used to calculate a weighted sum of scores.
-  /// When [ids] is specified, the result will contain only the set of ids in it.
+  ///
+  /// When [limitToIds] is specified, the result will contain only the set of
+  /// identifiers in it.
   Map<String, double> scoreDocs(TokenMatch tokenMatch,
-      {double weight = 1.0, int wordCount = 1, Set<String> ids}) {
+      {double weight = 1.0, int wordCount = 1, Set<String> limitToIds}) {
     // Summarize the scores for the documents.
     final queryWeight = tokenMatch.maxWeight;
     final Map<String, double> docScores = <String, double>{};
     for (String token in tokenMatch.tokens) {
       final docWeights = _inverseIds[token];
       for (String id in docWeights.keys) {
-        if (ids != null && !ids.contains(id)) continue;
+        if (limitToIds != null && !limitToIds.contains(id)) continue;
         final double prevValue = docScores[id] ?? 0.0;
         final double currentValue = tokenMatch[token] * docWeights[id];
         docScores[id] = math.max(prevValue, currentValue);


### PR DESCRIPTION
Fixes #3231 

Optimizations:
- start word matching from the longest words
- rolling restriction of the result packages, early cut-off when there is no result so far

Limits:
- only the longest 20 words are checked
- after 500 ms the rest of the words (and also the exact phrase matching) is not checked

I've benchmarked long queries, and I've measured 30% drop of processing time from the first two optimization, and further 40% from the 20-words limit.