### PR TITLE
More resilient email sending

### DIFF
--- a/app/lib/frontend/email_sender.dart
+++ b/app/lib/frontend/email_sender.dart
@@ -8,6 +8,7 @@ import 'package:gcloud/service_scope.dart' as ss;
 import 'package:logging/logging.dart';
 import 'package:mailer/mailer.dart';
 import 'package:mailer/smtp_server.dart';
+import 'package:retry/retry.dart';
 
 import '../service/secret/backend.dart';
 import '../shared/email.dart';
@@ -41,7 +42,14 @@ class EmailSender {
     } else {
       _logger.info('Sending email: $debugHeader...');
       try {
-        await send(_toMessage(message), _server);
+        await retry(
+          () => send(
+            _toMessage(message),
+            _server,
+            timeout: Duration(seconds: 15),
+          ),
+          delayFactor: Duration(seconds: 2),
+        );
       } catch (e, st) {
         _logger.severe('Sending email failed: $debugHeader.', e, st);
       }

--- a/app/lib/frontend/email_sender.dart
+++ b/app/lib/frontend/email_sender.dart
@@ -49,6 +49,7 @@ class EmailSender {
             timeout: Duration(seconds: 15),
           ),
           delayFactor: Duration(seconds: 2),
+          maxAttempts: 2,
         );
       } catch (e, st) {
         _logger.severe('Sending email failed: $debugHeader.', e, st);

--- a/app/lib/frontend/email_sender.dart
+++ b/app/lib/frontend/email_sender.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:io';
 
 import 'package:gcloud/service_scope.dart' as ss;
 import 'package:logging/logging.dart';
@@ -48,6 +49,7 @@ class EmailSender {
             _server,
             timeout: Duration(seconds: 15),
           ),
+          retryIf: (e) => e is TimeoutException || e is IOException,
           delayFactor: Duration(seconds: 2),
           maxAttempts: 2,
         );


### PR DESCRIPTION
- fixes #3537
- timeout for the call in `package:mailer` 
- `retry` in case a short transient error happens