### PR TITLE
Style update for my-liked-packages

### DIFF
--- a/app/lib/frontend/templates/admin.dart
+++ b/app/lib/frontend/templates/admin.dart
@@ -112,8 +112,8 @@ String renderMyLikedPackagesPage(
   final likedPackagesListHtml = renderMyLikedPackagesList(likes);
 
   final resultCountHtml = likes.isNotEmpty
-      ? 'You like ${likes.length} ${likes.length == 1 ? 'package' : 'packages'}. '
-      : 'You have not liked any packages yet.';
+      ? '<p>You like ${likes.length} ${likes.length == 1 ? 'package' : 'packages'}. </p>'
+      : '<p>You have not liked any packages yet.</p>';
 
   final tabContent = [
     resultCountHtml,

--- a/app/lib/frontend/templates/views/pkg/liked_package_list_experimental.mustache
+++ b/app/lib/frontend/templates/views/pkg/liked_package_list_experimental.mustache
@@ -1,0 +1,29 @@
+{{! Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+    for details. All rights reserved. Use of this source code is governed by a
+    BSD-style license that can be found in the LICENSE file. }}
+
+<div class="packages -compact">
+  {{#packages}}
+    <div class="packages-item">
+      <div class="packages-header">
+        <h3 class="packages-title"><a href="{{& url }}">{{ name }}</a></h3>
+        <div class="packages-icons">
+          <button
+            class="mdc-button mdc-button--unelevated -pub-like-button"
+            data-mdc-auto-init="MDCRipple"
+            data-package="{{name}}"
+            data-thumb_up_outlined="{{{static_assets.img__thumb-up-24px_svg}}}"
+            data-thumb_up_filled="{{{static_assets.img__thumb-up-filled-24px_svg}}}">
+            <div class="mdc-button__ripple"></div>
+            <img
+              class="mdc-button__icon -pub-like-button-img"
+              src="{{{static_assets.img__thumb-up-filled-24px_svg}}}"
+              aria-hidden="true"/>
+            <span class="mdc-button__label -pub-like-button-text">Unlike</span>
+          </button>
+        </div>
+      </div>
+      <p class="packages-metadata"> Liked on: <span>{{ liked_date }}</span></p>
+    </div>
+  {{/packages}}
+</div>

--- a/app/test/frontend/golden/my_liked_packages.html
+++ b/app/test/frontend/golden/my_liked_packages.html
@@ -107,9 +107,7 @@
           </ul>
           <div class="main detail-tabs-content">
             <section class="tab-content -active" data-name="-liked-packages-tab-">
-      You like 2 packages. 
-
-
+              <p>You like 2 packages. </p>
               <ul class="package-list">
                 <li class="list-item -compact">
                   <button class="mdc-button mdc-button--unelevated -pub-like-button" data-mdc-auto-init="MDCRipple" data-package="super_package" data-thumb_up_outlined="/static/img/thumb-up-24px.svg?hash=mocked_hash_808020279" data-thumb_up_filled="/static/img/thumb-up-filled-24px.svg?hash=mocked_hash_368133424">

--- a/pkg/web_css/lib/src/_base.scss
+++ b/pkg/web_css/lib/src/_base.scss
@@ -201,12 +201,19 @@ pre {
 }
 
 .-pub-like-button {
-  float: right;
-  width: 100px;
-}
+  body.non-experimental & {
+    float: right;
+    width: 100px;
 
-.-pub-like-button-text {
-  color: #000;
+    .-pub-like-button-text {
+      color: #000;
+    }
+  }
+
+  body.experimental & {
+    --mdc-theme-primary: #f8f8f8;
+    --mdc-theme-on-primary: #000000;
+  }
 }
 
 .center {

--- a/pkg/web_css/lib/src/_list_experimental.scss
+++ b/pkg/web_css/lib/src/_list_experimental.scss
@@ -319,6 +319,14 @@ body.experimental {
   .score-box {
     float: none;
   }
+
+  &.-compact {
+    .packages-item {
+      @media (min-width: $device-desktop-min-width) {
+        padding: 4px 8px;
+      }
+    }
+  }
 }
 
 /* non-indented rule to restrict the content of this block to the experimental pages */


### PR DESCRIPTION
- Updated template to use the same styles as we have for package listing + added `-compact` rule to that.
- Updated button style with the newly discovered material customization.
- Screenshot with this grey box is the highlight we get when hovering over the row:
  <img width="649" alt="Screen Shot 2020-03-04 at 16 50 21" src="https://user-images.githubusercontent.com/4778111/75897076-4b233700-5e38-11ea-872b-ceea1f0ccb59.png">
