### PR TITLE
Use likeCount as part of the default search rank.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ AppEngine version, listed here to ease deployment and troubleshooting.
  * `/documentation/` serving changed: content entry lookup first checks Datastore entity.
  * Upgraded `gcloud` to `0.7.3`, using the new `delimiter` to recursively
    delete from storage buckets.
+ * Search uses `Package.likes` as part of the default ranking.
 
 ## `20200610t120907-all`
  * Bumped runtimeVersion to `2020.06.10`.

--- a/app/lib/search/mem_index.dart
+++ b/app/lib/search/mem_index.dart
@@ -621,6 +621,8 @@ class _LikeTracker {
     _changed |= removed != null;
   }
 
+  /// Updates `_LikeScore.score` values, setting them between 0.0 (no likes) to
+  /// 1.0 (most likes).
   void _updateScores() {
     final entries = _values.values.toList();
     entries.sort((a, b) => a.likeCount.compareTo(b.likeCount));

--- a/app/lib/search/mem_index.dart
+++ b/app/lib/search/mem_index.dart
@@ -33,6 +33,7 @@ class InMemoryPackageIndex implements PackageIndex {
   final TokenIndex _readmeIndex = TokenIndex(minLength: 3);
   final TokenIndex _apiSymbolIndex = TokenIndex(minLength: 2);
   final TokenIndex _apiDartdocIndex = TokenIndex(minLength: 3);
+  final _likeTracker = _LikeTracker();
   DateTime _lastUpdated;
   bool _isReady = false;
 
@@ -97,6 +98,8 @@ class InMemoryPackageIndex implements PackageIndex {
     await Future.delayed(Duration.zero);
     _normalizedPackageText[doc.package] = normalizeBeforeIndexing(allText);
 
+    _likeTracker.trackLikeCount(doc.package, doc.likeCount ?? 0);
+
     await Future.delayed(Duration.zero);
     _lastUpdated = DateTime.now().toUtc();
   }
@@ -106,6 +109,7 @@ class InMemoryPackageIndex implements PackageIndex {
     for (PackageDocument doc in documents) {
       await addPackage(doc);
     }
+    _likeTracker._updateScores();
   }
 
   @override
@@ -122,6 +126,7 @@ class InMemoryPackageIndex implements PackageIndex {
       _apiSymbolIndex.remove(pageId);
       _apiDartdocIndex.remove(pageId);
     }
+    _likeTracker.removePackage(doc.package);
     _lastUpdated = DateTime.now().toUtc();
   }
 
@@ -371,11 +376,13 @@ class InMemoryPackageIndex implements PackageIndex {
   }
 
   Score _getOverallScore(Iterable<String> packages) {
-    final Map<String, double> values =
-        Map.fromIterable(packages, value: (package) {
+    final values = Map<String, double>.fromIterable(packages, value: (package) {
       final doc = _packages[package];
-      final double overall = calculateOverallScore(
-        popularity: doc.popularity ?? 0.0,
+      final downloadScore = doc.popularity ?? 0.0;
+      final likeScore = _likeTracker.getLikeScore(doc.package);
+      final popularity = (downloadScore + likeScore) / 2;
+      final overall = calculateOverallScore(
+        popularity: popularity,
         health: doc.health ?? 0.0,
         maintenance: doc.maintenance ?? 0.0,
       );
@@ -579,5 +586,50 @@ class _PackageNameIndex {
       values[pkg] = score;
     }
     return Score(values);
+  }
+}
+
+class _LikeScore {
+  final String package;
+  int likeCount = 0;
+  double score = 0.0;
+
+  _LikeScore(this.package, {this.likeCount = 0, this.score = 0.0});
+}
+
+class _LikeTracker {
+  final _values = <String, _LikeScore>{};
+  bool _changed = false;
+
+  double getLikeScore(String package) {
+    if (_changed) {
+      _updateScores();
+    }
+    return _values[package]?.score ?? 0.0;
+  }
+
+  void trackLikeCount(String package, int likeCount) {
+    final v = _values.putIfAbsent(package, () => _LikeScore(package));
+    if (v.likeCount != likeCount) {
+      _changed = true;
+      v.likeCount = likeCount;
+    }
+  }
+
+  void removePackage(String package) {
+    final removed = _values.remove(package);
+    _changed |= removed != null;
+  }
+
+  void _updateScores() {
+    final entries = _values.values.toList();
+    entries.sort((a, b) => a.likeCount.compareTo(b.likeCount));
+    for (int i = 0; i < entries.length; i++) {
+      if (i > 0 && entries[i].likeCount == entries[i - 1].likeCount) {
+        entries[i].score = entries[i - 1].score;
+      } else {
+        entries[i].score = (i + 1) / entries.length;
+      }
+    }
   }
 }

--- a/app/test/search/exact_name_test.dart
+++ b/app/test/search/exact_name_test.dart
@@ -45,11 +45,11 @@ void main() {
         'packages': [
           {
             'package': 'build_config',
-            'score': closeTo(0.586, 0.001),
+            'score': closeTo(0.457, 0.001),
           },
           {
             'package': 'build',
-            'score': closeTo(0.581, 0.001),
+            'score': closeTo(0.452, 0.001),
           },
         ],
       });

--- a/app/test/search/handlers_test.dart
+++ b/app/test/search/handlers_test.dart
@@ -49,7 +49,7 @@ void main() {
           'packages': [
             {
               'package': 'pkg_foo',
-              'score': closeTo(0.33, 0.01),
+              'score': closeTo(0.32, 0.01),
             }
           ],
         });
@@ -63,7 +63,7 @@ void main() {
           'packages': [
             {
               'package': 'pkg_foo',
-              'score': closeTo(0.30, 0.01),
+              'score': closeTo(0.28, 0.01),
             }
           ],
         });
@@ -78,7 +78,7 @@ void main() {
               'packages': [
                 {
                   'package': 'pkg_foo',
-                  'score': closeTo(0.30, 0.01),
+                  'score': closeTo(0.28, 0.01),
                 }
               ],
             });

--- a/app/test/search/mem_index_test.dart
+++ b/app/test/search/mem_index_test.dart
@@ -114,7 +114,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'packages': [
           {
             'package': 'async',
-            'score': closeTo(0.92, 0.01),
+            'score': closeTo(0.91, 0.01),
           },
         ]
       });
