### PR TITLE
Use yellow/orange on non-max|non-min scores.

### DIFF
--- a/app/lib/frontend/templates/views/pkg/analysis/report.mustache
+++ b/app/lib/frontend/templates/views/pkg/analysis/report.mustache
@@ -18,7 +18,7 @@
         {{/is_red}}
       </div>
       <div class="pkg-report-header-title">{{ title }}</div>
-      <div class="pkg-report-header-score{{#is_red}} -is-red{{/is_red}}">
+      <div class="pkg-report-header-score{{#is_red}} -is-red{{/is_red}}{{#is_yellow}} -is-yellow{{/is_yellow}}">
         <span class="pkg-report-header-score-granted">{{grantedPoints}}</span>
         /
         <span class="pkg-report-header-score-max">{{maxPoints}}</span>

--- a/pkg/web_css/lib/src/_pkg_experimental.scss
+++ b/pkg/web_css/lib/src/_pkg_experimental.scss
@@ -182,6 +182,10 @@ body.experimental {
       color: #e13701;
     }
 
+    &.-is-yellow {
+      color: #FFA500;
+    }
+
     .foldable-icon {
       margin-left: 18px;
       width: 12px;


### PR DESCRIPTION
<img width="127" alt="Screenshot 2020-07-13 at 15 33 36" src="https://user-images.githubusercontent.com/4778111/87310523-5c82fb00-c51e-11ea-9074-1a1c09a40582.png">
