### PR TITLE
Rounded outline on search input.

### DIFF
--- a/pkg/web_css/lib/src/_search.scss
+++ b/pkg/web_css/lib/src/_search.scss
@@ -6,12 +6,15 @@
   searchbar
 ******************************************************/
 .search-bar {
-  border: 1px solid $color-searchbar-dark-border;
   display: flex;
   align-items: center;
   border-radius: 3px;
   max-width: 650px;
   background: transparent;
+
+  .non-experimental & {
+    border: 1px solid $color-searchbar-dark-border;
+  }
 
   .experimental & {
     max-width: 710px;
@@ -50,6 +53,13 @@
       font-size: 24px;
       padding: 20px 35px 20px 65px;
       border-radius: 35px;
+    }
+  }
+
+  &:focus {
+    .experimental & {
+      outline: none;
+      box-shadow: 0 0 6px $color-input-primary;
     }
   }
 }


### PR DESCRIPTION
As the regular outline does not follow border radius, this is implemented with box-shadow:

<img width="320" alt="Screen Shot 2020-03-31 at 11 34 31" src="https://user-images.githubusercontent.com/4778111/78011336-bda60a80-7343-11ea-8ffe-60361fe2c67e.png">