@@ -129,7 +129,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'packages': [
           {
             'package': 'http',
-            'score': closeTo(0.79, 0.01),
+            'score': closeTo(0.83, 0.01),
           },
         ]
       });
@@ -144,7 +144,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'packages': [
           {
             'package': 'chrome_net',
-            'score': closeTo(0.39, 0.01),
+            'score': closeTo(0.43, 0.01),
           },
         ]
       });
@@ -157,8 +157,8 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'indexUpdated': isNotNull,
         'totalCount': 2,
         'packages': [
-          {'package': 'async', 'score': closeTo(0.82, 0.01)},
-          {'package': 'http', 'score': closeTo(0.65, 0.01)},
+          {'package': 'async', 'score': closeTo(0.80, 0.01)},
+          {'package': 'http', 'score': closeTo(0.68, 0.01)},
         ]
       });
     });
@@ -180,8 +180,8 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'indexUpdated': isNotNull,
         'totalCount': 2,
         'packages': [
-          {'package': 'async', 'score': closeTo(0.81, 0.01)},
-          {'package': 'http', 'score': closeTo(0.65, 0.01)},
+          {'package': 'async', 'score': closeTo(0.80, 0.01)},
+          {'package': 'http', 'score': closeTo(0.68, 0.01)},
         ],
       });
     });
@@ -193,7 +193,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'indexUpdated': isNotNull,
         'totalCount': 1,
         'packages': [
-          {'package': 'async', 'score': closeTo(0.38, 0.01)},
+          {'package': 'async', 'score': closeTo(0.37, 0.01)},
         ],
       });
     });
@@ -343,8 +343,8 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'indexUpdated': isNotNull,
         'totalCount': 2,
         'packages': [
-          {'package': 'async', 'score': closeTo(0.930, 0.001)},
-          {'package': 'http', 'score': closeTo(0.895, 0.001)},
+          {'package': 'http', 'score': closeTo(0.95, 0.01)},
+          {'package': 'async', 'score': closeTo(0.91, 0.01)},
         ],
       });
     });
