### PR TITLE
Updated Uri check in handlers.

### DIFF
--- a/app/lib/shared/handler_helpers.dart
+++ b/app/lib/shared/handler_helpers.dart
@@ -198,8 +198,10 @@ bool _isValidUri(shelf.Request request) {
   final uri = request.requestedUri;
   try {
     // should be able to parse path segments
-    uri.pathSegments.forEach(Uri.decodeComponent);
-  } catch (_) {
+    uri.pathSegments.forEach((_) => null);
+    // should be able to parse query parameters
+    uri.queryParameters.forEach((_, __) => null);
+  } on FormatException catch (_) {
     return false;
   }
   return true;


### PR DESCRIPTION
- Updated `pathSegments` - they are already decoded, no need to call it a second time.
- Added `queryParameters` iteration - they are lazily evaluated, they should be parsed upfront.
- Scoping check on `FormatException`.
- Solves recent client requests with "Bad UTF-8 encoding 0xff (at offset 22)" (on search URLs).
