### PR TITLE
Adjusted styles for the list of publishers.

### DIFF
--- a/app/lib/frontend/templates/publisher.dart
+++ b/app/lib/frontend/templates/publisher.dart
@@ -39,6 +39,7 @@ String renderPublisherList(List<Publisher> publishers,
       ? 'No publisher has been registered.'
       : 'You are not a member of any <a href="https://dart.dev/tools/pub/verified-publishers" target="_blank" rel="noreferrer">verified publishers</a>.';
   return templateCache.renderTemplate('publisher/publisher_list', {
+    'is_global': isGlobal,
     'title': isGlobal ? 'Publishers' : null,
     'no_publisher_message_html': noPublisherHtml,
     'has_publishers': publishers.isNotEmpty,

--- a/app/lib/frontend/templates/views/publisher/publisher_list_experimental.mustache
+++ b/app/lib/frontend/templates/views/publisher/publisher_list_experimental.mustache
@@ -1,0 +1,29 @@
+{{! Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+    for details. All rights reserved. Use of this source code is governed by a
+    BSD-style license that can be found in the LICENSE file. }}
+
+{{#title}}
+<h2>{{ title }}</h2>
+{{/title}}
+
+{{#has_publishers}}
+<div class="publishers{{#is_global}} -global{{/is_global}}">
+  {{#publishers}}
+  <div class="publishers-item">
+    <h3><a href="{{& url }}">{{ publisher_id }}</a></h3>
+    <p>
+      Registered on {{ short_created }}.
+    </p>
+  </div>
+  {{/publishers}}
+</div>
+{{/has_publishers}}
+
+{{^has_publishers}}
+<p>{{& no_publisher_message_html }}</p>
+{{/has_publishers}}
+
+<h3>Want to create a new publisher?</h3>
+<p>
+  Use the <a href="{{& create_publisher_url }}">create publisher</a> page.
+</p>

--- a/pkg/web_css/lib/src/_list_experimental.scss
+++ b/pkg/web_css/lib/src/_list_experimental.scss
@@ -330,5 +330,23 @@ body.experimental {
   }
 }
 
+.publishers {
+  .publishers-item {
+    padding: 4px;
+
+    &:hover {
+      background: #fafafa;
+    }
+  }
+
+  &.-global {
+    display: flex;
+
+    .publishers-item {
+      flex: 1 1 26%;
+    }
+  }
+}
+
 /* non-indented rule to restrict the content of this block to the experimental pages */
 }


### PR DESCRIPTION
Previously the package and publisher lists shared some of the layout, now they are separate, and this is adjusting the style name and the CSS rules for publishers.

<img width="652" alt="Screen Shot 2020-03-06 at 17 29 23" src="https://user-images.githubusercontent.com/4778111/76102447-514c1b80-5fd0-11ea-87d4-a94001e21ded.png">
