### PR TITLE
Do not use bottom border on score tab's score value.

### DIFF
--- a/app/lib/frontend/templates/detail_page.dart
+++ b/app/lib/frontend/templates/detail_page.dart
@@ -114,6 +114,7 @@ class Tab {
     final titleClasses = <String>[
       if (requestContext.isExperimental) 'detail-tab',
       contentHtml == null ? 'tab-link' : 'tab-button',
+      if (requestContext.isExperimental) 'detail-tab-$id-title',
       if (isActive) '-active',
     ];
     final contentClasses = <String>[

--- a/pkg/web_css/lib/src/_detail_page_experimental.scss
+++ b/pkg/web_css/lib/src/_detail_page_experimental.scss
@@ -367,6 +367,15 @@ $detail-tabs-width: calc(100% - 320px);
     border-bottom-color: $detail-tab-admin-color;
   }
 
+  .detail-tab-analysis-title {
+    // Separate the tab title's bottom border from the score.
+    position: relative;
+    margin-right: 60px;
+    > a {
+      margin-right: 0px;
+    }
+  }
+
   .score-value {
     background: $detail-tab-active-fg;
     color: white;
@@ -374,6 +383,9 @@ $detail-tabs-width: calc(100% - 320px);
     font-weight: 400;
     padding: 0px 8px;
     border-radius: 12px;
+    // Separate the tab title's bottom border from the score.
+    position: absolute;
+    margin-left: 8px;
   }
 }
 


### PR DESCRIPTION
This implementation is not the cleanest and borders the category of CSS hacks, but it is much simpler than all the DOM changes required for a cleaner CSS solution. Maybe once we remove the old style, the tabs can be refactored to allow a secondary content to their right side.

<img width="279" alt="Screenshot 2020-06-04 at 21 54 25" src="https://user-images.githubusercontent.com/4778111/83804300-3613a980-a6ae-11ea-99a4-cc4fac33dced.png">
