### PR TITLE
Upgrade Dart and Flutter SDKs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ Important changes to data-models, configuration and migrations between each
 AppEngine version, listed here to ease deployment and troubleshooting.
 
 ## Next Release (replace with git tag when deployed)
+ * Bumped runtimeVersion to `2020.05.29`.
+ * Upgraded Dart analysis SDK to `2.8.3`.
+ * Upgraded Flutter to `1.17.2`.
 
 ## `20200528t100233-all`
  * Bumped runtimeVersion to `2020.05.26`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN pub get --offline --no-precompile
 #ENV GCLOUD_PROJECT dartlang-pub
 
 RUN cd / && \
-  curl -sS https://storage.googleapis.com/dart-archive/channels/stable/raw/2.8.2/sdk/dartsdk-linux-x64-release.zip >/dartsdk.zip && \
+  curl -sS https://storage.googleapis.com/dart-archive/channels/stable/raw/2.8.3/sdk/dartsdk-linux-x64-release.zip >/dartsdk.zip && \
   unzip -q /dartsdk.zip && \
   rm -f /dartsdk.zip
 

--- a/app/lib/shared/versions.dart
+++ b/app/lib/shared/versions.dart
@@ -23,8 +23,8 @@ final RegExp runtimeVersionPattern = RegExp(r'^\d{4}\.\d{2}\.\d{2}$');
 /// Make sure that at least two versions are kept here as the next candidates
 /// when the version switch happens.
 const acceptedRuntimeVersions = <String>[
-  '2020.05.26', // The current [runtimeVersion].
-  '2020.05.15',
+  '2020.05.29', // The current [runtimeVersion].
+  '2020.05.26',
   '2020.05.08',
   '2020.05.03',
 ];
@@ -51,7 +51,7 @@ final String gcBeforeRuntimeVersion = acceptedRuntimeVersions.last;
 
 // keep in-sync with SDK version in .travis.yml, .mono_repo.yml and Dockerfile
 final String runtimeSdkVersion = '2.8.1';
-final String toolEnvSdkVersion = '2.8.2';
+final String toolEnvSdkVersion = '2.8.3';
 
 // Value comes from package:pana.
 final String panaVersion =
@@ -59,7 +59,7 @@ final String panaVersion =
     pana.packageVersion == '0.13.8-dev' ? '0.13.8' : pana.packageVersion;
 final Version semanticPanaVersion = Version.parse(panaVersion);
 
-final String flutterVersion = '1.17.1';
+final String flutterVersion = '1.17.2';
 final Version semanticFlutterVersion = Version.parse(flutterVersion);
 
 // keep in-sync with pkg/pub_dartdoc/pubspec.yaml

--- a/app/test/shared/versions_test.dart
+++ b/app/test/shared/versions_test.dart
@@ -33,7 +33,7 @@ void main() {
     // This test is a reminder that if pana, the SDK or any of the above
     // versions change, we should also adjust the [runtimeVersion]. Before
     // updating the hash value, double-check if it is being updated.
-    expect(hash, 347630509);
+    expect(hash, 253807104);
   });
 
   test('accepted runtime versions should be lexicographically ordered', () {
@@ -107,8 +107,8 @@ Please update flutterVersion in app/lib/shared/versions.dart
 and do not format to also bump the runtimeVersion.''',
       );
     },
-    // TODO: re-enable once we upgrade Flutter SDK
-    skip: 'Not ready to upgrade yet.', // Note: this test is easily skipped.
+    // TODO: investigate why skip was not working on CI
+    skip: false, // Note: this test is easily skipped.
   );
 
   test('dartdoc version should match pkg/pub_dartdoc', () async {


### PR DESCRIPTION
- Fixes CI
- I've removed `2020.05.15` from the accepted fallbacks.
