### PR TITLE
Remove ga-click event tracking from tabs that have links

### DIFF
--- a/app/lib/frontend/templates/detail_page.dart
+++ b/app/lib/frontend/templates/detail_page.dart
@@ -105,7 +105,7 @@ class Tab {
     String titleHtml,
     @required String href,
   })  : titleHtml =
-            '<a href="$href" data-ga-click-event="tab:$id">${titleHtml ?? htmlEscape.convert(title)}</a>',
+            '<a href="$href">${titleHtml ?? htmlEscape.convert(title)}</a>',
         contentHtml = null,
         isMarkdown = false,
         hasHref = true;

--- a/app/test/frontend/golden/my_liked_packages.html
+++ b/app/test/frontend/golden/my_liked_packages.html
@@ -100,11 +100,11 @@
             <div class="detail-container">
               <ul class="detail-tabs-header">
                 <li class="tab-link" data-name="-packages-tab-" role="button">
-                  <a href="/my-packages" data-ga-click-event="tab:packages">My packages</a>
+                  <a href="/my-packages">My packages</a>
                 </li>
                 <li class="tab-button -active" data-ga-click-event="tab:liked-packages" data-name="-liked-packages-tab-" role="button">My liked packages</li>
                 <li class="tab-link" data-name="-publishers-tab-" role="button">
-                  <a href="/my-publishers" data-ga-click-event="tab:publishers">My publishers</a>
+                  <a href="/my-publishers">My publishers</a>
                 </li>
               </ul>
             </div>

--- a/app/test/frontend/golden/my_packages.html
+++ b/app/test/frontend/golden/my_packages.html
@@ -101,10 +101,10 @@
               <ul class="detail-tabs-header">
                 <li class="tab-button -active" data-ga-click-event="tab:packages" data-name="-packages-tab-" role="button">My packages</li>
                 <li class="tab-link" data-name="-liked-packages-tab-" role="button">
-                  <a href="/my-liked-packages" data-ga-click-event="tab:liked-packages">My liked packages</a>
+                  <a href="/my-liked-packages">My liked packages</a>
                 </li>
                 <li class="tab-link" data-name="-publishers-tab-" role="button">
-                  <a href="/my-publishers" data-ga-click-event="tab:publishers">My publishers</a>
+                  <a href="/my-publishers">My publishers</a>
                 </li>
               </ul>
             </div>

--- a/app/test/frontend/golden/my_publishers.html
+++ b/app/test/frontend/golden/my_publishers.html
@@ -100,10 +100,10 @@
             <div class="detail-container">
               <ul class="detail-tabs-header">
                 <li class="tab-link" data-name="-packages-tab-" role="button">
-                  <a href="/my-packages" data-ga-click-event="tab:packages">My packages</a>
+                  <a href="/my-packages">My packages</a>
                 </li>
                 <li class="tab-link" data-name="-liked-packages-tab-" role="button">
-                  <a href="/my-liked-packages" data-ga-click-event="tab:liked-packages">My liked packages</a>
+                  <a href="/my-liked-packages">My liked packages</a>
                 </li>
                 <li class="tab-button -active" data-ga-click-event="tab:publishers" data-name="-publishers-tab-" role="button">My publishers</li>
               </ul>

--- a/app/test/frontend/golden/pkg_admin_page_outdated.html
+++ b/app/test/frontend/golden/pkg_admin_page_outdated.html
@@ -124,22 +124,22 @@ Published
             <div class="detail-container">
               <ul class="detail-tabs-header">
                 <li class="tab-link" data-name="-readme-tab-" role="button">
-                  <a href="/packages/foobar_pkg" data-ga-click-event="tab:readme">Readme</a>
+                  <a href="/packages/foobar_pkg">Readme</a>
                 </li>
                 <li class="tab-link" data-name="-changelog-tab-" role="button">
