### PR TITLE
Separate documentation links in infobox

### DIFF
--- a/app/lib/frontend/templates/package.dart
+++ b/app/lib/frontend/templates/package.dart
@@ -135,11 +135,13 @@ String renderPkgInfoBox(
     isLatest: selectedVersion.version == package.latestVersion,
   );
 
-  final links = <Map<String, dynamic>>[];
+  final metaLinks = <Map<String, dynamic>>[];
+  final docLinks = <Map<String, dynamic>>[];
   void addLink(
     String href,
     String label, {
     bool detectServiceProvider = false,
+    bool documentation = false,
   }) {
     if (href == null || href.isEmpty) {
       return;
@@ -150,7 +152,12 @@ String renderPkgInfoBox(
         label += ' ($providerName)';
       }
     }
-    links.add(<String, dynamic>{'href': href, 'label': label});
+    final linkData = <String, dynamic>{'href': href, 'label': label};
+    if (documentation) {
+      docLinks.add(linkData);
+    } else {
+      metaLinks.add(linkData);
+    }
   }
 
   if (packageLinks.repositoryUrl != packageLinks.homepageUrl) {
@@ -159,17 +166,19 @@ String renderPkgInfoBox(
   addLink(packageLinks.repositoryUrl, 'Repository',
       detectServiceProvider: true);
   addLink(packageLinks.issueTrackerUrl, 'View/report issues');
-  addLink(documentationUrl, 'Documentation');
+  addLink(documentationUrl, 'Documentation', documentation: true);
   if (analysis.hasApiDocs) {
-    addLink(dartdocsUrl, 'API reference');
+    addLink(dartdocsUrl, 'API reference', documentation: true);
   }
 
   return templateCache.renderTemplate('pkg/info_box', {
-    'is_flutter_favorite': requestContext.isExperimental &&
+    'is_flutter_favorite':
         (package.assignedTags ?? []).contains(PackageTags.isFlutterFavorite),
     'name': package.name,
     'description': selectedVersion.pubspec.description,
-    'links': links,
+    'meta_links': metaLinks,
+    'has_doc_links': docLinks.isNotEmpty,
+    'doc_links': docLinks,
     'publisher_id': package.publisherId,
     'publisher_link': package.publisherId == null
         ? null
@@ -180,6 +189,8 @@ String renderPkgInfoBox(
     'license_html': _renderLicenses(packageLinks.baseUrl, analysis?.licenses),
     'dependencies_html': _renderDependencyList(analysis),
     'search_deps_link': urls.searchUrl(q: 'dependency:${package.name}'),
+    // TODO: remove the below keys after we've migrated to the new UI
+    'all_links': [...metaLinks, ...docLinks],
   });
 }
 

--- a/app/lib/frontend/templates/package.dart
+++ b/app/lib/frontend/templates/package.dart
@@ -16,7 +16,6 @@ import '../../shared/email.dart' show EmailAddress;
 import '../../shared/tags.dart';
 import '../../shared/urls.dart' as urls;
 
-import '../request_context.dart';
 import '../static_files.dart';
 
 import '_cache.dart';

--- a/app/lib/frontend/templates/views/pkg/info_box_experimental.mustache
+++ b/app/lib/frontend/templates/views/pkg/info_box_experimental.mustache
@@ -1,6 +1,15 @@
-{{! Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+{{! Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
     for details. All rights reserved. Use of this source code is governed by a
     BSD-style license that can be found in the LICENSE file. }}
+
+{{#is_flutter_favorite}}
+<a href='https://flutter.dev/docs/development/packages-and-plugins/favorites'>
+  <img
+    src="{{{static_assets.img__ff_svg}}}"
+    height="100" width="100"
+    title="Package is a Flutter Favorite"/>
+</a>
+{{/is_flutter_favorite}}
 
 {{#publisher_id}}
 <h3 class="title">Publisher</h3>
@@ -13,15 +22,24 @@
 </p>
 {{/publisher_id}}
 
-<h3 class="title">About</h3>
+<h3 class="title">Metadata</h3>
 {{#description}}
   <p>{{description}}</p>
 {{/description}}
 <p>
-  {{#all_links}}
+  {{#meta_links}}
   <a class="link" href="{{& href}}">{{label}}</a><br/>
-  {{/all_links}}
+  {{/meta_links}}
 </p>
+
+{{#has_doc_links}}
+<h3 class="title">Documentation</h3>
+<p>
+  {{#doc_links}}
+    <a class="link" href="{{& href}}">{{label}}</a><br/>
+  {{/doc_links}}
+</p>
+{{/has_doc_links}}
 
 {{#uploaders_html}}
 <h3 class="title">{{uploaders_title}}</h3>


### PR DESCRIPTION
I've also forked the template, changed the "About" to "Metadata", and adjusted the data preparation to serve both templates.

<img width="297" alt="Screen Shot 2020-02-10 at 15 15 17" src="https://user-images.githubusercontent.com/4778111/74157232-34fad000-4c18-11ea-8572-66cfed7544c3.png">
