### PR TITLE
New details tab.

### DIFF
--- a/app/lib/frontend/templates/detail_page.dart
+++ b/app/lib/frontend/templates/detail_page.dart
@@ -6,6 +6,7 @@ import 'dart:convert';
 
 import 'package:meta/meta.dart';
 
+import '../request_context.dart';
 import '_cache.dart';
 
 /// Renders the `shared/detail/header.mustache` template
@@ -88,6 +89,7 @@ class Tab {
 
   Map _toMustacheData() {
     final titleClasses = <String>[
+      if (requestContext.isExperimental) 'detail-tab',
       contentHtml == null ? 'tab-link' : 'tab-button',
       if (isActive) '-active',
     ];

--- a/app/lib/frontend/templates/misc.dart
+++ b/app/lib/frontend/templates/misc.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:convert';
 import 'dart:math' show pi;
 
 import 'package:meta/meta.dart';
@@ -295,6 +296,7 @@ String renderScoreBox(
   @required bool isSkipped,
   bool isNewPackage,
   String package,
+  bool isTabHeader = false,
 }) {
   final String formattedScore = formatScore(overallScore);
   String title;
@@ -304,6 +306,10 @@ String renderScoreBox(
     title = 'Analysis and more details.';
   }
   if (requestContext.isExperimental) {
+    if (isTabHeader) {
+      return 'Score: <span class="score-value">'
+          '${htmlEscape.convert(formattedScore)}</span>';
+    }
     return renderScoreCircle(
       label: formattedScore,
       percent: overallScore == null ? 0 : (100 * overallScore).round(),

--- a/app/lib/frontend/templates/package.dart
+++ b/app/lib/frontend/templates/package.dart
@@ -337,9 +337,12 @@ List<Tab> _pkgTabs(
   ));
   tabs.add(Tab.withContent(
     id: 'analysis',
-    titleHtml: renderScoreBox(card?.overallScore,
-        isSkipped: card?.isSkipped ?? false,
-        isNewPackage: package.isNewPackage()),
+    titleHtml: renderScoreBox(
+      card?.overallScore,
+      isSkipped: card?.isSkipped ?? false,
+      isNewPackage: package.isNewPackage(),
+      isTabHeader: true,
+    ),
     contentHtml: renderAnalysisTab(selectedVersion.package,
         selectedVersion.pubspec.sdkConstraint, card, analysis),
   ));

--- a/app/lib/frontend/templates/package_admin.dart
+++ b/app/lib/frontend/templates/package_admin.dart
@@ -56,9 +56,12 @@ String renderPkgAdminPage(
   ));
   tabs.add(Tab.withLink(
       id: 'analysis',
-      titleHtml: renderScoreBox(card?.overallScore,
-          isSkipped: card?.isSkipped ?? false,
-          isNewPackage: package.isNewPackage()),
+      titleHtml: renderScoreBox(
+        card?.overallScore,
+        isSkipped: card?.isSkipped ?? false,
+        isNewPackage: package.isNewPackage(),
+        isTabHeader: true,
+      ),
       href: urls.pkgPageUrl(package.name, fragment: '-analysis-tab-')));
   tabs.add(Tab.withContent(
     id: 'admin',

--- a/app/lib/frontend/templates/package_versions.dart
+++ b/app/lib/frontend/templates/package_versions.dart
@@ -98,9 +98,12 @@ String renderPkgVersionsPage(
   ));
   tabs.add(Tab.withLink(
       id: 'analysis',
-      titleHtml: renderScoreBox(card?.overallScore,
-          isSkipped: card?.isSkipped ?? false,
-          isNewPackage: package.isNewPackage()),
+      titleHtml: renderScoreBox(
+        card?.overallScore,
+        isSkipped: card?.isSkipped ?? false,
+        isNewPackage: package.isNewPackage(),
+        isTabHeader: true,
+      ),
       href: urls.pkgPageUrl(package.name, fragment: '-analysis-tab-')));
   if (isAdmin) {
     tabs.add(Tab.withLink(

--- a/app/lib/frontend/templates/views/shared/detail/tabs.mustache
+++ b/app/lib/frontend/templates/views/shared/detail/tabs.mustache
@@ -3,7 +3,7 @@
     BSD-style license that can be found in the LICENSE file. }}
 <ul class="detail-tabs-header">
   {{#tabs}}
-    <li class="detail-tab {{title_classes}}" data-name="-{{id}}-tab-" role="button">{{& title_html}}</li>
+    <li class="{{title_classes}}" data-name="-{{id}}-tab-" role="button">{{& title_html}}</li>
   {{/tabs}}
 </ul>
 <div class="main detail-tabs-content">

--- a/app/lib/frontend/templates/views/shared/detail/tabs.mustache
+++ b/app/lib/frontend/templates/views/shared/detail/tabs.mustache
@@ -3,7 +3,7 @@
     BSD-style license that can be found in the LICENSE file. }}
 <ul class="detail-tabs-header">
   {{#tabs}}
-    <li class="{{title_classes}}" data-name="-{{id}}-tab-" role="button">{{& title_html}}</li>
+    <li class="detail-tab {{title_classes}}" data-name="-{{id}}-tab-" role="button">{{& title_html}}</li>
   {{/tabs}}
 </ul>
 <div class="main detail-tabs-content">

--- a/pkg/web_css/lib/src/_detail_page.scss
+++ b/pkg/web_css/lib/src/_detail_page.scss
@@ -80,6 +80,9 @@
   }
 }
 
+/* non-indented rule to restrict the content of this block to the non-experimental pages */
+body.non-experimental {
+
 .detail-tabs-header {
   margin: 10px 0 20px;
   padding: 0;
@@ -158,4 +161,7 @@
       display: block;
     }
   }
+}
+
+/* non-indented rule to restrict the content of this block to the non-experimental pages */
 }

--- a/pkg/web_css/lib/src/_detail_page_experimental.scss
+++ b/pkg/web_css/lib/src/_detail_page_experimental.scss
@@ -1,0 +1,111 @@
+/* Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+   for details. All rights reserved. Use of this source code is governed by a
+   BSD-style license that can be found in the LICENSE file. */
+
+/* non-indented rule to restrict the content of this block to the experimental pages */
+body.experimental {
+
+.detail-tabs-header {
+  list-style: none;
+  margin: 0 0 24px 0;
+  padding: 0;
+
+  background: $detail-tab-bg;
+  display: flex;
+  align-items: center;
+  overflow-y: auto;
+  white-space: nowrap;
+
+  /*
+    This block creates a shadow effect for mobile horizontal scrolling.
+    The first 2 background block provides a local solid background, which
+    is the background on a non-scrollable end. The second 2 background block
+    provides a gradient-shaded background on the sides that can be scrolled
+    towards.
+
+    The animation effect would be better if the at-border transition would
+    be a slide instead of just appearing, but this should be good-enough for
+    a while.
+  */
+  @media (max-width: $device-mobile-max-width) {
+    background-image: linear-gradient(to right, $detail-tab-bg, $detail-tab-bg), linear-gradient(to right, $detail-tab-bg, $detail-tab-bg), linear-gradient(to right, rgba(128, 128, 128, .50), $detail-tab-bg), linear-gradient(to left, rgba(128, 128, 128, .50), $detail-tab-bg);
+    background-position: left center, right center, left center, right center;
+    background-repeat: no-repeat;
+    background-color: $detail-tab-bg;
+    background-size: 20px 100%, 20px 100%, 10px 100%, 10px 100%;
+    background-attachment: local, local, scroll, scroll;
+  }
+
+  > .detail-tab {
+    display: block;
+    transition: opacity 200ms; // allow tabs to fade-in, if -hidden is removed.
+
+    &:last-child {
+      margin-right: 0;
+    }
+
+    &.-hidden {
+      visibility: hidden;
+      opacity: 0;
+    }
+  }
+
+  > .tab-button,
+  > .tab-link > a {
+    display: block;
+    color: #555555;
+    font-size: 14px;
+    font-weight: 300;
+    padding: 18px 9px 12px 9px;
+    border-bottom: 2px solid;
+    border-bottom-color: transparent;
+    cursor: pointer;
+
+    &:hover {
+      border-bottom-color: #dddddd;
+    }
+  }
+
+  > .tab-button {
+    &.-active {
+      font-weight: 500;
+      color: $detail-tab-active-fg;
+      border-bottom-color: $detail-tab-active-fg;
+    }
+  }
+
+  /* Render admin tab with red. */
+  > .tab-button[data-name="-admin-tab-"],
+  > .tab-link[data-name="-admin-tab-"] > a {
+    color: $detail-tab-admin-color;
+
+    &:hover {
+      border-bottom-color: $detail-tab-admin-color;
+    }
+  }
+  > .tab-button.-active[data-name="-admin-tab-"] {
+    border-bottom-color: $detail-tab-admin-color;
+  }
+
+  .score-value {
+    background: $detail-tab-active-fg;
+    color: white;
+    display: inline-block;
+    font-weight: 400;
+    padding: 1px 8px;
+    border-radius: 12px;
+  }
+}
+
+.detail-tabs-content {
+  > .tab-content {
+    display: none;
+
+    &.-active {
+      display: block;
+    }
+  }
+}
+
+/* non-indented rule to restrict the content of this block to the experimental pages */
+}

--- a/pkg/web_css/lib/src/_variables.scss
+++ b/pkg/web_css/lib/src/_variables.scss
@@ -4,6 +4,11 @@ $site-header-popup-bg: #1f3044;
 $site-header-popup-fg: #f8f9fa;
 $site-header-popup-line: mix($site-header-popup-bg, $site-header-popup-fg, 80%);
 
+$detail-tab-bg: #f5f5f7;
+$detail-tab-normal-fg: #555555;
+$detail-tab-active-fg: #1967d2;
+$detail-tab-admin-color: #990000;
+
 $device-desktop-min-width: 641px;
 $device-mobile-max-width: 640px;
 

--- a/pkg/web_css/lib/style.scss
+++ b/pkg/web_css/lib/style.scss
@@ -3,6 +3,7 @@
 @import 'src/_site_header';
 @import 'src/_site_header_experimental';
 @import 'src/_detail_page';
+@import 'src/_detail_page_experimental';
 @import 'src/_footer';
 @import 'src/_account';
 @import 'src/_list';


### PR DESCRIPTION
- Horizontal scrolling on mobile is aided with a small shadow hint on the sides.
- Score rendering is a tweak, but it also has a natural place in the template. It may be refactored (if needed) after we've migrated to the new design.
- Not sure about admin style, tracking in #3246.

Desktop view:
<img width="536" alt="Screen Shot 2020-02-03 at 16 28 19" src="https://user-images.githubusercontent.com/4778111/73666748-90badb80-46a3-11ea-8686-87262f54ffa4.png">

Mobile view:
<img width="381" alt="Screen Shot 2020-02-03 at 16 28 35" src="https://user-images.githubusercontent.com/4778111/73666765-96182600-46a3-11ea-9eff-fbbb357de722.png">