-                  <a href="/packages/foobar_pkg#-changelog-tab-" data-ga-click-event="tab:changelog">Changelog</a>
+                  <a href="/packages/foobar_pkg#-changelog-tab-">Changelog</a>
                 </li>
                 <li class="tab-link" data-name="-example-tab-" role="button">
-                  <a href="/packages/foobar_pkg#-example-tab-" data-ga-click-event="tab:example">Example</a>
+                  <a href="/packages/foobar_pkg#-example-tab-">Example</a>
                 </li>
                 <li class="tab-link" data-name="-installing-tab-" role="button">
-                  <a href="/packages/foobar_pkg#-installing-tab-" data-ga-click-event="tab:installing">Installing</a>
+                  <a href="/packages/foobar_pkg#-installing-tab-">Installing</a>
                 </li>
                 <li class="tab-link" data-name="-versions-tab-" role="button">
-                  <a href="/packages/foobar_pkg/versions" data-ga-click-event="tab:versions">Versions</a>
+                  <a href="/packages/foobar_pkg/versions">Versions</a>
                 </li>
                 <li class="tab-link" data-name="-analysis-tab-" role="button">
-                  <a href="/packages/foobar_pkg#-analysis-tab-" data-ga-click-event="tab:analysis">
+                  <a href="/packages/foobar_pkg#-analysis-tab-">
                     <div class="score-box">
                       <span class="number -rotten" title="Analysis and more details.">0</span>
                     </div>

--- a/app/test/frontend/golden/pkg_changelog_page.html
+++ b/app/test/frontend/golden/pkg_changelog_page.html
@@ -124,27 +124,27 @@ Published
             <div class="detail-container">
               <ul class="detail-tabs-header">
                 <li class="tab-link" data-name="-readme-tab-" role="button">
-                  <a href="/packages/foobar_pkg" data-ga-click-event="tab:readme">Readme</a>
+                  <a href="/packages/foobar_pkg">Readme</a>
                 </li>
                 <li class="tab-button -active" data-ga-click-event="tab:changelog" data-name="-changelog-tab-" role="button">Changelog</li>
                 <li class="tab-link" data-name="-example-tab-" role="button">
-                  <a href="/packages/foobar_pkg#-example-tab-" data-ga-click-event="tab:example">Example</a>
+                  <a href="/packages/foobar_pkg#-example-tab-">Example</a>
                 </li>
                 <li class="tab-link" data-name="-installing-tab-" role="button">
-                  <a href="/packages/foobar_pkg#-installing-tab-" data-ga-click-event="tab:installing">Installing</a>
+                  <a href="/packages/foobar_pkg#-installing-tab-">Installing</a>
                 </li>
                 <li class="tab-link" data-name="-versions-tab-" role="button">
-                  <a href="/packages/foobar_pkg/versions" data-ga-click-event="tab:versions">Versions</a>
+                  <a href="/packages/foobar_pkg/versions">Versions</a>
                 </li>
                 <li class="tab-link" data-name="-analysis-tab-" role="button">
-                  <a href="/packages/foobar_pkg#-analysis-tab-" data-ga-click-event="tab:analysis">
+                  <a href="/packages/foobar_pkg#-analysis-tab-">
                     <div class="score-box">
                       <span class="number -rotten" title="Analysis and more details.">3</span>
                     </div>
                   </a>
                 </li>
                 <li class="tab-link" data-name="-admin-tab-" role="button">
-                  <a href="/packages/foobar_pkg/admin" data-ga-click-event="tab:admin">Admin</a>
+                  <a href="/packages/foobar_pkg/admin">Admin</a>
                 </li>
               </ul>
             </div>

--- a/app/test/frontend/golden/pkg_example_page.html
+++ b/app/test/frontend/golden/pkg_example_page.html
@@ -124,27 +124,27 @@ Published
             <div class="detail-container">
               <ul class="detail-tabs-header">
                 <li class="tab-link" data-name="-readme-tab-" role="button">
