### PR TITLE
Increase timeout for integration tests.

### DIFF
--- a/pkg/fake_pub_server/pubspec.lock
+++ b/pkg/fake_pub_server/pubspec.lock
@@ -441,7 +441,7 @@ packages:
       name: pana
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.3"
+    version: "0.13.4"
   path:
     dependency: transitive
     description:
@@ -567,7 +567,7 @@ packages:
       name: shelf_router
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.7.1"
+    version: "0.7.2"
   shelf_static:
     dependency: transitive
     description:
@@ -630,7 +630,7 @@ packages:
       name: stream_transform
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.20"
+    version: "1.1.0"
   string_scanner:
     dependency: transitive
     description:

--- a/pkg/pub_integration/lib/src/fake_pub_server_process.dart
+++ b/pkg/pub_integration/lib/src/fake_pub_server_process.dart
@@ -11,6 +11,9 @@ import 'package:path/path.dart' as p;
 
 final _random = Random.secure();
 
+/// The timeout factor that should be used in integration tests.
+final testTimeoutFactor = 3.5;
+
 /// Wrapper and helper methods around the fake_pub_server process.
 class FakePubServerProcess {
   final int port;

--- a/pkg/pub_integration/test/browser_test.dart
+++ b/pkg/pub_integration/test/browser_test.dart
@@ -110,5 +110,5 @@ void main() {
         },
       );
     });
-  }, timeout: Timeout.factor(3));
+  }, timeout: Timeout.factor(testTimeoutFactor));
 }

--- a/pkg/pub_integration/test/dev_version_test.dart
+++ b/pkg/pub_integration/test/dev_version_test.dart
@@ -31,7 +31,7 @@ void main() {
       );
       await script.verify(false);
     });
-  }, timeout: Timeout.factor(2));
+  }, timeout: Timeout.factor(testTimeoutFactor));
 
   group('devVersion - stable first', () {
     FakePubServerProcess fakePubServerProcess;
@@ -54,5 +54,5 @@ void main() {
       );
       await script.verify(true);
     });
-  }, timeout: Timeout.factor(3));
+  }, timeout: Timeout.factor(testTimeoutFactor));
 }

--- a/pkg/pub_integration/test/pub_integration_test.dart
+++ b/pkg/pub_integration/test/pub_integration_test.dart
@@ -66,5 +66,5 @@ void main() {
         inviteCompleterFn: inviteCompleterFn,
       );
     });
-  }, timeout: Timeout.factor(3));
+  }, timeout: Timeout.factor(testTimeoutFactor));
 }

--- a/pkg/pub_integration/test/publisher_test.dart
+++ b/pkg/pub_integration/test/publisher_test.dart
@@ -68,5 +68,5 @@ void main() {
       );
       await script.verify();
     });
-  }, timeout: Timeout.factor(3));
+  }, timeout: Timeout.factor(testTimeoutFactor));
 }


### PR DESCRIPTION
Recently we had a lot of flakes when the fake server was starting, this should reduce it a bit.