### PR TITLE
Button widget

### DIFF
--- a/app/lib/frontend/templates/admin.dart
+++ b/app/lib/frontend/templates/admin.dart
@@ -19,6 +19,7 @@ import 'detail_page.dart';
 import 'layout.dart';
 import 'listing.dart';
 import 'publisher.dart' show renderPublisherList;
+import 'widget.dart';
 
 /// Renders the `views/account/authorized.mustache` template.
 String renderAuthorizedPage() {
@@ -36,6 +37,15 @@ String renderConsentPage({
   final content = templateCache.renderTemplate('account/consent', {
     'title': title,
     'description_html': descriptionHtml,
+    'reject_button_html': renderButton(
+      label: 'Reject',
+      id: '-admin-consent-reject-button',
+      classes: ['pub-button-cancel'],
+    ),
+    'accept_button_html': renderButton(
+      label: 'Accept',
+      id: '-admin-consent-accept-button',
+    ),
   });
   return renderLayoutPage(
     PageType.standalone,

--- a/app/lib/frontend/templates/listing.dart
+++ b/app/lib/frontend/templates/listing.dart
@@ -19,6 +19,7 @@ import '_consts.dart';
 import '_utils.dart';
 import 'layout.dart';
 import 'misc.dart';
+import 'widget.dart';
 
 /// Renders the `views/shared/pagination.mustache` template.
 String renderPagination(PageLinks pageLinks) {

--- a/app/lib/frontend/templates/listing.dart
+++ b/app/lib/frontend/templates/listing.dart
@@ -19,7 +19,6 @@ import '_consts.dart';
 import '_utils.dart';
 import 'layout.dart';
 import 'misc.dart';
-import 'widget.dart';
 
 /// Renders the `views/shared/pagination.mustache` template.
 String renderPagination(PageLinks pageLinks) {

--- a/app/lib/frontend/templates/package_admin.dart
+++ b/app/lib/frontend/templates/package_admin.dart
@@ -11,6 +11,7 @@ import 'detail_page.dart';
 import 'layout.dart';
 import 'misc.dart';
 import 'package.dart';
+import 'widget.dart';
 
 /// Renders the `views/pkg/admin_page` template.
 String renderPkgAdminPage(
@@ -75,6 +76,19 @@ String renderPkgAdminPage(
               })
           .toList(),
       'create_publisher_url': urls.createPublisherUrl(),
+      'transfer_to_publisher_button_html': renderButton(
+        label: 'Transfer to publisher',
+        id: '-admin-set-publisher-button',
+        danger: true,
+      ),
+      'mark_as_discontinued_button_html': renderButton(
+        label: 'Mark as "discontinued"',
+        id: '-admin-is-discontinued-toggle',
+      ),
+      'remove_discontinued_button_html': renderButton(
+        label: 'Remove "discontinued"',
+        id: '-admin-is-discontinued-toggle',
+      ),
     }),
   ));
 

--- a/app/lib/frontend/templates/publisher.dart
+++ b/app/lib/frontend/templates/publisher.dart
@@ -18,10 +18,16 @@ import '_cache.dart';
 import 'detail_page.dart';
 import 'layout.dart';
 import 'listing.dart';
+import 'widget.dart';
 
 /// Renders the `views/publisher/create.mustache` template.
 String renderCreatePublisherPage() {
-  final String content = templateCache.renderTemplate('publisher/create', {});
+  final content = templateCache.renderTemplate('publisher/create', {
+    'create_button_html': renderButton(
+      label: 'Create publisher',
+      id: '-admin-create-publisher',
+    ),
+  });
   return renderLayoutPage(
     PageType.standalone,
     content,
@@ -162,10 +168,23 @@ String renderPublisherAdminPage({
     'website_url': publisher.websiteUrl,
     'contact_email': publisher.contactEmail,
     'member_list': members.map((m) => {
-          'user_id': m.userId,
           'email': m.email,
           'role': m.role,
+          'remove_member_button_html': renderButton(
+            label: 'Remove',
+            classes: ['-pub-remove-user-button'],
+            data: {'user-id': m.userId, 'email': m.email},
+            danger: true,
+          ),
         }),
+    'update_info_button_html': renderButton(
+      label: 'Update',
+      id: '-publisher-update-button',
+    ),
+    'invite_member_button_html': renderButton(
+      label: 'Invite member',
+      id: '-admin-invite-member-button',
+    ),
   });
   final tabs = <Tab>[
     _packagesLinkTab(publisher.publisherId),

--- a/app/lib/frontend/templates/views/account/consent.mustache
+++ b/app/lib/frontend/templates/views/account/consent.mustache
@@ -8,12 +8,6 @@
 {{& description_html}}
 </div>
 <p id="-admin-consent-buttons">
-  <button
-    id="-admin-consent-reject-button"
-    class="mdc-button mdc-button--raised pub-button-cancel"
-    data-mdc-auto-init="MDCRipple">Reject</button>
-  <button
-    id="-admin-consent-accept-button"
-    class="mdc-button mdc-button--raised"
-    data-mdc-auto-init="MDCRipple">Accept</button>
+  {{& reject_button_html}}
+  {{& accept_button_html}}
 </p>

--- a/app/lib/frontend/templates/views/pkg/admin_page.mustache
+++ b/app/lib/frontend/templates/views/pkg/admin_page.mustache
@@ -35,10 +35,7 @@
     <div class="mdc-line-ripple"></div>
   </div>
   <br />
-  <button
-    id="-admin-set-publisher-button"
-    class="pub-button-danger mdc-button mdc-button--raised"
-    data-mdc-auto-init="MDCRipple">Transfer to publisher</button>
+  {{& transfer_to_publisher_button_html}}
   {{/user_has_publisher}}
   {{^user_has_publisher}}
   <p>
@@ -55,10 +52,7 @@
     Discontinued packages remain available, but pub.dev doesn’t display them in search results.
   </p>
   <p>
-    <button
-      id="-admin-is-discontinued-toggle"
-      class="mdc-button mdc-button--raised"
-      data-mdc-auto-init="MDCRipple">Mark as "discontinued"</button>
+    {{& mark_as_discontinued_button_html}}
   </p>
 </div>
 {{/is_discontinued}}
@@ -69,10 +63,7 @@
     The package will be analyzed and included in search results.
   </p>
   <p>
-    <button
-      id="-admin-is-discontinued-toggle"
-      class="mdc-button mdc-button--raised"
-      data-mdc-auto-init="MDCRipple">Remove "discontinued"</button>
+    {{& remove_discontinued_button_html}}
   </p>
 </div>
 {{/is_discontinued}}

--- a/app/lib/frontend/templates/views/publisher/admin_page.mustache
+++ b/app/lib/frontend/templates/views/publisher/admin_page.mustache
@@ -41,10 +41,7 @@
   </div>
 </div>
 <div class="-pub-form-row">
-  <button
-    id="-publisher-update-button"
-    class="mdc-button mdc-button--raised"
-    data-mdc-auto-init="MDCRipple">Update</button>
+  {{& update_info_button_html}}
 </div>
 <h3>Members</h3>
 
@@ -63,11 +60,7 @@
         <td class="mdc-data-table__cell">{{email}}</td>
         <td class="mdc-data-table__cell">{{role}}</td>
         <td class="mdc-data-table__cell">
-          <button
-            class="-pub-remove-user-button pub-button-danger mdc-button mdc-button--raised"
-            data-user-id="{{user_id}}"
-            data-email="{{email}}"
-            data-mdc-auto-init="MDCRipple">Remove</button>
+          {{& remove_member_button_html}}
         </td>
       </tr>
 {{/member_list}}
@@ -97,8 +90,5 @@
       <div class="mdc-notched-outline__trailing"></div>
     </div>
   </div>
-  <button
-    id="-admin-invite-member-button"
-    class="mdc-button mdc-button--raised"
-    data-mdc-auto-init="MDCRipple">Invite member</button>
+  {{& invite_member_button_html}}
 </p>

--- a/app/lib/frontend/templates/views/publisher/create.mustache
+++ b/app/lib/frontend/templates/views/publisher/create.mustache
@@ -39,10 +39,7 @@
       <div class="mdc-notched-outline__trailing"></div>
     </div>
   </div>
-  <button
-    id="-admin-create-publisher"
-    class="mdc-button mdc-button--raised"
-    data-mdc-auto-init="MDCRipple">Create publisher</button>
+  {{& create_button_html}}
 </p>
 <p>
   For more information on publishing and administering packages, see the

--- a/app/lib/frontend/templates/views/shared/widget/button.mustache
+++ b/app/lib/frontend/templates/views/shared/widget/button.mustache
@@ -1,0 +1,9 @@
+{{! Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+    for details. All rights reserved. Use of this source code is governed by a
+    BSD-style license that can be found in the LICENSE file. }}
+
+<button
+  {{#id}} id="{{id}}"{{/id}}
+  class="{{classes}}"
+  {{#data}} data-{{key}}="{{value}}"{{/data}}
+  data-mdc-auto-init="MDCRipple">{{label}}</button>

--- a/app/lib/frontend/templates/widget.dart
+++ b/app/lib/frontend/templates/widget.dart
@@ -1,0 +1,37 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:meta/meta.dart';
+
+import '_cache.dart';
+
+/// Renders the `views/shared/widget/button.mustache` template.
+String renderButton({
+  @required String label,
+  String id,
+  List<String> classes,
+  Map<String, String> data,
+  bool danger = false,
+  bool flat = false,
+}) {
+  final allClasses = <String>[
+    if (classes != null) ...classes,
+    if (danger) 'pub-button-danger',
+    'mdc-button',
+    if (!flat) 'mdc-button--raised',
+  ];
+  return templateCache.renderTemplate('shared/widget/button', {
+    'id': id,
+    'classes': allClasses.join(' '),
+    'data': data == null
+        ? null
+        : data.entries
+            .map((e) => {
+                  'key': e.key,
+                  'value': e.value,
+                })
+            .toList(),
+    'label': label,
+  });
+}


### PR DESCRIPTION
I'm not sure if this is something we want to do while using mustache as templates, but I've started the PR to have a discussion around it. The current template covers the basic button, and it shouldn't be too hard to also add the version with [changing icons](https://github.com/dart-lang/pub-dev/blob/master/app/lib/frontend/templates/views/pkg/liked_package_list.mustache#L14-L19). wdyt?