### PR TITLE
Subsection icons in report summaries.

### DIFF
--- a/app/lib/frontend/static_files.dart
+++ b/app/lib/frontend/static_files.dart
@@ -158,6 +158,9 @@ class StaticUrls {
   final String defaultProfilePng;
   final String githubMarkdownCss;
   final String packagesSideImage;
+  final String reportMissingIconRed;
+  final String reportMissingIconYellow;
+  final String reportOKIconGreen;
   Map _versionsTableIcons;
   Map<String, String> _assets;
 
@@ -178,7 +181,13 @@ class StaticUrls {
         githubMarkdownCss = _getCacheableStaticUrl(
             '$_defaultStaticPath/css/github-markdown.css'),
         packagesSideImage =
-            _getCacheableStaticUrl('$_defaultStaticPath/img/packages-side.png');
+            _getCacheableStaticUrl('$_defaultStaticPath/img/packages-side.png'),
+        reportMissingIconRed = _getCacheableStaticUrl(
+            '$_defaultStaticPath/img/report-missing-icon-red.svg'),
+        reportMissingIconYellow = _getCacheableStaticUrl(
+            '$_defaultStaticPath/img/report-missing-icon-yellow.svg'),
+        reportOKIconGreen = _getCacheableStaticUrl(
+            '$_defaultStaticPath/img/report-ok-icon-green.svg');
 
   // TODO: merge with [newVersionTableIcons] after migration to the new UI
   Map get versionsTableIcons {

--- a/app/lib/frontend/templates/package_analysis.dart
+++ b/app/lib/frontend/templates/package_analysis.dart
@@ -13,6 +13,7 @@ import '../../shared/utils.dart';
 
 import '../color.dart';
 import '../request_context.dart';
+import '../static_files.dart';
 
 import '_cache.dart';
 import '_consts.dart';
@@ -89,14 +90,36 @@ String renderAnalysisTab(
 /// Renders the `views/pkg/analysis/report.mustache` template.
 String _renderReport(Report report) {
   if (report?.sections == null) return null;
+
+  String renderSummary(String summary) {
+    final updated = summary.split('\n').map((line) {
+      if (!line.startsWith('### ')) return line;
+      return line
+          .replaceFirst(
+              '[*]',
+              '<img class="report-summary-icon" '
+                  'src="${staticUrls.reportOKIconGreen}" />')
+          .replaceFirst(
+              '[x]',
+              '<img class="report-summary-icon" '
+                  'src="${staticUrls.reportMissingIconRed}" />')
+          .replaceFirst(
+              '[~]',
+              '<img class="report-summary-icon" '
+                  'src="${staticUrls.reportMissingIconYellow}" />');
+    }).join('\n');
+    return markdownToHtml(updated);
+  }
+
   return templateCache.renderTemplate('pkg/analysis/report', {
     'sections': report.sections.map((s) => {
           'title': s.title,
           'grantedPoints': s.grantedPoints,
           'maxPoints': s.maxPoints,
-          'summary_html': markdownToHtml(s.summary),
-          'is_green': s.grantedPoints == s.maxPoints,
-          'is_red': s.grantedPoints != s.maxPoints,
+          'summary_html': renderSummary(s.summary),
+          'is_green': s.grantedPoints > 0 && s.grantedPoints == s.maxPoints,
+          'is_yellow': s.grantedPoints > 0 && s.grantedPoints != s.maxPoints,
+          'is_red': s.grantedPoints == 0,
         }),
   });
 }

--- a/app/lib/frontend/templates/views/pkg/analysis/report.mustache
+++ b/app/lib/frontend/templates/views/pkg/analysis/report.mustache
@@ -10,6 +10,9 @@
         {{#is_green}}
           <img src="{{& static_assets.img__report-ok-icon-green_svg }}" class="pkg-report-icon" />
         {{/is_green}}
+        {{#is_yellow}}
+          <img src="{{& static_assets.img__report-missing-icon-yellow_svg }}" class="pkg-report-icon" />
+        {{/is_yellow}}
         {{#is_red}}
           <img src="{{& static_assets.img__report-missing-icon-red_svg }}" class="pkg-report-icon" />
         {{/is_red}}

--- a/app/lib/shared/markdown.dart
+++ b/app/lib/shared/markdown.dart
@@ -27,6 +27,7 @@ const _whitelistedClassNames = <String>[
   'changelog-content',
   'hash-header',
   'hash-link',
+  'report-summary-icon',
 ];
 
 /// Renders markdown [text] to HTML.

--- a/pkg/web_css/lib/src/_pkg_experimental.scss
+++ b/pkg/web_css/lib/src/_pkg_experimental.scss
@@ -229,6 +229,19 @@ body.experimental {
 
   .pkg-report-content-summary {
     flex-grow: 1;
+
+    > h3 {
+      position: relative;
+
+      .report-summary-icon {
+        position: absolute;
+        right: 100%;
+        top: 4px;
+        width: 14px;
+        height: 14px;
+        margin-right: 6px;
+      }
+    }
   }
 }
 

--- a/static/img/report-missing-icon-yellow.svg
+++ b/static/img/report-missing-icon-yellow.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#FFA500" width="18px" height="18px"><path d="M0 0h24v24H0z" fill="none"/><path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/></svg>


### PR DESCRIPTION
- For simplicity I've repurposed the red cross icon as a yellow cross icon for the "so-so" category.
- Added the same icon to the section level too.

<img width="776" alt="Screenshot 2020-07-03 at 17 18 34" src="https://user-images.githubusercontent.com/4778111/86482075-7f105980-bd51-11ea-8fc1-5803944698b6.png">

