### PR TITLE
Fix code blocks horizontal scrolling

### DIFF
--- a/pkg/web_css/lib/src/_base.scss
+++ b/pkg/web_css/lib/src/_base.scss
@@ -158,13 +158,15 @@ code {
 .markdown-body pre,
 pre {
   background: #f5f5f7;
-  padding: 30px;
+  line-height: 100%;
+  padding: 0px;
   overflow-x: auto;
 
   > code {
-    padding: 0 !important;
+    padding: 30px !important;
     border-radius: 0;
     display: block;
+    overflow-x: unset !important;
   }
 }
 

--- a/pkg/web_css/lib/src/_pkg_experimental.scss
+++ b/pkg/web_css/lib/src/_pkg_experimental.scss
@@ -229,6 +229,7 @@ body.experimental {
 
   .pkg-report-content-summary {
     flex-grow: 1;
+    max-width: 100%;
 
     > h3 {
       position: relative;


### PR DESCRIPTION
- Moving padding from outer `pre` to inside `code` block.
- Folding block needed a maximum width setting, otherwise flex-grow took priority.