### PR TITLE
Adjust search client retry attempts

### DIFF
--- a/app/lib/search/search_client.dart
+++ b/app/lib/search/search_client.dart
@@ -37,8 +37,13 @@ class SearchClient {
     final String serviceUrl = '$httpHostPort/search$serviceUrlParams';
 
     Future<PackageSearchResult> searchFn() async {
-      final response = await getUrlWithRetry(_httpClient, serviceUrl,
-          timeout: Duration(seconds: 5));
+      final response = await getUrlWithRetry(
+        _httpClient,
+        serviceUrl,
+        timeout: Duration(seconds: 5),
+        // limit to a single attempt, no need to retry after timeout
+        retryCount: 0,
+      );
       if (response.statusCode == searchIndexNotReadyCode) {
         // Search request before the service initialization completed.
         return null;


### PR DESCRIPTION
Fixes #3363. The prior PR added the 5-second timeout, but the default retry on the method tried it a second time, making the original request serving to 10+ seconds. In one case this caused the user to reload the same search query several more times.
