### PR TITLE
Small analysis tab adjustments

### DIFF
--- a/app/lib/frontend/templates/views/pkg/analysis/suggestion_block_experimental.mustache
+++ b/app/lib/frontend/templates/views/pkg/analysis/suggestion_block_experimental.mustache
@@ -1,0 +1,16 @@
+{{! Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+    for details. All rights reserved. Use of this source code is governed by a
+    BSD-style license that can be found in the LICENSE file. }}
+<h2>{{label}}</h2>
+{{#suggestions}}
+<div class="suggestion-row">
+  <div class="suggestion-title">
+    <span class="{{icon_class}}"></span>
+    {{& title_html}}
+  </div>
+  <div class="suggestion-description">
+    {{& description_html}}
+    {{& suggestion_help_html}}
+  </div>
+</div>
+{{/suggestions}}

--- a/app/lib/frontend/templates/views/pkg/analysis/tab_experimental.mustache
+++ b/app/lib/frontend/templates/views/pkg/analysis/tab_experimental.mustache
@@ -1,0 +1,43 @@
+{{! Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+    for details. All rights reserved. Use of this source code is governed by a
+    BSD-style license that can be found in the LICENSE file. }}
+
+{{& score_table_html }}
+
+<div class="learn-more-scoring">
+  Learn more about <a class="learn-more-scoring-link" href="/help#scoring">scoring</a>.
+</div>
+
+{{#show_discontinued}}
+<p>This package is not analyzed, because it is discontinued.</p>
+{{/show_discontinued}}
+{{#show_outdated}}
+<p>
+  This package version is not analyzed, because it is more than two years old.
+  Check the <a href="{{& analysis_tab_url}}">latest stable version</a> for its analysis.
+</p>
+{{/show_outdated}}
+{{#show_legacy}}
+<p>
+  The package version is not analyzed, because it does not support Dart 2.
+  Until this is resolved, the package will receive a health and maintenance score of 0.
+</p>
+{{/show_legacy}}
+{{#show_analysis}}
+<p>
+  We analyzed this package on {{date_completed}}, and provided a score, details, and suggestions below.
+  Analysis was completed with status <i>{{analysis_status}}</i> using:
+</p>
+
+<ul>
+  <li>Dart: {{dart_sdk_version}}</li>
+  <li>pana: {{pana_version}}</li>
+{{#flutter_version}}<li>Flutter: {{flutter_version}}</li>{{/flutter_version}}
+</ul>
+{{/show_analysis}}
+
+{{& analysis_suggestions_html}}
+{{& health_suggestions_html}}
+{{& maintenance_suggestions_html}}
+
+{{& dep_table_html }}

--- a/pkg/web_css/lib/src/_pkg_experimental.scss
+++ b/pkg/web_css/lib/src/_pkg_experimental.scss
@@ -86,6 +86,17 @@ body.experimental {
   }
 }
 
+.learn-more-scoring {
+  border-bottom: 1px solid #c8c8ca;
+  padding-bottom: 4px;
+  margin-bottom: 16px;
+  text-align: right;
+
+  > .learn-more-scoring-link {
+    font-weight: 400;
+  }
+}
+
 .dependency-table {
   width: 100%;
   border-spacing: 0;


### PR DESCRIPTION
- "Learn more..." link is now handled with proper non-inlined style.
- "Health suggestions" is becomes `h2`.

Otherwise the templates are unchanged compared to the non-experimental versions.