### PR TITLE
Key facts: 'awaiting' when Report is not ready yet.

### DIFF
--- a/app/lib/frontend/templates/package_analysis.dart
+++ b/app/lib/frontend/templates/package_analysis.dart
@@ -119,9 +119,16 @@ String _renderPopularityKeyFigure(double popularity) {
 }
 
 String _renderPubPointsKeyFigure(Report report) {
+  if (report == null) {
+    return _renderKeyFigure(
+      value: '',
+      supplemental: 'awaiting',
+      label: 'pub points',
+    );
+  }
   var grantedPoints = 0;
   var maxPoints = 0;
-  report?.sections?.forEach((section) {
+  report.sections.forEach((section) {
     grantedPoints += section.grantedPoints;
     maxPoints += section.maxPoints;
   });


### PR DESCRIPTION
Instead of 0/0, we need to display something different while the result is not ready yet (e.g. new upload):

<img width="590" alt="awaiting" src="https://user-images.githubusercontent.com/4778111/86438231-76466600-bd06-11ea-94cb-6301369be557.png">
