### PR TITLE
(HTML-safe) inline markdown for publisher description.

### DIFF
--- a/app/lib/frontend/templates/_utils.dart
+++ b/app/lib/frontend/templates/_utils.dart
@@ -21,8 +21,10 @@ String renderFile(
   final content = file.text;
   if (content != null) {
     if (_isMarkdownFile(filename)) {
-      return markdownToHtml(content, baseUrl,
-          baseDir: p.dirname(filename), isChangelog: isChangelog);
+      return markdownToHtml(content,
+          baseUrl: baseUrl,
+          baseDir: p.dirname(filename),
+          isChangelog: isChangelog);
     } else if (_isDartFile(filename)) {
       return _renderDartCode(content);
     } else {
@@ -45,7 +47,7 @@ bool _isMarkdownFile(String filename) {
 bool _isDartFile(String filename) => filename.toLowerCase().endsWith('.dart');
 
 String _renderDartCode(String text) =>
-    markdownToHtml('````dart\n${text.trim()}\n````\n', null);
+    markdownToHtml('````dart\n${text.trim()}\n````\n');
 
 String _renderPlainText(String text) =>
     '<div class="highlight"><pre>${_escapeAngleBrackets(text)}</pre></div>';

--- a/app/lib/frontend/templates/misc.dart
+++ b/app/lib/frontend/templates/misc.dart
@@ -26,7 +26,7 @@ import 'layout.dart';
 String renderUnauthenticatedPage({String messageMarkdown}) {
   messageMarkdown ??= 'You need to be logged in to view this page.';
   final content = templateCache.renderTemplate('account/unauthenticated', {
-    'message_html': markdownToHtml(messageMarkdown, null),
+    'message_html': markdownToHtml(messageMarkdown),
   });
   return renderLayoutPage(
     PageType.standalone,
@@ -41,7 +41,7 @@ String renderUnauthenticatedPage({String messageMarkdown}) {
 String renderUnauthorizedPage({String messageMarkdown}) {
   messageMarkdown ??= 'You have insufficient permissions to view this page.';
   final content = templateCache.renderTemplate('account/unauthorized', {
-    'message_html': markdownToHtml(messageMarkdown, null),
+    'message_html': markdownToHtml(messageMarkdown),
   });
   return renderLayoutPage(
     PageType.standalone,
@@ -106,7 +106,7 @@ String _renderStandalonePageContent({
         'Only one of `contentHtml` and `contentMarkdown` must be specified.');
   }
 
-  contentHtml ??= markdownToHtml(contentMarkdown, null);
+  contentHtml ??= markdownToHtml(contentMarkdown);
   return templateCache.renderTemplate('page/standalone', {
     'content_html': contentHtml,
     'has_side_image': sideImageUrl != null,
@@ -118,7 +118,7 @@ String _renderStandalonePageContent({
 String renderErrorPage(String title, String message) {
   final values = {
     'title': title,
-    'message_html': markdownToHtml(message, null),
+    'message_html': markdownToHtml(message),
   };
   final String content = templateCache.renderTemplate('page/error', values);
   return renderLayoutPage(

--- a/app/lib/frontend/templates/package_analysis.dart
+++ b/app/lib/frontend/templates/package_analysis.dart
@@ -91,7 +91,7 @@ String _renderSuggestionBlockHtml(String header, List<Suggestion> suggestions) {
     return {
       'icon_class': _suggestionIconClass(suggestion.level),
       'title_html': _renderSuggestionTitle(suggestion.title, suggestion.score),
-      'description_html': markdownToHtml(suggestion.description, null),
+      'description_html': markdownToHtml(suggestion.description),
       'suggestion_help_html': getSuggestionHelpMessage(suggestion.code),
     };
   }).toList();
@@ -120,7 +120,7 @@ String _renderSuggestionTitle(String title, double score) {
   if (formattedScore != null) {
     title = '$title ($formattedScore)';
   }
-  return markdownToHtml(title, null);
+  return markdownToHtml(title);
 }
 
 String _formatSuggestionScore(double score) {

--- a/app/lib/frontend/templates/publisher.dart
+++ b/app/lib/frontend/templates/publisher.dart
@@ -7,6 +7,7 @@ import 'dart:convert';
 import 'package:client_data/publisher_api.dart' as api;
 import 'package:client_data/page_data.dart';
 import 'package:meta/meta.dart';
+import 'package:pub_dev/shared/markdown.dart';
 
 import '../../package/models.dart' show PackageView;
 import '../../publisher/models.dart' show Publisher;
@@ -74,7 +75,7 @@ String _shortDescriptionHtml(Publisher publisher) {
   if (description != null && description.length > 1010) {
     description = description.substring(0, 1000) + '[...]';
   }
-  return htmlEscape.convert(description);
+  return markdownToHtml(description, inlineOnly: true);
 }
 
 /// Renders the `views/publisher/info_box.mustache` template.

--- a/app/lib/search/text_utils.dart
+++ b/app/lib/search/text_utils.dart
@@ -41,7 +41,7 @@ String compactDescription(String text) => _compactText(text, maxLength: 500);
 
 String compactReadme(String text) {
   if (text == null || text.isEmpty) return '';
-  final html = markdownToHtml(text, null)
+  final html = markdownToHtml(text)
       .replaceAll('</li>', '\n</li>')
       .replaceAll('</p>', '\n</p>')
       .replaceAll('</ul>', '\n</ul>')

--- a/app/lib/shared/handler_helpers.dart
+++ b/app/lib/shared/handler_helpers.dart
@@ -145,8 +145,7 @@ shelf.Handler _logRequestWrapper(Logger logger, shelf.Handler handler) {
       if (shouldLog) {
         logger.info('Caught response exception: $e');
       }
-      final content =
-          markdownToHtml('# Error `${e.code}`\n\n${e.message}\n', null);
+      final content = markdownToHtml('# Error `${e.code}`\n\n${e.message}\n');
       return htmlResponse(
         renderLayoutPage(PageType.package, content, title: 'Error ${e.code}'),
         status: e.status,
@@ -173,7 +172,7 @@ Request ID: ${context.traceId}
       ''';
 
       final content = renderLayoutPage(
-          PageType.package, markdownToHtml(markdownText, null),
+          PageType.package, markdownToHtml(markdownText),
           title: title);
       return htmlResponse(content, status: 500, headers: debugHeaders);
     } finally {

--- a/app/lib/shared/markdown.dart
+++ b/app/lib/shared/markdown.dart
@@ -99,7 +99,7 @@ String _renderSafeHtml(List<m.Node> nodes, bool inlineOnly) {
     },
   );
   return inlineOnly
-      ? html.replaceAll(_multiLineBreakRegExp, '<br>\n')
+      ? html.replaceAll(_multiLineBreakRegExp, '<br />\n')
       : '$html\n';
 }
 

--- a/app/lib/shared/markdown.dart
+++ b/app/lib/shared/markdown.dart
@@ -15,6 +15,12 @@ final Logger _logger = Logger('pub.markdown');
 /// h4, h5 and h6 are considered formatting-only headers
 const _structuralHeaderTags = <String>{'h1', 'h2', 'h3'};
 
+/// Matches more than 1 line breaks.
+final _multiLineBreakRegExp = RegExp(r'\n{2,}');
+
+/// The element tags that are accepted when inline-only parsing is used.
+final _safeInlineTags = <String>{'em', 'strong'};
+
 const _whitelistedClassNames = <String>[
   'changelog-entry',
   'changelog-version',
@@ -92,10 +98,11 @@ String _renderSafeHtml(List<m.Node> nodes, bool inlineOnly) {
       return _whitelistedClassNames.contains(cn);
     },
   );
-  return inlineOnly ? html : '$html\n';
+  return inlineOnly
+      ? html.replaceAll(_multiLineBreakRegExp, '<br>\n')
+      : '$html\n';
 }
 
-final _safeInlineTags = <String>{'em', 'strong'};
 void _keepOnlyInlineElements(List<m.Node> nodes) {
   if (nodes == null) return;
   for (var i = nodes.length - 1; i >= 0; i--) {

--- a/app/test/frontend/golden/publisher_packages_page.html
+++ b/app/test/frontend/golden/publisher_packages_page.html
@@ -199,8 +199,9 @@ Publisher registered on Sep 13, 2019.
           <aside class="detail-info-box">
             <h3 class="title">Description</h3>
             <p>This is our little software developer shop.
-
-We develop full-stack in Dart, and happy about it.</p>
+              <br/>
+We develop full-stack in Dart, and happy about it.
+            </p>
             <h3 class="title">Publisher</h3>
             <p>
               <img class="-pub-publisher-shield" height="22" width="22" title="Domain ownership verified by pub.dev" src="/static/img/verified-publisher-blue.svg?hash=mocked_hash_919645162"/>example.com

--- a/app/test/shared/markdown_test.dart
+++ b/app/test/shared/markdown_test.dart
@@ -22,8 +22,12 @@ void main() {
     String inline(String source) => markdownToHtml(source, inlineOnly: true);
 
     test('empty lines', () {
-      expect(inline('abcd\n\nefg'), 'abcd\n\nefg');
-      expect(inline('abcd\r\n\r\nefg'), 'abcd\n\nefg');
+      expect(inline('abcd\nefg'), 'abcd\nefg');
+      expect(inline('abcd\r\nefg'), 'abcd\nefg');
+      expect(inline('abcd\n\nefg'), 'abcd<br>\nefg');
+      expect(inline('abcd\n\n\n\nefg'), 'abcd<br>\nefg');
+      expect(inline('abcd\r\n\r\nefg'), 'abcd<br>\nefg');
+      expect(inline('abcd\r\n\r\n\r\n\r\nefg'), 'abcd<br>\nefg');
     });
 
     test('*text*', () {

--- a/app/test/shared/markdown_test.dart
+++ b/app/test/shared/markdown_test.dart
@@ -9,12 +9,61 @@ import 'package:pub_dev/shared/markdown.dart';
 void main() {
   group('markup', () {
     test('emoji support', () {
-      expect(markdownToHtml(':white_check_mark:', null), '<p>✅</p>\n');
+      expect(markdownToHtml(':white_check_mark:'), '<p>✅</p>\n');
     });
 
     test('render link id and class', () {
-      expect(markdownToHtml('# ABC def', null),
+      expect(markdownToHtml('# ABC def'),
           '<h1 class="hash-header" id="abc-def">ABC def <a href="#abc-def" class="hash-link">#</a></h1>\n');
+    });
+  });
+
+  group('inline only', () {
+    String inline(String source) => markdownToHtml(source, inlineOnly: true);
+
+    test('empty lines', () {
+      expect(inline('abcd\n\nefg'), 'abcd\n\nefg');
+    });
+
+    test('*text*', () {
+      expect(inline('*'), '*');
+      expect(inline('*a'), '*a');
+      expect(inline('a*'), 'a*');
+      expect(inline('a*a'), 'a*a');
+      expect(inline('*a*'), '<em>a</em>');
+      expect(inline('b *a* b'), 'b <em>a</em> b');
+    });
+
+    test('**text**', () {
+      expect(inline('**'), '**');
+      expect(inline('**a'), '**a');
+      expect(inline('a**'), 'a**');
+      expect(inline('a**a'), 'a**a');
+      expect(inline('**a**'), '<strong>a</strong>');
+      expect(inline('b **a** b'), 'b <strong>a</strong> b');
+    });
+
+    test('mixed markup: **text*', () {
+      expect(inline('**a*'), '*<em>a</em>');
+      expect(inline('*a**'), '<em>a</em>*');
+    });
+
+    test('link is not transformed', () {
+      expect(inline('[text](http://example.com/)'), 'text');
+    });
+
+    test('image is not transformed', () {
+      expect(inline('![text](http://example.com/image.png)'), '');
+    });
+
+    test('link inside strong is not transformed', () {
+      expect(
+          inline('**[text](http://example.com/)**'), '<strong>text</strong>');
+    });
+
+    test('a reasonable text', () {
+      expect(inline('We are a **Flutter developer shop**. Blah, blah, blah...'),
+          'We are a <strong>Flutter developer shop</strong>. Blah, blah, blah...');
     });
   });
 
@@ -22,158 +71,166 @@ void main() {
     final String baseUrl = 'https://github.com/example/project';
 
     test('relative link within page', () {
-      expect(markdownToHtml('[text](#relative)', null),
+      expect(markdownToHtml('[text](#relative)'),
           '<p><a href="#relative">text</a></p>\n');
-      expect(markdownToHtml('[text](#relative)', baseUrl),
+      expect(markdownToHtml('[text](#relative)', baseUrl: baseUrl),
           '<p><a href="#relative">text</a></p>\n');
-      expect(markdownToHtml('[text](#relative)', '$baseUrl/'),
+      expect(markdownToHtml('[text](#relative)', baseUrl: '$baseUrl/'),
           '<p><a href="#relative">text</a></p>\n');
     });
 
     test('absolute link URL', () {
-      expect(markdownToHtml('[text](http://dartlang.org/)', null),
+      expect(markdownToHtml('[text](http://dartlang.org/)'),
           '<p><a href="http://dartlang.org/">text</a></p>\n');
-      expect(markdownToHtml('[text](http://dartlang.org/)', baseUrl),
+      expect(markdownToHtml('[text](http://dartlang.org/)', baseUrl: baseUrl),
           '<p><a href="http://dartlang.org/">text</a></p>\n');
-      expect(markdownToHtml('[text](http://dartlang.org/)', '$baseUrl/'),
+      expect(
+          markdownToHtml('[text](http://dartlang.org/)', baseUrl: '$baseUrl/'),
           '<p><a href="http://dartlang.org/">text</a></p>\n');
     });
 
     test('absolute image URL', () {
-      expect(markdownToHtml('![text](http://dartlang.org/image.png)', null),
-          '<p><img src="http://dartlang.org/image.png" alt="text" /></p>\n');
-      expect(markdownToHtml('![text](http://dartlang.org/image.png)', baseUrl),
+      expect(markdownToHtml('![text](http://dartlang.org/image.png)'),
           '<p><img src="http://dartlang.org/image.png" alt="text" /></p>\n');
       expect(
-          markdownToHtml('![text](http://dartlang.org/image.png)', '$baseUrl/'),
+          markdownToHtml('![text](http://dartlang.org/image.png)',
+              baseUrl: baseUrl),
+          '<p><img src="http://dartlang.org/image.png" alt="text" /></p>\n');
+      expect(
+          markdownToHtml('![text](http://dartlang.org/image.png)',
+              baseUrl: '$baseUrl/'),
           '<p><img src="http://dartlang.org/image.png" alt="text" /></p>\n');
     });
 
     test('sibling link within site', () {
-      expect(markdownToHtml('[text](README.md)', null),
+      expect(markdownToHtml('[text](README.md)'),
           '<p><a href="README.md">text</a></p>\n');
-      expect(markdownToHtml('[text](README.md)', baseUrl),
+      expect(markdownToHtml('[text](README.md)', baseUrl: baseUrl),
           '<p><a href="https://github.com/example/project/blob/master/README.md">text</a></p>\n');
-      expect(markdownToHtml('[text](README.md)', '$baseUrl/'),
+      expect(markdownToHtml('[text](README.md)', baseUrl: '$baseUrl/'),
           '<p><a href="https://github.com/example/project/blob/master/README.md">text</a></p>\n');
     });
 
     test('sibling image within site', () {
-      expect(markdownToHtml('![text](image.png)', null),
+      expect(markdownToHtml('![text](image.png)'),
           '<p><img src="image.png" alt="text" /></p>\n');
-      expect(markdownToHtml('![text](image.png)', baseUrl),
+      expect(markdownToHtml('![text](image.png)', baseUrl: baseUrl),
           '<p><img src="https://github.com/example/project/raw/master/image.png" alt="text" /></p>\n');
-      expect(markdownToHtml('![text](image.png)', '$baseUrl/'),
+      expect(markdownToHtml('![text](image.png)', baseUrl: '$baseUrl/'),
           '<p><img src="https://github.com/example/project/raw/master/image.png" alt="text" /></p>\n');
     });
 
     test('sibling image inside a relative directory', () {
-      expect(markdownToHtml('![text](image.png)', null, baseDir: 'example'),
+      expect(markdownToHtml('![text](image.png)', baseDir: 'example'),
           '<p><img src="image.png" alt="text" /></p>\n');
-      expect(markdownToHtml('![text](image.png)', baseUrl, baseDir: 'example'),
+      expect(
+          markdownToHtml('![text](image.png)',
+              baseUrl: baseUrl, baseDir: 'example'),
           '<p><img src="https://github.com/example/project/raw/master/example/image.png" alt="text" /></p>\n');
       expect(
-          markdownToHtml('![text](img/image.png)', '$baseUrl/',
-              baseDir: 'example'),
+          markdownToHtml('![text](img/image.png)',
+              baseUrl: '$baseUrl/', baseDir: 'example'),
           '<p><img src="https://github.com/example/project/raw/master/example/img/image.png" alt="text" /></p>\n');
     });
 
     test('sibling link plus relative link', () {
-      expect(markdownToHtml('[text](README.md#section)', null),
+      expect(markdownToHtml('[text](README.md#section)'),
           '<p><a href="README.md#section">text</a></p>\n');
-      expect(markdownToHtml('[text](README.md#section)', baseUrl),
+      expect(markdownToHtml('[text](README.md#section)', baseUrl: baseUrl),
           '<p><a href="https://github.com/example/project/blob/master/README.md#section">text</a></p>\n');
-      expect(markdownToHtml('[text](README.md#section)', '$baseUrl/'),
+      expect(markdownToHtml('[text](README.md#section)', baseUrl: '$baseUrl/'),
           '<p><a href="https://github.com/example/project/blob/master/README.md#section">text</a></p>\n');
     });
 
     test('child link within site', () {
-      expect(markdownToHtml('[text](example/README.md)', null),
+      expect(markdownToHtml('[text](example/README.md)'),
           '<p><a href="example/README.md">text</a></p>\n');
-      expect(markdownToHtml('[text](example/README.md)', baseUrl),
+      expect(markdownToHtml('[text](example/README.md)', baseUrl: baseUrl),
           '<p><a href="https://github.com/example/project/blob/master/example/README.md">text</a></p>\n');
-      expect(markdownToHtml('[text](example/README.md)', '$baseUrl/'),
+      expect(markdownToHtml('[text](example/README.md)', baseUrl: '$baseUrl/'),
           '<p><a href="https://github.com/example/project/blob/master/example/README.md">text</a></p>\n');
     });
 
     test('child image within site', () {
-      expect(markdownToHtml('![text](example/image.png)', null),
+      expect(markdownToHtml('![text](example/image.png)'),
           '<p><img src="example/image.png" alt="text" /></p>\n');
-      expect(markdownToHtml('![text](example/image.png)', baseUrl),
+      expect(markdownToHtml('![text](example/image.png)', baseUrl: baseUrl),
           '<p><img src="https://github.com/example/project/raw/master/example/image.png" alt="text" /></p>\n');
-      expect(markdownToHtml('![text](example/image.png)', '$baseUrl/'),
+      expect(markdownToHtml('![text](example/image.png)', baseUrl: '$baseUrl/'),
           '<p><img src="https://github.com/example/project/raw/master/example/image.png" alt="text" /></p>\n');
     });
 
     test('root link within site', () {
-      expect(markdownToHtml('[text](/README.md)', null),
+      expect(markdownToHtml('[text](/README.md)'),
           '<p><a href="/README.md">text</a></p>\n');
-      expect(markdownToHtml('[text](/example/README.md)', baseUrl),
+      expect(markdownToHtml('[text](/example/README.md)', baseUrl: baseUrl),
           '<p><a href="https://github.com/example/README.md">text</a></p>\n');
-      expect(markdownToHtml('[text](/example/README.md)', '$baseUrl/'),
+      expect(markdownToHtml('[text](/example/README.md)', baseUrl: '$baseUrl/'),
           '<p><a href="https://github.com/example/README.md">text</a></p>\n');
     });
 
     test('root image within site', () {
-      expect(markdownToHtml('![text](/image.png)', null),
+      expect(markdownToHtml('![text](/image.png)'),
           '<p><img src="/image.png" alt="text" /></p>\n');
-      expect(markdownToHtml('![text](/example/image.png)', baseUrl),
+      expect(markdownToHtml('![text](/example/image.png)', baseUrl: baseUrl),
           '<p><img src="https://github.com/example/image.png" alt="text" /></p>\n');
-      expect(markdownToHtml('![text](/example/image.png)', '$baseUrl/'),
+      expect(
+          markdownToHtml('![text](/example/image.png)', baseUrl: '$baseUrl/'),
           '<p><img src="https://github.com/example/image.png" alt="text" /></p>\n');
     });
 
     test('email', () {
-      expect(markdownToHtml('[me](mailto:email@example.com)', null),
+      expect(markdownToHtml('[me](mailto:email@example.com)'),
           '<p><a href="mailto:email@example.com">me</a></p>\n');
-      expect(markdownToHtml('[me](mailto:email@example.com)', baseUrl),
+      expect(markdownToHtml('[me](mailto:email@example.com)', baseUrl: baseUrl),
           '<p><a href="mailto:email@example.com">me</a></p>\n');
     });
   });
 
   group('Bad custom base URL', () {
     test('not http(s)', () {
-      expect(markdownToHtml('[text](README.md)', 'ftp://example.com/blah'),
+      expect(
+          markdownToHtml('[text](README.md)',
+              baseUrl: 'ftp://example.com/blah'),
           '<p><a href="README.md">text</a></p>\n');
     });
 
     test('not valid host', () {
-      expect(markdownToHtml('[text](README.md)', 'http://com/blah'),
+      expect(markdownToHtml('[text](README.md)', baseUrl: 'http://com/blah'),
           '<p><a href="README.md">text</a></p>\n');
     });
   });
 
   group('Unsafe markdown', () {
     test('javascript link', () {
-      expect(markdownToHtml('[a](javascript:alert("x"))', null),
-          '<p><a>a</a></p>\n');
+      expect(markdownToHtml('[a](javascript:alert("x"))'), '<p><a>a</a></p>\n');
     });
   });
 
   group('Bad markdown', () {
     test('bad link', () {
-      expect(markdownToHtml('[a][b]', 'http://www.example.com/'),
+      expect(markdownToHtml('[a][b]', baseUrl: 'http://www.example.com/'),
           '<p>[a][b]</p>\n');
     });
   });
 
   group('non-whitelisted inline HTML', () {
     test('script', () {
-      expect(markdownToHtml('<script></script>', null), '\n');
+      expect(markdownToHtml('<script></script>'), '\n');
     });
   });
 
   group('whitelisted inline HTML', () {
     test('a', () {
       expect(
-        markdownToHtml('<a href="https://google.com">link</a>', null),
+        markdownToHtml('<a href="https://google.com">link</a>'),
         '<p><a href="https://google.com">link</a></p>\n',
       );
     });
 
     test('<br/>', () {
-      expect(markdownToHtml('a <br>b', null), '<p>a <br />b</p>\n');
-      expect(markdownToHtml('a <br  />b', null), '<p>a <br />b</p>\n');
+      expect(markdownToHtml('a <br>b'), '<p>a <br />b</p>\n');
+      expect(markdownToHtml('a <br  />b'), '<p>a <br />b</p>\n');
     });
   });
 
@@ -181,8 +238,7 @@ void main() {
     test('absolute url: http://[..]/blob/master/[path].gif', () {
       expect(
           markdownToHtml(
-              '![text](https://github.com/rcpassos/progress_hud/blob/master/progress_hud.gif)',
-              null),
+              '![text](https://github.com/rcpassos/progress_hud/blob/master/progress_hud.gif)'),
           '<p><img src="https://github.com/rcpassos/progress_hud/raw/master/progress_hud.gif" alt="text" /></p>\n');
     });
 
@@ -190,14 +246,14 @@ void main() {
       expect(
           markdownToHtml(
               '![text](/rcpassos/progress_hud/blob/master/progress_hud.gif)',
-              'https://github.com/rcpassos/progress_hud'),
+              baseUrl: 'https://github.com/rcpassos/progress_hud'),
           '<p><img src="https://github.com/rcpassos/progress_hud/raw/master/progress_hud.gif" alt="text" /></p>\n');
     });
 
     test('relative path: [path].gif', () {
       expect(
           markdownToHtml('![text](progress_hud.gif)',
-              'https://github.com/rcpassos/progress_hud'),
+              baseUrl: 'https://github.com/rcpassos/progress_hud'),
           '<p><img src="https://github.com/rcpassos/progress_hud/raw/master/progress_hud.gif" alt="text" /></p>\n');
     });
   });
@@ -209,7 +265,6 @@ void main() {
               'a\n\n'
               'b\n\n'
               'c',
-              null,
               isChangelog: true),
           '<p>a</p>\n'
           '<p>b</p>\n'
@@ -223,7 +278,6 @@ void main() {
               '## 1.0.0\n'
               '\n'
               '- change1',
-              null,
               isChangelog: true),
           '<h1 class="hash-header" id="changelog">Changelog <a href="#changelog" class="hash-link">#</a></h1>'
           '<div class="changelog-entry">\n'
@@ -242,7 +296,6 @@ void main() {
               '# Changelog\n\n'
               '## 1.0.0\n\n- change1\n\n- change2\n\n'
               '## 0.9.0\n\nMostly refatoring',
-              null,
               isChangelog: true),
           '<h1 class="hash-header" id="changelog">Changelog <a href="#changelog" class="hash-link">#</a></h1>'
           '<div class="changelog-entry">\n'
@@ -282,7 +335,6 @@ void main() {
 
 # 1.0.0
  * Take care to feed lion before releasing mice.''',
-        null,
         isChangelog: true,
       );
       final lines = output.split('\n');

--- a/app/test/shared/markdown_test.dart
+++ b/app/test/shared/markdown_test.dart
@@ -24,10 +24,10 @@ void main() {
     test('empty lines', () {
       expect(inline('abcd\nefg'), 'abcd\nefg');
       expect(inline('abcd\r\nefg'), 'abcd\nefg');
-      expect(inline('abcd\n\nefg'), 'abcd<br>\nefg');
-      expect(inline('abcd\n\n\n\nefg'), 'abcd<br>\nefg');
-      expect(inline('abcd\r\n\r\nefg'), 'abcd<br>\nefg');
-      expect(inline('abcd\r\n\r\n\r\n\r\nefg'), 'abcd<br>\nefg');
+      expect(inline('abcd\n\nefg'), 'abcd<br />\nefg');
+      expect(inline('abcd\n\n\n\nefg'), 'abcd<br />\nefg');
+      expect(inline('abcd\r\n\r\nefg'), 'abcd<br />\nefg');
+      expect(inline('abcd\r\n\r\n\r\n\r\nefg'), 'abcd<br />\nefg');
     });
 
     test('*text*', () {

--- a/app/test/shared/markdown_test.dart
+++ b/app/test/shared/markdown_test.dart
@@ -23,6 +23,7 @@ void main() {
 
     test('empty lines', () {
       expect(inline('abcd\n\nefg'), 'abcd\n\nefg');
+      expect(inline('abcd\r\n\r\nefg'), 'abcd\n\nefg');
     });
 
     test('*text*', () {


### PR DESCRIPTION
- fixes #3527
- only `strong` and `em` elements are allowed/exposed