### PR TITLE
Update: account nav menu

### DIFF
--- a/app/lib/frontend/templates/views/shared/site_header_experimental.mustache
+++ b/app/lib/frontend/templates/views/shared/site_header_experimental.mustache
@@ -51,12 +51,15 @@
     </div>
     {{#is_logged_in}}
     <div class="nav-container nav-profile-container hoverable">
-      <img class="nav-profile-img" id="-account-profile-img" src="{{& user_session.image_url}}" />
+      <img class="nav-profile-img nav-profile-image-desktop" src="{{& user_session.image_url}}" />
       <div class="nav-hover-popup">
         <div class="nav-table-column">
-          <div class="nav-account-title">
-            {{#user_session.has_name}}<div>{{user_session.name}}</div>{{/user_session.has_name}}
-            <div class="nav-account-email" id="-account-profile-email">{{user_session.email}}</div>
+          <div class="nav-account-title-mobile">
+            <img class="nav-profile-img nav-profile-img-mobile" src="{{& user_session.image_url}}" />
+            <div class="nav-account-title">
+              {{#user_session.has_name}}<div class="nav-account-name">{{user_session.name}}</div>{{/user_session.has_name}}
+              <div class="nav-account-email" id="-account-profile-email">{{user_session.email}}</div>
+            </div>
           </div>
           <div class="nav-separator"></div>
           <a class="nav-link" id="-account-logout">Sign out</a>

--- a/pkg/web_css/lib/src/_site_header_experimental.scss
+++ b/pkg/web_css/lib/src/_site_header_experimental.scss
@@ -108,6 +108,20 @@ body.experimental {
     border-radius: 50%;
   }
 
+  .nav-account-name {
+    font-weight: 400;
+    font-size: 14px;
+  }
+
+  .nav-account-email {
+    font-weight: 400;
+    font-size: 12px;
+  }
+
+  .nav-profile-img-mobile {
+    display: none;
+  }
+
   .site-header-nav {
     /* Navigation styles for mobile. */
     @media (max-width: $device-mobile-max-width) {
@@ -144,7 +158,20 @@ body.experimental {
         order: 1;
 
         .nav-profile-img {
-          margin-left: 0px;
+          margin: 0 16px 0 0;
+        }
+
+        .nav-profile-image-desktop {
+          display: none;
+        }
+
+        .nav-profile-img-mobile {
+          display: block;
+        }
+
+        .nav-account-title-mobile {
+          display: flex;
+          align-items: center;
         }
       }
 
@@ -169,6 +196,7 @@ body.experimental {
 
       .nav-link {
         line-height: 38px;
+        opacity: 0.7;
       }
     }
 


### PR DESCRIPTION
- opacity updated for links on mobile view
- name and email styles and font size
- duplicated profile image for the mobile view's header layout

<img width="220" alt="Screen Shot 2020-04-01 at 16 56 39" src="https://user-images.githubusercontent.com/4778111/78152557-42735000-743a-11ea-9ba0-33c7efae83d1.png">

<img width="267" alt="Screen Shot 2020-04-01 at 16 56 56" src="https://user-images.githubusercontent.com/4778111/78152564-456e4080-743a-11ea-9a3f-8f67963555c5.png">
