### PR TITLE
Move FF badge inside the infobox.

### DIFF
--- a/app/lib/frontend/templates/detail_page.dart
+++ b/app/lib/frontend/templates/detail_page.dart
@@ -29,6 +29,7 @@ String renderDetailHeader({
     'like_count': '$packageLikes ${packageLikes == 1 ? "like" : "likes"}',
     'is_liked': isLiked,
     'has_likes': isLiked != null,
+    // TODO: remove values below after new UI is finalized
     'is_flutter_favorite': isFlutterFavorite,
   });
 }

--- a/app/lib/frontend/templates/package.dart
+++ b/app/lib/frontend/templates/package.dart
@@ -16,6 +16,7 @@ import '../../shared/email.dart' show EmailAddress;
 import '../../shared/tags.dart';
 import '../../shared/urls.dart' as urls;
 
+import '../request_context.dart';
 import '../static_files.dart';
 
 import '_cache.dart';
@@ -164,6 +165,8 @@ String renderPkgInfoBox(
   }
 
   return templateCache.renderTemplate('pkg/info_box', {
+    'is_flutter_favorite': requestContext.isExperimental &&
+        (package.assignedTags ?? []).contains(PackageTags.isFlutterFavorite),
     'name': package.name,
     'description': selectedVersion.pubspec.description,
     'links': links,

--- a/app/lib/frontend/templates/views/pkg/info_box.mustache
+++ b/app/lib/frontend/templates/views/pkg/info_box.mustache
@@ -2,6 +2,15 @@
     for details. All rights reserved. Use of this source code is governed by a
     BSD-style license that can be found in the LICENSE file. }}
 
+{{#is_flutter_favorite}}
+<a href='https://flutter.dev/docs/development/packages-and-plugins/favorites'>
+  <img
+    src="{{{static_assets.img__ff_svg}}}"
+    height="100" width="100"
+    title="Package is a Flutter Favorite"/>
+</a>
+{{/is_flutter_favorite}}
+
 {{#publisher_id}}
 <h3 class="title">Publisher</h3>
 <p>

--- a/app/lib/frontend/templates/views/shared/detail/header_experimental.mustache
+++ b/app/lib/frontend/templates/views/shared/detail/header_experimental.mustache
@@ -1,0 +1,48 @@
+{{! Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+    for details. All rights reserved. Use of this source code is governed by a
+    BSD-style license that can be found in the LICENSE file. }}
+
+<div class="detail-header">
+  <h2 class="title">{{#is_publisher}}<img
+    class="-pub-publisher-shield"
+    height="48" width="48"
+    title="Domain ownership verifed by pub.dev"
+    src="{{{static_assets.img__verified-publisher-blue_svg}}}" />{{/is_publisher}}{{title}}</h2>
+  <div class="metadata">
+    {{& metadata_html}}
+    {{#has_likes}}
+    <div class="-pub-likes" >
+      <div>
+        {{#is_liked}}
+        <button
+          id="-pub-like-icon-button"
+          class="mdc-icon-button mdc-icon-button--on"
+          aria-label="Unlike this package"
+          data-ga-click-event="toggle-like"
+          aria-hidden="true"
+          aria-pressed="true">
+        {{/is_liked}}
+        {{^is_liked}}
+        <button
+          id="-pub-like-icon-button"
+          class="mdc-icon-button"
+          aria-label="Like this package"
+          data-ga-click-event="toggle-like"
+          aria-hidden="true"
+          aria-pressed="true">
+        {{/is_liked}}
+          <img
+            height="18"
+            src="{{{static_assets.img__thumb-up-24px_svg}}}"
+            class="mdc-icon-button__icon"/>
+          <img
+            height="18"
+            width="18"
+            src="{{{static_assets.img__thumb-up-filled-24px_svg}}}"
+            class="mdc-icon-button__icon mdc-icon-button__icon--on"/>
+        </button>
+       <span id="likes-count">{{like_count}}</span></div></div>
+    {{/has_likes}}
+    <div class="tags">{{& tags_html}}</div>
+  </div>
+</div>

--- a/pkg/web_css/lib/src/_detail_page.scss
+++ b/pkg/web_css/lib/src/_detail_page.scss
@@ -19,6 +19,7 @@
 .detail-header {
   margin: 30px 0 10px;
 
+  /* TODO remove after the new UI is finalized. */
   img.ff-badge {
     float: right;
     margin-right: 15px;


### PR DESCRIPTION
I've created a new template for the detail header, as there will be further changes to it.

Screenshot:
<img width="288" alt="Screen Shot 2020-02-10 at 12 40 20" src="https://user-images.githubusercontent.com/4778111/74147061-bfd0d000-4c02-11ea-9bcd-4e992924b576.png">