-                  <a href="/packages/foobar_pkg" data-ga-click-event="tab:readme">Readme</a>
+                  <a href="/packages/foobar_pkg">Readme</a>
                 </li>
                 <li class="tab-link" data-name="-changelog-tab-" role="button">
-                  <a href="/packages/foobar_pkg#-changelog-tab-" data-ga-click-event="tab:changelog">Changelog</a>
+                  <a href="/packages/foobar_pkg#-changelog-tab-">Changelog</a>
                 </li>
                 <li class="tab-button -active" data-ga-click-event="tab:example" data-name="-example-tab-" role="button">Example</li>
                 <li class="tab-link" data-name="-installing-tab-" role="button">
-                  <a href="/packages/foobar_pkg#-installing-tab-" data-ga-click-event="tab:installing">Installing</a>
+                  <a href="/packages/foobar_pkg#-installing-tab-">Installing</a>
                 </li>
                 <li class="tab-link" data-name="-versions-tab-" role="button">
-                  <a href="/packages/foobar_pkg/versions" data-ga-click-event="tab:versions">Versions</a>
+                  <a href="/packages/foobar_pkg/versions">Versions</a>
                 </li>
                 <li class="tab-link" data-name="-analysis-tab-" role="button">
-                  <a href="/packages/foobar_pkg#-analysis-tab-" data-ga-click-event="tab:analysis">
+                  <a href="/packages/foobar_pkg#-analysis-tab-">
                     <div class="score-box">
                       <span class="number -rotten" title="Analysis and more details.">3</span>
                     </div>
                   </a>
                 </li>
                 <li class="tab-link" data-name="-admin-tab-" role="button">
-                  <a href="/packages/foobar_pkg/admin" data-ga-click-event="tab:admin">Admin</a>
+                  <a href="/packages/foobar_pkg/admin">Admin</a>
                 </li>
               </ul>
             </div>

--- a/app/test/frontend/golden/pkg_install_page.html
+++ b/app/test/frontend/golden/pkg_install_page.html
@@ -124,27 +124,27 @@ Published
             <div class="detail-container">
               <ul class="detail-tabs-header">
                 <li class="tab-link" data-name="-readme-tab-" role="button">
-                  <a href="/packages/foobar_pkg" data-ga-click-event="tab:readme">Readme</a>
+                  <a href="/packages/foobar_pkg">Readme</a>
                 </li>
                 <li class="tab-link" data-name="-changelog-tab-" role="button">
-                  <a href="/packages/foobar_pkg#-changelog-tab-" data-ga-click-event="tab:changelog">Changelog</a>
+                  <a href="/packages/foobar_pkg#-changelog-tab-">Changelog</a>
                 </li>
                 <li class="tab-link" data-name="-example-tab-" role="button">
-                  <a href="/packages/foobar_pkg#-example-tab-" data-ga-click-event="tab:example">Example</a>
+                  <a href="/packages/foobar_pkg#-example-tab-">Example</a>
                 </li>
                 <li class="tab-button -active" data-ga-click-event="tab:installing" data-name="-installing-tab-" role="button">Installing</li>
                 <li class="tab-link" data-name="-versions-tab-" role="button">
-                  <a href="/packages/foobar_pkg/versions" data-ga-click-event="tab:versions">Versions</a>
+                  <a href="/packages/foobar_pkg/versions">Versions</a>
                 </li>
                 <li class="tab-link" data-name="-analysis-tab-" role="button">
-                  <a href="/packages/foobar_pkg#-analysis-tab-" data-ga-click-event="tab:analysis">
+                  <a href="/packages/foobar_pkg#-analysis-tab-">
                     <div class="score-box">
                       <span class="number -rotten" title="Analysis and more details.">3</span>
                     </div>
                   </a>
                 </li>
                 <li class="tab-link" data-name="-admin-tab-" role="button">
