### PR TITLE
Refactor pub_server handlers

### DIFF
--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -161,7 +161,6 @@ class PackageBackend {
   /// Get a [Uri] which can be used to download a tarball of the pub package.
   Future<Uri> downloadUrl(String package, String version) async {
     version = canonicalizeVersion(version);
-    assert(repository.supportsDownloadUrl);
     return repository.downloadUrl(package, version);
   }
 
@@ -419,18 +418,12 @@ class GCloudPackageRepository extends PackageRepository {
   }
 
   @override
-  bool get supportsDownloadUrl => true;
-
-  @override
   Future<Uri> downloadUrl(String package, String version) async {
     version = canonicalizeVersion(version);
     return storage.downloadUrl(package, version);
   }
 
   // Upload support.
-
-  @override
-  bool get supportsUpload => true;
 
   @override
   Future<PackageVersion> upload(Stream<List<int>> data) async {
@@ -445,9 +438,6 @@ class GCloudPackageRepository extends PackageRepository {
     );
     return await finishAsyncUpload(finishUri);
   }
-
-  @override
-  bool get supportsAsyncUpload => true;
 
   @override
   Future<AsyncUploadInfo> startAsyncUpload(Uri redirectUrl) async {
@@ -672,9 +662,6 @@ class GCloudPackageRepository extends PackageRepository {
   }
 
   // Uploaders support.
-
-  @override
-  bool get supportsUploaders => true;
 
   @override
   Future<void> addUploader(String packageName, String uploaderEmail) async {

--- a/app/lib/package/pub_server/repository.dart
+++ b/app/lib/package/pub_server/repository.dart
@@ -123,17 +123,11 @@ abstract class PackageRepository {
   /// Whether the [version] of [package] exists.
   Future<PackageVersion> lookupVersion(String package, String version);
 
-  /// Whether this package repository supports uploading packages.
-  bool get supportsUpload => false;
-
   /// Uploads a  pub package.
   ///
   /// [data] must be a stream of a valid .tar.gz file.
   Future<PackageVersion> upload(Stream<List<int>> data) async =>
       throw UnsupportedError('No upload support.');
-
-  /// Whether this package repository supports asynchronous uploads.
-  bool get supportsAsyncUpload => false;
 
   /// Starts a  upload.
   ///
@@ -153,15 +147,9 @@ abstract class PackageRepository {
   /// Downloads a pub package.
   Future<Stream<List<int>>> download(String package, String version);
 
-  /// Whether this package repository supports download URLs.
-  bool get supportsDownloadUrl => false;
-
   /// A permanent download URL to a package (if supported).
   Future<Uri> downloadUrl(String package, String version) async =>
       throw UnsupportedError('No download link support.');
-
-  /// Whether this package repository supports adding/removing users.
-  bool get supportsUploaders => false;
 
   /// Adds [userEmail] as an uploader to [package].
   Future addUploader(String package, String userEmail) async =>


### PR DESCRIPTION
- #3343
- Tested with:
  - manual API calls
  - integration tests on fake_pub_server with `1.24.3`, `2.7.0` and `2.8.0-dev.10.0` SDKs

Notes for later follow-ups:
- `/api/packages/<package>/versions/<version>.tar.gz` is not working currently, maybe it is a pattern matching issue (#3427).
-  `/api/packages/versions/newUpload` has no known use by us (keeping it in the `shelf_pubserver.dart` for now)

