### PR TITLE
Do not allow filename-like version pattern.

### DIFF
--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -925,6 +925,10 @@ Future<_ValidatedUpload> _parseAndValidateUpload(
     throw GenericProcessingException(
         'Unable to canonicalize the version: ${pubspec.version}');
   }
+  if (versionString.endsWith('tar.gz')) {
+    throw GenericProcessingException(
+        'The version string must not contain archive filename pattern: ${pubspec.version}');
+  }
 
   final key =
       models.QualifiedVersionKey(package: pubspec.name, version: versionString);

--- a/app/test/package/backend_test.dart
+++ b/app/test/package/backend_test.dart
@@ -553,8 +553,9 @@ void main() {
         });
 
         // Returns the error message as String or null if it succeeded.
-        Future<String> fn(String name) async {
-          final pubspecContent = generatePubspecYaml(name, '0.2.0');
+        Future<String> fn(String name, {String version}) async {
+          version ??= '0.2.0';
+          final pubspecContent = generatePubspecYaml(name, version);
           try {
             final tarball =
                 await packageArchiveBytes(pubspecContent: pubspecContent);
@@ -590,6 +591,14 @@ void main() {
 
           expect(await fn('mo_derate'),
               'Package name is too similar to another active or moderated package.');
+        });
+
+        testWithServices('version with filename pattern is rejected', () async {
+          await nameTracker.scanDatastore();
+          registerAuthenticatedUser(hansUser);
+
+          expect(await fn('some_new_package_name', version: '1.0.0-tar.gz'),
+              'The version string must not contain archive filename pattern: 1.0.0-tar.gz');
         });
 
         testWithServices('upload-too-big', () async {


### PR DESCRIPTION
Not a full fix yet, but mitigates one vector of #3427.