### PR TITLE
Removing mobile-view style rules from footer.scss

### DIFF
--- a/pkg/web_css/lib/src/_footer.scss
+++ b/pkg/web_css/lib/src/_footer.scss
@@ -32,13 +32,3 @@
     }
   }
 }
-
-@media screen and (max-width: 640px) {
-  .site-footer {
-    padding: 0;
-
-    > .link {
-      display: block;
-    }
-  }
-}


### PR DESCRIPTION
Before:
<img width="407" alt="Screen Shot 2020-03-02 at 14 45 05" src="https://user-images.githubusercontent.com/4778111/75681780-8e44a500-5c94-11ea-9f37-cd0c8f014c53.png">

After:
<img width="406" alt="Screen Shot 2020-03-02 at 14 45 40" src="https://user-images.githubusercontent.com/4778111/75681787-90a6ff00-5c94-11ea-9d04-acf88abec35a.png">
