### PR TITLE
New infobox style.

### DIFF
--- a/pkg/web_css/lib/src/_detail_page.scss
+++ b/pkg/web_css/lib/src/_detail_page.scss
@@ -7,54 +7,11 @@
     display: inline-block;
     width: calc(100% - 300px);
     vertical-align: top;
-  }
 
-  > .detail-info-box {
-    display: inline-block;
-    vertical-align: top;
-    margin-left: 20px;
-    -webkit-box-flex: 0;
-    -ms-flex: 0 0 270px;
-    flex: 0 0 270px;
-    width: 270px;
-    padding: 10px 20px 22px 20px;
-    background: #F8F8F8;
-    border: 1px solid #DDD;
-    position: relative;
-    font-size: 14px;
-
-    > .title {
-      font-size: 14px;
-      margin: 12px 0 0 0;
-    }
-
-    > p {
-      margin: 0;
-    }
-
-    > .link {
-      text-overflow: ellipsis;
-      overflow: hidden;
-      white-space: nowrap;
-      max-width: 100%;
-      display: inline-block;
-      line-height: 1.2em;
-    }
-  }
-}
-
-@media screen and (max-width: 920px) {
-  .detail-container {
-    > .main {
+    @media screen and (max-width: 920px) {
       display: block;
       width: 100%;
       vertical-align: top;
-    }
-
-    > .detail-info-box {
-      display: block;
-      width: 100%;
-      margin: 60px 0 0;
     }
   }
 }
@@ -80,8 +37,50 @@
   }
 }
 
+.detail-info-box {
+  display: inline-block;
+  margin-left: 20px;
+  width: 270px;
+
+  @media screen and (max-width: 920px) {
+    display: block;
+    width: 100%;
+    margin: 60px 0 0;
+  }
+}
+
 /* non-indented rule to restrict the content of this block to the non-experimental pages */
 body.non-experimental {
+
+.detail-info-box {
+  vertical-align: top;
+  -webkit-box-flex: 0;
+  -ms-flex: 0 0 270px;
+  flex: 0 0 270px;
+  padding: 10px 20px 22px 20px;
+  background: #F8F8F8;
+  border: 1px solid #DDD;
+  position: relative;
+  font-size: 14px;
+
+  > .title {
+    font-size: 14px;
+    margin: 12px 0 0 0;
+  }
+
+  > p {
+    margin: 0;
+  }
+
+  > .link {
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+    max-width: 100%;
+    display: inline-block;
+    line-height: 1.2em;
+  }
+}
 
 .detail-tabs-header {
   margin: 10px 0 20px;

--- a/pkg/web_css/lib/src/_detail_page.scss
+++ b/pkg/web_css/lib/src/_detail_page.scss
@@ -37,6 +37,7 @@
   }
 }
 
+/* Separated layout styles from internals, in order to mask half of it separately. */
 .detail-info-box {
   display: inline-block;
   margin-left: 20px;

--- a/pkg/web_css/lib/src/_detail_page_experimental.scss
+++ b/pkg/web_css/lib/src/_detail_page_experimental.scss
@@ -5,6 +5,40 @@
 /* non-indented rule to restrict the content of this block to the experimental pages */
 body.experimental {
 
+.detail-info-box {
+  color: #4a4a4a;
+  font-size: 14px;
+  font-weight: 300;
+  line-height: 19px;
+
+  > .title {
+    font-size: 16px;
+    font-weight: 400;
+    margin: 0;
+
+    &:not(:first-child) {
+      margin-top: 16px;
+      border-top: 1px solid #c8c8ca;
+      padding-top: 16px;
+    }
+  }
+
+  br {
+    content: " " !important;
+    display: block !important;
+    margin-bottom: 8px !important;
+  }
+
+  > .link {
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+    max-width: 100%;
+    display: inline-block;
+    line-height: 1.2em;
+  }
+}
+
 .detail-tabs-header {
   list-style: none;
   margin: 0 0 24px 0;


### PR DESCRIPTION
- this is online the inline style, mobile wrapper style tracking is added to #3246
- icons are are black (should be lighter to match the text), added tracking to #3246
- separated the old style, as the layout part is still required (will be updated in a follow-up PR)
- structural changes (e.g. moving the API menu out) will be done in a follow-up PR

<img width="306" alt="Screen Shot 2020-02-06 at 15 15 05" src="https://user-images.githubusercontent.com/4778111/73945007-e2f23b80-48f3-11ea-9694-35c70c863362.png">
