### PR TITLE
Refactor tags SCSS.

### DIFF
--- a/pkg/web_css/lib/src/_detail_page.scss
+++ b/pkg/web_css/lib/src/_detail_page.scss
@@ -1,3 +1,7 @@
+/* Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+   for details. All rights reserved. Use of this source code is governed by a
+   BSD-style license that can be found in the LICENSE file. */
+
 .detail-container {
   > .main {
     display: inline-block;
@@ -73,35 +77,6 @@
   > .metadata {
     font-size: 14px;
     color: #555;
-  }
-}
-
-.-pub-tag-badge {
-  font-size: 12px;
-  display: inline-block;
-  margin-right: 15px;
-
-  > * {
-    display: inline-block;
-    text-transform: uppercase;
-    font-weight: 500;
-    padding: 2px 8px;
-    color: #555;
-    background: #e7f8ff;
-  }
-
-  > *:first-child {
-    background: #0175c2;
-    color: #e7f8ff;
-  }
-
-  > a:hover {
-    background: #ccc;
-    opacity: 1;
-  }
-
-  > a:first-child:hover {
-    background: #888;
   }
 }
 

--- a/pkg/web_css/lib/src/_list.scss
+++ b/pkg/web_css/lib/src/_list.scss
@@ -92,9 +92,6 @@ body.non-experimental {
   }
 }
 
-/* non-indented rule to restrict the content of this block to the non-experimental pages */
-}
-
 .-pub-mini-list-publisher-badge {
   font-size: 12px;
   float: right;
@@ -107,7 +104,6 @@ body.non-experimental {
   }
 }
 
-/* TODO(3246): Remove after migrating to the new UI. */
 .score-box {
   float: right;
   margin: 8px;
@@ -158,50 +154,6 @@ body.non-experimental {
     }
   }
 }
-
-.package-tag {
-  background: #eef9fe;
-  text-transform: uppercase;
-  display: inline-block;
-  font-size: 12px;
-  font-weight: 500;
-  margin: 0px 0 4px 4px;
-
-  .non-experimental & {
-    color: #555;
-    padding: 2px 8px;
-  }
-
-  .experimental & {
-    color: #2465df;
-    padding: 7px 10px;
-  }
-
-  &.missing {
-    background: #f0f0f0;
-
-    .experimental & {
-      color: #555;
-    }
-  }
-
-  &.unidentified {
-    background: #fff0f0;
-
-    .experimental & {
-      color: #555;
-    }
-  }
-
-  &.legacy,
-  &.discontinued {
-    background: #c0392b;
-    color: #f8f8f8;
-  }
-}
-
-/* non-indented rule to restrict the content of this block to the non-experimental pages */
-body.non-experimental {
 
 .list-filters {
   display: -webkit-inline-box;

--- a/pkg/web_css/lib/src/_tags.scss
+++ b/pkg/web_css/lib/src/_tags.scss
@@ -1,0 +1,75 @@
+/* Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+   for details. All rights reserved. Use of this source code is governed by a
+   BSD-style license that can be found in the LICENSE file. */
+
+/* Tag style used on listing pages. */
+.package-tag {
+  background: #eef9fe;
+  text-transform: uppercase;
+  display: inline-block;
+  font-size: 12px;
+  font-weight: 500;
+  margin: 0px 0 4px 4px;
+
+  .non-experimental & {
+    color: #555;
+    padding: 2px 8px;
+  }
+
+  .experimental & {
+    color: #2465df;
+    padding: 7px 10px;
+  }
+
+  &.missing {
+    background: #f0f0f0;
+
+    .experimental & {
+      color: #555;
+    }
+  }
+
+  &.unidentified {
+    background: #fff0f0;
+
+    .experimental & {
+      color: #555;
+    }
+  }
+
+  &.legacy,
+  &.discontinued {
+    background: #c0392b;
+    color: #f8f8f8;
+  }
+}
+
+/* Tag style used on package detail page for Dart/Flutter extended badges. */
+.-pub-tag-badge {
+  font-size: 12px;
+  display: inline-block;
+  margin-right: 15px;
+
+  > * {
+    display: inline-block;
+    text-transform: uppercase;
+    font-weight: 500;
+    padding: 2px 8px;
+    color: #555;
+    background: #e7f8ff;
+  }
+
+  > *:first-child {
+    background: #0175c2;
+    color: #e7f8ff;
+  }
+
+  > a:hover {
+    background: #ccc;
+    opacity: 1;
+  }
+
+  > a:first-child:hover {
+    background: #888;
+  }
+}

--- a/pkg/web_css/lib/style.scss
+++ b/pkg/web_css/lib/style.scss
@@ -11,4 +11,5 @@
 @import 'src/_pkg';
 @import 'src/_score_circle';
 @import 'src/_search';
+@import 'src/_tags';
 @import 'src/_overrides';


### PR DESCRIPTION
- Moved tag-styles into a separate file, as they are used by both old and new design (one of them has mixed rules for both).
- Extended and collapsed non-indented blocks on `_list.scss` to make tracking of it simpler.