### PR TITLE
Remove container class from current site-header.

### DIFF
--- a/app/lib/frontend/templates/views/shared/site_header.mustache
+++ b/app/lib/frontend/templates/views/shared/site_header.mustache
@@ -2,7 +2,7 @@
     for details. All rights reserved. Use of this source code is governed by a
     BSD-style license that can be found in the LICENSE file. }}
 <header class="site-header-row">
-  <div class="container site-header">
+  <div class="site-header">
     <h1 class="_visuallyhidden">Dart pub</h1>
     <button class="hamburger"></button>
     <div class="mask"></div>

--- a/app/test/frontend/golden/authorized_page.html
+++ b/app/test/frontend/golden/authorized_page.html
@@ -30,7 +30,7 @@
   </head>
   <body class="non-experimental">
     <header class="site-header-row">
-      <div class="container site-header">
+      <div class="site-header">
         <h1 class="_visuallyhidden">Dart pub</h1>
         <button class="hamburger"></button>
         <div class="mask"></div>

--- a/app/test/frontend/golden/error_page.html
+++ b/app/test/frontend/golden/error_page.html
@@ -30,7 +30,7 @@
   </head>
   <body class="non-experimental">
     <header class="site-header-row">
-      <div class="container site-header">
+      <div class="site-header">
         <h1 class="_visuallyhidden">Dart pub</h1>
         <button class="hamburger"></button>
         <div class="mask"></div>

--- a/app/test/frontend/golden/landing_page.html
+++ b/app/test/frontend/golden/landing_page.html
@@ -31,7 +31,7 @@
   </head>
   <body class="page-landing non-experimental">
     <header class="site-header-row">
-      <div class="container site-header">
+      <div class="site-header">
         <h1 class="_visuallyhidden">Dart pub</h1>
         <button class="hamburger"></button>
         <div class="mask"></div>

--- a/app/test/frontend/golden/my_liked_packages.html
+++ b/app/test/frontend/golden/my_liked_packages.html
@@ -32,7 +32,7 @@
   </head>
   <body class="non-experimental">
     <header class="site-header-row">
-      <div class="container site-header">
+      <div class="site-header">
         <h1 class="_visuallyhidden">Dart pub</h1>
         <button class="hamburger"></button>
         <div class="mask"></div>

--- a/app/test/frontend/golden/my_packages.html
+++ b/app/test/frontend/golden/my_packages.html
@@ -32,7 +32,7 @@
   </head>
   <body class="non-experimental">
     <header class="site-header-row">
-      <div class="container site-header">
+      <div class="site-header">
         <h1 class="_visuallyhidden">Dart pub</h1>
         <button class="hamburger"></button>
         <div class="mask"></div>

--- a/app/test/frontend/golden/my_publishers.html
+++ b/app/test/frontend/golden/my_publishers.html
@@ -32,7 +32,7 @@
   </head>
   <body class="non-experimental">
     <header class="site-header-row">
-      <div class="container site-header">
+      <div class="site-header">
         <h1 class="_visuallyhidden">Dart pub</h1>
         <button class="hamburger"></button>
         <div class="mask"></div>

--- a/app/test/frontend/golden/pkg_admin_page_outdated.html
+++ b/app/test/frontend/golden/pkg_admin_page_outdated.html
@@ -33,7 +33,7 @@
   </head>
   <body class="non-experimental">
     <header class="site-header-row">
-      <div class="container site-header">
+      <div class="site-header">
         <h1 class="_visuallyhidden">Dart pub</h1>
         <button class="hamburger"></button>
         <div class="mask"></div>

--- a/app/test/frontend/golden/pkg_index_page.html
+++ b/app/test/frontend/golden/pkg_index_page.html
@@ -32,7 +32,7 @@
   </head>
   <body class="non-experimental">
     <header class="site-header-row">
-      <div class="container site-header">
+      <div class="site-header">
         <h1 class="_visuallyhidden">Dart pub</h1>
         <button class="hamburger"></button>
         <div class="mask"></div>

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -32,7 +32,7 @@
   </head>
   <body class="non-experimental">
     <header class="site-header-row">
-      <div class="container site-header">
+      <div class="site-header">
         <h1 class="_visuallyhidden">Dart pub</h1>
         <button class="hamburger"></button>
         <div class="mask"></div>

--- a/app/test/frontend/golden/pkg_show_page_discontinued.html
+++ b/app/test/frontend/golden/pkg_show_page_discontinued.html
@@ -33,7 +33,7 @@
   </head>
   <body class="non-experimental">
     <header class="site-header-row">
