### PR TITLE
Key figures on new score page.

### DIFF
--- a/app/lib/frontend/templates/package.dart
+++ b/app/lib/frontend/templates/package.dart
@@ -444,8 +444,13 @@ Tab _scoreTab(PackagePageData data) {
   return Tab.withContent(
     id: 'analysis',
     titleHtml: renderScoreBox(data.toPackageView(), isTabHeader: true),
-    contentHtml: renderAnalysisTab(data.version.package,
-        data.version.pubspec.sdkConstraint, data.analysis?.card, data.analysis),
+    contentHtml: renderAnalysisTab(
+      data.version.package,
+      data.version.pubspec.sdkConstraint,
+      data.analysis?.card,
+      data.analysis,
+      likeCount: data.package.likes,
+    ),
   );
 }
 

--- a/app/lib/frontend/templates/package_analysis.dart
+++ b/app/lib/frontend/templates/package_analysis.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:meta/meta.dart';
 import 'package:pana/models.dart' show Report, ReportSection, SuggestionLevel;
 
 import '../../analyzer/analyzer_client.dart';
@@ -18,8 +19,13 @@ import '_consts.dart';
 import 'misc.dart';
 
 /// Renders the `views/pkg/analysis/tab.mustache` template.
-String renderAnalysisTab(String package, String sdkConstraint,
-    ScoreCardData card, AnalysisView analysis) {
+String renderAnalysisTab(
+  String package,
+  String sdkConstraint,
+  ScoreCardData card,
+  AnalysisView analysis, {
+  @required int likeCount,
+}) {
   if (card == null || analysis == null || !analysis.hasAnalysisData) {
     return '<i>Awaiting analysis to complete.</i>';
   }
@@ -71,6 +77,10 @@ String renderAnalysisTab(String package, String sdkConstraint,
     'score_table_html': _renderScoreTable(card),
     'dep_table_html': _renderDepTable(sdkConstraint, card, analysis),
     'report_html': _renderReport(report),
+    'like_key_figure_html': _renderLikeKeyFigure(likeCount),
+    'popularity_key_figure_html':
+        _renderPopularityKeyFigure(card.popularityScore),
+    'pubpoints_key_figure_html': _renderPubPointsKeyFigure(report),
   };
 
   return templateCache.renderTemplate('pkg/analysis/tab', data);
@@ -125,6 +135,50 @@ String _renderReport(Report report) {
           'is_green': s.grantedPoints == s.maxPoints,
           'is_red': s.grantedPoints != s.maxPoints,
         }),
+  });
+}
+
+String _renderLikeKeyFigure(int likeCount) {
+  // TODO: implement k/m supplemental for values larger than 1000
+  return _renderKeyFigure(
+    value: '$likeCount',
+    supplemental: '',
+    label: 'likes',
+  );
+}
+
+String _renderPopularityKeyFigure(double popularity) {
+  return _renderKeyFigure(
+    value: formatScore(popularity),
+    supplemental: '%',
+    label: 'popularity',
+  );
+}
+
+String _renderPubPointsKeyFigure(Report report) {
+  var grantedPoints = 0;
+  var maxPoints = 0;
+  report?.sections?.forEach((section) {
+    grantedPoints += section.grantedPoints;
+    maxPoints += section.maxPoints;
+  });
+  return _renderKeyFigure(
+    value: '$grantedPoints',
+    supplemental: '/ $maxPoints',
+    label: 'pub points',
+  );
+}
+
+/// Renders the `views/pkg/analysis/key_figure.mustache` template.
+String _renderKeyFigure({
+  @required String value,
+  @required String supplemental,
+  @required String label,
+}) {
+  return templateCache.renderTemplate('pkg/analysis/key_figure', {
+    'value': value,
+    'supplemental': supplemental,
+    'label': label,
   });
 }
 

