### PR TITLE
Do not make links bolder in the new design

### DIFF
--- a/pkg/web_css/lib/src/_base.scss
+++ b/pkg/web_css/lib/src/_base.scss
@@ -130,11 +130,14 @@ a {
   text-decoration: none;
   color: $color-link;
   cursor: pointer;
-  font-weight: 500;
   opacity: 1;
 
   &:hover {
     opacity: 0.8;
+  }
+
+  body.non-experimental & {
+    font-weight: 500;
   }
 }
 


### PR DESCRIPTION
We have a few `font-weight` compensation in the new design CSS files, checked them, and they are all required, can't really remove them with this change.