-                  <a href="/packages/foobar_pkg/admin" data-ga-click-event="tab:admin">Admin</a>
+                  <a href="/packages/foobar_pkg/admin">Admin</a>
                 </li>
               </ul>
             </div>

--- a/app/test/frontend/golden/pkg_score_page.html
+++ b/app/test/frontend/golden/pkg_score_page.html
@@ -124,19 +124,19 @@ Published
             <div class="detail-container">
               <ul class="detail-tabs-header">
                 <li class="tab-link" data-name="-readme-tab-" role="button">
-                  <a href="/packages/foobar_pkg" data-ga-click-event="tab:readme">Readme</a>
+                  <a href="/packages/foobar_pkg">Readme</a>
                 </li>
                 <li class="tab-link" data-name="-changelog-tab-" role="button">
-                  <a href="/packages/foobar_pkg#-changelog-tab-" data-ga-click-event="tab:changelog">Changelog</a>
+                  <a href="/packages/foobar_pkg#-changelog-tab-">Changelog</a>
                 </li>
                 <li class="tab-link" data-name="-example-tab-" role="button">
-                  <a href="/packages/foobar_pkg#-example-tab-" data-ga-click-event="tab:example">Example</a>
+                  <a href="/packages/foobar_pkg#-example-tab-">Example</a>
                 </li>
                 <li class="tab-link" data-name="-installing-tab-" role="button">
-                  <a href="/packages/foobar_pkg#-installing-tab-" data-ga-click-event="tab:installing">Installing</a>
+                  <a href="/packages/foobar_pkg#-installing-tab-">Installing</a>
                 </li>
                 <li class="tab-link" data-name="-versions-tab-" role="button">
-                  <a href="/packages/foobar_pkg/versions" data-ga-click-event="tab:versions">Versions</a>
+                  <a href="/packages/foobar_pkg/versions">Versions</a>
                 </li>
                 <li class="tab-button -active" data-ga-click-event="tab:analysis" data-name="-analysis-tab-" role="button">
                   <div class="score-box">
@@ -144,7 +144,7 @@ Published
                   </div>
                 </li>
                 <li class="tab-link" data-name="-admin-tab-" role="button">
-                  <a href="/packages/foobar_pkg/admin" data-ga-click-event="tab:admin">Admin</a>
+                  <a href="/packages/foobar_pkg/admin">Admin</a>
                 </li>
               </ul>
             </div>

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -128,7 +128,7 @@ Published
                 <li class="tab-button" data-ga-click-event="tab:example" data-name="-example-tab-" role="button">Example</li>
                 <li class="tab-button" data-ga-click-event="tab:installing" data-name="-installing-tab-" role="button">Installing</li>
                 <li class="tab-link" data-name="-versions-tab-" role="button">
-                  <a href="/packages/foobar_pkg/versions" data-ga-click-event="tab:versions">Versions</a>
+                  <a href="/packages/foobar_pkg/versions">Versions</a>
                 </li>
                 <li class="tab-button" data-ga-click-event="tab:analysis" data-name="-analysis-tab-" role="button">
                   <div class="score-box">
@@ -136,7 +136,7 @@ Published
                   </div>
                 </li>
                 <li class="tab-link" data-name="-admin-tab-" role="button">
-                  <a href="/packages/foobar_pkg/admin" data-ga-click-event="tab:admin">Admin</a>
+                  <a href="/packages/foobar_pkg/admin">Admin</a>
                 </li>
               </ul>
             </div>

--- a/app/test/frontend/golden/pkg_show_page_discontinued.html
+++ b/app/test/frontend/golden/pkg_show_page_discontinued.html
@@ -129,7 +129,7 @@ Published
                 <li class="tab-button" data-ga-click-event="tab:example" data-name="-example-tab-" role="button">Example</li>
                 <li class="tab-button" data-ga-click-event="tab:installing" data-name="-installing-tab-" role="button">Installing</li>
                 <li class="tab-link" data-name="-versions-tab-" role="button">