@@ -356,7 +356,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'indexUpdated': isNotNull,
         'totalCount': 1,
         'packages': [
-          {'package': 'chrome_net', 'score': closeTo(0.531, 0.001)},
+          {'package': 'chrome_net', 'score': closeTo(0.59, 0.01)},
         ],
       });
     });
@@ -368,8 +368,8 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'indexUpdated': isNotNull,
         'totalCount': 2,
         'packages': [
-          {'package': 'http', 'score': closeTo(0.895, 0.001)},
-          {'package': 'chrome_net', 'score': closeTo(0.531, 0.001)},
+          {'package': 'http', 'score': closeTo(0.95, 0.01)},
+          {'package': 'chrome_net', 'score': closeTo(0.59, 0.01)},
         ],
       });
     });
@@ -381,7 +381,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'indexUpdated': isNotNull,
         'totalCount': 1,
         'packages': [
-          {'package': 'http', 'score': closeTo(0.79, 0.01)},
+          {'package': 'http', 'score': closeTo(0.83, 0.01)},
         ],
       });
     });
@@ -393,7 +393,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'indexUpdated': isNotNull,
         'totalCount': 1,
         'packages': [
-          {'package': 'http', 'score': closeTo(0.895, 0.001)},
+          {'package': 'http', 'score': closeTo(0.95, 0.01)},
         ],
       });
     });
@@ -415,7 +415,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'indexUpdated': isNotNull,
         'totalCount': 1,
         'packages': [
-          {'package': 'async', 'score': closeTo(0.930, 0.001)},
+          {'package': 'async', 'score': closeTo(0.91, 0.01)},
         ],
       });
     });
@@ -437,7 +437,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'indexUpdated': isNotNull,
         'totalCount': 1,
         'packages': [
-          {'package': 'async', 'score': closeTo(0.930, 0.001)},
+          {'package': 'async', 'score': closeTo(0.91, 0.01)},
         ],
       });
     });
@@ -452,8 +452,8 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'indexUpdated': isNotNull,
         'totalCount': 2,
         'packages': [
-          {'package': 'async', 'score': closeTo(0.930, 0.001)},
-          {'package': 'http', 'score': closeTo(0.895, 0.001)},
+          {'package': 'http', 'score': closeTo(0.95, 0.01)},
+          {'package': 'async', 'score': closeTo(0.91, 0.01)},
         ],
       });
     });
@@ -475,8 +475,8 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'indexUpdated': isNotNull,
         'totalCount': 2,
         'packages': [
-          {'package': 'async', 'score': closeTo(0.930, 0.001)},
-          {'package': 'http', 'score': closeTo(0.895, 0.001)},
+          {'package': 'http', 'score': closeTo(0.95, 0.01)},
+          {'package': 'async', 'score': closeTo(0.91, 0.01)},
         ],
       });
     });

--- a/app/test/search/result_combiner_test.dart
+++ b/app/test/search/result_combiner_test.dart
@@ -63,7 +63,7 @@ void main() {
         'indexUpdated': isNotNull,
         'totalCount': 1,
         'packages': [
-          {'package': 'stringutils', 'score': closeTo(0.79, 0.01)},
+          {'package': 'stringutils', 'score': closeTo(0.72, 0.01)},
         ],
       });
     });
@@ -90,7 +90,7 @@ void main() {
               },
             ],
           },
-          {'package': 'stringutils', 'score': closeTo(0.58, 0.01)},
+          {'package': 'stringutils', 'score': closeTo(0.53, 0.01)},
         ],
       });
     });
@@ -102,7 +102,7 @@ void main() {
         'indexUpdated': isNotNull,
         'totalCount': 2,
         'packages': [
-          {'package': 'stringutils', 'score': closeTo(0.78, 0.01)},
+          {'package': 'stringutils', 'score': closeTo(0.72, 0.01)},
           {
             'package': 'dart:core',
             'score': closeTo(0.89, 0.01),


### PR DESCRIPTION
- tweaked the score calculation: same like counts should get the same score (otherwise it would be somewhat random in tests and unfair in prod)
- the reordering of `http` and `async` in one of the tests validates that the like count is part of the results