### PR TITLE
New detail page layout

### DIFF
--- a/app/lib/frontend/templates/views/shared/detail/page.mustache
+++ b/app/lib/frontend/templates/views/shared/detail/page.mustache
@@ -5,14 +5,6 @@
 <div class="detail-wrapper -active">
   {{& header_html}}
 
-  {{#info_box_lead}}
-    <div class="detail-lead">
-      <div class="detail-metadata-toggle">&rightarrow;</div>
-      <h3 class="detail-lead-title">Metadata</h3>
-      <p class="detail-lead-text">{{info_box_lead}}</p>
-    </div>
-  {{/info_box_lead}}
-
   <div class="detail-container">
     {{& tabs_html}}
 
@@ -25,13 +17,3 @@
 
   {{& footer_html}}
 </div>
-
-{{#info_box_lead}}
-<div class="detail-metadata">
-  <h3 class="detail-metadata-title"><span class="detail-metadata-toggle">&leftarrow;</span> Metadata</h3>
-
-  <div class="detail-info-box">
-  {{& info_box_html}}
-  </div>
-</div>
-{{/info_box_lead}}

--- a/app/lib/frontend/templates/views/shared/detail/page_experimental.mustache
+++ b/app/lib/frontend/templates/views/shared/detail/page_experimental.mustache
@@ -1,0 +1,39 @@
+{{! Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+    for details. All rights reserved. Use of this source code is governed by a
+    BSD-style license that can be found in the LICENSE file. }}
+
+<div class="detail-wrapper -active">
+  {{& header_html}}
+
+  {{#info_box_lead}}
+    <div class="detail-lead">
+      <div class="detail-metadata-toggle">&rightarrow;</div>
+      <h3 class="detail-lead-title">Metadata</h3>
+      <p class="detail-lead-text">{{info_box_lead}}</p>
+    </div>
+  {{/info_box_lead}}
+
+  <div class="detail-container">
+    <div class="detail-tabs">
+      {{& tabs_html}}
+    </div>
+
+    {{#info_box_html}}
+      <aside class="detail-info-box">
+        {{& info_box_html}}
+      </aside>
+    {{/info_box_html}}
+  </div>
+
+  {{& footer_html}}
+</div>
+
+{{#info_box_lead}}
+<div class="detail-metadata">
+  <h3 class="detail-metadata-title"><span class="detail-metadata-toggle">&leftarrow;</span> Metadata</h3>
+
+  <div class="detail-info-box">
+  {{& info_box_html}}
+  </div>
+</div>
+{{/info_box_lead}}

--- a/pkg/web_css/lib/src/_detail_page.scss
+++ b/pkg/web_css/lib/src/_detail_page.scss
@@ -2,22 +2,9 @@
    for details. All rights reserved. Use of this source code is governed by a
    BSD-style license that can be found in the LICENSE file. */
 
-.detail-container {
-  > .main {
-    display: inline-block;
-    width: calc(100% - 300px);
-    vertical-align: top;
-
-    @media screen and (max-width: 920px) {
-      display: block;
-      width: 100%;
-      vertical-align: top;
-    }
-  }
-}
-
 /* non-indented rule to restrict the content of this block to the non-experimental pages */
 body.non-experimental {
+
 .detail-header {
   margin: 30px 0 10px;
 
@@ -38,9 +25,20 @@ body.non-experimental {
     color: #555;
   }
 }
-/* non-indented rule to restrict the content of this block to the non-experimental pages */
-}
 
+.detail-container {
+  > .main {
+    display: inline-block;
+    width: calc(100% - 300px);
+    vertical-align: top;
+
+    @media screen and (max-width: 920px) {
+      display: block;
+      width: 100%;
+      vertical-align: top;
+    }
+  }
+}
 
 /* Separated layout styles from internals, in order to mask half of it separately. */
 .detail-info-box {
@@ -54,9 +52,6 @@ body.non-experimental {
     margin: 60px 0 0;
   }
 }
-
-/* non-indented rule to restrict the content of this block to the non-experimental pages */
-body.non-experimental {
 
 .detail-info-box {
   vertical-align: top;

--- a/pkg/web_css/lib/src/_detail_page_experimental.scss
+++ b/pkg/web_css/lib/src/_detail_page_experimental.scss
@@ -97,6 +97,23 @@ body.experimental {
   }
 }
 
+@media (min-width: $device-desktop-min-width) {
+  .detail-container {
+
+    >.detail-tabs {
+      vertical-align: top;
+      display: inline-block;
+      width: calc(100% - 320px);
+    }
+
+    >.detail-info-box {
+      display: inline-block;
+      margin-left: 120px;
+      width: 190px;
+    }
+  }
+}
+
 .detail-info-box {
   line-height: 19px;
 


### PR DESCRIPTION
- The tab bar is no longer full-width, infobox starts at the level of the tab bar.
- The infobox is thinner, the gap between the main content and infobox is larger.
- I've decided to fork the `page.mustache` template, I would do a small refactoring/renaming in an subsequent PR later.

<img width="961" alt="Screen Shot 2020-02-12 at 12 45 37" src="https://user-images.githubusercontent.com/4778111/74332386-e7a46d00-4d95-11ea-857b-2aaa0b2b9382.png">
