### PR TITLE
Fix storing dartdoc entry on DartdocReport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@ Important changes to data-models, configuration and migrations between each
 AppEngine version, listed here to ease deployment and troubleshooting.
 
 ## Next Release (replace with git tag when deployed)
+ * Fixed: storing dartdoc entries on `DartdocReport`.
 
 ## `20200714t110212-all`
-
+ * Enabled new UI by default.
  * Increased diskspace for analyzer and dartdoc to 25 GB
 
 ## `20200710t174722-all`

--- a/app/lib/dartdoc/dartdoc_runner.dart
+++ b/app/lib/dartdoc/dartdoc_runner.dart
@@ -216,7 +216,7 @@ class DartdocJobProcessor extends JobProcessor {
         logFileOutput.write('No content found!\n\n');
       }
 
-      final entry = await _createEntry(
+      entry = await _createEntry(
           job, outputDir, usesFlutter, depsResolved, hasContent);
       logFileOutput.write('entry created: ${entry.uuid}\n\n');
 


### PR DESCRIPTION
This was a silent override that masked the higher-level variable which gets eventually stored.