### PR TITLE
Change the atom feed ID generator after a certain date.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Important changes to data-models, configuration and migrations between each
 AppEngine version, listed here to ease deployment and troubleshooting.
 
 ## Next Release (replace with git tag when deployed)
+ * New atom feed ID scheduled to go live at 2020-04-04. Change this hardcoded
+   date if release does not go live before 2020-04-02.
 
 ## `20200309t104246-all`
  * Bumped runtimeVersion to `2020.03.09`.

--- a/app/lib/frontend/handlers/atom_feed.dart
+++ b/app/lib/frontend/handlers/atom_feed.dart
@@ -138,7 +138,7 @@ Feed feedFromPackageVersions(Uri requestedUri, List<PackageVersion> versions) {
     if (version.created.isAfter(DateTime(2020, 04, 04))) {
       final hash =
           sha512.convert(utf8.encode('${version.package}/${version.version}'));
-      id = formatUuid(hash.bytes.sublist(0, 16));
+      id = createUuid(hash.bytes.sublist(0, 16));
     } else {
       // TODO: remove the old ID after the above date passed in production use
       final seed = (requestedUri.host == 'pub.dartlang.org')

--- a/app/lib/frontend/handlers/atom_feed.dart
+++ b/app/lib/frontend/handlers/atom_feed.dart
@@ -7,6 +7,7 @@ library pub_dartlang_org.atom_feed;
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:crypto/crypto.dart';
 import 'package:markdown/markdown.dart' as md;
 import 'package:shelf/shelf.dart' as shelf;
 import 'package:uuid/uuid.dart';
@@ -15,6 +16,7 @@ import '../../package/backend.dart';
 import '../../package/models.dart';
 import '../../shared/configuration.dart';
 import '../../shared/urls.dart' as urls;
+import '../../shared/utils.dart';
 
 /// Handles requests for /feed.atom
 Future<shelf.Response> atomFeedHandler(shelf.Request request) async {
@@ -132,13 +134,20 @@ Feed feedFromPackageVersions(Uri requestedUri, List<PackageVersion> versions) {
         activeConfiguration.primarySiteUri.replace(path: pkgPage).toString();
     final alternateTitle = version.package;
 
-    // TODO: use only qualifiedVersion as seed after the domain migration
-    final seed = (requestedUri.host == 'pub.dartlang.org')
-        ? requestedUri
-            .resolve('/packages/${version.package}#${version.version}')
-            .toString()
-        : version.qualifiedVersionKey.toString();
-    final id = uuid.v5(Uuid.NAMESPACE_URL, seed);
+    String id;
+    if (version.created.isAfter(DateTime(2020, 04, 04))) {
+      final hash =
+          sha512.convert(utf8.encode('${version.package}/${version.version}'));
+      id = formatUuid(hash.bytes.sublist(0, 16));
+    } else {
+      // TODO: remove the old ID after the above date passed in production use
+      final seed = (requestedUri.host == 'pub.dartlang.org')
+          ? requestedUri
+              .resolve('/packages/${version.package}#${version.version}')
+              .toString()
+          : version.qualifiedVersionKey.toString();
+      id = uuid.v5(Uuid.NAMESPACE_URL, seed);
+    }
     final title = 'v${version.version} of ${version.package}';
 
     var content = 'No README Found';

--- a/app/lib/shared/utils.dart
+++ b/app/lib/shared/utils.dart
@@ -38,6 +38,7 @@ const fileAnIssueContent =
     'Please open an issue: https://github.com/dart-lang/pub-dev/issues/new';
 
 final Logger _logger = Logger('pub.utils');
+final _random = Random.secure();
 
 final DateFormat shortDateFormat = DateFormat.yMMMd();
 
@@ -391,12 +392,23 @@ Map<String, String> parseCookieHeader(String cookieHeader) {
   }
 }
 
-/// Returns the UUID-formatted string of [bytes].
-String formatUuid(List<int> bytes) {
+/// Returns a UUID in v4 format as a `String`.
+///
+/// If [bytes] is provided, it must be length 16 and have values between `0` and
+/// `255` inclusive.
+///
+/// If [bytes] is not provided, it is generated using `Random.secure`.
+String createUuid([List<int> bytes]) {
+  bytes ??= List<int>.generate(16, (_) => _random.nextInt(256));
   if (bytes.length != 16) {
     throw ArgumentError('16 bytes expected, got: ${bytes.length}');
   }
+  // See http://www.cryptosys.net/pki/uuid-rfc4122.html for notes
+  bytes[6] = (bytes[6] & 0x0F) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
   String formatByte(int byte) => byte.toRadixString(16).padLeft(2, '0');
+
   return [
     bytes.sublist(0, 4).map(formatByte).join(),
     bytes.sublist(4, 6).map(formatByte).join(),

--- a/app/lib/shared/utils.dart
+++ b/app/lib/shared/utils.dart
@@ -390,3 +390,18 @@ Map<String, String> parseCookieHeader(String cookieHeader) {
     return <String, String>{};
   }
 }
+
+/// Returns the UUID-formatted string of [bytes].
+String formatUuid(List<int> bytes) {
+  if (bytes.length != 16) {
+    throw ArgumentError('16 bytes expected, got: ${bytes.length}');
+  }
+  String formatByte(int byte) => byte.toRadixString(16).padLeft(2, '0');
+  return [
+    bytes.sublist(0, 4).map(formatByte).join(),
+    bytes.sublist(4, 6).map(formatByte).join(),
+    bytes.sublist(6, 8).map(formatByte).join(),
+    bytes.sublist(8, 10).map(formatByte).join(),
+    bytes.sublist(10).map(formatByte).join(),
+  ].join('-');
+}

--- a/app/test/shared/utils_test.dart
+++ b/app/test/shared/utils_test.dart
@@ -98,4 +98,13 @@ void main() {
       expect(parseCookieHeader('a=b; c=dd'), {'a': 'b', 'c': 'dd'});
     });
   });
+
+  group('uuid', () {
+    test('format known UUId', () {
+      expect(
+          formatUuid(
+              [11, 111, 22, 222, 33, 3, 44, 4, 55, 5, 66, 6, 77, 7, 88, 8]),
+          '0b6f16de-2103-2c04-3705-42064d075808');
+    });
+  });
 }

--- a/app/test/shared/utils_test.dart
+++ b/app/test/shared/utils_test.dart
@@ -101,10 +101,21 @@ void main() {
 
   group('uuid', () {
     test('format known UUId', () {
+      expect(createUuid(List<int>.filled(16, 0)),
+          '00000000-0000-4000-8000-000000000000');
       expect(
-          formatUuid(
+          createUuid(
               [11, 111, 22, 222, 33, 3, 44, 4, 55, 5, 66, 6, 77, 7, 88, 8]),
-          '0b6f16de-2103-2c04-3705-42064d075808');
+          '0b6f16de-2103-4c04-b705-42064d075808');
+      expect(createUuid(List<int>.filled(16, 255)),
+          'ffffffff-ffff-4fff-bfff-ffffffffffff');
+    });
+
+    test('random uuid', () {
+      final uuidRegexp = RegExp(
+          r'^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[8-9A-B][0-9A-F]{3}-[0-9A-F]{12}$',
+          caseSensitive: false);
+      expect(createUuid(), matches(uuidRegexp));
     });
   });
 }


### PR DESCRIPTION
- I am not sure if/when we can move off of the hostname-base seed generation, instead, a date-based change should be better. It makes sure that we have a clear cutoff for the new UUIDs.
- It also removes the `package:uuid` dependency (#3440).
