### PR TITLE
New icons on versions page

### DIFF
--- a/app/lib/frontend/static_files.dart
+++ b/app/lib/frontend/static_files.dart
@@ -177,12 +177,21 @@ class StaticUrls {
         githubMarkdownCss = _getCacheableStaticUrl(
             '$_defaultStaticPath/css/github-markdown.css');
 
+  // TODO: merge with [newVersionTableIcons] after migration to the new UI
   Map get versionsTableIcons {
     return _versionsTableIcons ??= {
       'documentation': documentationIcon,
       'download': downloadIcon,
     };
   }
+
+  // TODO: merge with [versionsTableIcons] after migration to the new UI
+  final newVersionsTableIcons = {
+    'documentation':
+        _getCacheableStaticUrl('$_defaultStaticPath/img/description-24px.svg'),
+    'download': _getCacheableStaticUrl(
+        '$_defaultStaticPath/img/vertical_align_bottom-24px.svg'),
+  };
 
   /// A hashed version of the static assets.
   ///

--- a/app/lib/frontend/templates/package_versions.dart
+++ b/app/lib/frontend/templates/package_versions.dart
@@ -5,6 +5,7 @@
 import '../../package/models.dart';
 import '../../shared/urls.dart' as urls;
 
+import '../request_context.dart';
 import '../static_files.dart';
 
 import '_cache.dart';
@@ -95,7 +96,9 @@ String renderVersionTableRow(PackageVersion version, String downloadUrl) {
     'dartdocs_url':
         _attr(urls.pkgDocUrl(version.package, version: version.version)),
     'download_url': _attr(downloadUrl),
-    'icons': staticUrls.versionsTableIcons,
+    'icons': requestContext.isExperimental
+        ? staticUrls.newVersionsTableIcons
+        : staticUrls.versionsTableIcons,
   };
   return templateCache.renderTemplate('pkg/versions/version_row', versionData);
 }

--- a/static/img/description-24px.svg
+++ b/static/img/description-24px.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M8 16h8v2H8zm0-4h8v2H8zm6-10H6c-1.1 0-2 .9-2 2v16c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6zm4 18H6V4h7v5h5v11z"/></svg>

--- a/static/img/vertical_align_bottom-24px.svg
+++ b/static/img/vertical_align_bottom-24px.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24"><path d="M16 13h-3V3h-2v10H8l4 4 4-4zM4 19v2h16v-2H4z"/><path d="M0 0h24v24H0z" fill="none"/></svg>


### PR DESCRIPTION
Icons were downloaded from material design.

<img width="231" alt="Screen Shot 2020-03-30 at 14 31 25" src="https://user-images.githubusercontent.com/4778111/77912701-4b75ed00-7293-11ea-9f7a-24d9bb96603f.png">
