### PR TITLE
Refactor: don't need to push down API handler object.

### DIFF
--- a/app/lib/frontend/handlers.dart
+++ b/app/lib/frontend/handlers.dart
@@ -26,13 +26,10 @@ void _logPubHeaders(shelf.Request request) {
 }
 
 /// Handler for the whole URL space of the pub site.
-///
-/// The passed in [shelfPubApi] handler will be used for handling requests to
-///   - /api/*
-shelf.Handler createAppHandler(shelf.Handler shelfPubApi) {
+shelf.Handler createAppHandler() {
   final legacyDartdocHandler = LegacyDartdocService().router.handler;
   final pubDartlangOrgHandler = PubDartlangOrgService().router.handler;
-  final pubSiteHandler = PubSiteService(shelfPubApi).router.handler;
+  final pubSiteHandler = PubSiteService().router.handler;
   return (shelf.Request request) async {
     _logPubHeaders(request);
 

--- a/app/lib/frontend/handlers/pubapi.dart
+++ b/app/lib/frontend/handlers/pubapi.dart
@@ -21,7 +21,7 @@ part 'pubapi.g.dart';
 class PubApi {
   final Handler _pubServerHandler;
 
-  PubApi(this._pubServerHandler);
+  PubApi() : _pubServerHandler = packageBackend.pubServer.requestHandler;
 
   Router get router => _$PubApiRouter(this);
 

--- a/app/lib/frontend/handlers/routes.dart
+++ b/app/lib/frontend/handlers/routes.dart
@@ -21,13 +21,10 @@ part 'routes.g.dart';
 
 /// The main routes that are processed by the pub site's frontend.
 class PubSiteService {
-  final Handler _pubServerHandler;
-  PubSiteService(this._pubServerHandler);
-
   Router get router => _$PubSiteServiceRouter(this);
 
   @Route.mount('/')
-  Router get _api => PubApi(_pubServerHandler).router;
+  Router get _api => PubApi().router;
 
   // ****
   // **** AppEngine health checks

--- a/app/lib/service/entrypoint/frontend.dart
+++ b/app/lib/service/entrypoint/frontend.dart
@@ -23,7 +23,6 @@ import '../../dartdoc/dartdoc_client.dart';
 import '../../frontend/handlers.dart';
 import '../../frontend/static_files.dart';
 import '../../frontend/templates/_cache.dart';
-import '../../package/backend.dart';
 import '../../package/deps_graph.dart';
 import '../../package/name_tracker.dart';
 import '../../package/upload_signer_service.dart';
@@ -76,8 +75,7 @@ Future _main(FrontendEntryMessage message) async {
       storageService,
       activeConfiguration.backupSnapshotBucketName,
     ));
-    final appHandler =
-        createAppHandler(packageBackend.pubServer.requestHandler);
+    final appHandler = createAppHandler();
 
     if (envConfig.isRunningLocally) {
       await _watchForResourceChanges();

--- a/app/test/frontend/handlers/_utils.dart
+++ b/app/test/frontend/handlers/_utils.dart
@@ -29,7 +29,7 @@ void tScopedTest(String name, Future<void> Function() func) {
 Future<shelf.Response> issueGet(String path, {String host}) async {
   final uri = host == null ? '$siteRoot$path' : 'https://$host$path';
   final request = shelf.Request('GET', Uri.parse(uri));
-  final handler = createAppHandler(null);
+  final handler = createAppHandler();
   final wrapped = wrapHandler(Logger('test'), handler, sanitize: true);
   return await ss.fork(() async {
     return await wrapped(request);

--- a/app/test/shared/test_services.dart
+++ b/app/test/shared/test_services.dart
@@ -125,7 +125,7 @@ http_testing.MockClient _httpClient({
   shelf.Handler handler,
   String authToken,
 }) {
-  handler ??= createAppHandler(null);
+  handler ??= createAppHandler();
   handler = wrapHandler(
     Logger.detached('test'),
     handler,

--- a/pkg/fake_pub_server/lib/fake_pub_server.dart
+++ b/pkg/fake_pub_server/lib/fake_pub_server.dart
@@ -19,7 +19,6 @@ import 'package:pub_dev/account/backend.dart';
 import 'package:pub_dev/account/testing/fake_auth_provider.dart';
 import 'package:pub_dev/frontend/handlers.dart';
 import 'package:pub_dev/frontend/testing/fake_upload_signer_service.dart';
-import 'package:pub_dev/package/backend.dart';
 import 'package:pub_dev/package/name_tracker.dart';
 import 'package:pub_dev/package/upload_signer_service.dart';
 import 'package:pub_dev/publisher/domain_verifier.dart';
@@ -56,9 +55,7 @@ class FakePubServer {
 
           nameTracker.startTracking();
 
-          final apiHandler = packageBackend.pubServer.requestHandler;
-
-          final appHandler = createAppHandler(apiHandler);
+          final appHandler = createAppHandler();
           final handler = wrapHandler(_logger, appHandler, sanitize: true);
 
           final server = await IOServer.bind('localhost', port);


### PR DESCRIPTION
In preparation for more #3343 refactoring.