### PR TITLE
Updated like: style + label

### DIFF
--- a/app/lib/frontend/templates/detail_page.dart
+++ b/app/lib/frontend/templates/detail_page.dart
@@ -4,6 +4,7 @@
 
 import 'dart:convert';
 
+import 'package:intl/intl.dart';
 import 'package:meta/meta.dart';
 
 import '../request_context.dart';
@@ -28,12 +29,18 @@ String renderDetailHeader({
     'metadata_html': metadataHtml,
     'tags_html': tagsHtml,
     'is_publisher': isPublisher,
-    'like_count': '$packageLikes ${packageLikes == 1 ? "like" : "likes"}',
+    'like_count': _formatPackageLikes(packageLikes),
     'is_liked': isLiked,
     'has_likes': isLiked != null,
     // TODO: remove values below after new UI is finalized
     'is_flutter_favorite': isFlutterFavorite,
   });
+}
+
+String _formatPackageLikes(int likesCount) {
+  if (likesCount == null) return null;
+  final formattedCount = NumberFormat.compact().format(likesCount);
+  return '$formattedCount ${likesCount == 1 ? 'like' : 'likes'}';
 }
 
 /// Renders the `shared/detail/page.mustache` template

--- a/pkg/web_app/lib/likes.dart
+++ b/pkg/web_app/lib/likes.dart
@@ -53,8 +53,8 @@ void setupLikes() {
 
   String likesString() {
     final likesCount = pageData.pkgData.likes + likesDelta;
-    return '${NumberFormat.compact().format(likesCount)}'
-        ' ${likesCount == 1 ? 'like' : 'likes'}';
+    final formattedCount = NumberFormat.compact().format(likesCount);
+    return '$formattedCount ${likesCount == 1 ? 'like' : 'likes'}';
   }
 
   iconButtonToggle.listen(MDCIconButtonToggle.changeEvent, (Event e) {

--- a/pkg/web_css/lib/src/_detail_page_experimental.scss
+++ b/pkg/web_css/lib/src/_detail_page_experimental.scss
@@ -108,6 +108,7 @@ $detail-tabs-width: calc(100% - 320px);
 
   .detail-like {
     font-size: 12px;
+    font-weight: 500;
     text-transform: uppercase;
     white-space: nowrap;
     display: flex;


### PR DESCRIPTION
- Server-rendered page didn't use the compact number format. Updated to use it.
- Added weight to new design:
  <img width="77" alt="Screen Shot 2020-03-26 at 16 43 55" src="https://user-images.githubusercontent.com/4778111/77668174-5a069080-6f83-11ea-97d7-781b76a87dca.png">
