### PR TITLE
New style for versions table.

### DIFF
--- a/app/lib/frontend/templates/views/pkg/versions/index.mustache
+++ b/app/lib/frontend/templates/views/pkg/versions/index.mustache
@@ -6,10 +6,10 @@
 <table class="version-table" data-package="{{package.name}}">
   <thead>
   <tr>
-    <th>Version</th>
-    <th>Uploaded</th>
-    <th class="documentation" width="80">Documentation</th>
-    <th class="archive" width="80">Archive</th>
+    <th class="version">Version</th>
+    <th class="uploaded"><span class="label">Uploaded</span></th>
+    <th class="documentation"><span class="label">Documentation</span></th>
+    <th class="archive"><span class="label">Archive</span></th>
   </tr>
   </thead>
   <tbody>

--- a/app/lib/frontend/templates/views/pkg/versions/version_row.mustache
+++ b/app/lib/frontend/templates/views/pkg/versions/version_row.mustache
@@ -3,8 +3,8 @@
     BSD-style license that can be found in the LICENSE file. }}
 
 <tr data-version="{{version}}">
-  <td><strong><a href="{{& version_url}}">{{version}}</a></strong></td>
-  <td>{{short_created}}</td>
+  <td class="version"><a href="{{& version_url}}">{{version}}</a></td>
+  <td class="uploaded">{{short_created}}</td>
   <td class="documentation">
     <a href="{{& dartdocs_url}}"
        rel="nofollow"

--- a/app/test/frontend/golden/pkg_versions_page.html
+++ b/app/test/frontend/golden/pkg_versions_page.html
@@ -146,20 +146,24 @@ Published
             <table class="version-table" data-package="foobar_pkg">
               <thead>
                 <tr>
-                  <th>Version</th>
-                  <th>Uploaded</th>
-                  <th class="documentation" width="80">Documentation</th>
-                  <th class="archive" width="80">Archive</th>
+                  <th class="version">Version</th>
+                  <th class="uploaded">
+                    <span class="label">Uploaded</span>
+                  </th>
+                  <th class="documentation">
+                    <span class="label">Documentation</span>
+                  </th>
+                  <th class="archive">
+                    <span class="label">Archive</span>
+                  </th>
                 </tr>
               </thead>
               <tbody>
                 <tr data-version="0.1.1+5">
-                  <td>
-                    <strong>
-                      <a href="/packages/foobar_pkg/versions/0.1.1+5">0.1.1+5</a>
-                    </strong>
+                  <td class="version">
+                    <a href="/packages/foobar_pkg/versions/0.1.1+5">0.1.1+5</a>
                   </td>
-                  <td>Jan 1, 2014</td>
+                  <td class="uploaded">Jan 1, 2014</td>
                   <td class="documentation">
                     <a href="/documentation/foobar_pkg/0.1.1+5/" rel="nofollow" title="Go to the documentation of foobar_pkg 0.1.1+5">
                       <img src="/static/img/ic_drive_document_black_24dp.svg?hash=mocked_hash_663394799" alt="Go to the documentation of foobar_pkg 0.1.1+5"/>
@@ -177,20 +181,24 @@ Published
             <table class="version-table" data-package="foobar_pkg">
               <thead>
                 <tr>
-                  <th>Version</th>
-                  <th>Uploaded</th>
-                  <th class="documentation" width="80">Documentation</th>
-                  <th class="archive" width="80">Archive</th>
+                  <th class="version">Version</th>
+                  <th class="uploaded">
+                    <span class="label">Uploaded</span>
+                  </th>
+                  <th class="documentation">
+                    <span class="label">Documentation</span>
+                  </th>
+                  <th class="archive">
+                    <span class="label">Archive</span>
+                  </th>
                 </tr>
               </thead>
               <tbody>
                 <tr data-version="0.2.0-dev">
-                  <td>
-                    <strong>
-                      <a href="/packages/foobar_pkg/versions/0.2.0-dev">0.2.0-dev</a>
-                    </strong>
+                  <td class="version">
+                    <a href="/packages/foobar_pkg/versions/0.2.0-dev">0.2.0-dev</a>
                   </td>
