### PR TITLE
Improve name match in search

### DIFF
--- a/app/lib/search/mem_index.dart
+++ b/app/lib/search/mem_index.dart
@@ -422,6 +422,9 @@ class InMemoryPackageIndex implements PackageIndex {
       final apiPagesScores = <Score>[];
       bool aborted = false;
 
+      final nameScore =
+          _packageNameIndex.searchWords(words, packages: packages);
+
       for (String word in words) {
         if (packages.isEmpty) break;
         if (sw.elapsedMilliseconds > 500) {
@@ -467,8 +470,6 @@ class InMemoryPackageIndex implements PackageIndex {
         // packages with zero won't be part of the result anyway.
         packages = score.getKeys(where: packages.contains).toSet();
       }
-      final nameScore =
-          _packageNameIndex.searchWords(words, packages: packages);
       final fuzzyScore = Score.multiply(pkgScores)
           .project(packages)
           .removeLowValues(fraction: 0.01, minValue: 0.001);

--- a/app/test/search/flutter_95_test.dart
+++ b/app/test/search/flutter_95_test.dart
@@ -1,0 +1,43 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:test/test.dart';
+
+import 'package:pub_dev/search/mem_index.dart';
+import 'package:pub_dev/search/search_service.dart';
+import 'package:pub_dev/search/text_utils.dart';
+
+void main() {
+  group('flutter_95', () {
+    InMemoryPackageIndex index;
+
+    setUpAll(() async {
+      index = InMemoryPackageIndex();
+      await index.addPackage(PackageDocument(
+        package: 'flutter95',
+        version: '0.0.7',
+        description: compactDescription(
+            'Windows95 UI components for Flutter apps. Bring back the nostalgic look and feel of old operating systems with this set of UI components ready to use.'),
+      ));
+      await index.markReady();
+    });
+
+    test('flutter 95', () async {
+      final PackageSearchResult result = await index.search(
+          SearchQuery.parse(query: 'flutter 95', order: SearchOrder.text));
+      expect(json.decode(json.encode(result)), {
+        'indexUpdated': isNotNull,
+        'totalCount': 1,
+        'packages': [
+          {
+            'package': 'flutter95',
+            'score': 1.0,
+          },
+        ],
+      });
+    });
+  });
+}

--- a/app/test/search/mem_index_test.dart
+++ b/app/test/search/mem_index_test.dart
@@ -224,8 +224,11 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
           .search(SearchQuery.parse(query: 't', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
-        'totalCount': 0,
-        'packages': [],
+        'totalCount': 2,
+        'packages': [
+          {'package': 'http', 'score': 0.25},
+          {'package': 'chrome_net', 'score': closeTo(0.11, 0.01)},
+        ],
       });
     });
 


### PR DESCRIPTION
- By doing the name matching before the inverted index matching, it becomes independent whether a phrase is indexed in the inverted index or not (see test with a single-letter search).
- Fixes #3771 (only in the scope of names).