--- a/app/lib/frontend/templates/views/pkg/analysis/key_figure.mustache
+++ b/app/lib/frontend/templates/views/pkg/analysis/key_figure.mustache
@@ -1,0 +1,11 @@
+{{! Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+    for details. All rights reserved. Use of this source code is governed by a
+    BSD-style license that can be found in the LICENSE file. }}
+
+<div class="score-key-figure">
+  <div class="score-key-figure-title">
+    <span class="score-key-figure-value">{{ value }}</span>
+    <span class="score-key-figure-supplemental">{{ supplemental }}</span>
+  </div>
+  <div class="score-key-figure-label">{{ label }}</div>
+</div>

--- a/app/lib/frontend/templates/views/pkg/analysis/tab_experimental.mustache
+++ b/app/lib/frontend/templates/views/pkg/analysis/tab_experimental.mustache
@@ -2,11 +2,13 @@
     for details. All rights reserved. Use of this source code is governed by a
     BSD-style license that can be found in the LICENSE file. }}
 
-{{& score_table_html }}
-
-<div class="learn-more-scoring">
-  Learn more about <a class="learn-more-scoring-link" href="/help#scoring">scoring</a>.
+<div class="score-key-figures">
+  {{& like_key_figure_html }}
+  {{& popularity_key_figure_html }}
+  {{& pubpoints_key_figure_html }}
 </div>
+
+{{& report_html }}
 
 {{#show_discontinued}}
 <p>This package is not analyzed, because it is discontinued.</p>
@@ -36,7 +38,11 @@
 </ul>
 {{/show_analysis}}
 
-{{& report_html }}
+{{& score_table_html }}
+
+<div class="learn-more-scoring">
+  Learn more about <a class="learn-more-scoring-link" href="/help#scoring">scoring</a>.
+</div>
 
 {{& analysis_suggestions_html}}
 {{& health_suggestions_html}}

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -377,7 +377,7 @@ void main() {
 
     scopedTest('no content for analysis tab', () async {
       // no content
-      expect(renderAnalysisTab('pkg_foo', null, null, null),
+      expect(renderAnalysisTab('pkg_foo', null, null, null, likeCount: 4),
           '<i>Awaiting analysis to complete.</i>');
     });
 
@@ -392,8 +392,13 @@ void main() {
       final panaReport =
           PanaReport.fromJson(reports['pana'] as Map<String, dynamic>);
       final view = AnalysisView(card: card, panaReport: panaReport);
-      final String html =
-          renderAnalysisTab('http', '>=1.23.0-dev.0.0 <2.0.0', card, view);
+      final String html = renderAnalysisTab(
+        'http',
+        '>=1.23.0-dev.0.0 <2.0.0',
+        card,
+        view,
+        likeCount: 0,
+      );
       expectGoldenFile(html, 'analysis_tab_http.html', isFragment: true);
     });
 
@@ -445,49 +450,59 @@ void main() {
             flags: null),
       );
       final String html = renderAnalysisTab(
-          'pkg_foo', '>=1.25.0-dev.9.0 <2.0.0', card, analysisView);
+        'pkg_foo',
+        '>=1.25.0-dev.9.0 <2.0.0',
+        card,
+        analysisView,
+        likeCount: 2000,
+      );
       expectGoldenFile(html, 'analysis_tab_mock.html', isFragment: true);
     });
 
     scopedTest('aborted analysis tab', () async {
       final String html = renderAnalysisTab(
-          'pkg_foo',
-          null,
-          ScoreCardData(),
-          AnalysisView(
-            card: ScoreCardData(
-              reportTypes: ['pana'],
-            ),
-            panaReport: PanaReport(
-              timestamp: DateTime(2017, 12, 18, 14, 26, 00),
-              panaRuntimeInfo: _panaRuntimeInfo,
-              reportStatus: ReportStatus.aborted,
-              healthScore: null,
-              maintenanceScore: null,
-              derivedTags: null,
-              pkgDependencies: null,
-              licenses: null,
-              panaSuggestions: null,
-              healthSuggestions: null,
-              maintenanceSuggestions: null,
-              report: Report(sections: <ReportSection>[]),
-              flags: null,
-            ),
-          ));
+        'pkg_foo',
+        null,
+        ScoreCardData(),
+        AnalysisView(
+          card: ScoreCardData(
+            reportTypes: ['pana'],
+          ),
+          panaReport: PanaReport(
+            timestamp: DateTime(2017, 12, 18, 14, 26, 00),
+            panaRuntimeInfo: _panaRuntimeInfo,
+            reportStatus: ReportStatus.aborted,
+            healthScore: null,
+            maintenanceScore: null,
+            derivedTags: null,
+            pkgDependencies: null,
+            licenses: null,
+            panaSuggestions: null,
+            healthSuggestions: null,
+            maintenanceSuggestions: null,
+            report: Report(sections: <ReportSection>[]),
+            flags: null,
+          ),
+        ),
+        likeCount: 1000000,
+      );
+
       expectGoldenFile(html, 'analysis_tab_aborted.html', isFragment: true);
     });
 
     scopedTest('outdated analysis tab', () async {
       final String html = renderAnalysisTab(
-          'pkg_foo',
-          null,
-          ScoreCardData(flags: [PackageFlags.isObsolete]),
-          AnalysisView(
-            card: ScoreCardData(
-              flags: [PackageFlags.isObsolete],
-              updated: DateTime(2017, 12, 18, 14, 26, 00),
-            ),
-          ));
+        'pkg_foo',
+        null,
+        ScoreCardData(flags: [PackageFlags.isObsolete]),
+        AnalysisView(
+          card: ScoreCardData(
+            flags: [PackageFlags.isObsolete],
+            updated: DateTime(2017, 12, 18, 14, 26, 00),
+          ),
+        ),
+        likeCount: 1111,
+      );
       expectGoldenFile(html, 'analysis_tab_outdated.html', isFragment: true);
     });
 

