### PR TITLE
Small fix to git dependency handling.

### DIFF
--- a/app/test/package/backend_test.dart
+++ b/app/test/package/backend_test.dart
@@ -592,6 +592,25 @@ void main() {
               'Package name is too similar to another active or moderated package.');
         });
 
+        testWithServices('has git dependency', () async {
+          registerAuthenticatedUser(joeUser);
+          final tarball = await packageArchiveBytes(
+              pubspecContent: generatePubspecYaml('xyz', '1.0.0') +
+                  '  abcd:\n'
+                      '    git:\n'
+                      '      url: git://github.com/a/b\n'
+                      '      path: x/y/z\n');
+          final rs =
+              packageBackend.repository.upload(Stream.fromIterable([tarball]));
+          await expectLater(
+              rs,
+              throwsA(isA<Exception>().having(
+                (e) => '$e',
+                'text',
+                contains('is a git dependency'),
+              )));
+        });
+
         testWithServices('upload-too-big', () async {
           registerAuthenticatedUser(hansUser);
 

--- a/pkg/pub_package_reader/lib/pub_package_reader.dart
+++ b/pkg/pub_package_reader/lib/pub_package_reader.dart
@@ -240,7 +240,7 @@ Iterable<ArchiveIssue> forbidGitDependencies(Pubspec pubspec) sync* {
     if (entry.value is GitDependency) {
       yield ArchiveIssue(
         'Package dependency $name is a git dependency, '
-        'this not allowed in published packages',
+        'this is not allowed in published packages',
       );
       continue;
     }

--- a/pkg/pub_package_reader/lib/pub_package_reader.dart
+++ b/pkg/pub_package_reader/lib/pub_package_reader.dart
@@ -240,7 +240,7 @@ Iterable<ArchiveIssue> forbidGitDependencies(Pubspec pubspec) sync* {
     if (entry.value is GitDependency) {
       yield ArchiveIssue(
         'Package dependency $name is a git dependency, '
-        'this is not allowed in published packages',
+        'this is not allowed in published packages.',
       );
       continue;
     }

--- a/pkg/pub_package_reader/test/package_archive_test.dart
+++ b/pkg/pub_package_reader/test/package_archive_test.dart
@@ -98,13 +98,26 @@ void main() {
       expect(forbidGitDependencies(pubspec).toList(), isEmpty);
     });
 
-    test('git dependencies are forbidden', () {
+    test('compact git dependency is forbidden', () {
       final pubspec = Pubspec.parse('''
       name: hack
       version: 1.0.1
       dependencies:
         kittens:
           git: git://github.com/munificent/kittens.git
+      ''');
+      expect(forbidGitDependencies(pubspec).toList(), isNotEmpty);
+    });
+
+    test('git dependency with url and path is forbidden', () {
+      final pubspec = Pubspec.parse('''
+      name: hack
+      version: 1.0.1
+      dependencies:
+        kittens:
+          git:
+            url: git://github.com/munificent/kittens.git
+            path: some/directory/inside/the/repo
       ''');
       expect(forbidGitDependencies(pubspec).toList(), isNotEmpty);
     });


### PR DESCRIPTION
- Fixed text: missing `is` and a dot.
- The tests were to double-check our code wrt. #3467 