### PR TITLE
Follow-up: rename fields from dev to prerelease.

### DIFF
--- a/app/bin/tools/remove_package.dart
+++ b/app/bin/tools/remove_package.dart
@@ -179,8 +179,8 @@ Future removePackageVersion(String packageName, String version) async {
       package.latestVersionKey = null;
       updatePackage = true;
     }
-    if (package != null && package.latestDevVersion == version) {
-      package.latestDevVersionKey = null;
+    if (package != null && package.latestPrereleaseVersion == version) {
+      package.latestPrereleaseVersionKey = null;
       updatePackage = true;
     }
     if (updatePackage) {

--- a/app/lib/frontend/templates/listing.dart
+++ b/app/lib/frontend/templates/listing.dart
@@ -57,9 +57,10 @@ String renderPackageList(
       'is_external': view.isExternal,
       'external_type': externalType,
       'version': view.version,
-      'show_dev_version': view.devVersion != null,
-      'dev_version': view.devVersion,
-      'dev_version_url': urls.pkgPageUrl(view.name, version: view.devVersion),
+      'show_prerelease_version': view.prereleaseVersion != null,
+      'prerelease_version': view.prereleaseVersion,
+      'prerelease_version_url':
+          urls.pkgPageUrl(view.name, version: view.prereleaseVersion),
       'is_new': addedXAgo != null,
       'added_x_ago': addedXAgo,
       'last_uploaded': view.shortUpdated,

--- a/app/lib/frontend/templates/package.dart
+++ b/app/lib/frontend/templates/package.dart
@@ -205,9 +205,9 @@ String renderPkgInfoBox(
 String renderPkgHeader(PackagePageData data) {
   final package = data.package;
   final selectedVersion = data.version;
-  final bool showDevVersion = package.showDevVersion;
+  final bool showPrereleaseVersion = package.showPrereleaseVersion;
   final bool showUpdated =
-      selectedVersion.version != package.latestVersion || showDevVersion;
+      selectedVersion.version != package.latestVersion || showPrereleaseVersion;
 
   final metadataHtml = templateCache.renderTemplate('pkg/header', {
     'publisher_id': package.publisherId,
@@ -216,12 +216,12 @@ String renderPkgHeader(PackagePageData data) {
         : urls.publisherUrl(package.publisherId),
     'latest': {
       'show_updated': showUpdated,
-      'show_dev_version': showDevVersion,
+      'show_prerelease_version': showPrereleaseVersion,
       'stable_url': urls.pkgPageUrl(package.name),
       'stable_version': package.latestVersion,
-      'dev_url':
-          urls.pkgPageUrl(package.name, version: package.latestDevVersion),
-      'dev_version': package.latestDevVersion,
+      'prerelease_url': urls.pkgPageUrl(package.name,
+          version: package.latestPrereleaseVersion),
+      'prerelease_version': package.latestPrereleaseVersion,
     },
     'short_created': selectedVersion.shortCreated,
   });

--- a/app/lib/frontend/templates/package_versions.dart
+++ b/app/lib/frontend/templates/package_versions.dart
@@ -23,9 +23,9 @@ String renderPkgVersionsPage(
   assert(versions.length == versionDownloadUrls.length);
 
   final stableVersionRows = [];
-  final devVersionRows = [];
-  final latestDevVersion = versions.firstWhere(
-    (v) => v.version == data.package.latestDevVersion,
+  final prereleaseVersionRows = [];
+  final latestPrereleaseVersion = versions.firstWhere(
+    (v) => v.version == data.package.latestPrereleaseVersion,
     orElse: () => null,
   );
   for (int i = 0; i < versions.length; i++) {
@@ -33,7 +33,7 @@ String renderPkgVersionsPage(
     final String url = versionDownloadUrls[i].toString();
     final rowHtml = renderVersionTableRow(version, url);
     if (version.semanticVersion.isPreRelease) {
-      devVersionRows.add(rowHtml);
+      prereleaseVersionRows.add(rowHtml);
     } else {
       stableVersionRows.add(rowHtml);
     }
@@ -41,11 +41,11 @@ String renderPkgVersionsPage(
 
   final htmlBlocks = <String>[];
   if (stableVersionRows.isNotEmpty &&
-      devVersionRows.isNotEmpty &&
-      data.package.showDevVersion) {
+      prereleaseVersionRows.isNotEmpty &&
+      data.package.showPrereleaseVersion) {
     htmlBlocks.add(
-        '<p>The latest prerelease was <a href="#prerelease">${latestDevVersion.version}</a> '
-        'on ${latestDevVersion.shortCreated}.</p>');
+        '<p>The latest prerelease was <a href="#prerelease">${latestPrereleaseVersion.version}</a> '
+        'on ${latestPrereleaseVersion.shortCreated}.</p>');
   }
   if (stableVersionRows.isNotEmpty) {
     htmlBlocks.add(templateCache.renderTemplate('pkg/versions/index', {
@@ -55,12 +55,12 @@ String renderPkgVersionsPage(
       'version_table_rows': stableVersionRows,
     }));
   }
-  if (devVersionRows.isNotEmpty) {
+  if (prereleaseVersionRows.isNotEmpty) {
     htmlBlocks.add(templateCache.renderTemplate('pkg/versions/index', {
       'id': 'prerelease',
       'kind': 'Prerelease',
       'package': {'name': data.package.name},
-      'version_table_rows': devVersionRows,
+      'version_table_rows': prereleaseVersionRows,
     }));
   }
 

--- a/app/lib/frontend/templates/views/pkg/header.mustache
+++ b/app/lib/frontend/templates/views/pkg/header.mustache
@@ -14,8 +14,8 @@ Published <span>{{short_created}}</span>
 {{#latest.show_updated}}
   &bull; Updated:
   <span><a href="{{& latest.stable_url}}">{{latest.stable_version}}</a></span>
-  {{#latest.show_dev_version}}
+  {{#latest.show_prerelease_version}}
     /
-    <span><a href="{{& latest.dev_url}}">{{latest.dev_version}}</a></span>
-  {{/latest.show_dev_version}}
+    <span><a href="{{& latest.prerelease_url}}">{{latest.prerelease_version}}</a></span>
+  {{/latest.show_prerelease_version}}
 {{/latest.show_updated}}

--- a/app/lib/frontend/templates/views/pkg/package_list.mustache
+++ b/app/lib/frontend/templates/views/pkg/package_list.mustache
@@ -19,7 +19,7 @@
       {{#show_metadata}}
       <p class="metadata">
         v <a href="{{& url}}">{{version}}</a>
-        {{#show_dev_version}} / <a href="{{& dev_version_url}}">{{dev_version}}</a>{{/show_dev_version}}
+        {{#show_prerelease_version}} / <a href="{{& prerelease_version_url}}">{{prerelease_version}}</a>{{/show_prerelease_version}}
         • updated: <span>{{last_uploaded}}</span>
         {{#publisher_id}}• <a href="{{& publisher_url}}"><img
           class="-pub-publisher-shield"

--- a/app/lib/frontend/templates/views/pkg/package_list_experimental.mustache
+++ b/app/lib/frontend/templates/views/pkg/package_list_experimental.mustache
@@ -34,7 +34,7 @@
     {{^is_external}}
     <p class="packages-metadata">
       v <a href="{{& url}}">{{version}}</a>
-      {{#show_dev_version}} / <a href="{{& dev_version_url}}">{{dev_version}}</a>{{/show_dev_version}}
+      {{#show_prerelease_version}} / <a href="{{& prerelease_version_url}}">{{prerelease_version}}</a>{{/show_prerelease_version}}
       • Updated: <span>{{last_uploaded}}</span>
       {{#publisher_id}}
       <img class="packages-vp-icon"

--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -876,7 +876,7 @@ Package _newPackageFromVersion(
     ..updated = now
     ..downloads = 0
     ..latestVersionKey = version.key
-    ..latestDevVersionKey = version.key
+    ..latestPrereleaseVersionKey = version.key
     ..uploaders = [userId]
     ..likes = 0
     ..doNotAdvertise = false

--- a/app/lib/package/models.dart
+++ b/app/lib/package/models.dart
@@ -55,7 +55,7 @@ class Package extends db.ExpandoModel {
   db.Key latestVersionKey;
 
   @db.ModelKeyProperty(propertyName: 'latest_dev_version')
-  db.Key latestDevVersionKey;
+  db.Key latestPrereleaseVersionKey;
 
   /// The publisher id (null, if the package does not have a publisher).
   @db.StringProperty()
@@ -89,14 +89,17 @@ class Package extends db.ExpandoModel {
   Version get latestSemanticVersion =>
       Version.parse(latestVersionKey.id as String);
 
-  String get latestDevVersion => latestDevVersionKey?.id as String;
+  String get latestPrereleaseVersion =>
+      latestPrereleaseVersionKey?.id as String;
 
-  Version get latestDevSemanticVersion =>
-      latestDevVersionKey == null ? null : Version.parse(latestDevVersion);
+  Version get latestPrereleaseSemanticVersion =>
+      latestPrereleaseVersionKey == null
+          ? null
+          : Version.parse(latestPrereleaseVersion);
 
-  bool get showDevVersion {
-    if (latestDevVersion == null) return false;
-    return latestSemanticVersion < latestDevSemanticVersion;
+  bool get showPrereleaseVersion {
+    if (latestPrereleaseVersion == null) return false;
+    return latestSemanticVersion < latestPrereleaseSemanticVersion;
   }
 
   String get shortUpdated {
@@ -139,9 +142,10 @@ class Package extends db.ExpandoModel {
       latestVersionKey = pv.key;
     }
 
-    if (latestDevVersionKey == null ||
-        isNewer(latestDevSemanticVersion, newVersion, pubSorted: false)) {
-      latestDevVersionKey = pv.key;
+    if (latestPrereleaseVersionKey == null ||
+        isNewer(latestPrereleaseSemanticVersion, newVersion,
+            pubSorted: false)) {
+      latestPrereleaseVersionKey = pv.key;
     }
   }
 
@@ -418,7 +422,7 @@ class PackageView extends Object with FlagMixin {
   final String version;
 
   // Not null only if there is a difference compared to the [version].
-  final String devVersion;
+  final String prereleaseVersion;
   final String ellipsizedDescription;
 
   /// The date when the package was first published.
@@ -450,7 +454,7 @@ class PackageView extends Object with FlagMixin {
     this.url,
     this.name,
     this.version,
-    this.devVersion,
+    this.prereleaseVersion,
     this.ellipsizedDescription,
     this.created,
     this.shortUpdated,
@@ -475,10 +479,10 @@ class PackageView extends Object with FlagMixin {
     ScoreCardData scoreCard,
     List<ApiPageRef> apiPages,
   }) {
-    final String devVersion =
-        package != null && package.latestVersion != package.latestDevVersion
-            ? package.latestDevVersion
-            : null;
+    final prereleaseVersion = package != null &&
+            package.latestVersion != package.latestPrereleaseVersion
+        ? package.latestPrereleaseVersion
+        : null;
     final hasPanaReport = scoreCard?.reportTypes != null &&
         scoreCard.reportTypes.contains(ReportType.pana);
     final isAwaiting =
@@ -492,7 +496,7 @@ class PackageView extends Object with FlagMixin {
     return PackageView(
       name: version?.package ?? package?.name,
       version: version?.version ?? package?.latestVersion,
-      devVersion: devVersion,
+      prereleaseVersion: prereleaseVersion,
       ellipsizedDescription: version?.ellipsizedDescription,
       created: package.created,
       shortUpdated: version?.shortCreated ?? package?.shortUpdated,
@@ -523,7 +527,7 @@ class PackageView extends Object with FlagMixin {
       url: url,
       name: name,
       version: version,
-      devVersion: devVersion,
+      prereleaseVersion: prereleaseVersion,
       ellipsizedDescription: ellipsizedDescription,
       created: created,
       shortUpdated: shortUpdated,

--- a/app/lib/package/models.g.dart
+++ b/app/lib/package/models.g.dart
@@ -12,7 +12,7 @@ PackageView _$PackageViewFromJson(Map<String, dynamic> json) {
     url: json['url'] as String,
     name: json['name'] as String,
     version: json['version'] as String,
-    devVersion: json['devVersion'] as String,
+    prereleaseVersion: json['prereleaseVersion'] as String,
     ellipsizedDescription: json['ellipsizedDescription'] as String,
     created: json['created'] == null
         ? null
@@ -47,7 +47,7 @@ Map<String, dynamic> _$PackageViewToJson(PackageView instance) {
   writeNotNull('url', instance.url);
   writeNotNull('name', instance.name);
   writeNotNull('version', instance.version);
-  writeNotNull('devVersion', instance.devVersion);
+  writeNotNull('prereleaseVersion', instance.prereleaseVersion);
   writeNotNull('ellipsizedDescription', instance.ellipsizedDescription);
   writeNotNull('created', instance.created?.toIso8601String());
   writeNotNull('shortUpdated', instance.shortUpdated);

--- a/app/lib/search/backend.dart
+++ b/app/lib/search/backend.dart
@@ -104,7 +104,6 @@ class SearchBackend {
     return PackageDocument(
       package: pv.package,
       version: p.latestVersion,
-      devVersion: p.latestDevVersion,
       tags: tags,
       description: compactDescription(pv.pubspec.description),
       created: p.created,
@@ -153,7 +152,6 @@ class SearchBackend {
       yield PackageDocument(
         package: p.name,
         version: p.latestVersion,
-        devVersion: p.latestDevVersion,
         tags: p.getTags(),
         created: p.created,
         updated: p.updated,

--- a/app/lib/search/search_service.dart
+++ b/app/lib/search/search_service.dart
@@ -74,7 +74,6 @@ abstract class PackageIndex {
 class PackageDocument {
   final String package;
   final String version;
-  final String devVersion;
   final String description;
   final DateTime created;
   final DateTime updated;
@@ -103,7 +102,6 @@ class PackageDocument {
   PackageDocument({
     this.package,
     this.version,
-    this.devVersion,
     this.description,
     this.created,
     this.updated,
@@ -128,7 +126,6 @@ class PackageDocument {
     return PackageDocument(
       package: internFn(package),
       version: version,
-      devVersion: devVersion,
       description: description,
       created: created,
       updated: updated,

--- a/app/lib/search/search_service.g.dart
+++ b/app/lib/search/search_service.g.dart
@@ -10,7 +10,6 @@ PackageDocument _$PackageDocumentFromJson(Map<String, dynamic> json) {
   return PackageDocument(
     package: json['package'] as String,
     version: json['version'] as String,
-    devVersion: json['devVersion'] as String,
     description: json['description'] as String,
     created: json['created'] == null
         ? null
@@ -44,7 +43,6 @@ Map<String, dynamic> _$PackageDocumentToJson(PackageDocument instance) =>
     <String, dynamic>{
       'package': instance.package,
       'version': instance.version,
-      'devVersion': instance.devVersion,
       'description': instance.description,
       'created': instance.created?.toIso8601String(),
       'updated': instance.updated?.toIso8601String(),

--- a/app/lib/shared/integrity.dart
+++ b/app/lib/shared/integrity.dart
@@ -270,10 +270,10 @@ class IntegrityChecker {
       _problems.add(
           'Package(${p.name}) has missing latestVersionKey: ${p.latestVersionKey.id}');
     }
-    if (p.latestDevVersionKey != null &&
-        !versionKeys.contains(p.latestDevVersionKey)) {
+    if (p.latestPrereleaseVersionKey != null &&
+        !versionKeys.contains(p.latestPrereleaseVersionKey)) {
       _problems.add(
-          'Package(${p.name}) has missing latestDevVersionKey: ${p.latestDevVersionKey.id}');
+          'Package(${p.name}) has missing latestPrereleaseVersionKey: ${p.latestPrereleaseVersionKey.id}');
     }
 
     // Checking if PackageVersionPubspec is referenced by a PackageVersion entity.

--- a/app/lib/shared/task_sources.dart
+++ b/app/lib/shared/task_sources.dart
@@ -93,7 +93,7 @@ class DatastoreHeadTaskSource implements TaskSource {
   }
 
   Task _packageToTask(Package p) =>
-      Task(p.name, p.latestVersion ?? p.latestDevVersion, p.updated);
+      Task(p.name, p.latestVersion ?? p.latestPrereleaseVersion, p.updated);
 
   Task _versionToTask(PackageVersion pv) =>
       Task(pv.package, pv.version, pv.created);
@@ -130,9 +130,9 @@ abstract class DatastoreHistoryTaskSource implements TaskSource {
             yield Task(p.name, p.latestVersion, p.updated);
           }
 
-          if (p.latestVersion != p.latestDevVersion &&
-              await requiresUpdate(p.name, p.latestDevVersion)) {
-            yield Task(p.name, p.latestDevVersion, p.updated);
+          if (p.latestVersion != p.latestPrereleaseVersion &&
+              await requiresUpdate(p.name, p.latestPrereleaseVersion)) {
+            yield Task(p.name, p.latestPrereleaseVersion, p.updated);
           }
         }
 

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -629,7 +629,7 @@ void main() {
           PackageView(
             name: 'another_package',
             version: '2.0.0',
-            devVersion: '3.0.0-beta2',
+            prereleaseVersion: '3.0.0-beta2',
             ellipsizedDescription: 'Camera plugin.',
             created: DateTime.utc(2019, 03, 30),
             shortUpdated: '30 Mar 2019',
@@ -664,7 +664,7 @@ void main() {
           PackageView(
             name: 'another_package',
             version: '2.0.0',
-            devVersion: '3.0.0-beta2',
+            prereleaseVersion: '3.0.0-beta2',
             ellipsizedDescription: 'Camera plugin.',
             created: DateTime.utc(2019, 03, 30),
             shortUpdated: '30 Mar 2019',

--- a/app/test/package/models_test.dart
+++ b/app/test/package/models_test.dart
@@ -16,84 +16,84 @@ void main() {
         final devVersion = foobarPkgKey.append(PackageVersion, id: '0.0.1-dev');
         final Package p = Package()
           ..latestVersionKey = devVersion
-          ..latestDevVersionKey = devVersion;
+          ..latestPrereleaseVersionKey = devVersion;
         p.updateVersion(PackageVersion()
           ..parentKey = foobarPkgKey
           ..id = '0.2.0-dev'
           ..version = '0.2.0-dev');
         expect(p.latestVersion, '0.2.0-dev');
-        expect(p.latestDevVersion, '0.2.0-dev');
+        expect(p.latestPrereleaseVersion, '0.2.0-dev');
       });
 
       test('update old with only dev version', () {
         final devVersion = foobarPkgKey.append(PackageVersion, id: '1.0.0-dev');
         final Package p = Package()
           ..latestVersionKey = devVersion
-          ..latestDevVersionKey = devVersion;
+          ..latestPrereleaseVersionKey = devVersion;
         p.updateVersion(PackageVersion()
           ..parentKey = foobarPkgKey
           ..id = '0.2.1-dev'
           ..version = '0.2.1-dev');
         expect(p.latestVersion, '1.0.0-dev');
-        expect(p.latestDevVersion, '1.0.0-dev');
+        expect(p.latestPrereleaseVersion, '1.0.0-dev');
       });
 
       test('stable after dev', () {
         final devVersion = foobarPkgKey.append(PackageVersion, id: '1.0.0-dev');
         final Package p = Package()
           ..latestVersionKey = devVersion
-          ..latestDevVersionKey = devVersion;
+          ..latestPrereleaseVersionKey = devVersion;
         p.updateVersion(PackageVersion()
           ..parentKey = foobarPkgKey
           ..id = '0.2.0'
           ..version = '0.2.0');
         expect(p.latestVersion, '0.2.0');
-        expect(p.latestDevVersion, '1.0.0-dev');
+        expect(p.latestPrereleaseVersion, '1.0.0-dev');
       });
 
       test('new stable version', () {
         final Package p = Package()
           ..latestVersionKey = foobarStablePVKey
-          ..latestDevVersionKey = foobarStablePVKey;
+          ..latestPrereleaseVersionKey = foobarStablePVKey;
         expect(p.latestVersion, '0.1.1+5');
         p.updateVersion(PackageVersion()
           ..parentKey = foobarPkgKey
           ..id = '0.2.0'
           ..version = '0.2.0');
         expect(p.latestVersion, '0.2.0');
-        expect(p.latestDevVersion, '0.2.0');
+        expect(p.latestPrereleaseVersion, '0.2.0');
       });
 
       test('update old stable version', () {
         final Package p = Package()
           ..latestVersionKey = foobarStablePVKey
-          ..latestDevVersionKey = foobarStablePVKey;
+          ..latestPrereleaseVersionKey = foobarStablePVKey;
         expect(p.latestVersion, '0.1.1+5');
         p.updateVersion(PackageVersion()
           ..parentKey = foobarPkgKey
           ..id = '0.1.0'
           ..version = '0.1.0');
         expect(p.latestVersion, '0.1.1+5');
-        expect(p.latestDevVersion, '0.1.1+5');
+        expect(p.latestPrereleaseVersion, '0.1.1+5');
       });
 
       test('new dev version', () {
         final Package p = Package()
           ..latestVersionKey = foobarStablePVKey
-          ..latestDevVersionKey = foobarStablePVKey;
+          ..latestPrereleaseVersionKey = foobarStablePVKey;
         expect(p.latestVersion, '0.1.1+5');
         p.updateVersion(PackageVersion()
           ..parentKey = foobarPkgKey
           ..id = '1.0.0-dev'
           ..version = '1.0.0-dev');
         expect(p.latestVersion, '0.1.1+5');
-        expect(p.latestDevVersion, '1.0.0-dev');
+        expect(p.latestPrereleaseVersion, '1.0.0-dev');
       });
 
       test('new dev version, then a stable patch', () {
         final Package p = Package()
           ..latestVersionKey = foobarStablePVKey
-          ..latestDevVersionKey = foobarStablePVKey;
+          ..latestPrereleaseVersionKey = foobarStablePVKey;
         expect(p.latestVersion, '0.1.1+5');
 
         p.updateVersion(PackageVersion()
@@ -101,14 +101,14 @@ void main() {
           ..id = '1.0.0-dev'
           ..version = '1.0.0-dev');
         expect(p.latestVersion, '0.1.1+5');
-        expect(p.latestDevVersion, '1.0.0-dev');
+        expect(p.latestPrereleaseVersion, '1.0.0-dev');
 
         p.updateVersion(PackageVersion()
           ..parentKey = foobarPkgKey
           ..id = '0.2.0'
           ..version = '0.2.0');
         expect(p.latestVersion, '0.2.0');
-        expect(p.latestDevVersion, '1.0.0-dev');
+        expect(p.latestPrereleaseVersion, '1.0.0-dev');
       });
     });
   });

--- a/app/test/search/handlers_test.dart
+++ b/app/test/search/handlers_test.dart
@@ -122,7 +122,6 @@ class MockSearchBackend implements SearchBackend {
     return PackageDocument(
       package: packageName,
       version: '1.0.1',
-      devVersion: '1.0.1-dev',
       tags: ['sdk:dart'],
       description: 'Foo package about nothing really. Maybe JSON.',
       readme: 'Some JSON to XML mapping.',

--- a/app/test/search/index_simple_test.dart
+++ b/app/test/search/index_simple_test.dart
@@ -142,7 +142,6 @@ void main() {
       await index.addPackage(PackageDocument(
         package: 'http',
         version: '0.11.3+14',
-        devVersion: '0.11.3+14',
         description: 'A composable, Future-based API for making HTTP requests.',
         readme: '''http
           A composable, Future-based library for making HTTP requests.
@@ -160,7 +159,6 @@ void main() {
       await index.addPackage(PackageDocument(
         package: 'async',
         version: '1.13.3',
-        devVersion: '1.13.3',
         description:
             'Utility functions and classes related to the \'dart:async\' library.',
         readme:
@@ -183,7 +181,6 @@ The delegating wrapper classes allow users to easily add functionality on top of
       await index.addPackage(PackageDocument(
         package: 'chrome_net',
         version: '0.1.0',
-        devVersion: '0.1.0',
         description: 'A set of networking library for Chrome Apps.',
         readme: '''TCP client and server libraries for Dart based Chrome Apps.
 tcp.dart contains abstractions over chrome.sockets to aid in working with TCP client sockets and server sockets (TcpClient and TcpServer).

--- a/app/test/shared/test_models.dart
+++ b/app/test/shared/test_models.dart
@@ -90,7 +90,7 @@ Package createFoobarPackage({String name, List<User> uploaders}) {
     ..updated = DateTime.utc(2015)
     ..uploaders = uploaders.map((user) => user.userId).toList()
     ..latestVersionKey = foobarStablePVKey
-    ..latestDevVersionKey = foobarDevPVKey
+    ..latestPrereleaseVersionKey = foobarDevPVKey
     ..downloads = 0
     ..likes = 0
     ..doNotAdvertise = false
@@ -256,7 +256,7 @@ class PkgBundle {
   PkgBundle._(this.package, this.versions, this.firstVersion,
       this.latestStableVersion, this.latestDevVersion) {
     assert(package.latestVersionKey != null);
-    assert(package.latestDevVersionKey != null);
+    assert(package.latestPrereleaseVersionKey != null);
   }
 
   factory PkgBundle(Package package, List<PackageVersion> versions) {
@@ -275,7 +275,7 @@ class PkgBundle {
     package.updated ??= versions.last.created;
     package.latestVersionKey ??=
         latestStableVersion?.key ?? latestDevVersion?.key;
-    package.latestDevVersionKey ??=
+    package.latestPrereleaseVersionKey ??=
         latestDevVersion?.key ?? package.latestVersionKey;
 
     return PkgBundle._(


### PR DESCRIPTION
- `PackageView` changing is breaking only if it is read from cache, but we will likely bump the `runtimeVersion` to mitigate that.
- `PackageDocument` does not need this field, removing.
- otherwise only refactor