### PR TITLE
Experimental platforms via URL parameters

### DIFF
--- a/app/lib/frontend/templates/layout.dart
+++ b/app/lib/frontend/templates/layout.dart
@@ -298,14 +298,27 @@ String renderSubSdkTabsHtml({@required SearchQuery searchQuery}) {
           tag: FlutterSdkTag.platformWeb,
           title: 'Packages compatible with Flutter on the Web platform',
         ),
-        // `macOS` platform is not yet stable, and we want to display it only when
-        // the user has already opted-in to get it displayed. The conditional
-        // predicate must be removed once the platform becomes stable.
+        // `Linux`, `macOS`, `Windows` platforms are not yet stable, and we want
+        // to display them only when the user has already opted-in to get them
+        // displayed.
+        // TODO: The conditional predicate must be removed once the platform becomes stable.
+        if (pred != null && pred.isRequiredTag(FlutterSdkTag.platformLinux))
+          _FilterOption(
+            label: 'Linux',
+            tag: FlutterSdkTag.platformLinux,
+            title: 'Packages compatible with Flutter on the Linux platform',
+          ),
         if (pred != null && pred.isRequiredTag(FlutterSdkTag.platformMacos))
           _FilterOption(
             label: 'macOS',
             tag: FlutterSdkTag.platformMacos,
             title: 'Packages compatible with Flutter on the macOS platform',
+          ),
+        if (pred != null && pred.isRequiredTag(FlutterSdkTag.platformWindows))
+          _FilterOption(
+            label: 'Windows',
+            tag: FlutterSdkTag.platformWindows,
+            title: 'Packages compatible with Flutter on the Windows platform',
           ),
       ],
     );

--- a/app/lib/shared/tags.dart
+++ b/app/lib/shared/tags.dart
@@ -110,13 +110,18 @@ abstract class FlutterSdkTag {
       'platform:${FlutterSdkPlatform.android}';
   static const String platformIos = 'platform:${FlutterSdkPlatform.ios}';
   static const String platformMacos = 'platform:${FlutterSdkPlatform.macos}';
+  static const String platformLinux = 'platform:${FlutterSdkPlatform.linux}';
   static const String platformWeb = 'platform:${FlutterSdkPlatform.web}';
+  static const String platformWindows =
+      'platform:${FlutterSdkPlatform.windows}';
 }
 
 /// Collection of Flutter SDK platform values.
 abstract class FlutterSdkPlatform {
   static const String android = 'android';
   static const String ios = 'ios';
+  static const String linux = 'linux';
   static const String macos = 'macos';
   static const String web = 'web';
+  static const String windows = 'windows';
 }


### PR DESCRIPTION
Adding `linux` and `windows` to the same method as `macos`. (I'd want to have this turned on as advanced search option, but it requires a bit more work, this can fill a gap until that happens.) 