### PR TITLE
New score circle.

### DIFF
--- a/app/lib/frontend/templates/views/shared/score_circle.mustache
+++ b/app/lib/frontend/templates/views/shared/score_circle.mustache
@@ -1,0 +1,17 @@
+{{! Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+    for details. All rights reserved. Use of this source code is governed by a
+    BSD-style license that can be found in the LICENSE file. }}
+
+<div class="score-circle"{{#title}} title="{{title}}"{{/title}}>
+  {{#link}}<a href="{{& link}}">{{/link}}
+  <svg class="score-circle-arc" viewBox="-{{radius}} -{{radius}} {{diameter}} {{diameter}}">
+    <circle cx="0" cy="0"
+            r="{{radius}}"
+            transform="rotate(270)"
+            stroke-width="{{diameter}}"
+            stroke-dasharray="{{active}}, {{inactive}}"
+            fill="transparent"></circle>
+  </svg>
+  <span class="score-circle-label">{{label}}</span>
+  {{#link}}</a>{{/link}}
+</div>

--- a/pkg/web_css/lib/src/_list.scss
+++ b/pkg/web_css/lib/src/_list.scss
@@ -107,6 +107,7 @@ body.non-experimental {
   }
 }
 
+/* TODO(3246): Remove after migrating to the new UI. */
 .score-box {
   float: right;
   margin: 8px;

--- a/pkg/web_css/lib/src/_score_circle.scss
+++ b/pkg/web_css/lib/src/_score_circle.scss
@@ -1,0 +1,40 @@
+/* Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+   for details. All rights reserved. Use of this source code is governed by a
+   BSD-style license that can be found in the LICENSE file. */
+
+.score-circle {
+  width: 40px;
+  height: 40px;
+  background: white;
+  border-radius: 50%;
+  position: relative;
+
+  .score-circle-outline,
+  .score-circle-arc,
+  .score-circle-label {
+    position: absolute;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    right: 0;
+    border-radius: 50%;
+  }
+
+  .score-circle-arc {
+    background: $score-circle-outline;
+    stroke: $score-circle-stroke;
+  }
+
+  .score-circle-label, {
+    margin: 10%;
+    background: white;
+
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    color: $score-circle-label;
+    font-size: 16px;
+    font-weight: 500;
+  }
+}

--- a/pkg/web_css/lib/src/_variables.scss
+++ b/pkg/web_css/lib/src/_variables.scss
@@ -9,6 +9,11 @@ $device-mobile-max-width: 640px;
 
 $z-index-nav-mask: 1000;
 
+$score-circle-outline: #f0f0f0;
+$score-circle-stroke: #168afd;
+$score-circle-stroke: #168afd;
+$score-circle-label: $score-circle-stroke;
+
 $site-max-width: 1000px;
 $color-header-dark-bg: #1C2834;
 $color-header-dark-fg: #f8f9fa;

--- a/pkg/web_css/lib/style.scss
+++ b/pkg/web_css/lib/style.scss
@@ -9,5 +9,6 @@
 @import 'src/_list_experimental';
 @import 'src/_home';
 @import 'src/_pkg';
+@import 'src/_score_circle';
 @import 'src/_search';
 @import 'src/_overrides';


### PR DESCRIPTION
I've started out by doing CSS-based design for this, but it turned out really complex and required either inlined styles or pre-generating a style for each step we have on the score arc. Instead, the inline-SVG-based solution seems to be easy to style and also easy to maintain, and modern browsers support it. The SVG component has a full circle slice (implemented with dash-array on the circumference), and the label has a wide margin and white background to block out the central part of it.

<img width="50" alt="Screen Shot 2020-01-24 at 15 33 53" src="https://user-images.githubusercontent.com/4778111/73076796-25148980-3ebf-11ea-820d-eb56535bc0f2.png">

Updated #3246 for missing item (new package indicator).
