### PR TITLE
Fix detail tab's height.

### DIFF
--- a/pkg/web_css/lib/src/_detail_page_experimental.scss
+++ b/pkg/web_css/lib/src/_detail_page_experimental.scss
@@ -269,7 +269,7 @@ $detail-tabs-width: calc(100% - 320px);
     color: white;
     display: inline-block;
     font-weight: 400;
-    padding: 1px 8px;
+    padding: 0px 8px;
     border-radius: 12px;
   }
 }


### PR DESCRIPTION
The extra padding pushed the bottom border 1-2px down, and it was off while hovering on top of it. The label seems to be ok without the extra pixel padding.