### PR TITLE
New announcement banner.

### DIFF
--- a/app/lib/frontend/templates/layout.dart
+++ b/app/lib/frontend/templates/layout.dart
@@ -10,6 +10,7 @@ import 'package:meta/meta.dart';
 import '../../account/backend.dart';
 import '../../account/models.dart' show SearchPreference;
 import '../../search/search_service.dart';
+import '../../service/announcement/backend.dart';
 import '../../shared/configuration.dart';
 import '../../shared/tags.dart';
 import '../../shared/urls.dart' as urls;
@@ -72,6 +73,7 @@ String renderLayoutPage(
     searchQuery: searchQuery,
     searchPlaceholder: searchPlaceHolder,
   );
+  final announcementBannerHtml = announcementBackend.getAnnouncementHtml();
   final values = {
     'is_experimental': requestContext.isExperimental,
     'is_landing': type == PageType.landing,
@@ -100,6 +102,9 @@ String renderLayoutPage(
     'schema_org_searchaction_json':
         isRoot ? encodeScriptSafeJson(_schemaOrgSearchAction) : null,
     'page_data_encoded': pageDataEncoded,
+    'has_announcement_banner':
+        requestContext.isExperimental && announcementBannerHtml != null,
+    'announcement_banner_html': announcementBannerHtml,
   };
 
   return templateCache.renderTemplate('shared/layout', values);

--- a/app/lib/frontend/templates/views/shared/layout.mustache
+++ b/app/lib/frontend/templates/views/shared/layout.mustache
@@ -59,7 +59,11 @@
 <body class="{{& body_class}}">
 {{& site_header_html}}
 
-<div id="banner-container"></div>
+<div id="banner-container">
+  {{#has_announcement_banner}}
+  <div class="announcement-banner">{{& announcement_banner_html}}</div>
+  {{/has_announcement_banner}}
+</div>
 
 {{#show_search_banner}}
 <div class="_banner-bg">

--- a/app/lib/service/announcement/backend.dart
+++ b/app/lib/service/announcement/backend.dart
@@ -1,0 +1,52 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:gcloud/service_scope.dart' as ss;
+
+/// Sets the announcement backend service.
+void registerAnnouncementBackend(AnnouncementBackend backend) =>
+    ss.register(#_announcementBackend, backend);
+
+/// The active announcement backend service.
+AnnouncementBackend get announcementBackend =>
+    ss.lookup(#_announcementBackend) as AnnouncementBackend;
+
+/// Represents the backend for the announcement handling and related utilities.
+class AnnouncementBackend {
+  String _announcementHtml;
+  Timer _updateTimer;
+
+  /// Loads the active announcement from Datastore.
+  Future<void> update() async {
+    // TODO: implement loading announcements from Datastore.
+  }
+
+  /// Sets a timer to update announcements regularly.
+  void scheduleRegularUpdates() {
+    _updateTimer = Timer.periodic(Duration(minutes: 10), (_) async {
+      await update();
+    });
+  }
+
+  /// Cancel timer and free resources.
+  Future<void> close() async {
+    _updateTimer?.cancel();
+    _updateTimer = null;
+  }
+
+  /// Returns the current announcement in sanitized HTML (if it is loaded).
+  ///
+  /// May be `null` if there is nothing to display.
+  String getAnnouncementHtml() {
+    return _announcementHtml;
+  }
+
+  /// Sets the current announcement.
+  /// [value] must be sanitized HTML from trusted source.
+  Future<void> setAnnouncementHtml(String value) async {
+    _announcementHtml = value;
+  }
+}

--- a/app/lib/service/entrypoint/frontend.dart
+++ b/app/lib/service/entrypoint/frontend.dart
@@ -13,6 +13,7 @@ import 'package:gcloud/storage.dart';
 import 'package:googleapis_auth/auth_io.dart' as auth;
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as path;
+import 'package:pub_dev/service/announcement/backend.dart';
 import 'package:stream_transform/stream_transform.dart' show RateLimit;
 import 'package:watcher/watcher.dart';
 
@@ -82,6 +83,8 @@ Future _main(FrontendEntryMessage message) async {
     }
     await popularityStorage.init();
     nameTracker.startTracking();
+    await announcementBackend.update();
+    announcementBackend.scheduleRegularUpdates();
 
     await runHandler(_logger, appHandler,
         sanitize: true, cronHandler: cron.handler);

--- a/app/lib/service/services.dart
+++ b/app/lib/service/services.dart
@@ -33,6 +33,7 @@ import '../shared/storage_retry.dart' show withStorageRetry;
 import '../shared/urls.dart';
 import '../shared/versions.dart';
 
+import 'announcement/backend.dart';
 import 'secret/backend.dart';
 
 /// Run [fn] with services;
@@ -55,6 +56,7 @@ Future<void> withPubServices(FutureOr<void> Function() fn) async {
     registerAccountBackend(AccountBackend(dbService));
     registerAdminBackend(AdminBackend(dbService));
     registerAnalyzerClient(AnalyzerClient());
+    registerAnnouncementBackend(AnnouncementBackend());
     registerAuthProvider(GoogleOauth2AuthProvider(
       <String>[
         activeConfiguration.pubClientAudience,
@@ -103,6 +105,7 @@ Future<void> withPubServices(FutureOr<void> Function() fn) async {
     // depends on previously registered services
     registerPackageBackend(PackageBackend(dbService, tarballStorage));
 
+    registerScopeExitCallback(announcementBackend.close);
     registerScopeExitCallback(() async => nameTracker.stopTracking());
     registerScopeExitCallback(indexUpdater.close);
     registerScopeExitCallback(authProvider.close);

--- a/app/test/shared/utils.dart
+++ b/app/test/shared/utils.dart
@@ -7,6 +7,7 @@ import 'dart:async';
 import 'package:gcloud/service_scope.dart';
 import 'package:test/test.dart';
 
+import 'package:pub_dev/service/announcement/backend.dart';
 import 'package:pub_dev/shared/configuration.dart';
 
 Future scoped(Function() func) {
@@ -20,6 +21,7 @@ void scopedTest(String name, Function() func, {Timeout timeout}) {
     return fork(() async {
       // double fork to allow further override
       registerActiveConfiguration(Configuration.test());
+      registerAnnouncementBackend(AnnouncementBackend());
       return await fork(() async => func());
     });
   }, timeout: timeout);

--- a/pkg/web_css/lib/src/_base.scss
+++ b/pkg/web_css/lib/src/_base.scss
@@ -318,6 +318,15 @@ pre {
   }
 }
 
+.announcement-banner {
+  padding: 12px 0;
+
+  background: black;
+  color: white;
+
+  text-align: center;
+}
+
 .back-to-referrer {
   display: flex;
   align-items: center;

--- a/pkg/web_css/lib/src/_base.scss
+++ b/pkg/web_css/lib/src/_base.scss
@@ -319,10 +319,11 @@ pre {
 }
 
 .announcement-banner {
-  padding: 12px 0;
+  padding: 10px 0;
 
-  background: black;
-  color: white;
+  background: #e7f8ff;
+  color: #4a4a4a;
+  font-size: 16px;
 
   text-align: center;
 }


### PR DESCRIPTION
- #2936
- follows the very simple design of dart.dev (+ thinner fonts from the new design + different link color as default)
- right now only per-deployment announcements are supported
- screenshots:
  
  
<img width="1229" alt="Screenshot 2020-05-18 at 17 29 26" src="https://user-images.githubusercontent.com/4778111/82231483-86a8aa00-992d-11ea-8982-5da223dd272b.png">
<img width="398" alt="Screenshot 2020-05-18 at 17 29 41" src="https://user-images.githubusercontent.com/4778111/82231488-88726d80-992d-11ea-96ee-39bd93153d1f.png">

<img width="1235" alt="Screenshot 2020-05-18 at 17 28 47" src="https://user-images.githubusercontent.com/4778111/82231455-7a245180-992d-11ea-96de-193f9a77ba10.png">

<img width="1230" alt="Screenshot 2020-05-18 at 17 29 14" src="https://user-images.githubusercontent.com/4778111/82231473-83152300-992d-11ea-91f6-dd0caa8f6ba4.png">

