### PR TITLE
Retry dartdoc upload on 504 response.

### DIFF
--- a/app/lib/shared/storage.dart
+++ b/app/lib/shared/storage.dart
@@ -93,7 +93,7 @@ Future uploadWithRetry(Bucket bucket, String objectName, int length,
     description: 'Upload to $objectName',
     shouldRetryOnError: (e) {
       if (e is DetailedApiRequestError) {
-        return e.status == 502 || e.status == 503;
+        return e.status == 502 || e.status == 503 || e.status == 504;
       }
       return false;
     },


### PR DESCRIPTION
Fixes #3714.

I've checked the logs from the recent release, and if there was an issue during the upload, it was always resolved with the second attempt of uploading the file.