### PR TITLE
New UI: add uploader dialog.

### DIFF
--- a/app/lib/frontend/templates/views/publisher/admin_page_experimental.mustache
+++ b/app/lib/frontend/templates/views/publisher/admin_page_experimental.mustache
@@ -68,29 +68,31 @@
   </table>
 </div>
 
-<h2>Invite new member</h2>
-<p>
-  You can invite new members to this verified publisher.
-  Once new members accept the invitation, they have full administrative rights, with the following abilities:
-</p>
-<ul>
-  <li>Transfer packages to and from this publisher</li>
-  <li>Upload new versions of packages owned by this publisher</li>
-  <li>Add and remove members of this publisher</li>
-</ul>
-<div class="-pub-form-row">
-  <label for="-admin-invite-member-input">Email address</label>
-  <div class="mdc-text-field mdc-text-field--outlined" data-mdc-auto-init="MDCTextField">
-    <input type="text" id="-admin-invite-member-input" class="mdc-text-field__input" />
-    <div class="mdc-notched-outline">
-      <div class="mdc-notched-outline__leading"></div>
-      <div class="mdc-notched-outline__trailing"></div>
-    </div>
-  </div>
-</div>
 <div class="-pub-form-right-aligned">
   <button
-    id="-admin-invite-member-button"
-    class="mdc-button mdc-button--raised"
-    data-mdc-auto-init="MDCRipple">Invite member</button>
+      id="-admin-add-member-button"
+      class="mdc-button mdc-button--raised"
+      data-mdc-auto-init="MDCRipple">Add member</button>
+</div>
+
+<div id="-admin-add-member-content" class="modal-content-hidden">
+  <p>
+    You can invite new members to this verified publisher.
+    Once new members accept the invitation, they have full administrative rights, with the following abilities:
+  </p>
+  <ul>
+    <li>Transfer packages to and from this publisher</li>
+    <li>Upload new versions of packages owned by this publisher</li>
+    <li>Add and remove members of this publisher</li>
+  </ul>
+  <div class="-pub-form-row">
+    <label for="-admin-invite-member-input">Email address</label>
+    <div class="mdc-text-field mdc-text-field--outlined" data-mdc-auto-init="MDCTextField">
+      <input type="text" id="-admin-invite-member-input" class="mdc-text-field__input" />
+      <div class="mdc-notched-outline">
+        <div class="mdc-notched-outline__leading"></div>
+        <div class="mdc-notched-outline__trailing"></div>
+      </div>
+    </div>
+  </div>
 </div>

