### PR TITLE
Preemptively reopen redis connections every hour.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ AppEngine version, listed here to ease deployment and troubleshooting.
  * Upgraded Flutter to `1.17.1`.
  * Deploy `index.yaml` to update index definition for `Like`
    `gcloud datastore indexes create index.yaml`
+ * Connection to `redis` is reopened every hour.
 
 ## `20200513t104411-all`
  * Bumped runtimeVersion to `2020.05.08`.


### PR DESCRIPTION
- Maybe related to the frontend memory issue, maybe not. #3450
- Implemented it with a timer, as it won't be blocking on the running services.