### PR TITLE
Restructure: main element + classes.

### DIFF
--- a/app/lib/frontend/templates/landing.dart
+++ b/app/lib/frontend/templates/landing.dart
@@ -58,5 +58,6 @@ String renderLandingPage({
     PageType.landing,
     content,
     title: 'Dart packages',
+    mainClasses: requestContext.isExperimental ? ['landing-main'] : null,
   );
 }

--- a/app/lib/frontend/templates/layout.dart
+++ b/app/lib/frontend/templates/layout.dart
@@ -48,7 +48,9 @@ String renderLayoutPage(
   bool noIndex = false,
   PageData pageData,
   String searchPlaceHolder,
+  List<String> mainClasses,
 }) {
+  mainClasses ??= ['container'];
   final isRoot = type == PageType.landing && sdk == null;
   final pageDataEncoded = pageData == null
       ? null
@@ -70,6 +72,7 @@ String renderLayoutPage(
     'dart_site_root': urls.dartSiteRoot,
     'oauth_client_id': activeConfiguration.pubSiteAudience,
     'body_class': bodyClasses.join(' '),
+    'main_class': mainClasses.join(' '),
     'no_index': noIndex,
     'favicon': faviconUrl ?? staticUrls.smallDartFavicon,
     'canonicalUrl': canonicalUrl,

--- a/app/lib/frontend/templates/views/shared/layout.mustache
+++ b/app/lib/frontend/templates/views/shared/layout.mustache
@@ -67,11 +67,9 @@
 </div>
 {{/show_search_banner}}
 
-<div class="container">
-  <main>
-    {{& content_html}}
-  </main>
-</div>
+<main class="{{main_class}}">
+{{& content_html}}
+</main>
 
 <footer class="site-footer">
   <a class="link" href="{{& dart_site_root}}/">Dart language</a>

--- a/app/test/frontend/golden/authorized_page.html
+++ b/app/test/frontend/golden/authorized_page.html
@@ -77,17 +77,15 @@
         </form>
       </div>
     </div>
-    <div class="container">
-      <main>
-        <h1>Pub Authorized Successfully</h1>
-        <p>
+    <main class="container">
+      <h1>Pub Authorized Successfully</h1>
+      <p>
   The 
-          <code>pub</code> client has been successfully authorized. You may now
+        <code>pub</code> client has been successfully authorized. You may now
   use it to upload packages and perform other tasks.
 
-        </p>
-      </main>
-    </div>
+      </p>
+    </main>
     <footer class="site-footer">
       <a class="link" href="https://dart.dev/">Dart language</a>
       <a class="link sep" href="https://www.google.com/intl/en/policies/terms/">Terms</a>

--- a/app/test/frontend/golden/error_page.html
+++ b/app/test/frontend/golden/error_page.html
@@ -77,27 +77,25 @@
         </form>
       </div>
     </div>
-    <div class="container">
-      <main>
-        <h2>error_title</h2>
-        <p>error_message</p>
-        <h2>Top packages</h2>
-        <div class="home-lists-container">
-          <ul class="package-list">
-            <li class="list-item -simple">
-              <h3 class="title">
-                <a href="/packages/popular_pkg">popular_pkg</a>
-              </h3>
-              <p class="metadata">
-                <a class="package-tag" href="/dart/packages" title="sdk:dart">dart</a>
-                <a class="package-tag" href="/flutter/packages" title="sdk:flutter">flutter</a>
-              </p>
-              <p class="description">Some popular package that is shown on the error page.</p>
-            </li>
-          </ul>
-        </div>
-      </main>
-    </div>
+    <main class="container">
+      <h2>error_title</h2>
+      <p>error_message</p>
+      <h2>Top packages</h2>
+      <div class="home-lists-container">
+        <ul class="package-list">
+          <li class="list-item -simple">
+            <h3 class="title">
+              <a href="/packages/popular_pkg">popular_pkg</a>
+            </h3>
+            <p class="metadata">
+              <a class="package-tag" href="/dart/packages" title="sdk:dart">dart</a>
+              <a class="package-tag" href="/flutter/packages" title="sdk:flutter">flutter</a>
+            </p>
+            <p class="description">Some popular package that is shown on the error page.</p>
+          </li>
+        </ul>
+      </div>
+    </main>
     <footer class="site-footer">
       <a class="link" href="https://dart.dev/">Dart language</a>
       <a class="link sep" href="https://www.google.com/intl/en/policies/terms/">Terms</a>

--- a/app/test/frontend/golden/landing_page.html
+++ b/app/test/frontend/golden/landing_page.html
@@ -100,57 +100,55 @@
         </p>
       </div>
     </div>
-    <div class="container">
-      <main>
-        <div class="home-lists-container">
-          <div class="landing-page-title-block">
-            <h2 class="center landing-page-title">Flutter Favorites</h2>
-          </div>
-          <ul class="package-list">
-            <li class="list-item -simple">
-              <h3 class="title">
-                <a href="/packages/foobar_pkg">foobar_pkg</a>
-              </h3>
-              <p class="metadata">
-                <a class="package-tag" href="/flutter/packages" title="sdk:flutter">flutter</a>
-              </p>
-              <p class="description">my package description</p>
-            </li>
-          </ul>
-          <div class="more">
-            <a href="/flutter/favorites">More Flutter Favorites...</a>
-          </div>
+    <main class="container">
+      <div class="home-lists-container">
+        <div class="landing-page-title-block">
+          <h2 class="center landing-page-title">Flutter Favorites</h2>
         </div>
-        <div class="home-lists-container">
-          <div class="landing-page-title-block">
-            <h2 class="center landing-page-title">Top packages</h2>
-          </div>
-          <ul class="package-list">
-            <li class="list-item -simple">
-              <h3 class="title">
-                <a href="/packages/foobar_pkg">foobar_pkg</a>
-              </h3>
-              <p class="metadata">
-                <a class="package-tag" href="/flutter/packages" title="sdk:flutter">flutter</a>
-              </p>
-              <p class="description">my package description</p>
-            </li>
-            <li class="list-item -simple">
-              <h3 class="title">
-                <a href="/packages/helium">helium</a>
-              </h3>
-              <p class="metadata">
-                <a class="package-tag" href="/dart/packages" title="sdk:dart">dart</a>
-              </p>
-              <p class="description">helium is a Dart package</p>
-            </li>
-          </ul>
-          <div class="more">
-            <a href="/packages">More packages...</a>
-          </div>
+        <ul class="package-list">
+          <li class="list-item -simple">
+            <h3 class="title">
+              <a href="/packages/foobar_pkg">foobar_pkg</a>
+            </h3>
+            <p class="metadata">
+              <a class="package-tag" href="/flutter/packages" title="sdk:flutter">flutter</a>
+            </p>
+            <p class="description">my package description</p>
+          </li>
+        </ul>
+        <div class="more">
+          <a href="/flutter/favorites">More Flutter Favorites...</a>
         </div>
-      </main>
-    </div>
+      </div>
+      <div class="home-lists-container">
+        <div class="landing-page-title-block">
+          <h2 class="center landing-page-title">Top packages</h2>
+        </div>
+        <ul class="package-list">
+          <li class="list-item -simple">
+            <h3 class="title">
+              <a href="/packages/foobar_pkg">foobar_pkg</a>
+            </h3>
+            <p class="metadata">
+              <a class="package-tag" href="/flutter/packages" title="sdk:flutter">flutter</a>
+            </p>
+            <p class="description">my package description</p>
+          </li>
+          <li class="list-item -simple">
+            <h3 class="title">
+              <a href="/packages/helium">helium</a>
+            </h3>
+            <p class="metadata">
+              <a class="package-tag" href="/dart/packages" title="sdk:dart">dart</a>
+            </p>
+            <p class="description">helium is a Dart package</p>
+          </li>
+        </ul>
+        <div class="more">
+          <a href="/packages">More packages...</a>
+        </div>
+      </div>
+    </main>
     <footer class="site-footer">
       <a class="link" href="https://dart.dev/">Dart language</a>
       <a class="link sep" href="https://www.google.com/intl/en/policies/terms/">Terms</a>

--- a/app/test/frontend/golden/my_liked_packages.html
+++ b/app/test/frontend/golden/my_liked_packages.html
@@ -79,70 +79,68 @@
         </form>
       </div>
     </div>
-    <div class="container">
-      <main>
-        <div class="detail-header">
-          <h2 class="title">User hans@juergen.com</h2>
-          <div class="metadata">
+    <main class="container">
+      <div class="detail-header">
+        <h2 class="title">User hans@juergen.com</h2>
+        <div class="metadata">
     Joined on Jan 1, 2014
     
-            <div class="tags"></div>
-          </div>
+          <div class="tags"></div>
         </div>
-        <div class="detail-container">
-          <ul class="detail-tabs-header">
-            <li class="tab-link" data-name="-packages-tab-" role="button">
-              <a href="/my-packages">My packages</a>
-            </li>
-            <li class="tab-button -active" data-name="-liked-packages-tab-" role="button">My liked packages</li>
-            <li class="tab-link" data-name="-publishers-tab-" role="button">
-              <a href="/my-publishers">My publishers</a>
-            </li>
-          </ul>
-          <div class="main detail-tabs-content">
-            <section class="tab-content -active" data-name="-liked-packages-tab-">
+      </div>
+      <div class="detail-container">
+        <ul class="detail-tabs-header">
+          <li class="tab-link" data-name="-packages-tab-" role="button">
+            <a href="/my-packages">My packages</a>
+          </li>
+          <li class="tab-button -active" data-name="-liked-packages-tab-" role="button">My liked packages</li>
+          <li class="tab-link" data-name="-publishers-tab-" role="button">
+            <a href="/my-publishers">My publishers</a>
+          </li>
+        </ul>
+        <div class="main detail-tabs-content">
+          <section class="tab-content -active" data-name="-liked-packages-tab-">
       You like 2 packages. 
 
 
-              <ul class="package-list">
-                <li class="list-item -compact">
-                  <button class="mdc-button mdc-button--unelevated -pub-like-button" data-mdc-auto-init="MDCRipple" data-package="super_package" data-thumb_up_outlined="/static/img/thumb-up-24px.svg?hash=mocked_hash_808020279" data-thumb_up_filled="/static/img/thumb-up-filled-24px.svg?hash=mocked_hash_368133424">
-                    <div class="mdc-button__ripple"></div>
-                    <img class="mdc-button__icon -pub-like-button-img" src="/static/img/thumb-up-filled-24px.svg?hash=mocked_hash_368133424" aria-hidden="true"/>
-                    <span class="mdc-button__label -pub-like-button-text">Unlike</span>
-                  </button>
-                  <h3 class="title">
-                    <a href="/packages/super_package">super_package</a>
-                  </h3>
-                  <p class="metadata"> Liked on: 
-                    <span>Nov 22, 2019</span>
-                  </p>
-                </li>
-                <li class="list-item -compact">
-                  <button class="mdc-button mdc-button--unelevated -pub-like-button" data-mdc-auto-init="MDCRipple" data-package="another_package" data-thumb_up_outlined="/static/img/thumb-up-24px.svg?hash=mocked_hash_808020279" data-thumb_up_filled="/static/img/thumb-up-filled-24px.svg?hash=mocked_hash_368133424">
-                    <div class="mdc-button__ripple"></div>
-                    <img class="mdc-button__icon -pub-like-button-img" src="/static/img/thumb-up-filled-24px.svg?hash=mocked_hash_368133424" aria-hidden="true"/>
-                    <span class="mdc-button__label -pub-like-button-text">Unlike</span>
-                  </button>
-                  <h3 class="title">
-                    <a href="/packages/another_package">another_package</a>
-                  </h3>
-                  <p class="metadata"> Liked on: 
-                    <span>Nov 22, 2019</span>
-                  </p>
-                </li>
-              </ul>
-            </section>
-          </div>
-          <aside class="detail-info-box">
-            <h3 class="title">Email</h3>
-            <p>hans@juergen.com</p>
-            <h3 class="title">Joined</h3>
-            <p>Jan 1, 2014</p>
-          </aside>
+            <ul class="package-list">
+              <li class="list-item -compact">
+                <button class="mdc-button mdc-button--unelevated -pub-like-button" data-mdc-auto-init="MDCRipple" data-package="super_package" data-thumb_up_outlined="/static/img/thumb-up-24px.svg?hash=mocked_hash_808020279" data-thumb_up_filled="/static/img/thumb-up-filled-24px.svg?hash=mocked_hash_368133424">
+                  <div class="mdc-button__ripple"></div>
+                  <img class="mdc-button__icon -pub-like-button-img" src="/static/img/thumb-up-filled-24px.svg?hash=mocked_hash_368133424" aria-hidden="true"/>
+                  <span class="mdc-button__label -pub-like-button-text">Unlike</span>
+                </button>
+                <h3 class="title">
+                  <a href="/packages/super_package">super_package</a>
+                </h3>
+                <p class="metadata"> Liked on: 
+                  <span>Nov 22, 2019</span>
+                </p>
+              </li>
+              <li class="list-item -compact">
+                <button class="mdc-button mdc-button--unelevated -pub-like-button" data-mdc-auto-init="MDCRipple" data-package="another_package" data-thumb_up_outlined="/static/img/thumb-up-24px.svg?hash=mocked_hash_808020279" data-thumb_up_filled="/static/img/thumb-up-filled-24px.svg?hash=mocked_hash_368133424">
+                  <div class="mdc-button__ripple"></div>
+                  <img class="mdc-button__icon -pub-like-button-img" src="/static/img/thumb-up-filled-24px.svg?hash=mocked_hash_368133424" aria-hidden="true"/>
+                  <span class="mdc-button__label -pub-like-button-text">Unlike</span>
+                </button>
+                <h3 class="title">
+                  <a href="/packages/another_package">another_package</a>
+                </h3>
+                <p class="metadata"> Liked on: 
+                  <span>Nov 22, 2019</span>
+                </p>
+              </li>
+            </ul>
+          </section>
         </div>
-      </main>
-    </div>
+        <aside class="detail-info-box">
+          <h3 class="title">Email</h3>
+          <p>hans@juergen.com</p>
+          <h3 class="title">Joined</h3>
+          <p>Jan 1, 2014</p>
+        </aside>
+      </div>
+    </main>
     <footer class="site-footer">
       <a class="link" href="https://dart.dev/">Dart language</a>
       <a class="link sep" href="https://www.google.com/intl/en/policies/terms/">Terms</a>

--- a/app/test/frontend/golden/my_packages.html
+++ b/app/test/frontend/golden/my_packages.html
@@ -79,118 +79,116 @@
         </form>
       </div>
     </div>
-    <div class="container">
-      <main>
-        <div class="detail-header">
-          <h2 class="title">User hans@juergen.com</h2>
-          <div class="metadata">
+    <main class="container">
+      <div class="detail-header">
+        <h2 class="title">User hans@juergen.com</h2>
+        <div class="metadata">
     Joined on Jan 1, 2014
     
-            <div class="tags"></div>
-          </div>
+          <div class="tags"></div>
         </div>
-        <div class="detail-container">
-          <ul class="detail-tabs-header">
-            <li class="tab-button -active" data-name="-packages-tab-" role="button">My packages</li>
-            <li class="tab-link" data-name="-liked-packages-tab-" role="button">
-              <a href="/my-liked-packages">My liked packages</a>
-            </li>
-            <li class="tab-link" data-name="-publishers-tab-" role="button">
-              <a href="/my-publishers">My publishers</a>
-            </li>
-          </ul>
-          <div class="main detail-tabs-content">
-            <section class="tab-content -active" data-name="-packages-tab-">
-              <div class="listing-sort-header">
-                <div class="tooltip-base hoverable">
-                  <span class="tooltip-dotted">Sorted by:</span>
-                  <select id="sort-control">
-                    <option value="listing_relevance" selected="selected">listing relevance</option>
-                    <option value="top">overall score</option>
-                    <option value="updated">recently updated</option>
-                    <option value="created">newest package</option>
-                    <option value="popularity">popularity</option>
-                  </select>
-                  <div class="tooltip-content tooltip-bottom-left">
+      </div>
+      <div class="detail-container">
+        <ul class="detail-tabs-header">
+          <li class="tab-button -active" data-name="-packages-tab-" role="button">My packages</li>
+          <li class="tab-link" data-name="-liked-packages-tab-" role="button">
+            <a href="/my-liked-packages">My liked packages</a>
+          </li>
+          <li class="tab-link" data-name="-publishers-tab-" role="button">
+            <a href="/my-publishers">My publishers</a>
+          </li>
+        </ul>
+        <div class="main detail-tabs-content">
+          <section class="tab-content -active" data-name="-packages-tab-">
+            <div class="listing-sort-header">
+              <div class="tooltip-base hoverable">
+                <span class="tooltip-dotted">Sorted by:</span>
+                <select id="sort-control">
+                  <option value="listing_relevance" selected="selected">listing relevance</option>
+                  <option value="top">overall score</option>
+                  <option value="updated">recently updated</option>
+                  <option value="created">newest package</option>
+                  <option value="popularity">popularity</option>
+                </select>
+                <div class="tooltip-content tooltip-bottom-left">
       Packages are sorted by the combination of their overall score and their specificity to the selected platform. More information on 
-                    <a href="/help#ranking">ranking</a>.
+                  <a href="/help#ranking">ranking</a>.
     
-                  </div>
                 </div>
               </div>
+            </div>
 
 You own 2 packages.
 
 
-              <ul class="package-list">
-                <li class="list-item -full">
-                  <a href="/packages/super_package#-analysis-tab-">
-                    <div class="score-box">
-                      <span class="number -solid" title="Analysis and more details.">97</span>
-                    </div>
-                  </a>
-                  <h3 class="title">
-                    <a href="/packages/super_package">super_package</a>
-                  </h3>
-                  <p class="description">A great web UI library.</p>
-                  <p class="metadata">
+            <ul class="package-list">
+              <li class="list-item -full">
+                <a href="/packages/super_package#-analysis-tab-">
+                  <div class="score-box">
+                    <span class="number -solid" title="Analysis and more details.">97</span>
+                  </div>
+                </a>
+                <h3 class="title">
+                  <a href="/packages/super_package">super_package</a>
+                </h3>
+                <p class="description">A great web UI library.</p>
+                <p class="metadata">
         v 
-                    <a href="/packages/super_package">1.0.0</a>
+                  <a href="/packages/super_package">1.0.0</a>
         
         • updated: 
-                    <span>3 Jan 2019</span>
-                    <a class="package-tag" href="/dart/packages" title="sdk:dart">dart</a>
-                  </p>
-                </li>
-                <li class="list-item -full">
-                  <a href="/packages/another_package#-analysis-tab-">
-                    <div class="score-box">
-                      <span class="number -solid" title="Analysis and more details.">90</span>
-                    </div>
-                  </a>
-                  <h3 class="title">
-                    <a href="/packages/another_package">another_package</a>
-                  </h3>
-                  <p class="description">Camera plugin.</p>
-                  <p class="metadata">
+                  <span>3 Jan 2019</span>
+                  <a class="package-tag" href="/dart/packages" title="sdk:dart">dart</a>
+                </p>
+              </li>
+              <li class="list-item -full">
+                <a href="/packages/another_package#-analysis-tab-">
+                  <div class="score-box">
+                    <span class="number -solid" title="Analysis and more details.">90</span>
+                  </div>
+                </a>
+                <h3 class="title">
+                  <a href="/packages/another_package">another_package</a>
+                </h3>
+                <p class="description">Camera plugin.</p>
+                <p class="metadata">
         v 
-                    <a href="/packages/another_package">2.0.0</a>
+                  <a href="/packages/another_package">2.0.0</a>
          / 
-                    <a href="/packages/another_package/versions/3.0.0-beta2">3.0.0-beta2</a>
+                  <a href="/packages/another_package/versions/3.0.0-beta2">3.0.0-beta2</a>
         • updated: 
-                    <span>30 Mar 2019</span>
-                    <a class="package-tag" href="/flutter/packages" title="sdk:flutter">flutter</a>
-                  </p>
-                </li>
-              </ul>
-              <ul class="pagination">
-                <li class="-disabled">
-                  <a href="">
-                    <span>«</span>
-                  </a>
-                </li>
-                <li class="-active">
-                  <a href="">
-                    <span>1</span>
-                  </a>
-                </li>
-                <li class="-disabled">
-                  <a href="">
-                    <span>»</span>
-                  </a>
-                </li>
-              </ul>
-            </section>
-          </div>
-          <aside class="detail-info-box">
-            <h3 class="title">Email</h3>
-            <p>hans@juergen.com</p>
-            <h3 class="title">Joined</h3>
-            <p>Jan 1, 2014</p>
-          </aside>
+                  <span>30 Mar 2019</span>
+                  <a class="package-tag" href="/flutter/packages" title="sdk:flutter">flutter</a>
+                </p>
+              </li>
+            </ul>
+            <ul class="pagination">
+              <li class="-disabled">
+                <a href="">
+                  <span>«</span>
+                </a>
+              </li>
+              <li class="-active">
+                <a href="">
+                  <span>1</span>
+                </a>
+              </li>
+              <li class="-disabled">
+                <a href="">
+                  <span>»</span>
+                </a>
+              </li>
+            </ul>
+          </section>
         </div>
-      </main>
-    </div>
+        <aside class="detail-info-box">
+          <h3 class="title">Email</h3>
+          <p>hans@juergen.com</p>
+          <h3 class="title">Joined</h3>
+          <p>Jan 1, 2014</p>
+        </aside>
+      </div>
+    </main>
     <footer class="site-footer">
       <a class="link" href="https://dart.dev/">Dart language</a>
       <a class="link sep" href="https://www.google.com/intl/en/policies/terms/">Terms</a>

--- a/app/test/frontend/golden/my_publishers.html
+++ b/app/test/frontend/golden/my_publishers.html
@@ -79,55 +79,53 @@
         </form>
       </div>
     </div>
-    <div class="container">
-      <main>
-        <div class="detail-header">
-          <h2 class="title">User hans@juergen.com</h2>
-          <div class="metadata">
+    <main class="container">
+      <div class="detail-header">
+        <h2 class="title">User hans@juergen.com</h2>
+        <div class="metadata">
     Joined on Jan 1, 2014
     
-            <div class="tags"></div>
-          </div>
+          <div class="tags"></div>
         </div>
-        <div class="detail-container">
-          <ul class="detail-tabs-header">
-            <li class="tab-link" data-name="-packages-tab-" role="button">
-              <a href="/my-packages">My packages</a>
-            </li>
-            <li class="tab-link" data-name="-liked-packages-tab-" role="button">
-              <a href="/my-liked-packages">My liked packages</a>
-            </li>
-            <li class="tab-button -active" data-name="-publishers-tab-" role="button">My publishers</li>
-          </ul>
-          <div class="main detail-tabs-content">
-            <section class="tab-content -active" data-name="-publishers-tab-">
-              <ul class="publisher-list">
-                <li class="list-item">
-                  <h3 class="title">
-                    <a href="/publishers/example.com">example.com</a>
-                  </h3>
-                  <p class="metadata">
+      </div>
+      <div class="detail-container">
+        <ul class="detail-tabs-header">
+          <li class="tab-link" data-name="-packages-tab-" role="button">
+            <a href="/my-packages">My packages</a>
+          </li>
+          <li class="tab-link" data-name="-liked-packages-tab-" role="button">
+            <a href="/my-liked-packages">My liked packages</a>
+          </li>
+          <li class="tab-button -active" data-name="-publishers-tab-" role="button">My publishers</li>
+        </ul>
+        <div class="main detail-tabs-content">
+          <section class="tab-content -active" data-name="-publishers-tab-">
+            <ul class="publisher-list">
+              <li class="list-item">
+                <h3 class="title">
+                  <a href="/publishers/example.com">example.com</a>
+                </h3>
+                <p class="metadata">
       Registered on Jul 15, 2019.
     </p>
-                </li>
-              </ul>
-              <h3>Want to create a new publisher?</h3>
-              <p>
+              </li>
+            </ul>
+            <h3>Want to create a new publisher?</h3>
+            <p>
   Use the 
-                <a href="/create-publisher">create publisher</a> page.
+              <a href="/create-publisher">create publisher</a> page.
 
-              </p>
-            </section>
-          </div>
-          <aside class="detail-info-box">
-            <h3 class="title">Email</h3>
-            <p>hans@juergen.com</p>
-            <h3 class="title">Joined</h3>
-            <p>Jan 1, 2014</p>
-          </aside>
+            </p>
+          </section>
         </div>
-      </main>
-    </div>
+        <aside class="detail-info-box">
+          <h3 class="title">Email</h3>
+          <p>hans@juergen.com</p>
+          <h3 class="title">Joined</h3>
+          <p>Jan 1, 2014</p>
+        </aside>
+      </div>
+    </main>
     <footer class="site-footer">
       <a class="link" href="https://dart.dev/">Dart language</a>
       <a class="link sep" href="https://www.google.com/intl/en/policies/terms/">Terms</a>

--- a/app/test/frontend/golden/pkg_admin_page_outdated.html
+++ b/app/test/frontend/golden/pkg_admin_page_outdated.html
@@ -80,128 +80,126 @@
         </form>
       </div>
     </div>
-    <div class="container">
-      <main>
-        <div class="detail-header">
-          <h2 class="title">foobar_pkg 0.1.1+5</h2>
-          <div class="metadata">
+    <main class="container">
+      <div class="detail-header">
+        <h2 class="title">foobar_pkg 0.1.1+5</h2>
+        <div class="metadata">
     
 Published 
-            <span>Jan 1, 2014</span>
-            <!-- &bull; Downloads: X -->
+          <span>Jan 1, 2014</span>
+          <!-- &bull; Downloads: X -->
   • Updated:
   
-            <span>
-              <a href="/packages/foobar_pkg">0.1.1+5</a>
-            </span>
+          <span>
+            <a href="/packages/foobar_pkg">0.1.1+5</a>
+          </span>
     /
     
-            <span>
-              <a href="/packages/foobar_pkg/versions/0.2.0-dev">0.2.0-dev</a>
-            </span>
-            <div class="-pub-likes">
-              <div>
-                <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" aria-hidden="true" aria-pressed="true">
-                  <img height="18" src="/static/img/thumb-up-24px.svg?hash=mocked_hash_808020279" class="mdc-icon-button__icon"/>
-                  <img height="18" width="18" src="/static/img/thumb-up-filled-24px.svg?hash=mocked_hash_368133424" class="mdc-icon-button__icon mdc-icon-button__icon--on"/>
-                </button>
-                <span id="likes-count">0 likes</span>
-              </div>
-            </div>
-            <div class="tags">
-              <span class="package-tag missing" title="Package version too old, check latest stable.">[outdated]</span>
+          <span>
+            <a href="/packages/foobar_pkg/versions/0.2.0-dev">0.2.0-dev</a>
+          </span>
+          <div class="-pub-likes">
+            <div>
+              <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" aria-hidden="true" aria-pressed="true">
+                <img height="18" src="/static/img/thumb-up-24px.svg?hash=mocked_hash_808020279" class="mdc-icon-button__icon"/>
+                <img height="18" width="18" src="/static/img/thumb-up-filled-24px.svg?hash=mocked_hash_368133424" class="mdc-icon-button__icon mdc-icon-button__icon--on"/>
+              </button>
+              <span id="likes-count">0 likes</span>
             </div>
           </div>
+          <div class="tags">
+            <span class="package-tag missing" title="Package version too old, check latest stable.">[outdated]</span>
+          </div>
         </div>
-        <div class="detail-container">
-          <ul class="detail-tabs-header">
-            <li class="tab-link" data-name="-readme-tab-" role="button">
-              <a href="/packages/foobar_pkg#-readme-tab-">Readme</a>
-            </li>
-            <li class="tab-link" data-name="-changelog-tab-" role="button">
-              <a href="/packages/foobar_pkg#-changelog-tab-">Changelog</a>
-            </li>
-            <li class="tab-link" data-name="-example-tab-" role="button">
-              <a href="/packages/foobar_pkg#-example-tab-">Example</a>
-            </li>
-            <li class="tab-link" data-name="-installing-tab-" role="button">
-              <a href="/packages/foobar_pkg#-installing-tab-">Installing</a>
-            </li>
-            <li class="tab-link" data-name="-versions-tab-" role="button">
-              <a href="/packages/foobar_pkg/versions">Versions</a>
-            </li>
-            <li class="tab-link" data-name="-analysis-tab-" role="button">
-              <a href="/packages/foobar_pkg#-analysis-tab-">
-                <div class="score-box">
-                  <span class="number -rotten" title="Analysis and more details.">0</span>
-                </div>
-              </a>
-            </li>
-            <li class="tab-button -active" data-name="-admin-tab-" role="button">Admin</li>
-          </ul>
-          <div class="main detail-tabs-content">
-            <section class="tab-content -active" data-name="-admin-tab-">
-              <h3>Package ownership</h3>
-              <div>
-                <p>
+      </div>
+      <div class="detail-container">
+        <ul class="detail-tabs-header">
+          <li class="tab-link" data-name="-readme-tab-" role="button">
+            <a href="/packages/foobar_pkg#-readme-tab-">Readme</a>
+          </li>
+          <li class="tab-link" data-name="-changelog-tab-" role="button">
+            <a href="/packages/foobar_pkg#-changelog-tab-">Changelog</a>
+          </li>
+          <li class="tab-link" data-name="-example-tab-" role="button">
+            <a href="/packages/foobar_pkg#-example-tab-">Example</a>
+          </li>
+          <li class="tab-link" data-name="-installing-tab-" role="button">
+            <a href="/packages/foobar_pkg#-installing-tab-">Installing</a>
+          </li>
+          <li class="tab-link" data-name="-versions-tab-" role="button">
+            <a href="/packages/foobar_pkg/versions">Versions</a>
+          </li>
+          <li class="tab-link" data-name="-analysis-tab-" role="button">
+            <a href="/packages/foobar_pkg#-analysis-tab-">
+              <div class="score-box">
+                <span class="number -rotten" title="Analysis and more details.">0</span>
+              </div>
+            </a>
+          </li>
+          <li class="tab-button -active" data-name="-admin-tab-" role="button">Admin</li>
+        </ul>
+        <div class="main detail-tabs-content">
+          <section class="tab-content -active" data-name="-admin-tab-">
+            <h3>Package ownership</h3>
+            <div>
+              <p>
     You can transfer this package to a verified publisher if you are a member of the publisher.
     Transferring the package removes the current uploaders, so that only the members of the publisher can upload new versions.
   </p>
-                <p>
-                  <strong>Upgrading to verified publishers is an irreversible operation.</strong>
+              <p>
+                <strong>Upgrading to verified publishers is an irreversible operation.</strong>
     Packages can be transferred between publishers, but they can't be converted back to legacy uploader ownership.
   
-                </p>
-                <div class="mdc-select" data-mdc-auto-init="MDCSelect">
-                  <i class="mdc-select__dropdown-icon"></i>
-                  <select id="-admin-set-publisher-input" class="mdc-select__native-control">
-                    <option value="" disabled="disabled" selected="selected"></option>
-                    <option value="example.com">example.com</option>
-                  </select>
-                  <label class="mdc-floating-label">Select a publisher</label>
-                  <div class="mdc-line-ripple"></div>
-                </div>
-                <br/>
-                <button id="-admin-set-publisher-button" class="pub-button-danger mdc-button mdc-button--raised" data-mdc-auto-init="MDCRipple">Transfer to publisher</button>
+              </p>
+              <div class="mdc-select" data-mdc-auto-init="MDCSelect">
+                <i class="mdc-select__dropdown-icon"></i>
+                <select id="-admin-set-publisher-input" class="mdc-select__native-control">
+                  <option value="" disabled="disabled" selected="selected"></option>
+                  <option value="example.com">example.com</option>
+                </select>
+                <label class="mdc-floating-label">Select a publisher</label>
+                <div class="mdc-line-ripple"></div>
               </div>
-              <h3>Discontinued</h3>
-              <div>
-                <p>
+              <br/>
+              <button id="-admin-set-publisher-button" class="pub-button-danger mdc-button mdc-button--raised" data-mdc-auto-init="MDCRipple">Transfer to publisher</button>
+            </div>
+            <h3>Discontinued</h3>
+            <div>
+              <p>
     If no one is maintaining this package, you can mark it as discontinued.
     Discontinued packages remain available, but pub.dev doesn’t display them in search results.
   </p>
-                <p>
-                  <button id="-admin-is-discontinued-toggle" class="mdc-button mdc-button--raised" data-mdc-auto-init="MDCRipple">Mark as "discontinued"</button>
-                </p>
-              </div>
-            </section>
-          </div>
-          <aside class="detail-info-box">
-            <h3 class="title">About</h3>
-            <p>my package description</p>
-            <p>
-              <a class="link" href="http://hans.juergen.com">Homepage</a>
-              <br/>
-            </p>
-            <h3 class="title">Uploader</h3>
-            <p>
-              <span class="author">
-                <a href="mailto:hans@juergen.com" title="Email hans@juergen.com">
-                  <i class="email-icon"></i>
-                </a>
-                <a href="/packages?q=email%3Ahans%40juergen.com" title="Search packages with hans@juergen.com" rel="nofollow">
-                  <i class="search-icon"></i>
-                </a> hans@juergen.com
-              </span>
-            </p>
-            <h3 class="title">More</h3>
-            <p>
-              <a href="/packages?q=dependency%3Afoobar_pkg" rel="nofollow">Packages that depend on foobar_pkg</a>
-            </p>
-          </aside>
+              <p>
+                <button id="-admin-is-discontinued-toggle" class="mdc-button mdc-button--raised" data-mdc-auto-init="MDCRipple">Mark as "discontinued"</button>
+              </p>
+            </div>
+          </section>
         </div>
-      </main>
-    </div>
+        <aside class="detail-info-box">
+          <h3 class="title">About</h3>
+          <p>my package description</p>
+          <p>
+            <a class="link" href="http://hans.juergen.com">Homepage</a>
+            <br/>
+          </p>
+          <h3 class="title">Uploader</h3>
+          <p>
+            <span class="author">
+              <a href="mailto:hans@juergen.com" title="Email hans@juergen.com">
+                <i class="email-icon"></i>
+              </a>
+              <a href="/packages?q=email%3Ahans%40juergen.com" title="Search packages with hans@juergen.com" rel="nofollow">
+                <i class="search-icon"></i>
+              </a> hans@juergen.com
+            </span>
+          </p>
+          <h3 class="title">More</h3>
+          <p>
+            <a href="/packages?q=dependency%3Afoobar_pkg" rel="nofollow">Packages that depend on foobar_pkg</a>
+          </p>
+        </aside>
+      </div>
+    </main>
     <footer class="site-footer">
       <a class="link" href="https://dart.dev/">Dart language</a>
       <a class="link sep" href="https://www.google.com/intl/en/policies/terms/">Terms</a>

--- a/app/test/frontend/golden/pkg_index_page.html
+++ b/app/test/frontend/golden/pkg_index_page.html
@@ -91,87 +91,85 @@
         </div>
       </div>
     </div>
-    <div class="container">
-      <main>
-        <div class="listing-sort-header">
-          <div class="tooltip-base hoverable">
-            <span class="tooltip-dotted">Sorted by:</span>
-            <select id="sort-control">
-              <option value="listing_relevance" selected="selected">listing relevance</option>
-              <option value="top">overall score</option>
-              <option value="updated">recently updated</option>
-              <option value="created">newest package</option>
-              <option value="popularity">popularity</option>
-            </select>
-            <div class="tooltip-content tooltip-bottom-left">
+    <main class="container">
+      <div class="listing-sort-header">
+        <div class="tooltip-base hoverable">
+          <span class="tooltip-dotted">Sorted by:</span>
+          <select id="sort-control">
+            <option value="listing_relevance" selected="selected">listing relevance</option>
+            <option value="top">overall score</option>
+            <option value="updated">recently updated</option>
+            <option value="created">newest package</option>
+            <option value="popularity">popularity</option>
+          </select>
+          <div class="tooltip-content tooltip-bottom-left">
       Packages are sorted by the combination of their overall score and their specificity to the selected platform. More information on 
-              <a href="/help#ranking">ranking</a>.
+            <a href="/help#ranking">ranking</a>.
     
-            </div>
           </div>
         </div>
-        <h2 class="listing-page-title">Top packages</h2>
-        <ul class="package-list">
-          <li class="list-item -full">
-            <a href="/packages/foobar_pkg#-analysis-tab-">
-              <div class="score-box">
-                <span class="number -rotten" title="Analysis and more details.">0</span>
-              </div>
-            </a>
-            <h3 class="title">
-              <a href="/packages/foobar_pkg">foobar_pkg</a>
-            </h3>
-            <p class="description">my package description</p>
-            <p class="metadata">
+      </div>
+      <h2 class="listing-page-title">Top packages</h2>
+      <ul class="package-list">
+        <li class="list-item -full">
+          <a href="/packages/foobar_pkg#-analysis-tab-">
+            <div class="score-box">
+              <span class="number -rotten" title="Analysis and more details.">0</span>
+            </div>
+          </a>
+          <h3 class="title">
+            <a href="/packages/foobar_pkg">foobar_pkg</a>
+          </h3>
+          <p class="description">my package description</p>
+          <p class="metadata">
         v 
-              <a href="/packages/foobar_pkg">0.1.1+5</a>
+            <a href="/packages/foobar_pkg">0.1.1+5</a>
          / 
-              <a href="/packages/foobar_pkg/versions/0.2.0-dev">0.2.0-dev</a>
+            <a href="/packages/foobar_pkg/versions/0.2.0-dev">0.2.0-dev</a>
         • updated: 
-              <span>Jan 1, 2014</span>
-              <span class="package-tag missing" title="Analysis should be ready soon.">[awaiting]</span>
-            </p>
-          </li>
-          <li class="list-item -full">
-            <a href="/packages/foobar_pkg#-analysis-tab-">
-              <div class="score-box">
-                <span class="number -rotten" title="Analysis and more details.">0</span>
-              </div>
-            </a>
-            <h3 class="title">
-              <a href="/packages/foobar_pkg">foobar_pkg</a>
-            </h3>
-            <p class="description">my package description</p>
-            <p class="metadata">
+            <span>Jan 1, 2014</span>
+            <span class="package-tag missing" title="Analysis should be ready soon.">[awaiting]</span>
+          </p>
+        </li>
+        <li class="list-item -full">
+          <a href="/packages/foobar_pkg#-analysis-tab-">
+            <div class="score-box">
+              <span class="number -rotten" title="Analysis and more details.">0</span>
+            </div>
+          </a>
+          <h3 class="title">
+            <a href="/packages/foobar_pkg">foobar_pkg</a>
+          </h3>
+          <p class="description">my package description</p>
+          <p class="metadata">
         v 
-              <a href="/packages/foobar_pkg">0.1.1+5</a>
+            <a href="/packages/foobar_pkg">0.1.1+5</a>
          / 
-              <a href="/packages/foobar_pkg/versions/0.2.0-dev">0.2.0-dev</a>
+            <a href="/packages/foobar_pkg/versions/0.2.0-dev">0.2.0-dev</a>
         • updated: 
-              <span>Jan 1, 2015</span>
-              <a class="package-tag" href="/flutter/packages" title="sdk:flutter">flutter</a>
-            </p>
-          </li>
-        </ul>
-        <ul class="pagination">
-          <li class="-disabled">
-            <a href="">
-              <span>«</span>
-            </a>
-          </li>
-          <li class="-active">
-            <a href="">
-              <span>1</span>
-            </a>
-          </li>
-          <li class="-disabled">
-            <a href="">
-              <span>»</span>
-            </a>
-          </li>
-        </ul>
-      </main>
-    </div>
+            <span>Jan 1, 2015</span>
+            <a class="package-tag" href="/flutter/packages" title="sdk:flutter">flutter</a>
+          </p>
+        </li>
+      </ul>
+      <ul class="pagination">
+        <li class="-disabled">
+          <a href="">
+            <span>«</span>
+          </a>
+        </li>
+        <li class="-active">
+          <a href="">
+            <span>1</span>
+          </a>
+        </li>
+        <li class="-disabled">
+          <a href="">
+            <span>»</span>
+          </a>
+        </li>
+      </ul>
+    </main>
     <footer class="site-footer">
       <a class="link" href="https://dart.dev/">Dart language</a>
       <a class="link sep" href="https://www.google.com/intl/en/policies/terms/">Terms</a>

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -79,296 +79,294 @@
         </form>
       </div>
     </div>
-    <div class="container">
-      <main>
-        <div class="detail-header">
-          <h2 class="title">foobar_pkg 0.1.1+5</h2>
-          <div class="metadata">
+    <main class="container">
+      <div class="detail-header">
+        <h2 class="title">foobar_pkg 0.1.1+5</h2>
+        <div class="metadata">
     
 Published 
-            <span>Jan 1, 2014</span>
-            <!-- &bull; Downloads: X -->
+          <span>Jan 1, 2014</span>
+          <!-- &bull; Downloads: X -->
   • Updated:
   
-            <span>
-              <a href="/packages/foobar_pkg">0.1.1+5</a>
-            </span>
+          <span>
+            <a href="/packages/foobar_pkg">0.1.1+5</a>
+          </span>
     /
     
-            <span>
-              <a href="/packages/foobar_pkg/versions/0.2.0-dev">0.2.0-dev</a>
-            </span>
-            <div class="-pub-likes">
-              <div>
-                <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" aria-hidden="true" aria-pressed="true">
-                  <img height="18" src="/static/img/thumb-up-24px.svg?hash=mocked_hash_808020279" class="mdc-icon-button__icon"/>
-                  <img height="18" width="18" src="/static/img/thumb-up-filled-24px.svg?hash=mocked_hash_368133424" class="mdc-icon-button__icon mdc-icon-button__icon--on"/>
-                </button>
-                <span id="likes-count">0 likes</span>
-              </div>
-            </div>
-            <div class="tags">
-              <a class="package-tag unidentified" href="#-analysis-tab-" title="Check the analysis tab for further details.">[unidentified]</a>
+          <span>
+            <a href="/packages/foobar_pkg/versions/0.2.0-dev">0.2.0-dev</a>
+          </span>
+          <div class="-pub-likes">
+            <div>
+              <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" aria-hidden="true" aria-pressed="true">
+                <img height="18" src="/static/img/thumb-up-24px.svg?hash=mocked_hash_808020279" class="mdc-icon-button__icon"/>
+                <img height="18" width="18" src="/static/img/thumb-up-filled-24px.svg?hash=mocked_hash_368133424" class="mdc-icon-button__icon mdc-icon-button__icon--on"/>
+              </button>
+              <span id="likes-count">0 likes</span>
             </div>
           </div>
+          <div class="tags">
+            <a class="package-tag unidentified" href="#-analysis-tab-" title="Check the analysis tab for further details.">[unidentified]</a>
+          </div>
         </div>
-        <div class="detail-container">
-          <ul class="detail-tabs-header">
-            <li class="tab-button -active" data-name="-readme-tab-" role="button">Readme</li>
-            <li class="tab-button" data-name="-changelog-tab-" role="button">Changelog</li>
-            <li class="tab-button" data-name="-example-tab-" role="button">Example</li>
-            <li class="tab-button" data-name="-installing-tab-" role="button">Installing</li>
-            <li class="tab-link" data-name="-versions-tab-" role="button">
-              <a href="/packages/foobar_pkg/versions">Versions</a>
-            </li>
-            <li class="tab-button" data-name="-analysis-tab-" role="button">
-              <div class="score-box">
-                <span class="number -rotten" title="Analysis and more details.">3</span>
-              </div>
-            </li>
-            <li class="tab-link" data-name="-admin-tab-" role="button">
-              <a href="/packages/foobar_pkg/admin">Admin</a>
-            </li>
-          </ul>
-          <div class="main detail-tabs-content">
-            <section class="tab-content -active markdown-body" data-name="-readme-tab-">
-              <h1 class="hash-header" id="test-package">Test Package 
-                <a href="#test-package" class="hash-link">#</a>
-              </h1>
-              <p>This is a readme file.</p>
-              <pre>
-                <code class="language-dart">void main() {
+      </div>
+      <div class="detail-container">
+        <ul class="detail-tabs-header">
+          <li class="tab-button -active" data-name="-readme-tab-" role="button">Readme</li>
+          <li class="tab-button" data-name="-changelog-tab-" role="button">Changelog</li>
+          <li class="tab-button" data-name="-example-tab-" role="button">Example</li>
+          <li class="tab-button" data-name="-installing-tab-" role="button">Installing</li>
+          <li class="tab-link" data-name="-versions-tab-" role="button">
+            <a href="/packages/foobar_pkg/versions">Versions</a>
+          </li>
+          <li class="tab-button" data-name="-analysis-tab-" role="button">
+            <div class="score-box">
+              <span class="number -rotten" title="Analysis and more details.">3</span>
+            </div>
+          </li>
+          <li class="tab-link" data-name="-admin-tab-" role="button">
+            <a href="/packages/foobar_pkg/admin">Admin</a>
+          </li>
+        </ul>
+        <div class="main detail-tabs-content">
+          <section class="tab-content -active markdown-body" data-name="-readme-tab-">
+            <h1 class="hash-header" id="test-package">Test Package 
+              <a href="#test-package" class="hash-link">#</a>
+            </h1>
+            <p>This is a readme file.</p>
+            <pre>
+              <code class="language-dart">void main() {
 }
 </code>
-              </pre>
-            </section>
-            <section class="tab-content markdown-body" data-name="-changelog-tab-">
-              <h1 class="hash-header" id="changelog">Changelog 
-                <a href="#changelog" class="hash-link">#</a>
-              </h1>
-              <p>0.1.1 - test package</p>
-            </section>
-            <section class="tab-content markdown-body" data-name="-example-tab-">
-              <p style="font-family: monospace">
-                <b>example/lib/main.dart</b>
-              </p>
-              <pre>
-                <code class="language-dart">main() {
+            </pre>
+          </section>
+          <section class="tab-content markdown-body" data-name="-changelog-tab-">
+            <h1 class="hash-header" id="changelog">Changelog 
+              <a href="#changelog" class="hash-link">#</a>
+            </h1>
+            <p>0.1.1 - test package</p>
+          </section>
+          <section class="tab-content markdown-body" data-name="-example-tab-">
+            <p style="font-family: monospace">
+              <b>example/lib/main.dart</b>
+            </p>
+            <pre>
+              <code class="language-dart">main() {
   print('Hello world!');
 }
 </code>
-              </pre>
-            </section>
-            <section class="tab-content" data-name="-installing-tab-">
-              <h2>Use this package as a library</h2>
-              <h3>1. Depend on it</h3>
-              <p>Add this to your package's pubspec.yaml file:</p>
-              <pre>
-                <code class="language-yaml">
+            </pre>
+          </section>
+          <section class="tab-content" data-name="-installing-tab-">
+            <h2>Use this package as a library</h2>
+            <h3>1. Depend on it</h3>
+            <p>Add this to your package's pubspec.yaml file:</p>
+            <pre>
+              <code class="language-yaml">
 dependencies:
   
-                  <strong>foobar_pkg: ^0.1.1+5</strong>
-                </code>
-              </pre>
-              <h3>2. Install it</h3>
-              <p>You can install packages from the command line:</p>
-              <p>with pub:</p>
-              <pre>
-                <code class="language-shell">
+                <strong>foobar_pkg: ^0.1.1+5</strong>
+              </code>
+            </pre>
+            <h3>2. Install it</h3>
+            <p>You can install packages from the command line:</p>
+            <p>with pub:</p>
+            <pre>
+              <code class="language-shell">
 $ 
-                  <strong>pub get</strong>
-                </code>
-              </pre>
-              <p>Alternatively, your editor might support 
-                <code>pub get</code>.
+                <strong>pub get</strong>
+              </code>
+            </pre>
+            <p>Alternatively, your editor might support 
+              <code>pub get</code>.
   Check the docs for your editor to learn more.
-              </p>
-              <h3>3. Import it</h3>
-              <p>Now in your Dart code, you can use:
+            </p>
+            <h3>3. Import it</h3>
+            <p>Now in your Dart code, you can use:
   </p>
-              <pre>
-                <code class="language-dart">
+            <pre>
+              <code class="language-dart">
 import 'package:foobar_pkg/foolib.dart';
   </code>
-              </pre>
-            </section>
-            <section class="tab-content" data-name="-analysis-tab-">
-              <table id='scores-table'>
-                <tr>
-                  <td class="score-name">
-                    <div class="tooltip-base hoverable">
-                      <span class="tooltip-dotted">Popularity:</span>
-                      <div class="tooltip-content">
+            </pre>
+          </section>
+          <section class="tab-content" data-name="-analysis-tab-">
+            <table id='scores-table'>
+              <tr>
+                <td class="score-name">
+                  <div class="tooltip-base hoverable">
+                    <span class="tooltip-dotted">Popularity:</span>
+                    <div class="tooltip-content">
           Describes how popular the package is relative to other packages.
           
-                        <a href="/help#popularity">[more]</a>
-                      </div>
+                      <a href="/help#popularity">[more]</a>
                     </div>
-                  </td>
-                  <td class="score-value">
-                    <div class="score-percent-row">
-                      <div class="score-percent" style="left: 0%;">--</div>
+                  </div>
+                </td>
+                <td class="score-value">
+                  <div class="score-percent-row">
+                    <div class="score-percent" style="left: 0%;">--</div>
+                  </div>
+                  <div class="score-progress-row">
+                    <div class="score-progress-frame">
+                      <div class="score-progress" style="width: 0%; background: rgb(204, 204, 204);"></div>
                     </div>
-                    <div class="score-progress-row">
-                      <div class="score-progress-frame">
-                        <div class="score-progress" style="width: 0%; background: rgb(204, 204, 204);"></div>
-                      </div>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="score-name">
-                    <div class="tooltip-base hoverable">
-                      <span class="tooltip-dotted">Health:</span>
-                      <div class="tooltip-content">
+                  </div>
+                </td>
+              </tr>
+              <tr>
+                <td class="score-name">
+                  <div class="tooltip-base hoverable">
+                    <span class="tooltip-dotted">Health:</span>
+                    <div class="tooltip-content">
           Code health derived from static analysis.
           
-                        <a href="/help#health">[more]</a>
-                      </div>
+                      <a href="/help#health">[more]</a>
                     </div>
-                  </td>
-                  <td class="score-value">
-                    <div class="score-percent-row">
-                      <div class="score-percent" style="left: 10%;">10</div>
+                  </div>
+                </td>
+                <td class="score-value">
+                  <div class="score-percent-row">
+                    <div class="score-percent" style="left: 10%;">10</div>
+                  </div>
+                  <div class="score-progress-row">
+                    <div class="score-progress-frame">
+                      <div class="score-progress" style="width: 10%; background: rgb(120, 134, 149);"></div>
                     </div>
-                    <div class="score-progress-row">
-                      <div class="score-progress-frame">
-                        <div class="score-progress" style="width: 10%; background: rgb(120, 134, 149);"></div>
-                      </div>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="score-name">
-                    <div class="tooltip-base hoverable">
-                      <span class="tooltip-dotted">Maintenance:</span>
-                      <div class="tooltip-content">
+                  </div>
+                </td>
+              </tr>
+              <tr>
+                <td class="score-name">
+                  <div class="tooltip-base hoverable">
+                    <span class="tooltip-dotted">Maintenance:</span>
+                    <div class="tooltip-content">
           Reflects how tidy and up-to-date the package is.
           
-                        <a href="/help#maintenance">[more]</a>
-                      </div>
+                      <a href="/help#maintenance">[more]</a>
                     </div>
-                  </td>
-                  <td class="score-value">
-                    <div class="score-percent-row">
-                      <div class="score-percent" style="left: 0%;">--</div>
+                  </div>
+                </td>
+                <td class="score-value">
+                  <div class="score-percent-row">
+                    <div class="score-percent" style="left: 0%;">--</div>
+                  </div>
+                  <div class="score-progress-row">
+                    <div class="score-progress-frame">
+                      <div class="score-progress" style="width: 0%; background: rgb(204, 204, 204);"></div>
                     </div>
-                    <div class="score-progress-row">
-                      <div class="score-progress-frame">
-                        <div class="score-progress" style="width: 0%; background: rgb(204, 204, 204);"></div>
-                      </div>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="score-name">
-                    <div class="tooltip-base hoverable">
-                      <span class="tooltip-dotted">
-                        <b>Overall:</b>
-                      </span>
-                      <div class="tooltip-content">
+                  </div>
+                </td>
+              </tr>
+              <tr>
+                <td class="score-name">
+                  <div class="tooltip-base hoverable">
+                    <span class="tooltip-dotted">
+                      <b>Overall:</b>
+                    </span>
+                    <div class="tooltip-content">
           Weighted score of the above.
           
-                        <a href="/help#overall-score">[more]</a>
-                      </div>
+                      <a href="/help#overall-score">[more]</a>
                     </div>
-                  </td>
-                  <td>
-                    <div class="score-percent-row">
-                      <div class="score-percent" style="left: 3%;">3</div>
+                  </div>
+                </td>
+                <td>
+                  <div class="score-percent-row">
+                    <div class="score-percent" style="left: 3%;">3</div>
+                  </div>
+                  <div class="score-progress-row">
+                    <div class="score-progress-frame">
+                      <div class="score-progress" style="width: 3%; background: rgb(187, 36, 0);"></div>
                     </div>
-                    <div class="score-progress-row">
-                      <div class="score-progress-frame">
-                        <div class="score-progress" style="width: 3%; background: rgb(187, 36, 0);"></div>
-                      </div>
-                    </div>
-                  </td>
-                </tr>
-              </table>
-              <div style="text-align: right; font-size: 10pt;">Learn more about 
-                <a href="/help#scoring">scoring</a>.
-              </div>
-              <hr/>
-              <p>
+                  </div>
+                </td>
+              </tr>
+            </table>
+            <div style="text-align: right; font-size: 10pt;">Learn more about 
+              <a href="/help#scoring">scoring</a>.
+            </div>
+            <hr/>
+            <p>
   We analyzed this package on Feb 5, 2018, and provided a score, details, and suggestions below.
   Analysis was completed with status 
-                <i>completed</i> using:
+              <i>completed</i> using:
 
-              </p>
-              <ul>
-                <li>Dart: 2.0.0-dev.7.0</li>
-                <li>pana: 0.6.2</li>
-              </ul>
-              <h4>Dependencies</h4>
-              <div class="overflow-x">
-                <table class="dependency-table">
-                  <tr>
-                    <th>Package</th>
-                    <th>Constraint</th>
-                    <th>Resolved</th>
-                    <th>Available</th>
-                  </tr>
-                  <tr>
-                    <th colspan="4" class="sub-header">Direct dependencies</th>
-                  </tr>
-                  <tr>
-                    <td>
-                      <a href="/packages/http">http</a>
-                    </td>
-                    <td>>=1.0.0 &lt;1.2.0</td>
-                    <td>1.2.0</td>
-                    <td>1.3.0</td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <a href="/packages/quiver">quiver</a>
-                    </td>
-                    <td>^1.0.0</td>
-                    <td>1.0.0</td>
-                    <td></td>
-                  </tr>
-                </table>
-              </div>
-            </section>
-          </div>
-          <aside class="detail-info-box">
-            <h3 class="title">About</h3>
-            <p>my package description</p>
-            <p>
-              <a class="link" href="http://hans.juergen.com">Homepage</a>
-              <br/>
-              <a class="link" href="/documentation/foobar_pkg/latest/">API reference</a>
-              <br/>
             </p>
-            <h3 class="title">Uploader</h3>
-            <p>
-              <span class="author">
-                <a href="mailto:hans@juergen.com" title="Email hans@juergen.com">
-                  <i class="email-icon"></i>
-                </a>
-                <a href="/packages?q=email%3Ahans%40juergen.com" title="Search packages with hans@juergen.com" rel="nofollow">
-                  <i class="search-icon"></i>
-                </a> hans@juergen.com
-              </span>
-            </p>
-            <h3 class="title">License</h3>
-            <p>BSD (LICENSE.txt)</p>
-            <h3 class="title">Dependencies</h3>
-            <p>
-              <a href="/packages/http">http</a>, 
-              <a href="/packages/quiver">quiver</a>
-            </p>
-            <h3 class="title">More</h3>
-            <p>
-              <a href="/packages?q=dependency%3Afoobar_pkg" rel="nofollow">Packages that depend on foobar_pkg</a>
-            </p>
-          </aside>
+            <ul>
+              <li>Dart: 2.0.0-dev.7.0</li>
+              <li>pana: 0.6.2</li>
+            </ul>
+            <h4>Dependencies</h4>
+            <div class="overflow-x">
+              <table class="dependency-table">
+                <tr>
+                  <th>Package</th>
+                  <th>Constraint</th>
+                  <th>Resolved</th>
+                  <th>Available</th>
+                </tr>
+                <tr>
+                  <th colspan="4" class="sub-header">Direct dependencies</th>
+                </tr>
+                <tr>
+                  <td>
+                    <a href="/packages/http">http</a>
+                  </td>
+                  <td>>=1.0.0 &lt;1.2.0</td>
+                  <td>1.2.0</td>
+                  <td>1.3.0</td>
+                </tr>
+                <tr>
+                  <td>
+                    <a href="/packages/quiver">quiver</a>
+                  </td>
+                  <td>^1.0.0</td>
+                  <td>1.0.0</td>
+                  <td></td>
+                </tr>
+              </table>
+            </div>
+          </section>
         </div>
-        <script type="application/ld+json">
+        <aside class="detail-info-box">
+          <h3 class="title">About</h3>
+          <p>my package description</p>
+          <p>
+            <a class="link" href="http://hans.juergen.com">Homepage</a>
+            <br/>
+            <a class="link" href="/documentation/foobar_pkg/latest/">API reference</a>
+            <br/>
+          </p>
+          <h3 class="title">Uploader</h3>
+          <p>
+            <span class="author">
+              <a href="mailto:hans@juergen.com" title="Email hans@juergen.com">
+                <i class="email-icon"></i>
+              </a>
+              <a href="/packages?q=email%3Ahans%40juergen.com" title="Search packages with hans@juergen.com" rel="nofollow">
+                <i class="search-icon"></i>
+              </a> hans@juergen.com
+            </span>
+          </p>
+          <h3 class="title">License</h3>
+          <p>BSD (LICENSE.txt)</p>
+          <h3 class="title">Dependencies</h3>
+          <p>
+            <a href="/packages/http">http</a>, 
+            <a href="/packages/quiver">quiver</a>
+          </p>
+          <h3 class="title">More</h3>
+          <p>
+            <a href="/packages?q=dependency%3Afoobar_pkg" rel="nofollow">Packages that depend on foobar_pkg</a>
+          </p>
+        </aside>
+      </div>
+      <script type="application/ld+json">
 {"@context":"http://schema.org","@type":"SoftwareSourceCode","name":"foobar_pkg","version":"0.1.1+5","description":"foobar_pkg - my package description","url":"https://pub.dev/packages/foobar_pkg","dateCreated":"2014-01-01T00:00:00.000Z","dateModified":"2014-01-01T00:00:00.000Z","programmingLanguage":"Dart","image":"https://pub.dev/static/img/dart-logo-400x400.png"}
 </script>
-      </main>
-    </div>
+    </main>
     <footer class="site-footer">
       <a class="link" href="https://dart.dev/">Dart language</a>
       <a class="link sep" href="https://www.google.com/intl/en/policies/terms/">Terms</a>

--- a/app/test/frontend/golden/pkg_show_page_discontinued.html
+++ b/app/test/frontend/golden/pkg_show_page_discontinued.html
@@ -80,245 +80,243 @@
         </form>
       </div>
     </div>
-    <div class="container">
-      <main>
-        <div class="detail-header">
-          <h2 class="title">foobar_pkg 0.1.1+5</h2>
-          <div class="metadata">
+    <main class="container">
+      <div class="detail-header">
+        <h2 class="title">foobar_pkg 0.1.1+5</h2>
+        <div class="metadata">
     
 Published 
-            <span>Jan 1, 2014</span>
-            <!-- &bull; Downloads: X -->
+          <span>Jan 1, 2014</span>
+          <!-- &bull; Downloads: X -->
   • Updated:
   
-            <span>
-              <a href="/packages/foobar_pkg">0.1.1+5</a>
-            </span>
+          <span>
+            <a href="/packages/foobar_pkg">0.1.1+5</a>
+          </span>
     /
     
-            <span>
-              <a href="/packages/foobar_pkg/versions/0.2.0-dev">0.2.0-dev</a>
-            </span>
-            <div class="-pub-likes">
-              <div>
-                <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" aria-hidden="true" aria-pressed="true">
-                  <img height="18" src="/static/img/thumb-up-24px.svg?hash=mocked_hash_808020279" class="mdc-icon-button__icon"/>
-                  <img height="18" width="18" src="/static/img/thumb-up-filled-24px.svg?hash=mocked_hash_368133424" class="mdc-icon-button__icon mdc-icon-button__icon--on"/>
-                </button>
-                <span id="likes-count">0 likes</span>
-              </div>
-            </div>
-            <div class="tags">
-              <span class="package-tag discontinued" title="Package was discontinued.">[discontinued]</span>
+          <span>
+            <a href="/packages/foobar_pkg/versions/0.2.0-dev">0.2.0-dev</a>
+          </span>
+          <div class="-pub-likes">
+            <div>
+              <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" aria-hidden="true" aria-pressed="true">
+                <img height="18" src="/static/img/thumb-up-24px.svg?hash=mocked_hash_808020279" class="mdc-icon-button__icon"/>
+                <img height="18" width="18" src="/static/img/thumb-up-filled-24px.svg?hash=mocked_hash_368133424" class="mdc-icon-button__icon mdc-icon-button__icon--on"/>
+              </button>
+              <span id="likes-count">0 likes</span>
             </div>
           </div>
+          <div class="tags">
+            <span class="package-tag discontinued" title="Package was discontinued.">[discontinued]</span>
+          </div>
         </div>
-        <div class="detail-container">
-          <ul class="detail-tabs-header">
-            <li class="tab-button -active" data-name="-readme-tab-" role="button">Readme</li>
-            <li class="tab-button" data-name="-changelog-tab-" role="button">Changelog</li>
-            <li class="tab-button" data-name="-example-tab-" role="button">Example</li>
-            <li class="tab-button" data-name="-installing-tab-" role="button">Installing</li>
-            <li class="tab-link" data-name="-versions-tab-" role="button">
-              <a href="/packages/foobar_pkg/versions">Versions</a>
-            </li>
-            <li class="tab-button" data-name="-analysis-tab-" role="button">
-              <div class="score-box">
-                <span class="number -rotten" title="Analysis and more details.">0</span>
-              </div>
-            </li>
-          </ul>
-          <div class="main detail-tabs-content">
-            <section class="tab-content -active markdown-body" data-name="-readme-tab-">
-              <h1 class="hash-header" id="test-package">Test Package 
-                <a href="#test-package" class="hash-link">#</a>
-              </h1>
-              <p>This is a readme file.</p>
-              <pre>
-                <code class="language-dart">void main() {
+      </div>
+      <div class="detail-container">
+        <ul class="detail-tabs-header">
+          <li class="tab-button -active" data-name="-readme-tab-" role="button">Readme</li>
+          <li class="tab-button" data-name="-changelog-tab-" role="button">Changelog</li>
+          <li class="tab-button" data-name="-example-tab-" role="button">Example</li>
+          <li class="tab-button" data-name="-installing-tab-" role="button">Installing</li>
+          <li class="tab-link" data-name="-versions-tab-" role="button">
+            <a href="/packages/foobar_pkg/versions">Versions</a>
+          </li>
+          <li class="tab-button" data-name="-analysis-tab-" role="button">
+            <div class="score-box">
+              <span class="number -rotten" title="Analysis and more details.">0</span>
+            </div>
+          </li>
+        </ul>
+        <div class="main detail-tabs-content">
+          <section class="tab-content -active markdown-body" data-name="-readme-tab-">
+            <h1 class="hash-header" id="test-package">Test Package 
+              <a href="#test-package" class="hash-link">#</a>
+            </h1>
+            <p>This is a readme file.</p>
+            <pre>
+              <code class="language-dart">void main() {
 }
 </code>
-              </pre>
-            </section>
-            <section class="tab-content markdown-body" data-name="-changelog-tab-">
-              <h1 class="hash-header" id="changelog">Changelog 
-                <a href="#changelog" class="hash-link">#</a>
-              </h1>
-              <p>0.1.1 - test package</p>
-            </section>
-            <section class="tab-content markdown-body" data-name="-example-tab-">
-              <p style="font-family: monospace">
-                <b>example/lib/main.dart</b>
-              </p>
-              <pre>
-                <code class="language-dart">main() {
+            </pre>
+          </section>
+          <section class="tab-content markdown-body" data-name="-changelog-tab-">
+            <h1 class="hash-header" id="changelog">Changelog 
+              <a href="#changelog" class="hash-link">#</a>
+            </h1>
+            <p>0.1.1 - test package</p>
+          </section>
+          <section class="tab-content markdown-body" data-name="-example-tab-">
+            <p style="font-family: monospace">
+              <b>example/lib/main.dart</b>
+            </p>
+            <pre>
+              <code class="language-dart">main() {
   print('Hello world!');
 }
 </code>
-              </pre>
-            </section>
-            <section class="tab-content" data-name="-installing-tab-">
-              <h2>Use this package as a library</h2>
-              <h3>1. Depend on it</h3>
-              <p>Add this to your package's pubspec.yaml file:</p>
-              <pre>
-                <code class="language-yaml">
+            </pre>
+          </section>
+          <section class="tab-content" data-name="-installing-tab-">
+            <h2>Use this package as a library</h2>
+            <h3>1. Depend on it</h3>
+            <p>Add this to your package's pubspec.yaml file:</p>
+            <pre>
+              <code class="language-yaml">
 dependencies:
   
-                  <strong>foobar_pkg: ^0.1.1+5</strong>
-                </code>
-              </pre>
-              <h3>2. Install it</h3>
-              <p>You can install packages from the command line:</p>
-              <p>with pub:</p>
-              <pre>
-                <code class="language-shell">
+                <strong>foobar_pkg: ^0.1.1+5</strong>
+              </code>
+            </pre>
+            <h3>2. Install it</h3>
+            <p>You can install packages from the command line:</p>
+            <p>with pub:</p>
+            <pre>
+              <code class="language-shell">
 $ 
-                  <strong>pub get</strong>
-                </code>
-              </pre>
-              <p>Alternatively, your editor might support 
-                <code>pub get</code>.
+                <strong>pub get</strong>
+              </code>
+            </pre>
+            <p>Alternatively, your editor might support 
+              <code>pub get</code>.
   Check the docs for your editor to learn more.
-              </p>
-              <h3>3. Import it</h3>
-              <p>Now in your Dart code, you can use:
+            </p>
+            <h3>3. Import it</h3>
+            <p>Now in your Dart code, you can use:
   </p>
-              <pre>
-                <code class="language-dart">
+            <pre>
+              <code class="language-dart">
 import 'package:foobar_pkg/foolib.dart';
   </code>
-              </pre>
-            </section>
-            <section class="tab-content" data-name="-analysis-tab-">
-              <table id='scores-table'>
-                <tr>
-                  <td class="score-name">
-                    <div class="tooltip-base hoverable">
-                      <span class="tooltip-dotted">Popularity:</span>
-                      <div class="tooltip-content">
+            </pre>
+          </section>
+          <section class="tab-content" data-name="-analysis-tab-">
+            <table id='scores-table'>
+              <tr>
+                <td class="score-name">
+                  <div class="tooltip-base hoverable">
+                    <span class="tooltip-dotted">Popularity:</span>
+                    <div class="tooltip-content">
           Describes how popular the package is relative to other packages.
           
-                        <a href="/help#popularity">[more]</a>
-                      </div>
+                      <a href="/help#popularity">[more]</a>
                     </div>
-                  </td>
-                  <td class="score-value">
-                    <div class="score-percent-row">
-                      <div class="score-percent" style="left: 0%;">--</div>
+                  </div>
+                </td>
+                <td class="score-value">
+                  <div class="score-percent-row">
+                    <div class="score-percent" style="left: 0%;">--</div>
+                  </div>
+                  <div class="score-progress-row">
+                    <div class="score-progress-frame">
+                      <div class="score-progress" style="width: 0%; background: rgb(204, 204, 204);"></div>
                     </div>
-                    <div class="score-progress-row">
-                      <div class="score-progress-frame">
-                        <div class="score-progress" style="width: 0%; background: rgb(204, 204, 204);"></div>
-                      </div>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="score-name">
-                    <div class="tooltip-base hoverable">
-                      <span class="tooltip-dotted">Health:</span>
-                      <div class="tooltip-content">
+                  </div>
+                </td>
+              </tr>
+              <tr>
+                <td class="score-name">
+                  <div class="tooltip-base hoverable">
+                    <span class="tooltip-dotted">Health:</span>
+                    <div class="tooltip-content">
           Code health derived from static analysis.
           
-                        <a href="/help#health">[more]</a>
-                      </div>
+                      <a href="/help#health">[more]</a>
                     </div>
-                  </td>
-                  <td class="score-value">
-                    <div class="score-percent-row">
-                      <div class="score-percent" style="left: 0%;">--</div>
+                  </div>
+                </td>
+                <td class="score-value">
+                  <div class="score-percent-row">
+                    <div class="score-percent" style="left: 0%;">--</div>
+                  </div>
+                  <div class="score-progress-row">
+                    <div class="score-progress-frame">
+                      <div class="score-progress" style="width: 0%; background: rgb(204, 204, 204);"></div>
                     </div>
-                    <div class="score-progress-row">
-                      <div class="score-progress-frame">
-                        <div class="score-progress" style="width: 0%; background: rgb(204, 204, 204);"></div>
-                      </div>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="score-name">
-                    <div class="tooltip-base hoverable">
-                      <span class="tooltip-dotted">Maintenance:</span>
-                      <div class="tooltip-content">
+                  </div>
+                </td>
+              </tr>
+              <tr>
+                <td class="score-name">
+                  <div class="tooltip-base hoverable">
+                    <span class="tooltip-dotted">Maintenance:</span>
+                    <div class="tooltip-content">
           Reflects how tidy and up-to-date the package is.
           
-                        <a href="/help#maintenance">[more]</a>
-                      </div>
+                      <a href="/help#maintenance">[more]</a>
                     </div>
-                  </td>
-                  <td class="score-value">
-                    <div class="score-percent-row">
-                      <div class="score-percent" style="left: 0%;">--</div>
+                  </div>
+                </td>
+                <td class="score-value">
+                  <div class="score-percent-row">
+                    <div class="score-percent" style="left: 0%;">--</div>
+                  </div>
+                  <div class="score-progress-row">
+                    <div class="score-progress-frame">
+                      <div class="score-progress" style="width: 0%; background: rgb(204, 204, 204);"></div>
                     </div>
-                    <div class="score-progress-row">
-                      <div class="score-progress-frame">
-                        <div class="score-progress" style="width: 0%; background: rgb(204, 204, 204);"></div>
-                      </div>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="score-name">
-                    <div class="tooltip-base hoverable">
-                      <span class="tooltip-dotted">
-                        <b>Overall:</b>
-                      </span>
-                      <div class="tooltip-content">
+                  </div>
+                </td>
+              </tr>
+              <tr>
+                <td class="score-name">
+                  <div class="tooltip-base hoverable">
+                    <span class="tooltip-dotted">
+                      <b>Overall:</b>
+                    </span>
+                    <div class="tooltip-content">
           Weighted score of the above.
           
-                        <a href="/help#overall-score">[more]</a>
-                      </div>
+                      <a href="/help#overall-score">[more]</a>
                     </div>
-                  </td>
-                  <td>
-                    <div class="score-percent-row">
-                      <div class="score-percent" style="left: 0%;">0</div>
+                  </div>
+                </td>
+                <td>
+                  <div class="score-percent-row">
+                    <div class="score-percent" style="left: 0%;">0</div>
+                  </div>
+                  <div class="score-progress-row">
+                    <div class="score-progress-frame">
+                      <div class="score-progress" style="width: 0%; background: rgb(187, 36, 0);"></div>
                     </div>
-                    <div class="score-progress-row">
-                      <div class="score-progress-frame">
-                        <div class="score-progress" style="width: 0%; background: rgb(187, 36, 0);"></div>
-                      </div>
-                    </div>
-                  </td>
-                </tr>
-              </table>
-              <div style="text-align: right; font-size: 10pt;">Learn more about 
-                <a href="/help#scoring">scoring</a>.
-              </div>
-              <hr/>
-              <p>This package is not analyzed, because it is discontinued.</p>
-            </section>
-          </div>
-          <aside class="detail-info-box">
-            <h3 class="title">About</h3>
-            <p>my package description</p>
-            <p>
-              <a class="link" href="http://hans.juergen.com">Homepage</a>
-              <br/>
-            </p>
-            <h3 class="title">Uploader</h3>
-            <p>
-              <span class="author">
-                <a href="mailto:hans@juergen.com" title="Email hans@juergen.com">
-                  <i class="email-icon"></i>
-                </a>
-                <a href="/packages?q=email%3Ahans%40juergen.com" title="Search packages with hans@juergen.com" rel="nofollow">
-                  <i class="search-icon"></i>
-                </a> hans@juergen.com
-              </span>
-            </p>
-            <h3 class="title">More</h3>
-            <p>
-              <a href="/packages?q=dependency%3Afoobar_pkg" rel="nofollow">Packages that depend on foobar_pkg</a>
-            </p>
-          </aside>
+                  </div>
+                </td>
+              </tr>
+            </table>
+            <div style="text-align: right; font-size: 10pt;">Learn more about 
+              <a href="/help#scoring">scoring</a>.
+            </div>
+            <hr/>
+            <p>This package is not analyzed, because it is discontinued.</p>
+          </section>
         </div>
-        <script type="application/ld+json">
+        <aside class="detail-info-box">
+          <h3 class="title">About</h3>
+          <p>my package description</p>
+          <p>
+            <a class="link" href="http://hans.juergen.com">Homepage</a>
+            <br/>
+          </p>
+          <h3 class="title">Uploader</h3>
+          <p>
+            <span class="author">
+              <a href="mailto:hans@juergen.com" title="Email hans@juergen.com">
+                <i class="email-icon"></i>
+              </a>
+              <a href="/packages?q=email%3Ahans%40juergen.com" title="Search packages with hans@juergen.com" rel="nofollow">
+                <i class="search-icon"></i>
+              </a> hans@juergen.com
+            </span>
+          </p>
+          <h3 class="title">More</h3>
+          <p>
+            <a href="/packages?q=dependency%3Afoobar_pkg" rel="nofollow">Packages that depend on foobar_pkg</a>
+          </p>
+        </aside>
+      </div>
+      <script type="application/ld+json">
 {"@context":"http://schema.org","@type":"SoftwareSourceCode","name":"foobar_pkg","version":"0.1.1+5","description":"foobar_pkg - my package description","url":"https://pub.dev/packages/foobar_pkg","dateCreated":"2014-01-01T00:00:00.000Z","dateModified":"2014-01-01T00:00:00.000Z","programmingLanguage":"Dart","image":"https://pub.dev/static/img/dart-logo-400x400.png"}
 </script>
-      </main>
-    </div>
+    </main>
     <footer class="site-footer">
       <a class="link" href="https://dart.dev/">Dart language</a>
       <a class="link sep" href="https://www.google.com/intl/en/policies/terms/">Terms</a>

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -79,249 +79,247 @@
         </form>
       </div>
     </div>
-    <div class="container">
-      <main>
-        <div class="detail-header">
-          <h2 class="title">foobar_pkg 0.1.1+5</h2>
-          <div class="metadata">
+    <main class="container">
+      <div class="detail-header">
+        <h2 class="title">foobar_pkg 0.1.1+5</h2>
+        <div class="metadata">
     
 Published 
-            <span>Jan 1, 2015</span>
-            <!-- &bull; Downloads: X -->
+          <span>Jan 1, 2015</span>
+          <!-- &bull; Downloads: X -->
   • Updated:
   
-            <span>
-              <a href="/packages/foobar_pkg">0.1.1+5</a>
-            </span>
+          <span>
+            <a href="/packages/foobar_pkg">0.1.1+5</a>
+          </span>
     /
     
-            <span>
-              <a href="/packages/foobar_pkg/versions/0.2.0-dev">0.2.0-dev</a>
-            </span>
-            <div class="-pub-likes">
-              <div>
-                <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" aria-hidden="true" aria-pressed="true">
-                  <img height="18" src="/static/img/thumb-up-24px.svg?hash=mocked_hash_808020279" class="mdc-icon-button__icon"/>
-                  <img height="18" width="18" src="/static/img/thumb-up-filled-24px.svg?hash=mocked_hash_368133424" class="mdc-icon-button__icon mdc-icon-button__icon--on"/>
-                </button>
-                <span id="likes-count">0 likes</span>
-              </div>
+          <span>
+            <a href="/packages/foobar_pkg/versions/0.2.0-dev">0.2.0-dev</a>
+          </span>
+          <div class="-pub-likes">
+            <div>
+              <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" aria-hidden="true" aria-pressed="true">
+                <img height="18" src="/static/img/thumb-up-24px.svg?hash=mocked_hash_808020279" class="mdc-icon-button__icon"/>
+                <img height="18" width="18" src="/static/img/thumb-up-filled-24px.svg?hash=mocked_hash_368133424" class="mdc-icon-button__icon mdc-icon-button__icon--on"/>
+              </button>
+              <span id="likes-count">0 likes</span>
             </div>
-            <div class="tags">
-              <div class="-pub-tag-badge">
-                <div title="Packages compatible with Flutter SDK">flutter</div>
-                <div title="Packages compatible with Flutter on the Android platform">android</div>
-              </div>
+          </div>
+          <div class="tags">
+            <div class="-pub-tag-badge">
+              <div title="Packages compatible with Flutter SDK">flutter</div>
+              <div title="Packages compatible with Flutter on the Android platform">android</div>
             </div>
           </div>
         </div>
-        <div class="detail-container">
-          <ul class="detail-tabs-header">
-            <li class="tab-button -active" data-name="-readme-tab-" role="button">Readme</li>
-            <li class="tab-button" data-name="-changelog-tab-" role="button">Changelog</li>
-            <li class="tab-button" data-name="-installing-tab-" role="button">Installing</li>
-            <li class="tab-link" data-name="-versions-tab-" role="button">
-              <a href="/packages/foobar_pkg/versions">Versions</a>
-            </li>
-            <li class="tab-button" data-name="-analysis-tab-" role="button">
-              <div class="score-box">
-                <span class="number -good" title="Analysis and more details.">65</span>
-              </div>
-            </li>
-            <li class="tab-link" data-name="-admin-tab-" role="button">
-              <a href="/packages/foobar_pkg/admin">Admin</a>
-            </li>
-          </ul>
-          <div class="main detail-tabs-content">
-            <section class="tab-content -active markdown-body" data-name="-readme-tab-">
-              <h1 class="hash-header" id="test-package">Test Package 
-                <a href="#test-package" class="hash-link">#</a>
-              </h1>
-              <p>This is a readme file.</p>
-              <pre>
-                <code class="language-dart">void main() {
+      </div>
+      <div class="detail-container">
+        <ul class="detail-tabs-header">
+          <li class="tab-button -active" data-name="-readme-tab-" role="button">Readme</li>
+          <li class="tab-button" data-name="-changelog-tab-" role="button">Changelog</li>
+          <li class="tab-button" data-name="-installing-tab-" role="button">Installing</li>
+          <li class="tab-link" data-name="-versions-tab-" role="button">
+            <a href="/packages/foobar_pkg/versions">Versions</a>
+          </li>
+          <li class="tab-button" data-name="-analysis-tab-" role="button">
+            <div class="score-box">
+              <span class="number -good" title="Analysis and more details.">65</span>
+            </div>
+          </li>
+          <li class="tab-link" data-name="-admin-tab-" role="button">
+            <a href="/packages/foobar_pkg/admin">Admin</a>
+          </li>
+        </ul>
+        <div class="main detail-tabs-content">
+          <section class="tab-content -active markdown-body" data-name="-readme-tab-">
+            <h1 class="hash-header" id="test-package">Test Package 
+              <a href="#test-package" class="hash-link">#</a>
+            </h1>
+            <p>This is a readme file.</p>
+            <pre>
+              <code class="language-dart">void main() {
 }
 </code>
-              </pre>
-            </section>
-            <section class="tab-content markdown-body" data-name="-changelog-tab-">
-              <h1 class="hash-header" id="changelog">Changelog 
-                <a href="#changelog" class="hash-link">#</a>
-              </h1>
-              <p>0.1.1 - test package</p>
-            </section>
-            <section class="tab-content" data-name="-installing-tab-">
-              <h2>Use this package as a library</h2>
-              <h3>1. Depend on it</h3>
-              <p>Add this to your package's pubspec.yaml file:</p>
-              <pre>
-                <code class="language-yaml">
+            </pre>
+          </section>
+          <section class="tab-content markdown-body" data-name="-changelog-tab-">
+            <h1 class="hash-header" id="changelog">Changelog 
+              <a href="#changelog" class="hash-link">#</a>
+            </h1>
+            <p>0.1.1 - test package</p>
+          </section>
+          <section class="tab-content" data-name="-installing-tab-">
+            <h2>Use this package as a library</h2>
+            <h3>1. Depend on it</h3>
+            <p>Add this to your package's pubspec.yaml file:</p>
+            <pre>
+              <code class="language-yaml">
 dependencies:
   
-                  <strong>foobar_pkg: ^0.1.1+5</strong>
-                </code>
-              </pre>
-              <h3>2. Install it</h3>
-              <p>You can install packages from the command line:</p>
-              <p>with Flutter:</p>
-              <pre>
-                <code class="language-shell">
+                <strong>foobar_pkg: ^0.1.1+5</strong>
+              </code>
+            </pre>
+            <h3>2. Install it</h3>
+            <p>You can install packages from the command line:</p>
+            <p>with Flutter:</p>
+            <pre>
+              <code class="language-shell">
 $ 
-                  <strong>flutter pub get</strong>
-                </code>
-              </pre>
-              <p>Alternatively, your editor might support 
-                <code>flutter pub get</code>.
+                <strong>flutter pub get</strong>
+              </code>
+            </pre>
+            <p>Alternatively, your editor might support 
+              <code>flutter pub get</code>.
   Check the docs for your editor to learn more.
-              </p>
-              <h3>3. Import it</h3>
-              <p>Now in your Dart code, you can use:
+            </p>
+            <h3>3. Import it</h3>
+            <p>Now in your Dart code, you can use:
   </p>
-              <pre>
-                <code class="language-dart">
+            <pre>
+              <code class="language-dart">
 import 'package:foobar_pkg/foolib.dart';
   </code>
-              </pre>
-            </section>
-            <section class="tab-content" data-name="-analysis-tab-">
-              <table id='scores-table'>
-                <tr>
-                  <td class="score-name">
-                    <div class="tooltip-base hoverable">
-                      <span class="tooltip-dotted">Popularity:</span>
-                      <div class="tooltip-content">
+            </pre>
+          </section>
+          <section class="tab-content" data-name="-analysis-tab-">
+            <table id='scores-table'>
+              <tr>
+                <td class="score-name">
+                  <div class="tooltip-base hoverable">
+                    <span class="tooltip-dotted">Popularity:</span>
+                    <div class="tooltip-content">
           Describes how popular the package is relative to other packages.
           
-                        <a href="/help#popularity">[more]</a>
-                      </div>
+                      <a href="/help#popularity">[more]</a>
                     </div>
-                  </td>
-                  <td class="score-value">
-                    <div class="score-percent-row">
-                      <div class="score-percent" style="left: 30%;">30</div>
+                  </div>
+                </td>
+                <td class="score-value">
+                  <div class="score-percent-row">
+                    <div class="score-percent" style="left: 30%;">30</div>
+                  </div>
+                  <div class="score-progress-row">
+                    <div class="score-progress-frame">
+                      <div class="score-progress" style="width: 30%; background: rgb(136, 147, 158);"></div>
                     </div>
-                    <div class="score-progress-row">
-                      <div class="score-progress-frame">
-                        <div class="score-progress" style="width: 30%; background: rgb(136, 147, 158);"></div>
-                      </div>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="score-name">
-                    <div class="tooltip-base hoverable">
-                      <span class="tooltip-dotted">Health:</span>
-                      <div class="tooltip-content">
+                  </div>
+                </td>
+              </tr>
+              <tr>
+                <td class="score-name">
+                  <div class="tooltip-base hoverable">
+                    <span class="tooltip-dotted">Health:</span>
+                    <div class="tooltip-content">
           Code health derived from static analysis.
           
-                        <a href="/help#health">[more]</a>
-                      </div>
+                      <a href="/help#health">[more]</a>
                     </div>
-                  </td>
-                  <td class="score-value">
-                    <div class="score-percent-row">
-                      <div class="score-percent" style="left: 99%;">99</div>
+                  </div>
+                </td>
+                <td class="score-value">
+                  <div class="score-percent-row">
+                    <div class="score-percent" style="left: 99%;">99</div>
+                  </div>
+                  <div class="score-progress-row">
+                    <div class="score-progress-frame">
+                      <div class="score-progress" style="width: 99%; background: rgb(191, 191, 192);"></div>
                     </div>
-                    <div class="score-progress-row">
-                      <div class="score-progress-frame">
-                        <div class="score-progress" style="width: 99%; background: rgb(191, 191, 192);"></div>
-                      </div>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="score-name">
-                    <div class="tooltip-base hoverable">
-                      <span class="tooltip-dotted">Maintenance:</span>
-                      <div class="tooltip-content">
+                  </div>
+                </td>
+              </tr>
+              <tr>
+                <td class="score-name">
+                  <div class="tooltip-base hoverable">
+                    <span class="tooltip-dotted">Maintenance:</span>
+                    <div class="tooltip-content">
           Reflects how tidy and up-to-date the package is.
           
-                        <a href="/help#maintenance">[more]</a>
-                      </div>
+                      <a href="/help#maintenance">[more]</a>
                     </div>
-                  </td>
-                  <td class="score-value">
-                    <div class="score-percent-row">
-                      <div class="score-percent" style="left: 99%;">99</div>
+                  </div>
+                </td>
+                <td class="score-value">
+                  <div class="score-percent-row">
+                    <div class="score-percent" style="left: 99%;">99</div>
+                  </div>
+                  <div class="score-progress-row">
+                    <div class="score-progress-frame">
+                      <div class="score-progress" style="width: 99%; background: rgb(191, 191, 192);"></div>
                     </div>
-                    <div class="score-progress-row">
-                      <div class="score-progress-frame">
-                        <div class="score-progress" style="width: 99%; background: rgb(191, 191, 192);"></div>
-                      </div>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="score-name">
-                    <div class="tooltip-base hoverable">
-                      <span class="tooltip-dotted">
-                        <b>Overall:</b>
-                      </span>
-                      <div class="tooltip-content">
+                  </div>
+                </td>
+              </tr>
+              <tr>
+                <td class="score-name">
+                  <div class="tooltip-base hoverable">
+                    <span class="tooltip-dotted">
+                      <b>Overall:</b>
+                    </span>
+                    <div class="tooltip-content">
           Weighted score of the above.
           
-                        <a href="/help#overall-score">[more]</a>
-                      </div>
+                      <a href="/help#overall-score">[more]</a>
                     </div>
-                  </td>
-                  <td>
-                    <div class="score-percent-row">
-                      <div class="score-percent" style="left: 65%;">65</div>
+                  </div>
+                </td>
+                <td>
+                  <div class="score-percent-row">
+                    <div class="score-percent" style="left: 65%;">65</div>
+                  </div>
+                  <div class="score-progress-row">
+                    <div class="score-progress-frame">
+                      <div class="score-progress" style="width: 65%; background: rgb(0, 196, 179);"></div>
                     </div>
-                    <div class="score-progress-row">
-                      <div class="score-progress-frame">
-                        <div class="score-progress" style="width: 65%; background: rgb(0, 196, 179);"></div>
-                      </div>
-                    </div>
-                  </td>
-                </tr>
-              </table>
-              <div style="text-align: right; font-size: 10pt;">Learn more about 
-                <a href="/help#scoring">scoring</a>.
-              </div>
-              <hr/>
-              <p>
+                  </div>
+                </td>
+              </tr>
+            </table>
+            <div style="text-align: right; font-size: 10pt;">Learn more about 
+              <a href="/help#scoring">scoring</a>.
+            </div>
+            <hr/>
+            <p>
   We analyzed this package on Feb 5, 2018, and provided a score, details, and suggestions below.
   Analysis was completed with status 
-                <i>completed</i> using:
+              <i>completed</i> using:
 
-              </p>
-              <ul>
-                <li>Dart: 2.0.0-dev.7.0</li>
-                <li>pana: 0.6.2</li>
-                <li>Flutter: 0.0.18</li>
-              </ul>
-            </section>
-          </div>
-          <aside class="detail-info-box">
-            <h3 class="title">About</h3>
-            <p>my package description</p>
-            <p>
-              <a class="link" href="http://hans.juergen.com">Homepage</a>
-              <br/>
             </p>
-            <h3 class="title">Uploader</h3>
-            <p>
-              <span class="author">
-                <a href="mailto:hans@juergen.com" title="Email hans@juergen.com">
-                  <i class="email-icon"></i>
-                </a>
-                <a href="/packages?q=email%3Ahans%40juergen.com" title="Search packages with hans@juergen.com" rel="nofollow">
-                  <i class="search-icon"></i>
-                </a> hans@juergen.com
-              </span>
-            </p>
-            <h3 class="title">More</h3>
-            <p>
-              <a href="/packages?q=dependency%3Afoobar_pkg" rel="nofollow">Packages that depend on foobar_pkg</a>
-            </p>
-          </aside>
+            <ul>
+              <li>Dart: 2.0.0-dev.7.0</li>
+              <li>pana: 0.6.2</li>
+              <li>Flutter: 0.0.18</li>
+            </ul>
+          </section>
         </div>
-        <script type="application/ld+json">
+        <aside class="detail-info-box">
+          <h3 class="title">About</h3>
+          <p>my package description</p>
+          <p>
+            <a class="link" href="http://hans.juergen.com">Homepage</a>
+            <br/>
+          </p>
+          <h3 class="title">Uploader</h3>
+          <p>
+            <span class="author">
+              <a href="mailto:hans@juergen.com" title="Email hans@juergen.com">
+                <i class="email-icon"></i>
+              </a>
+              <a href="/packages?q=email%3Ahans%40juergen.com" title="Search packages with hans@juergen.com" rel="nofollow">
+                <i class="search-icon"></i>
+              </a> hans@juergen.com
+            </span>
+          </p>
+          <h3 class="title">More</h3>
+          <p>
+            <a href="/packages?q=dependency%3Afoobar_pkg" rel="nofollow">Packages that depend on foobar_pkg</a>
+          </p>
+        </aside>
+      </div>
+      <script type="application/ld+json">
 {"@context":"http://schema.org","@type":"SoftwareSourceCode","name":"foobar_pkg","version":"0.1.1+5","description":"foobar_pkg - my package description","url":"https://pub.dev/packages/foobar_pkg","dateCreated":"2014-01-01T00:00:00.000Z","dateModified":"2015-01-01T00:00:00.000Z","programmingLanguage":"Dart","image":"https://pub.dev/static/img/dart-logo-400x400.png"}
 </script>
-      </main>
-    </div>
+    </main>
     <footer class="site-footer">
       <a class="link" href="https://dart.dev/">Dart language</a>
       <a class="link sep" href="https://www.google.com/intl/en/policies/terms/">Terms</a>

--- a/app/test/frontend/golden/pkg_show_page_legacy.html
+++ b/app/test/frontend/golden/pkg_show_page_legacy.html
@@ -80,272 +80,270 @@
         </form>
       </div>
     </div>
-    <div class="container">
-      <main>
-        <div class="detail-header">
-          <h2 class="title">foobar_pkg 0.1.1+5</h2>
-          <div class="metadata">
+    <main class="container">
+      <div class="detail-header">
+        <h2 class="title">foobar_pkg 0.1.1+5</h2>
+        <div class="metadata">
     
 Published 
-            <span>Jan 1, 2014</span>
-            <!-- &bull; Downloads: X -->
+          <span>Jan 1, 2014</span>
+          <!-- &bull; Downloads: X -->
   • Updated:
   
-            <span>
-              <a href="/packages/foobar_pkg">0.1.1+5</a>
-            </span>
+          <span>
+            <a href="/packages/foobar_pkg">0.1.1+5</a>
+          </span>
     /
     
-            <span>
-              <a href="/packages/foobar_pkg/versions/0.2.0-dev">0.2.0-dev</a>
-            </span>
-            <div class="-pub-likes">
-              <div>
-                <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" aria-hidden="true" aria-pressed="true">
-                  <img height="18" src="/static/img/thumb-up-24px.svg?hash=mocked_hash_808020279" class="mdc-icon-button__icon"/>
-                  <img height="18" width="18" src="/static/img/thumb-up-filled-24px.svg?hash=mocked_hash_368133424" class="mdc-icon-button__icon mdc-icon-button__icon--on"/>
-                </button>
-                <span id="likes-count">0 likes</span>
-              </div>
-            </div>
-            <div class="tags">
-              <span class="package-tag legacy" title="Package does not support Dart 2.">Dart 2 incompatible</span>
+          <span>
+            <a href="/packages/foobar_pkg/versions/0.2.0-dev">0.2.0-dev</a>
+          </span>
+          <div class="-pub-likes">
+            <div>
+              <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" aria-hidden="true" aria-pressed="true">
+                <img height="18" src="/static/img/thumb-up-24px.svg?hash=mocked_hash_808020279" class="mdc-icon-button__icon"/>
+                <img height="18" width="18" src="/static/img/thumb-up-filled-24px.svg?hash=mocked_hash_368133424" class="mdc-icon-button__icon mdc-icon-button__icon--on"/>
+              </button>
+              <span id="likes-count">0 likes</span>
             </div>
           </div>
+          <div class="tags">
+            <span class="package-tag legacy" title="Package does not support Dart 2.">Dart 2 incompatible</span>
+          </div>
         </div>
-        <div class="detail-container">
-          <ul class="detail-tabs-header">
-            <li class="tab-button -active" data-name="-readme-tab-" role="button">Readme</li>
-            <li class="tab-button" data-name="-changelog-tab-" role="button">Changelog</li>
-            <li class="tab-button" data-name="-example-tab-" role="button">Example</li>
-            <li class="tab-button" data-name="-installing-tab-" role="button">Installing</li>
-            <li class="tab-link" data-name="-versions-tab-" role="button">
-              <a href="/packages/foobar_pkg/versions">Versions</a>
-            </li>
-            <li class="tab-button" data-name="-analysis-tab-" role="button">
-              <div class="score-box">
-                <span class="number -rotten" title="Analysis and more details.">25</span>
-              </div>
-            </li>
-          </ul>
-          <div class="main detail-tabs-content">
-            <section class="tab-content -active markdown-body" data-name="-readme-tab-">
-              <h1 class="hash-header" id="test-package">Test Package 
-                <a href="#test-package" class="hash-link">#</a>
-              </h1>
-              <p>This is a readme file.</p>
-              <pre>
-                <code class="language-dart">void main() {
+      </div>
+      <div class="detail-container">
+        <ul class="detail-tabs-header">
+          <li class="tab-button -active" data-name="-readme-tab-" role="button">Readme</li>
+          <li class="tab-button" data-name="-changelog-tab-" role="button">Changelog</li>
+          <li class="tab-button" data-name="-example-tab-" role="button">Example</li>
+          <li class="tab-button" data-name="-installing-tab-" role="button">Installing</li>
+          <li class="tab-link" data-name="-versions-tab-" role="button">
+            <a href="/packages/foobar_pkg/versions">Versions</a>
+          </li>
+          <li class="tab-button" data-name="-analysis-tab-" role="button">
+            <div class="score-box">
+              <span class="number -rotten" title="Analysis and more details.">25</span>
+            </div>
+          </li>
+        </ul>
+        <div class="main detail-tabs-content">
+          <section class="tab-content -active markdown-body" data-name="-readme-tab-">
+            <h1 class="hash-header" id="test-package">Test Package 
+              <a href="#test-package" class="hash-link">#</a>
+            </h1>
+            <p>This is a readme file.</p>
+            <pre>
+              <code class="language-dart">void main() {
 }
 </code>
-              </pre>
-            </section>
-            <section class="tab-content markdown-body" data-name="-changelog-tab-">
-              <h1 class="hash-header" id="changelog">Changelog 
-                <a href="#changelog" class="hash-link">#</a>
-              </h1>
-              <p>0.1.1 - test package</p>
-            </section>
-            <section class="tab-content markdown-body" data-name="-example-tab-">
-              <p style="font-family: monospace">
-                <b>example/lib/main.dart</b>
-              </p>
-              <pre>
-                <code class="language-dart">main() {
+            </pre>
+          </section>
+          <section class="tab-content markdown-body" data-name="-changelog-tab-">
+            <h1 class="hash-header" id="changelog">Changelog 
+              <a href="#changelog" class="hash-link">#</a>
+            </h1>
+            <p>0.1.1 - test package</p>
+          </section>
+          <section class="tab-content markdown-body" data-name="-example-tab-">
+            <p style="font-family: monospace">
+              <b>example/lib/main.dart</b>
+            </p>
+            <pre>
+              <code class="language-dart">main() {
   print('Hello world!');
 }
 </code>
-              </pre>
-            </section>
-            <section class="tab-content" data-name="-installing-tab-">
-              <h2>Use this package as a library</h2>
-              <h3>1. Depend on it</h3>
-              <p>Add this to your package's pubspec.yaml file:</p>
-              <pre>
-                <code class="language-yaml">
+            </pre>
+          </section>
+          <section class="tab-content" data-name="-installing-tab-">
+            <h2>Use this package as a library</h2>
+            <h3>1. Depend on it</h3>
+            <p>Add this to your package's pubspec.yaml file:</p>
+            <pre>
+              <code class="language-yaml">
 dependencies:
   
-                  <strong>foobar_pkg: ^0.1.1+5</strong>
-                </code>
-              </pre>
-              <h3>2. Install it</h3>
-              <p>You can install packages from the command line:</p>
-              <p>with pub:</p>
-              <pre>
-                <code class="language-shell">
+                <strong>foobar_pkg: ^0.1.1+5</strong>
+              </code>
+            </pre>
+            <h3>2. Install it</h3>
+            <p>You can install packages from the command line:</p>
+            <p>with pub:</p>
+            <pre>
+              <code class="language-shell">
 $ 
-                  <strong>pub get</strong>
-                </code>
-              </pre>
-              <p>Alternatively, your editor might support 
-                <code>pub get</code>.
+                <strong>pub get</strong>
+              </code>
+            </pre>
+            <p>Alternatively, your editor might support 
+              <code>pub get</code>.
   Check the docs for your editor to learn more.
-              </p>
-              <h3>3. Import it</h3>
-              <p>Now in your Dart code, you can use:
+            </p>
+            <h3>3. Import it</h3>
+            <p>Now in your Dart code, you can use:
   </p>
-              <pre>
-                <code class="language-dart">
+            <pre>
+              <code class="language-dart">
 import 'package:foobar_pkg/foolib.dart';
   </code>
-              </pre>
-            </section>
-            <section class="tab-content" data-name="-analysis-tab-">
-              <table id='scores-table'>
-                <tr>
-                  <td class="score-name">
-                    <div class="tooltip-base hoverable">
-                      <span class="tooltip-dotted">Popularity:</span>
-                      <div class="tooltip-content">
+            </pre>
+          </section>
+          <section class="tab-content" data-name="-analysis-tab-">
+            <table id='scores-table'>
+              <tr>
+                <td class="score-name">
+                  <div class="tooltip-base hoverable">
+                    <span class="tooltip-dotted">Popularity:</span>
+                    <div class="tooltip-content">
           Describes how popular the package is relative to other packages.
           
-                        <a href="/help#popularity">[more]</a>
-                      </div>
+                      <a href="/help#popularity">[more]</a>
                     </div>
-                  </td>
-                  <td class="score-value">
-                    <div class="score-percent-row">
-                      <div class="score-percent" style="left: 50%;">50</div>
+                  </div>
+                </td>
+                <td class="score-value">
+                  <div class="score-percent-row">
+                    <div class="score-percent" style="left: 50%;">50</div>
+                  </div>
+                  <div class="score-progress-row">
+                    <div class="score-progress-frame">
+                      <div class="score-progress" style="width: 50%; background: rgb(152, 160, 168);"></div>
                     </div>
-                    <div class="score-progress-row">
-                      <div class="score-progress-frame">
-                        <div class="score-progress" style="width: 50%; background: rgb(152, 160, 168);"></div>
-                      </div>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="score-name">
-                    <div class="tooltip-base hoverable">
-                      <span class="tooltip-dotted">Health:</span>
-                      <div class="tooltip-content">
+                  </div>
+                </td>
+              </tr>
+              <tr>
+                <td class="score-name">
+                  <div class="tooltip-base hoverable">
+                    <span class="tooltip-dotted">Health:</span>
+                    <div class="tooltip-content">
           Code health derived from static analysis.
           
-                        <a href="/help#health">[more]</a>
-                      </div>
+                      <a href="/help#health">[more]</a>
                     </div>
-                  </td>
-                  <td class="score-value">
-                    <div class="score-percent-row">
-                      <div class="score-percent" style="left: 0%;">--</div>
+                  </div>
+                </td>
+                <td class="score-value">
+                  <div class="score-percent-row">
+                    <div class="score-percent" style="left: 0%;">--</div>
+                  </div>
+                  <div class="score-progress-row">
+                    <div class="score-progress-frame">
+                      <div class="score-progress" style="width: 0%; background: rgb(204, 204, 204);"></div>
                     </div>
-                    <div class="score-progress-row">
-                      <div class="score-progress-frame">
-                        <div class="score-progress" style="width: 0%; background: rgb(204, 204, 204);"></div>
-                      </div>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="score-name">
-                    <div class="tooltip-base hoverable">
-                      <span class="tooltip-dotted">Maintenance:</span>
-                      <div class="tooltip-content">
+                  </div>
+                </td>
+              </tr>
+              <tr>
+                <td class="score-name">
+                  <div class="tooltip-base hoverable">
+                    <span class="tooltip-dotted">Maintenance:</span>
+                    <div class="tooltip-content">
           Reflects how tidy and up-to-date the package is.
           
-                        <a href="/help#maintenance">[more]</a>
-                      </div>
+                      <a href="/help#maintenance">[more]</a>
                     </div>
-                  </td>
-                  <td class="score-value">
-                    <div class="score-percent-row">
-                      <div class="score-percent" style="left: 0%;">--</div>
+                  </div>
+                </td>
+                <td class="score-value">
+                  <div class="score-percent-row">
+                    <div class="score-percent" style="left: 0%;">--</div>
+                  </div>
+                  <div class="score-progress-row">
+                    <div class="score-progress-frame">
+                      <div class="score-progress" style="width: 0%; background: rgb(204, 204, 204);"></div>
                     </div>
-                    <div class="score-progress-row">
-                      <div class="score-progress-frame">
-                        <div class="score-progress" style="width: 0%; background: rgb(204, 204, 204);"></div>
-                      </div>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="score-name">
-                    <div class="tooltip-base hoverable">
-                      <span class="tooltip-dotted">
-                        <b>Overall:</b>
-                      </span>
-                      <div class="tooltip-content">
+                  </div>
+                </td>
+              </tr>
+              <tr>
+                <td class="score-name">
+                  <div class="tooltip-base hoverable">
+                    <span class="tooltip-dotted">
+                      <b>Overall:</b>
+                    </span>
+                    <div class="tooltip-content">
           Weighted score of the above.
           
-                        <a href="/help#overall-score">[more]</a>
-                      </div>
+                      <a href="/help#overall-score">[more]</a>
                     </div>
-                  </td>
-                  <td>
-                    <div class="score-percent-row">
-                      <div class="score-percent" style="left: 25%;">25</div>
+                  </div>
+                </td>
+                <td>
+                  <div class="score-percent-row">
+                    <div class="score-percent" style="left: 25%;">25</div>
+                  </div>
+                  <div class="score-progress-row">
+                    <div class="score-progress-frame">
+                      <div class="score-progress" style="width: 25%; background: rgb(187, 36, 0);"></div>
                     </div>
-                    <div class="score-progress-row">
-                      <div class="score-progress-frame">
-                        <div class="score-progress" style="width: 25%; background: rgb(187, 36, 0);"></div>
-                      </div>
-                    </div>
-                  </td>
-                </tr>
-              </table>
-              <div style="text-align: right; font-size: 10pt;">Learn more about 
-                <a href="/help#scoring">scoring</a>.
-              </div>
-              <hr/>
-              <p>
+                  </div>
+                </td>
+              </tr>
+            </table>
+            <div style="text-align: right; font-size: 10pt;">Learn more about 
+              <a href="/help#scoring">scoring</a>.
+            </div>
+            <hr/>
+            <p>
   The package version is not analyzed, because it does not support Dart 2.
   Until this is resolved, the package will receive a health and maintenance score of 0.
 </p>
-              <h4>Analysis issues and suggestions</h4>
-              <div class="suggestion-row">
-                <div class="suggestion-title">
-                  <span class="suggestion-icon-danger"></span>
-                  <p>Support Dart 2 in 
-                    <code>pubspec.yaml</code>.
-                  </p>
-                </div>
-                <div class="suggestion-description">
-                  <p>The SDK constraint in 
-                    <code>pubspec.yaml</code> doesn't allow the Dart 2.0.0 release. For information about upgrading it to be Dart 2 compatible, please see 
-                    <a href="https://dart.dev/dart-2#migration">https://dart.dev/dart-2#migration</a>.
-                  </p>
-                </div>
+            <h4>Analysis issues and suggestions</h4>
+            <div class="suggestion-row">
+              <div class="suggestion-title">
+                <span class="suggestion-icon-danger"></span>
+                <p>Support Dart 2 in 
+                  <code>pubspec.yaml</code>.
+                </p>
               </div>
-            </section>
-          </div>
-          <aside class="detail-info-box">
-            <h3 class="title">About</h3>
-            <p>my package description</p>
-            <p>
-              <a class="link" href="http://hans.juergen.com">Homepage</a>
-              <br/>
-            </p>
-            <h3 class="title">Uploaders</h3>
-            <p>
-              <span class="author">
-                <a href="mailto:hans@juergen.com" title="Email hans@juergen.com">
-                  <i class="email-icon"></i>
-                </a>
-                <a href="/packages?q=email%3Ahans%40juergen.com" title="Search packages with hans@juergen.com" rel="nofollow">
-                  <i class="search-icon"></i>
-                </a> hans@juergen.com
-              </span>
-              <br/>
-              <span class="author">
-                <a href="mailto:joe@example.com" title="Email joe@example.com">
-                  <i class="email-icon"></i>
-                </a>
-                <a href="/packages?q=email%3Ajoe%40example.com" title="Search packages with joe@example.com" rel="nofollow">
-                  <i class="search-icon"></i>
-                </a> joe@example.com
-              </span>
-            </p>
-            <h3 class="title">More</h3>
-            <p>
-              <a href="/packages?q=dependency%3Afoobar_pkg" rel="nofollow">Packages that depend on foobar_pkg</a>
-            </p>
-          </aside>
+              <div class="suggestion-description">
+                <p>The SDK constraint in 
+                  <code>pubspec.yaml</code> doesn't allow the Dart 2.0.0 release. For information about upgrading it to be Dart 2 compatible, please see 
+                  <a href="https://dart.dev/dart-2#migration">https://dart.dev/dart-2#migration</a>.
+                </p>
+              </div>
+            </div>
+          </section>
         </div>
-        <script type="application/ld+json">
+        <aside class="detail-info-box">
+          <h3 class="title">About</h3>
+          <p>my package description</p>
+          <p>
+            <a class="link" href="http://hans.juergen.com">Homepage</a>
+            <br/>
+          </p>
+          <h3 class="title">Uploaders</h3>
+          <p>
+            <span class="author">
+              <a href="mailto:hans@juergen.com" title="Email hans@juergen.com">
+                <i class="email-icon"></i>
+              </a>
+              <a href="/packages?q=email%3Ahans%40juergen.com" title="Search packages with hans@juergen.com" rel="nofollow">
+                <i class="search-icon"></i>
+              </a> hans@juergen.com
+            </span>
+            <br/>
+            <span class="author">
+              <a href="mailto:joe@example.com" title="Email joe@example.com">
+                <i class="email-icon"></i>
+              </a>
+              <a href="/packages?q=email%3Ajoe%40example.com" title="Search packages with joe@example.com" rel="nofollow">
+                <i class="search-icon"></i>
+              </a> joe@example.com
+            </span>
+          </p>
+          <h3 class="title">More</h3>
+          <p>
+            <a href="/packages?q=dependency%3Afoobar_pkg" rel="nofollow">Packages that depend on foobar_pkg</a>
+          </p>
+        </aside>
+      </div>
+      <script type="application/ld+json">
 {"@context":"http://schema.org","@type":"SoftwareSourceCode","name":"foobar_pkg","version":"0.1.1+5","description":"foobar_pkg - my package description","url":"https://pub.dev/packages/foobar_pkg","dateCreated":"2014-01-01T00:00:00.000Z","dateModified":"2014-01-01T00:00:00.000Z","programmingLanguage":"Dart","image":"https://pub.dev/static/img/dart-logo-400x400.png"}
 </script>
-      </main>
-    </div>
+    </main>
     <footer class="site-footer">
       <a class="link" href="https://dart.dev/">Dart language</a>
       <a class="link sep" href="https://www.google.com/intl/en/policies/terms/">Terms</a>

--- a/app/test/frontend/golden/pkg_show_page_outdated.html
+++ b/app/test/frontend/golden/pkg_show_page_outdated.html
@@ -80,250 +80,248 @@
         </form>
       </div>
     </div>
-    <div class="container">
-      <main>
-        <div class="detail-header">
-          <h2 class="title">foobar_pkg 0.1.1+5</h2>
-          <div class="metadata">
+    <main class="container">
+      <div class="detail-header">
+        <h2 class="title">foobar_pkg 0.1.1+5</h2>
+        <div class="metadata">
     
 Published 
-            <span>Jan 1, 2014</span>
-            <!-- &bull; Downloads: X -->
+          <span>Jan 1, 2014</span>
+          <!-- &bull; Downloads: X -->
   • Updated:
   
-            <span>
-              <a href="/packages/foobar_pkg">0.1.1+5</a>
-            </span>
+          <span>
+            <a href="/packages/foobar_pkg">0.1.1+5</a>
+          </span>
     /
     
-            <span>
-              <a href="/packages/foobar_pkg/versions/0.2.0-dev">0.2.0-dev</a>
-            </span>
-            <div class="-pub-likes">
-              <div>
-                <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" aria-hidden="true" aria-pressed="true">
-                  <img height="18" src="/static/img/thumb-up-24px.svg?hash=mocked_hash_808020279" class="mdc-icon-button__icon"/>
-                  <img height="18" width="18" src="/static/img/thumb-up-filled-24px.svg?hash=mocked_hash_368133424" class="mdc-icon-button__icon mdc-icon-button__icon--on"/>
-                </button>
-                <span id="likes-count">0 likes</span>
-              </div>
-            </div>
-            <div class="tags">
-              <span class="package-tag missing" title="Package version too old, check latest stable.">[outdated]</span>
+          <span>
+            <a href="/packages/foobar_pkg/versions/0.2.0-dev">0.2.0-dev</a>
+          </span>
+          <div class="-pub-likes">
+            <div>
+              <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" aria-hidden="true" aria-pressed="true">
+                <img height="18" src="/static/img/thumb-up-24px.svg?hash=mocked_hash_808020279" class="mdc-icon-button__icon"/>
+                <img height="18" width="18" src="/static/img/thumb-up-filled-24px.svg?hash=mocked_hash_368133424" class="mdc-icon-button__icon mdc-icon-button__icon--on"/>
+              </button>
+              <span id="likes-count">0 likes</span>
             </div>
           </div>
+          <div class="tags">
+            <span class="package-tag missing" title="Package version too old, check latest stable.">[outdated]</span>
+          </div>
         </div>
-        <div class="detail-container">
-          <ul class="detail-tabs-header">
-            <li class="tab-button -active" data-name="-readme-tab-" role="button">Readme</li>
-            <li class="tab-button" data-name="-changelog-tab-" role="button">Changelog</li>
-            <li class="tab-button" data-name="-example-tab-" role="button">Example</li>
-            <li class="tab-button" data-name="-installing-tab-" role="button">Installing</li>
-            <li class="tab-link" data-name="-versions-tab-" role="button">
-              <a href="/packages/foobar_pkg/versions">Versions</a>
-            </li>
-            <li class="tab-button" data-name="-analysis-tab-" role="button">
-              <div class="score-box">
-                <span class="number -rotten" title="Analysis and more details.">0</span>
-              </div>
-            </li>
-          </ul>
-          <div class="main detail-tabs-content">
-            <section class="tab-content -active markdown-body" data-name="-readme-tab-">
-              <h1 class="hash-header" id="test-package">Test Package 
-                <a href="#test-package" class="hash-link">#</a>
-              </h1>
-              <p>This is a readme file.</p>
-              <pre>
-                <code class="language-dart">void main() {
+      </div>
+      <div class="detail-container">
+        <ul class="detail-tabs-header">
+          <li class="tab-button -active" data-name="-readme-tab-" role="button">Readme</li>
+          <li class="tab-button" data-name="-changelog-tab-" role="button">Changelog</li>
+          <li class="tab-button" data-name="-example-tab-" role="button">Example</li>
+          <li class="tab-button" data-name="-installing-tab-" role="button">Installing</li>
+          <li class="tab-link" data-name="-versions-tab-" role="button">
+            <a href="/packages/foobar_pkg/versions">Versions</a>
+          </li>
+          <li class="tab-button" data-name="-analysis-tab-" role="button">
+            <div class="score-box">
+              <span class="number -rotten" title="Analysis and more details.">0</span>
+            </div>
+          </li>
+        </ul>
+        <div class="main detail-tabs-content">
+          <section class="tab-content -active markdown-body" data-name="-readme-tab-">
+            <h1 class="hash-header" id="test-package">Test Package 
+              <a href="#test-package" class="hash-link">#</a>
+            </h1>
+            <p>This is a readme file.</p>
+            <pre>
+              <code class="language-dart">void main() {
 }
 </code>
-              </pre>
-            </section>
-            <section class="tab-content markdown-body" data-name="-changelog-tab-">
-              <h1 class="hash-header" id="changelog">Changelog 
-                <a href="#changelog" class="hash-link">#</a>
-              </h1>
-              <p>0.1.1 - test package</p>
-            </section>
-            <section class="tab-content markdown-body" data-name="-example-tab-">
-              <p style="font-family: monospace">
-                <b>example/lib/main.dart</b>
-              </p>
-              <pre>
-                <code class="language-dart">main() {
+            </pre>
+          </section>
+          <section class="tab-content markdown-body" data-name="-changelog-tab-">
+            <h1 class="hash-header" id="changelog">Changelog 
+              <a href="#changelog" class="hash-link">#</a>
+            </h1>
+            <p>0.1.1 - test package</p>
+          </section>
+          <section class="tab-content markdown-body" data-name="-example-tab-">
+            <p style="font-family: monospace">
+              <b>example/lib/main.dart</b>
+            </p>
+            <pre>
+              <code class="language-dart">main() {
   print('Hello world!');
 }
 </code>
-              </pre>
-            </section>
-            <section class="tab-content" data-name="-installing-tab-">
-              <h2>Use this package as a library</h2>
-              <h3>1. Depend on it</h3>
-              <p>Add this to your package's pubspec.yaml file:</p>
-              <pre>
-                <code class="language-yaml">
+            </pre>
+          </section>
+          <section class="tab-content" data-name="-installing-tab-">
+            <h2>Use this package as a library</h2>
+            <h3>1. Depend on it</h3>
+            <p>Add this to your package's pubspec.yaml file:</p>
+            <pre>
+              <code class="language-yaml">
 dependencies:
   
-                  <strong>foobar_pkg: ^0.1.1+5</strong>
-                </code>
-              </pre>
-              <h3>2. Install it</h3>
-              <p>You can install packages from the command line:</p>
-              <p>with pub:</p>
-              <pre>
-                <code class="language-shell">
+                <strong>foobar_pkg: ^0.1.1+5</strong>
+              </code>
+            </pre>
+            <h3>2. Install it</h3>
+            <p>You can install packages from the command line:</p>
+            <p>with pub:</p>
+            <pre>
+              <code class="language-shell">
 $ 
-                  <strong>pub get</strong>
-                </code>
-              </pre>
-              <p>Alternatively, your editor might support 
-                <code>pub get</code>.
+                <strong>pub get</strong>
+              </code>
+            </pre>
+            <p>Alternatively, your editor might support 
+              <code>pub get</code>.
   Check the docs for your editor to learn more.
-              </p>
-              <h3>3. Import it</h3>
-              <p>Now in your Dart code, you can use:
+            </p>
+            <h3>3. Import it</h3>
+            <p>Now in your Dart code, you can use:
   </p>
-              <pre>
-                <code class="language-dart">
+            <pre>
+              <code class="language-dart">
 import 'package:foobar_pkg/foolib.dart';
   </code>
-              </pre>
-            </section>
-            <section class="tab-content" data-name="-analysis-tab-">
-              <table id='scores-table'>
-                <tr>
-                  <td class="score-name">
-                    <div class="tooltip-base hoverable">
-                      <span class="tooltip-dotted">Popularity:</span>
-                      <div class="tooltip-content">
+            </pre>
+          </section>
+          <section class="tab-content" data-name="-analysis-tab-">
+            <table id='scores-table'>
+              <tr>
+                <td class="score-name">
+                  <div class="tooltip-base hoverable">
+                    <span class="tooltip-dotted">Popularity:</span>
+                    <div class="tooltip-content">
           Describes how popular the package is relative to other packages.
           
-                        <a href="/help#popularity">[more]</a>
-                      </div>
+                      <a href="/help#popularity">[more]</a>
                     </div>
-                  </td>
-                  <td class="score-value">
-                    <div class="score-percent-row">
-                      <div class="score-percent" style="left: 0%;">--</div>
+                  </div>
+                </td>
+                <td class="score-value">
+                  <div class="score-percent-row">
+                    <div class="score-percent" style="left: 0%;">--</div>
+                  </div>
+                  <div class="score-progress-row">
+                    <div class="score-progress-frame">
+                      <div class="score-progress" style="width: 0%; background: rgb(204, 204, 204);"></div>
                     </div>
-                    <div class="score-progress-row">
-                      <div class="score-progress-frame">
-                        <div class="score-progress" style="width: 0%; background: rgb(204, 204, 204);"></div>
-                      </div>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="score-name">
-                    <div class="tooltip-base hoverable">
-                      <span class="tooltip-dotted">Health:</span>
-                      <div class="tooltip-content">
+                  </div>
+                </td>
+              </tr>
+              <tr>
+                <td class="score-name">
+                  <div class="tooltip-base hoverable">
+                    <span class="tooltip-dotted">Health:</span>
+                    <div class="tooltip-content">
           Code health derived from static analysis.
           
-                        <a href="/help#health">[more]</a>
-                      </div>
+                      <a href="/help#health">[more]</a>
                     </div>
-                  </td>
-                  <td class="score-value">
-                    <div class="score-percent-row">
-                      <div class="score-percent" style="left: 0%;">--</div>
+                  </div>
+                </td>
+                <td class="score-value">
+                  <div class="score-percent-row">
+                    <div class="score-percent" style="left: 0%;">--</div>
+                  </div>
+                  <div class="score-progress-row">
+                    <div class="score-progress-frame">
+                      <div class="score-progress" style="width: 0%; background: rgb(204, 204, 204);"></div>
                     </div>
-                    <div class="score-progress-row">
-                      <div class="score-progress-frame">
-                        <div class="score-progress" style="width: 0%; background: rgb(204, 204, 204);"></div>
-                      </div>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="score-name">
-                    <div class="tooltip-base hoverable">
-                      <span class="tooltip-dotted">Maintenance:</span>
-                      <div class="tooltip-content">
+                  </div>
+                </td>
+              </tr>
+              <tr>
+                <td class="score-name">
+                  <div class="tooltip-base hoverable">
+                    <span class="tooltip-dotted">Maintenance:</span>
+                    <div class="tooltip-content">
           Reflects how tidy and up-to-date the package is.
           
-                        <a href="/help#maintenance">[more]</a>
-                      </div>
+                      <a href="/help#maintenance">[more]</a>
                     </div>
-                  </td>
-                  <td class="score-value">
-                    <div class="score-percent-row">
-                      <div class="score-percent" style="left: 0%;">--</div>
+                  </div>
+                </td>
+                <td class="score-value">
+                  <div class="score-percent-row">
+                    <div class="score-percent" style="left: 0%;">--</div>
+                  </div>
+                  <div class="score-progress-row">
+                    <div class="score-progress-frame">
+                      <div class="score-progress" style="width: 0%; background: rgb(204, 204, 204);"></div>
                     </div>
-                    <div class="score-progress-row">
-                      <div class="score-progress-frame">
-                        <div class="score-progress" style="width: 0%; background: rgb(204, 204, 204);"></div>
-                      </div>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="score-name">
-                    <div class="tooltip-base hoverable">
-                      <span class="tooltip-dotted">
-                        <b>Overall:</b>
-                      </span>
-                      <div class="tooltip-content">
+                  </div>
+                </td>
+              </tr>
+              <tr>
+                <td class="score-name">
+                  <div class="tooltip-base hoverable">
+                    <span class="tooltip-dotted">
+                      <b>Overall:</b>
+                    </span>
+                    <div class="tooltip-content">
           Weighted score of the above.
           
-                        <a href="/help#overall-score">[more]</a>
-                      </div>
+                      <a href="/help#overall-score">[more]</a>
                     </div>
-                  </td>
-                  <td>
-                    <div class="score-percent-row">
-                      <div class="score-percent" style="left: 0%;">0</div>
+                  </div>
+                </td>
+                <td>
+                  <div class="score-percent-row">
+                    <div class="score-percent" style="left: 0%;">0</div>
+                  </div>
+                  <div class="score-progress-row">
+                    <div class="score-progress-frame">
+                      <div class="score-progress" style="width: 0%; background: rgb(187, 36, 0);"></div>
                     </div>
-                    <div class="score-progress-row">
-                      <div class="score-progress-frame">
-                        <div class="score-progress" style="width: 0%; background: rgb(187, 36, 0);"></div>
-                      </div>
-                    </div>
-                  </td>
-                </tr>
-              </table>
-              <div style="text-align: right; font-size: 10pt;">Learn more about 
-                <a href="/help#scoring">scoring</a>.
-              </div>
-              <hr/>
-              <p>
+                  </div>
+                </td>
+              </tr>
+            </table>
+            <div style="text-align: right; font-size: 10pt;">Learn more about 
+              <a href="/help#scoring">scoring</a>.
+            </div>
+            <hr/>
+            <p>
   This package version is not analyzed, because it is more than two years old.
   Check the 
-                <a href="/packages/foobar_pkg#-analysis-tab-">latest stable version</a> for its analysis.
+              <a href="/packages/foobar_pkg#-analysis-tab-">latest stable version</a> for its analysis.
 
-              </p>
-            </section>
-          </div>
-          <aside class="detail-info-box">
-            <h3 class="title">About</h3>
-            <p>my package description</p>
-            <p>
-              <a class="link" href="http://hans.juergen.com">Homepage</a>
-              <br/>
             </p>
-            <h3 class="title">Uploader</h3>
-            <p>
-              <span class="author">
-                <a href="mailto:hans@juergen.com" title="Email hans@juergen.com">
-                  <i class="email-icon"></i>
-                </a>
-                <a href="/packages?q=email%3Ahans%40juergen.com" title="Search packages with hans@juergen.com" rel="nofollow">
-                  <i class="search-icon"></i>
-                </a> hans@juergen.com
-              </span>
-            </p>
-            <h3 class="title">More</h3>
-            <p>
-              <a href="/packages?q=dependency%3Afoobar_pkg" rel="nofollow">Packages that depend on foobar_pkg</a>
-            </p>
-          </aside>
+          </section>
         </div>
-        <script type="application/ld+json">
+        <aside class="detail-info-box">
+          <h3 class="title">About</h3>
+          <p>my package description</p>
+          <p>
+            <a class="link" href="http://hans.juergen.com">Homepage</a>
+            <br/>
+          </p>
+          <h3 class="title">Uploader</h3>
+          <p>
+            <span class="author">
+              <a href="mailto:hans@juergen.com" title="Email hans@juergen.com">
+                <i class="email-icon"></i>
+              </a>
+              <a href="/packages?q=email%3Ahans%40juergen.com" title="Search packages with hans@juergen.com" rel="nofollow">
+                <i class="search-icon"></i>
+              </a> hans@juergen.com
+            </span>
+          </p>
+          <h3 class="title">More</h3>
+          <p>
+            <a href="/packages?q=dependency%3Afoobar_pkg" rel="nofollow">Packages that depend on foobar_pkg</a>
+          </p>
+        </aside>
+      </div>
+      <script type="application/ld+json">
 {"@context":"http://schema.org","@type":"SoftwareSourceCode","name":"foobar_pkg","version":"0.1.1+5","description":"foobar_pkg - my package description","url":"https://pub.dev/packages/foobar_pkg","dateCreated":"2014-01-01T00:00:00.000Z","dateModified":"2014-01-01T00:00:00.000Z","programmingLanguage":"Dart","image":"https://pub.dev/static/img/dart-logo-400x400.png"}
 </script>
-      </main>
-    </div>
+    </main>
     <footer class="site-footer">
       <a class="link" href="https://dart.dev/">Dart language</a>
       <a class="link sep" href="https://www.google.com/intl/en/policies/terms/">Terms</a>

--- a/app/test/frontend/golden/pkg_show_page_publisher.html
+++ b/app/test/frontend/golden/pkg_show_page_publisher.html
@@ -80,248 +80,246 @@
         </form>
       </div>
     </div>
-    <div class="container">
-      <main>
-        <div class="detail-header">
-          <h2 class="title">lithium 5.8.6</h2>
-          <div class="metadata">
+    <main class="container">
+      <div class="detail-header">
+        <h2 class="title">lithium 5.8.6</h2>
+        <div class="metadata">
     
 Published 
-            <span>Mar 5, 2014</span>
+          <span>Mar 5, 2014</span>
 • 
-            <a class="-pub-publisher" href="/publishers/example.com">
-              <img class="-pub-publisher-shield" height="22" width="22" title="Published by a pub.dev verified publisher" src="/static/img/verified-publisher-blue.svg"/>example.com
-            </a>
-            <!-- &bull; Downloads: X -->
-            <div class="-pub-likes">
-              <div>
-                <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" aria-hidden="true" aria-pressed="true">
-                  <img height="18" src="/static/img/thumb-up-24px.svg?hash=mocked_hash_808020279" class="mdc-icon-button__icon"/>
-                  <img height="18" width="18" src="/static/img/thumb-up-filled-24px.svg?hash=mocked_hash_368133424" class="mdc-icon-button__icon mdc-icon-button__icon--on"/>
-                </button>
-                <span id="likes-count">0 likes</span>
-              </div>
-            </div>
-            <div class="tags">
-              <span class="package-tag missing" title="Analysis should be ready soon.">[awaiting]</span>
+          <a class="-pub-publisher" href="/publishers/example.com">
+            <img class="-pub-publisher-shield" height="22" width="22" title="Published by a pub.dev verified publisher" src="/static/img/verified-publisher-blue.svg"/>example.com
+          </a>
+          <!-- &bull; Downloads: X -->
+          <div class="-pub-likes">
+            <div>
+              <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" aria-hidden="true" aria-pressed="true">
+                <img height="18" src="/static/img/thumb-up-24px.svg?hash=mocked_hash_808020279" class="mdc-icon-button__icon"/>
+                <img height="18" width="18" src="/static/img/thumb-up-filled-24px.svg?hash=mocked_hash_368133424" class="mdc-icon-button__icon mdc-icon-button__icon--on"/>
+              </button>
+              <span id="likes-count">0 likes</span>
             </div>
           </div>
+          <div class="tags">
+            <span class="package-tag missing" title="Analysis should be ready soon.">[awaiting]</span>
+          </div>
         </div>
-        <div class="detail-container">
-          <ul class="detail-tabs-header">
-            <li class="tab-button -active" data-name="-readme-tab-" role="button">Readme</li>
-            <li class="tab-button" data-name="-changelog-tab-" role="button">Changelog</li>
-            <li class="tab-button" data-name="-installing-tab-" role="button">Installing</li>
-            <li class="tab-link" data-name="-versions-tab-" role="button">
-              <a href="/packages/lithium/versions">Versions</a>
-            </li>
-            <li class="tab-button" data-name="-analysis-tab-" role="button">
-              <div class="score-box">
-                <span class="number -rotten" title="Analysis and more details.">0</span>
-              </div>
-            </li>
-          </ul>
-          <div class="main detail-tabs-content">
-            <section class="tab-content -active markdown-body" data-name="-readme-tab-">
-              <h1 class="hash-header" id="lithium">lithium 
-                <a href="#lithium" class="hash-link">#</a>
-              </h1>
-              <p>lithium is a Dart package</p>
-            </section>
-            <section class="tab-content markdown-body" data-name="-changelog-tab-">
-              <h2 class="hash-header" id="586">5.8.6 
-                <a href="#586" class="hash-link">#</a>
-              </h2>
-              <ul>
-                <li>Bug fix #17.</li>
-              </ul>
-            </section>
-            <section class="tab-content" data-name="-installing-tab-">
-              <h2>Use this package as a library</h2>
-              <h3>1. Depend on it</h3>
-              <p>Add this to your package's pubspec.yaml file:</p>
-              <pre>
-                <code class="language-yaml">
+      </div>
+      <div class="detail-container">
+        <ul class="detail-tabs-header">
+          <li class="tab-button -active" data-name="-readme-tab-" role="button">Readme</li>
+          <li class="tab-button" data-name="-changelog-tab-" role="button">Changelog</li>
+          <li class="tab-button" data-name="-installing-tab-" role="button">Installing</li>
+          <li class="tab-link" data-name="-versions-tab-" role="button">
+            <a href="/packages/lithium/versions">Versions</a>
+          </li>
+          <li class="tab-button" data-name="-analysis-tab-" role="button">
+            <div class="score-box">
+              <span class="number -rotten" title="Analysis and more details.">0</span>
+            </div>
+          </li>
+        </ul>
+        <div class="main detail-tabs-content">
+          <section class="tab-content -active markdown-body" data-name="-readme-tab-">
+            <h1 class="hash-header" id="lithium">lithium 
+              <a href="#lithium" class="hash-link">#</a>
+            </h1>
+            <p>lithium is a Dart package</p>
+          </section>
+          <section class="tab-content markdown-body" data-name="-changelog-tab-">
+            <h2 class="hash-header" id="586">5.8.6 
+              <a href="#586" class="hash-link">#</a>
+            </h2>
+            <ul>
+              <li>Bug fix #17.</li>
+            </ul>
+          </section>
+          <section class="tab-content" data-name="-installing-tab-">
+            <h2>Use this package as a library</h2>
+            <h3>1. Depend on it</h3>
+            <p>Add this to your package's pubspec.yaml file:</p>
+            <pre>
+              <code class="language-yaml">
 dependencies:
   
-                  <strong>lithium: ^5.8.6</strong>
-                </code>
-              </pre>
-              <h3>2. Install it</h3>
-              <p>You can install packages from the command line:</p>
-              <p>with pub:</p>
-              <pre>
-                <code class="language-shell">
+                <strong>lithium: ^5.8.6</strong>
+              </code>
+            </pre>
+            <h3>2. Install it</h3>
+            <p>You can install packages from the command line:</p>
+            <p>with pub:</p>
+            <pre>
+              <code class="language-shell">
 $ 
-                  <strong>pub get</strong>
-                </code>
-              </pre>
-              <p>Alternatively, your editor might support 
-                <code>pub get</code>.
+                <strong>pub get</strong>
+              </code>
+            </pre>
+            <p>Alternatively, your editor might support 
+              <code>pub get</code>.
   Check the docs for your editor to learn more.
-              </p>
-              <h3>3. Import it</h3>
-              <p>Now in your Dart code, you can use:
+            </p>
+            <h3>3. Import it</h3>
+            <p>Now in your Dart code, you can use:
   </p>
-              <pre>
-                <code class="language-dart">
+            <pre>
+              <code class="language-dart">
 import 'package:lithium/lib/lithium.dart';
   </code>
-              </pre>
-            </section>
-            <section class="tab-content" data-name="-analysis-tab-">
-              <table id='scores-table'>
-                <tr>
-                  <td class="score-name">
-                    <div class="tooltip-base hoverable">
-                      <span class="tooltip-dotted">Popularity:</span>
-                      <div class="tooltip-content">
+            </pre>
+          </section>
+          <section class="tab-content" data-name="-analysis-tab-">
+            <table id='scores-table'>
+              <tr>
+                <td class="score-name">
+                  <div class="tooltip-base hoverable">
+                    <span class="tooltip-dotted">Popularity:</span>
+                    <div class="tooltip-content">
           Describes how popular the package is relative to other packages.
           
-                        <a href="/help#popularity">[more]</a>
-                      </div>
+                      <a href="/help#popularity">[more]</a>
                     </div>
-                  </td>
-                  <td class="score-value">
-                    <div class="score-percent-row">
-                      <div class="score-percent" style="left: 0%;">--</div>
+                  </div>
+                </td>
+                <td class="score-value">
+                  <div class="score-percent-row">
+                    <div class="score-percent" style="left: 0%;">--</div>
+                  </div>
+                  <div class="score-progress-row">
+                    <div class="score-progress-frame">
+                      <div class="score-progress" style="width: 0%; background: rgb(204, 204, 204);"></div>
                     </div>
-                    <div class="score-progress-row">
-                      <div class="score-progress-frame">
-                        <div class="score-progress" style="width: 0%; background: rgb(204, 204, 204);"></div>
-                      </div>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="score-name">
-                    <div class="tooltip-base hoverable">
-                      <span class="tooltip-dotted">Health:</span>
-                      <div class="tooltip-content">
+                  </div>
+                </td>
+              </tr>
+              <tr>
+                <td class="score-name">
+                  <div class="tooltip-base hoverable">
+                    <span class="tooltip-dotted">Health:</span>
+                    <div class="tooltip-content">
           Code health derived from static analysis.
           
-                        <a href="/help#health">[more]</a>
-                      </div>
+                      <a href="/help#health">[more]</a>
                     </div>
-                  </td>
-                  <td class="score-value">
-                    <div class="score-percent-row">
-                      <div class="score-percent" style="left: 0%;">--</div>
+                  </div>
+                </td>
+                <td class="score-value">
+                  <div class="score-percent-row">
+                    <div class="score-percent" style="left: 0%;">--</div>
+                  </div>
+                  <div class="score-progress-row">
+                    <div class="score-progress-frame">
+                      <div class="score-progress" style="width: 0%; background: rgb(204, 204, 204);"></div>
                     </div>
-                    <div class="score-progress-row">
-                      <div class="score-progress-frame">
-                        <div class="score-progress" style="width: 0%; background: rgb(204, 204, 204);"></div>
-                      </div>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="score-name">
-                    <div class="tooltip-base hoverable">
-                      <span class="tooltip-dotted">Maintenance:</span>
-                      <div class="tooltip-content">
+                  </div>
+                </td>
+              </tr>
+              <tr>
+                <td class="score-name">
+                  <div class="tooltip-base hoverable">
+                    <span class="tooltip-dotted">Maintenance:</span>
+                    <div class="tooltip-content">
           Reflects how tidy and up-to-date the package is.
           
-                        <a href="/help#maintenance">[more]</a>
-                      </div>
+                      <a href="/help#maintenance">[more]</a>
                     </div>
-                  </td>
-                  <td class="score-value">
-                    <div class="score-percent-row">
-                      <div class="score-percent" style="left: 0%;">--</div>
+                  </div>
+                </td>
+                <td class="score-value">
+                  <div class="score-percent-row">
+                    <div class="score-percent" style="left: 0%;">--</div>
+                  </div>
+                  <div class="score-progress-row">
+                    <div class="score-progress-frame">
+                      <div class="score-progress" style="width: 0%; background: rgb(204, 204, 204);"></div>
                     </div>
-                    <div class="score-progress-row">
-                      <div class="score-progress-frame">
-                        <div class="score-progress" style="width: 0%; background: rgb(204, 204, 204);"></div>
-                      </div>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="score-name">
-                    <div class="tooltip-base hoverable">
-                      <span class="tooltip-dotted">
-                        <b>Overall:</b>
-                      </span>
-                      <div class="tooltip-content">
+                  </div>
+                </td>
+              </tr>
+              <tr>
+                <td class="score-name">
+                  <div class="tooltip-base hoverable">
+                    <span class="tooltip-dotted">
+                      <b>Overall:</b>
+                    </span>
+                    <div class="tooltip-content">
           Weighted score of the above.
           
-                        <a href="/help#overall-score">[more]</a>
-                      </div>
+                      <a href="/help#overall-score">[more]</a>
                     </div>
-                  </td>
-                  <td>
-                    <div class="score-percent-row">
-                      <div class="score-percent" style="left: 0%;">0</div>
+                  </div>
+                </td>
+                <td>
+                  <div class="score-percent-row">
+                    <div class="score-percent" style="left: 0%;">0</div>
+                  </div>
+                  <div class="score-progress-row">
+                    <div class="score-progress-frame">
+                      <div class="score-progress" style="width: 0%; background: rgb(187, 36, 0);"></div>
                     </div>
-                    <div class="score-progress-row">
-                      <div class="score-progress-frame">
-                        <div class="score-progress" style="width: 0%; background: rgb(187, 36, 0);"></div>
-                      </div>
-                    </div>
-                  </td>
-                </tr>
-              </table>
-              <div style="text-align: right; font-size: 10pt;">Learn more about 
-                <a href="/help#scoring">scoring</a>.
-              </div>
-              <hr/>
-              <p>
+                  </div>
+                </td>
+              </tr>
+            </table>
+            <div style="text-align: right; font-size: 10pt;">Learn more about 
+              <a href="/help#scoring">scoring</a>.
+            </div>
+            <hr/>
+            <p>
   We analyzed this package on , and provided a score, details, and suggestions below.
   Analysis was completed with status 
-                <i></i> using:
+              <i></i> using:
 
-              </p>
-              <ul>
-                <li>Dart: </li>
-                <li>pana: </li>
-              </ul>
-              <h4>Dependencies</h4>
-              <div class="overflow-x">
-                <table class="dependency-table">
-                  <tr>
-                    <th>Package</th>
-                    <th>Constraint</th>
-                    <th>Resolved</th>
-                    <th>Available</th>
-                  </tr>
-                  <tr>
-                    <th colspan="4" class="sub-header">Direct dependencies</th>
-                  </tr>
-                  <tr>
-                    <td>Dart SDK</td>
-                    <td>>=2.4.0 &lt;3.0.0</td>
-                    <td></td>
-                    <td></td>
-                  </tr>
-                </table>
-              </div>
-            </section>
-          </div>
-          <aside class="detail-info-box">
-            <h3 class="title">Publisher</h3>
-            <p>
-              <a href="/publishers/example.com">
-                <img class="-pub-publisher-shield" height="22" width="22" title="Published by a pub.dev verified publisher" src="/static/img/verified-publisher-blue.svg?hash=mocked_hash_919645162"/>example.com
-              </a>
             </p>
-            <h3 class="title">About</h3>
-            <p>lithium is a Dart package</p>
-            <p>
-              <a class="link" href="https://example.com/lithium">Homepage</a>
-              <br/>
-            </p>
-            <h3 class="title">More</h3>
-            <p>
-              <a href="/packages?q=dependency%3Alithium" rel="nofollow">Packages that depend on lithium</a>
-            </p>
-          </aside>
+            <ul>
+              <li>Dart: </li>
+              <li>pana: </li>
+            </ul>
+            <h4>Dependencies</h4>
+            <div class="overflow-x">
+              <table class="dependency-table">
+                <tr>
+                  <th>Package</th>
+                  <th>Constraint</th>
+                  <th>Resolved</th>
+                  <th>Available</th>
+                </tr>
+                <tr>
+                  <th colspan="4" class="sub-header">Direct dependencies</th>
+                </tr>
+                <tr>
+                  <td>Dart SDK</td>
+                  <td>>=2.4.0 &lt;3.0.0</td>
+                  <td></td>
+                  <td></td>
+                </tr>
+              </table>
+            </div>
+          </section>
         </div>
-        <script type="application/ld+json">
+        <aside class="detail-info-box">
+          <h3 class="title">Publisher</h3>
+          <p>
+            <a href="/publishers/example.com">
+              <img class="-pub-publisher-shield" height="22" width="22" title="Published by a pub.dev verified publisher" src="/static/img/verified-publisher-blue.svg?hash=mocked_hash_919645162"/>example.com
+            </a>
+          </p>
+          <h3 class="title">About</h3>
+          <p>lithium is a Dart package</p>
+          <p>
+            <a class="link" href="https://example.com/lithium">Homepage</a>
+            <br/>
+          </p>
+          <h3 class="title">More</h3>
+          <p>
+            <a href="/packages?q=dependency%3Alithium" rel="nofollow">Packages that depend on lithium</a>
+          </p>
+        </aside>
+      </div>
+      <script type="application/ld+json">
 {"@context":"http://schema.org","@type":"SoftwareSourceCode","name":"lithium","version":"5.8.6","description":"lithium - lithium is a Dart package","url":"https://pub.dev/packages/lithium","dateCreated":"2014-01-07T09:06:00.000","dateModified":"2014-03-05T06:15:00.000","programmingLanguage":"Dart","image":"https://pub.dev/static/img/dart-logo-400x400.png"}
 </script>
-      </main>
-    </div>
+    </main>
     <footer class="site-footer">
       <a class="link" href="https://dart.dev/">Dart language</a>
       <a class="link sep" href="https://www.google.com/intl/en/policies/terms/">Terms</a>

--- a/app/test/frontend/golden/pkg_show_version_page.html
+++ b/app/test/frontend/golden/pkg_show_version_page.html
@@ -81,282 +81,280 @@
         </form>
       </div>
     </div>
-    <div class="container">
-      <main>
-        <div class="detail-header">
-          <h2 class="title">foobar_pkg 0.2.0-dev</h2>
-          <div class="metadata">
+    <main class="container">
+      <div class="detail-header">
+        <h2 class="title">foobar_pkg 0.2.0-dev</h2>
+        <div class="metadata">
     
 Published 
-            <span>Jan 1, 2014</span>
-            <!-- &bull; Downloads: X -->
+          <span>Jan 1, 2014</span>
+          <!-- &bull; Downloads: X -->
   • Updated:
   
-            <span>
-              <a href="/packages/foobar_pkg">0.1.1+5</a>
-            </span>
+          <span>
+            <a href="/packages/foobar_pkg">0.1.1+5</a>
+          </span>
     /
     
-            <span>
-              <a href="/packages/foobar_pkg/versions/0.2.0-dev">0.2.0-dev</a>
-            </span>
-            <div class="-pub-likes">
-              <div>
-                <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" aria-hidden="true" aria-pressed="true">
-                  <img height="18" src="/static/img/thumb-up-24px.svg?hash=mocked_hash_808020279" class="mdc-icon-button__icon"/>
-                  <img height="18" width="18" src="/static/img/thumb-up-filled-24px.svg?hash=mocked_hash_368133424" class="mdc-icon-button__icon mdc-icon-button__icon--on"/>
-                </button>
-                <span id="likes-count">0 likes</span>
-              </div>
-            </div>
-            <div class="tags">
-              <a class="package-tag unidentified" href="#-analysis-tab-" title="Check the analysis tab for further details.">[unidentified]</a>
+          <span>
+            <a href="/packages/foobar_pkg/versions/0.2.0-dev">0.2.0-dev</a>
+          </span>
+          <div class="-pub-likes">
+            <div>
+              <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" aria-hidden="true" aria-pressed="true">
+                <img height="18" src="/static/img/thumb-up-24px.svg?hash=mocked_hash_808020279" class="mdc-icon-button__icon"/>
+                <img height="18" width="18" src="/static/img/thumb-up-filled-24px.svg?hash=mocked_hash_368133424" class="mdc-icon-button__icon mdc-icon-button__icon--on"/>
+              </button>
+              <span id="likes-count">0 likes</span>
             </div>
           </div>
+          <div class="tags">
+            <a class="package-tag unidentified" href="#-analysis-tab-" title="Check the analysis tab for further details.">[unidentified]</a>
+          </div>
         </div>
-        <div class="detail-container">
-          <ul class="detail-tabs-header">
-            <li class="tab-button -active" data-name="-readme-tab-" role="button">Readme</li>
-            <li class="tab-button" data-name="-changelog-tab-" role="button">Changelog</li>
-            <li class="tab-button" data-name="-installing-tab-" role="button">Installing</li>
-            <li class="tab-link" data-name="-versions-tab-" role="button">
-              <a href="/packages/foobar_pkg/versions">Versions</a>
-            </li>
-            <li class="tab-button" data-name="-analysis-tab-" role="button">
-              <div class="score-box">
-                <span class="number -rotten" title="Analysis and more details.">3</span>
-              </div>
-            </li>
-            <li class="tab-link" data-name="-admin-tab-" role="button">
-              <a href="/packages/foobar_pkg/admin">Admin</a>
-            </li>
-          </ul>
-          <div class="main detail-tabs-content">
-            <section class="tab-content -active markdown-body" data-name="-readme-tab-">
-              <h1 class="hash-header" id="test-package">Test Package 
-                <a href="#test-package" class="hash-link">#</a>
-              </h1>
-              <p>This is a readme file.</p>
-              <pre>
-                <code class="language-dart">void main() {
+      </div>
+      <div class="detail-container">
+        <ul class="detail-tabs-header">
+          <li class="tab-button -active" data-name="-readme-tab-" role="button">Readme</li>
+          <li class="tab-button" data-name="-changelog-tab-" role="button">Changelog</li>
+          <li class="tab-button" data-name="-installing-tab-" role="button">Installing</li>
+          <li class="tab-link" data-name="-versions-tab-" role="button">
+            <a href="/packages/foobar_pkg/versions">Versions</a>
+          </li>
+          <li class="tab-button" data-name="-analysis-tab-" role="button">
+            <div class="score-box">
+              <span class="number -rotten" title="Analysis and more details.">3</span>
+            </div>
+          </li>
+          <li class="tab-link" data-name="-admin-tab-" role="button">
+            <a href="/packages/foobar_pkg/admin">Admin</a>
+          </li>
+        </ul>
+        <div class="main detail-tabs-content">
+          <section class="tab-content -active markdown-body" data-name="-readme-tab-">
+            <h1 class="hash-header" id="test-package">Test Package 
+              <a href="#test-package" class="hash-link">#</a>
+            </h1>
+            <p>This is a readme file.</p>
+            <pre>
+              <code class="language-dart">void main() {
 }
 </code>
-              </pre>
-            </section>
-            <section class="tab-content markdown-body" data-name="-changelog-tab-">
-              <h1 class="hash-header" id="changelog">Changelog 
-                <a href="#changelog" class="hash-link">#</a>
-              </h1>
-              <p>0.1.1 - test package</p>
-            </section>
-            <section class="tab-content" data-name="-installing-tab-">
-              <h2>Use this package as a library</h2>
-              <h3>1. Depend on it</h3>
-              <p>Add this to your package's pubspec.yaml file:</p>
-              <pre>
-                <code class="language-yaml">
+            </pre>
+          </section>
+          <section class="tab-content markdown-body" data-name="-changelog-tab-">
+            <h1 class="hash-header" id="changelog">Changelog 
+              <a href="#changelog" class="hash-link">#</a>
+            </h1>
+            <p>0.1.1 - test package</p>
+          </section>
+          <section class="tab-content" data-name="-installing-tab-">
+            <h2>Use this package as a library</h2>
+            <h3>1. Depend on it</h3>
+            <p>Add this to your package's pubspec.yaml file:</p>
+            <pre>
+              <code class="language-yaml">
 dependencies:
   
-                  <strong>foobar_pkg: ^0.2.0-dev</strong>
-                </code>
-              </pre>
-              <h3>2. Install it</h3>
-              <p>You can install packages from the command line:</p>
-              <p>with pub:</p>
-              <pre>
-                <code class="language-shell">
+                <strong>foobar_pkg: ^0.2.0-dev</strong>
+              </code>
+            </pre>
+            <h3>2. Install it</h3>
+            <p>You can install packages from the command line:</p>
+            <p>with pub:</p>
+            <pre>
+              <code class="language-shell">
 $ 
-                  <strong>pub get</strong>
-                </code>
-              </pre>
-              <p>Alternatively, your editor might support 
-                <code>pub get</code>.
+                <strong>pub get</strong>
+              </code>
+            </pre>
+            <p>Alternatively, your editor might support 
+              <code>pub get</code>.
   Check the docs for your editor to learn more.
-              </p>
-              <h3>3. Import it</h3>
-              <p>Now in your Dart code, you can use:
+            </p>
+            <h3>3. Import it</h3>
+            <p>Now in your Dart code, you can use:
   </p>
-              <pre>
-                <code class="language-dart">
+            <pre>
+              <code class="language-dart">
 import 'package:foobar_pkg/foolib.dart';
   </code>
-              </pre>
-            </section>
-            <section class="tab-content" data-name="-analysis-tab-">
-              <table id='scores-table'>
-                <tr>
-                  <td class="score-name">
-                    <div class="tooltip-base hoverable">
-                      <span class="tooltip-dotted">Popularity:</span>
-                      <div class="tooltip-content">
+            </pre>
+          </section>
+          <section class="tab-content" data-name="-analysis-tab-">
+            <table id='scores-table'>
+              <tr>
+                <td class="score-name">
+                  <div class="tooltip-base hoverable">
+                    <span class="tooltip-dotted">Popularity:</span>
+                    <div class="tooltip-content">
           Describes how popular the package is relative to other packages.
           
-                        <a href="/help#popularity">[more]</a>
-                      </div>
+                      <a href="/help#popularity">[more]</a>
                     </div>
-                  </td>
-                  <td class="score-value">
-                    <div class="score-percent-row">
-                      <div class="score-percent" style="left: 0%;">--</div>
+                  </div>
+                </td>
+                <td class="score-value">
+                  <div class="score-percent-row">
+                    <div class="score-percent" style="left: 0%;">--</div>
+                  </div>
+                  <div class="score-progress-row">
+                    <div class="score-progress-frame">
+                      <div class="score-progress" style="width: 0%; background: rgb(204, 204, 204);"></div>
                     </div>
-                    <div class="score-progress-row">
-                      <div class="score-progress-frame">
-                        <div class="score-progress" style="width: 0%; background: rgb(204, 204, 204);"></div>
-                      </div>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="score-name">
-                    <div class="tooltip-base hoverable">
-                      <span class="tooltip-dotted">Health:</span>
-                      <div class="tooltip-content">
+                  </div>
+                </td>
+              </tr>
+              <tr>
+                <td class="score-name">
+                  <div class="tooltip-base hoverable">
+                    <span class="tooltip-dotted">Health:</span>
+                    <div class="tooltip-content">
           Code health derived from static analysis.
           
-                        <a href="/help#health">[more]</a>
-                      </div>
+                      <a href="/help#health">[more]</a>
                     </div>
-                  </td>
-                  <td class="score-value">
-                    <div class="score-percent-row">
-                      <div class="score-percent" style="left: 10%;">10</div>
+                  </div>
+                </td>
+                <td class="score-value">
+                  <div class="score-percent-row">
+                    <div class="score-percent" style="left: 10%;">10</div>
+                  </div>
+                  <div class="score-progress-row">
+                    <div class="score-progress-frame">
+                      <div class="score-progress" style="width: 10%; background: rgb(120, 134, 149);"></div>
                     </div>
-                    <div class="score-progress-row">
-                      <div class="score-progress-frame">
-                        <div class="score-progress" style="width: 10%; background: rgb(120, 134, 149);"></div>
-                      </div>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="score-name">
-                    <div class="tooltip-base hoverable">
-                      <span class="tooltip-dotted">Maintenance:</span>
-                      <div class="tooltip-content">
+                  </div>
+                </td>
+              </tr>
+              <tr>
+                <td class="score-name">
+                  <div class="tooltip-base hoverable">
+                    <span class="tooltip-dotted">Maintenance:</span>
+                    <div class="tooltip-content">
           Reflects how tidy and up-to-date the package is.
           
-                        <a href="/help#maintenance">[more]</a>
-                      </div>
+                      <a href="/help#maintenance">[more]</a>
                     </div>
-                  </td>
-                  <td class="score-value">
-                    <div class="score-percent-row">
-                      <div class="score-percent" style="left: 0%;">--</div>
+                  </div>
+                </td>
+                <td class="score-value">
+                  <div class="score-percent-row">
+                    <div class="score-percent" style="left: 0%;">--</div>
+                  </div>
+                  <div class="score-progress-row">
+                    <div class="score-progress-frame">
+                      <div class="score-progress" style="width: 0%; background: rgb(204, 204, 204);"></div>
                     </div>
-                    <div class="score-progress-row">
-                      <div class="score-progress-frame">
-                        <div class="score-progress" style="width: 0%; background: rgb(204, 204, 204);"></div>
-                      </div>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="score-name">
-                    <div class="tooltip-base hoverable">
-                      <span class="tooltip-dotted">
-                        <b>Overall:</b>
-                      </span>
-                      <div class="tooltip-content">
+                  </div>
+                </td>
+              </tr>
+              <tr>
+                <td class="score-name">
+                  <div class="tooltip-base hoverable">
+                    <span class="tooltip-dotted">
+                      <b>Overall:</b>
+                    </span>
+                    <div class="tooltip-content">
           Weighted score of the above.
           
-                        <a href="/help#overall-score">[more]</a>
-                      </div>
+                      <a href="/help#overall-score">[more]</a>
                     </div>
-                  </td>
-                  <td>
-                    <div class="score-percent-row">
-                      <div class="score-percent" style="left: 3%;">3</div>
+                  </div>
+                </td>
+                <td>
+                  <div class="score-percent-row">
+                    <div class="score-percent" style="left: 3%;">3</div>
+                  </div>
+                  <div class="score-progress-row">
+                    <div class="score-progress-frame">
+                      <div class="score-progress" style="width: 3%; background: rgb(187, 36, 0);"></div>
                     </div>
-                    <div class="score-progress-row">
-                      <div class="score-progress-frame">
-                        <div class="score-progress" style="width: 3%; background: rgb(187, 36, 0);"></div>
-                      </div>
-                    </div>
-                  </td>
-                </tr>
-              </table>
-              <div style="text-align: right; font-size: 10pt;">Learn more about 
-                <a href="/help#scoring">scoring</a>.
-              </div>
-              <hr/>
-              <p>
+                  </div>
+                </td>
+              </tr>
+            </table>
+            <div style="text-align: right; font-size: 10pt;">Learn more about 
+              <a href="/help#scoring">scoring</a>.
+            </div>
+            <hr/>
+            <p>
   We analyzed this package on Feb 5, 2018, and provided a score, details, and suggestions below.
   Analysis was completed with status 
-                <i>completed</i> using:
+              <i>completed</i> using:
 
-              </p>
-              <ul>
-                <li>Dart: 2.0.0-dev.7.0</li>
-                <li>pana: 0.6.2</li>
-              </ul>
-              <h4>Dependencies</h4>
-              <div class="overflow-x">
-                <table class="dependency-table">
-                  <tr>
-                    <th>Package</th>
-                    <th>Constraint</th>
-                    <th>Resolved</th>
-                    <th>Available</th>
-                  </tr>
-                  <tr>
-                    <th colspan="4" class="sub-header">Direct dependencies</th>
-                  </tr>
-                  <tr>
-                    <td>
-                      <a href="/packages/http">http</a>
-                    </td>
-                    <td>>=1.0.0 &lt;1.2.0</td>
-                    <td>1.2.0</td>
-                    <td>1.3.0</td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <a href="/packages/quiver">quiver</a>
-                    </td>
-                    <td>^1.0.0</td>
-                    <td>1.0.0</td>
-                    <td></td>
-                  </tr>
-                </table>
-              </div>
-            </section>
-          </div>
-          <aside class="detail-info-box">
-            <h3 class="title">About</h3>
-            <p>my package description</p>
-            <p>
-              <a class="link" href="http://hans.juergen.com">Homepage</a>
-              <br/>
             </p>
-            <h3 class="title">Uploader</h3>
-            <p>
-              <span class="author">
-                <a href="mailto:hans@juergen.com" title="Email hans@juergen.com">
-                  <i class="email-icon"></i>
-                </a>
-                <a href="/packages?q=email%3Ahans%40juergen.com" title="Search packages with hans@juergen.com" rel="nofollow">
-                  <i class="search-icon"></i>
-                </a> hans@juergen.com
-              </span>
-            </p>
-            <h3 class="title">License</h3>
-            <p>BSD (LICENSE.txt)</p>
-            <h3 class="title">Dependencies</h3>
-            <p>
-              <a href="/packages/http">http</a>, 
-              <a href="/packages/quiver">quiver</a>
-            </p>
-            <h3 class="title">More</h3>
-            <p>
-              <a href="/packages?q=dependency%3Afoobar_pkg" rel="nofollow">Packages that depend on foobar_pkg</a>
-            </p>
-          </aside>
+            <ul>
+              <li>Dart: 2.0.0-dev.7.0</li>
+              <li>pana: 0.6.2</li>
+            </ul>
+            <h4>Dependencies</h4>
+            <div class="overflow-x">
+              <table class="dependency-table">
+                <tr>
+                  <th>Package</th>
+                  <th>Constraint</th>
+                  <th>Resolved</th>
+                  <th>Available</th>
+                </tr>
+                <tr>
+                  <th colspan="4" class="sub-header">Direct dependencies</th>
+                </tr>
+                <tr>
+                  <td>
+                    <a href="/packages/http">http</a>
+                  </td>
+                  <td>>=1.0.0 &lt;1.2.0</td>
+                  <td>1.2.0</td>
+                  <td>1.3.0</td>
+                </tr>
+                <tr>
+                  <td>
+                    <a href="/packages/quiver">quiver</a>
+                  </td>
+                  <td>^1.0.0</td>
+                  <td>1.0.0</td>
+                  <td></td>
+                </tr>
+              </table>
+            </div>
+          </section>
         </div>
-        <script type="application/ld+json">
+        <aside class="detail-info-box">
+          <h3 class="title">About</h3>
+          <p>my package description</p>
+          <p>
+            <a class="link" href="http://hans.juergen.com">Homepage</a>
+            <br/>
+          </p>
+          <h3 class="title">Uploader</h3>
+          <p>
+            <span class="author">
+              <a href="mailto:hans@juergen.com" title="Email hans@juergen.com">
+                <i class="email-icon"></i>
+              </a>
+              <a href="/packages?q=email%3Ahans%40juergen.com" title="Search packages with hans@juergen.com" rel="nofollow">
+                <i class="search-icon"></i>
+              </a> hans@juergen.com
+            </span>
+          </p>
+          <h3 class="title">License</h3>
+          <p>BSD (LICENSE.txt)</p>
+          <h3 class="title">Dependencies</h3>
+          <p>
+            <a href="/packages/http">http</a>, 
+            <a href="/packages/quiver">quiver</a>
+          </p>
+          <h3 class="title">More</h3>
+          <p>
+            <a href="/packages?q=dependency%3Afoobar_pkg" rel="nofollow">Packages that depend on foobar_pkg</a>
+          </p>
+        </aside>
+      </div>
+      <script type="application/ld+json">
 {"@context":"http://schema.org","@type":"SoftwareSourceCode","name":"foobar_pkg","version":"0.2.0-dev","description":"foobar_pkg - my package description","url":"https://pub.dev/packages/foobar_pkg","dateCreated":"2014-01-01T00:00:00.000Z","dateModified":"2014-01-01T00:00:00.000Z","programmingLanguage":"Dart","image":"https://pub.dev/static/img/dart-logo-400x400.png"}
 </script>
-      </main>
-    </div>
+    </main>
     <footer class="site-footer">
       <a class="link" href="https://dart.dev/">Dart language</a>
       <a class="link sep" href="https://www.google.com/intl/en/policies/terms/">Terms</a>

--- a/app/test/frontend/golden/pkg_versions_page.html
+++ b/app/test/frontend/golden/pkg_versions_page.html
@@ -81,160 +81,158 @@
         </form>
       </div>
     </div>
-    <div class="container">
-      <main>
-        <div class="detail-header">
-          <h2 class="title">foobar_pkg 0.1.1+5</h2>
-          <div class="metadata">
+    <main class="container">
+      <div class="detail-header">
+        <h2 class="title">foobar_pkg 0.1.1+5</h2>
+        <div class="metadata">
     
 Published 
-            <span>Jan 1, 2014</span>
-            <!-- &bull; Downloads: X -->
+          <span>Jan 1, 2014</span>
+          <!-- &bull; Downloads: X -->
   • Updated:
   
-            <span>
-              <a href="/packages/foobar_pkg">0.1.1+5</a>
-            </span>
+          <span>
+            <a href="/packages/foobar_pkg">0.1.1+5</a>
+          </span>
     /
     
-            <span>
-              <a href="/packages/foobar_pkg/versions/0.2.0-dev">0.2.0-dev</a>
-            </span>
-            <div class="-pub-likes">
-              <div>
-                <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" aria-hidden="true" aria-pressed="true">
-                  <img height="18" src="/static/img/thumb-up-24px.svg?hash=mocked_hash_808020279" class="mdc-icon-button__icon"/>
-                  <img height="18" width="18" src="/static/img/thumb-up-filled-24px.svg?hash=mocked_hash_368133424" class="mdc-icon-button__icon mdc-icon-button__icon--on"/>
-                </button>
-                <span id="likes-count">0 likes</span>
+          <span>
+            <a href="/packages/foobar_pkg/versions/0.2.0-dev">0.2.0-dev</a>
+          </span>
+          <div class="-pub-likes">
+            <div>
+              <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" aria-hidden="true" aria-pressed="true">
+                <img height="18" src="/static/img/thumb-up-24px.svg?hash=mocked_hash_808020279" class="mdc-icon-button__icon"/>
+                <img height="18" width="18" src="/static/img/thumb-up-filled-24px.svg?hash=mocked_hash_368133424" class="mdc-icon-button__icon mdc-icon-button__icon--on"/>
+              </button>
+              <span id="likes-count">0 likes</span>
+            </div>
+          </div>
+          <div class="tags">
+            <span class="package-tag missing" title="Analysis should be ready soon.">[awaiting]</span>
+          </div>
+        </div>
+      </div>
+      <div class="detail-container">
+        <ul class="detail-tabs-header">
+          <li class="tab-link" data-name="-readme-tab-" role="button">
+            <a href="/packages/foobar_pkg#-readme-tab-">Readme</a>
+          </li>
+          <li class="tab-link" data-name="-changelog-tab-" role="button">
+            <a href="/packages/foobar_pkg#-changelog-tab-">Changelog</a>
+          </li>
+          <li class="tab-link" data-name="-example-tab-" role="button">
+            <a href="/packages/foobar_pkg#-example-tab-">Example</a>
+          </li>
+          <li class="tab-link" data-name="-installing-tab-" role="button">
+            <a href="/packages/foobar_pkg#-installing-tab-">Installing</a>
+          </li>
+          <li class="tab-button -active" data-name="-versions-tab-" role="button">Versions</li>
+          <li class="tab-link" data-name="-analysis-tab-" role="button">
+            <a href="/packages/foobar_pkg#-analysis-tab-">
+              <div class="score-box">
+                <span class="number -good" title="Analysis and more details.">55</span>
               </div>
-            </div>
-            <div class="tags">
-              <span class="package-tag missing" title="Analysis should be ready soon.">[awaiting]</span>
-            </div>
-          </div>
+            </a>
+          </li>
+        </ul>
+        <div class="main detail-tabs-content">
+          <section class="tab-content -active" data-name="-versions-tab-">
+            <p>The latest dev release was 
+              <a href="#dev">0.2.0-dev</a> on Jan 1, 2014.
+            </p>
+            <h2 id="stable">Stable versions of foobar_pkg</h2>
+            <table class="version-table" data-package="foobar_pkg">
+              <thead>
+                <tr>
+                  <th>Version</th>
+                  <th>Uploaded</th>
+                  <th class="documentation" width="80">Documentation</th>
+                  <th class="archive" width="80">Archive</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr data-version="0.1.1+5">
+                  <td>
+                    <strong>
+                      <a href="/packages/foobar_pkg/versions/0.1.1+5">0.1.1+5</a>
+                    </strong>
+                  </td>
+                  <td>Jan 1, 2014</td>
+                  <td class="documentation">
+                    <a href="/documentation/foobar_pkg/0.1.1+5/" rel="nofollow" title="Go to the documentation of foobar_pkg 0.1.1+5">
+                      <img src="/static/img/ic_drive_document_black_24dp.svg?hash=mocked_hash_663394799" alt="Go to the documentation of foobar_pkg 0.1.1+5"/>
+                    </a>
+                  </td>
+                  <td class="archive">
+                    <a href="https://pub.dartlang.org/mock-download-uri.tar.gz" title="Download foobar_pkg 0.1.1+5 archive">
+                      <img src="/static/img/ic_get_app_black_24dp.svg?hash=mocked_hash_341543596" alt="Download foobar_pkg 0.1.1+5 archive"/>
+                    </a>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <h2 id="dev">Dev versions of foobar_pkg</h2>
+            <table class="version-table" data-package="foobar_pkg">
+              <thead>
+                <tr>
+                  <th>Version</th>
+                  <th>Uploaded</th>
+                  <th class="documentation" width="80">Documentation</th>
+                  <th class="archive" width="80">Archive</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr data-version="0.2.0-dev">
+                  <td>
+                    <strong>
+                      <a href="/packages/foobar_pkg/versions/0.2.0-dev">0.2.0-dev</a>
+                    </strong>
+                  </td>
+                  <td>Jan 1, 2014</td>
+                  <td class="documentation">
+                    <a href="/documentation/foobar_pkg/0.2.0-dev/" rel="nofollow" title="Go to the documentation of foobar_pkg 0.2.0-dev">
+                      <img src="/static/img/ic_drive_document_black_24dp.svg?hash=mocked_hash_663394799" alt="Go to the documentation of foobar_pkg 0.2.0-dev"/>
+                    </a>
+                  </td>
+                  <td class="archive">
+                    <a href="https://pub.dartlang.org/mock-download-uri.tar.gz" title="Download foobar_pkg 0.2.0-dev archive">
+                      <img src="/static/img/ic_get_app_black_24dp.svg?hash=mocked_hash_341543596" alt="Download foobar_pkg 0.2.0-dev archive"/>
+                    </a>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </section>
         </div>
-        <div class="detail-container">
-          <ul class="detail-tabs-header">
-            <li class="tab-link" data-name="-readme-tab-" role="button">
-              <a href="/packages/foobar_pkg#-readme-tab-">Readme</a>
-            </li>
-            <li class="tab-link" data-name="-changelog-tab-" role="button">
-              <a href="/packages/foobar_pkg#-changelog-tab-">Changelog</a>
-            </li>
-            <li class="tab-link" data-name="-example-tab-" role="button">
-              <a href="/packages/foobar_pkg#-example-tab-">Example</a>
-            </li>
-            <li class="tab-link" data-name="-installing-tab-" role="button">
-              <a href="/packages/foobar_pkg#-installing-tab-">Installing</a>
-            </li>
-            <li class="tab-button -active" data-name="-versions-tab-" role="button">Versions</li>
-            <li class="tab-link" data-name="-analysis-tab-" role="button">
-              <a href="/packages/foobar_pkg#-analysis-tab-">
-                <div class="score-box">
-                  <span class="number -good" title="Analysis and more details.">55</span>
-                </div>
+        <aside class="detail-info-box">
+          <h3 class="title">About</h3>
+          <p>my package description</p>
+          <p>
+            <a class="link" href="http://hans.juergen.com">Homepage</a>
+            <br/>
+          </p>
+          <h3 class="title">Uploader</h3>
+          <p>
+            <span class="author">
+              <a href="mailto:hans@juergen.com" title="Email hans@juergen.com">
+                <i class="email-icon"></i>
               </a>
-            </li>
-          </ul>
-          <div class="main detail-tabs-content">
-            <section class="tab-content -active" data-name="-versions-tab-">
-              <p>The latest dev release was 
-                <a href="#dev">0.2.0-dev</a> on Jan 1, 2014.
-              </p>
-              <h2 id="stable">Stable versions of foobar_pkg</h2>
-              <table class="version-table" data-package="foobar_pkg">
-                <thead>
-                  <tr>
-                    <th>Version</th>
-                    <th>Uploaded</th>
-                    <th class="documentation" width="80">Documentation</th>
-                    <th class="archive" width="80">Archive</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr data-version="0.1.1+5">
-                    <td>
-                      <strong>
-                        <a href="/packages/foobar_pkg/versions/0.1.1+5">0.1.1+5</a>
-                      </strong>
-                    </td>
-                    <td>Jan 1, 2014</td>
-                    <td class="documentation">
-                      <a href="/documentation/foobar_pkg/0.1.1+5/" rel="nofollow" title="Go to the documentation of foobar_pkg 0.1.1+5">
-                        <img src="/static/img/ic_drive_document_black_24dp.svg?hash=mocked_hash_663394799" alt="Go to the documentation of foobar_pkg 0.1.1+5"/>
-                      </a>
-                    </td>
-                    <td class="archive">
-                      <a href="https://pub.dartlang.org/mock-download-uri.tar.gz" title="Download foobar_pkg 0.1.1+5 archive">
-                        <img src="/static/img/ic_get_app_black_24dp.svg?hash=mocked_hash_341543596" alt="Download foobar_pkg 0.1.1+5 archive"/>
-                      </a>
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
-              <h2 id="dev">Dev versions of foobar_pkg</h2>
-              <table class="version-table" data-package="foobar_pkg">
-                <thead>
-                  <tr>
-                    <th>Version</th>
-                    <th>Uploaded</th>
-                    <th class="documentation" width="80">Documentation</th>
-                    <th class="archive" width="80">Archive</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr data-version="0.2.0-dev">
-                    <td>
-                      <strong>
-                        <a href="/packages/foobar_pkg/versions/0.2.0-dev">0.2.0-dev</a>
-                      </strong>
-                    </td>
-                    <td>Jan 1, 2014</td>
-                    <td class="documentation">
-                      <a href="/documentation/foobar_pkg/0.2.0-dev/" rel="nofollow" title="Go to the documentation of foobar_pkg 0.2.0-dev">
-                        <img src="/static/img/ic_drive_document_black_24dp.svg?hash=mocked_hash_663394799" alt="Go to the documentation of foobar_pkg 0.2.0-dev"/>
-                      </a>
-                    </td>
-                    <td class="archive">
-                      <a href="https://pub.dartlang.org/mock-download-uri.tar.gz" title="Download foobar_pkg 0.2.0-dev archive">
-                        <img src="/static/img/ic_get_app_black_24dp.svg?hash=mocked_hash_341543596" alt="Download foobar_pkg 0.2.0-dev archive"/>
-                      </a>
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
-            </section>
-          </div>
-          <aside class="detail-info-box">
-            <h3 class="title">About</h3>
-            <p>my package description</p>
-            <p>
-              <a class="link" href="http://hans.juergen.com">Homepage</a>
-              <br/>
-            </p>
-            <h3 class="title">Uploader</h3>
-            <p>
-              <span class="author">
-                <a href="mailto:hans@juergen.com" title="Email hans@juergen.com">
-                  <i class="email-icon"></i>
-                </a>
-                <a href="/packages?q=email%3Ahans%40juergen.com" title="Search packages with hans@juergen.com" rel="nofollow">
-                  <i class="search-icon"></i>
-                </a> hans@juergen.com
-              </span>
-            </p>
-            <h3 class="title">More</h3>
-            <p>
-              <a href="/packages?q=dependency%3Afoobar_pkg" rel="nofollow">Packages that depend on foobar_pkg</a>
-            </p>
-          </aside>
-        </div>
-        <script type="application/ld+json">
+              <a href="/packages?q=email%3Ahans%40juergen.com" title="Search packages with hans@juergen.com" rel="nofollow">
+                <i class="search-icon"></i>
+              </a> hans@juergen.com
+            </span>
+          </p>
+          <h3 class="title">More</h3>
+          <p>
+            <a href="/packages?q=dependency%3Afoobar_pkg" rel="nofollow">Packages that depend on foobar_pkg</a>
+          </p>
+        </aside>
+      </div>
+      <script type="application/ld+json">
 {"@context":"http://schema.org","@type":"SoftwareSourceCode","name":"foobar_pkg","version":"0.1.1+5","description":"foobar_pkg - my package description","url":"https://pub.dev/packages/foobar_pkg","dateCreated":"2014-01-01T00:00:00.000Z","dateModified":"2014-01-01T00:00:00.000Z","programmingLanguage":"Dart","image":"https://pub.dev/static/img/dart-logo-400x400.png"}
 </script>
-      </main>
-    </div>
+    </main>
     <footer class="site-footer">
       <a class="link" href="https://dart.dev/">Dart language</a>
       <a class="link sep" href="https://www.google.com/intl/en/policies/terms/">Terms</a>

--- a/app/test/frontend/golden/publisher_list_page.html
+++ b/app/test/frontend/golden/publisher_list_page.html
@@ -90,35 +90,33 @@
         </div>
       </div>
     </div>
-    <div class="container">
-      <main>
-        <h2>Publishers</h2>
-        <ul class="publisher-list">
-          <li class="list-item">
-            <h3 class="title">
-              <a href="/publishers/example.com">example.com</a>
-            </h3>
-            <p class="metadata">
+    <main class="container">
+      <h2>Publishers</h2>
+      <ul class="publisher-list">
+        <li class="list-item">
+          <h3 class="title">
+            <a href="/publishers/example.com">example.com</a>
+          </h3>
+          <p class="metadata">
       Registered on Sep 13, 2019.
     </p>
-          </li>
-          <li class="list-item">
-            <h3 class="title">
-              <a href="/publishers/other-domain.com">other-domain.com</a>
-            </h3>
-            <p class="metadata">
+        </li>
+        <li class="list-item">
+          <h3 class="title">
+            <a href="/publishers/other-domain.com">other-domain.com</a>
+          </h3>
+          <p class="metadata">
       Registered on Sep 19, 2019.
     </p>
-          </li>
-        </ul>
-        <h3>Want to create a new publisher?</h3>
-        <p>
+        </li>
+      </ul>
+      <h3>Want to create a new publisher?</h3>
+      <p>
   Use the 
-          <a href="/create-publisher">create publisher</a> page.
+        <a href="/create-publisher">create publisher</a> page.
 
-        </p>
-      </main>
-    </div>
+      </p>
+    </main>
     <footer class="site-footer">
       <a class="link" href="https://dart.dev/">Dart language</a>
       <a class="link sep" href="https://www.google.com/intl/en/policies/terms/">Terms</a>

--- a/app/test/frontend/golden/publisher_packages_page.html
+++ b/app/test/frontend/golden/publisher_packages_page.html
@@ -79,135 +79,133 @@
         </form>
       </div>
     </div>
-    <div class="container">
-      <main>
-        <div class="detail-header">
-          <h2 class="title">
-            <img class="-pub-publisher-shield" height="48" width="48" title="Domain ownership verifed by pub.dev" src="/static/img/verified-publisher-blue.svg?hash=mocked_hash_919645162"/>example.com
-          </h2>
-          <div class="metadata">
+    <main class="container">
+      <div class="detail-header">
+        <h2 class="title">
+          <img class="-pub-publisher-shield" height="48" width="48" title="Domain ownership verifed by pub.dev" src="/static/img/verified-publisher-blue.svg?hash=mocked_hash_919645162"/>example.com
+        </h2>
+        <div class="metadata">
     Publisher registered on Sep 13, 2019.
     
-            <div class="tags"></div>
-          </div>
+          <div class="tags"></div>
         </div>
-        <div class="detail-container">
-          <ul class="detail-tabs-header">
-            <li class="tab-button -active" data-name="-packages-tab-" role="button">Packages</li>
-            <li class="tab-link" data-name="-admin-tab-" role="button">
-              <a href="/publishers/example.com/admin">Admin</a>
-            </li>
-          </ul>
-          <div class="main detail-tabs-content">
-            <section class="tab-content -active" data-name="-packages-tab-">
-              <div class="listing-sort-header">
-                <div class="tooltip-base hoverable">
-                  <span class="tooltip-dotted">Sorted by:</span>
-                  <select id="sort-control">
-                    <option value="listing_relevance" selected="selected">listing relevance</option>
-                    <option value="top">overall score</option>
-                    <option value="updated">recently updated</option>
-                    <option value="created">newest package</option>
-                    <option value="popularity">popularity</option>
-                  </select>
-                  <div class="tooltip-content tooltip-bottom-left">
+      </div>
+      <div class="detail-container">
+        <ul class="detail-tabs-header">
+          <li class="tab-button -active" data-name="-packages-tab-" role="button">Packages</li>
+          <li class="tab-link" data-name="-admin-tab-" role="button">
+            <a href="/publishers/example.com/admin">Admin</a>
+          </li>
+        </ul>
+        <div class="main detail-tabs-content">
+          <section class="tab-content -active" data-name="-packages-tab-">
+            <div class="listing-sort-header">
+              <div class="tooltip-base hoverable">
+                <span class="tooltip-dotted">Sorted by:</span>
+                <select id="sort-control">
+                  <option value="listing_relevance" selected="selected">listing relevance</option>
+                  <option value="top">overall score</option>
+                  <option value="updated">recently updated</option>
+                  <option value="created">newest package</option>
+                  <option value="popularity">popularity</option>
+                </select>
+                <div class="tooltip-content tooltip-bottom-left">
       Packages are sorted by the combination of their overall score and their specificity to the selected platform. More information on 
-                    <a href="/help#ranking">ranking</a>.
+                  <a href="/help#ranking">ranking</a>.
     
-                  </div>
                 </div>
               </div>
+            </div>
 
 2 package(s) owned by 
-              <code>example.com</code>.
+            <code>example.com</code>.
 
 
-              <ul class="package-list">
-                <li class="list-item -full">
-                  <a href="/packages/super_package#-analysis-tab-">
-                    <div class="score-box">
-                      <span class="number -solid" title="Analysis and more details.">97</span>
-                    </div>
-                  </a>
-                  <h3 class="title">
-                    <a href="/packages/super_package">super_package</a>
-                  </h3>
-                  <p class="description">A great web UI library.</p>
-                  <p class="metadata">
+            <ul class="package-list">
+              <li class="list-item -full">
+                <a href="/packages/super_package#-analysis-tab-">
+                  <div class="score-box">
+                    <span class="number -solid" title="Analysis and more details.">97</span>
+                  </div>
+                </a>
+                <h3 class="title">
+                  <a href="/packages/super_package">super_package</a>
+                </h3>
+                <p class="description">A great web UI library.</p>
+                <p class="metadata">
         v 
-                    <a href="/packages/super_package">1.0.0</a>
+                  <a href="/packages/super_package">1.0.0</a>
         
         • updated: 
-                    <span>3 Jan 2019</span>
-                    <a class="package-tag" href="/dart/packages" title="sdk:dart">dart</a>
-                  </p>
-                </li>
-                <li class="list-item -full">
-                  <a href="/packages/another_package#-analysis-tab-">
-                    <div class="score-box">
-                      <span class="number -solid" title="Analysis and more details.">90</span>
-                    </div>
-                  </a>
-                  <h3 class="title">
-                    <a href="/packages/another_package">another_package</a>
-                  </h3>
-                  <p class="description">Camera plugin.</p>
-                  <p class="metadata">
+                  <span>3 Jan 2019</span>
+                  <a class="package-tag" href="/dart/packages" title="sdk:dart">dart</a>
+                </p>
+              </li>
+              <li class="list-item -full">
+                <a href="/packages/another_package#-analysis-tab-">
+                  <div class="score-box">
+                    <span class="number -solid" title="Analysis and more details.">90</span>
+                  </div>
+                </a>
+                <h3 class="title">
+                  <a href="/packages/another_package">another_package</a>
+                </h3>
+                <p class="description">Camera plugin.</p>
+                <p class="metadata">
         v 
-                    <a href="/packages/another_package">2.0.0</a>
+                  <a href="/packages/another_package">2.0.0</a>
          / 
-                    <a href="/packages/another_package/versions/3.0.0-beta2">3.0.0-beta2</a>
+                  <a href="/packages/another_package/versions/3.0.0-beta2">3.0.0-beta2</a>
         • updated: 
-                    <span>30 Mar 2019</span>
-                    <a class="package-tag" href="/flutter/packages" title="sdk:flutter">flutter</a>
-                  </p>
-                </li>
-              </ul>
-              <ul class="pagination">
-                <li class="-disabled">
-                  <a href="">
-                    <span>«</span>
-                  </a>
-                </li>
-                <li class="-active">
-                  <a href="">
-                    <span>1</span>
-                  </a>
-                </li>
-                <li class="-disabled">
-                  <a href="">
-                    <span>»</span>
-                  </a>
-                </li>
-              </ul>
-            </section>
-          </div>
-          <aside class="detail-info-box">
-            <h3 class="title">Description</h3>
-            <p>This is our little software developer shop.
+                  <span>30 Mar 2019</span>
+                  <a class="package-tag" href="/flutter/packages" title="sdk:flutter">flutter</a>
+                </p>
+              </li>
+            </ul>
+            <ul class="pagination">
+              <li class="-disabled">
+                <a href="">
+                  <span>«</span>
+                </a>
+              </li>
+              <li class="-active">
+                <a href="">
+                  <span>1</span>
+                </a>
+              </li>
+              <li class="-disabled">
+                <a href="">
+                  <span>»</span>
+                </a>
+              </li>
+            </ul>
+          </section>
+        </div>
+        <aside class="detail-info-box">
+          <h3 class="title">Description</h3>
+          <p>This is our little software developer shop.
 
 We develop full-stack in Dart, and happy about it.</p>
-            <h3 class="title">Publisher</h3>
-            <p>
-              <img class="-pub-publisher-shield" height="22" width="22" title="Domain ownership verified by pub.dev" src="/static/img/verified-publisher-blue.svg?hash=mocked_hash_919645162"/>example.com
+          <h3 class="title">Publisher</h3>
+          <p>
+            <img class="-pub-publisher-shield" height="22" width="22" title="Domain ownership verified by pub.dev" src="/static/img/verified-publisher-blue.svg?hash=mocked_hash_919645162"/>example.com
 
-            </p>
-            <h3 class="title">Website</h3>
-            <p>
-              <a href="https://example.com/">example.com/</a>
-            </p>
-            <h3 class="title">Contact</h3>
-            <p>
-              <a href="mailto:hello@example.com">hello@example.com</a>
-            </p>
-            <h3 class="title">More</h3>
-            <p>
-              <a href="/packages?q=publisher%3Aexample.com" rel="nofollow">All packages of example.com</a>
-            </p>
-          </aside>
-        </div>
-      </main>
-    </div>
+          </p>
+          <h3 class="title">Website</h3>
+          <p>
+            <a href="https://example.com/">example.com/</a>
+          </p>
+          <h3 class="title">Contact</h3>
+          <p>
+            <a href="mailto:hello@example.com">hello@example.com</a>
+          </p>
+          <h3 class="title">More</h3>
+          <p>
+            <a href="/packages?q=publisher%3Aexample.com" rel="nofollow">All packages of example.com</a>
+          </p>
+        </aside>
+      </div>
+    </main>
     <footer class="site-footer">
       <a class="link" href="https://dart.dev/">Dart language</a>
       <a class="link sep" href="https://www.google.com/intl/en/policies/terms/">Terms</a>

--- a/app/test/frontend/golden/search_page.html
+++ b/app/test/frontend/golden/search_page.html
@@ -92,125 +92,123 @@
         </div>
       </div>
     </div>
-    <div class="container">
-      <main>
-        <div class="listing-sort-header">
-          <div class="tooltip-base hoverable">
-            <span class="tooltip-dotted">Sorted by:</span>
-            <select id="sort-control">
-              <option value="search_relevance">search relevance</option>
-              <option value="top" selected="selected">overall score</option>
-              <option value="updated">recently updated</option>
-              <option value="created">newest package</option>
-              <option value="popularity">popularity</option>
-            </select>
-            <div class="tooltip-content tooltip-bottom-left">
+    <main class="container">
+      <div class="listing-sort-header">
+        <div class="tooltip-base hoverable">
+          <span class="tooltip-dotted">Sorted by:</span>
+          <select id="sort-control">
+            <option value="search_relevance">search relevance</option>
+            <option value="top" selected="selected">overall score</option>
+            <option value="updated">recently updated</option>
+            <option value="created">newest package</option>
+            <option value="popularity">popularity</option>
+          </select>
+          <div class="tooltip-content tooltip-bottom-left">
       Packages are sorted by the overall score. More information on 
-              <a href="/help#ranking">ranking</a>.
+            <a href="/help#ranking">ranking</a>.
     
-            </div>
           </div>
         </div>
-        <p class="package-count">
-          <span>2</span> results for 
-          <code>foobar</code>
-        </p>
-        <ul class="package-list">
-          <li class="list-item -full">
-            <a href="/packages/foobar_pkg#-analysis-tab-">
-              <div class="score-box">
-                <span class="number -rotten" title="Analysis and more details.">0</span>
-              </div>
-            </a>
-            <h3 class="title">
-              <a href="/packages/foobar_pkg">foobar_pkg</a>
-            </h3>
-            <p class="description">my package description</p>
-            <p class="metadata">
+      </div>
+      <p class="package-count">
+        <span>2</span> results for 
+        <code>foobar</code>
+      </p>
+      <ul class="package-list">
+        <li class="list-item -full">
+          <a href="/packages/foobar_pkg#-analysis-tab-">
+            <div class="score-box">
+              <span class="number -rotten" title="Analysis and more details.">0</span>
+            </div>
+          </a>
+          <h3 class="title">
+            <a href="/packages/foobar_pkg">foobar_pkg</a>
+          </h3>
+          <p class="description">my package description</p>
+          <p class="metadata">
         v 
-              <a href="/packages/foobar_pkg">0.1.1+5</a>
+            <a href="/packages/foobar_pkg">0.1.1+5</a>
          / 
-              <a href="/packages/foobar_pkg/versions/0.2.0-dev">0.2.0-dev</a>
+            <a href="/packages/foobar_pkg/versions/0.2.0-dev">0.2.0-dev</a>
         • updated: 
-              <span>Jan 1, 2014</span>
-              <span class="package-tag missing" title="Analysis should be ready soon.">[awaiting]</span>
-            </p>
-            <div class="api_pages">
+            <span>Jan 1, 2014</span>
+            <span class="package-tag missing" title="Analysis should be ready soon.">[awaiting]</span>
+          </p>
+          <div class="api_pages">
         API results:
         
-              <ul>
-                <li>
-                  <a href="/documentation/foobar_pkg/latest/some/some-library.html">some/some-library.html</a>
-                </li>
-                <li>
-                  <a href="/documentation/foobar_pkg/latest/some/x-class.html">Class X</a>
-                </li>
-              </ul>
+            <ul>
+              <li>
+                <a href="/documentation/foobar_pkg/latest/some/some-library.html">some/some-library.html</a>
+              </li>
+              <li>
+                <a href="/documentation/foobar_pkg/latest/some/x-class.html">Class X</a>
+              </li>
+            </ul>
+          </div>
+        </li>
+        <li class="list-item -full">
+          <a href="/packages/foobar_pkg#-analysis-tab-">
+            <div class="score-box">
+              <span class="number -rotten" title="Analysis and more details.">0</span>
             </div>
-          </li>
-          <li class="list-item -full">
-            <a href="/packages/foobar_pkg#-analysis-tab-">
-              <div class="score-box">
-                <span class="number -rotten" title="Analysis and more details.">0</span>
-              </div>
-            </a>
-            <h3 class="title">
-              <a href="/packages/foobar_pkg">foobar_pkg</a>
-            </h3>
-            <p class="description">my package description</p>
-            <p class="metadata">
+          </a>
+          <h3 class="title">
+            <a href="/packages/foobar_pkg">foobar_pkg</a>
+          </h3>
+          <p class="description">my package description</p>
+          <p class="metadata">
         v 
-              <a href="/packages/foobar_pkg">0.1.1+5</a>
+            <a href="/packages/foobar_pkg">0.1.1+5</a>
          / 
-              <a href="/packages/foobar_pkg/versions/0.2.0-dev">0.2.0-dev</a>
+            <a href="/packages/foobar_pkg/versions/0.2.0-dev">0.2.0-dev</a>
         • updated: 
-              <span>Jan 1, 2015</span>
-              <a class="package-tag" href="/flutter/packages" title="sdk:flutter">flutter</a>
-            </p>
-          </li>
-        </ul>
-        <ul class="pagination">
-          <li class="-disabled">
-            <a href="">
-              <span>«</span>
-            </a>
-          </li>
-          <li class="-active">
-            <a href="">
-              <span>1</span>
-            </a>
-          </li>
-          <li class="">
-            <a href="/packages?q=foobar&amp;sort=top&amp;page=2" rel="next">
-              <span>2</span>
-            </a>
-          </li>
-          <li class="">
-            <a href="/packages?q=foobar&amp;sort=top&amp;page=3">
-              <span>3</span>
-            </a>
-          </li>
-          <li class="">
-            <a href="/packages?q=foobar&amp;sort=top&amp;page=4">
-              <span>4</span>
-            </a>
-          </li>
-          <li class="">
-            <a href="/packages?q=foobar&amp;sort=top&amp;page=5">
-              <span>5</span>
-            </a>
-          </li>
-          <li class="">
-            <a href="/packages?q=foobar&amp;sort=top&amp;page=2">
-              <span>»</span>
-            </a>
-          </li>
-        </ul>
-        <p>Check our help page for 
-          <a href="/help#search">advanced search expressions</a>.
-        </p>
-      </main>
-    </div>
+            <span>Jan 1, 2015</span>
+            <a class="package-tag" href="/flutter/packages" title="sdk:flutter">flutter</a>
+          </p>
+        </li>
+      </ul>
+      <ul class="pagination">
+        <li class="-disabled">
+          <a href="">
+            <span>«</span>
+          </a>
+        </li>
+        <li class="-active">
+          <a href="">
+            <span>1</span>
+          </a>
+        </li>
+        <li class="">
+          <a href="/packages?q=foobar&amp;sort=top&amp;page=2" rel="next">
+            <span>2</span>
+          </a>
+        </li>
+        <li class="">
+          <a href="/packages?q=foobar&amp;sort=top&amp;page=3">
+            <span>3</span>
+          </a>
+        </li>
+        <li class="">
+          <a href="/packages?q=foobar&amp;sort=top&amp;page=4">
+            <span>4</span>
+          </a>
+        </li>
+        <li class="">
+          <a href="/packages?q=foobar&amp;sort=top&amp;page=5">
+            <span>5</span>
+          </a>
+        </li>
+        <li class="">
+          <a href="/packages?q=foobar&amp;sort=top&amp;page=2">
+            <span>»</span>
+          </a>
+        </li>
+      </ul>
+      <p>Check our help page for 
+        <a href="/help#search">advanced search expressions</a>.
+      </p>
+    </main>
     <footer class="site-footer">
       <a class="link" href="https://dart.dev/">Dart language</a>
       <a class="link sep" href="https://www.google.com/intl/en/policies/terms/">Terms</a>

--- a/pkg/web_css/lib/src/_home.scss
+++ b/pkg/web_css/lib/src/_home.scss
@@ -93,13 +93,8 @@
 /* non-indented rule to restrict the content of this block to the experimental pages */
 .experimental {
 
-&.page-landing {
+.landing-main {
   background-image: url('/static/img/square-bg.png');
-  >.container {
-    margin: 0px;
-    padding: 0px;
-    max-width: inherit;
-  }
 }
 
 .home-block {


### PR DESCRIPTION
The main change is in `layout.mustache`: the `main` element is now top-level, and its classes are provided by the caller template method. This enables simpler styling, we don't need to override the `.container`'s max-width every place we need an in-page full-width block.

(One alternative would have been https://css-tricks.com/full-width-containers-limited-width-parents/#article-header-id-6)