### PR TITLE
Updated score tab

### DIFF
--- a/app/lib/frontend/templates/package_analysis.dart
+++ b/app/lib/frontend/templates/package_analysis.dart
@@ -59,10 +59,15 @@ String renderAnalysisTab(
     'date_completed': analysis.timestamp == null
         ? null
         : shortDateFormat.format(analysis.timestamp),
+    'granted_points': report?.grantedPoints ?? 0,
+    'max_points': report?.maxPoints ?? 0,
+    'report_html': _renderReport(report),
+    'like_key_figure_html': _renderLikeKeyFigure(likeCount),
+    'popularity_key_figure_html':
+        _renderPopularityKeyFigure(card.popularityScore),
+    'pubpoints_key_figure_html': _renderPubPointsKeyFigure(report),
+    // TODO: remove after we've migrated to the new UI
     'analysis_status': statusText,
-    'dart_sdk_version': analysis.dartSdkVersion,
-    'pana_version': analysis.panaVersion,
-    'flutter_version': analysis.flutterVersion,
     'analysis_suggestions_html': requestContext.isExperimental
         ? null
         : _renderSuggestionBlockHtml('Analysis', analysis.panaSuggestions),
@@ -74,12 +79,9 @@ String renderAnalysisTab(
         : _renderSuggestionBlockHtml(
             'Maintenance', analysis.maintenanceSuggestions),
     'dep_table_html': _renderDepTable(sdkConstraint, card, analysis),
-    'report_html': _renderReport(report),
-    'like_key_figure_html': _renderLikeKeyFigure(likeCount),
-    'popularity_key_figure_html':
-        _renderPopularityKeyFigure(card.popularityScore),
-    'pubpoints_key_figure_html': _renderPubPointsKeyFigure(report),
-    // TODO: remove after we've migrated to the new UI
+    'dart_sdk_version': analysis.dartSdkVersion,
+    'pana_version': analysis.panaVersion,
+    'flutter_version': analysis.flutterVersion,
     'score_table_html': _renderScoreTable(card),
   };
 

--- a/app/lib/frontend/templates/views/pkg/analysis/tab_experimental.mustache
+++ b/app/lib/frontend/templates/views/pkg/analysis/tab_experimental.mustache
@@ -8,8 +8,6 @@
   {{& popularity_key_figure_html }}
 </div>
 
-{{& report_html }}
-
 {{#show_discontinued}}
 <p class="analysis-info">This package is not analyzed, because it is discontinued.</p>
 {{/show_discontinued}}
@@ -27,15 +25,9 @@
 {{/show_legacy}}
 {{#show_analysis}}
 <p class="analysis-info">
-  We analyzed this package on {{date_completed}}, and provided a score, details, and suggestions below.
-  Analysis was completed with status <i>{{analysis_status}}</i> using:
+  We analyzed this package on {{ date_completed }}, and awarded it {{ granted_points }}
+  pub points (of a possible {{ max_points }}):
 </p>
-
-<ul>
-  <li>Dart: {{dart_sdk_version}}</li>
-  <li>pana: {{pana_version}}</li>
-{{#flutter_version}}<li>Flutter: {{flutter_version}}</li>{{/flutter_version}}
-</ul>
 {{/show_analysis}}
 
-{{& dep_table_html }}
+{{& report_html }}

--- a/pkg/web_css/lib/src/_pkg_experimental.scss
+++ b/pkg/web_css/lib/src/_pkg_experimental.scss
@@ -245,11 +245,5 @@ body.experimental {
   }
 }
 
-.analysis-info {
-  border-top: 1px solid #c8c8ca;
-  margin-top: 32px;
-  padding-top: 16px;
-}
-
 /* non-indented rule to restrict the content of the file to the experimental pages */
 }


### PR DESCRIPTION
- removed dependency table
- moved report sections below the lead text
- updated lead text and style
- moved template variables that are no longer used under the `TODO` marker