### PR TITLE
Refactor: PackageIndex.merge()

### DIFF
--- a/app/lib/search/handlers.dart
+++ b/app/lib/search/handlers.dart
@@ -41,7 +41,8 @@ Future<shelf.Response> _livenessCheckHandler(shelf.Request request) async {
 
 /// Handles /readiness_check requests.
 Future<shelf.Response> _readinessCheckHandler(shelf.Request request) async {
-  if (packageIndex.isReady) {
+  final info = await packageIndex.indexInfo();
+  if (info.isReady) {
     return htmlResponse('OK');
   } else {
     return htmlResponse('Service Unavailable', status: 503);
@@ -49,16 +50,15 @@ Future<shelf.Response> _readinessCheckHandler(shelf.Request request) async {
 }
 
 /// Handler /debug requests
-shelf.Response _debugHandler(shelf.Request request) {
-  return debugResponse({
-    'ready': packageIndex.isReady,
-    'info': packageIndex.debugInfo,
-  });
+Future<shelf.Response> _debugHandler(shelf.Request request) async {
+  final info = await packageIndex.indexInfo();
+  return debugResponse(info.toJson());
 }
 
 /// Handles /search requests.
 Future<shelf.Response> _searchHandler(shelf.Request request) async {
-  if (!packageIndex.isReady) {
+  final info = await packageIndex.indexInfo();
+  if (!info.isReady) {
     return htmlResponse(searchIndexNotReadyText,
         status: searchIndexNotReadyCode);
   }

--- a/app/lib/search/search_service.dart
+++ b/app/lib/search/search_service.dart
@@ -56,6 +56,11 @@ abstract class PackageIndex {
   Future<void> addPackages(Iterable<PackageDocument> documents);
   Future<void> removePackage(String package);
   Future<PackageSearchResult> search(SearchQuery query);
+
+  /// A package index may be accessed while the initialization phase is still
+  /// running. Once the initialization is done (either via a snapshot or a
+  /// `Package`-scan completes), the updater should call this method to indicate
+  /// to the frontend load-balancer that the instance now accepts requests.
   Future<void> markReady();
   Future<IndexInfo> indexInfo();
 }

--- a/app/lib/search/search_service.dart
+++ b/app/lib/search/search_service.dart
@@ -29,15 +29,35 @@ final _detectedTagPrefixes = <String>{
   ...allowedTagPrefixes.expand((s) => [s, '-$s', '+$s']),
 };
 
+/// Statistics about the index content.
+class IndexInfo {
+  final bool isReady;
+  final int packageCount;
+  final DateTime lastUpdated;
+
+  IndexInfo({
+    @required this.isReady,
+    @required this.packageCount,
+    @required this.lastUpdated,
+  });
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'isReady': isReady,
+        'packageCount': packageCount,
+        'lastUpdated': lastUpdated?.toIso8601String(),
+        if (lastUpdated != null)
+          'lastUpdateDelta': DateTime.now().difference(lastUpdated).toString(),
+      };
+}
+
 /// Package search index and lookup.
 abstract class PackageIndex {
-  bool get isReady;
   Future<void> addPackage(PackageDocument doc);
   Future<void> addPackages(Iterable<PackageDocument> documents);
   Future<void> removePackage(String package);
-  Future<void> merge();
   Future<PackageSearchResult> search(SearchQuery query);
-  Map<String, dynamic> get debugInfo;
+  Future<void> markReady();
+  Future<IndexInfo> indexInfo();
 }
 
 /// A summary information about a package that goes into the search index.

--- a/app/test/search/angular_test.dart
+++ b/app/test/search/angular_test.dart
@@ -26,7 +26,7 @@ void main() {
         version: '0.6.5',
         description: compactDescription('Port of Angular-UI to Dart.'),
       ));
-      await index.merge();
+      await index.markReady();
     });
 
     test('angular', () async {

--- a/app/test/search/api_doc_page_test.dart
+++ b/app/test/search/api_doc_page_test.dart
@@ -47,7 +47,7 @@ void main() {
         version: '2.0.0',
         description: compactDescription('Unrelated package'),
       ));
-      await index.merge();
+      await index.markReady();
     });
 
     test('foo', () async {

--- a/app/test/search/bluetooth_test.dart
+++ b/app/test/search/bluetooth_test.dart
@@ -27,7 +27,7 @@ void main() {
         description: compactDescription(
             'A Dart library for smooth scroll effect on a web page.'),
       ));
-      await index.merge();
+      await index.markReady();
     });
 
     test('bluetooth', () async {

--- a/app/test/search/exact_name_test.dart
+++ b/app/test/search/exact_name_test.dart
@@ -33,7 +33,7 @@ void main() {
         popularity: 1.0,
         maintenance: 1.0,
       ));
-      await index.merge();
+      await index.markReady();
     });
 
     test('build_config', () async {

--- a/app/test/search/flutter_iap_test.dart
+++ b/app/test/search/flutter_iap_test.dart
@@ -45,7 +45,7 @@ void main() {
             'A new flutter package to render wavefront obj files into a canvas.'),
       ));
 
