### PR TITLE
Package admin page adjustment

### DIFF
--- a/app/lib/frontend/templates/views/pkg/admin_page.mustache
+++ b/app/lib/frontend/templates/views/pkg/admin_page.mustache
@@ -2,7 +2,7 @@
     for details. All rights reserved. Use of this source code is governed by a
     BSD-style license that can be found in the LICENSE file. }}
 
-<h3>Package ownership</h3>
+<h2>Package ownership</h2>
 <div>
   {{^pkg_has_publisher}}
   <p>
@@ -34,11 +34,12 @@
     <label class="mdc-floating-label">Select a publisher</label>
     <div class="mdc-line-ripple"></div>
   </div>
-  <br />
-  <button
-    id="-admin-set-publisher-button"
-    class="pub-button-danger mdc-button mdc-button--raised"
-    data-mdc-auto-init="MDCRipple">Transfer to publisher</button>
+  <p>
+    <button
+      id="-admin-set-publisher-button"
+      class="pub-button-danger mdc-button mdc-button--raised"
+      data-mdc-auto-init="MDCRipple">Transfer to publisher</button>
+  </p>
   {{/user_has_publisher}}
   {{^user_has_publisher}}
   <p>
@@ -47,7 +48,7 @@
   {{/user_has_publisher}}
 </div>
 
-<h3>Discontinued</h3>
+<h2>Discontinued</h2>
 {{^is_discontinued}}
 <div>
   <p>

--- a/app/test/frontend/golden/pkg_admin_page_outdated.html
+++ b/app/test/frontend/golden/pkg_admin_page_outdated.html
@@ -147,7 +147,7 @@ Published
           </ul>
           <div class="main detail-tabs-content">
             <section class="tab-content -active" data-name="-admin-tab-">
-              <h3>Package ownership</h3>
+              <h2>Package ownership</h2>
               <div>
                 <p>
     You can transfer this package to a verified publisher if you are a member of the publisher.
@@ -167,10 +167,11 @@ Published
                   <label class="mdc-floating-label">Select a publisher</label>
                   <div class="mdc-line-ripple"></div>
                 </div>
-                <br/>
-                <button id="-admin-set-publisher-button" class="pub-button-danger mdc-button mdc-button--raised" data-mdc-auto-init="MDCRipple">Transfer to publisher</button>
+                <p>
+                  <button id="-admin-set-publisher-button" class="pub-button-danger mdc-button mdc-button--raised" data-mdc-auto-init="MDCRipple">Transfer to publisher</button>
+                </p>
               </div>
-              <h3>Discontinued</h3>
+              <h2>Discontinued</h2>
               <div>
                 <p>
     If no one is maintaining this package, you can mark it as discontinued.

--- a/pkg/web_css/lib/src/_account.scss
+++ b/pkg/web_css/lib/src/_account.scss
@@ -15,10 +15,6 @@
   margin-left: 20px;
 }
 
-#-admin-set-publisher-button {
-  margin-top: 20px;
-}
-
 #-admin-set-publisher-input {
   min-width: 200px;
 }


### PR DESCRIPTION
This is mostly for the new UI, but it was non-controversial to have the same change on the current UI, therefore I haven't added a new template or additional rules.

- Header levels are `h2`.
- Removed top header and leading `<br>` from the  "Transfer to publisher" button, added it inside a `<p>` block.