--- a/pkg/web_app/lib/src/_dom_helper.dart
+++ b/pkg/web_app/lib/src/_dom_helper.dart
@@ -114,7 +114,7 @@ String _requestExceptionMessage(RequestException e) {
 
 /// Displays a message via the modal window.
 Future modalMessage(String title, Element content) async {
-  await _modalWindow(
+  await modalWindow(
     titleText: title,
     content: content,
     isQuestion: false,
@@ -124,7 +124,7 @@ Future modalMessage(String title, Element content) async {
 /// Display [content] to user (assumed it has a question format), and return
 /// true if 'OK' was selected.
 Future<bool> modalConfirm(Element content) async {
-  return await _modalWindow(
+  return await modalWindow(
     titleText: 'Confirm',
     content: content,
     isQuestion: true,
@@ -135,19 +135,31 @@ Future<bool> modalConfirm(Element content) async {
 /// false, it will omit the "Cancel" button.
 ///
 /// Returns true if "OK" was pressed, false otherwise.
-Future<bool> _modalWindow({
+Future<bool> modalWindow({
   @required String titleText,
   @required Element content,
   @required bool isQuestion,
   String cancelButtonText,
   String okButtonText,
+
+  /// If specified, this callback function will be called on "OK" button clicks,
+  /// and the dialog window will be kept open. Returns with the success status
+  /// of the operation, and if `true`, the dialog will be closed, otherwise the
+  /// dialog is kept open (e.g. the user may update the form).
+  FutureOr<bool> Function() onOkButtonClicked,
 }) async {
   final c = Completer<bool>();
   final root = _buildDialog(
     titleText: titleText,
     content: content,
     isQuestion: isQuestion,
-    close: c.complete,
+    closing: (bool pushedOk) async {
+      final complete =
+          !pushedOk || onOkButtonClicked == null || await onOkButtonClicked();
+      if (complete && !c.isCompleted) {
+        c.complete(pushedOk);
+      }
+    },
     cancelButtonText: cancelButtonText,
     okButtonText: okButtonText,
   );
@@ -168,9 +180,12 @@ Element _buildDialog({
   @required String titleText,
   @required Element content,
   @required bool isQuestion,
-  @required void Function(bool) close,
   String cancelButtonText,
   String okButtonText,
+
+  /// The callback will be called with `true` when "OK" was clicked, and `false`
+  /// when "Cancel" was clicked.
+  @required Function(bool) closing,
 }) =>
     Element.div()
       ..classes.add('mdc-dialog')
@@ -205,7 +220,9 @@ Element _buildDialog({
                           'mdc-dialog__button',
                         ])
                         ..tabIndex = 2
-                        ..onClick.first.whenComplete(() => close(false))
+                        ..onClick.listen((_) {
+                          closing(false);
+                        })
                         ..children = [
                           Element.span()
                             ..classes.add('mdc-button__label')
@@ -217,7 +234,9 @@ Element _buildDialog({
                         'mdc-dialog__button',
                       ])
                       ..tabIndex = 1
-                      ..onClick.first.whenComplete(() => close(true))
+                      ..onClick.listen((_) {
+                        closing(true);
+                      })
                       ..children = [
                         Element.span()
                           ..classes.add('mdc-button__label')

--- a/pkg/web_app/lib/src/_dom_helper.dart
+++ b/pkg/web_app/lib/src/_dom_helper.dart
@@ -146,7 +146,7 @@ Future<bool> modalWindow({
   /// and the dialog window will be kept open. Returns with the success status
   /// of the operation, and if `true`, the dialog will be closed, otherwise the
   /// dialog is kept open (e.g. the user may update the form).
-  FutureOr<bool> Function() onOkButtonClicked,
+  FutureOr<bool> Function() onExecute,
 }) async {
   final c = Completer<bool>();
   final root = _buildDialog(
@@ -154,8 +154,7 @@ Future<bool> modalWindow({
     content: content,
     isQuestion: isQuestion,
     closing: (bool pushedOk) async {
-      final complete =
-          !pushedOk || onOkButtonClicked == null || await onOkButtonClicked();
+      final complete = !pushedOk || onExecute == null || await onExecute();
       if (complete && !c.isCompleted) {
         c.complete(pushedOk);
       }

--- a/pkg/web_app/lib/src/account.dart
+++ b/pkg/web_app/lib/src/account.dart
@@ -361,7 +361,7 @@ class _PublisherAdminWidget {
       isQuestion: true,
       okButtonText: 'Add',
       content: _addMemberContent,
-      onOkButtonClicked: () => _inviteMember(false),
+      onExecute: () => _inviteMember(false),
     );
   }
 

--- a/pkg/web_app/lib/src/account.dart
+++ b/pkg/web_app/lib/src/account.dart
@@ -296,6 +296,8 @@ class _PublisherAdminWidget {
   InputElement _websiteUrlInput;
   InputElement _contactEmailInput;
   InputElement _inviteMemberInput;
+  Element _addMemberButton;
+  Element _addMemberContent;
   Element _inviteMemberButton;
   String _originalContactEmail;
 
@@ -310,11 +312,19 @@ class _PublisherAdminWidget {
         document.getElementById('-publisher-contact-email') as InputElement;
     _inviteMemberInput =
         document.getElementById('-admin-invite-member-input') as InputElement;
+    _addMemberButton = document.getElementById('-admin-add-member-button');
+    _addMemberContent = document.getElementById('-admin-add-member-content');
     _inviteMemberButton =
         document.getElementById('-admin-invite-member-button');
     _originalContactEmail = _contactEmailInput?.value;
     _updateButton?.onClick?.listen((_) => _updatePublisher());
-    _inviteMemberButton?.onClick?.listen((_) => _inviteMember());
+    _addMemberButton?.onClick?.listen((_) => _addMember());
+    if (_addMemberContent != null) {
+      _addMemberContent.remove();
+      _addMemberContent.classes.remove('modal-content-hidden');
+    }
+    // TODO: remove _inviteMemberButton after migrating to the new UI
+    _inviteMemberButton?.onClick?.listen((_) => _inviteMember(true));
     for (final btn in document.querySelectorAll('.-pub-remove-user-button')) {
       btn.onClick.listen((_) => _removeMember(
             btn.dataset['user-id'],
@@ -345,17 +355,29 @@ class _PublisherAdminWidget {
     );
   }
 
-  Future<void> _inviteMember() async {
+  Future<void> _addMember() async {
+    await modalWindow(
+      titleText: 'Invite new member',
+      isQuestion: true,
+      okButtonText: 'Add',
+      content: _addMemberContent,
+      onOkButtonClicked: () => _inviteMember(false),
+    );
+  }
+
+  Future<bool> _inviteMember(bool requestConfirm) async {
     final email = _inviteMemberInput.value.trim();
     if (email.isEmpty || !email.contains('@') || !email.contains('.')) {
       await modalMessage(
           'Input validation', text('Please specify a valid e-mail.'));
-      return;
+      return false;
     }
 
     await rpc(
-      confirmQuestion: markdown('Are you sure you want to invite `$email` '
-          'as an administrator member to this publisher?'),
+      confirmQuestion: requestConfirm
+          ? markdown('Are you sure you want to invite `$email` '
+              'as an administrator member to this publisher?')
+          : null,
       fn: () async {
         await client.invitePublisherMember(
             pageData.publisher.publisherId, InviteMemberRequest(email: email));
@@ -365,6 +387,7 @@ class _PublisherAdminWidget {
         _inviteMemberInput.value = '';
       },
     );
+    return true;
   }
 
   Future<void> _removeMember(String userId, String email) async {

--- a/pkg/web_app/lib/src/account.dart
+++ b/pkg/web_app/lib/src/account.dart
@@ -365,6 +365,7 @@ class _PublisherAdminWidget {
     );
   }
 
+  // TODO: remove [requestConfirm] after we've migrated to the new UI.
   Future<bool> _inviteMember(bool requestConfirm) async {
     final email = _inviteMemberInput.value.trim();
     if (email.isEmpty || !email.contains('@') || !email.contains('.')) {

--- a/pkg/web_css/lib/src/_form.scss
+++ b/pkg/web_css/lib/src/_form.scss
@@ -2,6 +2,15 @@
    for details. All rights reserved. Use of this source code is governed by a
    BSD-style license that can be found in the LICENSE file. */
 
+/*
+ * Modal content is generated as part of the HTML page, and hidden initially.
+ * The web_app code will remove it from the DOM and remove this class rule
+ * before passing it to the modal window's content area.
+ */
+.modal-content-hidden {
+  display: none;
+}
+
 /* non-indented rule to restrict the content of this block to the experimental pages */
 body.experimental {
 


### PR DESCRIPTION
- The new dialog window enables us to stack them on top of each other (like on the screenshot below): a dialog with the main form, then a second dialog to communicate errors, while the core dialog is not immediately hidden.

- The form content is generated the same way on the server side mustache, but it is removed from the DOM in the browser.

<img width="1089" alt="Screen Shot 2020-04-15 at 12 10 16" src="https://user-images.githubusercontent.com/4778111/79326114-a0ac3280-7f12-11ea-80c7-380d92f82141.png">
