### PR TITLE
Include more word in token lookup.

### DIFF
--- a/app/lib/search/index_simple.dart
+++ b/app/lib/search/index_simple.dart
@@ -702,8 +702,10 @@ class TokenIndex {
       final Map<String, double> weights =
           _inverseIds.putIfAbsent(token, () => <String, double>{});
       // on the first insert of an entry, we populate the similarity candidates
+      print('$token ${weights.isEmpty}');
       if (weights.isEmpty) {
         for (String reduced in deriveLookupCandidates(token)) {
+          print('r: $reduced');
           _lookupCandidates.putIfAbsent(reduced, () => <String>{}).add(token);
         }
       }
@@ -748,12 +750,15 @@ class TokenIndex {
         candidates.addAll(_lookupCandidates[token]);
       }
       for (String reduced in deriveLookupCandidates(token)) {
+        if (_inverseIds.containsKey(reduced)) {
+          candidates.add(reduced);
+        }
         final set = _lookupCandidates[reduced];
         if (set != null) {
           candidates.addAll(set);
         }
       }
-      final tokenNgrams = ngrams(token, _minLength, 6);
+      Set<String> tokenNgrams;
       double tokenWeightSum;
       for (String candidate in candidates) {
         double candidateWeight = 0.0;
@@ -764,6 +769,7 @@ class TokenIndex {
         } else if (candidate.startsWith(token) || candidate.endsWith(token)) {
           candidateWeight = token.length / candidate.length;
         } else {
+          tokenNgrams ??= ngrams(token, _minLength, 6);
           final candidateNgrams = ngrams(candidate, _minLength, 6);
           tokenWeightSum ??= tokenNgrams.fold<double>(0.0, _ngramWeightSum);
           candidateWeight =

--- a/app/lib/search/index_simple.dart
+++ b/app/lib/search/index_simple.dart
@@ -702,10 +702,8 @@ class TokenIndex {
       final Map<String, double> weights =
           _inverseIds.putIfAbsent(token, () => <String, double>{});
       // on the first insert of an entry, we populate the similarity candidates
-      print('$token ${weights.isEmpty}');
       if (weights.isEmpty) {
         for (String reduced in deriveLookupCandidates(token)) {
-          print('r: $reduced');
           _lookupCandidates.putIfAbsent(reduced, () => <String>{}).add(token);
         }
       }

--- a/app/test/search/bluetooth_test.dart
+++ b/app/test/search/bluetooth_test.dart
@@ -39,7 +39,7 @@ void main() {
         'packages': [
           {
             'package': 'flutter_blue',
-            'score': closeTo(0.89, 0.01),
+            'score': closeTo(0.99, 0.01),
           },
         ],
       });

--- a/app/test/search/haversine_test.dart
+++ b/app/test/search/haversine_test.dart
@@ -381,7 +381,7 @@ MIT'''),
           SearchQuery.parse(query: 'haversine', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
-        'totalCount': 3,
+        'totalCount': 4,
         'packages': [
           {
             // should be the top
@@ -397,6 +397,11 @@ MIT'''),
             // should be present
             'package': 'latlong',
             'score': closeTo(0.71, 0.01),
+          },
+          {
+            // not relevant result, should have low score
+            'package': 'reversi',
+            'score': closeTo(0.39, 0.01),
           },
         ]
       });

--- a/app/test/search/maps_test.dart
+++ b/app/test/search/maps_test.dart
@@ -25,9 +25,10 @@ void main() {
           .search(SearchQuery.parse(query: 'maps', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
-        'totalCount': 1,
+        'totalCount': 2,
         'packages': [
           {'package': 'maps', 'score': closeTo(0.993, 0.001)},
+          {'package': 'map', 'score': closeTo(0.745, 0.001)},
         ],
       });
     });

--- a/pkg/web_css/lib/src/_list_experimental.scss
+++ b/pkg/web_css/lib/src/_list_experimental.scss
@@ -153,13 +153,13 @@ body.experimental {
       position: relative;
       top: -1px;
       opacity: 0.6;
-      transform: rotate(0deg);
+      transform: rotate(180deg);
       transition: transform 0.3s linear;
     }
 
     &.-active {
       .search-controls-more-carot {
-        transform: rotate(180deg);
+        transform: rotate(0deg);
       }
     }
   }


### PR DESCRIPTION
- improves #3235 (see `maps_test.dart` changes)
- slightly more candidates means a bit more CPU time, but they are relevant to the query
- the ngram calculation is now done lazily
- the required memory does not change
