### PR TITLE
Updated markdown table for the new design.

### DIFF
--- a/app/lib/frontend/templates/views/pkg/analysis/report.mustache
+++ b/app/lib/frontend/templates/views/pkg/analysis/report.mustache
@@ -28,7 +28,7 @@
     <div class="foldable-content">
       <div class="pkg-report-content">
         <div class="pkg-report-content-icon"></div>
-        <div class="pkg-report-content-summary markdown-content">
+        <div class="pkg-report-content-summary markdown-body">
           {{& summary_html }}
         </div>
         <div class="pkg-report-content-score"></div>

--- a/pkg/web_css/lib/src/_base.scss
+++ b/pkg/web_css/lib/src/_base.scss
@@ -146,6 +146,10 @@ body.experimental {
   }
 }
 
+strong {
+  font-weight: 400;
+}
+
 .markdown-body code,
 code {
   background: #f5f5f7;
@@ -167,6 +171,46 @@ pre {
     border-radius: 0;
     display: block;
     overflow-x: unset !important;
+  }
+}
+
+.markdown-body {
+  p {
+    margin-top: 8px; /* overrides github-markdown.css */
+    margin-bottom: 12px; /* overrides github-markdown.css */
+  }
+
+  table {
+    display: table; /* overrides github-markdown.css */
+
+    td, th {
+      padding: 12px 12px 12px 0; /* overrides github-markdown.css */
+      border: none; /* overrides github-markdown.css */
+    }
+
+    tr {
+      border-top: none; /* overrides github-markdown.css */
+
+      &:nth-child(2n) {
+        background-color: inherit; /* overrides github-markdown.css */
+      }
+    }
+
+    th {
+      font-family: $font-family-google-sans;
+      font-size: 16px;
+      font-weight: 400; /* overrides github-markdown.css */
+      border-bottom: 1px solid #c8c8ca;
+      text-align: left;
+    }
+
+    td {
+      border-bottom: 1px solid #f5f5f7;
+    }
+
+    img {
+      background-color: inherit; /* overrides github-markdown.css */
+    }
   }
 }
 

--- a/pkg/web_css/lib/src/_pkg_experimental.scss
+++ b/pkg/web_css/lib/src/_pkg_experimental.scss
@@ -92,31 +92,6 @@ body.experimental {
   }
 }
 
-.dependency-table {
-  width: 100%;
-  border-spacing: 0;
-
-  td, th {
-    width: 25%;
-    text-align: left;
-    padding-right: 2px;
-    padding-top: 2px;
-  }
-
-  .main-header {
-    border-bottom: 1px solid #c8c8ca;
-  }
-
-  .sub-header {
-    font-weight: 500;
-    padding-top: 24px;
-  }
-
-  .hosted-pkg-link {
-    font-weight: 400;
-  }
-}
-
 .score-key-figures {
   display: flex;
   align-items: center;
@@ -229,6 +204,7 @@ body.experimental {
 
   .pkg-report-content-summary {
     flex-grow: 1;
+    margin: 12px 0;
     max-width: 100%;
 
     > h3 {
@@ -241,6 +217,12 @@ body.experimental {
         width: 14px;
         height: 14px;
         margin-right: 6px;
+      }
+    }
+
+    table {
+      a {
+        font-weight: 400;
       }
     }
   }


### PR DESCRIPTION
<img width="712" alt="Screenshot 2020-07-08 at 19 45 34" src="https://user-images.githubusercontent.com/4778111/86952720-b2892480-c153-11ea-82e9-b1a93d1ef992.png">
