### PR TITLE
Consistent tag display on listing page (using the same tags as on package page)

### DIFF
--- a/app/lib/frontend/templates/listing.dart
+++ b/app/lib/frontend/templates/listing.dart
@@ -84,6 +84,7 @@ String renderPackageList(
       'tags_html': renderTags(
         package: view,
         searchQuery: searchQuery,
+        showTagBadges: requestContext.isExperimental,
       ),
       'labeled_scores_html': renderLabeledScores(view),
       'has_api_pages': hasApiPages,


### PR DESCRIPTION
- Mobile view:
  <img width="427" alt="Screenshot 2020-07-10 at 10 10 15" src="https://user-images.githubusercontent.com/4778111/87132140-bb820f00-c295-11ea-89fa-73709e5729e0.png">

- Desktop view:
  <img width="651" alt="Screenshot 2020-07-10 at 10 10 28" src="https://user-images.githubusercontent.com/4778111/87132144-bde46900-c295-11ea-8335-8e84687a6f52.png">