--- a/pkg/web_css/lib/src/_pkg_experimental.scss
+++ b/pkg/web_css/lib/src/_pkg_experimental.scss
@@ -97,6 +97,7 @@ body.experimental {
   padding-bottom: 4px;
   margin-bottom: 16px;
   text-align: right;
+  opacity: 0.5; /* Will be removed from the page. */
 
   > .learn-more-scoring-link {
     font-weight: 400;
@@ -133,6 +134,8 @@ body.experimental {
   width: 100%;
   align-items: center;
   margin: 16px 0;
+  opacity: 0.5; /* Will be removed from the page. */
+  padding-top: 200px; /* Will be removed from the page. */
 
   .score-items {
     flex-grow: 1;
@@ -195,6 +198,48 @@ body.experimental {
         font-weight: 300;
       }
     }
+  }
+}
+
+.score-key-figures {
+  display: flex;
+  align-items: center;
+  justify-content: space-evenly;
+  padding: 20px 0 30px 0;
+
+  @media (min-width: $device-desktop-min-width) {
+    padding: 40px 0 50px 0;
+  }
+
+  .score-key-figure-title {
+    color: #1967d2;
+    text-align: center;
+  }
+
+  .score-key-figure-value {
+    font-family: $font-family-google-sans-display;
+    font-size: 32px;
+    font-weight: 400;
+    line-height: 1;
+
+    @media (min-width: $device-desktop-min-width) {
+      font-size: 64px;
+    }
+  }
+
+  .score-key-figure-supplemental {
+    font-family: $font-family-google-sans;
+    font-size: 24px;
+    font-weight: 400;
+  }
+
+  .score-key-figure-label {
+    color: #555555;
+    font-family: $font-family-roboto;
+    font-size: 14px;
+    font-weight: 300;
+    text-align: center;
+    text-transform: uppercase;
   }
 }
 


### PR DESCRIPTION
- slightly smaller on mobile view
- like count's `k`/`m` abbreviation is not yet implemented
- will do a follow-up PR to remove/cleanup the score table and circle (added an extra margin and decreased opacity so that we know what will be removed).

<img width="536" alt="Screenshot 2020-06-18 at 13 29 18" src="https://user-images.githubusercontent.com/4778111/85015204-df0adb80-b167-11ea-9df5-d139f80134ae.png">
