### PR TITLE
Fixed list of accepted runtimeVersions.

### DIFF
--- a/app/lib/shared/storage.dart
+++ b/app/lib/shared/storage.dart
@@ -107,8 +107,8 @@ class VersionedJsonStorage {
   }
 
   /// Gets the content of the data file decoded as JSON Map.
-  Future<Map<String, dynamic>> getContentAsJsonMap(
-      [String version = versions.runtimeVersion]) async {
+  Future<Map<String, dynamic>> getContentAsJsonMap([String version]) async {
+    version ??= versions.runtimeVersion;
     final objectName = _objectName(version);
     _logger.info('Loading snapshot: $objectName');
     final map = await _bucket
@@ -183,11 +183,11 @@ class VersionedJsonStorage {
     });
   }
 
-  String getBucketUri([String version = versions.runtimeVersion]) =>
-      bucketUri(_bucket, _objectName(version));
+  String getBucketUri([String version]) =>
+      bucketUri(_bucket, _objectName(version ?? versions.runtimeVersion));
 
-  String _objectName([String version = versions.runtimeVersion]) {
-    assert(version != null);
+  String _objectName([String version]) {
+    version ??= versions.runtimeVersion;
     return '$_prefix$version$_extension';
   }
 }

--- a/app/lib/shared/versions.dart
+++ b/app/lib/shared/versions.dart
@@ -17,6 +17,18 @@ import 'utils.dart' show isNewer;
 /// a future dates are used.
 final RegExp runtimeVersionPattern = RegExp(r'^\d{4}\.\d{2}\.\d{2}$');
 
+/// The list (and priority order) of runtimeVersions where version-specific data
+/// is accepted from.
+///
+/// Make sure that at least two versions are kept here as the next candidates
+/// when the version switch happens.
+const acceptedRuntimeVersions = <String>[
+  '2020.05.08', // The current [runtimeVersion].
+  '2020.05.03',
+  '2020.04.22',
+  '2020.04.07',
+];
+
 /// Represents a combined version of the overall toolchain and processing,
 /// allowing easy check for data compatibility, age comparison and also reflects
 /// whether an analysis needs to be re-done.
@@ -25,21 +37,17 @@ final RegExp runtimeVersionPattern = RegExp(r'^\d{4}\.\d{2}\.\d{2}$');
 /// reprocessing, including: risk of data corruption in analysis, version change
 /// in pana, dartdoc, or the SDKs, or when an feature or bugfix should be picked
 /// up by the analysis ASAP.
-const String runtimeVersion = '2020.05.08';
+final String runtimeVersion = acceptedRuntimeVersions.first;
 final Version semanticRuntimeVersion = Version.parse(runtimeVersion);
+
+/// The list of runtime versions to use when looking for past version-specific
+/// data.
+final fallbackRuntimeVersions = acceptedRuntimeVersions.skip(1).toList();
 
 /// The version which marks the earliest version of the data which we'd like to
 /// keep during various GC processes. Data prior to this version is subject to
 /// delete (unless there is another rule in place to keep it).
-///
-/// Make sure that at least two versions are kept here as the next candidates
-/// when the version switch happens:
-/// - 2020.05.03
-/// - 2020.04.22
-final String gcBeforeRuntimeVersion = '2020.04.07';
-
-/// The versions which contain data that we should not fall back to.
-final blacklistedRuntimeVersions = ['2019.12.05', '2019.12.05+1'];
+final String gcBeforeRuntimeVersion = acceptedRuntimeVersions.last;
 
 // keep in-sync with SDK version in .travis.yml, .mono_repo.yml and Dockerfile
 final String runtimeSdkVersion = '2.8.1';

--- a/app/test/shared/versions_test.dart
+++ b/app/test/shared/versions_test.dart
@@ -36,10 +36,13 @@ void main() {
     expect(hash, 695108292);
   });
 
-  test('runtime version should be (somewhat) lexicographically ordered', () {
-    expect(runtimeVersion.length, greaterThanOrEqualTo(10));
-    expect(RegExp(r'\d{4}\.\d{2}\.\d{2}.*').matchAsPrefix(runtimeVersion),
-        isNotNull);
+  test('accepted runtime versions should be lexicographically ordered', () {
+    for (final version in acceptedRuntimeVersions) {
+      expect(runtimeVersionPattern.hasMatch(version), isTrue);
+    }
+    final sorted = [...acceptedRuntimeVersions]
+      ..sort((a, b) => -a.compareTo(b));
+    expect(acceptedRuntimeVersions, sorted);
   });
 
   test('runtime sdk version should match travis and dockerfile', () async {

--- a/app/test/shared/versions_test.dart
+++ b/app/test/shared/versions_test.dart
@@ -45,6 +45,10 @@ void main() {
     expect(acceptedRuntimeVersions, sorted);
   });
 
+  test('No more than 5 accepted runtimeVersions', () {
+    expect(acceptedRuntimeVersions, hasLength(lessThan(6)));
+  });
+
   test('runtime sdk version should match travis and dockerfile', () async {
     final String docker = await File('../Dockerfile').readAsString();
     expect(


### PR DESCRIPTION
- Makes the change of `gcBeforeRuntimeVersion` automatic.
- We don't need to handle blacklisted versions.
- Slightly better `ScoreCard` access while the analysis is not ready yet (using lookup instead of query).