### PR TITLE
Separate PackageVersionAsset entities

### DIFF
--- a/app/bin/tools/backfill_packageversions.dart
+++ b/app/bin/tools/backfill_packageversions.dart
@@ -23,6 +23,8 @@ Future main(List<String> args) async {
         'Ensures a matching PackageVersionPubspec entity exists for each PackageVersion.');
     print(
         'Ensures a matching PackageVersionInfo entity exists for each PackageVersion.');
+    print(
+        'Ensures that PackageVersionAsset entities exists for each PackageVersion.');
     print(_argParser.usage);
     return;
   }
@@ -32,9 +34,11 @@ Future main(List<String> args) async {
 
   await withToolRuntime(() async {
     if (package != null) {
-      await backfillAllVersionsOfPackage(package);
+      final stat = await backfillAllVersionsOfPackage(package);
+      print(stat);
     } else {
-      await backfillAllVersionsOfPackages(concurrency);
+      final stat = await backfillAllVersionsOfPackages(concurrency);
+      print(stat);
     }
   });
 }

--- a/app/bin/tools/remove_old_derived_versions.dart
+++ b/app/bin/tools/remove_old_derived_versions.dart
@@ -17,6 +17,8 @@ final _argParser = ArgParser()
   ..addOption('package', abbr: 'p', help: 'The package to process.')
   ..addFlag('help', abbr: 'h', defaultsTo: false, help: 'Show help.');
 
