### PR TITLE
Move like button on new detail page.

### DIFF
--- a/app/lib/frontend/templates/views/shared/detail/header_experimental.mustache
+++ b/app/lib/frontend/templates/views/shared/detail/header_experimental.mustache
@@ -8,41 +8,31 @@
     height="48" width="48"
     title="Domain ownership verifed by pub.dev"
     src="{{{static_assets.img__verified-publisher-blue_svg}}}" />{{/is_publisher}}{{title}}</h2>
-  <div class="metadata">
-    {{& metadata_html}}
-    {{#has_likes}}
-    <div class="-pub-likes" >
-      <div>
-        {{#is_liked}}
-        <button
-          id="-pub-like-icon-button"
-          class="mdc-icon-button mdc-icon-button--on"
-          aria-label="Unlike this package"
-          data-ga-click-event="toggle-like"
-          aria-hidden="true"
-          aria-pressed="true">
-        {{/is_liked}}
-        {{^is_liked}}
-        <button
-          id="-pub-like-icon-button"
-          class="mdc-icon-button"
-          aria-label="Like this package"
-          data-ga-click-event="toggle-like"
-          aria-hidden="true"
-          aria-pressed="true">
-        {{/is_liked}}
-          <img
-            height="18"
-            src="{{{static_assets.img__thumb-up-24px_svg}}}"
-            class="mdc-icon-button__icon"/>
-          <img
-            height="18"
-            width="18"
-            src="{{{static_assets.img__thumb-up-filled-24px_svg}}}"
-            class="mdc-icon-button__icon mdc-icon-button__icon--on"/>
-        </button>
-       <span id="likes-count">{{like_count}}</span></div></div>
+  <div class="metadata">{{& metadata_html}}</div>
+  <div class="detail-tags-and-like">
+    <div class="detail-tags">{{& tags_html}}</div>
+    <div class="detail-like">
+      {{#has_likes}}
+      <span id="likes-count">{{like_count}}</span>
+      <button
+        id="-pub-like-icon-button"
+        class="mdc-icon-button{{#is_liked}} mdc-icon-button--on{{/is_liked}}"
+        aria-label="{{#is_liked}}Unlike{{/is_liked}}{{^is_liked}}Like{{/is_liked}} this package"
+        data-ga-click-event="toggle-like"
+        aria-hidden="true"
+        aria-pressed="true">
+        <img
+          height="18"
+          width="18"
+          src="{{{static_assets.img__thumb-up-24px_svg}}}"
+          class="mdc-icon-button__icon"/>
+        <img
+          height="18"
+          width="18"
+          src="{{{static_assets.img__thumb-up-filled-24px_svg}}}"
+          class="mdc-icon-button__icon mdc-icon-button__icon--on"/>
+      </button>
     {{/has_likes}}
-    <div class="tags">{{& tags_html}}</div>
+    </div>
   </div>
 </div>

--- a/pkg/web_css/lib/src/_base.scss
+++ b/pkg/web_css/lib/src/_base.scss
@@ -199,17 +199,6 @@ pre > code {
   display: inline-block;
 }
 
-#-pub-like-icon-button {
-  vertical-align: top;
-  margin-right: -5px;
-  margin-top: -15px;
-}
-
-.-pub-likes {
- display: inline-block;
-  margin-right: 2px;
-}
-
 .-pub-like-button {
   float: right;
   width: 100px;

--- a/pkg/web_css/lib/src/_detail_page.scss
+++ b/pkg/web_css/lib/src/_detail_page.scss
@@ -164,5 +164,16 @@ body.non-experimental {
   }
 }
 
+#-pub-like-icon-button {
+  vertical-align: top;
+  margin-right: -5px;
+  margin-top: -15px;
+}
+
+.-pub-likes {
+ display: inline-block;
+  margin-right: 2px;
+}
+
 /* non-indented rule to restrict the content of this block to the non-experimental pages */
 }

--- a/pkg/web_css/lib/src/_detail_page_experimental.scss
+++ b/pkg/web_css/lib/src/_detail_page_experimental.scss
@@ -46,6 +46,28 @@ body.experimental {
   }
 }
 
+.detail-header {
+  .metadata {
+    margin-bottom: 8px;
+  }
+
+  .detail-tags-and-like {
+    display: flex;
+  }
+
+  .detail-tags {
+    flex-grow: 1;
+  }
+
+  .detail-like {
+    color: #4a4a4a;
+    font-size: 12px;
+    font-weight: 300;
+    text-transform: uppercase;
+    white-space: nowrap;
+  }
+}
+
 .detail-metadata {
   display: none;
 


### PR DESCRIPTION
- Icon is still on old design (tracked in #3246)
- label and icon is not positioned correctly, probably because of material button, needs separate investigation (tracked in #3246)

Desktop:

<img width="972" alt="Screen Shot 2020-02-12 at 17 13 46" src="https://user-images.githubusercontent.com/4778111/74354056-1719a080-4dbb-11ea-8f6e-469a79ee6641.png">

Mobile:

<img width="373" alt="Screen Shot 2020-02-12 at 17 13 57" src="https://user-images.githubusercontent.com/4778111/74354070-1d0f8180-4dbb-11ea-82b4-2e21340256f8.png">
