### PR TITLE
Explicit exception for zero-length uploaded archives.

### DIFF
--- a/app/lib/shared/exceptions.dart
+++ b/app/lib/shared/exceptions.dart
@@ -178,8 +178,7 @@ class PackageRejectedException extends ResponseException {
   /// The package archive tar.gz file is empty, possibly an error happened
   /// during the upload or the system was unable to create an archive.
   PackageRejectedException.archiveEmpty()
-      : super._(
-            400, 'PackageRejected', 'Package archive is empty (size = 0).');
+      : super._(400, 'PackageRejected', 'Package archive is empty (size = 0).');
 
   /// The [package] name is reserved.
   PackageRejectedException.nameReserved(String package)

--- a/app/lib/shared/exceptions.dart
+++ b/app/lib/shared/exceptions.dart
@@ -175,6 +175,12 @@ class PackageRejectedException extends ResponseException {
       : super._(
             400, 'PackageRejected', 'Package archive exceeded $limit bytes.');
 
+  /// The package archive tar.gz file is empty, possibly an error happened
+  /// during the upload or the system was unable to create an archive.
+  PackageRejectedException.archiveEmpty()
+      : super._(
+            400, 'PackageRejected', 'Package archive is empty (size = 0).');
+
   /// The [package] name is reserved.
   PackageRejectedException.nameReserved(String package)
       : super._(400, 'PackageRejected', 'Package name $package is reserved.');


### PR DESCRIPTION
- Fixes #3521. (I think zero-length archives are the majority of the reasons while uploads fail).
- I've also updated the too-big upload test, larger chunks are faster.