+/// Deletes PackageVersionPubspec and PackageVersionInfo using old IDs, see CHANGELOG.md
+/// For when to run this.
 Future main(List<String> args) async {
   final argv = _argParser.parse(args);
   if (argv['help'] as bool == true) {

--- a/app/bin/tools/remove_old_derived_versions.dart
+++ b/app/bin/tools/remove_old_derived_versions.dart
@@ -1,0 +1,77 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:args/args.dart';
+import 'package:gcloud/db.dart';
+import 'package:pool/pool.dart';
+
+import 'package:pub_dev/package/models.dart';
+import 'package:pub_dev/service/entrypoint/tools.dart';
+
+final _argParser = ArgParser()
+  ..addOption('concurrency',
+      abbr: 'c', defaultsTo: '1', help: 'Number of concurrent processing.')
+  ..addOption('package', abbr: 'p', help: 'The package to process.')
+  ..addFlag('help', abbr: 'h', defaultsTo: false, help: 'Show help.');
+
+Future main(List<String> args) async {
+  final argv = _argParser.parse(args);
+  if (argv['help'] as bool == true) {
+    print('Usage: dart remove_old_derived_versions.dart');
+    print('Deletes PackageVersionPubspec entities with old ids.');
+    print('Deletes PackageVersionInfo entities with old ids.');
+    print(_argParser.usage);
+    return;
+  }
+
+  final concurrency = int.parse(argv['concurrency'] as String);
+  final package = argv['package'] as String;
+
+  await withToolRuntime(() async {
+    if (package == null) {
+      final pool = Pool(concurrency);
+      final futures = <Future>[];
+
+      await for (final package in dbService.query<Package>().run()) {
+        futures.add(_processPackage(package.name));
+      }
+
+      await Future.wait(futures);
+      await pool.close();
+    } else {
+      await _processPackage(package);
+    }
+  });
+}
+
+Future<void> _processPackage(String package) async {
+  await _deleteWithQuery<PackageVersionPubspec>(
+    dbService.query<PackageVersionPubspec>()..filter('package =', package),
+    where: (p) => p.id.toString() == p.qualifiedVersionKey.oldQualifiedVersion,
+  );
+
+  await _deleteWithQuery<PackageVersionInfo>(
+    dbService.query<PackageVersionInfo>()..filter('package =', package),
+    where: (p) => p.id.toString() == p.qualifiedVersionKey.oldQualifiedVersion,
+  );
+}
+
+Future _deleteWithQuery<T>(Query query, {bool Function(T item) where}) async {
+  final deletes = <Key>[];
+  await for (Model m in query.run()) {
+    final shouldDelete = where == null || where(m as T);
+    if (shouldDelete) {
+      deletes.add(m.key);
+      if (deletes.length >= 500) {
+        await dbService.commit(deletes: deletes);
+        deletes.clear();
+      }
+    }
+  }
+  if (deletes.isNotEmpty) {
+    await dbService.commit(deletes: deletes);
+  }
+}

--- a/app/bin/tools/remove_package.dart
+++ b/app/bin/tools/remove_package.dart
@@ -180,6 +180,11 @@ Future removePackageVersion(String packageName, String version) async {
   );
 
   await _deleteWithQuery(
+    dbService.query<PackageVersionAsset>()..filter('package =', packageName),
+    where: (PackageVersionAsset asset) => asset.version == version,
+  );
+
+  await _deleteWithQuery(
     dbService.query<Job>()..filter('packageName =', packageName),
     where: (Job job) => job.packageVersion == version,
   );

--- a/app/lib/admin/backend.dart
+++ b/app/lib/admin/backend.dart
@@ -353,6 +353,10 @@ class AdminBackend {
     await _deleteWithQuery(
         _db.query<PackageVersionInfo>()..filter('package =', packageName));
 
+    _logger.info('Removing package from PackageVersionAsset ...');
+    await _deleteWithQuery(dbService.query<PackageVersionAsset>()
+      ..filter('package =', packageName));
+
     _logger.info('Removing package from Jobs ...');
     await _deleteWithQuery(
         _db.query<Job>()..filter('packageName =', packageName));

--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -924,6 +924,7 @@ Future<_ValidatedUpload> _parseAndValidateUpload(
     archive: archive,
     versionCreated: version.created,
   );
+  // TODO: verify if assets sizes are within the transaction limit (10 MB)
   return _ValidatedUpload(version, derived.packageVersionPubspec,
       derived.packageVersionInfo, derived.assets);
 }

--- a/app/lib/package/models.dart
+++ b/app/lib/package/models.dart
@@ -428,6 +428,7 @@ abstract class AssetKind {
 /// A derived entity that holds extracted asset of a [PackageVersion] archive.
 @db.Kind(name: 'PackageVersionAsset', idType: db.IdType.String)
 class PackageVersionAsset extends db.ExpandoModel {
+  /// ID format: an URI path with <package>/<version>/<kind>
   String get assetId => id as String;
 
   @db.StringProperty(required: true)
@@ -439,6 +440,7 @@ class PackageVersionAsset extends db.ExpandoModel {
   @db.StringProperty(required: true)
   String packageVersion;
 
+  /// One of the values in [AssetKind].
   @db.StringProperty(required: true)
   String kind;
 

--- a/app/lib/package/models.dart
+++ b/app/lib/package/models.dart
@@ -4,6 +4,7 @@
 
 library pub_dartlang_org.appengine_repository.models;
 
+import 'dart:convert';
 import 'dart:math';
 
 import 'package:gcloud/db.dart' as db;
@@ -296,6 +297,12 @@ class PackageVersionPubspec extends db.ExpandoModel<String> {
   @db.StringProperty(required: true)
   String version;
 
+  /// The created timestamp of the [PackageVersion] (the time of publishing).
+  // TODO: add required: true once we run the backfill and removed outdated entities
+  @db.DateTimeProperty()
+  DateTime versionCreated;
+
+  // TODO: add required: true once we run the backfill and removed outdated entities
   @db.DateTimeProperty()
   DateTime updated;
 
@@ -303,6 +310,24 @@ class PackageVersionPubspec extends db.ExpandoModel<String> {
   Pubspec pubspec;
 
   PackageVersionPubspec();
+
+  /// Updates the current instance with the newly [derived] data.
+  /// Returns true if the current instance changed.
+  bool updateIfChanged(PackageVersionPubspec derived) {
+    var changed = false;
+    if (versionCreated != derived.versionCreated) {
+      versionCreated = derived.versionCreated;
+      changed = true;
+    }
+    if (pubspec?.jsonString != derived.pubspec?.jsonString) {
+      pubspec = derived.pubspec;
+      changed = true;
+    }
+    if (changed) {
+      updated = DateTime.now().toUtc();
+    }
+    return changed;
+  }
 
   void initFromKey(QualifiedVersionKey key) {
     id = key.qualifiedVersion;
@@ -327,21 +352,150 @@ class PackageVersionInfo extends db.ExpandoModel<String> {
   @db.StringProperty(required: true)
   String version;
 
+  /// The created timestamp of the [PackageVersion] (the time of publishing).
+  // TODO: add required: true once we run the backfill and removed outdated entities
+  @db.DateTimeProperty()
+  DateTime versionCreated;
+
+  // TODO: add required: true once we run the backfill and removed outdated entities
   @db.DateTimeProperty()
   DateTime updated;
 
-  @CompatibleStringListProperty()
-  List<String> libraries;
+  @db.StringListProperty()
+  List<String> libraries = <String>[];
 
+  // TODO: add required: true once we run the backfill and removed outdated entities
   @db.IntProperty()
   int libraryCount;
 
+  /// The [AssetKind] identifier of assets extracted from the archive.
+  @db.StringListProperty()
+  List<String> assets = <String>[];
+
+  @db.IntProperty()
+  int assetCount;
+
   PackageVersionInfo();
+
+  /// Updates the current instance with the newly [derived] data.
+  /// Returns true if the current instance changed.
+  bool updateIfChanged(PackageVersionInfo derived) {
+    var changed = false;
+    if (versionCreated != derived.versionCreated) {
+      versionCreated = derived.versionCreated;
+      changed = true;
+    }
+    // TODO: implement more efficient difference check
+    if (json.encode(libraries) != json.encode(derived.libraries)) {
+      libraries = derived.libraries;
+      libraryCount = libraries?.length ?? 0;
+      changed = true;
+    }
+    // TODO: implement more efficient difference check
+    if (json.encode(assets) != json.encode(derived.assets)) {
+      assets = derived.assets;
+      assetCount = assets?.length ?? 0;
+      changed = true;
+    }
+    if (changed) {
+      updated = DateTime.now().toUtc();
+    }
+    return changed;
+  }
 
   void initFromKey(QualifiedVersionKey key) {
     id = key.qualifiedVersion;
     package = key.package;
     version = key.version;
+  }
+
+  QualifiedVersionKey get qualifiedVersionKey {
+    return QualifiedVersionKey(
+      package: package,
+      version: version,
+    );
+  }
+}
+
+/// The kind classifier of the extracted [PackageVersionAsset].
+abstract class AssetKind {
+  static const pubspec = 'pubspec';
+  static const readme = 'readme';
+  static const changelog = 'changelog';
+  static const example = 'example';
+}
+
+/// A derived entity that holds extracted asset of a [PackageVersion] archive.
+@db.Kind(name: 'PackageVersionAsset', idType: db.IdType.String)
+class PackageVersionAsset extends db.ExpandoModel {
+  String get assetId => id as String;
+
+  @db.StringProperty(required: true)
+  String package;
+
+  @db.StringProperty(required: true)
+  String version;
+
+  @db.StringProperty(required: true)
+  String packageVersion;
+
+  @db.StringProperty(required: true)
+  String kind;
+
+  /// The created timestamp of the [PackageVersion] (the time of publishing).
+  @db.DateTimeProperty(required: true)
+  DateTime versionCreated;
+
+  @db.DateTimeProperty(required: true)
+  DateTime updated;
+
+  @db.StringProperty(required: true)
+  String path;
+
+  @db.IntProperty(required: true)
+  int contentLength;
+
+  @db.StringProperty(required: true)
+  String textContent;
+
+  PackageVersionAsset();
+
+  PackageVersionAsset.init({
+    @required this.package,
+    @required this.version,
+    @required this.kind,
+    @required this.versionCreated,
+    DateTime updated,
+    @required this.path,
+    @required this.textContent,
+  }) {
+    id = Uri(pathSegments: [package, version, kind]).path;
+    packageVersion = Uri(pathSegments: [package, version]).path;
+    this.updated = updated ?? DateTime.now().toUtc();
+    contentLength = textContent.length;
+  }
+
+  /// Updates the current instance with the newly [derived] data.
+  /// Returns true if the current instance changed.
+  bool updateIfChanged(PackageVersionAsset derived) {
+    var changed = false;
+    if (versionCreated != derived.versionCreated) {
+      versionCreated = derived.versionCreated;
+      changed = true;
+    }
+    if (path != derived.path) {
+      path = derived.path;
+      changed = true;
+    }
+    if (textContent != derived.textContent) {
+      textContent = derived.textContent;
+      contentLength = textContent.length;
+      changed = true;
+    }
+    if (changed) {
+      updated = DateTime.now().toUtc();
+    }
+    return changed;
   }
 
   QualifiedVersionKey get qualifiedVersionKey {
@@ -384,7 +538,14 @@ class QualifiedVersionKey {
     @required this.version,
   });
 
-  String get qualifiedVersion => '$package-$version';
+  /// The qualified key in `<package>-<version>` format.
+  String get oldQualifiedVersion => '$package-$version';
+
+  /// The qualified key in `<package>/<version>` format.
+  String get qualifiedVersion => Uri(pathSegments: [package, version]).path;
+
+  String assetId(String kind) =>
+      Uri(pathSegments: [package, version, kind]).path;
 
   @override
   bool operator ==(Object other) =>

--- a/app/lib/tool/backfill/backfill_packageversions.dart
+++ b/app/lib/tool/backfill/backfill_packageversions.dart
@@ -2,11 +2,18 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:io';
+
+import 'package:http/http.dart' as http;
 import 'package:gcloud/db.dart';
 import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
+import 'package:path/path.dart' as p;
 import 'package:pool/pool.dart';
 
+import 'package:pub_package_reader/pub_package_reader.dart';
+
+import '../../package/backend.dart';
 import '../../package/models.dart';
 
 final _logger = Logger('backfill.packageversions');
@@ -27,52 +34,128 @@ Future<BackfillStat> backfillAllVersionsOfPackages(int concurrency) async {
   return stats.reduce((a, b) => a + b);
 }
 
+typedef ArchiveResolver = Future<PackageSummary> Function(
+    String package, String version);
+
 /// Ensures a matching [PackageVersionPubspec] entity exists for each [PackageVersion]
 /// Ensures a matching [PackageVersionInfo] entity exists for each [PackageVersion].
-Future<BackfillStat> backfillAllVersionsOfPackage(String package) async {
-  _logger.info('Backfill PackageVersion[Pubspec|Info] in: $package');
+Future<BackfillStat> backfillAllVersionsOfPackage(
+  String package, {
+  @visibleForTesting ArchiveResolver archiveResolver,
+}) async {
+  _logger.info('Backfill PackageVersion[Pubspec|Info|Asset(s)] in: $package');
 
   final packageKey = dbService.emptyKey.append(Package, id: package);
   final query = dbService.query<PackageVersion>(ancestorKey: packageKey);
-  int versionCount = 0;
-  int pvInfoCount = 0;
-  int pvPubspecCount = 0;
+  final stats = <BackfillStat>[];
+  final httpClient = http.Client();
+  archiveResolver ??= (p, v) => _parseArchive(httpClient, p, v);
   await for (PackageVersion pv in query.run()) {
-    versionCount++;
-    final qualifiedKey =
-        QualifiedVersionKey(package: pv.package, version: pv.version);
-
-    final pvPubspecKey = dbService.emptyKey
-        .append(PackageVersionPubspec, id: qualifiedKey.qualifiedVersion);
-    final pvInfoKey = dbService.emptyKey
-        .append(PackageVersionInfo, id: qualifiedKey.qualifiedVersion);
-
-    final items = await dbService.lookup([pvPubspecKey, pvInfoKey]);
-    final inserts = <Model>[];
-    if (items[0] == null) {
-      pvPubspecCount++;
-      inserts.add(PackageVersionPubspec()
-        ..initFromKey(qualifiedKey)
-        ..pubspec = pv.pubspec
-        ..updated = pv.created);
-    }
-    if (items[1] == null) {
-      pvInfoCount++;
-      inserts.add(PackageVersionInfo()
-        ..initFromKey(qualifiedKey)
-        ..libraries = pv.libraries
-        ..libraryCount = pv.libraries.length
-        ..updated = pv.created);
-    }
-    if (inserts.isNotEmpty) {
-      await dbService.commit(inserts: inserts);
-    }
+    final archive = await archiveResolver(pv.package, pv.version);
+    final stat = await backfillPackageVersion(
+      package: pv.package,
+      version: pv.version,
+      archive: archive,
+      versionCreated: pv.created,
+    );
+    stats.add(stat);
   }
-  return BackfillStat(
-    versionCount: versionCount,
-    pvPubspecCount: pvPubspecCount,
-    pvInfoCount: pvInfoCount,
+  httpClient.close();
+  return stats.reduce((a, b) => a + b);
+}
+
+Future<BackfillStat> backfillPackageVersion({
+  @required String package,
+  @required String version,
+  @required PackageSummary archive,
+  @required DateTime versionCreated,
+}) async {
+  _logger.info(
+      'Backfill PackageVersion[Pubspec|Info|Asset(s)] in: $package/$version');
+  final derived = derivePackageVersionEntities(
+    archive: archive,
+    versionCreated: versionCreated,
   );
+  final qualifiedVersionKey = derived.packageVersionInfo.qualifiedVersionKey;
+  final existingAssetQuery = dbService.query<PackageVersionAsset>()
+    ..filter('packageVersion =', qualifiedVersionKey.qualifiedVersion);
+  final existingAssetKeys =
+      await existingAssetQuery.run().map((a) => a.key).toList();
+
+  return await dbService.withTransaction((tx) async {
+    final pvPubspec = await tx.lookupValue<PackageVersionPubspec>(
+        dbService.emptyKey.append(PackageVersionPubspec,
+            id: derived.packageVersionPubspec.id),
+        orElse: () => null);
+    final pvInfo = await tx.lookupValue<PackageVersionInfo>(
+      dbService.emptyKey
+          .append(PackageVersionInfo, id: derived.packageVersionInfo.id),
+      orElse: () => null,
+    );
+    final pvAssets = await tx.lookup<PackageVersionAsset>(existingAssetKeys);
+
+    final inserts = <Model>[];
+    final deletes = <Key>[];
+
+    if (pvPubspec == null) {
+      inserts.add(derived.packageVersionPubspec);
+    } else if (pvPubspec.updateIfChanged(derived.packageVersionPubspec)) {
+      inserts.add(pvPubspec);
+    }
+
+    if (pvInfo == null) {
+      inserts.add(derived.packageVersionInfo);
+    } else if (pvInfo.updateIfChanged(derived.packageVersionInfo)) {
+      inserts.add(pvInfo);
+    }
+
+    // insert of update derived assets
+    for (final derivedAsset in derived.assets) {
+      final pvAsset = pvAssets.firstWhere(
+          (a) => a.assetId == derivedAsset.assetId,
+          orElse: () => null);
+      if (pvAsset == null) {
+        inserts.add(derivedAsset);
+      } else if (pvAsset.updateIfChanged(derivedAsset)) {
+        inserts.add(pvAsset);
+      }
+    }
+
+    // remove assets that are no longer derived
+    deletes.addAll(pvAssets
+        .where(
+            (asset) => !derived.assets.any((e) => e.assetId == asset.assetId))
+        .map((a) => a.key));
+
+    if (inserts.isNotEmpty || deletes.isNotEmpty) {
+      tx.queueMutations(inserts: inserts, deletes: deletes);
+    }
+    await tx.commit();
+    return BackfillStat(
+      versionCount: 1,
+      pvPubspecCount: inserts.whereType<PackageVersionPubspec>().length,
+      pvInfoCount: inserts.whereType<PackageVersionInfo>().length,
+      pvAssetUpdatedCount: inserts.whereType<PackageVersionAsset>().length,
+      pvAssetDeletedCount: deletes.length, // only assets are deleted
+    );
+  });
+}
+
+Future<PackageSummary> _parseArchive(
+    http.Client httpClient, String package, String version) async {
+  final fn = '$package-$version.tar.gz';
+  final uri = 'https://storage.googleapis.com/pub-packages/packages/$fn';
+  final rs = await httpClient.get(uri);
+  if (rs.statusCode != 200) {
+    throw Exception('Unable to download: $uri');
+  }
+  final tempFile = File(p.join(Directory.systemTemp.path, fn));
+  await tempFile.writeAsBytes(rs.bodyBytes);
+  try {
+    return await summarizePackageArchive(tempFile.path);
+  } finally {
+    await tempFile.delete();
+  }
 }
 
 class BackfillStat {
@@ -81,16 +164,35 @@ class BackfillStat {
   // updated counts
   final int pvPubspecCount;
   final int pvInfoCount;
+  final int pvAssetUpdatedCount;
+  final int pvAssetDeletedCount;
 
   BackfillStat({
     @required this.versionCount,
     @required this.pvPubspecCount,
     @required this.pvInfoCount,
+    @required this.pvAssetUpdatedCount,
+    @required this.pvAssetDeletedCount,
   });
 
   BackfillStat operator +(BackfillStat other) => BackfillStat(
         versionCount: versionCount + other.versionCount,
         pvInfoCount: pvInfoCount + other.pvInfoCount,
         pvPubspecCount: pvPubspecCount + other.pvPubspecCount,
+        pvAssetUpdatedCount: pvAssetUpdatedCount + other.pvAssetUpdatedCount,
+        pvAssetDeletedCount: pvAssetDeletedCount + other.pvAssetDeletedCount,
       );
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'versionCount': versionCount,
+        'pvPubspecCount': pvPubspecCount,
+        'pvInfoCount': pvInfoCount,
+        'pvAssetUpdatedCount': pvAssetUpdatedCount,
+        'pvAssetDeletedCount': pvAssetDeletedCount,
+      };
+
+  @override
+  String toString() {
+    return toJson().entries.map((e) => '${e.key}=${e.value}').join(' ');
+  }
 }

--- a/app/test/package/backend_test.dart
+++ b/app/test/package/backend_test.dart
@@ -68,7 +68,7 @@ void main() {
         final list =
             await packageBackend.latestPackageVersions(offset: 2, limit: 1);
         expect(list.map((pv) => pv.qualifiedVersionKey.toString()),
-            ['helium-2.0.5']);
+            ['helium/2.0.5']);
       });
 
       testWithServices('empty', () async {
@@ -120,7 +120,7 @@ void main() {
         final list = await packageBackend
             .lookupLatestVersions([hydrogen.package, helium.package]);
         expect(list.map((pv) => pv.qualifiedVersionKey.toString()),
-            ['hydrogen-2.0.8', 'helium-2.0.5']);
+            ['hydrogen/2.0.8', 'helium/2.0.5']);
       });
     });
 

--- a/app/test/shared/test_models.dart
+++ b/app/test/shared/test_models.dart
@@ -207,6 +207,7 @@ PackageVersionPubspec _pvPubspec(PackageVersion pv) {
   return PackageVersionPubspec()
     ..parentKey = pv.parentKey.parent
     ..initFromKey(pv.qualifiedVersionKey)
+    ..versionCreated = pv.created
     ..updated = pv.created
     ..pubspec = pv.pubspec;
 }
@@ -215,6 +216,7 @@ PackageVersionInfo _pvInfo(PackageVersion pv) {
   return PackageVersionInfo()
     ..parentKey = pv.parentKey.parent
     ..initFromKey(pv.qualifiedVersionKey)
+    ..versionCreated = pv.created
     ..updated = pv.created
     ..libraries = pv.libraries
     ..libraryCount = pv.libraries.length;

--- a/app/test/tool/backfill/backfill_packageversions_test.dart
+++ b/app/test/tool/backfill/backfill_packageversions_test.dart
@@ -3,45 +3,150 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:gcloud/db.dart';
-import 'package:pub_dev/package/models.dart';
 import 'package:test/test.dart';
 
+import 'package:pub_dev/package/models.dart';
 import 'package:pub_dev/tool/backfill/backfill_packageversions.dart';
+import 'package:pub_package_reader/pub_package_reader.dart';
 
 import '../../shared/test_models.dart';
 import '../../shared/test_services.dart';
 
 void main() {
   group('normalization tests', () {
-    testWithServices('no update', () async {
-      final stats = await backfillAllVersionsOfPackage('hydrogen');
-      expect(stats.versionCount, 13);
-      expect(stats.pvInfoCount, 0);
-      expect(stats.pvPubspecCount, 0);
+    Future<PackageSummary> _archive(String package, String version) async {
+      return PackageSummary(
+        pubspecContent: 'name: $package\nversion: $version\n',
+        libraries: ['$package.dart'],
+        readmePath: 'README.md',
+        readmeContent: '# $package\n\nA dart package',
+      );
+    }
+
+    Future<void> _updateModels() async {
+      // Entries in the test were not extracted the same way we are doing here.
+      // TODO: make sure test entries follow the same pattern and remove this method.
+      final stat = await backfillAllVersionsOfPackage(
+        'hydrogen',
+        archiveResolver: _archive,
+      );
+      expect(
+        stat.toJson(),
+        {
+          'versionCount': 13,
+          'pvPubspecCount': 13,
+          'pvInfoCount': 13,
+          'pvAssetUpdatedCount': 26,
+          'pvAssetDeletedCount': 0,
+        },
+      );
+    }
+
+    testWithServices('second time no update', () async {
+      await _updateModels();
+      // second time there should be no update
+      final stats = await backfillAllVersionsOfPackage(
+        'hydrogen',
+        archiveResolver: _archive,
+      );
+      expect(
+        stats.toJson(),
+        {
+          'versionCount': 13,
+          'pvPubspecCount': 0,
+          'pvInfoCount': 0,
+          'pvAssetUpdatedCount': 0,
+          'pvAssetDeletedCount': 0,
+        },
+      );
+      final query = dbService.query<PackageVersionAsset>()
+        ..filter('package =', 'hydrogen');
+      final assets = await query.run().toList();
+      assets.sort((a, b) => a.assetId.compareTo(b.assetId));
+      final summary = assets.take(4).fold(
+          {},
+          (map, a) => {
+                ...map,
+                a.assetId: {
+                  'path': a.path,
+                  'length': a.textContent.length,
+                }
+              });
+      expect(summary, {
+        'hydrogen/1.0.0/pubspec': {'path': 'pubspec.yaml', 'length': 30},
+        'hydrogen/1.0.0/readme': {'path': 'README.md', 'length': 26},
+        'hydrogen/1.0.9/pubspec': {'path': 'pubspec.yaml', 'length': 30},
+        'hydrogen/1.0.9/readme': {'path': 'README.md', 'length': 26},
+      });
     });
 
     testWithServices('info missing', () async {
+      await _updateModels();
       final lastId =
           hydrogen.versions.last.qualifiedVersionKey.qualifiedVersion;
       await dbService.commit(deletes: [
         dbService.emptyKey.append(PackageVersionInfo, id: lastId),
       ]);
-      final stats = await backfillAllVersionsOfPackage('hydrogen');
-      expect(stats.versionCount, 13);
-      expect(stats.pvInfoCount, 1);
-      expect(stats.pvPubspecCount, 0);
+      final stats = await backfillAllVersionsOfPackage(
+        'hydrogen',
+        archiveResolver: _archive,
+      );
+      expect(
+        stats.toJson(),
+        {
+          'versionCount': 13,
+          'pvPubspecCount': 0,
+          'pvInfoCount': 1,
+          'pvAssetUpdatedCount': 0,
+          'pvAssetDeletedCount': 0,
+        },
+      );
     });
 
     testWithServices('pubspec missing', () async {
+      await _updateModels();
       final lastId =
           hydrogen.versions.last.qualifiedVersionKey.qualifiedVersion;
       await dbService.commit(deletes: [
         dbService.emptyKey.append(PackageVersionPubspec, id: lastId)
       ]);
-      final stats = await backfillAllVersionsOfPackage('hydrogen');
-      expect(stats.versionCount, 13);
-      expect(stats.pvInfoCount, 0);
-      expect(stats.pvPubspecCount, 1);
+      final stats = await backfillAllVersionsOfPackage(
+        'hydrogen',
+        archiveResolver: _archive,
+      );
+      expect(
+        stats.toJson(),
+        {
+          'versionCount': 13,
+          'pvPubspecCount': 1,
+          'pvInfoCount': 0,
+          'pvAssetUpdatedCount': 0,
+          'pvAssetDeletedCount': 0,
+        },
+      );
+    });
+
+    testWithServices('asset missing', () async {
+      await _updateModels();
+      final lastId =
+          hydrogen.versions.last.qualifiedVersionKey.qualifiedVersion;
+      await dbService.commit(deletes: [
+        dbService.emptyKey.append(PackageVersionAsset, id: '$lastId/readme')
+      ]);
+      final stats = await backfillAllVersionsOfPackage(
+        'hydrogen',
+        archiveResolver: _archive,
+      );
+      expect(
+        stats.toJson(),
+        {
+          'versionCount': 13,
+          'pvPubspecCount': 0,
+          'pvInfoCount': 0,
+          'pvAssetUpdatedCount': 1,
+          'pvAssetDeletedCount': 0,
+        },
+      );
     });
   });
 }

--- a/doc/entities.md
+++ b/doc/entities.md
@@ -1,0 +1,42 @@
+# Design guideline for Datastore entities
+
+We classify the data in the following categories:
+
+- **Canonical data**: facts about an upload, or about a publisher
+  - `Package`
+  - `PackageVersion`
+  - `User`
+  - `Publisher`
+
+- **Calculated data**: package analysis with a given runtime
+  - `ScoreCard`
+  - `ScoreCardReport`
+  - `Job`
+
+- **Derived data**: extracted from uploaded package content, rollup statistics
+  - `PackageVersionInfo`
+  - `PackageVersionPubspec`
+  - `PackageVersionAsset`
+
+## Migration
+
+**Canonical data** should rarely (ideally never) change, we should
+keep only a single entity of it.
+
+**Calculated data** should be versioned with the current runtime.
+When accessing runtime-versioned data which is not yet available,
+a known list of fallback versions could be used to serve user
+requests when needed.
+
+**Derived data** could be versioned, but for practical reasons
+we try to keep them simple and un-versioned. To handle ambiguity
+from inconsistent or evolving processing between versions, the
+following methods could be used as part of the schema migration:
+
+- New field(s) can be used to hold the new data structure.
+
+- For at least one release both the old, and the new field(s)
+  must be populated.
+
+- Subsequent releases may populate the old field with new data
+  or remove one of the fields.


### PR DESCRIPTION
- "soft" breaking change: `PackageVersionInfo` and `PackageVersionPubspec` changes id format from `<p>-<v>` to `<p>/<v>`. In the short term this shouldn't cause issues, in the long term `tools/remove_old_derived_versions.dart` will remove the old entities.
- `PackageVersionAsset` using `<p>/<v>/<asset>` as id
- extraction on upload and backfill using the same logic
- backfill is using a simple diff algorithm to check if the entity needs to be updated
- updated integrity check to test for assets referencing back to version entities, and also info entity referencing individual assets
- updated backfill tests, so it is closer to a real upload
- `doc/entities.md` to document some of the entity and future migration approaches