### PR TITLE
Updated package badge

### DIFF
--- a/app/lib/frontend/templates/detail_page.dart
+++ b/app/lib/frontend/templates/detail_page.dart
@@ -22,6 +22,7 @@ String renderDetailHeader({
   bool isFlutterFavorite = false,
   String metadataHtml,
   String tagsHtml,
+
   /// Set true for more whitespace in the header.
   bool isLoose = false,
   bool isPublisher = false,

--- a/app/lib/frontend/templates/views/pkg/tags.mustache
+++ b/app/lib/frontend/templates/views/pkg/tags.mustache
@@ -2,7 +2,12 @@
     for details. All rights reserved. Use of this source code is governed by a
     BSD-style license that can be found in the LICENSE file. }}
 {{#tag_badges}}
-  <div class="-pub-tag-badge"><div{{#title}} title="{{title}}"{{/title}}>{{sdk}}</div>{{#sub_tags}}<div{{#title}} title="{{title}}"{{/title}}>{{text}}</div>{{/sub_tags}}</div>
+<div class="-pub-tag-badge">
+  <span class="tag-badge-main"{{#title}} title="{{title}}"{{/title}}>{{sdk}}</span>
+  {{#sub_tags}}
+  <span class="tag-badge-sub"{{#title}} title="{{title}}"{{/title}}>{{text}}</span>
+  {{/sub_tags}}
+</div>
 {{/tag_badges}}
 {{#tags}}
   {{#has_href}}

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -116,8 +116,8 @@ Published
             </div>
             <div class="tags">
               <div class="-pub-tag-badge">
-                <div title="Packages compatible with Flutter SDK">flutter</div>
-                <div title="Packages compatible with Flutter on the Android platform">android</div>
+                <span class="tag-badge-main" title="Packages compatible with Flutter SDK">flutter</span>
+                <span class="tag-badge-sub" title="Packages compatible with Flutter on the Android platform">android</span>
               </div>
             </div>
           </div>

--- a/pkg/web_css/lib/src/_tags.scss
+++ b/pkg/web_css/lib/src/_tags.scss
@@ -44,32 +44,61 @@
   }
 }
 
+/* non-indented rule to restrict the content of this block to the non-experimental pages */
+body.non-experimental {
+
 /* Tag style used on package detail page for Dart/Flutter extended badges. */
 .-pub-tag-badge {
   font-size: 12px;
   display: inline-block;
   margin-right: 15px;
+  background: #e7f8ff;
 
-  > * {
+  > .tag-badge-main,
+  > .tag-badge-sub {
     display: inline-block;
     text-transform: uppercase;
     font-weight: 500;
     padding: 2px 8px;
     color: #555;
-    background: #e7f8ff;
   }
 
-  > *:first-child {
+  > .tag-badge-main {
     background: #0175c2;
     color: #e7f8ff;
   }
+}
 
-  > a:hover {
-    background: #ccc;
-    opacity: 1;
+/* non-indented rule to restrict the content of this block to the non-experimental pages */
+}
+
+/* non-indented rule to restrict the content of this block to the experimental pages */
+body.experimental {
+
+/* Tag style used on package detail page for Dart/Flutter extended badges. */
+.-pub-tag-badge {
+  font-size: 12px;
+  display: inline-block;
+  margin-right: 15px;
+  background: #e7f8ff;
+  padding-top: 2px;
+
+  > .tag-badge-main,
+  > .tag-badge-sub {
+    display: inline-block;
+    text-transform: uppercase;
+    font-weight: 300;
+    padding: 2px 8px;
+    color: #555;
+    border-bottom: 2px solid #e7f8ff;
   }
 
-  > a:first-child:hover {
-    background: #888;
+  > .tag-badge-main {
+    color: #1967d2;
+    font-weight: 400;
+    border-bottom: 2px solid #1967d2;
   }
+}
+
+/* non-indented rule to restrict the content of this block to the experimental pages */
 }


### PR DESCRIPTION
- Updated template to include class name and also to break lines. (Updated old rules to match these.)
- Updated styles behind experimental flag.

<img width="392" alt="Screen Shot 2020-04-01 at 11 56 50" src="https://user-images.githubusercontent.com/4778111/78124669-4a1dff00-7410-11ea-82bf-97257f7b27bc.png">
