### PR TITLE
New package pages

### DIFF
--- a/app/lib/frontend/handlers/package.dart
+++ b/app/lib/frontend/handlers/package.dart
@@ -87,6 +87,74 @@ Future<shelf.Response> packageVersionsListHandler(
   );
 }
 
+/// Handles requests for /packages/<package>/changelog
+/// Handles requests for /packages/<package>/versions/<version>/changelog
+Future<shelf.Response> packageChangelogHandler(
+    shelf.Request request, String packageName,
+    {String versionName}) async {
+  return await _handlePackagePage(
+    request: request,
+    packageName: packageName,
+    versionName: versionName,
+    renderFn: (data) {
+      if (data.version.changelog == null) {
+        return redirectResponse(
+            urls.pkgPageUrl(packageName, version: versionName));
+      }
+      return renderPkgChangelogPage(data);
+    },
+    cacheEntry: cache.uiPackageChangelog(packageName, versionName),
+  );
+}
+
+/// Handles requests for /packages/<package>/example
+/// Handles requests for /packages/<package>/versions/<version>/example
+Future<shelf.Response> packageExampleHandler(
+    shelf.Request request, String packageName,
+    {String versionName}) async {
+  return await _handlePackagePage(
+    request: request,
+    packageName: packageName,
+    versionName: versionName,
+    renderFn: (data) {
+      if (data.version.example == null) {
+        return redirectResponse(
+            urls.pkgPageUrl(packageName, version: versionName));
+      }
+      return renderPkgExamplePage(data);
+    },
+    cacheEntry: cache.uiPackageExample(packageName, versionName),
+  );
+}
+
+/// Handles requests for /packages/<package>/install
+/// Handles requests for /packages/<package>/versions/<version>/install
+Future<shelf.Response> packageInstallHandler(
+    shelf.Request request, String packageName,
+    {String versionName}) async {
+  return await _handlePackagePage(
+    request: request,
+    packageName: packageName,
+    versionName: versionName,
+    renderFn: (data) => renderPkgInstallPage(data),
+    cacheEntry: cache.uiPackageInstall(packageName, versionName),
+  );
+}
+
+/// Handles requests for /packages/<package>/score
+/// Handles requests for /packages/<package>/versions/<version>/score
+Future<shelf.Response> packageScoreHandler(
+    shelf.Request request, String packageName,
+    {String versionName}) async {
+  return await _handlePackagePage(
+    request: request,
+    packageName: packageName,
+    versionName: versionName,
+    renderFn: (data) => renderPkgScorePage(data),
+    cacheEntry: cache.uiPackageScore(packageName, versionName),
+  );
+}
+
 /// Handles requests for /packages/<package>
 /// Handles requests for /packages/<package>/versions/<version>
 Future<shelf.Response> packageVersionHandlerHtml(

--- a/app/lib/frontend/handlers/routes.dart
+++ b/app/lib/frontend/handlers/routes.dart
@@ -84,6 +84,26 @@ class PubSiteService {
   // **** Packages
   // ****
 
+  @Route.get('/packages/<package>/versions/<version>/changelog')
+  Future<Response> packageVersionChangelog(
+          Request request, String package, String version) =>
+      packageChangelogHandler(request, package, versionName: version);
+
+  @Route.get('/packages/<package>/versions/<version>/example')
+  Future<Response> packageVersionExample(
+          Request request, String package, String version) =>
+      packageExampleHandler(request, package, versionName: version);
+
+  @Route.get('/packages/<package>/versions/<version>/install')
+  Future<Response> packageVersionInstall(
+          Request request, String package, String version) =>
+      packageInstallHandler(request, package, versionName: version);
+
+  @Route.get('/packages/<package>/versions/<version>/score')
+  Future<Response> packageVersionScore(
+          Request request, String package, String version) =>
+      packageScoreHandler(request, package, versionName: version);
+
   @Route.get('/packages/<package>/versions/<version>')
   Future<Response> packageVersion(
           Request request, String package, String version) =>
@@ -92,6 +112,22 @@ class PubSiteService {
   @Route.get('/packages/<package>/admin')
   Future<Response> packageAdmin(Request request, String package) =>
       packageAdminHandler(request, package);
+
+  @Route.get('/packages/<package>/changelog')
+  Future<Response> packageChangelog(Request request, String package) =>
+      packageChangelogHandler(request, package);
+
+  @Route.get('/packages/<package>/example')
+  Future<Response> packageExample(Request request, String package) =>
+      packageExampleHandler(request, package);
+
+  @Route.get('/packages/<package>/install')
+  Future<Response> packageInstall(Request request, String package) =>
+      packageInstallHandler(request, package);
+
+  @Route.get('/packages/<package>/score')
+  Future<Response> packageScore(Request request, String package) =>
+      packageScoreHandler(request, package);
 
   @Route.get('/packages/<package>/versions')
   Future<Response> packageVersions(Request request, String package) =>

--- a/app/lib/frontend/handlers/routes.dart
+++ b/app/lib/frontend/handlers/routes.dart
@@ -94,7 +94,7 @@ class PubSiteService {
       packageAdminHandler(request, package);
 
   @Route.get('/packages/<package>/versions')
-  Future<Response> packageVersionsJson(Request request, String package) =>
+  Future<Response> packageVersions(Request request, String package) =>
       packageVersionsListHandler(request, package);
 
   @Route.get('/packages/<package>')

--- a/app/lib/frontend/handlers/routes.g.dart
+++ b/app/lib/frontend/handlers/routes.g.dart
@@ -20,9 +20,21 @@ Router _$PubSiteServiceRouter(PubSiteService service) {
   router.add('GET', r'/flutter/packages', service.flutterPackages);
   router.add('GET', r'/flutter/favorites', service.flutterFavoritesPackages);
   router.add('GET', r'/web/packages', service.webPackages);
+  router.add('GET', r'/packages/<package>/versions/<version>/changelog',
+      service.packageVersionChangelog);
+  router.add('GET', r'/packages/<package>/versions/<version>/example',
+      service.packageVersionExample);
+  router.add('GET', r'/packages/<package>/versions/<version>/install',
+      service.packageVersionInstall);
+  router.add('GET', r'/packages/<package>/versions/<version>/score',
+      service.packageVersionScore);
   router.add(
       'GET', r'/packages/<package>/versions/<version>', service.packageVersion);
   router.add('GET', r'/packages/<package>/admin', service.packageAdmin);
+  router.add('GET', r'/packages/<package>/changelog', service.packageChangelog);
+  router.add('GET', r'/packages/<package>/example', service.packageExample);
+  router.add('GET', r'/packages/<package>/install', service.packageInstall);
+  router.add('GET', r'/packages/<package>/score', service.packageScore);
   router.add('GET', r'/packages/<package>/versions', service.packageVersions);
   router.add('GET', r'/packages/<package>', service.package);
   router.add('GET', r'/documentation/<package>/<version>/<path|[^]*>',

--- a/app/lib/frontend/handlers/routes.g.dart
+++ b/app/lib/frontend/handlers/routes.g.dart
@@ -23,8 +23,7 @@ Router _$PubSiteServiceRouter(PubSiteService service) {
   router.add(
       'GET', r'/packages/<package>/versions/<version>', service.packageVersion);
   router.add('GET', r'/packages/<package>/admin', service.packageAdmin);
-  router.add(
-      'GET', r'/packages/<package>/versions', service.packageVersionsJson);
+  router.add('GET', r'/packages/<package>/versions', service.packageVersions);
   router.add('GET', r'/packages/<package>', service.package);
   router.add('GET', r'/documentation/<package>/<version>/<path|[^]*>',
       service.documentation);

--- a/app/lib/shared/redis_cache.dart
+++ b/app/lib/shared/redis_cache.dart
@@ -77,6 +77,26 @@ class CachePatterns {
       .withTTL(Duration(minutes: 10))
       .withCodec(utf8)['$package-$version'];
 
+  Entry<String> uiPackageChangelog(String package, String version) => _cache
+      .withPrefix('ui-package-changelog')
+      .withTTL(Duration(minutes: 10))
+      .withCodec(utf8)['$package-$version'];
+
+  Entry<String> uiPackageExample(String package, String version) => _cache
+      .withPrefix('ui-package-example')
+      .withTTL(Duration(minutes: 10))
+      .withCodec(utf8)['$package-$version'];
+
+  Entry<String> uiPackageInstall(String package, String version) => _cache
+      .withPrefix('ui-package-install')
+      .withTTL(Duration(minutes: 10))
+      .withCodec(utf8)['$package-$version'];
+
+  Entry<String> uiPackageScore(String package, String version) => _cache
+      .withPrefix('ui-package-score')
+      .withTTL(Duration(minutes: 10))
+      .withCodec(utf8)['$package-$version'];
+
   Entry<String> uiIndexPage() => _cache
       .withPrefix('ui-indexpage')
       .withTTL(Duration(minutes: 60))

--- a/app/lib/shared/urls.dart
+++ b/app/lib/shared/urls.dart
@@ -4,6 +4,7 @@
 
 import 'package:path/path.dart' as p;
 
+import '../frontend/request_context.dart' show requestContext;
 import '../package/overrides.dart';
 import '../search/search_service.dart' show SearchOrder, SearchQuery;
 import 'versions.dart';
@@ -38,18 +39,26 @@ String pkgReadmeUrl(String package, {String version}) =>
     pkgPageUrl(package, version: version);
 
 String pkgChangelogUrl(String package, {String version}) =>
-    pkgPageUrl(package, version: version, fragment: '-changelog-tab-');
+    requestContext.isExperimental
+        ? pkgPageUrl(package, version: version) + '/changelog'
+        : pkgPageUrl(package, version: version, fragment: '-changelog-tab-');
 
 String pkgExampleUrl(String package, {String version}) =>
-    pkgPageUrl(package, version: version, fragment: '-example-tab-');
+    requestContext.isExperimental
+        ? pkgPageUrl(package, version: version) + '/example'
+        : pkgPageUrl(package, version: version, fragment: '-example-tab-');
 
 String pkgInstallUrl(String package, {String version}) =>
-    pkgPageUrl(package, version: version, fragment: '-installing-tab-');
+    requestContext.isExperimental
+        ? pkgPageUrl(package, version: version) + '/install'
+        : pkgPageUrl(package, version: version, fragment: '-installing-tab-');
 
 String pkgVersionsUrl(String package) => pkgPageUrl(package) + '/versions';
 
 String pkgScoreUrl(String package, {String version}) =>
-    pkgPageUrl(package, version: version, fragment: '-analysis-tab-');
+    requestContext.isExperimental
+        ? pkgPageUrl(package, version: version) + '/score'
+        : pkgPageUrl(package, version: version, fragment: '-analysis-tab-');
 
 String pkgAdminUrl(String package) => pkgPageUrl(package) + '/admin';
 

--- a/app/test/frontend/golden/pkg_changelog_page.html
+++ b/app/test/frontend/golden/pkg_changelog_page.html
@@ -1,0 +1,217 @@
+<!DOCTYPE html>
+<html lang="en-us">
+  <head>
+    <script async="async" src="https://www.googletagmanager.com/gtag/js?id=UA-26406144-13"></script>
+    <script src="/static/js/gtag.js?hash=mocked_hash_221832925"></script>
+    <meta charset="utf-8"/>
+    <meta http-equiv="x-ua-compatible" content="ie=edge"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <!-- Twitter tags -->
+    <meta name="twitter:card" content="summary"/>
+    <meta name="twitter:site" content="@dart_lang"/>
+    <meta name="twitter:description" content="my package description"/>
+    <meta name="twitter:image" content="https://pub.dev/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <!-- Facebook OG tags -->
+    <meta property="og:type" content="website"/>
+    <meta property="og:site_name" content="Dart packages"/>
+    <meta property="og:title" content="foobar_pkg | Dart Package"/>
+    <meta property="og:description" content="my package description"/>
+    <meta property="og:image" content="https://pub.dev/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <meta property="og:url" content="https://pub.dev/packages/foobar_pkg"/>
+    <title>foobar_pkg | Dart Package</title>
+    <link href="https://fonts.googleapis.com/css?family=Google+Sans:300,400,500|Google+Sans+Display:400|Roboto:300,400,500,700|Roboto+Mono:300,400,700" rel="stylesheet"/>
+    <meta content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
+    <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/osd.xml?hash=mocked_hash_869379763"/>
+    <meta name="description" content="my package description"/>
+    <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
+    <link href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842" rel="stylesheet" type="text/css"/>
+    <link href="/static/highlight/github.css?hash=mocked_hash_145446167" rel="stylesheet"/>
+    <link href="/static/css/github-markdown.css?hash=mocked_hash_488759485" rel="stylesheet" type="text/css"/>
+    <link href="/static/css/style.css?hash=mocked_hash_537099079" rel="stylesheet" type="text/css"/>
+    <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
+    <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
+    <script async="async" defer="defer" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
+    <meta name="google-signin-client_id" content=""/>
+    <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
+    <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJmb29iYXJfcGtnIiwidmVyc2lvbiI6IjAuMS4xKzUiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlfX0="/>
+  </head>
+  <body class="non-experimental">
+    <header class="site-header-row">
+      <div class="site-header">
+        <h1 class="_visuallyhidden">Dart pub</h1>
+        <button class="hamburger"></button>
+        <div class="mask"></div>
+        <div class="nav-wrap">
+          <div class="nav-header">
+            <a class="logo" href="/">
+              <img src="/static/img/pub-dev-logo-2x.png?hash=mocked_hash_685890546" alt="dart pub logo"/>
+            </a>
+            <div class="_flex-space"></div>
+            <button class="close"></button>
+          </div>
+          <nav class="site-nav">
+            <span>Getting Started:</span>
+            <div class="sub-wrap hoverable">
+              <button class="button">Flutter</button>
+              <div class="sub-nav">
+                <a class="link" target="_blank" rel="noopener" href="https://flutter.io/using-packages/">Using packages</a>
+                <a class="link" target="_blank" rel="noopener" href="https://flutter.io/developing-packages/">Developing packages and plugins</a>
+                <a class="link" target="_blank" rel="noopener" href="https://dart.dev/tools/pub/publishing">Publishing a package</a>
+                <a class="link" target="_blank" rel="noopener" href="https://dart.dev/tools/pub">Pub tool</a>
+              </div>
+            </div>
+            <div class="sub-wrap hoverable">
+              <button class="button">Web &amp; Server</button>
+              <div class="sub-nav">
+                <a class="link" target="_blank" rel="noopener" href="https://dart.dev/tools/pub/get-started">Using packages</a>
+                <a class="link" target="_blank" rel="noopener" href="https://dart.dev/tools/pub/publishing">Publishing a package</a>
+                <a class="link" target="_blank" rel="noopener" href="https://dart.dev/tools/pub">Pub tool</a>
+              </div>
+            </div>
+          </nav>
+          <div></div>
+        </div>
+        <div id="account-nav">
+          <a id="-account-login" class="link">Sign in</a>
+        </div>
+      </div>
+    </header>
+    <div class="_banner-bg">
+      <div class="container">
+        <form class="search-bar banner-item" action="/packages">
+          <input class="input" name="q" placeholder="Search packages" autocomplete="on" autofocus="autofocus"/>
+          <button class="icon"></button>
+          <input id="search-legacy-field" type="hidden" name="legacy" value="1" disabled="disabled"/>
+        </form>
+      </div>
+    </div>
+    <main class="container">
+      <div class="detail-wrapper -active">
+        <div class="detail-header">
+          <h2 class="title">foobar_pkg 0.1.1+5</h2>
+          <div class="metadata">
+    
+Published 
+            <span>Jan 1, 2014</span>
+            <!-- &bull; Downloads: X -->
+  • Updated:
+  
+            <span>
+              <a href="/packages/foobar_pkg">0.1.1+5</a>
+            </span>
+    /
+    
+            <span>
+              <a href="/packages/foobar_pkg/versions/0.2.0-dev">0.2.0-dev</a>
+            </span>
+            <div class="-pub-likes">
+              <div>
+                <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-hidden="true" aria-pressed="true">
+                  <img height="18" src="/static/img/thumb-up-24px.svg?hash=mocked_hash_808020279" class="mdc-icon-button__icon"/>
+                  <img height="18" width="18" src="/static/img/thumb-up-filled-24px.svg?hash=mocked_hash_368133424" class="mdc-icon-button__icon mdc-icon-button__icon--on"/>
+                </button>
+                <span id="likes-count">0 likes</span>
+              </div>
+            </div>
+            <div class="tags">
+              <a class="package-tag unidentified" href="/packages/foobar_pkg#-analysis-tab-" title="Check the analysis tab for further details.">[unidentified]</a>
+            </div>
+          </div>
+        </div>
+        <div class="detail-body">
+          <div class="detail-tabs-wide-header">
+            <div class="detail-container">
+              <ul class="detail-tabs-header">
+                <li class="tab-link" data-name="-readme-tab-" role="button">
+                  <a href="/packages/foobar_pkg" data-ga-click-event="tab:readme">Readme</a>
+                </li>
+                <li class="tab-button -active" data-ga-click-event="tab:changelog" data-name="-changelog-tab-" role="button">Changelog</li>
+                <li class="tab-link" data-name="-example-tab-" role="button">
+                  <a href="/packages/foobar_pkg#-example-tab-" data-ga-click-event="tab:example">Example</a>
+                </li>
+                <li class="tab-link" data-name="-installing-tab-" role="button">
+                  <a href="/packages/foobar_pkg#-installing-tab-" data-ga-click-event="tab:installing">Installing</a>
+                </li>
+                <li class="tab-link" data-name="-versions-tab-" role="button">
+                  <a href="/packages/foobar_pkg/versions" data-ga-click-event="tab:versions">Versions</a>
+                </li>
+                <li class="tab-link" data-name="-analysis-tab-" role="button">
+                  <a href="/packages/foobar_pkg#-analysis-tab-" data-ga-click-event="tab:analysis">
+                    <div class="score-box">
+                      <span class="number -rotten" title="Analysis and more details.">3</span>
+                    </div>
+                  </a>
+                </li>
+                <li class="tab-link" data-name="-admin-tab-" role="button">
+                  <a href="/packages/foobar_pkg/admin" data-ga-click-event="tab:admin">Admin</a>
+                </li>
+              </ul>
+            </div>
+          </div>
+          <div class="detail-container detail-body-main">
+            <div class="detail-tabs-content">
+              <section class="tab-content -active markdown-body" data-name="-changelog-tab-">
+                <h1 class="hash-header" id="changelog">Changelog 
+                  <a href="#changelog" class="hash-link">#</a>
+                </h1>
+                <p>0.1.1 - test package</p>
+              </section>
+            </div>
+          </div>
+          <aside class="detail-info-box">
+            <h3 class="title">About</h3>
+            <p>my package description</p>
+            <p>
+              <a class="link" href="http://hans.juergen.com">Homepage</a>
+              <br/>
+              <a class="link" href="/documentation/foobar_pkg/latest/">API reference</a>
+              <br/>
+            </p>
+            <h3 class="title">Uploader</h3>
+            <p>
+              <span class="author">
+                <a href="mailto:hans@juergen.com" title="Email hans@juergen.com">
+                  <i class="email-icon"></i>
+                </a>
+                <a href="/packages?q=email%3Ahans%40juergen.com" title="Search packages with hans@juergen.com" rel="nofollow">
+                  <i class="search-icon"></i>
+                </a> hans@juergen.com
+              </span>
+            </p>
+            <h3 class="title">License</h3>
+            <p>BSD (LICENSE.txt)</p>
+            <h3 class="title">Dependencies</h3>
+            <p>
+              <a href="/packages/http">http</a>, 
+              <a href="/packages/quiver">quiver</a>
+            </p>
+            <h3 class="title">More</h3>
+            <p>
+              <a href="/packages?q=dependency%3Afoobar_pkg" rel="nofollow">Packages that depend on foobar_pkg</a>
+            </p>
+          </aside>
+        </div>
+        <script type="application/ld+json">
+{"@context":"http://schema.org","@type":"SoftwareSourceCode","name":"foobar_pkg","version":"0.1.1+5","description":"foobar_pkg - my package description","url":"https://pub.dev/packages/foobar_pkg","dateCreated":"2014-01-01T00:00:00.000Z","dateModified":"2014-01-01T00:00:00.000Z","programmingLanguage":"Dart","image":"https://pub.dev/static/img/dart-logo-400x400.png"}
+</script>
+      </div>
+    </main>
+    <footer class="site-footer">
+      <a class="link" href="https://dart.dev/">Dart language</a>
+      <a class="link sep" href="/policy">Policy</a>
+      <a class="link sep" href="https://www.google.com/intl/en/policies/terms/">Terms</a>
+      <a class="link sep" href="/security">Security</a>
+      <a class="link sep" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
+      <a class="link sep" href="/help">Help</a>
+      <a class="link sep icon" href="/feed.atom">
+        <img src="/static/img/atom-feed-icon-32x32.png?hash=mocked_hash_251226050" class="inline-icon" alt="RSS/atom feed" title="RSS/atom feed"/>
+      </a>
+      <a class="link icon github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">
+        <img src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" class="inline-icon" alt="Report an issue with this site" title="Report an issue with this site"/>
+      </a>
+    </footer>
+    <script src="/static/highlight/highlight.pack.js?hash=mocked_hash_252154265"></script>
+    <script src="/static/highlight/init.js?hash=mocked_hash_180963889"></script>
+  </body>
+</html>

--- a/app/test/frontend/golden/pkg_example_page.html
+++ b/app/test/frontend/golden/pkg_example_page.html
@@ -1,0 +1,222 @@
+<!DOCTYPE html>
+<html lang="en-us">
+  <head>
+    <script async="async" src="https://www.googletagmanager.com/gtag/js?id=UA-26406144-13"></script>
+    <script src="/static/js/gtag.js?hash=mocked_hash_221832925"></script>
+    <meta charset="utf-8"/>
+    <meta http-equiv="x-ua-compatible" content="ie=edge"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <!-- Twitter tags -->
+    <meta name="twitter:card" content="summary"/>
+    <meta name="twitter:site" content="@dart_lang"/>
+    <meta name="twitter:description" content="my package description"/>
+    <meta name="twitter:image" content="https://pub.dev/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <!-- Facebook OG tags -->
+    <meta property="og:type" content="website"/>
+    <meta property="og:site_name" content="Dart packages"/>
+    <meta property="og:title" content="foobar_pkg | Dart Package"/>
+    <meta property="og:description" content="my package description"/>
+    <meta property="og:image" content="https://pub.dev/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <meta property="og:url" content="https://pub.dev/packages/foobar_pkg"/>
+    <title>foobar_pkg | Dart Package</title>
+    <link href="https://fonts.googleapis.com/css?family=Google+Sans:300,400,500|Google+Sans+Display:400|Roboto:300,400,500,700|Roboto+Mono:300,400,700" rel="stylesheet"/>
+    <meta content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
+    <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/osd.xml?hash=mocked_hash_869379763"/>
+    <meta name="description" content="my package description"/>
+    <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
+    <link href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842" rel="stylesheet" type="text/css"/>
+    <link href="/static/highlight/github.css?hash=mocked_hash_145446167" rel="stylesheet"/>
+    <link href="/static/css/github-markdown.css?hash=mocked_hash_488759485" rel="stylesheet" type="text/css"/>
+    <link href="/static/css/style.css?hash=mocked_hash_537099079" rel="stylesheet" type="text/css"/>
+    <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
+    <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
+    <script async="async" defer="defer" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
+    <meta name="google-signin-client_id" content=""/>
+    <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
+    <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJmb29iYXJfcGtnIiwidmVyc2lvbiI6IjAuMS4xKzUiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlfX0="/>
+  </head>
+  <body class="non-experimental">
+    <header class="site-header-row">
+      <div class="site-header">
+        <h1 class="_visuallyhidden">Dart pub</h1>
+        <button class="hamburger"></button>
+        <div class="mask"></div>
+        <div class="nav-wrap">
+          <div class="nav-header">
+            <a class="logo" href="/">
+              <img src="/static/img/pub-dev-logo-2x.png?hash=mocked_hash_685890546" alt="dart pub logo"/>
+            </a>
+            <div class="_flex-space"></div>
+            <button class="close"></button>
+          </div>
+          <nav class="site-nav">
+            <span>Getting Started:</span>
+            <div class="sub-wrap hoverable">
+              <button class="button">Flutter</button>
+              <div class="sub-nav">
+                <a class="link" target="_blank" rel="noopener" href="https://flutter.io/using-packages/">Using packages</a>
+                <a class="link" target="_blank" rel="noopener" href="https://flutter.io/developing-packages/">Developing packages and plugins</a>
+                <a class="link" target="_blank" rel="noopener" href="https://dart.dev/tools/pub/publishing">Publishing a package</a>
+                <a class="link" target="_blank" rel="noopener" href="https://dart.dev/tools/pub">Pub tool</a>
+              </div>
+            </div>
+            <div class="sub-wrap hoverable">
+              <button class="button">Web &amp; Server</button>
+              <div class="sub-nav">
+                <a class="link" target="_blank" rel="noopener" href="https://dart.dev/tools/pub/get-started">Using packages</a>
+                <a class="link" target="_blank" rel="noopener" href="https://dart.dev/tools/pub/publishing">Publishing a package</a>
+                <a class="link" target="_blank" rel="noopener" href="https://dart.dev/tools/pub">Pub tool</a>
+              </div>
+            </div>
+          </nav>
+          <div></div>
+        </div>
+        <div id="account-nav">
+          <a id="-account-login" class="link">Sign in</a>
+        </div>
+      </div>
+    </header>
+    <div class="_banner-bg">
+      <div class="container">
+        <form class="search-bar banner-item" action="/packages">
+          <input class="input" name="q" placeholder="Search packages" autocomplete="on" autofocus="autofocus"/>
+          <button class="icon"></button>
+          <input id="search-legacy-field" type="hidden" name="legacy" value="1" disabled="disabled"/>
+        </form>
+      </div>
+    </div>
+    <main class="container">
+      <div class="detail-wrapper -active">
+        <div class="detail-header">
+          <h2 class="title">foobar_pkg 0.1.1+5</h2>
+          <div class="metadata">
+    
+Published 
+            <span>Jan 1, 2014</span>
+            <!-- &bull; Downloads: X -->
+  • Updated:
+  
+            <span>
+              <a href="/packages/foobar_pkg">0.1.1+5</a>
+            </span>
+    /
+    
+            <span>
+              <a href="/packages/foobar_pkg/versions/0.2.0-dev">0.2.0-dev</a>
+            </span>
+            <div class="-pub-likes">
+              <div>
+                <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-hidden="true" aria-pressed="true">
+                  <img height="18" src="/static/img/thumb-up-24px.svg?hash=mocked_hash_808020279" class="mdc-icon-button__icon"/>
+                  <img height="18" width="18" src="/static/img/thumb-up-filled-24px.svg?hash=mocked_hash_368133424" class="mdc-icon-button__icon mdc-icon-button__icon--on"/>
+                </button>
+                <span id="likes-count">0 likes</span>
+              </div>
+            </div>
+            <div class="tags">
+              <a class="package-tag unidentified" href="/packages/foobar_pkg#-analysis-tab-" title="Check the analysis tab for further details.">[unidentified]</a>
+            </div>
+          </div>
+        </div>
+        <div class="detail-body">
+          <div class="detail-tabs-wide-header">
+            <div class="detail-container">
+              <ul class="detail-tabs-header">
+                <li class="tab-link" data-name="-readme-tab-" role="button">
+                  <a href="/packages/foobar_pkg" data-ga-click-event="tab:readme">Readme</a>
+                </li>
+                <li class="tab-link" data-name="-changelog-tab-" role="button">
+                  <a href="/packages/foobar_pkg#-changelog-tab-" data-ga-click-event="tab:changelog">Changelog</a>
+                </li>
+                <li class="tab-button -active" data-ga-click-event="tab:example" data-name="-example-tab-" role="button">Example</li>
+                <li class="tab-link" data-name="-installing-tab-" role="button">
+                  <a href="/packages/foobar_pkg#-installing-tab-" data-ga-click-event="tab:installing">Installing</a>
+                </li>
+                <li class="tab-link" data-name="-versions-tab-" role="button">
+                  <a href="/packages/foobar_pkg/versions" data-ga-click-event="tab:versions">Versions</a>
+                </li>
+                <li class="tab-link" data-name="-analysis-tab-" role="button">
+                  <a href="/packages/foobar_pkg#-analysis-tab-" data-ga-click-event="tab:analysis">
+                    <div class="score-box">
+                      <span class="number -rotten" title="Analysis and more details.">3</span>
+                    </div>
+                  </a>
+                </li>
+                <li class="tab-link" data-name="-admin-tab-" role="button">
+                  <a href="/packages/foobar_pkg/admin" data-ga-click-event="tab:admin">Admin</a>
+                </li>
+              </ul>
+            </div>
+          </div>
+          <div class="detail-container detail-body-main">
+            <div class="detail-tabs-content">
+              <section class="tab-content -active markdown-body" data-name="-example-tab-">
+                <p style="font-family: monospace">
+                  <b>example/lib/main.dart</b>
+                </p>
+                <pre>
+                  <code class="language-dart">main() {
+  print('Hello world!');
+}
+</code>
+                </pre>
+              </section>
+            </div>
+          </div>
+          <aside class="detail-info-box">
+            <h3 class="title">About</h3>
+            <p>my package description</p>
+            <p>
+              <a class="link" href="http://hans.juergen.com">Homepage</a>
+              <br/>
+              <a class="link" href="/documentation/foobar_pkg/latest/">API reference</a>
+              <br/>
+            </p>
+            <h3 class="title">Uploader</h3>
+            <p>
+              <span class="author">
+                <a href="mailto:hans@juergen.com" title="Email hans@juergen.com">
+                  <i class="email-icon"></i>
+                </a>
+                <a href="/packages?q=email%3Ahans%40juergen.com" title="Search packages with hans@juergen.com" rel="nofollow">
+                  <i class="search-icon"></i>
+                </a> hans@juergen.com
+              </span>
+            </p>
+            <h3 class="title">License</h3>
+            <p>BSD (LICENSE.txt)</p>
+            <h3 class="title">Dependencies</h3>
+            <p>
+              <a href="/packages/http">http</a>, 
+              <a href="/packages/quiver">quiver</a>
+            </p>
+            <h3 class="title">More</h3>
+            <p>
+              <a href="/packages?q=dependency%3Afoobar_pkg" rel="nofollow">Packages that depend on foobar_pkg</a>
+            </p>
+          </aside>
+        </div>
+        <script type="application/ld+json">
+{"@context":"http://schema.org","@type":"SoftwareSourceCode","name":"foobar_pkg","version":"0.1.1+5","description":"foobar_pkg - my package description","url":"https://pub.dev/packages/foobar_pkg","dateCreated":"2014-01-01T00:00:00.000Z","dateModified":"2014-01-01T00:00:00.000Z","programmingLanguage":"Dart","image":"https://pub.dev/static/img/dart-logo-400x400.png"}
+</script>
+      </div>
+    </main>
+    <footer class="site-footer">
+      <a class="link" href="https://dart.dev/">Dart language</a>
+      <a class="link sep" href="/policy">Policy</a>
+      <a class="link sep" href="https://www.google.com/intl/en/policies/terms/">Terms</a>
+      <a class="link sep" href="/security">Security</a>
+      <a class="link sep" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
+      <a class="link sep" href="/help">Help</a>
+      <a class="link sep icon" href="/feed.atom">
+        <img src="/static/img/atom-feed-icon-32x32.png?hash=mocked_hash_251226050" class="inline-icon" alt="RSS/atom feed" title="RSS/atom feed"/>
+      </a>
+      <a class="link icon github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">
+        <img src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" class="inline-icon" alt="Report an issue with this site" title="Report an issue with this site"/>
+      </a>
+    </footer>
+    <script src="/static/highlight/highlight.pack.js?hash=mocked_hash_252154265"></script>
+    <script src="/static/highlight/init.js?hash=mocked_hash_180963889"></script>
+  </body>
+</html>

--- a/app/test/frontend/golden/pkg_install_page.html
+++ b/app/test/frontend/golden/pkg_install_page.html
@@ -1,0 +1,244 @@
+<!DOCTYPE html>
+<html lang="en-us">
+  <head>
+    <script async="async" src="https://www.googletagmanager.com/gtag/js?id=UA-26406144-13"></script>
+    <script src="/static/js/gtag.js?hash=mocked_hash_221832925"></script>
+    <meta charset="utf-8"/>
+    <meta http-equiv="x-ua-compatible" content="ie=edge"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <!-- Twitter tags -->
+    <meta name="twitter:card" content="summary"/>
+    <meta name="twitter:site" content="@dart_lang"/>
+    <meta name="twitter:description" content="my package description"/>
+    <meta name="twitter:image" content="https://pub.dev/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <!-- Facebook OG tags -->
+    <meta property="og:type" content="website"/>
+    <meta property="og:site_name" content="Dart packages"/>
+    <meta property="og:title" content="foobar_pkg | Dart Package"/>
+    <meta property="og:description" content="my package description"/>
+    <meta property="og:image" content="https://pub.dev/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <meta property="og:url" content="https://pub.dev/packages/foobar_pkg"/>
+    <title>foobar_pkg | Dart Package</title>
+    <link href="https://fonts.googleapis.com/css?family=Google+Sans:300,400,500|Google+Sans+Display:400|Roboto:300,400,500,700|Roboto+Mono:300,400,700" rel="stylesheet"/>
+    <meta content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
+    <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/osd.xml?hash=mocked_hash_869379763"/>
+    <meta name="description" content="my package description"/>
+    <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
+    <link href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842" rel="stylesheet" type="text/css"/>
+    <link href="/static/highlight/github.css?hash=mocked_hash_145446167" rel="stylesheet"/>
+    <link href="/static/css/github-markdown.css?hash=mocked_hash_488759485" rel="stylesheet" type="text/css"/>
+    <link href="/static/css/style.css?hash=mocked_hash_537099079" rel="stylesheet" type="text/css"/>
+    <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
+    <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
+    <script async="async" defer="defer" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
+    <meta name="google-signin-client_id" content=""/>
+    <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
+    <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJmb29iYXJfcGtnIiwidmVyc2lvbiI6IjAuMS4xKzUiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlfX0="/>
+  </head>
+  <body class="non-experimental">
+    <header class="site-header-row">
+      <div class="site-header">
+        <h1 class="_visuallyhidden">Dart pub</h1>
+        <button class="hamburger"></button>
+        <div class="mask"></div>
+        <div class="nav-wrap">
+          <div class="nav-header">
+            <a class="logo" href="/">
+              <img src="/static/img/pub-dev-logo-2x.png?hash=mocked_hash_685890546" alt="dart pub logo"/>
+            </a>
+            <div class="_flex-space"></div>
+            <button class="close"></button>
+          </div>
+          <nav class="site-nav">
+            <span>Getting Started:</span>
+            <div class="sub-wrap hoverable">
+              <button class="button">Flutter</button>
+              <div class="sub-nav">
+                <a class="link" target="_blank" rel="noopener" href="https://flutter.io/using-packages/">Using packages</a>
+                <a class="link" target="_blank" rel="noopener" href="https://flutter.io/developing-packages/">Developing packages and plugins</a>
+                <a class="link" target="_blank" rel="noopener" href="https://dart.dev/tools/pub/publishing">Publishing a package</a>
+                <a class="link" target="_blank" rel="noopener" href="https://dart.dev/tools/pub">Pub tool</a>
+              </div>
+            </div>
+            <div class="sub-wrap hoverable">
+              <button class="button">Web &amp; Server</button>
+              <div class="sub-nav">
+                <a class="link" target="_blank" rel="noopener" href="https://dart.dev/tools/pub/get-started">Using packages</a>
+                <a class="link" target="_blank" rel="noopener" href="https://dart.dev/tools/pub/publishing">Publishing a package</a>
+                <a class="link" target="_blank" rel="noopener" href="https://dart.dev/tools/pub">Pub tool</a>
+              </div>
+            </div>
+          </nav>
+          <div></div>
+        </div>
+        <div id="account-nav">
+          <a id="-account-login" class="link">Sign in</a>
+        </div>
+      </div>
+    </header>
+    <div class="_banner-bg">
+      <div class="container">
+        <form class="search-bar banner-item" action="/packages">
+          <input class="input" name="q" placeholder="Search packages" autocomplete="on" autofocus="autofocus"/>
+          <button class="icon"></button>
+          <input id="search-legacy-field" type="hidden" name="legacy" value="1" disabled="disabled"/>
+        </form>
+      </div>
+    </div>
+    <main class="container">
+      <div class="detail-wrapper -active">
+        <div class="detail-header">
+          <h2 class="title">foobar_pkg 0.1.1+5</h2>
+          <div class="metadata">
+    
+Published 
+            <span>Jan 1, 2014</span>
+            <!-- &bull; Downloads: X -->
+  • Updated:
+  
+            <span>
+              <a href="/packages/foobar_pkg">0.1.1+5</a>
+            </span>
+    /
+    
+            <span>
+              <a href="/packages/foobar_pkg/versions/0.2.0-dev">0.2.0-dev</a>
+            </span>
+            <div class="-pub-likes">
+              <div>
+                <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-hidden="true" aria-pressed="true">
+                  <img height="18" src="/static/img/thumb-up-24px.svg?hash=mocked_hash_808020279" class="mdc-icon-button__icon"/>
+                  <img height="18" width="18" src="/static/img/thumb-up-filled-24px.svg?hash=mocked_hash_368133424" class="mdc-icon-button__icon mdc-icon-button__icon--on"/>
+                </button>
+                <span id="likes-count">0 likes</span>
+              </div>
+            </div>
+            <div class="tags">
+              <a class="package-tag unidentified" href="/packages/foobar_pkg#-analysis-tab-" title="Check the analysis tab for further details.">[unidentified]</a>
+            </div>
+          </div>
+        </div>
+        <div class="detail-body">
+          <div class="detail-tabs-wide-header">
+            <div class="detail-container">
+              <ul class="detail-tabs-header">
+                <li class="tab-link" data-name="-readme-tab-" role="button">
+                  <a href="/packages/foobar_pkg" data-ga-click-event="tab:readme">Readme</a>
+                </li>
+                <li class="tab-link" data-name="-changelog-tab-" role="button">
+                  <a href="/packages/foobar_pkg#-changelog-tab-" data-ga-click-event="tab:changelog">Changelog</a>
+                </li>
+                <li class="tab-link" data-name="-example-tab-" role="button">
+                  <a href="/packages/foobar_pkg#-example-tab-" data-ga-click-event="tab:example">Example</a>
+                </li>
+                <li class="tab-button -active" data-ga-click-event="tab:installing" data-name="-installing-tab-" role="button">Installing</li>
+                <li class="tab-link" data-name="-versions-tab-" role="button">
+                  <a href="/packages/foobar_pkg/versions" data-ga-click-event="tab:versions">Versions</a>
+                </li>
+                <li class="tab-link" data-name="-analysis-tab-" role="button">
+                  <a href="/packages/foobar_pkg#-analysis-tab-" data-ga-click-event="tab:analysis">
+                    <div class="score-box">
+                      <span class="number -rotten" title="Analysis and more details.">3</span>
+                    </div>
+                  </a>
+                </li>
+                <li class="tab-link" data-name="-admin-tab-" role="button">
+                  <a href="/packages/foobar_pkg/admin" data-ga-click-event="tab:admin">Admin</a>
+                </li>
+              </ul>
+            </div>
+          </div>
+          <div class="detail-container detail-body-main">
+            <div class="detail-tabs-content">
+              <section class="tab-content -active" data-name="-installing-tab-">
+                <h2>Use this package as a library</h2>
+                <h3>1. Depend on it</h3>
+                <p>Add this to your package's pubspec.yaml file:</p>
+                <pre>
+                  <code class="language-yaml">
+dependencies:
+  
+                    <strong>foobar_pkg: ^0.1.1+5</strong>
+                  </code>
+                </pre>
+                <h3>2. Install it</h3>
+                <p>You can install packages from the command line:</p>
+                <p>with pub:</p>
+                <pre>
+                  <code class="language-shell">
+$ 
+                    <strong>pub get</strong>
+                  </code>
+                </pre>
+                <p>Alternatively, your editor might support 
+                  <code>pub get</code>.
+  Check the docs for your editor to learn more.
+                </p>
+                <h3>3. Import it</h3>
+                <p>Now in your Dart code, you can use:
+  </p>
+                <pre>
+                  <code class="language-dart">
+import 'package:foobar_pkg/foolib.dart';
+  </code>
+                </pre>
+              </section>
+            </div>
+          </div>
+          <aside class="detail-info-box">
+            <h3 class="title">About</h3>
+            <p>my package description</p>
+            <p>
+              <a class="link" href="http://hans.juergen.com">Homepage</a>
+              <br/>
+              <a class="link" href="/documentation/foobar_pkg/latest/">API reference</a>
+              <br/>
+            </p>
+            <h3 class="title">Uploader</h3>
+            <p>
+              <span class="author">
+                <a href="mailto:hans@juergen.com" title="Email hans@juergen.com">
+                  <i class="email-icon"></i>
+                </a>
+                <a href="/packages?q=email%3Ahans%40juergen.com" title="Search packages with hans@juergen.com" rel="nofollow">
+                  <i class="search-icon"></i>
+                </a> hans@juergen.com
+              </span>
+            </p>
+            <h3 class="title">License</h3>
+            <p>BSD (LICENSE.txt)</p>
+            <h3 class="title">Dependencies</h3>
+            <p>
+              <a href="/packages/http">http</a>, 
+              <a href="/packages/quiver">quiver</a>
+            </p>
+            <h3 class="title">More</h3>
+            <p>
+              <a href="/packages?q=dependency%3Afoobar_pkg" rel="nofollow">Packages that depend on foobar_pkg</a>
+            </p>
+          </aside>
+        </div>
+        <script type="application/ld+json">
+{"@context":"http://schema.org","@type":"SoftwareSourceCode","name":"foobar_pkg","version":"0.1.1+5","description":"foobar_pkg - my package description","url":"https://pub.dev/packages/foobar_pkg","dateCreated":"2014-01-01T00:00:00.000Z","dateModified":"2014-01-01T00:00:00.000Z","programmingLanguage":"Dart","image":"https://pub.dev/static/img/dart-logo-400x400.png"}
+</script>
+      </div>
+    </main>
+    <footer class="site-footer">
+      <a class="link" href="https://dart.dev/">Dart language</a>
+      <a class="link sep" href="/policy">Policy</a>
+      <a class="link sep" href="https://www.google.com/intl/en/policies/terms/">Terms</a>
+      <a class="link sep" href="/security">Security</a>
+      <a class="link sep" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
+      <a class="link sep" href="/help">Help</a>
+      <a class="link sep icon" href="/feed.atom">
+        <img src="/static/img/atom-feed-icon-32x32.png?hash=mocked_hash_251226050" class="inline-icon" alt="RSS/atom feed" title="RSS/atom feed"/>
+      </a>
+      <a class="link icon github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">
+        <img src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" class="inline-icon" alt="Report an issue with this site" title="Report an issue with this site"/>
+      </a>
+    </footer>
+    <script src="/static/highlight/highlight.pack.js?hash=mocked_hash_252154265"></script>
+    <script src="/static/highlight/init.js?hash=mocked_hash_180963889"></script>
+  </body>
+</html>

--- a/app/test/frontend/golden/pkg_score_page.html
+++ b/app/test/frontend/golden/pkg_score_page.html
@@ -1,0 +1,349 @@
+<!DOCTYPE html>
+<html lang="en-us">
+  <head>
+    <script async="async" src="https://www.googletagmanager.com/gtag/js?id=UA-26406144-13"></script>
+    <script src="/static/js/gtag.js?hash=mocked_hash_221832925"></script>
+    <meta charset="utf-8"/>
+    <meta http-equiv="x-ua-compatible" content="ie=edge"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <!-- Twitter tags -->
+    <meta name="twitter:card" content="summary"/>
+    <meta name="twitter:site" content="@dart_lang"/>
+    <meta name="twitter:description" content="my package description"/>
+    <meta name="twitter:image" content="https://pub.dev/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <!-- Facebook OG tags -->
+    <meta property="og:type" content="website"/>
+    <meta property="og:site_name" content="Dart packages"/>
+    <meta property="og:title" content="foobar_pkg | Dart Package"/>
+    <meta property="og:description" content="my package description"/>
+    <meta property="og:image" content="https://pub.dev/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <meta property="og:url" content="https://pub.dev/packages/foobar_pkg"/>
+    <title>foobar_pkg | Dart Package</title>
+    <link href="https://fonts.googleapis.com/css?family=Google+Sans:300,400,500|Google+Sans+Display:400|Roboto:300,400,500,700|Roboto+Mono:300,400,700" rel="stylesheet"/>
+    <meta content="/static/img/dart-logo-400x400.png?hash=mocked_hash_58383222"/>
+    <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
+    <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/osd.xml?hash=mocked_hash_869379763"/>
+    <meta name="description" content="my package description"/>
+    <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
+    <link href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842" rel="stylesheet" type="text/css"/>
+    <link href="/static/highlight/github.css?hash=mocked_hash_145446167" rel="stylesheet"/>
+    <link href="/static/css/github-markdown.css?hash=mocked_hash_488759485" rel="stylesheet" type="text/css"/>
+    <link href="/static/css/style.css?hash=mocked_hash_537099079" rel="stylesheet" type="text/css"/>
+    <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
+    <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
+    <script async="async" defer="defer" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
+    <meta name="google-signin-client_id" content=""/>
+    <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
+    <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJmb29iYXJfcGtnIiwidmVyc2lvbiI6IjAuMS4xKzUiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlfX0="/>
+  </head>
+  <body class="non-experimental">
+    <header class="site-header-row">
+      <div class="site-header">
+        <h1 class="_visuallyhidden">Dart pub</h1>
+        <button class="hamburger"></button>
+        <div class="mask"></div>
+        <div class="nav-wrap">
+          <div class="nav-header">
+            <a class="logo" href="/">
+              <img src="/static/img/pub-dev-logo-2x.png?hash=mocked_hash_685890546" alt="dart pub logo"/>
+            </a>
+            <div class="_flex-space"></div>
+            <button class="close"></button>
+          </div>
+          <nav class="site-nav">
+            <span>Getting Started:</span>
+            <div class="sub-wrap hoverable">
+              <button class="button">Flutter</button>
+              <div class="sub-nav">
+                <a class="link" target="_blank" rel="noopener" href="https://flutter.io/using-packages/">Using packages</a>
+                <a class="link" target="_blank" rel="noopener" href="https://flutter.io/developing-packages/">Developing packages and plugins</a>
+                <a class="link" target="_blank" rel="noopener" href="https://dart.dev/tools/pub/publishing">Publishing a package</a>
+                <a class="link" target="_blank" rel="noopener" href="https://dart.dev/tools/pub">Pub tool</a>
+              </div>
+            </div>
+            <div class="sub-wrap hoverable">
+              <button class="button">Web &amp; Server</button>
+              <div class="sub-nav">
+                <a class="link" target="_blank" rel="noopener" href="https://dart.dev/tools/pub/get-started">Using packages</a>
+                <a class="link" target="_blank" rel="noopener" href="https://dart.dev/tools/pub/publishing">Publishing a package</a>
+                <a class="link" target="_blank" rel="noopener" href="https://dart.dev/tools/pub">Pub tool</a>
+              </div>
+            </div>
+          </nav>
+          <div></div>
+        </div>
+        <div id="account-nav">
+          <a id="-account-login" class="link">Sign in</a>
+        </div>
+      </div>
+    </header>
+    <div class="_banner-bg">
+      <div class="container">
+        <form class="search-bar banner-item" action="/packages">
+          <input class="input" name="q" placeholder="Search packages" autocomplete="on" autofocus="autofocus"/>
+          <button class="icon"></button>
+          <input id="search-legacy-field" type="hidden" name="legacy" value="1" disabled="disabled"/>
+        </form>
+      </div>
+    </div>
+    <main class="container">
+      <div class="detail-wrapper -active">
+        <div class="detail-header">
+          <h2 class="title">foobar_pkg 0.1.1+5</h2>
+          <div class="metadata">
+    
+Published 
+            <span>Jan 1, 2014</span>
+            <!-- &bull; Downloads: X -->
+  • Updated:
+  
+            <span>
+              <a href="/packages/foobar_pkg">0.1.1+5</a>
+            </span>
+    /
+    
+            <span>
+              <a href="/packages/foobar_pkg/versions/0.2.0-dev">0.2.0-dev</a>
+            </span>
+            <div class="-pub-likes">
+              <div>
+                <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-hidden="true" aria-pressed="true">
+                  <img height="18" src="/static/img/thumb-up-24px.svg?hash=mocked_hash_808020279" class="mdc-icon-button__icon"/>
+                  <img height="18" width="18" src="/static/img/thumb-up-filled-24px.svg?hash=mocked_hash_368133424" class="mdc-icon-button__icon mdc-icon-button__icon--on"/>
+                </button>
+                <span id="likes-count">0 likes</span>
+              </div>
+            </div>
+            <div class="tags">
+              <a class="package-tag unidentified" href="/packages/foobar_pkg#-analysis-tab-" title="Check the analysis tab for further details.">[unidentified]</a>
+            </div>
+          </div>
+        </div>
+        <div class="detail-body">
+          <div class="detail-tabs-wide-header">
+            <div class="detail-container">
+              <ul class="detail-tabs-header">
+                <li class="tab-link" data-name="-readme-tab-" role="button">
+                  <a href="/packages/foobar_pkg" data-ga-click-event="tab:readme">Readme</a>
+                </li>
+                <li class="tab-link" data-name="-changelog-tab-" role="button">
+                  <a href="/packages/foobar_pkg#-changelog-tab-" data-ga-click-event="tab:changelog">Changelog</a>
+                </li>
+                <li class="tab-link" data-name="-example-tab-" role="button">
+                  <a href="/packages/foobar_pkg#-example-tab-" data-ga-click-event="tab:example">Example</a>
+                </li>
+                <li class="tab-link" data-name="-installing-tab-" role="button">
+                  <a href="/packages/foobar_pkg#-installing-tab-" data-ga-click-event="tab:installing">Installing</a>
+                </li>
+                <li class="tab-link" data-name="-versions-tab-" role="button">
+                  <a href="/packages/foobar_pkg/versions" data-ga-click-event="tab:versions">Versions</a>
+                </li>
+                <li class="tab-button -active" data-ga-click-event="tab:analysis" data-name="-analysis-tab-" role="button">
+                  <div class="score-box">
+                    <span class="number -rotten" title="Analysis and more details.">3</span>
+                  </div>
+                </li>
+                <li class="tab-link" data-name="-admin-tab-" role="button">
+                  <a href="/packages/foobar_pkg/admin" data-ga-click-event="tab:admin">Admin</a>
+                </li>
+              </ul>
+            </div>
+          </div>
+          <div class="detail-container detail-body-main">
+            <div class="detail-tabs-content">
+              <section class="tab-content -active" data-name="-analysis-tab-">
+                <table id='scores-table'>
+                  <tr>
+                    <td class="score-name">
+                      <div class="tooltip-base hoverable">
+                        <span class="tooltip-dotted">Popularity:</span>
+                        <div class="tooltip-content">
+          Describes how popular the package is relative to other packages.
+          
+                          <a href="/help#popularity">[more]</a>
+                        </div>
+                      </div>
+                    </td>
+                    <td class="score-value">
+                      <div class="score-percent-row">
+                        <div class="score-percent" style="left: 0%;">--</div>
+                      </div>
+                      <div class="score-progress-row">
+                        <div class="score-progress-frame">
+                          <div class="score-progress" style="width: 0%; background: rgb(204, 204, 204);"></div>
+                        </div>
+                      </div>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td class="score-name">
+                      <div class="tooltip-base hoverable">
+                        <span class="tooltip-dotted">Health:</span>
+                        <div class="tooltip-content">
+          Code health derived from static analysis.
+          
+                          <a href="/help#health">[more]</a>
+                        </div>
+                      </div>
+                    </td>
+                    <td class="score-value">
+                      <div class="score-percent-row">
+                        <div class="score-percent" style="left: 10%;">10</div>
+                      </div>
+                      <div class="score-progress-row">
+                        <div class="score-progress-frame">
+                          <div class="score-progress" style="width: 10%; background: rgb(120, 134, 149);"></div>
+                        </div>
+                      </div>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td class="score-name">
+                      <div class="tooltip-base hoverable">
+                        <span class="tooltip-dotted">Maintenance:</span>
+                        <div class="tooltip-content">
+          Reflects how tidy and up-to-date the package is.
+          
+                          <a href="/help#maintenance">[more]</a>
+                        </div>
+                      </div>
+                    </td>
+                    <td class="score-value">
+                      <div class="score-percent-row">
+                        <div class="score-percent" style="left: 0%;">--</div>
+                      </div>
+                      <div class="score-progress-row">
+                        <div class="score-progress-frame">
+                          <div class="score-progress" style="width: 0%; background: rgb(204, 204, 204);"></div>
+                        </div>
+                      </div>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td class="score-name">
+                      <div class="tooltip-base hoverable">
+                        <span class="tooltip-dotted">
+                          <b>Overall:</b>
+                        </span>
+                        <div class="tooltip-content">
+          Weighted score of the above.
+          
+                          <a href="/help#overall-score">[more]</a>
+                        </div>
+                      </div>
+                    </td>
+                    <td>
+                      <div class="score-percent-row">
+                        <div class="score-percent" style="left: 3%;">3</div>
+                      </div>
+                      <div class="score-progress-row">
+                        <div class="score-progress-frame">
+                          <div class="score-progress" style="width: 3%; background: rgb(187, 36, 0);"></div>
+                        </div>
+                      </div>
+                    </td>
+                  </tr>
+                </table>
+                <div style="text-align: right; font-size: 10pt;">Learn more about 
+                  <a href="/help#scoring">scoring</a>.
+                </div>
+                <hr/>
+                <p>
+  We analyzed this package on Feb 5, 2018, and provided a score, details, and suggestions below.
+  Analysis was completed with status 
+                  <i>completed</i> using:
+
+                </p>
+                <ul>
+                  <li>Dart: 2.0.0-dev.7.0</li>
+                  <li>pana: 0.6.2</li>
+                </ul>
+                <h4>Dependencies</h4>
+                <div class="overflow-x">
+                  <table class="dependency-table">
+                    <tr>
+                      <th>Package</th>
+                      <th>Constraint</th>
+                      <th>Resolved</th>
+                      <th>Available</th>
+                    </tr>
+                    <tr>
+                      <th colspan="4" class="sub-header">Direct dependencies</th>
+                    </tr>
+                    <tr>
+                      <td>
+                        <a href="/packages/http" class="hosted-pkg-link">http</a>
+                      </td>
+                      <td>>=1.0.0 &lt;1.2.0</td>
+                      <td>1.2.0</td>
+                      <td>1.3.0</td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <a href="/packages/quiver" class="hosted-pkg-link">quiver</a>
+                      </td>
+                      <td>^1.0.0</td>
+                      <td>1.0.0</td>
+                      <td></td>
+                    </tr>
+                  </table>
+                </div>
+              </section>
+            </div>
+          </div>
+          <aside class="detail-info-box">
+            <h3 class="title">About</h3>
+            <p>my package description</p>
+            <p>
+              <a class="link" href="http://hans.juergen.com">Homepage</a>
+              <br/>
+              <a class="link" href="/documentation/foobar_pkg/latest/">API reference</a>
+              <br/>
+            </p>
+            <h3 class="title">Uploader</h3>
+            <p>
+              <span class="author">
+                <a href="mailto:hans@juergen.com" title="Email hans@juergen.com">
+                  <i class="email-icon"></i>
+                </a>
+                <a href="/packages?q=email%3Ahans%40juergen.com" title="Search packages with hans@juergen.com" rel="nofollow">
+                  <i class="search-icon"></i>
+                </a> hans@juergen.com
+              </span>
+            </p>
+            <h3 class="title">License</h3>
+            <p>BSD (LICENSE.txt)</p>
+            <h3 class="title">Dependencies</h3>
+            <p>
+              <a href="/packages/http">http</a>, 
+              <a href="/packages/quiver">quiver</a>
+            </p>
+            <h3 class="title">More</h3>
+            <p>
+              <a href="/packages?q=dependency%3Afoobar_pkg" rel="nofollow">Packages that depend on foobar_pkg</a>
+            </p>
+          </aside>
+        </div>
+        <script type="application/ld+json">
+{"@context":"http://schema.org","@type":"SoftwareSourceCode","name":"foobar_pkg","version":"0.1.1+5","description":"foobar_pkg - my package description","url":"https://pub.dev/packages/foobar_pkg","dateCreated":"2014-01-01T00:00:00.000Z","dateModified":"2014-01-01T00:00:00.000Z","programmingLanguage":"Dart","image":"https://pub.dev/static/img/dart-logo-400x400.png"}
+</script>
+      </div>
+    </main>
+    <footer class="site-footer">
+      <a class="link" href="https://dart.dev/">Dart language</a>
+      <a class="link sep" href="/policy">Policy</a>
+      <a class="link sep" href="https://www.google.com/intl/en/policies/terms/">Terms</a>
+      <a class="link sep" href="/security">Security</a>
+      <a class="link sep" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
+      <a class="link sep" href="/help">Help</a>
+      <a class="link sep icon" href="/feed.atom">
+        <img src="/static/img/atom-feed-icon-32x32.png?hash=mocked_hash_251226050" class="inline-icon" alt="RSS/atom feed" title="RSS/atom feed"/>
+      </a>
+      <a class="link icon github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">
+        <img src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" class="inline-icon" alt="Report an issue with this site" title="Report an issue with this site"/>
+      </a>
+    </footer>
+    <script src="/static/highlight/highlight.pack.js?hash=mocked_hash_252154265"></script>
+    <script src="/static/highlight/init.js?hash=mocked_hash_180963889"></script>
+  </body>
+</html>

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -135,61 +135,82 @@ void main() {
       expectGoldenFile(html, 'landing_page.html');
     });
 
-    scopedTest('package show page', () {
-      final String html = renderPkgShowPage(PackagePageData(
-        package: foobarPackage,
-        isLiked: false,
-        uploaderEmails: foobarUploaderEmails,
-        version: foobarStablePV,
-        analysis: AnalysisView(
-          card: ScoreCardData(
-            reportTypes: ['pana', 'dartdoc'],
-            healthScore: 0.1,
-          ),
-          panaReport: PanaReport(
-              timestamp: DateTime(2018, 02, 05),
-              panaRuntimeInfo: _panaRuntimeInfo,
-              reportStatus: ReportStatus.success,
-              healthScore: null,
-              maintenanceScore: null,
-              derivedTags: null,
-              pkgDependencies: [
-                PkgDependency(
-                  package: 'quiver',
-                  dependencyType: 'direct',
-                  constraintType: 'normal',
-                  constraint: VersionConstraint.parse('^1.0.0'),
-                  resolved: Version.parse('1.0.0'),
-                  available: null,
-                  errors: null,
-                ),
-                PkgDependency(
-                  package: 'http',
-                  dependencyType: 'direct',
-                  constraintType: 'normal',
-                  constraint: VersionConstraint.parse('>=1.0.0 <1.2.0'),
-                  resolved: Version.parse('1.2.0'),
-                  available: Version.parse('1.3.0'),
-                  errors: null,
-                )
-              ],
-              licenses: [LicenseFile('LICENSE.txt', 'BSD')],
-              panaSuggestions: null,
-              healthSuggestions: null,
-              maintenanceSuggestions: null,
-              flags: null),
-          dartdocReport: DartdocReport(
-            reportStatus: ReportStatus.success,
-            coverage: 1.0,
-            coverageScore: 1.0,
-            healthSuggestions: [],
-            maintenanceSuggestions: [],
-          ),
+    final foobarPageData = PackagePageData(
+      package: foobarPackage,
+      isLiked: false,
+      uploaderEmails: foobarUploaderEmails,
+      version: foobarStablePV,
+      analysis: AnalysisView(
+        card: ScoreCardData(
+          reportTypes: ['pana', 'dartdoc'],
+          healthScore: 0.1,
         ),
-        isAdmin: true,
-      ));
+        panaReport: PanaReport(
+            timestamp: DateTime(2018, 02, 05),
+            panaRuntimeInfo: _panaRuntimeInfo,
+            reportStatus: ReportStatus.success,
+            healthScore: null,
+            maintenanceScore: null,
+            derivedTags: null,
+            pkgDependencies: [
+              PkgDependency(
+                package: 'quiver',
+                dependencyType: 'direct',
+                constraintType: 'normal',
+                constraint: VersionConstraint.parse('^1.0.0'),
+                resolved: Version.parse('1.0.0'),
+                available: null,
+                errors: null,
+              ),
+              PkgDependency(
+                package: 'http',
+                dependencyType: 'direct',
+                constraintType: 'normal',
+                constraint: VersionConstraint.parse('>=1.0.0 <1.2.0'),
+                resolved: Version.parse('1.2.0'),
+                available: Version.parse('1.3.0'),
+                errors: null,
+              )
+            ],
+            licenses: [LicenseFile('LICENSE.txt', 'BSD')],
+            panaSuggestions: null,
+            healthSuggestions: null,
+            maintenanceSuggestions: null,
+            flags: null),
+        dartdocReport: DartdocReport(
+          reportStatus: ReportStatus.success,
+          coverage: 1.0,
+          coverageScore: 1.0,
+          healthSuggestions: [],
+          maintenanceSuggestions: [],
+        ),
+      ),
+      isAdmin: true,
+    );
 
+    scopedTest('package show page', () {
+      final String html = renderPkgShowPage(foobarPageData);
       expectGoldenFile(html, 'pkg_show_page.html');
+    });
+
+    scopedTest('package changelog page', () {
+      final String html = renderPkgChangelogPage(foobarPageData);
+      expectGoldenFile(html, 'pkg_changelog_page.html');
+    });
+
+    scopedTest('package example page', () {
+      final String html = renderPkgExamplePage(foobarPageData);
+      expectGoldenFile(html, 'pkg_example_page.html');
+    });
+
+    scopedTest('package install page', () {
+      final String html = renderPkgInstallPage(foobarPageData);
+      expectGoldenFile(html, 'pkg_install_page.html');
+    });
+
+    scopedTest('package score page', () {
+      final String html = renderPkgScorePage(foobarPageData);
+      expectGoldenFile(html, 'pkg_score_page.html');
     });
 
     scopedTest('package show page - with version', () {


### PR DESCRIPTION
- #3390
- new pages are behind experimental flag
- known issue: non-experimental fetch of them is a bit broken as the in-page tab links are rendered but they are not working
- reusing most of the render logic of the current package page (in a follow-up PR we'll need to decide which pages will be indexed, what the canonical page URL should be, and which pages should expose other metadata, e.g. for sharing).
- added templates tests for new pages (integration tests in a follow-up PR)