### PR TITLE
Separate analysis info block from the report

### DIFF
--- a/app/lib/frontend/templates/package_analysis.dart
+++ b/app/lib/frontend/templates/package_analysis.dart
@@ -47,7 +47,6 @@ String renderAnalysisTab(
 
   // TODO: use only `analysis.report` after we've migrated to the new UI.
   final report = requestContext.isExperimental ? analysis.report : null;
-  final hasReport = report != null;
 
   final Map<String, dynamic> data = {
     'package': package,
@@ -63,13 +62,13 @@ String renderAnalysisTab(
     'dart_sdk_version': analysis.dartSdkVersion,
     'pana_version': analysis.panaVersion,
     'flutter_version': analysis.flutterVersion,
-    'analysis_suggestions_html': hasReport
+    'analysis_suggestions_html': requestContext.isExperimental
         ? null
         : _renderSuggestionBlockHtml('Analysis', analysis.panaSuggestions),
-    'health_suggestions_html': hasReport
+    'health_suggestions_html': requestContext.isExperimental
         ? null
         : _renderSuggestionBlockHtml('Health', analysis.healthSuggestions),
-    'maintenance_suggestions_html': hasReport
+    'maintenance_suggestions_html': requestContext.isExperimental
         ? null
         : _renderSuggestionBlockHtml(
             'Maintenance', analysis.maintenanceSuggestions),

--- a/app/lib/frontend/templates/views/pkg/analysis/tab_experimental.mustache
+++ b/app/lib/frontend/templates/views/pkg/analysis/tab_experimental.mustache
@@ -11,7 +11,7 @@
 {{& report_html }}
 
 {{#show_discontinued}}
-<p>This package is not analyzed, because it is discontinued.</p>
+<p class="analysis-info">This package is not analyzed, because it is discontinued.</p>
 {{/show_discontinued}}
 {{#show_outdated}}
 <p>
@@ -20,13 +20,13 @@
 </p>
 {{/show_outdated}}
 {{#show_legacy}}
-<p>
+  <p class="analysis-info">
   The package version is not analyzed, because it does not support Dart 2.
   Until this is resolved, the package will receive a health and maintenance score of 0.
 </p>
 {{/show_legacy}}
 {{#show_analysis}}
-<p>
+<p class="analysis-info">
   We analyzed this package on {{date_completed}}, and provided a score, details, and suggestions below.
   Analysis was completed with status <i>{{analysis_status}}</i> using:
 </p>
@@ -37,9 +37,5 @@
 {{#flutter_version}}<li>Flutter: {{flutter_version}}</li>{{/flutter_version}}
 </ul>
 {{/show_analysis}}
-
-{{& analysis_suggestions_html}}
-{{& health_suggestions_html}}
-{{& maintenance_suggestions_html}}
 
 {{& dep_table_html }}

--- a/pkg/web_css/lib/src/_pkg_experimental.scss
+++ b/pkg/web_css/lib/src/_pkg_experimental.scss
@@ -232,5 +232,11 @@ body.experimental {
   }
 }
 
+.analysis-info {
+  border-top: 1px solid #c8c8ca;
+  margin-top: 32px;
+  padding-top: 16px;
+}
+
 /* non-indented rule to restrict the content of the file to the experimental pages */
 }


### PR DESCRIPTION
- same line color as in the report
- extra space 

<img width="770" alt="Screenshot 2020-07-06 at 9 55 47" src="https://user-images.githubusercontent.com/4778111/86569566-dfc8ad80-bf6e-11ea-8f3f-ca4ddfea45ab.png">