-      await index.merge();
+      await index.markReady();
     });
 
     test('flutter iap', () async {

--- a/app/test/search/handlers_test.dart
+++ b/app/test/search/handlers_test.dart
@@ -38,7 +38,7 @@ void main() {
         registerDartSdkIndex(SimplePackageIndex());
         await packageIndex
             .addPackage(await searchBackend.loadDocument('pkg_foo'));
-        await packageIndex.merge();
+        await packageIndex.markReady();
       }
 
       scopedTest('Finds package by name', () async {

--- a/app/test/search/haversine_test.dart
+++ b/app/test/search/haversine_test.dart
@@ -373,7 +373,7 @@ class MyBot implements Bot {
 MIT'''),
         ),
       ]);
-      await index.merge();
+      await index.markReady();
     });
 
     test('haversine', () async {

--- a/app/test/search/in_app_payments_test.dart
+++ b/app/test/search/in_app_payments_test.dart
@@ -23,7 +23,7 @@ void main() {
           readme: compactReadme('''# flutter_iap
 
 Add _In-App Payments_ to your Flutter app with this plugin.''')));
-      await index.merge();
+      await index.markReady();
     });
 
     test('IAP', () async {

--- a/app/test/search/index_simple_test.dart
+++ b/app/test/search/index_simple_test.dart
@@ -194,7 +194,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         maintenance: 0.9,
         dependencies: {'foo': 'direct'},
       ));
-      await index.merge();
+      await index.markReady();
     });
 
     test('health scores', () {

--- a/app/test/search/json_tool_test.dart
+++ b/app/test/search/json_tool_test.dart
@@ -18,7 +18,7 @@ void main() {
       await index.addPackage(PackageDocument(package: 'jsontool'));
       await index.addPackage(PackageDocument(package: 'json2entity'));
       await index.addPackage(PackageDocument(package: 'json_to_model'));
-      await index.merge();
+      await index.markReady();
     });
 
     test('json_tool', () async {
@@ -56,7 +56,7 @@ void main() {
         readme:
             'Command line tool for generating Dart models (json_serializable) from Json file.',
       ));
-      await index.merge();
+      await index.markReady();
     });
 
     test('json_tool', () async {

--- a/app/test/search/lombok_test.dart
+++ b/app/test/search/lombok_test.dart
@@ -19,7 +19,7 @@ void main() {
         package: 'lombok',
         version: '1.0.0',
       ));
-      await index.merge();
+      await index.markReady();
     });
 
     test('lombock', () async {

--- a/app/test/search/maps_test.dart
+++ b/app/test/search/maps_test.dart
@@ -17,7 +17,7 @@ void main() {
       index = SimplePackageIndex();
       await index.addPackage(PackageDocument(package: 'maps'));
       await index.addPackage(PackageDocument(package: 'map'));
-      await index.merge();
+      await index.markReady();
     });
 
     test('maps', () async {

--- a/app/test/search/rest_api_test.dart
+++ b/app/test/search/rest_api_test.dart
@@ -44,7 +44,7 @@ Recent versions (0.3.x and 0.4.x) of this plugin require [extensible codec funct
             'Currency Cloud Dart API A dart library for the Currency Cloud '
             'service Usage A simple usage example'),
       ));
-      await index.merge();
+      await index.markReady();
     });
 
     test('REST API', () async {

--- a/app/test/search/result_combiner_test.dart
+++ b/app/test/search/result_combiner_test.dart
@@ -40,8 +40,8 @@ void main() {
         ],
       ));
 
-      await primaryIndex.merge();
-      await dartSdkIndex.merge();
+      await primaryIndex.markReady();
+      await dartSdkIndex.markReady();
     });
 
     test('non-text ranking', () async {

--- a/app/test/search/scope_specificity_test.dart
+++ b/app/test/search/scope_specificity_test.dart
@@ -57,7 +57,7 @@ void main() {
         package: 'json_3',
         tags: ['sdk:dart', 'sdk:flutter'],
       ));
-      await index.merge();
+      await index.markReady();
     });
 
     test('text search without platform', () async {

--- a/app/test/search/stack_trace_test.dart
+++ b/app/test/search/stack_trace_test.dart
@@ -24,7 +24,7 @@ void main() {
               'A package for manipulating stack traces and printing them readably.'),
         ),
       ]);
-      await index.merge();
+      await index.markReady();
     });
 
     // should find full word

--- a/app/test/search/tags_test.dart
+++ b/app/test/search/tags_test.dart
@@ -14,7 +14,7 @@ void main() {
     test('No tags in documents: positive tag match', () async {
       final index = SimplePackageIndex();
       await index.addPackage(PackageDocument(package: 'pkg1'));
-      await index.merge();
+      await index.markReady();
 
       final rs = await index.search(SearchQuery.parse(
         tagsPredicate: TagsPredicate(requiredTags: ['is:a']),
@@ -29,7 +29,7 @@ void main() {
     test('No tags in documents: negative tag match', () async {
       final index = SimplePackageIndex();
       await index.addPackage(PackageDocument(package: 'pkg1'));
-      await index.merge();
+      await index.markReady();
 
       final rs = await index.search(SearchQuery.parse(
         tagsPredicate: TagsPredicate(prohibitedTags: ['is:a']),
@@ -47,7 +47,7 @@ void main() {
       final index = SimplePackageIndex();
       await index.addPackage(PackageDocument(package: 'pkg1', tags: ['is:a']));
       await index.addPackage(PackageDocument(package: 'pkg2', tags: ['is:b']));
-      await index.merge();
+      await index.markReady();
 
       final rs = await index.search(SearchQuery.parse(
         tagsPredicate: TagsPredicate(prohibitedTags: ['is:a']),
@@ -65,7 +65,7 @@ void main() {
       final index = SimplePackageIndex();
       await index.addPackage(PackageDocument(package: 'pkg1', tags: ['is:a']));
       await index.addPackage(PackageDocument(package: 'pkg2', tags: ['is:b']));
-      await index.merge();
+      await index.markReady();
 
       final rs = await index.search(SearchQuery.parse(
         tagsPredicate: TagsPredicate.parseQueryValues(['is:a']),
@@ -85,7 +85,7 @@ void main() {
           PackageDocument(package: 'pkg1', tags: ['is:a', 'is:dart1']));
       await index.addPackage(
           PackageDocument(package: 'pkg2', tags: ['is:b', 'is:dart1']));
-      await index.merge();
+      await index.markReady();
 
       final rs = await index.search(SearchQuery.parse(
         tagsPredicate: TagsPredicate.parseQueryValues(['is:dart1']),
@@ -106,7 +106,7 @@ void main() {
           PackageDocument(package: 'pkg1', tags: ['is:a', 'is:dart1']));
       await index.addPackage(
           PackageDocument(package: 'pkg2', tags: ['is:b', 'is:dart1']));
-      await index.merge();
+      await index.markReady();
 
       final rs = await index.search(SearchQuery.parse(
         tagsPredicate: TagsPredicate.parseQueryValues(['is:dart1', 'is:b']),
@@ -126,7 +126,7 @@ void main() {
           PackageDocument(package: 'pkg1', tags: ['is:a', 'is:dart1']));
       await index.addPackage(
           PackageDocument(package: 'pkg2', tags: ['is:b', 'is:dart1']));
-      await index.merge();
+      await index.markReady();
 
       final rs = await index.search(SearchQuery.parse(
         tagsPredicate: TagsPredicate.parseQueryValues(['is:dart1', '-is:b']),
@@ -145,7 +145,7 @@ void main() {
       await index
           .addPackage(PackageDocument(package: 'pkg1', tags: ['is:a', 'is:b']));
       await index.addPackage(PackageDocument(package: 'pkg2', tags: ['is:b']));
-      await index.merge();
+      await index.markReady();
 
       final rs = await index.search(SearchQuery.parse(query: 'is:b -is:a'));
       expect(json.decode(json.encode(rs.toJson())), {
@@ -162,7 +162,7 @@ void main() {
       await index
           .addPackage(PackageDocument(package: 'pkg1', tags: ['is:a', 'is:b']));
       await index.addPackage(PackageDocument(package: 'pkg2', tags: ['is:a']));
-      await index.merge();
+      await index.markReady();
 
       final rs = await index.search(SearchQuery.parse(
           tagsPredicate: TagsPredicate(prohibitedTags: ['is:b']),

--- a/app/test/search/travis_test.dart
+++ b/app/test/search/travis_test.dart
@@ -48,7 +48,7 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor i
 '''),
         ));
       }
-      await index.merge();
+      await index.markReady();
     });
 
     test('travis', () async {

--- a/app/test/shared/test_services.dart
+++ b/app/test/shared/test_services.dart
@@ -90,7 +90,7 @@ void testWithServices(String name, Future<void> Function() fn) {
         registerEmailSender(FakeEmailSender());
         registerUploadSigner(FakeUploadSignerService('https://storage.url'));
 
-        await dartSdkIndex.merge();
+        await dartSdkIndex.markReady();
         await indexUpdater.updateAllPackages();
 
         registerSearchClient(


### PR DESCRIPTION
- `PackageIndex.merge` was not used for really merging the index for a long time, as the index update happens when we are adding the document. Renaming it to `markReady` clarifies its intent.
- Moved the update of `lastUpdated` around to more appropriate places.
- Created a typed `IndexInfo`.