### PR TITLE
Fix missing await in dartdoc entry loading.

### DIFF
--- a/app/lib/dartdoc/backend.dart
+++ b/app/lib/dartdoc/backend.dart
@@ -176,7 +176,7 @@ class DartdocBackend {
     }
 
     Future<DartdocEntry> loadVersion(String v) async {
-      final entry = _tryLoadLastReportedEntry(package, v);
+      final entry = await _tryLoadLastReportedEntry(package, v);
       if (entry != null) return entry;
 
       final entries = await _listEntries(storage_path.entryPrefix(package, v));


### PR DESCRIPTION
- The `unawaited Future` linter rule did not warn us, because we were returning the `Future<DartdocEntry>` instance.
- We were always returning the instance, and on a new deployment it always resolved to `null`.