### PR TITLE
Misc style updates

### DIFF
--- a/app/lib/frontend/templates/views/publisher/publisher_list_experimental.mustache
+++ b/app/lib/frontend/templates/views/publisher/publisher_list_experimental.mustache
@@ -10,7 +10,7 @@
 <div class="publishers{{#is_global}} -global{{/is_global}}">
   {{#publishers}}
   <div class="publishers-item">
-    <h3><a href="{{& url }}">{{ publisher_id }}</a></h3>
+    <h3 class="publishers-item-title"><a href="{{& url }}">{{ publisher_id }}</a></h3>
     <p>
       Registered on {{ short_created }}.
     </p>

--- a/app/lib/frontend/templates/views/shared/sort_control_experimental.mustache
+++ b/app/lib/frontend/templates/views/shared/sort_control_experimental.mustache
@@ -3,7 +3,7 @@
     BSD-style license that can be found in the LICENSE file. }}
 
 <div class="sort-control hoverable">
-  <div class="info-identifier">Sort by <span class="sort-control-selected">{{selected_label}}</span> &darr;</div>
+  <div class="info-identifier">Sort by <span class="sort-control-selected">{{selected_label}}</span></div>
   <div class="sort-control-popup">
     {{#options}}
     <div class="sort-control-option {{#selected}}selected{{/selected}}" data-value="{{value}}">{{label}}</div>

--- a/pkg/web_css/lib/src/_detail_page_experimental.scss
+++ b/pkg/web_css/lib/src/_detail_page_experimental.scss
@@ -6,9 +6,12 @@
 body.experimental {
 
 $info-box-width: 190px;
-$info-box-margin: 120px;
-$info-box-total-width: 320px; /* 190 + 120 + 10 (extra space for layout) */
-$detail-tabs-width: calc(100% - 320px);
+$info-box-margin:        120px;
+$info-box-tablet-margin:  40px;
+$info-box-total-width:       320px; /* 190 + 120 + 10 (extra space for layout) */
+$info-box-table-total-width: 240px; /* 190 +  40 + 10 (extra space for layout) */
+$detail-tabs-width:        calc(100% - 320px);
+$detail-tabs-tablet-width: calc(100% - 240px);
 
 .-wide-header-detail-page {
   .detail-header,
@@ -219,6 +222,10 @@ $detail-tabs-width: calc(100% - 320px);
       display: inline-block;
       margin-left: $info-box-margin;
       width: $info-box-width;
+
+      @media (max-width: $device-tablet-max-width) {
+        margin-left: $info-box-tablet-margin;
+      }
     }
   }
 
@@ -227,6 +234,10 @@ $detail-tabs-width: calc(100% - 320px);
     .detail-body > .detail-tabs {
       display: inline-block;
       width: $detail-tabs-width;
+
+      @media (max-width: $device-tablet-max-width) {
+        width: $detail-tabs-tablet-width;
+      }
     }
   }
 }

--- a/pkg/web_css/lib/src/_list_experimental.scss
+++ b/pkg/web_css/lib/src/_list_experimental.scss
@@ -412,8 +412,12 @@ body.experimental {
 
   &.-compact {
     .packages-item {
+      padding: 0;
+      margin: 8px 0;
+
       @media (min-width: $device-desktop-min-width) {
         padding: 4px 8px;
+        margin-left: -8px;
       }
     }
   }
@@ -422,9 +426,16 @@ body.experimental {
 .publishers {
   .publishers-item {
     padding: 4px;
+    margin-left: -4px;
+    margin-right: 8px;
 
     &:hover {
       background: #fafafa;
+    }
+
+    .publishers-item-title {
+      font-size: 22px;
+      font-weight: 500;
     }
   }
 

--- a/pkg/web_css/lib/src/_search.scss
+++ b/pkg/web_css/lib/src/_search.scss
@@ -60,7 +60,6 @@
   &:focus {
     .experimental & {
       outline: none;
-      box-shadow: 0 0 6px $color-input-primary;
     }
   }
 }

--- a/pkg/web_css/lib/src/_variables.scss
+++ b/pkg/web_css/lib/src/_variables.scss
@@ -16,6 +16,7 @@ $detail-tab-admin-color: #990000;
 
 $device-desktop-min-width: 641px;
 $device-mobile-max-width: 640px;
+$device-tablet-max-width: 979px;
 
 $z-index-nav-mask: 1000;
 


### PR DESCRIPTION
- removed down arrow from sort control
- my publishers's publisher name has the same style as package listing's package name
- my publisher items are aligned with the leftmost tab
- my liked packages items are aligned with the leftmost tab
- removed blue highlight from the search input field
- package detail page has small gap when screen resolution is tablet-sized (requires scroll indicator later)