### PR TITLE
Updated caching for versions list API endpoint.

### DIFF
--- a/app/lib/frontend/handlers/package.dart
+++ b/app/lib/frontend/handlers/package.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:meta/meta.dart';
 import 'package:neat_cache/neat_cache.dart';
@@ -268,4 +269,17 @@ Future<PackagePageData> _loadPackagePageData(
     isAdmin: isAdmin,
     isLiked: isLiked,
   );
+}
+
+/// Handles /api/packages/<package> requests.
+Future<shelf.Response> listVersionsHandler(
+    shelf.Request request, Uri baseUri, String package) async {
+  final body = await cache.packageData(package).get(() async {
+    final data = await packageBackend.listVersions(baseUri, package);
+    return utf8.encode(json.encode(data.toJson()));
+  });
+  return shelf.Response(200, body: body, headers: {
+    'content-type': 'application/json; charset="utf-8"',
+    'x-content-type-options': 'nosniff',
+  });
 }

--- a/app/lib/frontend/handlers/pubapi.client.dart
+++ b/app/lib/frontend/handlers/pubapi.client.dart
@@ -26,11 +26,11 @@ class PubApiClient {
 
   final _i2.Client _client;
 
-  Future<_i3.PackageData> packageData(String package) async {
-    return _i3.PackageData.fromJson(await _client.requestJson(
+  Future<List<int>> listVersions(String package) async {
+    return await _client.requestBytes(
       verb: 'get',
       path: '/api/packages/$package',
-    ));
+    );
   }
 
   Future<_i3.VersionInfo> packageVersionInfo(

--- a/app/lib/frontend/handlers/pubapi.dart
+++ b/app/lib/frontend/handlers/pubapi.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'package:api_builder/api_builder.dart';
 import 'package:client_data/account_api.dart';
 import 'package:client_data/admin_api.dart';
@@ -29,9 +33,10 @@ class PubApi {
   /// Getting information about all versions of a package.
   /// https://github.com/dart-lang/pub/blob/master/doc/repository-spec-v2.md#list-all-versions-of-a-package
   @EndPoint.get('/api/packages/<package>')
-  Future<PackageData> packageData(Request request, String package) async =>
-      await packageBackend.listVersions(
-          _replaceHost(request.requestedUri), package);
+  Future<Response> listVersions(Request request, String package) async {
+    final baseUri = _replaceHost(request.requestedUri);
+    return await listVersionsHandler(request, baseUri, package);
+  }
 
   /// Getting information about a specific (package, version) pair.
   /// https://github.com/dart-lang/pub/blob/master/doc/repository-spec-v2.md#deprecated-inspect-a-specific-version-of-a-package

--- a/app/lib/frontend/handlers/pubapi.g.dart
+++ b/app/lib/frontend/handlers/pubapi.g.dart
@@ -11,11 +11,11 @@ Router _$PubApiRouter(PubApi service) {
   router.add('GET', r'/api/packages/<package>',
       (Request request, String package) async {
     try {
-      final _$result = await service.packageData(
+      final _$result = await service.listVersions(
         request,
         package,
       );
-      return $utilities.jsonResponse(_$result.toJson());
+      return _$result;
     } on ApiResponseException catch (e) {
       return e.asApiResponse();
     } catch (e, st) {

--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -323,27 +323,24 @@ class PackageBackend {
   ///
   /// Used in `pub` client for finding which versions exist.
   Future<api.PackageData> listVersions(Uri baseUri, String package) async {
-    return await cache.packageData(package).get(() async {
-      final pkg = await packageBackend.lookupPackage(package);
-      final packageVersions = await packageBackend.versionsOfPackage(package);
-      if (packageVersions.isEmpty) {
-        throw NotFoundException.resource('package "$package"');
-      }
-      packageVersions
-          .sort((a, b) => a.semanticVersion.compareTo(b.semanticVersion));
-      final latest = packageVersions.lastWhere(
-        (pv) => !pv.semanticVersion.isPreRelease,
-        orElse: () => packageVersions.last,
-      );
-      return api.PackageData(
-        name: package,
-        isDiscontinued: pkg.isDiscontinued ? true : null,
-        latest: _toApiVersionInfo(baseUri, latest),
-        versions: packageVersions
-            .map((pv) => _toApiVersionInfo(baseUri, pv))
-            .toList(),
-      );
-    });
+    final pkg = await packageBackend.lookupPackage(package);
+    final packageVersions = await packageBackend.versionsOfPackage(package);
+    if (packageVersions.isEmpty) {
+      throw NotFoundException.resource('package "$package"');
+    }
+    packageVersions
+        .sort((a, b) => a.semanticVersion.compareTo(b.semanticVersion));
+    final latest = packageVersions.lastWhere(
+      (pv) => !pv.semanticVersion.isPreRelease,
+      orElse: () => packageVersions.last,
+    );
+    return api.PackageData(
+      name: package,
+      isDiscontinued: pkg.isDiscontinued ? true : null,
+      latest: _toApiVersionInfo(baseUri, latest),
+      versions:
+          packageVersions.map((pv) => _toApiVersionInfo(baseUri, pv)).toList(),
+    );
   }
 
   /// Lookup and return the API's version info object.

--- a/app/lib/shared/redis_cache.dart
+++ b/app/lib/shared/redis_cache.dart
@@ -7,7 +7,6 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:appengine/appengine.dart';
-import 'package:client_data/package_api.dart' show PackageData;
 import 'package:gcloud/service_scope.dart' as ss;
 import 'package:logging/logging.dart';
 import 'package:neat_cache/neat_cache.dart';
@@ -114,15 +113,9 @@ class CachePatterns {
       .withTTL(Duration(minutes: 60))
       .withCodec(utf8)[publisherId];
 
-  Entry<PackageData> packageData(String package) => _cache
-      .withPrefix('api-package-data')
-      .withTTL(Duration(minutes: 10))
-      .withCodec(utf8)
-      .withCodec(json)
-      .withCodec(wrapAsCodec(
-        encode: (PackageData pd) => pd.toJson(),
-        decode: (d) => PackageData.fromJson(d as Map<String, dynamic>),
-      ))['$package'];
+  Entry<List<int>> packageData(String package) => _cache
+      .withPrefix('api-package-data-by-uri')
+      .withTTL(Duration(minutes: 10))['$package'];
 
   Entry<PackageView> packageView(String package) => _cache
       .withPrefix('package-view')

--- a/pkg/fake_pub_server/pubspec.lock
+++ b/pkg/fake_pub_server/pubspec.lock
@@ -434,7 +434,7 @@ packages:
       name: pana
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.7"
+    version: "0.13.8"
   path:
     dependency: transitive
     description:

--- a/pkg/web_app/lib/src/pubapi.client.dart
+++ b/pkg/web_app/lib/src/pubapi.client.dart
@@ -26,11 +26,11 @@ class PubApiClient {
 
   final _i2.Client _client;
 
-  Future<_i3.PackageData> packageData(String package) async {
-    return _i3.PackageData.fromJson(await _client.requestJson(
+  Future<List<int>> listVersions(String package) async {
+    return await _client.requestBytes(
       verb: 'get',
       path: '/api/packages/$package',
-    ));
+    );
   }
 
   Future<_i3.VersionInfo> packageVersionInfo(


### PR DESCRIPTION
- Caching was changed in #3508, but we have observed increased latencies, it is likely that the bytes -> object -> bytes extra serialization is causing it.
- The change leaves the `_replaceHost` call in `pubapi.dart` for now, we may need to review if it is needed or useful in this form.