### PR TITLE
Do not create User when accepting Consent.

### DIFF
--- a/app/lib/account/consent_backend.dart
+++ b/app/lib/account/consent_backend.dart
@@ -232,10 +232,8 @@ class ConsentBackend {
       }
 
       // Checking that consent is for the current user.
-      if (c.userId != null) {
-        InvalidInputException.check(c.userId == user.userId,
-            'This invitation is not for the user account currently logged in.');
-      }
+      InvalidInputException.check(c.userId == null || c.userId == user.userId,
+          'This invitation is not for the user account currently logged in.');
       final action = _actions[c.kind];
       if (!action.permitConfirmationWithOtherEmail && c.email != null) {
         InvalidInputException.check(c.email == user.email,

--- a/app/lib/account/consent_backend.dart
+++ b/app/lib/account/consent_backend.dart
@@ -326,6 +326,8 @@ class _PackageUploaderAction extends ConsentAction {
         ? await accountBackend.lookupUserById(consent.userId)
         : await accountBackend.lookupUserByEmail(consent.email);
     if (uploader == null) {
+      // NOTE: This should never happen because `userId` of the consent entity
+      //       will be set when it is loaded.
       throw AuthenticationException.userNotFound();
     }
 
@@ -424,6 +426,8 @@ class _PublisherMemberAction extends ConsentAction {
         ? await accountBackend.lookupUserById(consent.userId)
         : await accountBackend.lookupUserByEmail(consent.email);
     if (member == null) {
+      // NOTE: This should never happen because `userId` of the consent entity
+      //       will be set when it is loaded.
       throw AuthenticationException.userNotFound();
     }
     final publisherId = consent.args.single;

--- a/app/lib/account/consent_backend.dart
+++ b/app/lib/account/consent_backend.dart
@@ -228,7 +228,7 @@ class ConsentBackend {
       }
       if (c.userId == null && c.email == user.email) {
         c.userId = user.userId;
-        tx.queueMutations(inserts: [c]);
+        tx.insert(c);
       }
 
       // Checking that consent is for the current user.

--- a/app/lib/shared/exceptions.dart
+++ b/app/lib/shared/exceptions.dart
@@ -197,6 +197,10 @@ class AuthenticationException extends ResponseException
       AuthenticationException._(
           '`accessToken` does not match current active user.');
 
+  /// Signaling that User lookup (via e-mail) failed.
+  factory AuthenticationException.userNotFound() =>
+      AuthenticationException._('User not found.');
+
   @override
   String toString() => '$code: $message'; // used by package:pub_server
 }


### PR DESCRIPTION
I think the `AuthenticationException.userNotFound` should never be thrown, but I left it there to make sure we have a user-facing error message in case it happens (vs. generic server error).