### PR TITLE
Store and use the latest dartdoc entry uuid which has content.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ Important changes to data-models, configuration and migrations between each
 AppEngine version, listed here to ease deployment and troubleshooting.
 
 ## Next Release (replace with git tag when deployed)
-
+ * `/documentation/` serving changed: content entry lookup first checks Datastore entity.
 
 ## `20200610t120907-all`
  * Bumped runtimeVersion to `2020.06.10`.

--- a/app/lib/dartdoc/dartdoc_runner.dart
+++ b/app/lib/dartdoc/dartdoc_runner.dart
@@ -159,6 +159,7 @@ class DartdocJobProcessor extends JobProcessor {
 
     String reportStatus = ReportStatus.failed;
     String abortLog;
+    String dartdocEntryUuid;
     final healthSuggestions = <Suggestion>[];
     final maintenanceSuggestions = <Suggestion>[];
     try {
@@ -236,6 +237,9 @@ class DartdocJobProcessor extends JobProcessor {
       } else {
         await dartdocBackend.uploadDir(entry, outputDir);
         reportStatus = hasContent ? ReportStatus.success : ReportStatus.failed;
+        if (hasContent) {
+          dartdocEntryUuid = entry.uuid;
+        }
       }
 
       if (!hasContent && isLatestStable) {
@@ -290,6 +294,7 @@ class DartdocJobProcessor extends JobProcessor {
         job,
         DartdocReport(
           reportStatus: reportStatus,
+          dartdocEntryUuid: dartdocEntryUuid,
           coverage: coverage?.percent ?? 0.0,
           coverageScore: coverage?.score ?? 0.0,
           healthSuggestions:
@@ -531,6 +536,7 @@ String _mergeOutput(ProcessResult pr, {bool compressStdout = false}) {
 
 DartdocReport _emptyReport() => DartdocReport(
       reportStatus: ReportStatus.aborted,
+      dartdocEntryUuid: null,
       coverage: 0.0,
       coverageScore: 0.0,
       healthSuggestions: [],

--- a/app/lib/scorecard/models.dart
+++ b/app/lib/scorecard/models.dart
@@ -418,6 +418,9 @@ class DartdocReport implements ReportData {
   @override
   final String reportStatus;
 
+  /// The latest dartdoc entry's UUID that has valid documentation content.
+  final String dartdocEntryUuid;
+
   /// The percent of API symbols with documentation.
   final double coverage;
   final double coverageScore;
@@ -432,6 +435,7 @@ class DartdocReport implements ReportData {
 
   DartdocReport({
     @required this.reportStatus,
+    @required this.dartdocEntryUuid,
     @required this.coverage,
     @required this.coverageScore,
     @required this.healthSuggestions,

--- a/app/lib/scorecard/models.g.dart
+++ b/app/lib/scorecard/models.g.dart
@@ -115,6 +115,7 @@ Map<String, dynamic> _$PanaReportToJson(PanaReport instance) {
 DartdocReport _$DartdocReportFromJson(Map<String, dynamic> json) {
   return DartdocReport(
     reportStatus: json['reportStatus'] as String,
+    dartdocEntryUuid: json['dartdocEntryUuid'] as String,
     coverage: (json['coverage'] as num)?.toDouble(),
     coverageScore: (json['coverageScore'] as num)?.toDouble(),
     healthSuggestions: (json['healthSuggestions'] as List)
@@ -131,6 +132,7 @@ DartdocReport _$DartdocReportFromJson(Map<String, dynamic> json) {
 Map<String, dynamic> _$DartdocReportToJson(DartdocReport instance) {
   final val = <String, dynamic>{
     'reportStatus': instance.reportStatus,
+    'dartdocEntryUuid': instance.dartdocEntryUuid,
     'coverage': instance.coverage,
     'coverageScore': instance.coverageScore,
   };

--- a/app/lib/shared/markdown.dart
+++ b/app/lib/shared/markdown.dart
@@ -98,7 +98,8 @@ String _renderSafeHtml(List<m.Node> nodes, bool inlineOnly) {
   // Renders the sanitized HTML.
   final html = sanitizeHtml(
     rawHtml,
-    allowElementId: (String id) => true, // TODO: Use a denylist for ids used by pub site
+    allowElementId: (String id) =>
+        true, // TODO: Use a denylist for ids used by pub site
     allowClassName: (String cn) {
       if (cn.startsWith('language-')) return true;
       return _whitelistedClassNames.contains(cn);

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -179,6 +179,7 @@ void main() {
             flags: null),
         dartdocReport: DartdocReport(
           reportStatus: ReportStatus.success,
+          dartdocEntryUuid: '1234-5678-dartdocentry-90ab',
           coverage: 1.0,
           coverageScore: 1.0,
           healthSuggestions: [],


### PR DESCRIPTION
- Storing the latest successful uuid is cheap.
- On the optimistic path (when the entity does exists), accessing it should be faster than listing the storage bucket. 