-                  <a href="/packages/foobar_pkg/versions" data-ga-click-event="tab:versions">Versions</a>
+                  <a href="/packages/foobar_pkg/versions">Versions</a>
                 </li>
                 <li class="tab-button" data-ga-click-event="tab:analysis" data-name="-analysis-tab-" role="button">
                   <div class="score-box">

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -130,7 +130,7 @@ Published
                 <li class="tab-button" data-ga-click-event="tab:changelog" data-name="-changelog-tab-" role="button">Changelog</li>
                 <li class="tab-button" data-ga-click-event="tab:installing" data-name="-installing-tab-" role="button">Installing</li>
                 <li class="tab-link" data-name="-versions-tab-" role="button">
-                  <a href="/packages/foobar_pkg/versions" data-ga-click-event="tab:versions">Versions</a>
+                  <a href="/packages/foobar_pkg/versions">Versions</a>
                 </li>
                 <li class="tab-button" data-ga-click-event="tab:analysis" data-name="-analysis-tab-" role="button">
                   <div class="score-box">
@@ -138,7 +138,7 @@ Published
                   </div>
                 </li>
                 <li class="tab-link" data-name="-admin-tab-" role="button">
-                  <a href="/packages/foobar_pkg/admin" data-ga-click-event="tab:admin">Admin</a>
+                  <a href="/packages/foobar_pkg/admin">Admin</a>
                 </li>
               </ul>
             </div>

--- a/app/test/frontend/golden/pkg_show_page_legacy.html
+++ b/app/test/frontend/golden/pkg_show_page_legacy.html
@@ -129,7 +129,7 @@ Published
                 <li class="tab-button" data-ga-click-event="tab:example" data-name="-example-tab-" role="button">Example</li>
                 <li class="tab-button" data-ga-click-event="tab:installing" data-name="-installing-tab-" role="button">Installing</li>
                 <li class="tab-link" data-name="-versions-tab-" role="button">
-                  <a href="/packages/foobar_pkg/versions" data-ga-click-event="tab:versions">Versions</a>
+                  <a href="/packages/foobar_pkg/versions">Versions</a>
                 </li>
                 <li class="tab-button" data-ga-click-event="tab:analysis" data-name="-analysis-tab-" role="button">
                   <div class="score-box">

--- a/app/test/frontend/golden/pkg_show_page_outdated.html
+++ b/app/test/frontend/golden/pkg_show_page_outdated.html
@@ -129,7 +129,7 @@ Published
                 <li class="tab-button" data-ga-click-event="tab:example" data-name="-example-tab-" role="button">Example</li>
                 <li class="tab-button" data-ga-click-event="tab:installing" data-name="-installing-tab-" role="button">Installing</li>
                 <li class="tab-link" data-name="-versions-tab-" role="button">
-                  <a href="/packages/foobar_pkg/versions" data-ga-click-event="tab:versions">Versions</a>
+                  <a href="/packages/foobar_pkg/versions">Versions</a>
                 </li>
                 <li class="tab-button" data-ga-click-event="tab:analysis" data-name="-analysis-tab-" role="button">
                   <div class="score-box">

--- a/app/test/frontend/golden/pkg_show_page_publisher.html
+++ b/app/test/frontend/golden/pkg_show_page_publisher.html
@@ -122,7 +122,7 @@ Published
                 <li class="tab-button" data-ga-click-event="tab:changelog" data-name="-changelog-tab-" role="button">Changelog</li>
                 <li class="tab-button" data-ga-click-event="tab:installing" data-name="-installing-tab-" role="button">Installing</li>
                 <li class="tab-link" data-name="-versions-tab-" role="button">
-                  <a href="/packages/lithium/versions" data-ga-click-event="tab:versions">Versions</a>
+                  <a href="/packages/lithium/versions">Versions</a>
                 </li>
                 <li class="tab-button" data-ga-click-event="tab:analysis" data-name="-analysis-tab-" role="button">
                   <div class="score-box">

