### PR TITLE
Update landing page styles.

### DIFF
--- a/pkg/web_css/lib/src/_home.scss
+++ b/pkg/web_css/lib/src/_home.scss
@@ -119,7 +119,7 @@
 
     &.home-block-ff {
       .home-block-content {
-        max-width: 1180px;
+        max-width: 1200px;
         margin: 0 auto;
       }
 
@@ -130,8 +130,14 @@
       }
 
       .mini-list-item {
-        width: 360px;
-        margin: 8px 16px;
+        width: 48%;
+        max-width: 360px;
+        margin: 16px 1%;
+
+        // At this width the package box has a width of ~260px.
+        @media (min-width: 906px) {
+          width: 30%;
+        }
       }
     }
 
@@ -139,14 +145,16 @@
     &.home-block-tf,
     &.home-block-td, {
       display: flex;
+      max-width: 1480px;
+      margin: 0 auto;
 
       .home-block-image {
-        flex-basis: 33%;
+        flex-basis: 25%;
         margin-top: 80px;
       }
 
       .home-block-content {
-        flex-basis: 67%;
+        flex-basis: 75%;
       }
 
       .mini-list {
@@ -156,8 +164,14 @@
       }
 
       .mini-list-item {
-        width: 20vw;
-        margin: 8px;
+        width: 48%;
+        max-width: 360px;
+        margin: 0 1% 2% 1%;
+
+        // At this width the package box has a width of ~260px.
+        @media (min-width: 1196px) {
+          width: 30%;
+        }
       }
     }
   }
@@ -181,8 +195,8 @@
 
     .description {
       margin: 8px 0px;
-      max-height: 100px;
-      overflow: hidden;
+      max-height: 120px;
+      overflow: auto;
     }
 
     .publisher {


### PR DESCRIPTION
These were optimisations to have better "elasticity" between screen width of 900-1500px:
- Package boxes are between 260-360px, depending on the resolution.
- Smaller images in order to give enough space for package boxes when 3 of them are displayed.
- Full screen average laptop width (1280px) now displays 3 packages in a row with reasonable width.
- Large screen (1400px+) are now not looking that weird with the limit on the max width we are using.
- A bit larger description heigh, so that most descriptions will fit into it. Overflow changed to scroll in case we have some edge case that doesn't fit.

Mobile view was unchanged.