### PR TITLE
Better mobile view for listing page tabs.

### DIFF
--- a/app/lib/frontend/templates/listing.dart
+++ b/app/lib/frontend/templates/listing.dart
@@ -120,6 +120,7 @@ String renderPkgIndexPage(
   final isSearch = searchQuery != null && searchQuery.hasQuery;
   final values = {
     'sdk_tabs_html': renderSdkTabs(searchQuery: searchQuery),
+    'subsdk_label': _subSdkLabel(searchQuery),
     'subsdk_tabs_html': renderSubSdkTabsHtml(searchQuery: searchQuery),
     'sort_control_html': renderSortControl(searchQuery),
     'is_search': isSearch,
@@ -151,6 +152,16 @@ String renderPkgIndexPage(
     searchPlaceHolder: searchPlaceholder,
     mainClasses: requestContext.isExperimental ? [] : null,
   );
+}
+
+String _subSdkLabel(SearchQuery sq) {
+  if (sq?.sdk == SdkTagValue.dart) {
+    return 'Runtime';
+  } else if (sq?.sdk == SdkTagValue.flutter) {
+    return 'Platform';
+  } else {
+    return null;
+  }
 }
 
 /// Renders the `views/shared/sort_control.mustache` template.

--- a/app/lib/frontend/templates/views/pkg/index_experimental.mustache
+++ b/app/lib/frontend/templates/views/pkg/index_experimental.mustache
@@ -5,7 +5,9 @@
 <div class="search-controls">
   <div class="container">
     <div class="search-controls-primary">
-      <div class="search-controls-sdk search-controls-tabs">{{& sdk_tabs_html}}</div>
+      <div class="search-controls-sdk search-controls-tabs">
+        {{& sdk_tabs_html}}
+      </div>
       <div class="search-controls-sdk search-controls-buttons">
         <span class="search-controls-label">SDK</span>
         {{& sdk_tabs_html}}

--- a/app/lib/frontend/templates/views/pkg/index_experimental.mustache
+++ b/app/lib/frontend/templates/views/pkg/index_experimental.mustache
@@ -5,8 +5,15 @@
 <div class="search-controls">
   <div class="container">
     <div class="search-controls-primary">
-      <div class="search-controls-sdk">{{& sdk_tabs_html}}</div>
-      <div class="search-controls-subsdk">{{& subsdk_tabs_html}}</div>
+      <div class="search-controls-sdk search-controls-tabs">{{& sdk_tabs_html}}</div>
+      <div class="search-controls-sdk search-controls-buttons">
+        <span class="search-controls-label">SDK</span>
+        {{& sdk_tabs_html}}
+      </div>
+      <div class="search-controls-subsdk search-controls-buttons">
+        <span class="search-controls-label">{{subsdk_label}}</span>
+        {{& subsdk_tabs_html}}
+      </div>
     </div>
   </div>
 </div>

--- a/pkg/web_css/lib/src/_list_experimental.scss
+++ b/pkg/web_css/lib/src/_list_experimental.scss
@@ -18,13 +18,6 @@ body.experimental {
   }
 }
 
-.search-controls-break {
-  @media (max-width: $device-mobile-max-width) {
-    flex-basis: 100%;
-    height: 0;
-  }
-}
-
 .search-controls {
   background: #f5f5f7;
 

--- a/pkg/web_css/lib/src/_list_experimental.scss
+++ b/pkg/web_css/lib/src/_list_experimental.scss
@@ -5,17 +5,56 @@
 /* non-indented rule to restrict the content of this block to the experimental pages */
 body.experimental {
 
+.search-controls-label {
+  display: none;
+  color: #5f6368;
+  font-size: 12px;
+  font-weight: bold;
+  margin-bottom: 8px;
+  text-transform: uppercase;
+
+  @media (max-width: $device-mobile-max-width) {
+    display: block;
+  }
+}
+
+.search-controls-break {
+  @media (max-width: $device-mobile-max-width) {
+    flex-basis: 100%;
+    height: 0;
+  }
+}
+
 .search-controls {
   background: #f5f5f7;
 
   .search-controls-primary {
-    display: flex;
-    align-items: center;
+    padding: 8px 0px;
+
+    @media (min-width: $device-desktop-min-width) {
+      display: flex;
+      align-items: center;
+      padding: 0;
+    }
   }
 
   .search-controls-sdk {
     flex-grow: 1;
 
+    &.search-controls-buttons {
+      @media (min-width: $device-desktop-min-width) {
+        display: none;
+      }
+    }
+
+    &.search-controls-tabs {
+      @media (max-width: $device-mobile-max-width) {
+        display: none;
+      }
+    }
+  }
+
+  .search-controls-tabs {
     .list-filters {
       .filter {
         color: #555555;
@@ -42,8 +81,13 @@ body.experimental {
     }
   }
 
-  .search-controls-subsdk {
+  .search-controls-buttons {
     .list-filters {
+
+      @media (max-width: $device-mobile-max-width) {
+        margin-bottom: 8px;
+      }
+
       .filter {
         background: #f5f5f7;
         border: 1px solid #ccc;


### PR DESCRIPTION
This is an intermediate step before adding the open/close function to mobile menu (or the advanced option on the desktop menu). I've tried to reuse the SDK tabs as single DOM element, but the SCSS rules got really big and complex, instead:
- the DOM is duplicated, with `search-controls-tabs` and `search-controls-buttons` as a style that controls how the tabs look
- there is an XOR logic which shows the tabs in desktop mode and the buttons in mobile mode
- mobile mode also displays the labels and it breaks up the row

<img width="428" alt="Screen Shot 2020-01-30 at 19 03 16" src="https://user-images.githubusercontent.com/4778111/73476854-64494b80-4393-11ea-8857-b0818a3e0bc5.png">
