### PR TITLE
Updated page metadata.

### DIFF
--- a/app/lib/frontend/templates/layout.dart
+++ b/app/lib/frontend/templates/layout.dart
@@ -40,7 +40,13 @@ String renderLayoutPage(
   @required String title,
   String pageDescription,
   String faviconUrl,
+
+  /// The canonical content link that will be put in the header.
+  /// https://support.google.com/webmasters/answer/139066?hl=en
   String canonicalUrl,
+
+  /// The page's URL that will be used in social share metadata.
+  String shareUrl,
   String sdk,
   String publisherId,
   SearchQuery searchQuery,
@@ -69,6 +75,7 @@ String renderLayoutPage(
   final values = {
     'is_experimental': requestContext.isExperimental,
     'is_landing': type == PageType.landing,
+    'pub_site_root': urls.siteRoot,
     'dart_site_root': urls.dartSiteRoot,
     'oauth_client_id': activeConfiguration.pubSiteAudience,
     'body_class': bodyClasses.join(' '),
@@ -76,6 +83,7 @@ String renderLayoutPage(
     'no_index': noIndex,
     'favicon': faviconUrl ?? staticUrls.smallDartFavicon,
     'canonicalUrl': canonicalUrl,
+    'share_url': shareUrl,
     'pageDescription': pageDescription == null
         ? _defaultPageDescriptionEscaped
         : htmlEscape.convert(pageDescription),

--- a/app/lib/frontend/templates/package.dart
+++ b/app/lib/frontend/templates/package.dart
@@ -268,6 +268,11 @@ String renderPkgShowPage(
       '$packageAndVersion | ${isFlutterPackage ? 'Flutter' : 'Dart'} Package';
   final canonicalUrl =
       isVersionPage ? urls.pkgPageUrl(package.name, includeHost: true) : null;
+  final shareUrl = urls.pkgPageUrl(
+    package.name,
+    version: isVersionPage ? selectedVersion.version : null,
+    includeHost: true,
+  );
   final noIndex = (card?.isSkipped ?? false) ||
       (card?.overallScore == 0.0) ||
       package.isDiscontinued;
@@ -278,6 +283,7 @@ String renderPkgShowPage(
     pageDescription: selectedVersion.ellipsizedDescription,
     faviconUrl: isFlutterPackage ? staticUrls.flutterLogo32x32 : null,
     canonicalUrl: canonicalUrl,
+    shareUrl: shareUrl,
     noIndex: noIndex,
     pageData: pkgPageData(package, selectedVersion),
   );

--- a/app/lib/frontend/templates/views/shared/layout.mustache
+++ b/app/lib/frontend/templates/views/shared/layout.mustache
@@ -12,24 +12,34 @@
   {{#no_index}}
   <meta name="robots" content="noindex" />
   {{/no_index}}
+
+  <!-- Twitter tags -->
   <meta name="twitter:card" content="summary" />
   <meta name="twitter:site" content="@dart_lang" />
+  <meta name="twitter:description" content="{{& pageDescription}}" />
+  <meta name="twitter:image" content="{{& pub_site_root}}{{& static_assets.img__dart-logo-400x400_png}}" />
+
+  <!-- Facebook OG tags -->
+  <meta property="og:type" content="website" />
   <meta property="og:site_name" content="Dart packages" />
-  <title>{{& title}}</title>
   <meta property="og:title" content="{{& title}}" />
+  <meta property="og:description" content="{{& pageDescription}}" />
+  <meta property="og:image" content="{{& pub_site_root}}{{& static_assets.img__dart-logo-400x400_png}}" />
+  {{#share_url}}
+  <meta property="og:url" content="{{& share_url}}" />
+  {{/share_url}}
+
+  <title>{{& title}}</title>
   <link href="https://fonts.googleapis.com/css?family=Google+Sans:300,400,500|Google+Sans+Display:400|Roboto:300,400,500,700|Roboto+Mono:300,400,700" rel="stylesheet" />
   <meta content="{{{static_assets.img__dart-logo-400x400_png}}}" />
-  <meta property="og:image" content="{{{static_assets.img__dart-logo-400x400_png}}}" />
   {{#favicon}}
   <link rel="shortcut icon" href="{{{favicon}}}" />
   {{/favicon}}
   <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="{{{static_assets.osd_xml}}}" />
   {{#canonicalUrl}}
   <link rel="canonical" href="{{{canonicalUrl}}}"/>
-  <meta property="og:url" content="{{{canonicalUrl}}}" />
   {{/canonicalUrl}}
   <meta name="description" content="{{& pageDescription}}" />
-  <meta property="og:description" content="{{& pageDescription}}" />
   <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom" />
   <link href="{{{static_assets.material__material-components-web_min_css}}}" rel="stylesheet" type="text/css" />
   <link href="{{{static_assets.highlight__github_css}}}" rel="stylesheet" />

--- a/app/test/frontend/golden/authorized_page.html
+++ b/app/test/frontend/golden/authorized_page.html
@@ -6,18 +6,23 @@
     <meta charset="utf-8"/>
     <meta http-equiv="x-ua-compatible" content="ie=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <!-- Twitter tags -->
     <meta name="twitter:card" content="summary"/>
     <meta name="twitter:site" content="@dart_lang"/>
+    <meta name="twitter:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
+    <meta name="twitter:image" content="https://pub.dev/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <!-- Facebook OG tags -->
+    <meta property="og:type" content="website"/>
     <meta property="og:site_name" content="Dart packages"/>
-    <title>Pub Authorized Successfully</title>
     <meta property="og:title" content="Pub Authorized Successfully"/>
+    <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
+    <meta property="og:image" content="https://pub.dev/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <title>Pub Authorized Successfully</title>
     <link href="https://fonts.googleapis.com/css?family=Google+Sans:300,400,500|Google+Sans+Display:400|Roboto:300,400,500,700|Roboto+Mono:300,400,700" rel="stylesheet"/>
     <meta content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
-    <meta property="og:image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
     <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
     <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/osd.xml?hash=mocked_hash_869379763"/>
     <meta name="description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
-    <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
     <link href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842" rel="stylesheet" type="text/css"/>
     <link href="/static/highlight/github.css?hash=mocked_hash_145446167" rel="stylesheet"/>

--- a/app/test/frontend/golden/error_page.html
+++ b/app/test/frontend/golden/error_page.html
@@ -6,18 +6,23 @@
     <meta charset="utf-8"/>
     <meta http-equiv="x-ua-compatible" content="ie=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <!-- Twitter tags -->
     <meta name="twitter:card" content="summary"/>
     <meta name="twitter:site" content="@dart_lang"/>
+    <meta name="twitter:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
+    <meta name="twitter:image" content="https://pub.dev/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <!-- Facebook OG tags -->
+    <meta property="og:type" content="website"/>
     <meta property="og:site_name" content="Dart packages"/>
-    <title>error_title</title>
     <meta property="og:title" content="error_title"/>
+    <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
+    <meta property="og:image" content="https://pub.dev/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <title>error_title</title>
     <link href="https://fonts.googleapis.com/css?family=Google+Sans:300,400,500|Google+Sans+Display:400|Roboto:300,400,500,700|Roboto+Mono:300,400,700" rel="stylesheet"/>
     <meta content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
-    <meta property="og:image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
     <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
     <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/osd.xml?hash=mocked_hash_869379763"/>
     <meta name="description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
-    <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
     <link href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842" rel="stylesheet" type="text/css"/>
     <link href="/static/highlight/github.css?hash=mocked_hash_145446167" rel="stylesheet"/>

--- a/app/test/frontend/golden/landing_page.html
+++ b/app/test/frontend/golden/landing_page.html
@@ -6,18 +6,23 @@
     <meta charset="utf-8"/>
     <meta http-equiv="x-ua-compatible" content="ie=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <!-- Twitter tags -->
     <meta name="twitter:card" content="summary"/>
     <meta name="twitter:site" content="@dart_lang"/>
+    <meta name="twitter:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
+    <meta name="twitter:image" content="https://pub.dev/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <!-- Facebook OG tags -->
+    <meta property="og:type" content="website"/>
     <meta property="og:site_name" content="Dart packages"/>
-    <title>Dart packages</title>
     <meta property="og:title" content="Dart packages"/>
+    <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
+    <meta property="og:image" content="https://pub.dev/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <title>Dart packages</title>
     <link href="https://fonts.googleapis.com/css?family=Google+Sans:300,400,500|Google+Sans+Display:400|Roboto:300,400,500,700|Roboto+Mono:300,400,700" rel="stylesheet"/>
     <meta content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
-    <meta property="og:image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
     <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
     <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/osd.xml?hash=mocked_hash_869379763"/>
     <meta name="description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
-    <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
     <link href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842" rel="stylesheet" type="text/css"/>
     <link href="/static/highlight/github.css?hash=mocked_hash_145446167" rel="stylesheet"/>

--- a/app/test/frontend/golden/my_liked_packages.html
+++ b/app/test/frontend/golden/my_liked_packages.html
@@ -7,18 +7,23 @@
     <meta http-equiv="x-ua-compatible" content="ie=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <meta name="robots" content="noindex"/>
+    <!-- Twitter tags -->
     <meta name="twitter:card" content="summary"/>
     <meta name="twitter:site" content="@dart_lang"/>
+    <meta name="twitter:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
+    <meta name="twitter:image" content="https://pub.dev/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <!-- Facebook OG tags -->
+    <meta property="og:type" content="website"/>
     <meta property="og:site_name" content="Dart packages"/>
-    <title>My liked packages</title>
     <meta property="og:title" content="My liked packages"/>
+    <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
+    <meta property="og:image" content="https://pub.dev/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <title>My liked packages</title>
     <link href="https://fonts.googleapis.com/css?family=Google+Sans:300,400,500|Google+Sans+Display:400|Roboto:300,400,500,700|Roboto+Mono:300,400,700" rel="stylesheet"/>
     <meta content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
-    <meta property="og:image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
     <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
     <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/osd.xml?hash=mocked_hash_869379763"/>
     <meta name="description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
-    <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
     <link href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842" rel="stylesheet" type="text/css"/>
     <link href="/static/highlight/github.css?hash=mocked_hash_145446167" rel="stylesheet"/>

--- a/app/test/frontend/golden/my_packages.html
+++ b/app/test/frontend/golden/my_packages.html
@@ -7,18 +7,23 @@
     <meta http-equiv="x-ua-compatible" content="ie=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <meta name="robots" content="noindex"/>
+    <!-- Twitter tags -->
     <meta name="twitter:card" content="summary"/>
     <meta name="twitter:site" content="@dart_lang"/>
+    <meta name="twitter:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
+    <meta name="twitter:image" content="https://pub.dev/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <!-- Facebook OG tags -->
+    <meta property="og:type" content="website"/>
     <meta property="og:site_name" content="Dart packages"/>
-    <title>My packages</title>
     <meta property="og:title" content="My packages"/>
+    <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
+    <meta property="og:image" content="https://pub.dev/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <title>My packages</title>
     <link href="https://fonts.googleapis.com/css?family=Google+Sans:300,400,500|Google+Sans+Display:400|Roboto:300,400,500,700|Roboto+Mono:300,400,700" rel="stylesheet"/>
     <meta content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
-    <meta property="og:image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
     <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
     <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/osd.xml?hash=mocked_hash_869379763"/>
     <meta name="description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
-    <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
     <link href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842" rel="stylesheet" type="text/css"/>
     <link href="/static/highlight/github.css?hash=mocked_hash_145446167" rel="stylesheet"/>

--- a/app/test/frontend/golden/my_publishers.html
+++ b/app/test/frontend/golden/my_publishers.html
@@ -7,18 +7,23 @@
     <meta http-equiv="x-ua-compatible" content="ie=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <meta name="robots" content="noindex"/>
+    <!-- Twitter tags -->
     <meta name="twitter:card" content="summary"/>
     <meta name="twitter:site" content="@dart_lang"/>
+    <meta name="twitter:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
+    <meta name="twitter:image" content="https://pub.dev/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <!-- Facebook OG tags -->
+    <meta property="og:type" content="website"/>
     <meta property="og:site_name" content="Dart packages"/>
-    <title>My publishers</title>
     <meta property="og:title" content="My publishers"/>
+    <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
+    <meta property="og:image" content="https://pub.dev/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <title>My publishers</title>
     <link href="https://fonts.googleapis.com/css?family=Google+Sans:300,400,500|Google+Sans+Display:400|Roboto:300,400,500,700|Roboto+Mono:300,400,700" rel="stylesheet"/>
     <meta content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
-    <meta property="og:image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
     <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
     <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/osd.xml?hash=mocked_hash_869379763"/>
     <meta name="description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
-    <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
     <link href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842" rel="stylesheet" type="text/css"/>
     <link href="/static/highlight/github.css?hash=mocked_hash_145446167" rel="stylesheet"/>

--- a/app/test/frontend/golden/pkg_admin_page_outdated.html
+++ b/app/test/frontend/golden/pkg_admin_page_outdated.html
@@ -7,18 +7,23 @@
     <meta http-equiv="x-ua-compatible" content="ie=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <meta name="robots" content="noindex"/>
+    <!-- Twitter tags -->
     <meta name="twitter:card" content="summary"/>
     <meta name="twitter:site" content="@dart_lang"/>
+    <meta name="twitter:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
+    <meta name="twitter:image" content="https://pub.dev/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <!-- Facebook OG tags -->
+    <meta property="og:type" content="website"/>
     <meta property="og:site_name" content="Dart packages"/>
-    <title>foobar_pkg package - Admin</title>
     <meta property="og:title" content="foobar_pkg package - Admin"/>
+    <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
+    <meta property="og:image" content="https://pub.dev/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <title>foobar_pkg package - Admin</title>
     <link href="https://fonts.googleapis.com/css?family=Google+Sans:300,400,500|Google+Sans+Display:400|Roboto:300,400,500,700|Roboto+Mono:300,400,700" rel="stylesheet"/>
     <meta content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
-    <meta property="og:image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
     <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
     <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/osd.xml?hash=mocked_hash_869379763"/>
     <meta name="description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
-    <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
     <link href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842" rel="stylesheet" type="text/css"/>
     <link href="/static/highlight/github.css?hash=mocked_hash_145446167" rel="stylesheet"/>

--- a/app/test/frontend/golden/pkg_index_page.html
+++ b/app/test/frontend/golden/pkg_index_page.html
@@ -7,18 +7,23 @@
     <meta http-equiv="x-ua-compatible" content="ie=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <meta name="robots" content="noindex"/>
+    <!-- Twitter tags -->
     <meta name="twitter:card" content="summary"/>
     <meta name="twitter:site" content="@dart_lang"/>
+    <meta name="twitter:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
+    <meta name="twitter:image" content="https://pub.dev/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <!-- Facebook OG tags -->
+    <meta property="og:type" content="website"/>
     <meta property="og:site_name" content="Dart packages"/>
-    <title>Top packages</title>
     <meta property="og:title" content="Top packages"/>
+    <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
+    <meta property="og:image" content="https://pub.dev/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <title>Top packages</title>
     <link href="https://fonts.googleapis.com/css?family=Google+Sans:300,400,500|Google+Sans+Display:400|Roboto:300,400,500,700|Roboto+Mono:300,400,700" rel="stylesheet"/>
     <meta content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
-    <meta property="og:image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
     <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
     <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/osd.xml?hash=mocked_hash_869379763"/>
     <meta name="description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
-    <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
     <link href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842" rel="stylesheet" type="text/css"/>
     <link href="/static/highlight/github.css?hash=mocked_hash_145446167" rel="stylesheet"/>

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -6,18 +6,24 @@
     <meta charset="utf-8"/>
     <meta http-equiv="x-ua-compatible" content="ie=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <!-- Twitter tags -->
     <meta name="twitter:card" content="summary"/>
     <meta name="twitter:site" content="@dart_lang"/>
+    <meta name="twitter:description" content="my package description"/>
+    <meta name="twitter:image" content="https://pub.dev/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <!-- Facebook OG tags -->
+    <meta property="og:type" content="website"/>
     <meta property="og:site_name" content="Dart packages"/>
-    <title>foobar_pkg | Dart Package</title>
     <meta property="og:title" content="foobar_pkg | Dart Package"/>
+    <meta property="og:description" content="my package description"/>
+    <meta property="og:image" content="https://pub.dev/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <meta property="og:url" content="https://pub.dev/packages/foobar_pkg"/>
+    <title>foobar_pkg | Dart Package</title>
     <link href="https://fonts.googleapis.com/css?family=Google+Sans:300,400,500|Google+Sans+Display:400|Roboto:300,400,500,700|Roboto+Mono:300,400,700" rel="stylesheet"/>
     <meta content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
-    <meta property="og:image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
     <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
     <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/osd.xml?hash=mocked_hash_869379763"/>
     <meta name="description" content="my package description"/>
-    <meta property="og:description" content="my package description"/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
     <link href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842" rel="stylesheet" type="text/css"/>
     <link href="/static/highlight/github.css?hash=mocked_hash_145446167" rel="stylesheet"/>

--- a/app/test/frontend/golden/pkg_show_page_discontinued.html
+++ b/app/test/frontend/golden/pkg_show_page_discontinued.html
@@ -7,18 +7,24 @@
     <meta http-equiv="x-ua-compatible" content="ie=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <meta name="robots" content="noindex"/>
+    <!-- Twitter tags -->
     <meta name="twitter:card" content="summary"/>
     <meta name="twitter:site" content="@dart_lang"/>
+    <meta name="twitter:description" content="my package description"/>
+    <meta name="twitter:image" content="https://pub.dev/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <!-- Facebook OG tags -->
+    <meta property="og:type" content="website"/>
     <meta property="og:site_name" content="Dart packages"/>
-    <title>foobar_pkg | Dart Package</title>
     <meta property="og:title" content="foobar_pkg | Dart Package"/>
+    <meta property="og:description" content="my package description"/>
+    <meta property="og:image" content="https://pub.dev/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <meta property="og:url" content="https://pub.dev/packages/foobar_pkg"/>
+    <title>foobar_pkg | Dart Package</title>
     <link href="https://fonts.googleapis.com/css?family=Google+Sans:300,400,500|Google+Sans+Display:400|Roboto:300,400,500,700|Roboto+Mono:300,400,700" rel="stylesheet"/>
     <meta content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
-    <meta property="og:image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
     <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
     <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/osd.xml?hash=mocked_hash_869379763"/>
     <meta name="description" content="my package description"/>
-    <meta property="og:description" content="my package description"/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
     <link href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842" rel="stylesheet" type="text/css"/>
     <link href="/static/highlight/github.css?hash=mocked_hash_145446167" rel="stylesheet"/>

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -6,18 +6,24 @@
     <meta charset="utf-8"/>
     <meta http-equiv="x-ua-compatible" content="ie=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <!-- Twitter tags -->
     <meta name="twitter:card" content="summary"/>
     <meta name="twitter:site" content="@dart_lang"/>
+    <meta name="twitter:description" content="my package description"/>
+    <meta name="twitter:image" content="https://pub.dev/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <!-- Facebook OG tags -->
+    <meta property="og:type" content="website"/>
     <meta property="og:site_name" content="Dart packages"/>
-    <title>foobar_pkg | Flutter Package</title>
     <meta property="og:title" content="foobar_pkg | Flutter Package"/>
+    <meta property="og:description" content="my package description"/>
+    <meta property="og:image" content="https://pub.dev/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <meta property="og:url" content="https://pub.dev/packages/foobar_pkg"/>
+    <title>foobar_pkg | Flutter Package</title>
     <link href="https://fonts.googleapis.com/css?family=Google+Sans:300,400,500|Google+Sans+Display:400|Roboto:300,400,500,700|Roboto+Mono:300,400,700" rel="stylesheet"/>
     <meta content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
-    <meta property="og:image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
     <link rel="shortcut icon" href="/static/img/flutter-logo-32x32.png?hash=mocked_hash_318836230"/>
     <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/osd.xml?hash=mocked_hash_869379763"/>
     <meta name="description" content="my package description"/>
-    <meta property="og:description" content="my package description"/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
     <link href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842" rel="stylesheet" type="text/css"/>
     <link href="/static/highlight/github.css?hash=mocked_hash_145446167" rel="stylesheet"/>

--- a/app/test/frontend/golden/pkg_show_page_legacy.html
+++ b/app/test/frontend/golden/pkg_show_page_legacy.html
@@ -7,18 +7,24 @@
     <meta http-equiv="x-ua-compatible" content="ie=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <meta name="robots" content="noindex"/>
+    <!-- Twitter tags -->
     <meta name="twitter:card" content="summary"/>
     <meta name="twitter:site" content="@dart_lang"/>
+    <meta name="twitter:description" content="my package description"/>
+    <meta name="twitter:image" content="https://pub.dev/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <!-- Facebook OG tags -->
+    <meta property="og:type" content="website"/>
     <meta property="og:site_name" content="Dart packages"/>
-    <title>foobar_pkg | Dart Package</title>
     <meta property="og:title" content="foobar_pkg | Dart Package"/>
+    <meta property="og:description" content="my package description"/>
+    <meta property="og:image" content="https://pub.dev/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <meta property="og:url" content="https://pub.dev/packages/foobar_pkg"/>
+    <title>foobar_pkg | Dart Package</title>
     <link href="https://fonts.googleapis.com/css?family=Google+Sans:300,400,500|Google+Sans+Display:400|Roboto:300,400,500,700|Roboto+Mono:300,400,700" rel="stylesheet"/>
     <meta content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
-    <meta property="og:image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
     <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
     <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/osd.xml?hash=mocked_hash_869379763"/>
     <meta name="description" content="my package description"/>
-    <meta property="og:description" content="my package description"/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
     <link href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842" rel="stylesheet" type="text/css"/>
     <link href="/static/highlight/github.css?hash=mocked_hash_145446167" rel="stylesheet"/>

--- a/app/test/frontend/golden/pkg_show_page_outdated.html
+++ b/app/test/frontend/golden/pkg_show_page_outdated.html
@@ -7,18 +7,24 @@
     <meta http-equiv="x-ua-compatible" content="ie=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <meta name="robots" content="noindex"/>
+    <!-- Twitter tags -->
     <meta name="twitter:card" content="summary"/>
     <meta name="twitter:site" content="@dart_lang"/>
+    <meta name="twitter:description" content="my package description"/>
+    <meta name="twitter:image" content="https://pub.dev/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <!-- Facebook OG tags -->
+    <meta property="og:type" content="website"/>
     <meta property="og:site_name" content="Dart packages"/>
-    <title>foobar_pkg | Dart Package</title>
     <meta property="og:title" content="foobar_pkg | Dart Package"/>
+    <meta property="og:description" content="my package description"/>
+    <meta property="og:image" content="https://pub.dev/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <meta property="og:url" content="https://pub.dev/packages/foobar_pkg"/>
+    <title>foobar_pkg | Dart Package</title>
     <link href="https://fonts.googleapis.com/css?family=Google+Sans:300,400,500|Google+Sans+Display:400|Roboto:300,400,500,700|Roboto+Mono:300,400,700" rel="stylesheet"/>
     <meta content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
-    <meta property="og:image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
     <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
     <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/osd.xml?hash=mocked_hash_869379763"/>
     <meta name="description" content="my package description"/>
-    <meta property="og:description" content="my package description"/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
     <link href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842" rel="stylesheet" type="text/css"/>
     <link href="/static/highlight/github.css?hash=mocked_hash_145446167" rel="stylesheet"/>

--- a/app/test/frontend/golden/pkg_show_page_publisher.html
+++ b/app/test/frontend/golden/pkg_show_page_publisher.html
@@ -7,18 +7,24 @@
     <meta http-equiv="x-ua-compatible" content="ie=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <meta name="robots" content="noindex"/>
+    <!-- Twitter tags -->
     <meta name="twitter:card" content="summary"/>
     <meta name="twitter:site" content="@dart_lang"/>
+    <meta name="twitter:description" content="lithium is a Dart package"/>
+    <meta name="twitter:image" content="https://pub.dev/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <!-- Facebook OG tags -->
+    <meta property="og:type" content="website"/>
     <meta property="og:site_name" content="Dart packages"/>
-    <title>lithium | Dart Package</title>
     <meta property="og:title" content="lithium | Dart Package"/>
+    <meta property="og:description" content="lithium is a Dart package"/>
+    <meta property="og:image" content="https://pub.dev/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <meta property="og:url" content="https://pub.dev/packages/lithium"/>
+    <title>lithium | Dart Package</title>
     <link href="https://fonts.googleapis.com/css?family=Google+Sans:300,400,500|Google+Sans+Display:400|Roboto:300,400,500,700|Roboto+Mono:300,400,700" rel="stylesheet"/>
     <meta content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
-    <meta property="og:image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
     <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
     <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/osd.xml?hash=mocked_hash_869379763"/>
     <meta name="description" content="lithium is a Dart package"/>
-    <meta property="og:description" content="lithium is a Dart package"/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
     <link href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842" rel="stylesheet" type="text/css"/>
     <link href="/static/highlight/github.css?hash=mocked_hash_145446167" rel="stylesheet"/>

--- a/app/test/frontend/golden/pkg_show_version_page.html
+++ b/app/test/frontend/golden/pkg_show_version_page.html
@@ -6,20 +6,25 @@
     <meta charset="utf-8"/>
     <meta http-equiv="x-ua-compatible" content="ie=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <!-- Twitter tags -->
     <meta name="twitter:card" content="summary"/>
     <meta name="twitter:site" content="@dart_lang"/>
+    <meta name="twitter:description" content="my package description"/>
+    <meta name="twitter:image" content="https://pub.dev/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <!-- Facebook OG tags -->
+    <meta property="og:type" content="website"/>
     <meta property="og:site_name" content="Dart packages"/>
-    <title>foobar_pkg 0.2.0-dev | Dart Package</title>
     <meta property="og:title" content="foobar_pkg 0.2.0-dev | Dart Package"/>
+    <meta property="og:description" content="my package description"/>
+    <meta property="og:image" content="https://pub.dev/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <meta property="og:url" content="https://pub.dev/packages/foobar_pkg/versions/0.2.0-dev"/>
+    <title>foobar_pkg 0.2.0-dev | Dart Package</title>
     <link href="https://fonts.googleapis.com/css?family=Google+Sans:300,400,500|Google+Sans+Display:400|Roboto:300,400,500,700|Roboto+Mono:300,400,700" rel="stylesheet"/>
     <meta content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
-    <meta property="og:image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
     <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
     <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/osd.xml?hash=mocked_hash_869379763"/>
     <link rel="canonical" href="https://pub.dev/packages/foobar_pkg"/>
-    <meta property="og:url" content="https://pub.dev/packages/foobar_pkg"/>
     <meta name="description" content="my package description"/>
-    <meta property="og:description" content="my package description"/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
     <link href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842" rel="stylesheet" type="text/css"/>
     <link href="/static/highlight/github.css?hash=mocked_hash_145446167" rel="stylesheet"/>

--- a/app/test/frontend/golden/pkg_versions_page.html
+++ b/app/test/frontend/golden/pkg_versions_page.html
@@ -6,20 +6,24 @@
     <meta charset="utf-8"/>
     <meta http-equiv="x-ua-compatible" content="ie=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <!-- Twitter tags -->
     <meta name="twitter:card" content="summary"/>
     <meta name="twitter:site" content="@dart_lang"/>
+    <meta name="twitter:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
+    <meta name="twitter:image" content="https://pub.dev/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <!-- Facebook OG tags -->
+    <meta property="og:type" content="website"/>
     <meta property="og:site_name" content="Dart packages"/>
-    <title>foobar_pkg package - All Versions</title>
     <meta property="og:title" content="foobar_pkg package - All Versions"/>
+    <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
+    <meta property="og:image" content="https://pub.dev/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <title>foobar_pkg package - All Versions</title>
     <link href="https://fonts.googleapis.com/css?family=Google+Sans:300,400,500|Google+Sans+Display:400|Roboto:300,400,500,700|Roboto+Mono:300,400,700" rel="stylesheet"/>
     <meta content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
-    <meta property="og:image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
     <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
     <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/osd.xml?hash=mocked_hash_869379763"/>
     <link rel="canonical" href="https://pub.dev/packages/foobar_pkg"/>
-    <meta property="og:url" content="https://pub.dev/packages/foobar_pkg"/>
     <meta name="description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
-    <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
     <link href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842" rel="stylesheet" type="text/css"/>
     <link href="/static/highlight/github.css?hash=mocked_hash_145446167" rel="stylesheet"/>

--- a/app/test/frontend/golden/publisher_list_page.html
+++ b/app/test/frontend/golden/publisher_list_page.html
@@ -6,18 +6,23 @@
     <meta charset="utf-8"/>
     <meta http-equiv="x-ua-compatible" content="ie=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <!-- Twitter tags -->
     <meta name="twitter:card" content="summary"/>
     <meta name="twitter:site" content="@dart_lang"/>
+    <meta name="twitter:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
+    <meta name="twitter:image" content="https://pub.dev/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <!-- Facebook OG tags -->
+    <meta property="og:type" content="website"/>
     <meta property="og:site_name" content="Dart packages"/>
-    <title>Publishers</title>
     <meta property="og:title" content="Publishers"/>
+    <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
+    <meta property="og:image" content="https://pub.dev/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <title>Publishers</title>
     <link href="https://fonts.googleapis.com/css?family=Google+Sans:300,400,500|Google+Sans+Display:400|Roboto:300,400,500,700|Roboto+Mono:300,400,700" rel="stylesheet"/>
     <meta content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
-    <meta property="og:image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
     <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
     <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/osd.xml?hash=mocked_hash_869379763"/>
     <meta name="description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
-    <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
     <link href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842" rel="stylesheet" type="text/css"/>
     <link href="/static/highlight/github.css?hash=mocked_hash_145446167" rel="stylesheet"/>

--- a/app/test/frontend/golden/publisher_packages_page.html
+++ b/app/test/frontend/golden/publisher_packages_page.html
@@ -6,18 +6,23 @@
     <meta charset="utf-8"/>
     <meta http-equiv="x-ua-compatible" content="ie=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <!-- Twitter tags -->
     <meta name="twitter:card" content="summary"/>
     <meta name="twitter:site" content="@dart_lang"/>
+    <meta name="twitter:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
+    <meta name="twitter:image" content="https://pub.dev/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <!-- Facebook OG tags -->
+    <meta property="og:type" content="website"/>
     <meta property="og:site_name" content="Dart packages"/>
-    <title>Packages of publisher example.com</title>
     <meta property="og:title" content="Packages of publisher example.com"/>
+    <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
+    <meta property="og:image" content="https://pub.dev/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <title>Packages of publisher example.com</title>
     <link href="https://fonts.googleapis.com/css?family=Google+Sans:300,400,500|Google+Sans+Display:400|Roboto:300,400,500,700|Roboto+Mono:300,400,700" rel="stylesheet"/>
     <meta content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
-    <meta property="og:image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
     <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
     <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/osd.xml?hash=mocked_hash_869379763"/>
     <meta name="description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
-    <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
     <link href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842" rel="stylesheet" type="text/css"/>
     <link href="/static/highlight/github.css?hash=mocked_hash_145446167" rel="stylesheet"/>

--- a/app/test/frontend/golden/search_page.html
+++ b/app/test/frontend/golden/search_page.html
@@ -7,18 +7,23 @@
     <meta http-equiv="x-ua-compatible" content="ie=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <meta name="robots" content="noindex"/>
+    <!-- Twitter tags -->
     <meta name="twitter:card" content="summary"/>
     <meta name="twitter:site" content="@dart_lang"/>
+    <meta name="twitter:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
+    <meta name="twitter:image" content="https://pub.dev/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <!-- Facebook OG tags -->
+    <meta property="og:type" content="website"/>
     <meta property="og:site_name" content="Dart packages"/>
-    <title>Search results for foobar.</title>
     <meta property="og:title" content="Search results for foobar."/>
+    <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
+    <meta property="og:image" content="https://pub.dev/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <title>Search results for foobar.</title>
     <link href="https://fonts.googleapis.com/css?family=Google+Sans:300,400,500|Google+Sans+Display:400|Roboto:300,400,500,700|Roboto+Mono:300,400,700" rel="stylesheet"/>
     <meta content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
-    <meta property="og:image" content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
     <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
     <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/osd.xml?hash=mocked_hash_869379763"/>
     <meta name="description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
-    <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
     <link href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842" rel="stylesheet" type="text/css"/>
     <link href="/static/highlight/github.css?hash=mocked_hash_145446167" rel="stylesheet"/>


### PR DESCRIPTION
- Addresses most issues in #3330
- Refactored header to make it clear what we are sharing as social tag metadata.
- Fixed the difference between `rel="canonical"` (which is used to de-duplicate potentially similar content for Google) and `og:url` (which is to use FB share links).
- Fixed the image url: full URI is needed.