### PR TITLE
Bump runtimeVersion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Important changes to data-models, configuration and migrations between each
 AppEngine version, listed here to ease deployment and troubleshooting.
 
 ## Next Release (replace with git tag when deployed)
+ * Bumped runtimeVersion to `2020.06.18`.
  * `/documentation/` serving changed: content entry lookup first checks Datastore entity.
  * Upgraded `gcloud` to `0.7.3`, using the new `delimiter` to recursively
    delete from storage buckets.

--- a/app/lib/shared/versions.dart
+++ b/app/lib/shared/versions.dart
@@ -21,10 +21,10 @@ final RegExp runtimeVersionPattern = RegExp(r'^\d{4}\.\d{2}\.\d{2}$');
 /// Make sure that at least two versions are kept here as the next candidates
 /// when the version switch happens.
 const acceptedRuntimeVersions = <String>[
-  '2020.06.10', // The current [runtimeVersion].
+  '2020.06.18', // The current [runtimeVersion].
+  '2020.06.10',
   '2020.05.26',
   '2020.05.08',
-  '2020.05.03',
 ];
 
 /// Represents a combined version of the overall toolchain and processing,

--- a/app/test/shared/versions_test.dart
+++ b/app/test/shared/versions_test.dart
@@ -33,7 +33,7 @@ void main() {
     // This test is a reminder that if pana, the SDK or any of the above
     // versions change, we should also adjust the [runtimeVersion]. Before
     // updating the hash value, double-check if it is being updated.
-    expect(hash, 280494580);
+    expect(hash, 480808392);
   });
 
   test('accepted runtime versions should be lexicographically ordered', () {


### PR DESCRIPTION
- Storing the `dartdocEntryUuid` in the scorecard report takes effect only after the content is generated, forcing the `runtimeVersion` change will force the field to be updated.