### PR TITLE
New style for package lists.

### DIFF
--- a/app/lib/frontend/templates/listing.dart
+++ b/app/lib/frontend/templates/listing.dart
@@ -55,7 +55,6 @@ String renderPackageList(
       'name': view.name,
       'is_external': view.isExternal,
       'external_type': externalType,
-      'show_metadata': !view.isExternal,
       'version': view.version,
       'show_dev_version': view.devVersion != null,
       'dev_version': view.devVersion,
@@ -85,6 +84,8 @@ String renderPackageList(
                         isLatest: true, relativePath: page.path),
               })
           ?.toList(),
+      // TODO(3246): remove the keys below after we have migrated to the new design
+      'show_metadata': !view.isExternal,
     });
   }
   return templateCache.renderTemplate('pkg/package_list', {

--- a/app/lib/frontend/templates/views/pkg/package_list_experimental.mustache
+++ b/app/lib/frontend/templates/views/pkg/package_list_experimental.mustache
@@ -1,0 +1,49 @@
+{{! Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+    for details. All rights reserved. Use of this source code is governed by a
+    BSD-style license that can be found in the LICENSE file. }}
+
+<div class="packages">
+  {{#packages}}
+  <div class="packages-item">
+    <div class="packages-header">
+      <h3 class="packages-title"><a href="{{& url}}">{{name}}</a></h3>
+      <div class="packages-icons">
+        {{#is_flutter_favorite}}
+        <img src="{{static_assets.img__ff_svg}}"
+             class="packages-ff-icon"
+             title="Package {{name}} have been awarded Flutter Favorite" />
+        {{/is_flutter_favorite}}
+        {{& score_box_html }}
+      </div>
+    </div>
+    <p class="packages-description">{{desc}}</p>
+    {{#is_external}}
+    <p class="packages-metadata">v {{version}} • {{external_type}}</p>
+    {{/is_external}}
+    {{^is_external}}
+    <p class="packages-metadata">
+      v <a href="{{& url}}">{{version}}</a>
+      {{#show_dev_version}} / <a href="{{& dev_version_url}}">{{dev_version}}</a>{{/show_dev_version}}
+      • Updated: <span>{{last_uploaded}}</span>
+      {{#publisher_id}}
+      <img class="packages-vp-icon"
+           src="{{& static_assets.img__verified-publisher-gray_svg}}"
+           title="Published by a pub.dev verified publisher" />
+      <a href="/publishers/{{publisher_id}}">{{publisher_id}}</a>
+      {{/publisher_id}}
+    </p>
+    {{/is_external}}
+    <div>{{& tags_html}}</div>
+    {{#has_api_pages}}
+    <div class="packages-api">
+      API results
+      <ul>
+        {{#api_pages}}
+        <li><a href="{{& href}}">{{title}}</a></li>
+        {{/api_pages}}
+      </ul>
+    </div>
+    {{/has_api_pages}}
+  </div>
+  {{/packages}}
+</div>

--- a/pkg/web_css/lib/src/_list.scss
+++ b/pkg/web_css/lib/src/_list.scss
@@ -22,9 +22,6 @@ body.non-experimental {
   margin: 24px 6px 10px;
 }
 
-/* non-indented rule to restrict the content of this block to the non-experimental pages */
-}
-
 /******************************************************
   other listing page
 ******************************************************/
@@ -93,6 +90,9 @@ body.non-experimental {
   > .api_pages {
     font-size: 12px;
   }
+}
+
+/* non-indented rule to restrict the content of this block to the non-experimental pages */
 }
 
 .-pub-mini-list-publisher-badge {

--- a/pkg/web_css/lib/src/_list_experimental.scss
+++ b/pkg/web_css/lib/src/_list_experimental.scss
@@ -73,5 +73,80 @@ body.experimental {
   }
 }
 
+.packages {
+  .packages-item {
+    margin: 0px -4px 12px -4px;
+    padding: 4px;
+
+    &:hover {
+      background: #fafafa;
+    }
+  }
+
+  .packages-header {
+    display: flex;
+    align-items: center;
+    min-height: 40px;
+  }
+
+  .packages-title {
+    flex-grow: 1;
+    font-size: 22px;
+    margin: 0;
+  }
+
+  .packages-icons {
+    display: flex;
+    align-items: center;
+  }
+
+  .packages-ff-icon {
+    width: 40px;
+  }
+
+  .packages-description {
+    font-size: 14px;
+    font-weight: 300;
+    margin: 4px 0px;
+  }
+
+  .packages-metadata {
+    font-size: 12px;
+  }
+
+  .packages-vp-icon {
+    display: inline-block;
+    height: 14px;
+    margin-left: 4px;
+    position: relative;
+    top: 3px;
+  }
+
+  .packages-api {
+    color: #3c4043;
+    font-size: 12px;
+    margin-top: 6px;
+
+    > ul {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+
+      @media (min-width: $device-desktop-min-width) {
+        display: flex;
+
+        > li {
+          display: block;
+          margin-right: 32px;
+        }
+      }
+    }
+  }
+
+  .score-box {
+    float: none;
+  }
+}
+
 /* non-indented rule to restrict the content of this block to the experimental pages */
 }


### PR DESCRIPTION
Tags and score circle is not styled yet (added to #3246 to track, among other small items).

<img width="981" alt="Screen Shot 2020-01-23 at 19 14 31" src="https://user-images.githubusercontent.com/4778111/73011982-a1eb2900-3e15-11ea-9b20-1fcdead27921.png">
