### PR TITLE
Shared package page data and handler logic.

### DIFF
--- a/app/lib/frontend/templates/package_admin.dart
+++ b/app/lib/frontend/templates/package_admin.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import '../../analyzer/analyzer_client.dart';
 import '../../package/models.dart';
 import '../../shared/urls.dart' as urls;
 
@@ -13,29 +12,23 @@ import 'package.dart';
 
 /// Renders the `views/pkg/admin_page` template.
 String renderPkgAdminPage(
-  Package package,
-  List<String> uploaderEmails,
-  PackageVersion version,
-  AnalysisView analysis,
+  PackagePageData data,
   List<String> userPublishers,
 ) {
   final tabs = buildPackageTabs(
-    package: package,
-    version: version,
-    analysis: analysis,
-    isAdmin: true,
+    packagePageData: data,
     adminTab: Tab.withContent(
       id: 'admin',
       title: 'Admin',
       contentHtml: templateCache.renderTemplate('pkg/admin_page', {
-        'pkg_has_publisher': package.publisherId != null,
-        'publisher_id': package.publisherId,
-        'is_discontinued': package.isDiscontinued,
+        'pkg_has_publisher': data.package.publisherId != null,
+        'publisher_id': data.package.publisherId,
+        'is_discontinued': data.package.isDiscontinued,
         'user_has_publisher': userPublishers.isNotEmpty,
         'user_publishers': userPublishers
             .map((s) => {
                   'publisher_id': s,
-                  'selected': s == package.publisherId,
+                  'selected': s == data.package.publisherId,
                 })
             .toList(),
         'create_publisher_url': urls.createPublisherUrl(),
@@ -44,17 +37,17 @@ String renderPkgAdminPage(
   );
 
   final content = renderDetailPage(
-    headerHtml: renderPkgHeader(package, version, false, analysis),
+    headerHtml: renderPkgHeader(data),
     tabs: tabs,
-    infoBoxLead: version.ellipsizedDescription,
-    infoBoxHtml: renderPkgInfoBox(package, version, uploaderEmails, analysis),
+    infoBoxLead: data.version.ellipsizedDescription,
+    infoBoxHtml: renderPkgInfoBox(data),
   );
 
   return renderLayoutPage(
     PageType.package,
     content,
-    title: '${package.name} package - Admin',
-    pageData: pkgPageData(package, version),
+    title: '${data.package.name} package - Admin',
+    pageData: pkgPageData(data.package, data.version),
     noIndex: true,
   );
 }

--- a/app/lib/frontend/templates/package_versions.dart
+++ b/app/lib/frontend/templates/package_versions.dart
@@ -2,9 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:meta/meta.dart';
-
-import '../../analyzer/analyzer_client.dart';
 import '../../package/models.dart';
 import '../../shared/urls.dart' as urls;
 
@@ -18,14 +15,10 @@ import 'package.dart';
 
 /// Renders the `views/pkg/versions/index` template.
 String renderPkgVersionsPage(
-    Package package,
-    bool isLiked,
-    List<String> uploaderEmails,
-    PackageVersion latestVersion,
-    List<PackageVersion> versions,
-    List<Uri> versionDownloadUrls,
-    AnalysisView latestAnalysis,
-    {@required bool isAdmin}) {
+  PackagePageData data,
+  List<PackageVersion> versions,
+  List<Uri> versionDownloadUrls,
+) {
   assert(versions.length == versionDownloadUrls.length);
 
   final stableVersionRows = [];
@@ -53,7 +46,7 @@ String renderPkgVersionsPage(
     htmlBlocks.add(templateCache.renderTemplate('pkg/versions/index', {
       'id': 'stable',
       'kind': 'Stable',
-      'package': {'name': package.name},
+      'package': {'name': data.package.name},
       'version_table_rows': stableVersionRows,
     }));
   }
@@ -61,16 +54,13 @@ String renderPkgVersionsPage(
     htmlBlocks.add(templateCache.renderTemplate('pkg/versions/index', {
       'id': 'dev',
       'kind': 'Dev',
-      'package': {'name': package.name},
+      'package': {'name': data.package.name},
       'version_table_rows': devVersionRows,
     }));
   }
 
   final tabs = buildPackageTabs(
-    package: package,
-    version: latestVersion,
-    analysis: latestAnalysis,
-    isAdmin: isAdmin,
+    packagePageData: data,
     versionsTab: Tab.withContent(
       id: 'versions',
       title: 'Versions',
@@ -79,23 +69,20 @@ String renderPkgVersionsPage(
   );
 
   final content = renderDetailPage(
-    headerHtml:
-        renderPkgHeader(package, latestVersion, isLiked, latestAnalysis),
+    headerHtml: renderPkgHeader(data),
     tabs: tabs,
-    infoBoxLead: latestVersion.ellipsizedDescription,
-    infoBoxHtml: renderPkgInfoBox(
-        package, latestVersion, uploaderEmails, latestAnalysis),
-    footerHtml:
-        renderPackageSchemaOrgHtml(package, latestVersion, latestAnalysis),
+    infoBoxLead: data.version.ellipsizedDescription,
+    infoBoxHtml: renderPkgInfoBox(data),
+    footerHtml: renderPackageSchemaOrgHtml(data),
   );
 
   return renderLayoutPage(
     PageType.package,
     content,
-    title: '${package.name} package - All Versions',
-    canonicalUrl: urls.pkgPageUrl(package.name, includeHost: true),
-    pageData: pkgPageData(package, latestVersion),
-    noIndex: package.isDiscontinued,
+    title: '${data.package.name} package - All Versions',
+    canonicalUrl: urls.pkgPageUrl(data.package.name, includeHost: true),
+    pageData: pkgPageData(data.package, data.version),
+    noIndex: data.package.isDiscontinued,
   );
 }
 

--- a/app/lib/package/models.dart
+++ b/app/lib/package/models.dart
@@ -11,6 +11,7 @@ import 'package:json_annotation/json_annotation.dart';
 import 'package:meta/meta.dart';
 import 'package:pub_semver/pub_semver.dart';
 
+import '../analyzer/analyzer_client.dart' show AnalysisView;
 import '../package/model_properties.dart';
 import '../scorecard/models.dart';
 import '../search/search_service.dart' show ApiPageRef;
@@ -564,6 +565,40 @@ class PackageLinks {
       repositoryUrl: repositoryUrl,
       issueTrackerUrl: issueTrackerUrl,
       baseUrl: baseUrl,
+    );
+  }
+}
+
+/// Common data structure shared between package pages.
+class PackagePageData {
+  final Package package;
+  final PackageVersion version;
+  final AnalysisView analysis;
+  final List<String> uploaderEmails;
+  final bool isAdmin;
+  final bool isLiked;
+
+  PackagePageData({
+    @required this.package,
+    @required this.version,
+    @required this.analysis,
+    @required this.uploaderEmails,
+    @required this.isAdmin,
+    @required this.isLiked,
+  });
+
+  PackagePageData.missingVersion({@required this.package})
+      : version = null,
+        analysis = null,
+        uploaderEmails = null,
+        isAdmin = null,
+        isLiked = null;
+
+  PackageView toPackageView() {
+    return PackageView.fromModel(
+      package: package,
+      version: version,
+      scoreCard: analysis?.card,
     );
   }
 }

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -136,12 +136,12 @@ void main() {
     });
 
     scopedTest('package show page', () {
-      final String html = renderPkgShowPage(
-        foobarPackage,
-        false,
-        foobarUploaderEmails,
-        foobarStablePV,
-        AnalysisView(
+      final String html = renderPkgShowPage(PackagePageData(
+        package: foobarPackage,
+        isLiked: false,
+        uploaderEmails: foobarUploaderEmails,
+        version: foobarStablePV,
+        analysis: AnalysisView(
           card: ScoreCardData(
             reportTypes: ['pana', 'dartdoc'],
             healthScore: 0.1,
@@ -187,18 +187,18 @@ void main() {
           ),
         ),
         isAdmin: true,
-      );
+      ));
 
       expectGoldenFile(html, 'pkg_show_page.html');
     });
 
     scopedTest('package show page - with version', () {
-      final String html = renderPkgShowPage(
-        foobarPackage,
-        false,
-        foobarUploaderEmails,
-        foobarDevPV,
-        AnalysisView(
+      final String html = renderPkgShowPage(PackagePageData(
+        package: foobarPackage,
+        isLiked: false,
+        uploaderEmails: foobarUploaderEmails,
+        version: foobarDevPV,
+        analysis: AnalysisView(
           card: ScoreCardData(reportTypes: ['pana'], healthScore: 0.1),
           panaReport: PanaReport(
               timestamp: DateTime(2018, 02, 05),
@@ -235,17 +235,17 @@ void main() {
           dartdocReport: null,
         ),
         isAdmin: true,
-      );
+      ));
       expectGoldenFile(html, 'pkg_show_version_page.html');
     });
 
     scopedTest('package show page with flutter_plugin', () {
-      final String html = renderPkgShowPage(
-        foobarPackage,
-        false,
-        foobarUploaderEmails,
-        flutterPackageVersion,
-        AnalysisView(
+      final String html = renderPkgShowPage(PackagePageData(
+        package: foobarPackage,
+        isLiked: false,
+        uploaderEmails: foobarUploaderEmails,
+        version: flutterPackageVersion,
+        analysis: AnalysisView(
           card: ScoreCardData(
             healthScore: 0.99,
             maintenanceScore: 0.99,
@@ -269,42 +269,42 @@ void main() {
               flags: null),
         ),
         isAdmin: true,
-      );
+      ));
       expectGoldenFile(html, 'pkg_show_page_flutter_plugin.html');
     });
 
     scopedTest('package show page with outdated version', () {
-      final String html = renderPkgShowPage(
-        foobarPackage,
-        false,
-        foobarUploaderEmails,
-        foobarStablePV,
-        AnalysisView(
+      final String html = renderPkgShowPage(PackagePageData(
+        package: foobarPackage,
+        isLiked: false,
+        uploaderEmails: foobarUploaderEmails,
+        version: foobarStablePV,
+        analysis: AnalysisView(
           card: ScoreCardData(
             flags: [PackageFlags.isObsolete],
             updated: DateTime(2018, 02, 05),
           ),
         ),
         isAdmin: false,
-      );
+      ));
 
       expectGoldenFile(html, 'pkg_show_page_outdated.html');
     });
 
     scopedTest('package show page with discontinued version', () {
-      final String html = renderPkgShowPage(
-        discontinuedPackage,
-        false,
-        foobarUploaderEmails,
-        foobarStablePV,
-        AnalysisView(
+      final String html = renderPkgShowPage(PackagePageData(
+        package: discontinuedPackage,
+        isLiked: false,
+        uploaderEmails: foobarUploaderEmails,
+        version: foobarStablePV,
+        analysis: AnalysisView(
           card: ScoreCardData(
             flags: [PackageFlags.isDiscontinued],
             updated: DateTime(2018, 02, 05),
           ),
         ),
         isAdmin: false,
-      );
+      ));
 
       expectGoldenFile(html, 'pkg_show_page_discontinued.html');
     });
@@ -312,15 +312,15 @@ void main() {
     scopedTest('package show page with legacy version', () {
       final summary = createPanaSummaryForLegacy(
           foobarStablePV.package, foobarStablePV.version);
-      final String html = renderPkgShowPage(
-        foobarPackage,
-        false,
-        <String>[
+      final String html = renderPkgShowPage(PackagePageData(
+        package: foobarPackage,
+        isLiked: false,
+        uploaderEmails: <String>[
           hansUser.email,
           joeUser.email,
         ],
-        foobarStablePV,
-        AnalysisView(
+        version: foobarStablePV,
+        analysis: AnalysisView(
           card: ScoreCardData(
             popularityScore: 0.5,
             flags: [PackageFlags.isLegacy],
@@ -328,24 +328,24 @@ void main() {
           panaReport: panaReportFromSummary(summary),
         ),
         isAdmin: false,
-      );
+      ));
 
       expectGoldenFile(html, 'pkg_show_page_legacy.html');
     });
 
     scopedTest('package show page with publisher', () {
-      final String html = renderPkgShowPage(
-        lithium.package,
-        false,
-        <String>[],
-        lithium.versions.last,
-        AnalysisView(
+      final String html = renderPkgShowPage(PackagePageData(
+        package: lithium.package,
+        isLiked: false,
+        uploaderEmails: <String>[],
+        version: lithium.versions.last,
+        analysis: AnalysisView(
           card: ScoreCardData(
             updated: DateTime(2018, 02, 05),
           ),
         ),
         isAdmin: false,
-      );
+      ));
 
       expectGoldenFile(html, 'pkg_show_page_publisher.html');
     });
@@ -466,14 +466,18 @@ void main() {
 
     scopedTest('package admin page with outdated version', () {
       final String html = renderPkgAdminPage(
-        foobarPackage,
-        foobarUploaderEmails,
-        foobarStablePV,
-        AnalysisView(
-          card: ScoreCardData(
-            flags: [PackageFlags.isObsolete],
-            updated: DateTime(2018, 02, 05),
+        PackagePageData(
+          package: foobarPackage,
+          uploaderEmails: foobarUploaderEmails,
+          version: foobarStablePV,
+          analysis: AnalysisView(
+            card: ScoreCardData(
+              flags: [PackageFlags.isObsolete],
+              updated: DateTime(2018, 02, 05),
+            ),
           ),
+          isLiked: false,
+          isAdmin: true,
         ),
         [
           'example.com',
@@ -533,10 +537,21 @@ void main() {
 
     scopedTest('package versions page', () {
       final String html = renderPkgVersionsPage(
-        foobarPackage,
-        false,
-        foobarUploaderEmails,
-        foobarStablePV,
+        PackagePageData(
+          package: foobarPackage,
+          isLiked: false,
+          uploaderEmails: foobarUploaderEmails,
+          version: foobarStablePV,
+          analysis: AnalysisView(
+            card: ScoreCardData(
+              derivedTags: ['sdk:dart', 'sdk:flutter'],
+              maintenanceScore: 0.9,
+              healthScore: 0.9,
+              popularityScore: 0.2,
+            ),
+          ),
+          isAdmin: false,
+        ),
         [
           foobarStablePV,
           foobarDevPV,
@@ -545,15 +560,6 @@ void main() {
           Uri.parse('https://pub.dartlang.org/mock-download-uri.tar.gz'),
           Uri.parse('https://pub.dartlang.org/mock-download-uri.tar.gz'),
         ],
-        AnalysisView(
-          card: ScoreCardData(
-            derivedTags: ['sdk:dart', 'sdk:flutter'],
-            maintenanceScore: 0.9,
-            healthScore: 0.9,
-            popularityScore: 0.2,
-          ),
-        ),
-        isAdmin: false,
       );
       expectGoldenFile(html, 'pkg_versions_page.html');
     });


### PR DESCRIPTION
- In preparation for #3390.
- Fixes one bug: package admin page always displayed likes as not-liked.
- Otherwise no functional changes.
- `PackagePageData` is shared across many parts of the handler logic, e.g.:
  - redirecting when package (or version) is missing
  - rendering header, infobox
  - rendering page metadata
