### PR TITLE
Reduce concurrent snapshot writes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ AppEngine version, listed here to ease deployment and troubleshooting.
 
 ## Next Release (replace with git tag when deployed)
  * Search index skips updates when task timestamp predates index document.
+ * Reduced frequency and concurrency of search snapshot writes to storage bucket.
 
 ## `20200619t091224-all`
  * Bumped runtimeVersion to `2020.06.19`.

--- a/app/lib/search/backend.dart
+++ b/app/lib/search/backend.dart
@@ -297,6 +297,12 @@ class SnapshotStorage {
     return null;
   }
 
+  /// Returns `true` if this or another search index updated the snapshot bucket
+  /// in the past 24 hours.
+  Future<bool> wasUpdatedRecently() async {
+    return await _snapshots.hasCurrentData(maxAge: Duration(hours: 24));
+  }
+
   Future<void> store(SearchSnapshot snapshot) async {
     await _snapshots.uploadDataAsJsonMap(snapshot.toJson());
   }

--- a/app/lib/search/updater.dart
+++ b/app/lib/search/updater.dart
@@ -178,6 +178,7 @@ class IndexUpdater implements TaskRunner {
   }
 
   Future<void> _updateSnapshotIfNeeded() async {
+    // TODO: make the catch-all block narrower
     try {
       if (await snapshotStorage.wasUpdatedRecently()) {
         _logger.info('Snapshot update skipped (found recent snapshot).');

--- a/app/lib/search/updater.dart
+++ b/app/lib/search/updater.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:math';
 
 import 'package:_discoveryapis_commons/_discoveryapis_commons.dart'
     show DetailedApiRequestError;
@@ -34,8 +35,8 @@ class IndexUpdater implements TaskRunner {
   final DatastoreDB _db;
   final PackageIndex _packageIndex;
   SearchSnapshot _snapshot;
-  DateTime _lastSnapshotWrite = DateTime.now();
   Timer _statsTimer;
+  Timer _snapshotWriteTimer;
 
   IndexUpdater(this._db, this._packageIndex);
 
@@ -56,6 +57,10 @@ class IndexUpdater implements TaskRunner {
       await _packageIndex.markReady();
       _logger.info('Minimum package index loaded with $cnt packages.');
     }
+    _snapshotWriteTimer ??= Timer.periodic(
+        Duration(hours: 6, minutes: Random.secure().nextInt(120)), (_) {
+      _updateSnapshotIfNeeded();
+    });
   }
 
   /// Updates all packages in the index.
@@ -129,6 +134,8 @@ class IndexUpdater implements TaskRunner {
   Future<void> close() async {
     _statsTimer?.cancel();
     _statsTimer = null;
+    _snapshotWriteTimer?.cancel();
+    _snapshotWriteTimer = null;
     // TODO: close scheduler
   }
 
@@ -168,20 +175,19 @@ class IndexUpdater implements TaskRunner {
     } on MissingAnalysisException catch (_) {
       // Nothing to do yet, keeping old version if it exists.
     }
-    await _updateSnapshotIfNeeded();
   }
 
   Future<void> _updateSnapshotIfNeeded() async {
-    final DateTime now = DateTime.now();
-    if (now.difference(_lastSnapshotWrite).inHours > 12) {
-      _lastSnapshotWrite = now;
-      try {
+    try {
+      if (await snapshotStorage.wasUpdatedRecently()) {
+        _logger.info('Snapshot update skipped (found recent snapshot).');
+      } else {
         _logger.info('Updating search snapshot...');
         await snapshotStorage.store(_snapshot);
         _logger.info('Search snapshot update completed.');
-      } catch (e, st) {
-        _logger.warning('Unable to update search snapshot.', e, st);
       }
+    } catch (e, st) {
+      _logger.warning('Unable to update search snapshot.', e, st);
     }
   }
 

--- a/app/lib/shared/storage.dart
+++ b/app/lib/shared/storage.dart
@@ -123,11 +123,17 @@ class VersionedJsonStorage {
   }
 
   /// Whether the storage bucket has a data file for the current runtime version.
-  /// TODO: decide whether we should re-generate the file after a certain age
-  Future<bool> hasCurrentData() async {
+  Future<bool> hasCurrentData({Duration maxAge}) async {
     try {
       final info = await _bucket.info(_objectName());
-      return info != null;
+      if (info == null) {
+        return false;
+      }
+      final now = DateTime.now();
+      if (maxAge != null && now.difference(info.updated) > maxAge) {
+        return false;
+      }
+      return true;
     } catch (e) {
       if (e is DetailedApiRequestError && e.status == 404) {
         return false;


### PR DESCRIPTION
Writing a snapshot to the storage bucket may take about 10-15 seconds (serialization + upload latency). The current code does not have any randomization or existing file check, and as a result, search instances trying to write the snapshot will try to write it around the same time (initially at least, later it diverges), causing unresponsive windows around the same times.

This PR uses a randomized timer to pace out the events, and also has a check for recency: only one snapshot will be written in every 24 hours, making it unlikely that two running instances will be occupied with the snapshot write at the same time.
