### PR TITLE
Pre-release instead of dev on /versions page.

### DIFF
--- a/app/lib/frontend/templates/package.dart
+++ b/app/lib/frontend/templates/package.dart
@@ -205,8 +205,7 @@ String renderPkgInfoBox(
 String renderPkgHeader(PackagePageData data) {
   final package = data.package;
   final selectedVersion = data.version;
-  final bool showDevVersion = package.latestDevVersion != null &&
-      package.latestSemanticVersion < package.latestDevSemanticVersion;
+  final bool showDevVersion = package.showDevVersion;
   final bool showUpdated =
       selectedVersion.version != package.latestVersion || showDevVersion;
 

--- a/app/lib/frontend/templates/package_versions.dart
+++ b/app/lib/frontend/templates/package_versions.dart
@@ -24,13 +24,15 @@ String renderPkgVersionsPage(
 
   final stableVersionRows = [];
   final devVersionRows = [];
-  PackageVersion latestDevVersion;
+  final latestDevVersion = versions.firstWhere(
+    (v) => v.version == data.package.latestDevVersion,
+    orElse: () => null,
+  );
   for (int i = 0; i < versions.length; i++) {
     final PackageVersion version = versions[i];
     final String url = versionDownloadUrls[i].toString();
     final rowHtml = renderVersionTableRow(version, url);
     if (version.semanticVersion.isPreRelease) {
-      latestDevVersion ??= version;
       devVersionRows.add(rowHtml);
     } else {
       stableVersionRows.add(rowHtml);
@@ -38,9 +40,11 @@ String renderPkgVersionsPage(
   }
 
   final htmlBlocks = <String>[];
-  if (stableVersionRows.isNotEmpty && devVersionRows.isNotEmpty) {
+  if (stableVersionRows.isNotEmpty &&
+      devVersionRows.isNotEmpty &&
+      data.package.showDevVersion) {
     htmlBlocks.add(
-        '<p>The latest dev release was <a href="#dev">${latestDevVersion.version}</a> '
+        '<p>The latest pre-release was <a href="#dev">${latestDevVersion.version}</a> '
         'on ${latestDevVersion.shortCreated}.</p>');
   }
   if (stableVersionRows.isNotEmpty) {
@@ -54,7 +58,7 @@ String renderPkgVersionsPage(
   if (devVersionRows.isNotEmpty) {
     htmlBlocks.add(templateCache.renderTemplate('pkg/versions/index', {
       'id': 'dev',
-      'kind': 'Dev',
+      'kind': 'Pre-release',
       'package': {'name': data.package.name},
       'version_table_rows': devVersionRows,
     }));

--- a/app/lib/frontend/templates/package_versions.dart
+++ b/app/lib/frontend/templates/package_versions.dart
@@ -44,7 +44,7 @@ String renderPkgVersionsPage(
       devVersionRows.isNotEmpty &&
       data.package.showDevVersion) {
     htmlBlocks.add(
-        '<p>The latest pre-release was <a href="#dev">${latestDevVersion.version}</a> '
+        '<p>The latest prerelease was <a href="#prerelease">${latestDevVersion.version}</a> '
         'on ${latestDevVersion.shortCreated}.</p>');
   }
   if (stableVersionRows.isNotEmpty) {
@@ -57,8 +57,8 @@ String renderPkgVersionsPage(
   }
   if (devVersionRows.isNotEmpty) {
     htmlBlocks.add(templateCache.renderTemplate('pkg/versions/index', {
-      'id': 'dev',
-      'kind': 'Pre-release',
+      'id': 'prerelease',
+      'kind': 'Prerelease',
       'package': {'name': data.package.name},
       'version_table_rows': devVersionRows,
     }));

--- a/app/lib/package/models.dart
+++ b/app/lib/package/models.dart
@@ -94,6 +94,11 @@ class Package extends db.ExpandoModel {
   Version get latestDevSemanticVersion =>
       latestDevVersionKey == null ? null : Version.parse(latestDevVersion);
 
+  bool get showDevVersion {
+    if (latestDevVersion == null) return false;
+    return latestSemanticVersion < latestDevSemanticVersion;
+  }
+
   String get shortUpdated {
     return shortDateFormat.format(updated);
   }

--- a/app/test/frontend/golden/pkg_versions_page.html
+++ b/app/test/frontend/golden/pkg_versions_page.html
@@ -150,7 +150,7 @@ Published
           <div class="detail-container detail-body-main">
             <div class="detail-tabs-content">
               <section class="tab-content -active" data-name="-versions-tab-">
-                <p>The latest dev release was 
+                <p>The latest pre-release was 
                   <a href="#dev">0.2.0-dev</a> on Jan 1, 2014.
                 </p>
                 <h2 id="stable">Stable versions of foobar_pkg</h2>
@@ -188,7 +188,7 @@ Published
                     </tr>
                   </tbody>
                 </table>
-                <h2 id="dev">Dev versions of foobar_pkg</h2>
+                <h2 id="dev">Pre-release versions of foobar_pkg</h2>
                 <table class="version-table" data-package="foobar_pkg">
                   <thead>
                     <tr>

--- a/app/test/frontend/golden/pkg_versions_page.html
+++ b/app/test/frontend/golden/pkg_versions_page.html
@@ -150,8 +150,8 @@ Published
           <div class="detail-container detail-body-main">
             <div class="detail-tabs-content">
               <section class="tab-content -active" data-name="-versions-tab-">
-                <p>The latest pre-release was 
-                  <a href="#dev">0.2.0-dev</a> on Jan 1, 2014.
+                <p>The latest prerelease was 
+                  <a href="#prerelease">0.2.0-dev</a> on Jan 1, 2014.
                 </p>
                 <h2 id="stable">Stable versions of foobar_pkg</h2>
                 <table class="version-table" data-package="foobar_pkg">
@@ -188,7 +188,7 @@ Published
                     </tr>
                   </tbody>
                 </table>
-                <h2 id="dev">Pre-release versions of foobar_pkg</h2>
+                <h2 id="prerelease">Prerelease versions of foobar_pkg</h2>
                 <table class="version-table" data-package="foobar_pkg">
                   <thead>
                     <tr>


### PR DESCRIPTION
- Fixes #3615 (uses `Package.showDevVersion`)
- Fixes #3616 (uses `pre-release` and not `prerelease`).