### PR TITLE
Change (future) archive download endpoint.

### DIFF
--- a/app/lib/frontend/handlers/pubapi.client.dart
+++ b/app/lib/frontend/handlers/pubapi.client.dart
@@ -43,7 +43,7 @@ class PubApiClient {
   Future<List<int>> fetchPackage(String package, String version) async {
     return await _client.requestBytes(
       verb: 'get',
-      path: '/api/packages/$package/versions/$version.tar.gz',
+      path: '/api/packages/$package/versions/$version/archive.tar.gz',
     );
   }
 

--- a/app/lib/frontend/handlers/pubapi.dart
+++ b/app/lib/frontend/handlers/pubapi.dart
@@ -45,7 +45,7 @@ class PubApi {
 
   /// Downloading package.
   /// https://github.com/dart-lang/pub/blob/master/doc/repository-spec-v2.md#download-a-specific-version-of-a-package
-  @EndPoint.get('/api/packages/<package>/versions/<version>.tar.gz')
+  @EndPoint.get('/api/packages/<package>/versions/<version>/archive.tar.gz')
   @EndPoint.get('/packages/<package>/versions/<version>.tar.gz')
   Future<Response> fetchPackage(
     Request request,

--- a/app/lib/frontend/handlers/pubapi.dart
+++ b/app/lib/frontend/handlers/pubapi.dart
@@ -45,6 +45,9 @@ class PubApi {
 
   /// Downloading package.
   /// https://github.com/dart-lang/pub/blob/master/doc/repository-spec-v2.md#download-a-specific-version-of-a-package
+  ///
+  /// NOTE: `/packages/<package>/versions/<version>.tar.gz` is hardcoded into the
+  /// clients, so while this is deprecated we need to support it indefinitely.
   @EndPoint.get('/api/packages/<package>/versions/<version>/archive.tar.gz')
   @EndPoint.get('/packages/<package>/versions/<version>.tar.gz')
   Future<Response> fetchPackage(

--- a/app/lib/frontend/handlers/pubapi.g.dart
+++ b/app/lib/frontend/handlers/pubapi.g.dart
@@ -37,8 +37,9 @@ Router _$PubApiRouter(PubApi service) {
       return $utilities.unhandledError(e, st);
     }
   });
-  router.add('GET', r'/api/packages/<package>/versions/<version>.tar.gz',
-      (Request request, String package, String version) async {
+  router
+      .add('GET', r'/api/packages/<package>/versions/<version>/archive.tar.gz',
+          (Request request, String package, String version) async {
     try {
       final _$result = await service.fetchPackage(
         request,

--- a/pkg/web_app/lib/src/pubapi.client.dart
+++ b/pkg/web_app/lib/src/pubapi.client.dart
@@ -43,7 +43,7 @@ class PubApiClient {
   Future<List<int>> fetchPackage(String package, String version) async {
     return await _client.requestBytes(
       verb: 'get',
-      path: '/api/packages/$package/versions/$version.tar.gz',
+      path: '/api/packages/$package/versions/$version/archive.tar.gz',
     );
   }
 


### PR DESCRIPTION
- Fixes #3427
- I think `[..]/archive.tar.gz` is better than `[..]/archive`, as it indicates that it will be a file in the given format.