### PR TITLE
Refactor template: listing_info

### DIFF
--- a/app/lib/frontend/templates/listing.dart
+++ b/app/lib/frontend/templates/listing.dart
@@ -4,6 +4,8 @@
 
 import 'dart:math';
 
+import 'package:meta/meta.dart';
+
 import 'package:pub_dev/account/models.dart';
 import 'package:pub_dev/shared/utils.dart';
 
@@ -122,16 +124,16 @@ String renderPkgIndexPage(
     'sdk_tabs_html': renderSdkTabs(searchQuery: searchQuery),
     'subsdk_label': _subSdkLabel(searchQuery),
     'subsdk_tabs_html': renderSubSdkTabsHtml(searchQuery: searchQuery),
-    'sort_control_html': renderSortControl(searchQuery),
     'is_search': isSearch,
+    'listing_info_html': renderListingInfo(
+      searchQuery: searchQuery,
+      totalCount: totalCount,
+      title: title ?? topPackages,
+    ),
     'package_list_html': renderPackageList(packages, searchQuery: searchQuery),
     'has_packages': packages.isNotEmpty,
     'pagination': renderPagination(links),
-    'total_count': totalCount,
     'legacy_search_enabled': searchQuery?.includeLegacy ?? false,
-    // TODO(3246): remove the keys below after we have migrated to the new design
-    'title': title ?? topPackages,
-    'search_query': searchQuery?.query,
   };
   final content = templateCache.renderTemplate('pkg/index', values);
 
@@ -153,6 +155,24 @@ String renderPkgIndexPage(
     searchPlaceHolder: searchPlaceholder,
     mainClasses: requestContext.isExperimental ? [] : null,
   );
+}
+
+/// Renders the `views/shared/listing_info.mustache` template.
+String renderListingInfo({
+  @required SearchQuery searchQuery,
+  @required int totalCount,
+  String title,
+}) {
+  final isSearch = searchQuery != null && searchQuery.hasQuery;
+  return templateCache.renderTemplate('shared/listing_info', {
+    'sort_control_html': renderSortControl(searchQuery),
+    'total_count': totalCount,
+    // TODO(3246): remove the keys below after we have migrated to the new design
+    'is_search': isSearch,
+    'has_title': !isSearch && title != null,
+    'title': title,
+    'search_query': searchQuery?.query,
+  });
 }
 
 String _subSdkLabel(SearchQuery sq) {

--- a/app/lib/frontend/templates/views/pkg/index.mustache
+++ b/app/lib/frontend/templates/views/pkg/index.mustache
@@ -2,14 +2,7 @@
     for details. All rights reserved. Use of this source code is governed by a
     BSD-style license that can be found in the LICENSE file. }}
 
-{{& sort_control_html}}
-
-{{^is_search}}
-<h2 class="listing-page-title">{{title}}</h2>
-{{/is_search}}
-{{#is_search}}
-  <p class="package-count"><span>{{total_count}}</span> results for <code>{{search_query}}</code></p>
-{{/is_search}}
+{{& listing_info_html }}
 
 {{& package_list_html}}
 

--- a/app/lib/frontend/templates/views/pkg/index_experimental.mustache
+++ b/app/lib/frontend/templates/views/pkg/index_experimental.mustache
@@ -33,13 +33,7 @@
 </div>
 
 <div class="container">
-  <div class="listing-info">
-    <div class="listing-info-count">
-      <span class="info-identifier">Results</span>
-      <span class="count">{{total_count}}</span>
-    </div>
-    {{& sort_control_html}}
-  </div>
+  {{& listing_info_html }}
 
   {{& package_list_html}}
 

--- a/app/lib/frontend/templates/views/shared/listing_info.mustache
+++ b/app/lib/frontend/templates/views/shared/listing_info.mustache
@@ -1,0 +1,13 @@
+{{! Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+    for details. All rights reserved. Use of this source code is governed by a
+    BSD-style license that can be found in the LICENSE file. }}
+
+{{& sort_control_html }}
+
+{{#has_title}}
+  <h2 class="listing-page-title">{{title}}</h2>
+{{/has_title}}
+
+{{#is_search}}
+  <p class="package-count"><span>{{total_count}}</span> results for <code>{{search_query}}</code></p>
+{{/is_search}}

--- a/app/lib/frontend/templates/views/shared/listing_info_experimental.mustache
+++ b/app/lib/frontend/templates/views/shared/listing_info_experimental.mustache
@@ -1,0 +1,11 @@
+{{! Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+    for details. All rights reserved. Use of this source code is governed by a
+    BSD-style license that can be found in the LICENSE file. }}
+
+<div class="listing-info">
+  <div class="listing-info-count">
+    <span class="info-identifier">Results</span>
+    <span class="count">{{ total_count }}</span>
+  </div>
+  {{& sort_control_html }}
+</div>


### PR DESCRIPTION
`listing_info` is the template for the top of the listing pages: title, number of results, sort control... However, we are using a slightly different method of displaying the same thing for publishers, this refactor is the first step to unify the two, and eventually use the same template.