### PR TITLE
Adjusted tags style.

### DIFF
--- a/pkg/web_css/lib/src/_list.scss
+++ b/pkg/web_css/lib/src/_list.scss
@@ -165,16 +165,32 @@ body.non-experimental {
   display: inline-block;
   font-size: 12px;
   font-weight: 500;
-  color: #555;
-  padding: 2px 8px;
   margin: 0px 0 4px 4px;
+
+  .non-experimental & {
+    color: #555;
+    padding: 2px 8px;
+  }
+
+  .experimental & {
+    color: #2465df;
+    padding: 7px 10px;
+  }
 
   &.missing {
     background: #f0f0f0;
+
+    .experimental & {
+      color: #555;
+    }
   }
 
   &.unidentified {
     background: #fff0f0;
+
+    .experimental & {
+      color: #555;
+    }
   }
 
   &.legacy,


### PR DESCRIPTION
#3246 (more padding, different text color)

<img width="140" alt="Screen Shot 2020-01-29 at 18 19 45" src="https://user-images.githubusercontent.com/4778111/73380478-68f2fe80-42c4-11ea-8fe9-83b103c94a95.png">
