### PR TITLE
Update search index in smaller batches.

### DIFF
--- a/app/lib/search/index_simple.dart
+++ b/app/lib/search/index_simple.dart
@@ -81,25 +81,37 @@ class SimplePackageIndex implements PackageIndex {
 
   @override
   Future<void> addPackage(PackageDocument document) async {
-    final PackageDocument doc = document.intern(_internPool.intern);
+    final doc = document.intern(_internPool.intern);
 
     _packages[doc.package] = doc;
-    _nameIndex.add(doc.package, doc.package);
-    _descrIndex.add(doc.package, doc.description);
-    _readmeIndex.add(doc.package, doc.readme);
+    await Future.delayed(Duration.zero, () {
+      _nameIndex.add(doc.package, doc.package);
+    });
+    await Future.delayed(Duration.zero, () {
+      _descrIndex.add(doc.package, doc.description);
+    });
+    await Future.delayed(Duration.zero, () {
+      _readmeIndex.add(doc.package, doc.readme);
+    });
     for (ApiDocPage page in doc.apiDocPages ?? const []) {
       final pageId = _apiDocPageId(doc.package, page);
       if (page.symbols != null && page.symbols.isNotEmpty) {
-        _apiSymbolIndex.add(pageId, page.symbols.join(' '));
+        await Future.delayed(Duration.zero, () {
+          _apiSymbolIndex.add(pageId, page.symbols.join(' '));
+        });
       }
       if (page.textBlocks != null && page.textBlocks.isNotEmpty) {
-        _apiDartdocIndex.add(pageId, page.textBlocks.join(' '));
+        await Future.delayed(Duration.zero, () {
+          _apiDartdocIndex.add(pageId, page.textBlocks.join(' '));
+        });
       }
     }
     final String allText = [doc.package, doc.description, doc.readme]
         .where((s) => s != null)
         .join(' ');
-    _normalizedPackageText[doc.package] = normalizeBeforeIndexing(allText);
+    await Future.delayed(Duration.zero, () {
+      _normalizedPackageText[doc.package] = normalizeBeforeIndexing(allText);
+    });
   }
 
   @override

--- a/app/lib/search/index_simple.dart
+++ b/app/lib/search/index_simple.dart
@@ -82,36 +82,39 @@ class SimplePackageIndex implements PackageIndex {
   @override
   Future<void> addPackage(PackageDocument document) async {
     final doc = document.intern(_internPool.intern);
-
     _packages[doc.package] = doc;
-    await Future.delayed(Duration.zero, () {
-      _nameIndex.add(doc.package, doc.package);
-    });
-    await Future.delayed(Duration.zero, () {
-      _descrIndex.add(doc.package, doc.description);
-    });
-    await Future.delayed(Duration.zero, () {
-      _readmeIndex.add(doc.package, doc.readme);
-    });
+
+    // The method could be a single sync block, however, while the index update
+    // happens, we are not serving queries. With the forced async segments,
+    // the waiting queries will be served earlier.
+    await Future.delayed(Duration.zero);
+    _nameIndex.add(doc.package, doc.package);
+
+    await Future.delayed(Duration.zero);
+    _descrIndex.add(doc.package, doc.description);
+
+    await Future.delayed(Duration.zero);
+    _readmeIndex.add(doc.package, doc.readme);
+
     for (ApiDocPage page in doc.apiDocPages ?? const []) {
       final pageId = _apiDocPageId(doc.package, page);
       if (page.symbols != null && page.symbols.isNotEmpty) {
-        await Future.delayed(Duration.zero, () {
-          _apiSymbolIndex.add(pageId, page.symbols.join(' '));
-        });
+        await Future.delayed(Duration.zero);
+        _apiSymbolIndex.add(pageId, page.symbols.join(' '));
       }
       if (page.textBlocks != null && page.textBlocks.isNotEmpty) {
-        await Future.delayed(Duration.zero, () {
-          _apiDartdocIndex.add(pageId, page.textBlocks.join(' '));
-        });
+        await Future.delayed(Duration.zero);
+        _apiDartdocIndex.add(pageId, page.textBlocks.join(' '));
       }
     }
+
+    await Future.delayed(Duration.zero);
     final String allText = [doc.package, doc.description, doc.readme]
         .where((s) => s != null)
         .join(' ');
-    await Future.delayed(Duration.zero, () {
-      _normalizedPackageText[doc.package] = normalizeBeforeIndexing(allText);
-    });
+
+    await Future.delayed(Duration.zero);
+    _normalizedPackageText[doc.package] = normalizeBeforeIndexing(allText);
   }
 
   @override


### PR DESCRIPTION
On my local tests this increased the wall-clock latency by about ~15-20% (indexing the snapshot at startup increased from 10.4s to 12.1s), it introduces a few ms window of slightly inconsistent index results, but I think it is worth it up.
