### PR TITLE
Non-stable platforms under advanced search options

### DIFF
--- a/app/lib/frontend/templates/layout.dart
+++ b/app/lib/frontend/templates/layout.dart
@@ -196,8 +196,9 @@ String _renderSearchBanner({
     'hidden_inputs': hiddenInputs,
     'sdk_tabs_html': isExperimental ? null : sdkTabsHtml,
     'show_legacy_checkbox': !isExperimental && sp.sdk == null,
-    'secondary_tabs_html':
-        isExperimental ? null : renderSubSdkTabsHtml(searchQuery: searchQuery),
+    'secondary_tabs_html': isExperimental
+        ? null
+        : renderSubSdkTabsHtml(searchQuery: searchQuery, detectAdvanced: true),
   });
 }
 
@@ -260,61 +261,79 @@ class _FilterOption {
   });
 }
 
-String renderSubSdkTabsHtml({@required SearchQuery searchQuery}) {
+String renderSubSdkTabsHtml({
+  @required SearchQuery searchQuery,
+  bool detectAdvanced = false,
+  bool onlyAdvanced = false,
+}) {
   final pred = searchQuery?.tagsPredicate;
   if (searchQuery?.sdk == SdkTagValue.dart) {
     return _renderFilterTabs(
       searchQuery: searchQuery,
       options: [
-        _FilterOption(
-          label: 'native',
-          tag: DartSdkTag.runtimeNativeJit,
-          title:
-              'Packages compatible with Dart running on a native platform (JIT/AOT)',
-        ),
-        _FilterOption(
-          label: 'JS',
-          tag: DartSdkTag.runtimeWeb,
-          title: 'Packages compatible with Dart compiled for the web',
-        ),
+        if (!onlyAdvanced)
+          _FilterOption(
+            label: 'native',
+            tag: DartSdkTag.runtimeNativeJit,
+            title:
+                'Packages compatible with Dart running on a native platform (JIT/AOT)',
+          ),
+        if (!onlyAdvanced)
+          _FilterOption(
+            label: 'JS',
+            tag: DartSdkTag.runtimeWeb,
+            title: 'Packages compatible with Dart compiled for the web',
+          ),
       ],
     );
   } else if (searchQuery?.sdk == SdkTagValue.flutter) {
     return _renderFilterTabs(
       searchQuery: searchQuery,
       options: [
-        _FilterOption(
-          label: 'Android',
-          tag: FlutterSdkTag.platformAndroid,
-          title: 'Packages compatible with Flutter on the Android platform',
-        ),
-        _FilterOption(
-          label: 'iOS',
-          tag: FlutterSdkTag.platformIos,
-          title: 'Packages compatible with Flutter on the iOS platform',
-        ),
-        _FilterOption(
-          label: 'Web',
-          tag: FlutterSdkTag.platformWeb,
-          title: 'Packages compatible with Flutter on the Web platform',
-        ),
+        if (!onlyAdvanced)
+          _FilterOption(
+            label: 'Android',
+            tag: FlutterSdkTag.platformAndroid,
+            title: 'Packages compatible with Flutter on the Android platform',
+          ),
+        if (!onlyAdvanced)
+          _FilterOption(
+            label: 'iOS',
+            tag: FlutterSdkTag.platformIos,
+            title: 'Packages compatible with Flutter on the iOS platform',
+          ),
+        if (!onlyAdvanced)
+          _FilterOption(
+            label: 'Web',
+            tag: FlutterSdkTag.platformWeb,
+            title: 'Packages compatible with Flutter on the Web platform',
+          ),
         // `Linux`, `macOS`, `Windows` platforms are not yet stable, and we want
         // to display them only when the user has already opted-in to get them
         // displayed.
         // TODO: The conditional predicate must be removed once the platform becomes stable.
-        if (pred != null && pred.isRequiredTag(FlutterSdkTag.platformLinux))
+        if (onlyAdvanced ||
+            (detectAdvanced &&
+                pred != null &&
+                pred.isRequiredTag(FlutterSdkTag.platformLinux)))
           _FilterOption(
             label: 'Linux',
             tag: FlutterSdkTag.platformLinux,
             title: 'Packages compatible with Flutter on the Linux platform',
           ),
-        if (pred != null && pred.isRequiredTag(FlutterSdkTag.platformMacos))
+        if (onlyAdvanced ||
+            (detectAdvanced &&
+                pred != null &&
+                pred.isRequiredTag(FlutterSdkTag.platformMacos)))
           _FilterOption(
             label: 'macOS',
             tag: FlutterSdkTag.platformMacos,
             title: 'Packages compatible with Flutter on the macOS platform',
           ),
-        if (pred != null && pred.isRequiredTag(FlutterSdkTag.platformWindows))
+        if (onlyAdvanced ||
+            (detectAdvanced &&
+                pred != null &&
+                pred.isRequiredTag(FlutterSdkTag.platformWindows)))
           _FilterOption(
             label: 'Windows',
             tag: FlutterSdkTag.platformWindows,
@@ -330,6 +349,7 @@ String _renderFilterTabs({
   @required SearchQuery searchQuery,
   @required List<_FilterOption> options,
 }) {
+  if (options.isEmpty) return null;
   final tp = searchQuery.tagsPredicate;
   String searchWithTagsLink(TagsPredicate tagsPredicate) {
     return searchQuery.change(tagsPredicate: tagsPredicate).toSearchLink();

--- a/app/lib/frontend/templates/listing.dart
+++ b/app/lib/frontend/templates/listing.dart
@@ -132,12 +132,19 @@ String renderPkgIndexPage(
   final topPackages = getSdkDict(sdk).topSdkPackages;
   final isSearch = searchQuery != null && searchQuery.hasQuery;
   final includeLegacy = searchQuery?.includeLegacy ?? false;
-  final hasActiveAdvanced = includeLegacy;
+  final subSdkTabsAdvanced =
+      renderSubSdkTabsHtml(searchQuery: searchQuery, onlyAdvanced: true);
+  // TODO: There should be a more efficient way to calculate this
+  final hasActiveSubSdkAdvanced =
+      subSdkTabsAdvanced != null && subSdkTabsAdvanced.contains('-active');
+  final hasActiveAdvanced = includeLegacy || hasActiveSubSdkAdvanced;
   final values = {
     'has_active_advanced': hasActiveAdvanced,
     'sdk_tabs_html': renderSdkTabs(searchQuery: searchQuery),
     'subsdk_label': _subSdkLabel(searchQuery),
     'subsdk_tabs_html': renderSubSdkTabsHtml(searchQuery: searchQuery),
+    'has_subsdk_tabs_advanced_html': subSdkTabsAdvanced != null,
+    'subsdk_tabs_advanced_html': subSdkTabsAdvanced,
     'is_search': isSearch,
     'listing_info_html': renderListingInfo(
       searchQuery: searchQuery,

--- a/app/lib/frontend/templates/views/pkg/index_experimental.mustache
+++ b/app/lib/frontend/templates/views/pkg/index_experimental.mustache
@@ -25,7 +25,8 @@
   <div class="search-controls-advanced">
     <div class="container">
       {{#has_subsdk_tabs_advanced_html}}
-      <div class="search-controls-subsdk-advanced search-controls-buttons">
+      <div class="search-controls-subsdk-advanced search-controls-buttons"
+           title="Prerelease platforms">
         <span class="search-controls-label">Prerelease platforms</span>
         {{& subsdk_tabs_advanced_html }}
       </div>

--- a/app/lib/frontend/templates/views/pkg/index_experimental.mustache
+++ b/app/lib/frontend/templates/views/pkg/index_experimental.mustache
@@ -26,7 +26,7 @@
     <div class="container">
       {{#has_subsdk_tabs_advanced_html}}
       <div class="search-controls-subsdk-advanced search-controls-buttons">
-        <span class="search-controls-label">Platforms under development</span>
+        <span class="search-controls-label">Prerelease platforms</span>
         {{& subsdk_tabs_advanced_html }}
       </div>
       {{/has_subsdk_tabs_advanced_html}}

--- a/app/lib/frontend/templates/views/pkg/index_experimental.mustache
+++ b/app/lib/frontend/templates/views/pkg/index_experimental.mustache
@@ -24,6 +24,12 @@
   </div>
   <div class="search-controls-advanced">
     <div class="container">
+      {{#has_subsdk_tabs_advanced_html}}
+      <div class="search-controls-subsdk-advanced search-controls-buttons">
+        <span class="search-controls-label">Platforms under development</span>
+        {{& subsdk_tabs_advanced_html }}
+      </div>
+      {{/has_subsdk_tabs_advanced_html}}
       <div class="search-controls-checkbox">
         <input id="search-legacy-checkbox" type="checkbox" name="legacy" valye="1" {{#legacy_search_enabled}} checked="checked"{{/legacy_search_enabled}} />
         <label for="search-legacy-checkbox">Include Dart 1.x results</label>

--- a/pkg/web_css/lib/src/_list_experimental.scss
+++ b/pkg/web_css/lib/src/_list_experimental.scss
@@ -176,6 +176,10 @@ body.experimental {
     }
   }
 
+  .search-controls-subsdk-advanced {
+    padding: 12px 0 8px 0;
+  }
+
   .search-controls-checkbox {
     padding: 8px 0px;
   }


### PR DESCRIPTION
- Keeping the URI-based advanced platform detection for the old UI.

- Desktop view:
  <img width="1112" alt="Screenshot 2020-07-06 at 15 01 26" src="https://user-images.githubusercontent.com/4778111/86600284-25519e80-bfa0-11ea-8092-141cb0df21f9.png">

- Mobile view:
  <img width="429" alt="Screenshot 2020-07-06 at 15 52 29" src="https://user-images.githubusercontent.com/4778111/86600741-c2acd280-bfa0-11ea-916e-847d9a28c4f1.png">
