### PR TITLE
Profile image on new my-profile pages.

### DIFF
--- a/app/lib/account/models.dart
+++ b/app/lib/account/models.dart
@@ -9,6 +9,7 @@ import 'package:gcloud/db.dart' as db;
 import 'package:meta/meta.dart';
 import 'package:ulid/ulid.dart';
 
+import '../frontend/static_files.dart';
 import '../search/search_service.dart' show SearchQuery;
 
 part 'models.g.dart';
@@ -196,6 +197,17 @@ class UserSessionData {
       _$UserSessionDataFromJson(json);
 
   Map<String, dynamic> toJson() => _$UserSessionDataToJson(this);
+
+  /// Set image size to NxN pixels for faster loading, see:
+  /// https://developers.google.com/people/image-sizing
+  String imageUrlOfSize(int layoutSize) {
+    if (imageUrl == null) {
+      return staticUrls.defaultProfilePng;
+    }
+    // Double the layout size, for better quality on higher dpi displays.
+    final imageSize = layoutSize * 2;
+    return '$imageUrl=s$imageSize';
+  }
 }
 
 /// Derived data for [User] for fast lookup.

--- a/app/lib/frontend/handlers/account.dart
+++ b/app/lib/frontend/handlers/account.dart
@@ -214,6 +214,7 @@ Future<shelf.Response> accountPackagesPageHandler(shelf.Request request) async {
 
   final html = renderAccountPackagesPage(
     user: await accountBackend.lookupUserById(userSessionData.userId),
+    userSessionData: userSessionData,
     packages: searchResult.packages,
     pageLinks: links,
     searchQuery: searchQuery,
@@ -231,7 +232,11 @@ Future<shelf.Response> accountMyLikedPackagesPageHandler(
 
   final user = await accountBackend.lookupUserById(userSessionData.userId);
   final likes = await accountBackend.listPackageLikes(user);
-  final html = renderMyLikedPackagesPage(user: user, likes: likes);
+  final html = renderMyLikedPackagesPage(
+    user: user,
+    userSessionData: userSessionData,
+    likes: likes,
+  );
   return htmlResponse(html);
 }
 
@@ -246,6 +251,7 @@ Future<shelf.Response> accountPublishersPageHandler(
       await publisherBackend.listPublishersForUser(userSessionData.userId);
   final content = renderAccountPublishersPage(
     user: await accountBackend.lookupUserById(userSessionData.userId),
+    userSessionData: userSessionData,
     publishers: publishers,
   );
   return htmlResponse(content);

--- a/app/lib/frontend/templates/admin.dart
+++ b/app/lib/frontend/templates/admin.dart
@@ -183,7 +183,7 @@ String _accountDetailHeader(User user, UserSessionData userSessionData) {
   if (requestContext.isExperimental) {
     return renderDetailHeader(
       title: userSessionData.name,
-      imageUrl: userSessionData.imageUrl,
+      imageUrl: userSessionData.imageUrlOfSize(200),
       metadataHtml: '<p>${htmlEscape.convert(user.email)}</p>'
           '<p>${htmlEscape.convert('Joined on $shortJoined')}</p>',
     );

--- a/app/lib/frontend/templates/detail_page.dart
+++ b/app/lib/frontend/templates/detail_page.dart
@@ -17,6 +17,7 @@ final wideHeaderDetailPageClassName = '-wide-header-detail-page';
 /// The like button in the header will not be displayed when [isLiked] is null.
 String renderDetailHeader({
   @required String title,
+  String imageUrl,
   int packageLikes,
   bool isLiked,
   bool isFlutterFavorite = false,
@@ -36,6 +37,8 @@ String renderDetailHeader({
     'like_count': _formatPackageLikes(packageLikes),
     'is_liked': isLiked,
     'has_likes': isLiked != null,
+    'image_url': imageUrl,
+    'has_image_url': imageUrl != null && imageUrl.isNotEmpty,
     // TODO: remove values below after new UI is finalized
     'is_flutter_favorite': isFlutterFavorite,
   });

--- a/app/lib/frontend/templates/layout.dart
+++ b/app/lib/frontend/templates/layout.dart
@@ -112,11 +112,7 @@ String _renderSiteHeader(PageType pageType) {
           'email': userSessionData.email,
           'has_name': userSessionData.name != null,
           'name': userSessionData.name,
-          'image_url': userSessionData.imageUrl == null
-              ? staticUrls.defaultProfilePng
-              // Set image size to 30x30 pixels for faster loading, see:
-              // https://developers.google.com/people/image-sizing
-              : '${userSessionData.imageUrl}=s30',
+          'image_url': userSessionData.imageUrlOfSize(30),
         };
 
   return templateCache.renderTemplate('shared/site_header', {

--- a/app/lib/frontend/templates/views/shared/detail/header_experimental.mustache
+++ b/app/lib/frontend/templates/views/shared/detail/header_experimental.mustache
@@ -4,37 +4,46 @@
 
 <div class="detail-header{{#is_loose}} -is-loose{{/is_loose}}">
   <div class="detail-container">
-  <h1 class="title">{{#is_publisher}}<img
-      class="-pub-publisher-shield"
-      height="48" width="48"
-      title="Domain ownership verifed by pub.dev"
-      src="{{{static_assets.img__verified-publisher-blue_svg}}}" />{{/is_publisher}}{{title}}</h1>
-    <div class="metadata">{{& metadata_html}}</div>
-    <div class="detail-tags-and-like">
-      <div class="detail-tags">{{& tags_html}}</div>
-      <div class="detail-like">
-        {{#has_likes}}
-        <span id="likes-count">{{like_count}}</span>
-        <button
-          id="-pub-like-icon-button"
-          class="mdc-icon-button{{#is_liked}} mdc-icon-button--on{{/is_liked}}"
-          aria-label="{{#is_liked}}Unlike{{/is_liked}}{{^is_liked}}Like{{/is_liked}} this package"
-          data-ga-click-event="toggle-like"
-          aria-hidden="true"
-          aria-pressed="true">
-          <img
-            height="18"
-            width="18"
-            src="{{{static_assets.img__like-inactive_svg}}}"
-            class="mdc-icon-button__icon"/>
-          <img
-            height="18"
-            width="18"
-            src="{{{static_assets.img__like-active_svg}}}"
-            class="mdc-icon-button__icon mdc-icon-button__icon--on"/>
-        </button>
-      {{/has_likes}}
+    <div class="detail-header-outer-block">
+      {{#has_image_url}}
+      <div class="detail-header-image-block">
+        <img src="{{image_url}}" class="detail-header-image" />
+      </div>
+      {{/has_image_url}}
+      <div class="detail-header-content-block">
+        <h1 class="title">{{#is_publisher}}<img
+            class="-pub-publisher-shield"
+            height="48" width="48"
+            title="Domain ownership verifed by pub.dev"
+            src="{{{static_assets.img__verified-publisher-blue_svg}}}" />{{/is_publisher}}{{title}}</h1>
+        <div class="metadata">{{& metadata_html}}</div>
+        <div class="detail-tags-and-like">
+          <div class="detail-tags">{{& tags_html}}</div>
+          <div class="detail-like">
+            {{#has_likes}}
+              <span id="likes-count">{{like_count}}</span>
+              <button
+                  id="-pub-like-icon-button"
+                  class="mdc-icon-button{{#is_liked}} mdc-icon-button--on{{/is_liked}}"
+                  aria-label="{{#is_liked}}Unlike{{/is_liked}}{{^is_liked}}Like{{/is_liked}} this package"
+                  data-ga-click-event="toggle-like"
+                  aria-hidden="true"
+                  aria-pressed="true">
+                <img
+                    height="18"
+                    width="18"
+                    src="{{{static_assets.img__like-inactive_svg}}}"
+                    class="mdc-icon-button__icon"/>
+                <img
+                    height="18"
+                    width="18"
+                    src="{{{static_assets.img__like-active_svg}}}"
+                    class="mdc-icon-button__icon mdc-icon-button__icon--on"/>
+              </button>
+            {{/has_likes}}
+          </div>
+        </div>
+      </div>
       </div>
     </div>
-  </div>
 </div>

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -648,6 +648,7 @@ void main() {
           SearchQuery.parse(uploaderOrPublishers: [hansUser.email]);
       final String html = renderAccountPackagesPage(
         user: hansUser,
+        userSessionData: hansUserSessionData,
         packages: [
           PackageView(
             name: 'super_package',
@@ -675,20 +676,25 @@ void main() {
     });
 
     scopedTest('/my-liked-packages page', () {
-      final String html = renderMyLikedPackagesPage(user: hansUser, likes: [
-        LikeData(
-            package: 'super_package',
-            created: DateTime.fromMillisecondsSinceEpoch(1574423824000)),
-        LikeData(
-            package: 'another_package',
-            created: DateTime.fromMillisecondsSinceEpoch(1574423824000))
-      ]);
+      final String html = renderMyLikedPackagesPage(
+        user: hansUser,
+        userSessionData: hansUserSessionData,
+        likes: [
+          LikeData(
+              package: 'super_package',
+              created: DateTime.fromMillisecondsSinceEpoch(1574423824000)),
+          LikeData(
+              package: 'another_package',
+              created: DateTime.fromMillisecondsSinceEpoch(1574423824000))
+        ],
+      );
       expectGoldenFile(html, 'my_liked_packages.html');
     });
 
     scopedTest('/my-publishers page', () {
       final String html = renderAccountPublishersPage(
         user: hansUser,
+        userSessionData: hansUserSessionData,
         publishers: [
           exampleComPublisher,
         ],

--- a/app/test/shared/test_models.dart
+++ b/app/test/shared/test_models.dart
@@ -49,6 +49,15 @@ final hansUser = User()
   ..email = 'hans@juergen.com'
   ..created = DateTime.utc(2014)
   ..isDeletedFlag = false;
+final hansUserSessionData = UserSessionData(
+  userId: hansUser.userId,
+  sessionId: 'hans-at-juergen-dot-com--session',
+  email: hansUser.email,
+  name: 'Hans Juergen',
+  imageUrl: 'https://juergen.com/hans.jpg',
+  created: hansUser.created,
+  expires: DateTime.now().add(Duration(days: 7)),
+);
 final joeUser = User()
   ..id = 'joe-at-example-dot-com'
   ..email = 'joe@example.com'

--- a/pkg/web_css/lib/src/_detail_page_experimental.scss
+++ b/pkg/web_css/lib/src/_detail_page_experimental.scss
@@ -86,6 +86,23 @@ $detail-tabs-width: calc(100% - 320px);
 }
 
 .detail-header {
+  .detail-header-outer-block {
+    display: flex;
+  }
+
+  .detail-header-image {
+    border-radius: 50%;
+    margin-right: 24px;
+
+    max-width: 200px;
+    max-height: 200px;
+
+    @media (max-width: $device-mobile-max-width) {
+      max-width: 100px;
+      max-height: 100px;
+    }
+  }
+
   .metadata {
     margin-bottom: 8px;
   }


### PR DESCRIPTION
- added a parent wrapper (with display: flex)
- image is scaled down on mobile view

<img width="239" alt="Screenshot 2020-04-21 at 18 01 06" src="https://user-images.githubusercontent.com/4778111/79887965-ffcee300-83fb-11ea-8203-08f795b7ce19.png">
