### PR TITLE
Upgrade gcloud to 0.7.0

### DIFF
--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -42,7 +42,7 @@ packages:
       name: appengine
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.10.5"
+    version: "0.11.0"
   archive:
     dependency: "direct main"
     description:
@@ -245,7 +245,7 @@ packages:
       name: gcloud
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.3"
+    version: "0.7.0+1"
   glob:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -7,14 +7,14 @@ dependencies:
   _popularity:
     path: ../pkg/_popularity
   neat_cache: ^1.0.0
-  appengine: '^0.10.5'
+  appengine: '^0.11.0'
   args: '>=0.13.7 <2.0.0'
   basics: ^0.4.0
   client_data:
     path: ../pkg/client_data
   convert: '^2.0.0'
   crypto: '^2.0.2'
-  gcloud: '^0.6.3'
+  gcloud: '^0.7.0'
   googleapis: '^0.54.0'
   googleapis_auth: ^0.2.4
   html: '>=0.12.0 <0.15.0'

--- a/pkg/fake_gcloud/pubspec.lock
+++ b/pkg/fake_gcloud/pubspec.lock
@@ -91,7 +91,7 @@ packages:
       name: gcloud
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.3"
+    version: "0.7.0+1"
   glob:
     dependency: transitive
     description:

--- a/pkg/fake_gcloud/pubspec.yaml
+++ b/pkg/fake_gcloud/pubspec.yaml
@@ -6,7 +6,7 @@ environment:
   sdk: '>=2.6.0 <3.0.0'
 
 dependencies:
-  gcloud: '^0.6.0'
+  gcloud: '^0.7.0'
   logging: ^0.11.3
   meta: '^1.0.0'
 


### PR DESCRIPTION
- Fixes #3580
- I'm not sure if we can use `Model<String>` interface, as our models use ExpandoModel which is `Model<dynamic>`, and we can't add `implements Model<String>` to override it.