### PR TITLE
Remove SDK predicate from flutter favorites listing.

### DIFF
--- a/app/lib/frontend/handlers/listing.dart
+++ b/app/lib/frontend/handlers/listing.dart
@@ -51,7 +51,6 @@ Future<shelf.Response> flutterFavoritesPackagesHandlerHtml(
 ) {
   return _packagesHandlerHtmlCore(
     request,
-    sdk: SdkTagValue.flutter,
     title: 'Flutter Favorite packages',
     tagsPredicate: TagsPredicate.regularSearch().appendPredicate(TagsPredicate(
       requiredTags: [PackageTags.isFlutterFavorite],


### PR DESCRIPTION
Fixes #3329.