### PR TITLE
New FF icon in package listing

### DIFF
--- a/app/lib/frontend/templates/views/pkg/package_list_experimental.mustache
+++ b/app/lib/frontend/templates/views/pkg/package_list_experimental.mustache
@@ -6,15 +6,17 @@
   {{#packages}}
   <div class="packages-item">
     <div class="packages-header">
-      <h3 class="packages-title"><a href="{{& url}}">{{name}}</a></h3>
-      <div class="packages-icons">
-        {{#is_flutter_favorite}}
-        <div class="packages-icon">
+      <h3 class="packages-title">
+        <a href="{{& url}}">
+          {{name}}
+          {{#is_flutter_favorite}}
           <img src="{{static_assets.img__ff-20px_svg}}"
                class="packages-ff-icon"
                title="Package {{name}} have been awarded Flutter Favorite" />
-        </div>
-        {{/is_flutter_favorite}}
+          {{/is_flutter_favorite}}
+        </a>
+      </h3>
+      <div class="packages-icons">
         <div class="packages-icon">
           {{& score_box_html }}
         </div>

--- a/app/lib/frontend/templates/views/pkg/package_list_experimental.mustache
+++ b/app/lib/frontend/templates/views/pkg/package_list_experimental.mustache
@@ -10,7 +10,7 @@
       <div class="packages-icons">
         {{#is_flutter_favorite}}
         <div class="packages-icon">
-          <img src="{{static_assets.img__ff_svg}}"
+          <img src="{{static_assets.img__ff-20px_svg}}"
                class="packages-ff-icon"
                title="Package {{name}} have been awarded Flutter Favorite" />
         </div>

--- a/pkg/web_css/lib/src/_list_experimental.scss
+++ b/pkg/web_css/lib/src/_list_experimental.scss
@@ -269,9 +269,10 @@ body.experimental {
   }
 
   .packages-ff-icon {
-    display: block;
-    height: 20px;
+    display: inline-block;
+    height: 16px;
     width: auto;
+    margin-left: 16px;
   }
 
   .packages-description {

--- a/pkg/web_css/lib/src/_list_experimental.scss
+++ b/pkg/web_css/lib/src/_list_experimental.scss
@@ -270,8 +270,8 @@ body.experimental {
 
   .packages-ff-icon {
     display: block;
-    width: 40px;
-    height: 40px;
+    height: 20px;
+    width: auto;
   }
 
   .packages-description {


### PR DESCRIPTION
This is an experimental take: a mixture of the new design's icon position + old icon. wdyt? Should we rather put it near the title?

<img width="985" alt="Screen Shot 2020-02-18 at 13 45 00" src="https://user-images.githubusercontent.com/4778111/74737370-03f05000-5255-11ea-9905-e7f82c664808.png">
