### PR TITLE
Base typography for new design

### DIFF
--- a/pkg/web_css/lib/src/_base.scss
+++ b/pkg/web_css/lib/src/_base.scss
@@ -22,6 +22,23 @@ body, input, button {
   -webkit-font-smoothing: antialiased;
 }
 
+body.experimental {
+  color: #4a4a4a;
+  font-size: 14px;
+  font-weight: 300;
+
+  h1, h2, h3, h4, h5, h6 {
+    font-weight: 400;
+  }
+
+  h1 { font-size: 36px; }
+  h2 { font-size: 24px; }
+  h3 { font-size: 16px; }
+  h4 { font-size: 16px; }
+  h5 { font-size: 14px; }
+  h6 { font-size: 14px; }
+}
+
 img {
   max-width: 100%;
 }

--- a/pkg/web_css/lib/src/_detail_page_experimental.scss
+++ b/pkg/web_css/lib/src/_detail_page_experimental.scss
@@ -22,9 +22,6 @@ body.experimental {
 .detail-lead {
   display: none;
   margin-top: 16px;
-  color: #4a4a4a;
-  font-size: 14px;
-  font-weight: 300;
 
   @media (max-width: $device-mobile-max-width) {
     display: block;
@@ -60,9 +57,7 @@ body.experimental {
   }
 
   .detail-like {
-    color: #4a4a4a;
     font-size: 12px;
-    font-weight: 300;
     text-transform: uppercase;
     white-space: nowrap;
   }
@@ -82,7 +77,6 @@ body.experimental {
   }
 
   .detail-metadata-title {
-    color: #4a4a4a;
     font-size: 36px;
     font-weight: 400;
     margin: 8px 0;
@@ -94,9 +88,6 @@ body.experimental {
 }
 
 .detail-info-box {
-  color: #4a4a4a;
-  font-size: 14px;
-  font-weight: 300;
   line-height: 19px;
 
   > .title {
@@ -176,8 +167,6 @@ body.experimental {
   > .tab-link > a {
     display: block;
     color: #555555;
-    font-size: 14px;
-    font-weight: 300;
     padding: 18px 9px 12px 9px;
     border-bottom: 2px solid;
     border-bottom-color: transparent;

--- a/pkg/web_css/lib/src/_home.scss
+++ b/pkg/web_css/lib/src/_home.scss
@@ -180,7 +180,6 @@
     }
 
     .description {
-      font-weight: 300;
       margin: 8px 0px;
       max-height: 100px;
       overflow: hidden;
@@ -198,7 +197,6 @@
     }
 
     .publisher-link {
-      color: #4a4a4a;
       font-size: 12px;
       display: inline-block;
     }
@@ -209,7 +207,6 @@
   }
 
   .home-block-view-all-link {
-    font-size: 14px;
     text-transform: uppercase;
   }
 }

--- a/pkg/web_css/lib/src/_list_experimental.scss
+++ b/pkg/web_css/lib/src/_list_experimental.scss
@@ -74,8 +74,6 @@ body.experimental {
       .filter {
         color: #555555;
         display: inline-block;
-        font-size: 14px;
-        font-weight: 300;
         padding: 18px 18px 10px 18px;
 
         .filter-icon {
@@ -136,7 +134,6 @@ body.experimental {
     display: none;
     color: #555555;
     font-size: 12px;
-    font-weight: 300;
     white-space: nowrap;
     cursor: pointer;
 
@@ -197,7 +194,6 @@ body.experimental {
     background: rgba(218, 220, 224, 0.26);
     display: inline-block;
     font-size: 12px;
-    font-weight: 300;
     font-family: monospace;
     padding: 5px;
   }
@@ -276,8 +272,6 @@ body.experimental {
   }
 
   .packages-description {
-    font-size: 14px;
-    font-weight: 300;
     margin: 4px 0px;
   }
 

--- a/pkg/web_css/lib/src/_pkg_experimental.scss
+++ b/pkg/web_css/lib/src/_pkg_experimental.scss
@@ -8,7 +8,6 @@ body.experimental {
 .version-table {
   width: 100%;
   border-spacing: 0;
-  color: #4a4a4a;
 
   td, th {
     border-bottom: 1px solid #c8c8ca;
@@ -60,10 +59,6 @@ body.experimental {
 
     .version {
       font-size: 24px;
-    }
-
-    .uploaded {
-      font-weight: 300;
     }
   }
 }


### PR DESCRIPTION
In hindsight we should have started with this, but I've tried to remove the now-obsolete rules that will be inherited from the base style.

The font sizes are coming from various UIs, I think we have only one or two screens where `h1` was `48px` instead of `36px`, those will be handled separately.