-      <div class="container site-header">
+      <div class="site-header">
         <h1 class="_visuallyhidden">Dart pub</h1>
         <button class="hamburger"></button>
         <div class="mask"></div>

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -32,7 +32,7 @@
   </head>
   <body class="non-experimental">
     <header class="site-header-row">
-      <div class="container site-header">
+      <div class="site-header">
         <h1 class="_visuallyhidden">Dart pub</h1>
         <button class="hamburger"></button>
         <div class="mask"></div>

--- a/app/test/frontend/golden/pkg_show_page_legacy.html
+++ b/app/test/frontend/golden/pkg_show_page_legacy.html
@@ -33,7 +33,7 @@
   </head>
   <body class="non-experimental">
     <header class="site-header-row">
-      <div class="container site-header">
+      <div class="site-header">
         <h1 class="_visuallyhidden">Dart pub</h1>
         <button class="hamburger"></button>
         <div class="mask"></div>

--- a/app/test/frontend/golden/pkg_show_page_outdated.html
+++ b/app/test/frontend/golden/pkg_show_page_outdated.html
@@ -33,7 +33,7 @@
   </head>
   <body class="non-experimental">
     <header class="site-header-row">
-      <div class="container site-header">
+      <div class="site-header">
         <h1 class="_visuallyhidden">Dart pub</h1>
         <button class="hamburger"></button>
         <div class="mask"></div>

--- a/app/test/frontend/golden/pkg_show_page_publisher.html
+++ b/app/test/frontend/golden/pkg_show_page_publisher.html
@@ -33,7 +33,7 @@
   </head>
   <body class="non-experimental">
     <header class="site-header-row">
-      <div class="container site-header">
+      <div class="site-header">
         <h1 class="_visuallyhidden">Dart pub</h1>
         <button class="hamburger"></button>
         <div class="mask"></div>

--- a/app/test/frontend/golden/pkg_show_version_page.html
+++ b/app/test/frontend/golden/pkg_show_version_page.html
@@ -34,7 +34,7 @@
   </head>
   <body class="non-experimental">
     <header class="site-header-row">
-      <div class="container site-header">
+      <div class="site-header">
         <h1 class="_visuallyhidden">Dart pub</h1>
         <button class="hamburger"></button>
         <div class="mask"></div>

--- a/app/test/frontend/golden/pkg_versions_page.html
+++ b/app/test/frontend/golden/pkg_versions_page.html
@@ -34,7 +34,7 @@
   </head>
   <body class="non-experimental">
     <header class="site-header-row">
-      <div class="container site-header">
+      <div class="site-header">
         <h1 class="_visuallyhidden">Dart pub</h1>
         <button class="hamburger"></button>
         <div class="mask"></div>

--- a/app/test/frontend/golden/publisher_list_page.html
+++ b/app/test/frontend/golden/publisher_list_page.html
@@ -31,7 +31,7 @@
   </head>
   <body class="non-experimental">
     <header class="site-header-row">
-      <div class="container site-header">
+      <div class="site-header">
         <h1 class="_visuallyhidden">Dart pub</h1>
         <button class="hamburger"></button>
         <div class="mask"></div>

--- a/app/test/frontend/golden/publisher_packages_page.html
+++ b/app/test/frontend/golden/publisher_packages_page.html
@@ -32,7 +32,7 @@
   </head>
   <body class="non-experimental">
     <header class="site-header-row">
-      <div class="container site-header">
+      <div class="site-header">
         <h1 class="_visuallyhidden">Dart pub</h1>
         <button class="hamburger"></button>
         <div class="mask"></div>

--- a/app/test/frontend/golden/search_page.html
+++ b/app/test/frontend/golden/search_page.html
@@ -32,7 +32,7 @@
   </head>
   <body class="non-experimental">
     <header class="site-header-row">
-      <div class="container site-header">
+      <div class="site-header">
         <h1 class="_visuallyhidden">Dart pub</h1>
         <button class="hamburger"></button>
         <div class="mask"></div>

--- a/pkg/web_css/lib/src/_site_header.scss
+++ b/pkg/web_css/lib/src/_site_header.scss
@@ -17,6 +17,9 @@ body.non-experimental {
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  max-width: $site-max-width;
+  margin: 0 auto;
+  padding: 0 20px;
 
   > .hamburger {
     display: none;


### PR DESCRIPTION
I'm trying to decouple the `container` style from other components, as it is easier to implement the new design without it.