### PR TITLE
Search controls toggle for new mobile listing page.

### DIFF
--- a/app/lib/frontend/templates/layout.dart
+++ b/app/lib/frontend/templates/layout.dart
@@ -170,6 +170,7 @@ String _renderSearchBanner({
   }
   final isExperimental = requestContext.isExperimental;
   return templateCache.renderTemplate('shared/search_banner', {
+    'show_search_filters_btn': isExperimental && type == PageType.listing,
     'show_details': !isExperimental &&
         (type == PageType.listing || type == PageType.landing),
     'show_options': !isExperimental && type == PageType.listing,

--- a/app/lib/frontend/templates/views/shared/search_banner.mustache
+++ b/app/lib/frontend/templates/views/shared/search_banner.mustache
@@ -5,6 +5,12 @@
 <form class="search-bar banner-item" action="{{& search_form_url}}">
   <input class="input" name="q" placeholder="{{search_query_placeholder}}" autocomplete="on" autofocus="autofocus"{{#search_query_html}} value="{{& search_query_html}}"{{/search_query_html}}/>
   <button class="icon"></button>
+  {{#show_search_filters_btn}}
+  <div class="search-filters-btn-wrapper">
+    <img class="search-filters-btn search-filters-btn-inactive" src="{{& static_assets.img__search-filters-inactive_svg}}" />
+    <img class="search-filters-btn search-filters-btn-active" src="{{& static_assets.img__search-filters-active_svg}}" />
+  </div>
+  {{/show_search_filters_btn}}
   {{#show_details}}
   {{#search_sort_param}}<input type="hidden" name="sort" value="{{search_sort_param}}"/>{{/search_sort_param}}
   <input id="search-legacy-field" type="hidden" name="legacy" value="1"{{^legacy_search_enabled}} disabled="disabled"{{/legacy_search_enabled}} />

--- a/pkg/web_app/lib/src/search.dart
+++ b/pkg/web_app/lib/src/search.dart
@@ -6,6 +6,7 @@ import 'dart:html';
 
 void setupSearch() {
   _setEventForSearchInput();
+  _setEventForFiltersToggle();
   _setEventForSortControl();
   _setEventForCheckboxChanges();
 }
@@ -24,6 +25,18 @@ void _setEventForSearchInput() {
       final String newHref = oldUri.replace(queryParameters: params).toString();
       a.setAttribute('href', newHref);
     }
+  });
+}
+
+void _setEventForFiltersToggle() {
+  document.querySelectorAll('.search-filters-btn').forEach((e) {
+    e.onClick.listen((_) {
+      document
+          .querySelector('.search-filters-btn-wrapper')
+          ?.classes
+          ?.toggle('-active');
+      document.querySelector('.search-controls')?.classes?.toggle('-active');
+    });
   });
 }
 

--- a/pkg/web_css/lib/src/_list_experimental.scss
+++ b/pkg/web_css/lib/src/_list_experimental.scss
@@ -20,6 +20,15 @@ body.experimental {
 
 .search-controls {
   background: #f5f5f7;
+  display: none;
+
+  &.-active {
+    display: block;
+  }
+
+  @media (min-width: $device-desktop-min-width) {
+    display: block;
+  }
 
   .search-controls-primary {
     padding: 8px 0px;

--- a/pkg/web_css/lib/src/_search.scss
+++ b/pkg/web_css/lib/src/_search.scss
@@ -1,3 +1,7 @@
+/* Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+   for details. All rights reserved. Use of this source code is governed by a
+   BSD-style license that can be found in the LICENSE file. */
+
 /******************************************************
   searchbar
 ******************************************************/
@@ -76,6 +80,42 @@
     @media (min-width: $device-desktop-min-width) {
       left: 20px;
       transform: scale(1.0);
+    }
+  }
+}
+
+.search-filters-btn-wrapper {
+  display: none;
+
+  .experimental & {
+    @media (max-width: $device-mobile-max-width) {
+      display: block;
+    }
+  }
+
+  .search-filters-btn {
+    cursor: pointer;
+    display: block;
+    width: 40px;
+    height: 40px;
+    margin-left: 8px;
+  }
+
+  .search-filters-btn-inactive {
+    display: block;
+  }
+
+  .search-filters-btn-active {
+    display: none;
+  }
+
+  &.-active {
+    .search-filters-btn-inactive {
+      display: none;
+    }
+
+    .search-filters-btn-active {
+      display: block;
     }
   }
 }

--- a/static/img/search-filters-active.svg
+++ b/static/img/search-filters-active.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="42px" height="42px" viewBox="0 0 42 42" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <g id="pub.dev" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="general-ui---icons-and-components" transform="translate(-458.000000, -206.000000)" fill="#0066D9">
+            <path d="M479,206 C490.59798,206 500,215.40202 500,227 C500,238.59798 490.59798,248 479,248 C467.40202,248 458,238.59798 458,227 C458,215.40202 467.40202,206 479,206 Z M480,230 L478,230 L478,236 L480,236 L480,234 L488,234 L488,232 L480,232 L480,230 Z M476,232 L470,232 L470,234 L476,234 L476,232 Z M476,224 L474,224 L474,226 L470,226 L470,228 L474,228 L474,230 L476,230 L476,224 Z M488,226 L478,226 L478,228 L488,228 L488,226 Z M484,218 L482,218 L482,224 L484,224 L484,222 L488,222 L488,220 L484,220 L484,218 Z M480,220 L470,220 L470,222 L480,222 L480,220 Z" id="btn---filter-active"></path>
+        </g>
+    </g>
+</svg>

--- a/static/img/search-filters-inactive.svg
+++ b/static/img/search-filters-inactive.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="42px" height="42px" viewBox="0 0 42 42" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <g id="pub.dev" stroke="#808080" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="general-ui---icons-and-components" transform="translate(-458.000000, -206.000000)" fill="none">
+            <path d="M479,206 C490.59798,206 500,215.40202 500,227 C500,238.59798 490.59798,248 479,248 C467.40202,248 458,238.59798 458,227 C458,215.40202 467.40202,206 479,206 Z M480,230 L478,230 L478,236 L480,236 L480,234 L488,234 L488,232 L480,232 L480,230 Z M476,232 L470,232 L470,234 L476,234 L476,232 Z M476,224 L474,224 L474,226 L470,226 L470,228 L474,228 L474,230 L476,230 L476,224 Z M488,226 L478,226 L478,228 L488,228 L488,226 Z M484,218 L482,218 L482,224 L484,224 L484,222 L488,222 L488,220 L484,220 L484,218 Z M480,220 L470,220 L470,222 L480,222 L480,220 Z" id="btn---filter-active"></path>
+        </g>
+    </g>
+</svg>


### PR DESCRIPTION
- Toggle button is displayed only on the new design's listing page, on mobile.
- The inactive toggle button is not the one provided by the designer (misses the inner white bars) (tracked in #3246).

Inactive view:
<img width="428" alt="Screen Shot 2020-01-31 at 14 53 24" src="https://user-images.githubusercontent.com/4778111/73544889-7205dc00-443a-11ea-8017-0d7ce688dbbc.png">

Active view:
<img width="428" alt="Screen Shot 2020-01-31 at 14 53 32" src="https://user-images.githubusercontent.com/4778111/73544901-7631f980-443a-11ea-8ab7-b7426c401b72.png">
