### PR TITLE
New publisher admin styles.

### DIFF
--- a/app/lib/frontend/templates/publisher.dart
+++ b/app/lib/frontend/templates/publisher.dart
@@ -161,11 +161,13 @@ String renderPublisherAdminPage({
     'description': publisher.description,
     'website_url': publisher.websiteUrl,
     'contact_email': publisher.contactEmail,
-    'member_list': members.map((m) => {
-          'user_id': m.userId,
-          'email': m.email,
-          'role': m.role,
-        }),
+    'member_list': members
+        .map((m) => {
+              'user_id': m.userId,
+              'email': m.email,
+              'role': m.role,
+            })
+        .toList(),
   });
   final tabs = <Tab>[
     _packagesLinkTab(publisher.publisherId),
@@ -173,7 +175,6 @@ String renderPublisherAdminPage({
       id: 'admin',
       title: 'Admin',
       contentHtml: adminContent,
-      isMarkdown: true,
     ),
   ];
 

--- a/app/lib/frontend/templates/views/publisher/admin_page_experimental.mustache
+++ b/app/lib/frontend/templates/views/publisher/admin_page_experimental.mustache
@@ -1,0 +1,104 @@
+{{! Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+    for details. All rights reserved. Use of this source code is governed by a
+    BSD-style license that can be found in the LICENSE file. }}
+
+<h2>Publisher information</h2>
+<div class="-pub-form-row">
+  <div class="mdc-text-field mdc-text-field--textarea" data-mdc-auto-init="MDCTextField">
+    <div class="mdc-text-field-character-counter">0 / 4096</div>
+    <textarea id="-publisher-description" class="mdc-text-field__input" rows="5" cols="60" maxlength="4096">{{description}}</textarea>
+    <div class="mdc-notched-outline">
+      <div class="mdc-notched-outline__leading"></div>
+      <div class="mdc-notched-outline__notch">
+        <label for="-publisher-description" class="mdc-floating-label">Description</label>
+      </div>
+      <div class="mdc-notched-outline__trailing"></div>
+    </div>
+  </div>
+</div>
+<div class="-pub-form-row">
+  <div class="mdc-text-field mdc-text-field--outlined" data-mdc-auto-init="MDCTextField">
+    <input type="text" id="-publisher-website-url" class="mdc-text-field__input" value="{{website_url}}" />
+    <div class="mdc-notched-outline">
+      <div class="mdc-notched-outline__leading"></div>
+      <div class="mdc-notched-outline__notch">
+        <label for="-publisher-website-url" class="mdc-floating-label">Website</label>
+      </div>
+      <div class="mdc-notched-outline__trailing"></div>
+    </div>
+  </div>
+</div>
+<div class="-pub-form-row">
+  <div class="mdc-text-field mdc-text-field--outlined" data-mdc-auto-init="MDCTextField">
+    <input type="text" id="-publisher-contact-email" class="mdc-text-field__input" value="{{contact_email}}" />
+    <div class="mdc-notched-outline">
+      <div class="mdc-notched-outline__leading"></div>
+      <div class="mdc-notched-outline__notch">
+        <label for="-publisher-contact-email" class="mdc-floating-label">Contact email</label>
+      </div>
+      <div class="mdc-notched-outline__trailing"></div>
+    </div>
+  </div>
+</div>
+<p class="-pub-form-right-aligned">
+  <button
+    id="-publisher-update-button"
+    class="mdc-button mdc-button--raised"
+    data-mdc-auto-init="MDCRipple">Update</button>
+</p>
+<h2>Members</h2>
+
+<div id="-pub-publisher-admin-members-table" class="mdc-data-table">
+  <table class="mdc-data-table__table" aria-label="Members of publisher">
+    <thead>
+      <tr class="mdc-data-table__header-row">
+        <th class="mdc-data-table__header-cell email-header" role="columnheader" scope="col">Email</th>
+        <th class="mdc-data-table__header-cell role-header" role="columnheader" scope="col">Role</th>
+        <th class="mdc-data-table__header-cell icons-header" role="columnheader" scope="col"></th>
+      </tr>
+    </thead>
+    <tbody class="mdc-data-table__content">
+      {{#member_list}}
+      <tr class="mdc-data-table__row">
+        <td class="mdc-data-table__cell">{{email}}</td>
+        <td class="mdc-data-table__cell">{{role}}</td>
+        <td class="mdc-data-table__cell">
+          <a class="-pub-remove-user-button"
+             data-user-id="{{user_id}}"
+             data-email="{{email}}"
+             title="Remove member">&times;</a>
+        </td>
+      </tr>
+      {{/member_list}}
+    </tbody>
+  </table>
+</div>
+
+<h2>Invite new member</h2>
+<p>
+  You can invite new members to this verified publisher.
+  Once new members accept the invitation, they have full administrative rights, with the following abilities:
+</p>
+<ul>
+  <li>Transfer packages to and from this publisher</li>
+  <li>Upload new versions of packages owned by this publisher</li>
+  <li>Add and remove members of this publisher</li>
+</ul>
+<div class="-pub-form-row">
+  <div class="mdc-text-field mdc-text-field--outlined" data-mdc-auto-init="MDCTextField">
+    <input type="text" id="-admin-invite-member-input" class="mdc-text-field__input" />
+    <div class="mdc-notched-outline">
+      <div class="mdc-notched-outline__leading"></div>
+      <div class="mdc-notched-outline__notch">
+        <label for="-admin-invite-member-input" class="mdc-floating-label">email address</label>
+      </div>
+      <div class="mdc-notched-outline__trailing"></div>
+    </div>
+  </div>
+</div>
+<p class="-pub-form-right-aligned">
+  <button
+    id="-admin-invite-member-button"
+    class="mdc-button mdc-button--raised"
+    data-mdc-auto-init="MDCRipple">Invite member</button>
+</p>

--- a/pkg/web_css/lib/src/_account.scss
+++ b/pkg/web_css/lib/src/_account.scss
@@ -1,3 +1,11 @@
+/* Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+   for details. All rights reserved. Use of this source code is governed by a
+   BSD-style license that can be found in the LICENSE file. */
+
+/* TODO: Delete this file after we have migrated to the new UI */
+/* non-indented rule to restrict the content of this block to the non-experimental pages */
+body.non-experimental {
+
 .-pub-form-row {
   margin: 20px 0px;
   
@@ -17,4 +25,7 @@
 
 #-admin-set-publisher-input {
   min-width: 200px;
+}
+
+/* non-indented rule to restrict the content of this block to the non-experimental pages */
 }

--- a/pkg/web_css/lib/src/_form.scss
+++ b/pkg/web_css/lib/src/_form.scss
@@ -1,0 +1,62 @@
+/* Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+   for details. All rights reserved. Use of this source code is governed by a
+   BSD-style license that can be found in the LICENSE file. */
+
+/* non-indented rule to restrict the content of this block to the experimental pages */
+body.experimental {
+
+.-pub-form-row {
+  margin: 20px 0px;
+
+  .mdc-text-field {
+    min-width: 100%;
+  }
+}
+
+.-pub-form-right-aligned {
+  text-align: right;
+}
+
+#-pub-publisher-admin-members-table {
+  width: 100%;
+  border-width: 0px;
+
+  .mdc-data-table__row {
+    border-top-color: #f5f5f7;
+
+    &:hover {
+      background: inherit;
+    }
+
+    &:nth-child(even) {
+      background: #f5f5f7;
+    }
+  }
+
+  .mdc-data-table__header-cell,
+  .mdc-data-table__cell {
+    font-weight: 300;
+  }
+
+  .mdc-data-table__cell {
+    color: rgba(0, 0, 0, 0.85);
+  }
+
+  .email-header { width: 60%; }
+  .role-header  { width: 30%; }
+
+  .-pub-remove-user-button {
+    border-radius: 3px;
+    color: #444444;
+    display: inline-block;
+    padding: 2px 8px;
+
+    &:hover {
+      background: $color-input-danger;
+      color: white;
+    }
+  }
+}
+
+/* non-indented rule to restrict the content of this block to the experimental pages */
+}

--- a/pkg/web_css/lib/style.scss
+++ b/pkg/web_css/lib/style.scss
@@ -5,6 +5,7 @@
 @import 'src/_detail_page';
 @import 'src/_detail_page_experimental';
 @import 'src/_footer';
+@import 'src/_form';
 @import 'src/_account';
 @import 'src/_list';
 @import 'src/_list_experimental';


### PR DESCRIPTION
The following items were added as pending to #3246:
- Input fields have their label inside / on the border, and not outside. Should we use that? (should be consistent with other places, e.g. create publisher)
- "Invite member" flow has many extra text currently, new design does not have it. Should we display that as part of the confirm?
- "Remove member" button is unstyled and non-material (no ripple).

Screenshot:
<img width="445" alt="Screen Shot 2020-02-28 at 14 01 29" src="https://user-images.githubusercontent.com/4778111/75550832-0dd33980-5a33-11ea-954f-e992c426e458.png">

`_admin.scss` was a bad name for such styles, I've started `_form.scss` instead.