-                  <td>Jan 1, 2014</td>
+                  <td class="uploaded">Jan 1, 2014</td>
                   <td class="documentation">
                     <a href="/documentation/foobar_pkg/0.2.0-dev/" rel="nofollow" title="Go to the documentation of foobar_pkg 0.2.0-dev">
                       <img src="/static/img/ic_drive_document_black_24dp.svg?hash=mocked_hash_663394799" alt="Go to the documentation of foobar_pkg 0.2.0-dev"/>

--- a/pkg/web_css/lib/src/_pkg.scss
+++ b/pkg/web_css/lib/src/_pkg.scss
@@ -1,6 +1,13 @@
+/* Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+   for details. All rights reserved. Use of this source code is governed by a
+   BSD-style license that can be found in the LICENSE file. */
+
 /******************************************************
   package page
 ******************************************************/
+
+/* non-indented rule to restrict the content of this block to the non-experimental pages */
+body.non-experimental {
 
 .version-table {
   width: 100%;
@@ -10,6 +17,15 @@
     padding: 4px 10px;
     text-align: left;
   }
+
+  tbody {
+    .version {
+      font-weight: bold;
+    }
+  }
+}
+
+/* non-indented rule to restrict the content of this block to the non-experimental pages */
 }
 
 .dependency-table {

--- a/pkg/web_css/lib/src/_pkg_experimental.scss
+++ b/pkg/web_css/lib/src/_pkg_experimental.scss
@@ -1,0 +1,72 @@
+/* Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+   for details. All rights reserved. Use of this source code is governed by a
+   BSD-style license that can be found in the LICENSE file. */
+
+/* non-indented rule to restrict the content of the file to the experimental pages */
+body.experimental {
+
+.version-table {
+  width: 100%;
+  border-spacing: 0;
+  color: #4a4a4a;
+
+  td, th {
+    border-bottom: 1px solid #c8c8ca;
+    padding: 4px 10px;
+    text-align: left;
+
+    &.version {
+    }
+
+    &.uploaded {
+      white-space: nowrap;
+      width: 100px;
+    }
+
+    &.documentation {
+      width: 60px; /* TODO: change to 40 after 'failed' text is removed. '*/
+      text-align: center;
+    }
+
+    &.archive {
+      width: 40px;
+      text-align: center;
+    }
+  }
+
+  > thead > tr > th {
+    font-size: 16px;
+    font-weight: 400;
+
+    &.version > span.label {
+      display: inline-block;
+      min-width: 100%;
+    }
+
+    &.documentation > span.label,
+    &.archive > span.label {
+      display: none;
+    }
+
+    @media (max-width: $device-mobile-max-width) {
+      &.uploaded > span.label{
+        display: none;
+      }
+    }
+  }
+
+  > tbody {
+    font-size: 14px;
+
+    .version {
+      font-size: 24px;
+    }
+
+    .uploaded {
+      font-weight: 300;
+    }
+  }
+}
+
+/* non-indented rule to restrict the content of the file to the experimental pages */
+}

--- a/pkg/web_css/lib/style.scss
+++ b/pkg/web_css/lib/style.scss
@@ -10,6 +10,7 @@
 @import 'src/_list_experimental';
 @import 'src/_home';
 @import 'src/_pkg';
+@import 'src/_pkg_experimental';
 @import 'src/_score_circle';
 @import 'src/_search';
 @import 'src/_tags';


### PR DESCRIPTION
- Icons were missing on Drive, but the JS updater is making it difficult to change it in a single PR. (tracked in #3246)
- Detail tab content headers need a consistent style, will do it in a subsequent PR. (tracked in #3246)

Desktop view (some headers need to be hidden):
<img width="671" alt="Screen Shot 2020-02-07 at 17 28 13" src="https://user-images.githubusercontent.com/4778111/74047222-48b3f580-49d0-11ea-89ac-c6b74b93e831.png">

Mobile view (more headers need to be hidden):
<img width="379" alt="Screen Shot 2020-02-07 at 17 28 20" src="https://user-images.githubusercontent.com/4778111/74047244-50739a00-49d0-11ea-87bd-cde58076e996.png">
