### PR TITLE
Adjusted paddings

### DIFF
--- a/pkg/web_css/lib/src/_detail_page_experimental.scss
+++ b/pkg/web_css/lib/src/_detail_page_experimental.scss
@@ -210,7 +210,7 @@ $detail-tabs-width: calc(100% - 320px);
     display: block;
     font-weight: 300;
     color: #555555;
-    padding: 18px 9px 12px 9px;
+    padding: 12px 9px 12px 9px;
     border-bottom: 2px solid;
     border-bottom-color: transparent;
     cursor: pointer;

--- a/pkg/web_css/lib/src/_list_experimental.scss
+++ b/pkg/web_css/lib/src/_list_experimental.scss
@@ -242,6 +242,10 @@ body.experimental {
     margin: 0px -4px 12px -4px;
     padding: 4px;
 
+    @media (min-width: $device-desktop-min-width) {
+      padding: 16px 32px;
+    }
+
     &:hover {
       background: #fafafa;
     }


### PR DESCRIPTION
- Detail page tabs are now 50px height (matching the design height).
- Listing view on desktop now has larger padding, closer to the non-exact numbers of the design. The -4px margins are kept for mobile view (if they have a hover action, it is nicer that way).