### PR TITLE
Advanced menu opener for new listing page.

### DIFF
--- a/app/lib/frontend/templates/listing.dart
+++ b/app/lib/frontend/templates/listing.dart
@@ -128,6 +128,7 @@ String renderPkgIndexPage(
     'has_packages': packages.isNotEmpty,
     'pagination': renderPagination(links),
     'total_count': totalCount,
+    'legacy_search_enabled': searchQuery?.includeLegacy ?? false,
     // TODO(3246): remove the keys below after we have migrated to the new design
     'title': title ?? topPackages,
     'search_query': searchQuery?.query,

--- a/app/lib/frontend/templates/views/pkg/index_experimental.mustache
+++ b/app/lib/frontend/templates/views/pkg/index_experimental.mustache
@@ -16,6 +16,18 @@
         <span class="search-controls-label">{{subsdk_label}}</span>
         {{& subsdk_tabs_html}}
       </div>
+      <div class="search-filters-btn search-filters-btn-wrapper search-controls-more">
+        Advanced
+        <img src="{{& static_assets.img__carot-up_svg}}" class="search-controls-more-carot" />
+      </div>
+    </div>
+  </div>
+  <div class="search-controls-advanced">
+    <div class="container">
+      <div class="search-controls-checkbox">
+        <input id="search-legacy-checkbox" type="checkbox" name="legacy" valye="1" {{#legacy_search_enabled}} checked="checked"{{/legacy_search_enabled}} />
+        <label for="search-legacy-checkbox">Include Dart 1.x results</label>
+      </div>
     </div>
   </div>
 </div>

--- a/app/lib/frontend/templates/views/shared/search_banner.mustache
+++ b/app/lib/frontend/templates/views/shared/search_banner.mustache
@@ -11,10 +11,8 @@
     <img class="search-filters-btn search-filters-btn-active" src="{{& static_assets.img__search-filters-active_svg}}" />
   </div>
   {{/show_search_filters_btn}}
-  {{#show_details}}
   {{#search_sort_param}}<input type="hidden" name="sort" value="{{search_sort_param}}"/>{{/search_sort_param}}
   <input id="search-legacy-field" type="hidden" name="legacy" value="1"{{^legacy_search_enabled}} disabled="disabled"{{/legacy_search_enabled}} />
-  {{/show_details}}
   {{#hidden_inputs}}
   <input type="hidden" name="{{name}}" value="{{value}}" />
   {{/hidden_inputs}}

--- a/app/test/frontend/golden/authorized_page.html
+++ b/app/test/frontend/golden/authorized_page.html
@@ -74,6 +74,7 @@
         <form class="search-bar banner-item" action="/packages">
           <input class="input" name="q" placeholder="Search packages" autocomplete="on" autofocus="autofocus"/>
           <button class="icon"></button>
+          <input id="search-legacy-field" type="hidden" name="legacy" value="1" disabled="disabled"/>
         </form>
       </div>
     </div>

--- a/app/test/frontend/golden/error_page.html
+++ b/app/test/frontend/golden/error_page.html
@@ -74,6 +74,7 @@
         <form class="search-bar banner-item" action="/packages">
           <input class="input" name="q" placeholder="Search packages" autocomplete="on" autofocus="autofocus"/>
           <button class="icon"></button>
+          <input id="search-legacy-field" type="hidden" name="legacy" value="1" disabled="disabled"/>
         </form>
       </div>
     </div>

--- a/app/test/frontend/golden/my_liked_packages.html
+++ b/app/test/frontend/golden/my_liked_packages.html
@@ -76,6 +76,7 @@
         <form class="search-bar banner-item" action="/my-packages">
           <input class="input" name="q" placeholder="Search your packages" autocomplete="on" autofocus="autofocus"/>
           <button class="icon"></button>
+          <input id="search-legacy-field" type="hidden" name="legacy" value="1" disabled="disabled"/>
         </form>
       </div>
     </div>

--- a/app/test/frontend/golden/my_packages.html
+++ b/app/test/frontend/golden/my_packages.html
@@ -76,6 +76,7 @@
         <form class="search-bar banner-item" action="/my-packages">
           <input class="input" name="q" placeholder="Search your packages" autocomplete="on" autofocus="autofocus"/>
           <button class="icon"></button>
+          <input id="search-legacy-field" type="hidden" name="legacy" value="1" disabled="disabled"/>
         </form>
       </div>
     </div>

--- a/app/test/frontend/golden/my_publishers.html
+++ b/app/test/frontend/golden/my_publishers.html
@@ -76,6 +76,7 @@
         <form class="search-bar banner-item" action="/my-packages">
           <input class="input" name="q" placeholder="Search your packages" autocomplete="on" autofocus="autofocus"/>
           <button class="icon"></button>
+          <input id="search-legacy-field" type="hidden" name="legacy" value="1" disabled="disabled"/>
         </form>
       </div>
     </div>

--- a/app/test/frontend/golden/pkg_admin_page_outdated.html
+++ b/app/test/frontend/golden/pkg_admin_page_outdated.html
@@ -77,6 +77,7 @@
         <form class="search-bar banner-item" action="/packages">
           <input class="input" name="q" placeholder="Search packages" autocomplete="on" autofocus="autofocus"/>
           <button class="icon"></button>
+          <input id="search-legacy-field" type="hidden" name="legacy" value="1" disabled="disabled"/>
         </form>
       </div>
     </div>

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -76,6 +76,7 @@
         <form class="search-bar banner-item" action="/packages">
           <input class="input" name="q" placeholder="Search packages" autocomplete="on" autofocus="autofocus"/>
           <button class="icon"></button>
+          <input id="search-legacy-field" type="hidden" name="legacy" value="1" disabled="disabled"/>
         </form>
       </div>
     </div>

--- a/app/test/frontend/golden/pkg_show_page_discontinued.html
+++ b/app/test/frontend/golden/pkg_show_page_discontinued.html
@@ -77,6 +77,7 @@
         <form class="search-bar banner-item" action="/packages">
           <input class="input" name="q" placeholder="Search packages" autocomplete="on" autofocus="autofocus"/>
           <button class="icon"></button>
+          <input id="search-legacy-field" type="hidden" name="legacy" value="1" disabled="disabled"/>
         </form>
       </div>
     </div>

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -76,6 +76,7 @@
         <form class="search-bar banner-item" action="/packages">
           <input class="input" name="q" placeholder="Search packages" autocomplete="on" autofocus="autofocus"/>
           <button class="icon"></button>
+          <input id="search-legacy-field" type="hidden" name="legacy" value="1" disabled="disabled"/>
         </form>
       </div>
     </div>

--- a/app/test/frontend/golden/pkg_show_page_legacy.html
+++ b/app/test/frontend/golden/pkg_show_page_legacy.html
@@ -77,6 +77,7 @@
         <form class="search-bar banner-item" action="/packages">
           <input class="input" name="q" placeholder="Search packages" autocomplete="on" autofocus="autofocus"/>
           <button class="icon"></button>
+          <input id="search-legacy-field" type="hidden" name="legacy" value="1" disabled="disabled"/>
         </form>
       </div>
     </div>

--- a/app/test/frontend/golden/pkg_show_page_outdated.html
+++ b/app/test/frontend/golden/pkg_show_page_outdated.html
@@ -77,6 +77,7 @@
         <form class="search-bar banner-item" action="/packages">
           <input class="input" name="q" placeholder="Search packages" autocomplete="on" autofocus="autofocus"/>
           <button class="icon"></button>
+          <input id="search-legacy-field" type="hidden" name="legacy" value="1" disabled="disabled"/>
         </form>
       </div>
     </div>

--- a/app/test/frontend/golden/pkg_show_page_publisher.html
+++ b/app/test/frontend/golden/pkg_show_page_publisher.html
@@ -77,6 +77,7 @@
         <form class="search-bar banner-item" action="/packages">
           <input class="input" name="q" placeholder="Search packages" autocomplete="on" autofocus="autofocus"/>
           <button class="icon"></button>
+          <input id="search-legacy-field" type="hidden" name="legacy" value="1" disabled="disabled"/>
         </form>
       </div>
     </div>

--- a/app/test/frontend/golden/pkg_show_version_page.html
+++ b/app/test/frontend/golden/pkg_show_version_page.html
@@ -78,6 +78,7 @@
         <form class="search-bar banner-item" action="/packages">
           <input class="input" name="q" placeholder="Search packages" autocomplete="on" autofocus="autofocus"/>
           <button class="icon"></button>
+          <input id="search-legacy-field" type="hidden" name="legacy" value="1" disabled="disabled"/>
         </form>
       </div>
     </div>

--- a/app/test/frontend/golden/pkg_versions_page.html
+++ b/app/test/frontend/golden/pkg_versions_page.html
@@ -78,6 +78,7 @@
         <form class="search-bar banner-item" action="/packages">
           <input class="input" name="q" placeholder="Search packages" autocomplete="on" autofocus="autofocus"/>
           <button class="icon"></button>
+          <input id="search-legacy-field" type="hidden" name="legacy" value="1" disabled="disabled"/>
         </form>
       </div>
     </div>

--- a/app/test/frontend/golden/publisher_packages_page.html
+++ b/app/test/frontend/golden/publisher_packages_page.html
@@ -76,6 +76,7 @@
         <form class="search-bar banner-item" action="/publishers/example.com/packages">
           <input class="input" name="q" placeholder="Search example.com packages" autocomplete="on" autofocus="autofocus"/>
           <button class="icon"></button>
+          <input id="search-legacy-field" type="hidden" name="legacy" value="1" disabled="disabled"/>
         </form>
       </div>
     </div>

--- a/pkg/web_app/lib/src/search.dart
+++ b/pkg/web_app/lib/src/search.dart
@@ -32,9 +32,8 @@ void _setEventForFiltersToggle() {
   document.querySelectorAll('.search-filters-btn').forEach((e) {
     e.onClick.listen((_) {
       document
-          .querySelector('.search-filters-btn-wrapper')
-          ?.classes
-          ?.toggle('-active');
+          .querySelectorAll('.search-filters-btn-wrapper')
+          .forEach((e) => e.classes.toggle('-active'));
       document.querySelector('.search-controls')?.classes?.toggle('-active');
     });
   });

--- a/pkg/web_css/lib/src/_list_experimental.scss
+++ b/pkg/web_css/lib/src/_list_experimental.scss
@@ -22,8 +22,20 @@ body.experimental {
   background: #f5f5f7;
   display: none;
 
+  .search-controls-advanced {
+    display: none;
+
+    @media (min-width: $device-desktop-min-width) {
+      background: white;
+    }
+  }
+
   &.-active {
     display: block;
+
+    .search-controls-advanced {
+      display: block;
+    }
   }
 
   @media (min-width: $device-desktop-min-width) {
@@ -37,6 +49,7 @@ body.experimental {
       display: flex;
       align-items: center;
       padding: 0;
+      position: relative;
     }
   }
 
@@ -117,6 +130,43 @@ body.experimental {
         }
       }
     }
+  }
+
+  .search-controls-more {
+    display: none;
+    color: #555555;
+    font-size: 12px;
+    font-weight: 300;
+    white-space: nowrap;
+    cursor: pointer;
+
+    @media (min-width: $device-desktop-min-width) {
+      display: block;
+      position: absolute;
+      left: 100%;
+      margin: 1px 0 0 12px;
+    }
+
+    .search-controls-more-carot {
+      margin-left: 3px;
+      width: 6px;
+      height: 6px;
+      position: relative;
+      top: -1px;
+      opacity: 0.6;
+      transform: rotate(0deg);
+      transition: transform 0.3s linear;
+    }
+
+    &.-active {
+      .search-controls-more-carot {
+        transform: rotate(180deg);
+      }
+    }
+  }
+
+  .search-controls-checkbox {
+    padding: 8px 0px;
   }
 }
 

--- a/static/img/carot-up.svg
+++ b/static/img/carot-up.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="6px" height="3px" viewBox="0 0 6 3" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 61.2 (89653) - https://sketch.com -->
+    <title>carot op1 - closed</title>
+    <desc>Created with Sketch.</desc>
+    <g id="pub.dev" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="general-ui---icons-and-components" transform="translate(-669.000000, -404.000000)" fill="#3C4043" stroke="#3C4043">
+            <polygon id="carot-op1---closed" transform="translate(672.000000, 405.000000) rotate(-180.000000) translate(-672.000000, -405.000000) " points="670 404 672 406 674 404"></polygon>
+        </g>
+    </g>
+</svg>


### PR DESCRIPTION
Updated tracked item in #3246.

Desktop view has the right-side "Advanced ^" button (outside of the normal container) to open it (with white background):

<img width="1075" alt="Screen Shot 2020-02-05 at 14 38 26" src="https://user-images.githubusercontent.com/4778111/73846728-4a8d8580-4825-11ea-9e39-aa93037662a0.png">

Mobile view has the same grey background:

<img width="390" alt="Screen Shot 2020-02-05 at 14 38 15" src="https://user-images.githubusercontent.com/4778111/73846749-55e0b100-4825-11ea-8f21-802fe50427e9.png">
