### PR TITLE
Updated versions tab.

### DIFF
--- a/app/lib/frontend/static_files.dart
+++ b/app/lib/frontend/static_files.dart
@@ -185,6 +185,7 @@ class StaticUrls {
     return _versionsTableIcons ??= {
       'documentation': documentationIcon,
       'download': downloadIcon,
+      'hasDocumentationFailed': false,
     };
   }
 
@@ -192,8 +193,11 @@ class StaticUrls {
   final newVersionsTableIcons = {
     'documentation':
         _getCacheableStaticUrl('$_defaultStaticPath/img/description-24px.svg'),
+    'documentationFailed': _getCacheableStaticUrl(
+        '$_defaultStaticPath/img/documentation-failed-icon.svg'),
     'download': _getCacheableStaticUrl(
         '$_defaultStaticPath/img/vertical_align_bottom-24px.svg'),
+    'hasDocumentationFailed': true,
   };
 
   /// A hashed version of the static assets.

--- a/app/lib/frontend/templates/views/pkg/versions/version_row.mustache
+++ b/app/lib/frontend/templates/views/pkg/versions/version_row.mustache
@@ -9,13 +9,21 @@
     <a href="{{& dartdocs_url}}"
        rel="nofollow"
        title="Go to the documentation of {{package}} {{version}}">
-        <img src="{{& icons.documentation}}" alt="Go to the documentation of {{package}} {{version}}" />
+        <img class="version-table-icon"
+             src="{{& icons.documentation}}"
+             {{#icons.hasDocumentationFailed}}
+             data-failed-icon="{{& icons.documentationFailed }}"
+             {{/icons.hasDocumentationFailed}}
+             alt="Go to the documentation of {{package}} {{version}}" />
     </a>
   </td>
   <td class="archive">
     <a href="{{& download_url}}"
+       rel="nofollow"
        title="Download {{package}} {{version}} archive">
-      <img src="{{& icons.download}}" alt="Download {{package}} {{version}} archive" />
+      <img class="version-table-icon"
+           src="{{& icons.download}}"
+           alt="Download {{package}} {{version}} archive" />
     </a>
   </td>
 </tr>

--- a/app/test/frontend/golden/pkg_versions_page.html
+++ b/app/test/frontend/golden/pkg_versions_page.html
@@ -177,12 +177,12 @@ Published
                       <td class="uploaded">Jan 1, 2014</td>
                       <td class="documentation">
                         <a href="/documentation/foobar_pkg/0.1.1+5/" rel="nofollow" title="Go to the documentation of foobar_pkg 0.1.1+5">
-                          <img src="/static/img/ic_drive_document_black_24dp.svg?hash=mocked_hash_663394799" alt="Go to the documentation of foobar_pkg 0.1.1+5"/>
+                          <img class="version-table-icon" src="/static/img/ic_drive_document_black_24dp.svg?hash=mocked_hash_663394799" alt="Go to the documentation of foobar_pkg 0.1.1+5"/>
                         </a>
                       </td>
                       <td class="archive">
-                        <a href="https://pub.dartlang.org/mock-download-uri.tar.gz" title="Download foobar_pkg 0.1.1+5 archive">
-                          <img src="/static/img/ic_get_app_black_24dp.svg?hash=mocked_hash_341543596" alt="Download foobar_pkg 0.1.1+5 archive"/>
+                        <a href="https://pub.dartlang.org/mock-download-uri.tar.gz" rel="nofollow" title="Download foobar_pkg 0.1.1+5 archive">
+                          <img class="version-table-icon" src="/static/img/ic_get_app_black_24dp.svg?hash=mocked_hash_341543596" alt="Download foobar_pkg 0.1.1+5 archive"/>
                         </a>
                       </td>
                     </tr>
@@ -212,12 +212,12 @@ Published
                       <td class="uploaded">Jan 1, 2014</td>
                       <td class="documentation">
                         <a href="/documentation/foobar_pkg/0.2.0-dev/" rel="nofollow" title="Go to the documentation of foobar_pkg 0.2.0-dev">
-                          <img src="/static/img/ic_drive_document_black_24dp.svg?hash=mocked_hash_663394799" alt="Go to the documentation of foobar_pkg 0.2.0-dev"/>
+                          <img class="version-table-icon" src="/static/img/ic_drive_document_black_24dp.svg?hash=mocked_hash_663394799" alt="Go to the documentation of foobar_pkg 0.2.0-dev"/>
                         </a>
                       </td>
                       <td class="archive">
-                        <a href="https://pub.dartlang.org/mock-download-uri.tar.gz" title="Download foobar_pkg 0.2.0-dev archive">
-                          <img src="/static/img/ic_get_app_black_24dp.svg?hash=mocked_hash_341543596" alt="Download foobar_pkg 0.2.0-dev archive"/>
+                        <a href="https://pub.dartlang.org/mock-download-uri.tar.gz" rel="nofollow" title="Download foobar_pkg 0.2.0-dev archive">
+                          <img class="version-table-icon" src="/static/img/ic_get_app_black_24dp.svg?hash=mocked_hash_341543596" alt="Download foobar_pkg 0.2.0-dev archive"/>
                         </a>
                       </td>
                     </tr>

--- a/pkg/web_app/lib/src/dartdoc_status.dart
+++ b/pkg/web_app/lib/src/dartdoc_status.dart
@@ -54,7 +54,12 @@ void updateDartdocStatus() {
               } else {
                 docCol.dataset[_hasDocumentationAttr] = '0';
                 docLink.href += 'log.txt';
-                docLink.text = 'failed';
+                final img = docLink.querySelector('img.version-table-icon');
+                if (img != null && img.dataset.containsKey('failed-icon')) {
+                  img.setAttribute('src', img.dataset['failed-icon']);
+                } else {
+                  docLink.text = 'failed';
+                }
               }
             },
           );

--- a/pkg/web_css/lib/src/_pkg_experimental.scss
+++ b/pkg/web_css/lib/src/_pkg_experimental.scss
@@ -11,10 +11,12 @@ body.experimental {
 
   td, th {
     border-bottom: 1px solid #c8c8ca;
-    padding: 4px 0px;
+    padding: 8px 0px;
     text-align: left;
 
     &.version {
+      font-family: $font-family-google-sans;
+      font-size: 24px;
     }
 
     &.uploaded {
@@ -64,6 +66,10 @@ body.experimental {
         font-weight: 400;
       }
     }
+  }
+
+  .version-table-icon {
+    opacity: 0.7;
   }
 }
 

--- a/static/img/documentation-failed-icon.svg
+++ b/static/img/documentation-failed-icon.svg
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="16px" height="20px" viewBox="0 0 16 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<title>icon: generation failed</title>
+<defs>
+<polygon id="path-1" points="0 0 15.9998 0 15.9998 20 0 20"></polygon>
+<polygon id="path-3" points="0 20 16 20 16 0 0 0"></polygon>
+</defs>
+<g id="pub.dev" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+<g id="detail---versions-03" transform="translate(-865.000000, -582.000000)">
+<g id="item-copy-2" transform="translate(189.000000, 577.000000)">
+<g id="icon:-generation-failed" transform="translate(676.000000, 5.000000)">
+<polygon id="Fill-1" fill="#000000" points="4 12 12 12 12 10 4 10"></polygon>
+<g id="Group-8">
+<g id="Group-4">
+<mask id="mask-2" fill="white">
+<use xlink:href="#path-1"></use>
+</mask>
+<g id="Clip-3"></g>
+<path d="M13.9998,9 L13.9998,18 L1.9998,18 L1.9998,2 L6.9998,2 L6.9998,0 L1.9998,0 C0.8998,0 -0.0002,0.9 -0.0002,2 L-0.0002,18 C-0.0002,19.1 0.8898,20 1.9898,20 L13.9998,20 C15.0998,20 15.9998,19.1 15.9998,18 L15.9998,9 L13.9998,9 Z" id="Fill-2" fill="#000000" mask="url(#mask-2)"></path>
+</g>
+<mask id="mask-4" fill="white">
+<use xlink:href="#path-3"></use>
+</mask>
+<g id="Clip-6"></g>
+<polygon id="Fill-5" fill="#000000" mask="url(#mask-4)" points="4 16 12 16 12 14 4 14"></polygon>
+<polygon id="Fill-7" fill="#000000" mask="url(#mask-4)" points="15.9998 1.4917 14.5088 -0.0003 12.3128 2.1957 10.1178 -0.0003 8.6258 1.4917 10.8208 3.6867 8.6258 5.8827 10.1178 7.3737 12.3128 5.1787 14.5088 7.3737 15.9998 5.8827 13.8048 3.6867"></polygon>
+</g>
+</g>
+</g>
+</g>
+</g>
+</svg>


### PR DESCRIPTION
- Updated font, padding and opacity.
- Using a new icon for failed documentation. The `data-` attribute is used in the new design only.

<img width="757" alt="Screenshot 2020-06-04 at 14 07 17" src="https://user-images.githubusercontent.com/4778111/83755112-5cfdbb80-a66d-11ea-8b7f-9e459b352d05.png">