--- a/app/test/frontend/golden/pkg_show_version_page.html
+++ b/app/test/frontend/golden/pkg_show_version_page.html
@@ -128,7 +128,7 @@ Published
                 <li class="tab-button" data-ga-click-event="tab:changelog" data-name="-changelog-tab-" role="button">Changelog</li>
                 <li class="tab-button" data-ga-click-event="tab:installing" data-name="-installing-tab-" role="button">Installing</li>
                 <li class="tab-link" data-name="-versions-tab-" role="button">
-                  <a href="/packages/foobar_pkg/versions" data-ga-click-event="tab:versions">Versions</a>
+                  <a href="/packages/foobar_pkg/versions">Versions</a>
                 </li>
                 <li class="tab-button" data-ga-click-event="tab:analysis" data-name="-analysis-tab-" role="button">
                   <div class="score-box">
@@ -136,7 +136,7 @@ Published
                   </div>
                 </li>
                 <li class="tab-link" data-name="-admin-tab-" role="button">
-                  <a href="/packages/foobar_pkg/admin" data-ga-click-event="tab:admin">Admin</a>
+                  <a href="/packages/foobar_pkg/admin">Admin</a>
                 </li>
               </ul>
             </div>

--- a/app/test/frontend/golden/pkg_versions_page.html
+++ b/app/test/frontend/golden/pkg_versions_page.html
@@ -124,20 +124,20 @@ Published
             <div class="detail-container">
               <ul class="detail-tabs-header">
                 <li class="tab-link" data-name="-readme-tab-" role="button">
-                  <a href="/packages/foobar_pkg" data-ga-click-event="tab:readme">Readme</a>
+                  <a href="/packages/foobar_pkg">Readme</a>
                 </li>
                 <li class="tab-link" data-name="-changelog-tab-" role="button">
-                  <a href="/packages/foobar_pkg#-changelog-tab-" data-ga-click-event="tab:changelog">Changelog</a>
+                  <a href="/packages/foobar_pkg#-changelog-tab-">Changelog</a>
                 </li>
                 <li class="tab-link" data-name="-example-tab-" role="button">
-                  <a href="/packages/foobar_pkg#-example-tab-" data-ga-click-event="tab:example">Example</a>
+                  <a href="/packages/foobar_pkg#-example-tab-">Example</a>
                 </li>
                 <li class="tab-link" data-name="-installing-tab-" role="button">
-                  <a href="/packages/foobar_pkg#-installing-tab-" data-ga-click-event="tab:installing">Installing</a>
+                  <a href="/packages/foobar_pkg#-installing-tab-">Installing</a>
                 </li>
                 <li class="tab-button -active" data-ga-click-event="tab:versions" data-name="-versions-tab-" role="button">Versions</li>
                 <li class="tab-link" data-name="-analysis-tab-" role="button">
-                  <a href="/packages/foobar_pkg#-analysis-tab-" data-ga-click-event="tab:analysis">
+                  <a href="/packages/foobar_pkg#-analysis-tab-">
                     <div class="score-box">
                       <span class="number -good" title="Analysis and more details.">55</span>
                     </div>

--- a/app/test/frontend/golden/publisher_packages_page.html
+++ b/app/test/frontend/golden/publisher_packages_page.html
@@ -105,7 +105,7 @@ Publisher registered on Sep 13, 2019.
               <ul class="detail-tabs-header">
                 <li class="tab-button -active" data-ga-click-event="tab:packages" data-name="-packages-tab-" role="button">Packages</li>
                 <li class="tab-link" data-name="-admin-tab-" role="button">
-                  <a href="/publishers/example.com/admin" data-ga-click-event="tab:admin">Admin</a>
+                  <a href="/publishers/example.com/admin">Admin</a>
                 </li>
               </ul>
             </div>


### PR DESCRIPTION
This prevents CTRL+click (open in new tab).