### PR TITLE
Code blocks styles on new UI

### DIFF
--- a/app/lib/frontend/templates/views/pkg/install_tab_experimental.mustache
+++ b/app/lib/frontend/templates/views/pkg/install_tab_experimental.mustache
@@ -1,0 +1,46 @@
+{{! Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+    for details. All rights reserved. Use of this source code is governed by a
+    BSD-style license that can be found in the LICENSE file. }}
+{{#use_as_an_executable}}
+<h2>Use this package as an executable</h2>
+<h3>1. Install it</h3>
+<p>You can install the package from the command line:</p>
+<pre><code class="language-shell">$ <strong>pub global activate {{package}}</strong>
+</code></pre>
+<h3>2. Use it</h3>
+<p>The package has the following executables:</p>
+<pre><code class="language-shell">{{#executables}}$ <strong>{{.}}</strong>
+{{/executables}}
+</code></pre>
+{{/use_as_an_executable}}
+{{#use_as_a_library}}
+<h2>Use this package as a library</h2>
+<h3>1. Depend on it</h3>
+<p>Add this to your package's pubspec.yaml file:</p>
+<pre><code class="language-yaml">dependencies:
+  <strong>{{package}}: {{example_version_constraint}}</strong>
+</code></pre>
+<h3>2. Install it</h3>
+<p>You can install packages from the command line:</p>
+{{#use_pub_get}}
+  <p>with pub:</p>
+  <pre><code class="language-shell">$ <strong>pub get</strong>
+</code></pre>
+{{/use_pub_get}}
+{{#use_flutter_packages_get}}
+  <p>with Flutter:</p>
+  <pre><code class="language-shell">$ <strong>flutter pub get</strong>
+</code></pre>
+{{/use_flutter_packages_get}}
+{{#show_editor_support}}
+<p>Alternatively, your editor might support {{& editor_supported_tool_html}}.
+  Check the docs for your editor to learn more.</p>
+{{/show_editor_support}}
+{{#has_libraries}}
+  <h3>3. Import it</h3>
+  <p>Now in your Dart code, you can use:
+  </p>
+  <pre><code class="language-dart">{{#import_examples}}import 'package:{{package}}/{{library}}';
+{{/import_examples}}</code></pre>
+{{/has_libraries}}
+{{/use_as_a_library}}

--- a/pkg/web_css/lib/src/_base.scss
+++ b/pkg/web_css/lib/src/_base.scss
@@ -156,6 +156,7 @@ main {
   padding: 0 20px;
 }
 
+/* TODO: remove this block after migrating to the new UI */
 code {
   background: #f8f8f8;
   border: 1px solid #eee;
@@ -164,10 +165,43 @@ code {
   padding: 2px;
 }
 
+/* TODO: remove this block after migrating to the new UI */
 pre > code {
   display: block;
-  overflow-x: auto;
   padding: 0.5em;
+  overflow-x: auto;
+
+  body.non-experimental & {
+    overflow-x: auto;
+  }
+}
+
+/* non-indented rule to restrict the content of this block to the experimental pages */
+body.experimental {
+
+.markdown-body code,
+code {
+  background: #f5f5f7;
+  border: none;
+  border-radius: 4px;
+  font-family: $font-family-roboto-mono;
+  padding: 2px 4px;
+}
+
+.markdown-body pre,
+pre {
+  background: #f5f5f7;
+  padding: 30px;
+  overflow-x: auto;
+
+  > code {
+    padding: 0 !important;
+    border-radius: 0;
+    display: block;
+  }
+}
+
+/* non-indented rule to restrict the content of this block to the experimental pages */
 }
 
 ._banner-bg {


### PR DESCRIPTION
- Removed extra empty lines from "Installing" tab.
- Added padding to `<pre>` blocks, adjusted border styles.

It turns out that three styles are competing to change the look and feel here:
- `github-markdown.css`
- `highlightjs`'s style
- our own style

It limits how we can change the style in a gradual way, and I can't use the `.non-experimental` wrapper around the old rules.

<img width="677" alt="Screen Shot 2020-02-21 at 16 41 57" src="https://user-images.githubusercontent.com/4778111/75048899-91d47100-54c9-11ea-8a5b-4a05fcdca7e7.png">
