### PR TITLE
New changelog page.

### DIFF
--- a/app/lib/frontend/templates/_utils.dart
+++ b/app/lib/frontend/templates/_utils.dart
@@ -12,12 +12,17 @@ import '../../shared/markdown.dart';
 const HtmlEscape htmlAttrEscape = HtmlEscape(HtmlEscapeMode.attribute);
 
 /// Renders a file content (e.g. markdown, dart source file) into HTML.
-String renderFile(FileObject file, String baseUrl) {
+String renderFile(
+  FileObject file,
+  String baseUrl, {
+  bool isChangelog = false,
+}) {
   final filename = file.filename;
   final content = file.text;
   if (content != null) {
     if (_isMarkdownFile(filename)) {
-      return markdownToHtml(content, baseUrl, baseDir: p.dirname(filename));
+      return markdownToHtml(content, baseUrl,
+          baseDir: p.dirname(filename), isChangelog: isChangelog);
     } else if (_isDartFile(filename)) {
       return _renderDartCode(content);
     } else {

--- a/app/lib/frontend/templates/package.dart
+++ b/app/lib/frontend/templates/package.dart
@@ -16,6 +16,7 @@ import '../../shared/email.dart' show EmailAddress;
 import '../../shared/tags.dart';
 import '../../shared/urls.dart' as urls;
 
+import '../request_context.dart';
 import '../static_files.dart';
 
 import '_cache.dart';
@@ -310,7 +311,8 @@ List<Tab> _pkgTabs(
 
   String renderedChangelog;
   if (selectedVersion.changelog != null) {
-    renderedChangelog = renderFile(selectedVersion.changelog, baseUrl);
+    renderedChangelog = renderFile(selectedVersion.changelog, baseUrl,
+        isChangelog: requestContext.isExperimental);
   }
 
   String renderedExample;

--- a/app/lib/shared/markdown.dart
+++ b/app/lib/shared/markdown.dart
@@ -255,7 +255,7 @@ Iterable<m.Node> _groupChangelogNodes(List<m.Node> nodes) sync* {
         ? _extractVersion(node.children.first.textContent)
         : null;
     if (version != null) {
-      final titleElem = m.Element('h2', [m.Text(version)])
+      final titleElem = m.Element('h2', [m.Text(version.toString())])
         ..attributes['class'] = 'changelog-version';
       final generatedId = (node as m.Element).generatedId;
       if (generatedId != null) {
@@ -279,7 +279,8 @@ Iterable<m.Node> _groupChangelogNodes(List<m.Node> nodes) sync* {
   }
 }
 
-String _extractVersion(String text) {
+/// Returns the extracted version (if it is a specific version, not `any` or empty).
+Version _extractVersion(String text) {
   if (text == null || text.isEmpty) return null;
   text = text.trim();
   if (text.startsWith('v')) {
@@ -289,7 +290,7 @@ String _extractVersion(String text) {
   try {
     final v = Version.parse(text);
     if (v.isEmpty || v.isAny) return null;
-    return v.toString();
+    return v;
   } on FormatException catch (_) {
     return null;
   }

--- a/app/lib/shared/markdown.dart
+++ b/app/lib/shared/markdown.dart
@@ -290,7 +290,7 @@ String _extractVersion(String text) {
     final v = Version.parse(text);
     if (v.isEmpty || v.isAny) return null;
     return v.toString();
-  } catch (_) {
+  } on FormatException catch (_) {
     return null;
   }
 }

--- a/app/lib/shared/markdown.dart
+++ b/app/lib/shared/markdown.dart
@@ -241,7 +241,7 @@ String _pruneBaseUrl(String url) {
 ///
 /// The output is in the following structure:
 /// <div class="changelog-entry">
-///   <h3 class="changelog-version">{{version - stripped from styles}}</h3>
+///   <h2 class="changelog-version">{{version - stripped from styles}}</h2>
 ///   <div class="changelog-content">
 ///     {{log entries in their original HTML format}}
 ///   </div>

--- a/app/test/shared/markdown_test.dart
+++ b/app/test/shared/markdown_test.dart
@@ -201,4 +201,65 @@ void main() {
           '<p><img src="https://github.com/rcpassos/progress_hud/raw/master/progress_hud.gif" alt="text" /></p>\n');
     });
   });
+
+  group('changelog', () {
+    test('no structure', () {
+      expect(
+          markdownToHtml(
+              'a\n\n'
+              'b\n\n'
+              'c',
+              null,
+              isChangelog: true),
+          '<p>a</p>\n'
+          '<p>b</p>\n'
+          '<p>c</p>\n');
+    });
+
+    test('single entry', () {
+      expect(
+          markdownToHtml(
+              '# Changelog\n\n'
+              '## 1.0.0\n'
+              '\n'
+              '- change1',
+              null,
+              isChangelog: true),
+          '<h1 class="hash-header" id="changelog">Changelog <a href="#changelog" class="hash-link">#</a></h1>'
+          '<div class="changelog-entry">\n'
+          '<h2 class="changelog-version hash-header" id="100">1.0.0 <a href="#100" class="hash-link">#</a></h2>'
+          '<div class="changelog-content">\n'
+          '<ul>\n'
+          '<li>change1</li>\n'
+          '</ul>'
+          '</div>'
+          '</div>\n');
+    });
+
+    test('multiple entries', () {
+      expect(
+          markdownToHtml(
+              '# Changelog\n\n'
+              '## 1.0.0\n\n- change1\n\n- change2\n\n'
+              '## 0.9.0\n\nMostly refatoring',
+              null,
+              isChangelog: true),
+          '<h1 class="hash-header" id="changelog">Changelog <a href="#changelog" class="hash-link">#</a></h1>'
+          '<div class="changelog-entry">\n'
+          '<h2 class="changelog-version hash-header" id="100">1.0.0 <a href="#100" class="hash-link">#</a></h2>'
+          '<div class="changelog-content">\n'
+          '<ul>\n'
+          '<li>\n<p>change1</p>\n</li>\n'
+          '<li>\n<p>change2</p>\n</li>\n'
+          '</ul>'
+          '</div>'
+          '</div>'
+          '<div class="changelog-entry">\n'
+          '<h2 class="changelog-version hash-header" id="090">0.9.0 <a href="#090" class="hash-link">#</a></h2>'
+          '<div class="changelog-content">\n'
+          '<p>Mostly refatoring</p>'
+          '</div>'
+          '</div>\n');
+    });
+  });
 }

--- a/pkg/web_css/lib/src/_pkg_experimental.scss
+++ b/pkg/web_css/lib/src/_pkg_experimental.scss
@@ -63,5 +63,24 @@ body.experimental {
   }
 }
 
+.changelog-entry {
+  display: flex;
+  padding: 12px 0;
+  border-bottom: 1px solid #c8c8ca;
+
+  .changelog-version {
+    border-bottom: none;
+    margin: 0;
+    width: 120px;
+  }
+
+  .changelog-content {
+    flex-grow: 1;
+    font-size: 14px;
+    margin: 4px 0 4px 16px;
+    width: 100%;
+  }
+}
+
 /* non-indented rule to restrict the content of the file to the experimental pages */
 }


### PR DESCRIPTION
I've started to implement this with CSS-only, but it only worked for a limited case. Rewriting the markdown tree is a bit more work, but creates a consistent experience.

Desktop view:

<img width="676" alt="Screen Shot 2020-02-14 at 14 32 41" src="https://user-images.githubusercontent.com/4778111/74535814-eeb6b100-4f36-11ea-8cbe-7bdfe608f85c.png">

