### PR TITLE
Migrating pub_server: versions list API.

### DIFF
--- a/app/lib/frontend/handlers/pubapi.client.dart
+++ b/app/lib/frontend/handlers/pubapi.client.dart
@@ -26,11 +26,11 @@ class PubApiClient {
 
   final _i2.Client _client;
 
-  Future<List<int>> listPackageVersions(String package) async {
-    return await _client.requestBytes(
+  Future<_i3.PackageData> packageData(String package) async {
+    return _i3.PackageData.fromJson(await _client.requestJson(
       verb: 'get',
       path: '/api/packages/$package',
-    );
+    ));
   }
 
   Future<_i3.VersionInfo> packageVersionInfo(

--- a/app/lib/frontend/handlers/pubapi.dart
+++ b/app/lib/frontend/handlers/pubapi.dart
@@ -31,7 +31,7 @@ class PubApi {
   @EndPoint.get('/api/packages/<package>')
   Future<PackageData> packageData(Request request, String package) async =>
       await packageBackend.repository
-          .packageData(_replaceHost(request.requestedUri), package);
+          .listVersions(_replaceHost(request.requestedUri), package);
 
   /// Getting information about a specific (package, version) pair.
   /// https://github.com/dart-lang/pub/blob/master/doc/repository-spec-v2.md#deprecated-inspect-a-specific-version-of-a-package

--- a/app/lib/frontend/handlers/pubapi.dart
+++ b/app/lib/frontend/handlers/pubapi.dart
@@ -29,9 +29,9 @@ class PubApi {
   /// Getting information about all versions of a package.
   /// https://github.com/dart-lang/pub/blob/master/doc/repository-spec-v2.md#list-all-versions-of-a-package
   @EndPoint.get('/api/packages/<package>')
-  Future<Response> listPackageVersions(Request request, String package) async =>
-      await packageBackend.pubServer
-          .listVersions(_replaceHost(request.requestedUri), package);
+  Future<PackageData> packageData(Request request, String package) async =>
+      await packageBackend.repository
+          .packageData(_replaceHost(request.requestedUri), package);
 
   /// Getting information about a specific (package, version) pair.
   /// https://github.com/dart-lang/pub/blob/master/doc/repository-spec-v2.md#deprecated-inspect-a-specific-version-of-a-package

--- a/app/lib/frontend/handlers/pubapi.g.dart
+++ b/app/lib/frontend/handlers/pubapi.g.dart
@@ -11,11 +11,11 @@ Router _$PubApiRouter(PubApi service) {
   router.add('GET', r'/api/packages/<package>',
       (Request request, String package) async {
     try {
-      final _$result = await service.listPackageVersions(
+      final _$result = await service.packageData(
         request,
         package,
       );
-      return _$result;
+      return $utilities.jsonResponse(_$result.toJson());
     } on ApiResponseException catch (e) {
       return e.asApiResponse();
     } catch (e, st) {

--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -378,7 +378,9 @@ class GCloudPackageRepository extends pub_server.PackageRepository {
   GCloudPackageRepository(this.db, this.storage);
 
   /// Returns the known versions of [package].
-  Future<api.PackageData> packageData(Uri baseUri, String package) async {
+  ///
+  /// Used in `pub` client for finding which versions exist.
+  Future<api.PackageData> listVersions(Uri baseUri, String package) async {
     return await cache.packageData(package).get(() async {
       final packageVersions = await packageBackend.versionsOfPackage(package);
       if (packageVersions.isEmpty) {

--- a/app/lib/package/pub_server/repository.dart
+++ b/app/lib/package/pub_server/repository.dart
@@ -50,9 +50,6 @@ class PackageVersion {
 
 /// Represents a pub repository.
 abstract class PackageRepository {
-  /// Returns the known versions of [package].
-  Stream<PackageVersion> versions(String package);
-
   /// Starts a  upload.
   ///
   /// The given [redirectUrl] instructs the uploading client to make a GET

--- a/app/lib/shared/redis_cache.dart
+++ b/app/lib/shared/redis_cache.dart
@@ -6,10 +6,11 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:neat_cache/neat_cache.dart';
-import 'package:gcloud/service_scope.dart' as ss;
 import 'package:appengine/appengine.dart';
+import 'package:client_data/package_api.dart' show PackageData;
+import 'package:gcloud/service_scope.dart' as ss;
 import 'package:logging/logging.dart';
+import 'package:neat_cache/neat_cache.dart';
 
 import '../account/models.dart' show LikeData, UserSessionData;
 import '../dartdoc/models.dart' show DartdocEntry, FileInfo;
@@ -113,9 +114,15 @@ class CachePatterns {
       .withTTL(Duration(minutes: 60))
       .withCodec(utf8)[publisherId];
 
-  Entry<List<int>> packageData(String package) => _cache
-      .withPrefix('package-data')
-      .withTTL(Duration(minutes: 10))['$package'];
+  Entry<PackageData> packageData(String package) => _cache
+      .withPrefix('api-package-data')
+      .withTTL(Duration(minutes: 10))
+      .withCodec(utf8)
+      .withCodec(json)
+      .withCodec(wrapAsCodec(
+        encode: (PackageData pd) => pd.toJson(),
+        decode: (d) => PackageData.fromJson(d as Map<String, dynamic>),
+      ))['$package'];
 
   Entry<PackageView> packageView(String package) => _cache
       .withPrefix('package-view')

--- a/app/test/package/backend_test.dart
+++ b/app/test/package/backend_test.dart
@@ -347,22 +347,23 @@ void main() {
       });
     });
 
-    group('GCloudRepository.versions', () {
+    group('GCloudRepository.packageData', () {
+      final baseUri = Uri.parse('https://pub.dev');
+
       testWithServices('not found', () async {
-        final versions =
-            await packageBackend.repository.versions('non_hydrogen').toList();
-        expect(versions, isEmpty);
+        final rs =
+            packageBackend.repository.packageData(baseUri, 'non_hydrogen');
+        await expectLater(rs, throwsA(isA<NotFoundException>()));
       });
 
       testWithServices('found', () async {
-        final versions =
-            await packageBackend.repository.versions('hydrogen').toList();
-        expect(versions, isNotEmpty);
-        expect(versions, hasLength(13));
-        expect(versions.first.packageName, 'hydrogen');
-        expect(versions.first.versionString, '1.0.0');
-        expect(versions.last.packageName, 'hydrogen');
-        expect(versions.last.versionString, '2.0.8');
+        final pd =
+            await packageBackend.repository.packageData(baseUri, 'hydrogen');
+        expect(pd.versions, isNotEmpty);
+        expect(pd.versions, hasLength(13));
+        expect(pd.versions.first.version, '1.0.0');
+        expect(pd.versions.last.version, '2.0.8');
+        expect(pd.latest.version, '2.0.8');
       });
     });
 

--- a/app/test/package/backend_test.dart
+++ b/app/test/package/backend_test.dart
@@ -352,13 +352,13 @@ void main() {
 
       testWithServices('not found', () async {
         final rs =
-            packageBackend.repository.packageData(baseUri, 'non_hydrogen');
+            packageBackend.repository.listVersions(baseUri, 'non_hydrogen');
         await expectLater(rs, throwsA(isA<NotFoundException>()));
       });
 
       testWithServices('found', () async {
         final pd =
-            await packageBackend.repository.packageData(baseUri, 'hydrogen');
+            await packageBackend.repository.listVersions(baseUri, 'hydrogen');
         expect(pd.versions, isNotEmpty);
         expect(pd.versions, hasLength(13));
         expect(pd.versions.first.version, '1.0.0');

--- a/pkg/client_data/lib/package_api.dart
+++ b/pkg/client_data/lib/package_api.dart
@@ -89,6 +89,24 @@ class Message {
 }
 
 @JsonSerializable()
+class PackageData {
+  final String name;
+  final VersionInfo latest;
+  final List<VersionInfo> versions;
+
+  PackageData({
+    @required this.name,
+    @required this.latest,
+    @required this.versions,
+  });
+
+  factory PackageData.fromJson(Map<String, dynamic> json) =>
+      _$PackageDataFromJson(json);
+
+  Map<String, dynamic> toJson() => _$PackageDataToJson(this);
+}
+
+@JsonSerializable()
 class VersionInfo {
   final String version;
 

--- a/pkg/client_data/lib/package_api.dart
+++ b/pkg/client_data/lib/package_api.dart
@@ -88,10 +88,21 @@ class Message {
   Map<String, dynamic> toJson() => _$MessageToJson(this);
 }
 
+/// Used in `pub` client for finding which versions exist.
+/// (`listVersions` method in pubapi)
 @JsonSerializable()
 class PackageData {
+  /// Package name.
   final String name;
+
+  /// This is merely a convenience property, because the [VersionInfo] for the
+  /// latest version also exists in the [versions] list.
+  ///
+  /// This is the latest that is NOT a pre-release, unless there only is
+  /// pre-releases in the [versions] list.
   final VersionInfo latest;
+
+  /// The available versions, sorted by their semantic version number (ascending).
   final List<VersionInfo> versions;
 
   PackageData({
@@ -112,6 +123,7 @@ class VersionInfo {
 
   final Map<String, dynamic> pubspec;
 
+  /// As of Dart 2.8 `pub` client uses [archiveUrl] to find the archive.
   @JsonKey(name: 'archive_url')
   final String archiveUrl;
 

--- a/pkg/client_data/lib/package_api.g.dart
+++ b/pkg/client_data/lib/package_api.g.dart
@@ -67,6 +67,26 @@ Map<String, dynamic> _$MessageToJson(Message instance) => <String, dynamic>{
       'message': instance.message,
     };
 
+PackageData _$PackageDataFromJson(Map<String, dynamic> json) {
+  return PackageData(
+    name: json['name'] as String,
+    latest: json['latest'] == null
+        ? null
+        : VersionInfo.fromJson(json['latest'] as Map<String, dynamic>),
+    versions: (json['versions'] as List)
+        ?.map((e) =>
+            e == null ? null : VersionInfo.fromJson(e as Map<String, dynamic>))
+        ?.toList(),
+  );
+}
+
+Map<String, dynamic> _$PackageDataToJson(PackageData instance) =>
+    <String, dynamic>{
+      'name': instance.name,
+      'latest': instance.latest,
+      'versions': instance.versions,
+    };
+
 VersionInfo _$VersionInfoFromJson(Map<String, dynamic> json) {
   return VersionInfo(
     version: json['version'] as String,

--- a/pkg/web_app/lib/src/pubapi.client.dart
+++ b/pkg/web_app/lib/src/pubapi.client.dart
@@ -26,11 +26,11 @@ class PubApiClient {
 
   final _i2.Client _client;
 
-  Future<List<int>> listPackageVersions(String package) async {
-    return await _client.requestBytes(
+  Future<_i3.PackageData> packageData(String package) async {
+    return _i3.PackageData.fromJson(await _client.requestJson(
       verb: 'get',
       path: '/api/packages/$package',
-    );
+    ));
   }
 
   Future<_i3.VersionInfo> packageVersionInfo(


### PR DESCRIPTION
- #3343
- Tested with the latest 1.24 and the latest stable and the latest 2.8 dev SDKs.

- Caching is less efficient, but I'm not sure what the real impact would be.
