### PR TITLE
Fix Bucket.list(prefix:) calls with ending slashes.

### DIFF
--- a/app/lib/dartdoc/backend.dart
+++ b/app/lib/dartdoc/backend.dart
@@ -55,8 +55,8 @@ class DartdocBackend {
   final _gcTasks = <_GCTask>{};
 
   DartdocBackend(this._db, this._storage)
-      : _sdkStorage = VersionedJsonStorage(
-            _storage, '${storage_path.dartSdkDartdocPrefix()}/');
+      : _sdkStorage =
+            VersionedJsonStorage(_storage, storage_path.dartSdkDartdocPrefix());
 
   /// Whether the storage bucket has a usable extracted data file.
   /// Only the existence of the file is checked.
@@ -376,6 +376,9 @@ class DartdocBackend {
   }
 
   Future<List<DartdocEntry>> _listEntries(String prefix) async {
+    if (!prefix.endsWith('/')) {
+      throw ArgumentError('Directory prefix must end with `/`.');
+    }
     return retry(
       () async {
         final List<DartdocEntry> list = [];

--- a/app/lib/dartdoc/storage_path.dart
+++ b/app/lib/dartdoc/storage_path.dart
@@ -25,25 +25,25 @@ String sharedAssetObjectName(String dartdocVersion, String relativePath) =>
 
 /// Entry prefix for uploads in progress.
 String inProgressPrefix(String packageName, String packageVersion) =>
-    '$packageName/$packageVersion/in-progress';
+    '$packageName/$packageVersion/in-progress/';
 
 /// ObjectName of the DartdocEntry for uploads in progress.
 String inProgressObjectName(
         String packageName, String packageVersion, String uuid) =>
-    '${inProgressPrefix(packageName, packageVersion)}/$uuid.json';
+    p.join(inProgressPrefix(packageName, packageVersion), '$uuid.json');
 
 /// Entry prefix for completed uploads.
 String entryPrefix(String packageName, String packageVersion) =>
-    '$packageName/$packageVersion/entry';
+    '$packageName/$packageVersion/entry/';
 
 /// ObjectName of the DartdocEntry for completed uploads.
 String entryObjectName(
         String packageName, String packageVersion, String uuid) =>
-    '${entryPrefix(packageName, packageVersion)}/$uuid.json';
+    p.join(entryPrefix(packageName, packageVersion), '$uuid.json');
 
 /// Content path prefix.
 String contentPrefix(String packageName, String packageVersion, String uuid) =>
-    '$packageName/$packageVersion/content/$uuid';
+    '$packageName/$packageVersion/content/$uuid/';
 
 /// ObjectName of the generated content.
 String contentObjectName(String packageName, String packageVersion, String uuid,
@@ -51,14 +51,9 @@ String contentObjectName(String packageName, String packageVersion, String uuid,
   return p.join(contentPrefix(packageName, packageVersion, uuid), relativePath);
 }
 
-/// ObjectName of an SDK asset.
-String sdkObjectName(String relativePath) {
-  return p.join(_sdkAssetPrefix, relativePath);
-}
-
 /// The parent prefix for the Dart SDK's extracted dartdoc content.
 String dartSdkDartdocPrefix() {
-  return sdkObjectName('dart/pub-dartdoc-data');
+  return '$_sdkAssetPrefix/dart/pub-dartdoc-data/';
 }
 
 /// The ObjectName for the Dart SDK's extracted dartdoc content.

--- a/app/lib/shared/storage.dart
+++ b/app/lib/shared/storage.dart
@@ -78,7 +78,9 @@ class VersionedJsonStorage {
   VersionedJsonStorage(Bucket bucket, String prefix)
       : _bucket = bucket,
         _prefix = prefix {
-    assert(prefix.endsWith('/'));
+    if (!_prefix.endsWith('/')) {
+      throw ArgumentError('Directory prefix must end with `/`.');
+    }
   }
 
   /// Whether the storage bucket has a data file for the current runtime version.

--- a/app/test/dartdoc/storage_path_test.dart
+++ b/app/test/dartdoc/storage_path_test.dart
@@ -37,17 +37,23 @@ void main() {
       archiveSize: 10000,
       totalSize: 60000,
     );
-    expect(entry.inProgressPrefix, 'pkg_foo/1.2.3/in-progress');
+    expect(entry.inProgressPrefix, 'pkg_foo/1.2.3/in-progress/');
     expect(entry.inProgressObjectName,
         'pkg_foo/1.2.3/in-progress/12345678-abcdef10.json');
-    expect(entry.entryPrefix, 'pkg_foo/1.2.3/entry');
+    expect(entry.entryPrefix, 'pkg_foo/1.2.3/entry/');
     expect(entry.entryObjectName, 'pkg_foo/1.2.3/entry/12345678-abcdef10.json');
-    expect(entry.contentPrefix, 'pkg_foo/1.2.3/content/12345678-abcdef10');
+    expect(entry.contentPrefix, 'pkg_foo/1.2.3/content/12345678-abcdef10/');
     expect(entry.objectName('static-assets/css/style.css'),
         'shared-assets/dartdoc/0.16.0/static-assets/css/style.css');
     expect(entry.objectName('index.html'),
         'pkg_foo/1.2.3/content/12345678-abcdef10/index.html');
     expect(entry.objectName('library/index.html'),
         'pkg_foo/1.2.3/content/12345678-abcdef10/library/index.html');
+  });
+
+  test('SDK paths', () {
+    expect(dartSdkDartdocPrefix(), 'sdk-assets/dart/pub-dartdoc-data/');
+    expect(dartSdkDartdocDataName('2020.05.27'),
+        'sdk-assets/dart/pub-dartdoc-data/2020.05.27.json.gz');
   });
 }

--- a/pkg/fake_gcloud/lib/mem_storage.dart
+++ b/pkg/fake_gcloud/lib/mem_storage.dart
@@ -195,7 +195,20 @@ class _Bucket implements Bucket {
   Stream<BucketEntry> list({String prefix}) async* {
     _validateObjectName(prefix, allowNull: true);
     for (String name in _files.keys) {
-      if (prefix == null || name.startsWith(prefix)) {
+      bool matchesPrefix() {
+        // without prefix, return everything
+        if (prefix == null) return true;
+        // exclude everything that does not match the prefix
+        if (!name.startsWith(prefix)) return false;
+        // prefix does not end with directory separator, only files are matched
+        if (!prefix.endsWith('/') &&
+            name.substring(prefix.length).contains('/')) {
+          return false;
+        }
+        return true;
+      }
+
+      if (matchesPrefix()) {
         yield _BucketEntry(name, true);
       }
     }

--- a/pkg/fake_pub_server/pubspec.lock
+++ b/pkg/fake_pub_server/pubspec.lock
@@ -42,7 +42,7 @@ packages:
       name: appengine
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.10.5"
+    version: "0.11.0"
   archive:
     dependency: transitive
     description:
@@ -217,7 +217,7 @@ packages:
       name: gcloud
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.3"
+    version: "0.7.0+1"
   glob:
     dependency: transitive
     description:

--- a/pkg/pub_integration/lib/pub_integration.dart
+++ b/pkg/pub_integration/lib/pub_integration.dart
@@ -13,6 +13,7 @@ Future verifyPub({
   @required String credentialsFileContent,
   @required String invitedEmail,
   @required InviteCompleterFn inviteCompleterFn,
+  bool omitDocumentationPage = false,
   String clientSdkDir,
 }) async {
   final pubToolScript = PublishingScript(
@@ -21,6 +22,7 @@ Future verifyPub({
     credentialsFileContent,
     invitedEmail,
     inviteCompleterFn,
+    omitDocumentationPage,
   );
   await pubToolScript.verify();
 

--- a/pkg/pub_integration/lib/src/pub_http_client.dart
+++ b/pkg/pub_integration/lib/src/pub_http_client.dart
@@ -93,6 +93,10 @@ class PubHttpClient {
     return rs.body;
   }
 
+  Future<String> getDocumentationPage(String package,
+          [String version = 'latest']) async =>
+      getContent('/documentation/$package/$version/');
+
   /// Creates a publisher.
   Future<void> createPublisher({
     @required String authToken,

--- a/pkg/pub_integration/test/pub_integration_test.dart
+++ b/pkg/pub_integration/test/pub_integration_test.dart
@@ -66,6 +66,7 @@ void main() {
         invitedEmail: 'dev@example.org',
         inviteCompleterFn: inviteCompleterFn,
         clientSdkDir: Platform.environment['PUB_INTEGRATION_CLIENT_SDK_DIR'],
+        omitDocumentationPage: true,
       );
     });
   }, timeout: Timeout.factor(testTimeoutFactor));


### PR DESCRIPTION
- hard argument checking to use an ending slash in all of our prefixes
- updated `fake_gcloud` to use the hopefully correct behavior
- added a documentation page check that would have caught the issue at post-deployment checks (but it is not yet automated)
