### PR TITLE
Full-width tab and content for detail pages without info-box.

### DIFF
--- a/app/lib/frontend/templates/detail_page.dart
+++ b/app/lib/frontend/templates/detail_page.dart
@@ -46,6 +46,7 @@ String renderDetailPage({
     'header_html': headerHtml,
     'tabs_html': renderDetailTabs(tabs),
     'info_box_lead': requestContext.isExperimental ? infoBoxLead : null,
+    'has_info_box': infoBoxHtml != null,
     'info_box_html': infoBoxHtml,
     'footer_html': footerHtml,
   });

--- a/app/lib/frontend/templates/views/shared/detail/page_experimental.mustache
+++ b/app/lib/frontend/templates/views/shared/detail/page_experimental.mustache
@@ -2,16 +2,16 @@
     for details. All rights reserved. Use of this source code is governed by a
     BSD-style license that can be found in the LICENSE file. }}
 
-<div class="detail-wrapper -active">
+<div class="detail-wrapper -active{{#has_info_box}} -has-info-box{{/has_info_box}}">
   {{& header_html}}
 
-  {{#info_box_lead}}
+  {{#has_info_box}}
     <div class="detail-lead">
       <div class="detail-metadata-toggle">&rightarrow;</div>
       <h3 class="detail-lead-title">Metadata</h3>
       <p class="detail-lead-text">{{info_box_lead}}</p>
     </div>
-  {{/info_box_lead}}
+  {{/has_info_box}}
 
   <div class="detail-container">
     <div class="detail-tabs">
@@ -28,7 +28,7 @@
   {{& footer_html}}
 </div>
 
-{{#info_box_lead}}
+{{#has_info_box}}
 <div class="detail-metadata">
   <h3 class="detail-metadata-title"><span class="detail-metadata-toggle">&leftarrow;</span> Metadata</h3>
 
@@ -36,4 +36,4 @@
   {{& info_box_html}}
   </div>
 </div>
-{{/info_box_lead}}
+{{/has_info_box}}

--- a/pkg/web_css/lib/src/_detail_page_experimental.scss
+++ b/pkg/web_css/lib/src/_detail_page_experimental.scss
@@ -110,22 +110,24 @@ $detail-tabs-width: calc(100% - 320px);
 }
 
 @media (min-width: $device-desktop-min-width) {
-  .detail-header {
-    width: $detail-tabs-width;
-  }
-
   .detail-container {
 
     >.detail-tabs {
       vertical-align: top;
       display: inline-block;
-      width: $detail-tabs-width;
     }
 
     >.detail-info-box {
       display: inline-block;
       margin-left: $info-box-margin;
       width: $info-box-width;
+    }
+  }
+
+  .detail-wrapper.-has-info-box {
+    .detail-header,
+    .detail-container > .detail-tabs {
+      width: $detail-tabs-width;
     }
   }
 }


### PR DESCRIPTION
- This is the first half of the layout change required for publisher's header styles.
- Also fixes the mobile-view "metadata" link: if there is an infobox without a lead text, we still want to display the "Metadata ->" link to view the infobox.