### PR TITLE
Boost token match weights of (potential) singular-plural phrase pairs.

### DIFF
--- a/app/lib/search/text_utils.dart
+++ b/app/lib/search/text_utils.dart
@@ -167,3 +167,17 @@ Set<String> deriveLookupCandidates(String token) {
   }
   return set;
 }
+
+/// Returns true if the provided words could be singular-plural pairs.
+bool couldBeSingularAndPlural(
+  String singular,
+  String plural, {
+
+  /// Set to `true` if `singular` is a known prefix of `plural`.
+  bool isKnownPrefix: false,
+}) {
+  if (!isKnownPrefix && !plural.startsWith(singular)) {
+    return false;
+  }
+  return (singular.length == plural.length - 1) && plural.endsWith('s');
+}

--- a/app/lib/search/text_utils.dart
+++ b/app/lib/search/text_utils.dart
@@ -174,7 +174,7 @@ bool couldBeSingularAndPlural(
   String plural, {
 
   /// Set to `true` if `singular` is a known prefix of `plural`.
-  bool isKnownPrefix: false,
+  bool isKnownPrefix = false,
 }) {
   if (!isKnownPrefix && !plural.startsWith(singular)) {
     return false;

--- a/app/lib/search/token_index.dart
+++ b/app/lib/search/token_index.dart
@@ -214,9 +214,19 @@ class TokenIndex {
         double candidateWeight = 0.0;
         if (token == candidate) {
           candidateWeight = 1.0;
-        } else if (token.startsWith(candidate) || token.endsWith(candidate)) {
+        } else if (token.startsWith(candidate)) {
           candidateWeight = candidate.length / token.length;
-        } else if (candidate.startsWith(token) || candidate.endsWith(token)) {
+          if (couldBeSingularAndPlural(candidate, token, isKnownPrefix: true)) {
+            candidateWeight = math.pow(candidateWeight, 0.2).toDouble();
+          }
+        } else if (token.endsWith(candidate)) {
+          candidateWeight = candidate.length / token.length;
+        } else if (candidate.startsWith(token)) {
+          candidateWeight = token.length / candidate.length;
+          if (couldBeSingularAndPlural(token, candidate, isKnownPrefix: true)) {
+            candidateWeight = math.pow(candidateWeight, 0.2).toDouble();
+          }
+        } else if (candidate.endsWith(token)) {
           candidateWeight = token.length / candidate.length;
         } else {
           tokenNgrams ??= ngrams(token, _minLength, 6);

--- a/app/test/search/api_doc_page_test.dart
+++ b/app/test/search/api_doc_page_test.dart
@@ -127,7 +127,7 @@ void main() {
           },
           {
             'package': 'other_with_api',
-            'score': closeTo(0.034, 0.001), // find serveWebPages (low score)
+            'score': closeTo(0.041, 0.001), // find serveWebPages (low score)
             'apiPages': [
               {'title': null, 'path': 'serve.html'},
             ],

--- a/app/test/search/maps_test.dart
+++ b/app/test/search/maps_test.dart
@@ -28,7 +28,7 @@ void main() {
         'totalCount': 2,
         'packages': [
           {'package': 'maps', 'score': 1.0},
-          {'package': 'map', 'score': closeTo(0.745, 0.001)},
+          {'package': 'map', 'score': closeTo(0.938, 0.001)},
         ],
       });
     });
@@ -41,7 +41,7 @@ void main() {
         'totalCount': 2,
         'packages': [
           {'package': 'map', 'score': 1.0},
-          {'package': 'maps', 'score': 0.75},
+          {'package': 'maps', 'score': closeTo(0.938, 0.001)},
         ],
       });
     });

--- a/app/test/search/token_index_test.dart
+++ b/app/test/search/token_index_test.dart
@@ -99,12 +99,24 @@ void main() {
       });
     });
 
-    test('short words: lookup for app', () {
+    test('short words: lookup for app(s)', () {
       final index = TokenIndex(minLength: 2);
       index.add('app', 'app');
       index.add('apps', 'apps');
       final match = index.lookupTokens('app');
-      expect(match.tokenWeights, {'app': 1.0, 'apps': 0.75});
+      expect(match.tokenWeights, {'app': 1.0, 'apps': closeTo(0.94, 0.005)});
+      final match2 = index.lookupTokens('apps');
+      expect(match2.tokenWeights, {'apps': 1.0, 'app': closeTo(0.94, 0.005)});
+    });
+
+    test('short words: lookup for app(z)', () {
+      final index = TokenIndex(minLength: 2);
+      index.add('app', 'app');
+      index.add('appz', 'appz');
+      final match = index.lookupTokens('app');
+      expect(match.tokenWeights, {'app': 1.0, 'appz': 0.75});
+      final match2 = index.lookupTokens('appz');
+      expect(match2.tokenWeights, {'appz': 1.0, 'app': 0.75});
     });
   });
 


### PR DESCRIPTION
- This is a low-cost attempt to support the plural forms of words without any real natural language analysis.
- Fixes #3235.