### PR TITLE
Local integration script to test with multiple SDKs.

### DIFF
--- a/pkg/pub_integration/lib/pub_integration.dart
+++ b/pkg/pub_integration/lib/pub_integration.dart
@@ -13,8 +13,10 @@ Future verifyPub({
   @required String credentialsFileContent,
   @required String invitedEmail,
   @required InviteCompleterFn inviteCompleterFn,
+  String clientSdkDir,
 }) async {
   final pubToolScript = PublishingScript(
+    clientSdkDir,
     pubHostedUrl,
     credentialsFileContent,
     invitedEmail,

--- a/pkg/pub_integration/lib/script/publishing.dart
+++ b/pkg/pub_integration/lib/script/publishing.dart
@@ -19,6 +19,7 @@ typedef InviteCompleterFn = Future<void> Function();
 /// A single object to execute integration script and verification tests with the
 /// `pub` tool on the pub.dev site (or on a test site).
 class PublishingScript {
+  final String clientSdkDir;
   final String pubHostedUrl;
   final String credentialsFileContent;
   final String invitedEmail;
@@ -35,6 +36,7 @@ class PublishingScript {
   Directory _retryDir;
 
   PublishingScript(
+    this.clientSdkDir,
     this.pubHostedUrl,
     this.credentialsFileContent,
     this.invitedEmail,

--- a/pkg/pub_integration/test/pub_integration_test.dart
+++ b/pkg/pub_integration/test/pub_integration_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:http/http.dart' as http;
 import 'package:test/test.dart';
@@ -64,6 +65,7 @@ void main() {
         credentialsFileContent: fakeCredentialsFileContent(),
         invitedEmail: 'dev@example.org',
         inviteCompleterFn: inviteCompleterFn,
+        clientSdkDir: Platform.environment['PUB_INTEGRATION_CLIENT_SDK_DIR'],
       );
     });
   }, timeout: Timeout.factor(testTimeoutFactor));

--- a/pkg/pub_integration/tool/download-local-dart-sdks-mac.sh
+++ b/pkg/pub_integration/tool/download-local-dart-sdks-mac.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Downloads Dart SDKs for Mac to test old (and bleeding edge) pub clients for potential breaking changes.
+
+set -e
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+PUB_INTEGRATION_DIR="$( cd ${SCRIPT_DIR}/.. && pwd )"
+PROJECT_DIR="$( cd ${PUB_INTEGRATION_DIR}/../.. && pwd )"
+LOCAL_DART_SDKS_DIR="${PUB_INTEGRATION_DIR}/.local-dart-sdks"
+
+# Change to pkg/pub_integration/.dart-sdks folder
+mkdir ${LOCAL_DART_SDKS_DIR}
+cd ${LOCAL_DART_SDKS_DIR}
+
+# Clear previously downloaded SDKs
+rm -rf ${LOCAL_DART_SDKS_DIR}/*
+
+# Last 1.X stable
+curl -sS https://storage.googleapis.com/dart-archive/channels/stable/release/1.24.3/sdk/dartsdk-macos-x64-release.zip >dartsdk.zip
+unzip -q dartsdk.zip && rm -f dartsdk.zip
+mv dart-sdk dart-sdk-1.24.3
+
+# Current bleeding edge
+curl -sS https://storage.googleapis.com/dart-archive/channels/dev/release/2.8.0-dev.10.0/sdk/dartsdk-macos-x64-release.zip >dartsdk.zip
+unzip -q dartsdk.zip && rm -f dartsdk.zip
+mv dart-sdk dart-sdk-2.8.0-dev.10.0

--- a/pkg/pub_integration/tool/test-fake-with-local-dart-sdks.sh
+++ b/pkg/pub_integration/tool/test-fake-with-local-dart-sdks.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Runs the fake_pub_server pub integration test with the downloaded local Dart SDKs.
+
+set -e
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+PUB_INTEGRATION_DIR="$( cd ${SCRIPT_DIR}/.. && pwd )"
+PROJECT_DIR="$( cd ${PUB_INTEGRATION_DIR}/../.. && pwd )"
+LOCAL_DART_SDKS_DIR="${PUB_INTEGRATION_DIR}/.local-dart-sdks"
+
+# Change to pkg/pub_integration
+ls -1 ${LOCAL_DART_SDKS_DIR} | while read i;
+do
+  echo "Running tests using ${i}..."
+  PUB_INTEGRATION_CLIENT_SDK_DIR="${LOCAL_DART_SDKS_DIR}/${i}" pub run test test/pub_integration_test.dart
+done


### PR DESCRIPTION
The intended scope is to test old (and new) SDKs (their `pub` client tool) with the current `pkg/fake_pub_server` (and check the #3343 refactoring to not break anything). It is a local testing only script (download part is for Mac).
