### PR TITLE
Do not autofocus search bar when query text was specified.

### DIFF
--- a/app/lib/frontend/templates/layout.dart
+++ b/app/lib/frontend/templates/layout.dart
@@ -178,7 +178,10 @@ String _renderSearchBanner({
   }
   final isExperimental = requestContext.isExperimental;
   return templateCache.renderTemplate('shared/search_banner', {
-    'show_autofocus': queryText == null,
+    // When search is active (query text has a non-empty value) users may expect
+    // to scroll through the results via keyboard. We should only autofocus the
+    // search field when there is no active search.
+    'autofocus': queryText == null,
     'show_search_filters_btn': isExperimental && type == PageType.listing,
     'show_details': !isExperimental &&
         (type == PageType.listing || type == PageType.landing),

--- a/app/lib/frontend/templates/layout.dart
+++ b/app/lib/frontend/templates/layout.dart
@@ -178,6 +178,7 @@ String _renderSearchBanner({
   }
   final isExperimental = requestContext.isExperimental;
   return templateCache.renderTemplate('shared/search_banner', {
+    'show_autofocus': queryText == null,
     'show_search_filters_btn': isExperimental && type == PageType.listing,
     'show_details': !isExperimental &&
         (type == PageType.listing || type == PageType.landing),

--- a/app/lib/frontend/templates/views/shared/search_banner.mustache
+++ b/app/lib/frontend/templates/views/shared/search_banner.mustache
@@ -3,7 +3,7 @@
     BSD-style license that can be found in the LICENSE file. }}
 
 <form class="search-bar banner-item" action="{{& search_form_url}}">
-  <input class="input" name="q" placeholder="{{search_query_placeholder}}" autocomplete="on"{{#show_autofocus}} autofocus="autofocus"{{/show_autofocus}}{{#search_query_html}} value="{{& search_query_html}}"{{/search_query_html}}/>
+  <input class="input" name="q" placeholder="{{search_query_placeholder}}" autocomplete="on"{{#autofocus}} autofocus="autofocus"{{/autofocus}}{{#search_query_html}} value="{{& search_query_html}}"{{/search_query_html}}/>
   <button class="icon"></button>
   {{#show_search_filters_btn}}
   <div class="search-filters-btn-wrapper">

--- a/app/lib/frontend/templates/views/shared/search_banner.mustache
+++ b/app/lib/frontend/templates/views/shared/search_banner.mustache
@@ -3,7 +3,7 @@
     BSD-style license that can be found in the LICENSE file. }}
 
 <form class="search-bar banner-item" action="{{& search_form_url}}">
-  <input class="input" name="q" placeholder="{{search_query_placeholder}}" autocomplete="on" autofocus="autofocus"{{#search_query_html}} value="{{& search_query_html}}"{{/search_query_html}}/>
+  <input class="input" name="q" placeholder="{{search_query_placeholder}}" autocomplete="on"{{#show_autofocus}} autofocus="autofocus"{{/show_autofocus}}{{#search_query_html}} value="{{& search_query_html}}"{{/search_query_html}}/>
   <button class="icon"></button>
   {{#show_search_filters_btn}}
   <div class="search-filters-btn-wrapper">

--- a/app/test/frontend/golden/search_page.html
+++ b/app/test/frontend/golden/search_page.html
@@ -79,7 +79,7 @@
     <div class="_banner-bg">
       <div class="container">
         <form class="search-bar banner-item" action="/packages">
-          <input class="input" name="q" placeholder="Search packages" autocomplete="on" autofocus="autofocus" value="foobar"/>
+          <input class="input" name="q" placeholder="Search packages" autocomplete="on" value="foobar"/>
           <button class="icon"></button>
           <input type="hidden" name="sort" value="top"/>
           <input id="search-legacy-field" type="hidden" name="legacy" value="1" disabled="disabled"/>


### PR DESCRIPTION
Fixes #3452. We could probably remove autofocus in other cases, but for now I'd rather keep it to the really justified one: when the user entered some text in search.