### PR TITLE
Adjust icons on new package list page

### DIFF
--- a/app/lib/frontend/templates/views/pkg/package_list_experimental.mustache
+++ b/app/lib/frontend/templates/views/pkg/package_list_experimental.mustache
@@ -9,11 +9,15 @@
       <h3 class="packages-title"><a href="{{& url}}">{{name}}</a></h3>
       <div class="packages-icons">
         {{#is_flutter_favorite}}
-        <img src="{{static_assets.img__ff_svg}}"
-             class="packages-ff-icon"
-             title="Package {{name}} have been awarded Flutter Favorite" />
+        <div class="packages-icon">
+          <img src="{{static_assets.img__ff_svg}}"
+               class="packages-ff-icon"
+               title="Package {{name}} have been awarded Flutter Favorite" />
+        </div>
         {{/is_flutter_favorite}}
-        {{& score_box_html }}
+        <div class="packages-icon">
+          {{& score_box_html }}
+        </div>
       </div>
     </div>
     <p class="packages-description">{{desc}}</p>

--- a/pkg/web_css/lib/src/_list_experimental.scss
+++ b/pkg/web_css/lib/src/_list_experimental.scss
@@ -98,10 +98,16 @@ body.experimental {
   .packages-icons {
     display: flex;
     align-items: center;
+
+    .packages-icon:not(:last-child) {
+      margin-right: 8px;
+    }
   }
 
   .packages-ff-icon {
+    display: block;
     width: 40px;
+    height: 40px;
   }
 
   .packages-description {


### PR DESCRIPTION
- needed a new DOM element + class
- icon image needs to be `display: block`, otherwise it had a 7px bottom padding which I couldn't explain nor compensate