### PR TITLE
Store granted and max points on ScoreCard and use it on listing and detail pages.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Important changes to data-models, configuration and migrations between each
 AppEngine version, listed here to ease deployment and troubleshooting.
 
 ## Next Release (replace with git tag when deployed)
+ * Bumped runtimeVersion to `2020.07.03`.
 
 ## `20200702t124059-all`
  * Bumped runtimeVersion to `2020.07.02`.

--- a/app/lib/analyzer/analyzer_client.dart
+++ b/app/lib/analyzer/analyzer_client.dart
@@ -97,15 +97,8 @@ class AnalysisView {
     return version as String;
   }
 
-  Report get report {
-    if (_report == null) {
-      _report = _pana?.report;
-      if (_report != null && _dartdoc?.documentationSection != null) {
-        _report = _report.joinSection(_dartdoc.documentationSection);
-      }
-    }
-    return _report;
-  }
+  Report get report =>
+      _report ??= joinReport(panaReport: _pana, dartdocReport: _dartdoc);
 
   List<String> get derivedTags => _card?.derivedTags ?? const <String>[];
 

--- a/app/lib/frontend/templates/listing.dart
+++ b/app/lib/frontend/templates/listing.dart
@@ -78,7 +78,8 @@ String renderPackageList(
       'like_score_html': _renderLabeledScore('likes', view.likes, ''),
       'popularity_score_html':
           _renderLabeledScore('popularity', view.popularity, '%'),
-      'health_score_html': _renderLabeledScore('health', view.health, '%'),
+      'health_score_html':
+          _renderLabeledScore('health', view.grantedPubPoints, ''),
       'has_api_pages': view.apiPages != null && view.apiPages.isNotEmpty,
       'api_pages': view.apiPages
           ?.map((page) => {

--- a/app/lib/frontend/templates/misc.dart
+++ b/app/lib/frontend/templates/misc.dart
@@ -356,6 +356,30 @@ String renderScoreBox(
   PackageView view, {
   bool isTabHeader = false,
 }) {
+  if (requestContext.isExperimental) {
+    final formattedScore =
+        view.grantedPubPoints == null ? '--' : view.grantedPubPoints.toString();
+    String title;
+    if (!view.isSkipped && view.grantedPubPoints == null) {
+      title = 'Awaiting analysis to complete.';
+    } else {
+      title = 'Analysis and more details.';
+    }
+    if (isTabHeader) {
+      return 'Score: <span class="score-value">'
+          '${htmlEscape.convert(formattedScore)}</span>';
+    }
+    return renderScoreCircle(
+      label: formattedScore,
+      percent: view.grantedPubPoints == null || view.maxPubPoints == 0
+          ? 0
+          : (100 * view.grantedPubPoints / view.maxPubPoints).round(),
+      title: title,
+      link: urls.pkgScoreUrl(view.name),
+    );
+  }
+
+  // TODO(3246): Remove the rest of the method after migrating to the new UI.
   final overallScore = view.overallScore;
   final String formattedScore = formatScore(overallScore);
   String title;
@@ -364,20 +388,6 @@ String renderScoreBox(
   } else {
     title = 'Analysis and more details.';
   }
-  if (requestContext.isExperimental) {
-    if (isTabHeader) {
-      return 'Score: <span class="score-value">'
-          '${htmlEscape.convert(formattedScore)}</span>';
-    }
-    return renderScoreCircle(
-      label: formattedScore,
-      percent: overallScore == null ? 0 : (100 * overallScore).round(),
-      title: title,
-      link: urls.pkgScoreUrl(view.name),
-    );
-  }
-
-  // TODO(3246): Remove the rest of the method after migrating to the new UI.
   final String scoreClass = _classifyScore(overallScore);
   final String escapedTitle = htmlAttrEscape.convert(title);
   final newIndicator = view.isNewPackage

--- a/app/lib/package/models.dart
+++ b/app/lib/package/models.dart
@@ -424,6 +424,14 @@ class PackageView extends Object with FlagMixin {
 
   final int likes;
 
+  /// The package's granted points from pana and dartdoc analysis.
+  /// May be `null` if the analysis is not available yet.
+  final int grantedPubPoints;
+
+  /// The package's max points from pana and dartdoc analysis.
+  /// May be `null` if the analysis is not available yet.
+  final int maxPubPoints;
+
   /// The package's health score value (on the scale of 0-100).
   /// May be `null` if the score is not available yet.
   final int health;
@@ -451,6 +459,8 @@ class PackageView extends Object with FlagMixin {
     this.publisherId,
     this.isAwaiting = false,
     this.likes,
+    this.grantedPubPoints,
+    this.maxPubPoints,
     this.health,
     this.popularity,
     this.overallScore,
@@ -493,6 +503,8 @@ class PackageView extends Object with FlagMixin {
       publisherId: package.publisherId,
       isAwaiting: isAwaiting,
       likes: package.likes,
+      grantedPubPoints: scoreCard?.grantedPubPoints,
+      maxPubPoints: scoreCard?.maxPubPoints,
       health: scoreCard?.healthScore == null
           ? null
           : (100.0 * scoreCard.healthScore).round(),
@@ -524,6 +536,8 @@ class PackageView extends Object with FlagMixin {
       publisherId: publisherId,
       isAwaiting: isAwaiting,
       likes: likes,
+      grantedPubPoints: grantedPubPoints,
+      maxPubPoints: maxPubPoints,
       health: health,
       popularity: popularity,
       overallScore: overallScore,

--- a/app/lib/package/models.g.dart
+++ b/app/lib/package/models.g.dart
@@ -22,6 +22,8 @@ PackageView _$PackageViewFromJson(Map<String, dynamic> json) {
     publisherId: json['publisherId'] as String,
     isAwaiting: json['isAwaiting'] as bool,
     likes: json['likes'] as int,
+    grantedPubPoints: json['grantedPubPoints'] as int,
+    maxPubPoints: json['maxPubPoints'] as int,
     health: json['health'] as int,
     popularity: json['popularity'] as int,
     overallScore: (json['overallScore'] as num)?.toDouble(),
@@ -55,6 +57,8 @@ Map<String, dynamic> _$PackageViewToJson(PackageView instance) {
   writeNotNull('publisherId', instance.publisherId);
   writeNotNull('isAwaiting', instance.isAwaiting);
   writeNotNull('likes', instance.likes);
+  writeNotNull('grantedPubPoints', instance.grantedPubPoints);
+  writeNotNull('maxPubPoints', instance.maxPubPoints);
   writeNotNull('health', instance.health);
   writeNotNull('popularity', instance.popularity);
   writeNotNull('overallScore', instance.overallScore);

--- a/app/lib/scorecard/models.g.dart
+++ b/app/lib/scorecard/models.g.dart
@@ -20,6 +20,8 @@ ScoreCardData _$ScoreCardDataFromJson(Map<String, dynamic> json) {
     packageVersionCreated: json['packageVersionCreated'] == null
         ? null
         : DateTime.parse(json['packageVersionCreated'] as String),
+    grantedPubPoints: json['grantedPubPoints'] as int,
+    maxPubPoints: json['maxPubPoints'] as int,
     healthScore: (json['healthScore'] as num)?.toDouble(),
     maintenanceScore: (json['maintenanceScore'] as num)?.toDouble(),
     popularityScore: (json['popularityScore'] as num)?.toDouble(),
@@ -40,6 +42,8 @@ Map<String, dynamic> _$ScoreCardDataToJson(ScoreCardData instance) =>
       'packageCreated': instance.packageCreated?.toIso8601String(),
       'packageVersionCreated':
           instance.packageVersionCreated?.toIso8601String(),
+      'grantedPubPoints': instance.grantedPubPoints,
+      'maxPubPoints': instance.maxPubPoints,
       'healthScore': instance.healthScore,
       'maintenanceScore': instance.maintenanceScore,
       'popularityScore': instance.popularityScore,

--- a/app/lib/shared/versions.dart
+++ b/app/lib/shared/versions.dart
@@ -21,10 +21,9 @@ final RegExp runtimeVersionPattern = RegExp(r'^\d{4}\.\d{2}\.\d{2}$');
 /// Make sure that at least two versions are kept here as the next candidates
 /// when the version switch happens.
 const acceptedRuntimeVersions = <String>[
+  '2020.07.03',
   '2020.07.02', // The current [runtimeVersion].
   '2020.06.10',
-  '2020.05.26',
-  '2020.05.08',
 ];
 
 /// Represents a combined version of the overall toolchain and processing,

--- a/app/test/shared/versions_test.dart
+++ b/app/test/shared/versions_test.dart
@@ -33,7 +33,7 @@ void main() {
     // This test is a reminder that if pana, the SDK or any of the above
     // versions change, we should also adjust the [runtimeVersion]. Before
     // updating the hash value, double-check if it is being updated.
-    expect(hash, 111136121);
+    expect(hash, 550028407);
   });
 
   test('accepted runtime versions should be lexicographically ordered', () {


### PR DESCRIPTION
- bumping `runtimeVersion` as the `ScoreCard` instances need to be updated for this to work