### PR TITLE
Remove package name from the beginning of the readme.

### DIFF
--- a/app/lib/frontend/templates/_utils.dart
+++ b/app/lib/frontend/templates/_utils.dart
@@ -19,7 +19,7 @@ String renderFile(FileObject file, String baseUrl, {String packageName}) {
     if (_isMarkdownFile(filename)) {
       // Remove leading package name from the beginning of the markdown file.
       if (packageName != null) {
-        final regexp = RegExp('#+ $packageName\n');
+        final regexp = RegExp('#+ ${RegExp.escape(packageName)}\n');
         if (regexp.matchAsPrefix(content) != null) {
           content = content.replaceFirst(regexp, '');
         }

--- a/app/lib/frontend/templates/_utils.dart
+++ b/app/lib/frontend/templates/_utils.dart
@@ -12,11 +12,18 @@ import '../../shared/markdown.dart';
 const HtmlEscape htmlAttrEscape = HtmlEscape(HtmlEscapeMode.attribute);
 
 /// Renders a file content (e.g. markdown, dart source file) into HTML.
-String renderFile(FileObject file, String baseUrl) {
+String renderFile(FileObject file, String baseUrl, {String packageName}) {
   final filename = file.filename;
-  final content = file.text;
+  String content = file.text;
   if (content != null) {
     if (_isMarkdownFile(filename)) {
+      // Remove leading package name from the beginning of the markdown file.
+      if (packageName != null) {
+        final regexp = RegExp('#+ $packageName\n');
+        if (regexp.matchAsPrefix(content) != null) {
+          content = content.replaceFirst(regexp, '');
+        }
+      }
       return markdownToHtml(content, baseUrl, baseDir: p.dirname(filename));
     } else if (_isDartFile(filename)) {
       return _renderDartCode(content);

--- a/app/lib/frontend/templates/package.dart
+++ b/app/lib/frontend/templates/package.dart
@@ -291,7 +291,8 @@ List<Tab> _pkgTabs(
   final packageLinks = selectedVersion.packageLinks;
   final baseUrl = packageLinks.baseUrl;
   if (selectedVersion.readme != null) {
-    renderedReadme = renderFile(selectedVersion.readme, baseUrl);
+    renderedReadme =
+        renderFile(selectedVersion.readme, baseUrl, packageName: package.name);
   }
 
   String renderedChangelog;

--- a/app/test/frontend/golden/pkg_show_page_publisher.html
+++ b/app/test/frontend/golden/pkg_show_page_publisher.html
@@ -122,9 +122,6 @@ Published
         </ul>
         <div class="main detail-tabs-content">
           <section class="tab-content -active markdown-body" data-name="-readme-tab-">
-            <h1 class="hash-header" id="lithium">lithium 
-              <a href="#lithium" class="hash-link">#</a>
-            </h1>
             <p>lithium is a Dart package</p>
           </section>
           <section class="tab-content markdown-body" data-name="-changelog-tab-">


### PR DESCRIPTION
Fixes #3238. 

I think we shouldn't be too smart about this: earlier stagehand templates (before https://github.com/dart-lang/stagehand/pull/578) had the project name in the readme, but it has been dropped since then. I've seen some packages using `##` instead of `#`, but otherwise it is usually either this simple pattern, or a different text. Let's not try to detect more than that, e.g. when we'll have proper markdown parsing, ToC extraction etc...