### PR TITLE
Reduce the publisher shield size to 15px

### DIFF
--- a/app/lib/frontend/templates/views/pkg/header_experimental.mustache
+++ b/app/lib/frontend/templates/views/pkg/header_experimental.mustache
@@ -1,0 +1,20 @@
+{{! Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+    for details. All rights reserved. Use of this source code is governed by a
+    BSD-style license that can be found in the LICENSE file. }}
+
+Published <span>{{short_created}}</span>
+{{#publisher_id}}
+&bull; <a class="-pub-publisher" href="{{& publisher_url}}"><img
+          class="-pub-publisher-shield"
+          title="Published by a pub.dev verified publisher"
+          src="/static/img/verified-publisher-blue.svg" />{{publisher_id}}</a>
+{{/publisher_id}}
+
+{{#latest.show_updated}}
+  &bull; Updated:
+  <span><a href="{{& latest.stable_url}}">{{latest.stable_version}}</a></span>
+  {{#latest.show_prerelease_version}}
+    /
+    <span><a href="{{& latest.prerelease_url}}">{{latest.prerelease_version}}</a></span>
+  {{/latest.show_prerelease_version}}
+{{/latest.show_updated}}

--- a/app/lib/frontend/templates/views/pkg/info_box_experimental.mustache
+++ b/app/lib/frontend/templates/views/pkg/info_box_experimental.mustache
@@ -7,7 +7,6 @@
 <p>
   <a href="{{& publisher_link}}"><img
           class="-pub-publisher-shield"
-          height="22" width="22"
           title="Published by a pub.dev verified publisher"
           src="{{{static_assets.img__verified-publisher-blue_svg}}}" />{{publisher_id}}</a>
 </p>

--- a/pkg/web_css/lib/src/_base.scss
+++ b/pkg/web_css/lib/src/_base.scss
@@ -206,9 +206,22 @@ pre {
   overflow-x: auto;
 }
 
+/* non-indented rule to restrict the content of this block to the non-experimental pages */
+.non-experimental {
 .-pub-publisher-shield {
   vertical-align: top;
   margin-right: 2px;
+}
+}
+
+/* non-indented rule to restrict the content of this block to the experimental pages */
+.experimental {
+.-pub-publisher-shield {
+  vertical-align: middle;
+  margin: -1px 2px 0 0;
+  width: 15px;
+  height: 15px;
+}
 }
 
 .-pub-publisher {


### PR DESCRIPTION
- only affects the new design
- removed HTML markup that set the size to 22px
- <img width="269" alt="Screenshot 2020-05-28 at 16 33 18" src="https://user-images.githubusercontent.com/4778111/83155744-d80d2200-a101-11ea-9efd-0d4ccce10f88.png">
