### PR TITLE
Fix dartdoc customization issues.

### DIFF
--- a/app/lib/dartdoc/customization.dart
+++ b/app/lib/dartdoc/customization.dart
@@ -164,9 +164,11 @@ class DartdocCustomizer {
     final pubPackageText = '$packageName package';
     if (breadcrumbs.children.length == 1) {
       // we are on the index page
-      final firstLink = breadcrumbs.querySelector('a');
-      firstLink.attributes['href'] = pubPackageLink;
-      firstLink.text = pubPackageText;
+      final newItem = Element.tag('li');
+      newItem.append(Element.tag('a')
+        ..attributes['href'] = pubPackageLink
+        ..text = pubPackageText);
+      breadcrumbs.children.first.replaceWith(newItem);
 
       final docitem = Element.tag('li')
         ..className = 'self-crumb'

--- a/app/lib/dartdoc/dartdoc_runner.dart
+++ b/app/lib/dartdoc/dartdoc_runner.dart
@@ -204,10 +204,16 @@ class DartdocJobProcessor extends JobProcessor {
       }
 
       if (hasContent) {
-        await DartdocCustomizer(
-                job.packageName, job.packageVersion, job.isLatestStable)
-            .customizeDir(outputDir);
-        logFileOutput.write('Content customization completed.\n\n');
+        try {
+          await DartdocCustomizer(
+                  job.packageName, job.packageVersion, job.isLatestStable)
+              .customizeDir(outputDir);
+          logFileOutput.write('Content customization completed.\n\n');
+        } catch (e, st) {
+          // Do not block on customization failure.
+          _logger.severe('Dartdoc customization failed ($job).', e, st);
+          logFileOutput.write('Content customization failed.\n\n');
+        }
 
         await _tar(tempDirPath, tarDir, outputDir, logFileOutput);
       } else {

--- a/app/test/dartdoc/customization_test.dart
+++ b/app/test/dartdoc/customization_test.dart
@@ -47,32 +47,37 @@ void main() {
         golden.split('\n').where((s) => s.isNotEmpty));
   }
 
-  group('pana 0.10.2', () {
-    final prevCustomizer = DartdocCustomizer('pana', '0.12.2', false);
-    final latestCustomizer = DartdocCustomizer('pana', '0.12.2', true);
+  void expectMatch(String package, String version, String name) {
+    test('Match $package $version $name', () {
+      final prevCustomizer = DartdocCustomizer(package, version, false);
+      final latestCustomizer = DartdocCustomizer(package, version, true);
 
-    void expectMatch(String name) {
-      test(name, () {
-        final inputName = 'pana_0.12.2_$name.html';
-        final outputName = 'pana_0.12.2_$name.out.html';
-        final diffName = 'pana_0.12.2_$name.latest.diff';
-        final html = File('$goldenDir/$inputName').readAsStringSync();
-        final prevResult = prevCustomizer.customizeHtml(html) ?? html;
-        final latestResult = latestCustomizer.customizeHtml(html) ?? html;
-        expectGoldenFile(prevResult, outputName);
-        expectGoldenFile(_miniDiff(prevResult, latestResult), diffName);
+      final path = '${package}_${version}_$name';
+      final inputName = '$path.html';
+      final outputName = '$path.out.html';
+      final diffName = '$path.latest.diff';
+      final html = File('$goldenDir/$inputName').readAsStringSync();
+      final prevResult = prevCustomizer.customizeHtml(html) ?? html;
+      final latestResult = latestCustomizer.customizeHtml(html) ?? html;
+      expectGoldenFile(prevResult, outputName);
+      expectGoldenFile(_miniDiff(prevResult, latestResult), diffName);
 
-        if (_regenerateGoldens) {
-          fail('Set `_regenerateGoldens` to `false` to run tests.');
-        }
-      });
-    }
+      if (_regenerateGoldens) {
+        fail('Set `_regenerateGoldens` to `false` to run tests.');
+      }
+    });
+  }
 
-    expectMatch('index');
-    expectMatch('license_file_class');
-    expectMatch('license_file_constructor');
-    expectMatch('license_file_name_field');
-    expectMatch('pretty_json');
+  group('pana 0.12.2', () {
+    expectMatch('pana', '0.12.2', 'index');
+    expectMatch('pana', '0.12.2', 'license_file_class');
+    expectMatch('pana', '0.12.2', 'license_file_constructor');
+    expectMatch('pana', '0.12.2', 'license_file_name_field');
+    expectMatch('pana', '0.12.2', 'pretty_json');
+  });
+
+  group('Misc packages', () {
+    expectMatch('dygraph', '0.1.1', 'index');
   });
 }
 

--- a/app/test/dartdoc/golden/dygraph_0.1.1_index.html
+++ b/app/test/dartdoc/golden/dygraph_0.1.1_index.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1, user-scalable=no">
+  <meta name="generator" content="made with love by dartdoc 0.32.1">
+  <meta name="description" content="dygraph API docs, for the Dart programming language.">
+  <title>dygraph - Dart API docs</title>
+
+  
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body data-base-href=""
+      data-using-base-href="false">
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li class="self-crumb">dygraph package</li>
+  </ol>
+  <div class="self-name">dygraph</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div id="dartdoc-sidebar-left" class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <header id="header-search-sidebar" class="hidden-l">
+      <form class="search-sidebar" role="search">
+        <input type="text" id="search-sidebar" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+      </form>
+    </header>
+    
+    <ol class="breadcrumbs gt-separated dark hidden-l" id="sidebar-nav">
+      <li class="self-crumb">dygraph package</li>
+    </ol>
+    
+    <h5 class="hidden-xs"><span class="package-name">dygraph</span> <span class="package-kind">package</span></h5>
+    <ol>
+          <li class="section-title">Libraries</li>
+          <li><a href="dygraph/dygraph-library.html">dygraph</a></li>
+    </ol>
+  </div>
+
+  <div id="dartdoc-main-content" class="col-xs-12 col-sm-9 col-md-8 main-content">
+      <section class="desc markdown">
+        <h1 id="dygraph-dart">Dygraph (Dart)</h1>
+<p>Dart JS interop for <a href="https://github.com/danvk/dygraphs">Dygraph v2+</a> - fast, flexible open source JavaScript charting library.</p>
+<h2 id="usage">Usage</h2>
+<ol>
+<li>
+<p>Register the Dart package in your <code>pubspec.yaml</code>:</p>
+<pre class="language-yaml"><code class="language-yaml"> dependencies:
+   dygraph: ^0.1.0
+</code></pre>
+</li>
+<li>
+<p>Load the latest Dygraph source (js and css) in your html layout:</p>
+<pre class="language-html"><code class="language-html"> &lt;link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/dygraph/2.1.0/dygraph.min.css"&gt;
+ &lt;script src="https://cdnjs.cloudflare.com/ajax/libs/dygraph/2.1.0/dygraph.min.js"&gt;&lt;/script&gt;
+</code></pre>
+</li>
+<li>
+<p>Create a <code>Dygraph</code> instance:</p>
+<pre class="language-dart"><code class="language-dart"> import 'dart:html';
+
+ import 'package:dygraph/dygraph.dart';
+
+ void main() {
+   final el = document.getElementById('chart_container');
+
+   final options = DygraphOptions(
+     labels: ['Index', 'X', 'Y'],
+     colors: ['blue', 'red'],
+   );
+
+   final data = [
+     [1, 10, 100],
+     [2, 20, 80],
+     [3, 50, 60],
+     [4, 70, 80],
+   ];
+
+   Dygraph(el, data, options);
+ }
+</code></pre>
+</li>
+</ol>
+<blockquote>
+<p><strong>Note 1:</strong> Dart DateTime objects need to be converted to native js dates by using <code>dart:html_common</code> and <code>convertDartToNative_DateTime()</code>.</p>
+</blockquote>
+<blockquote>
+<p><strong>Note 2:</strong> When passing a Dart function as a callback, make sure to wrap it with <code>allowInterop()</code> or <code>allowInteropCaptureThis()</code>.</p>
+</blockquote>
+<p>Check the <a href="https://pub.dev/documentation/dygraph/latest/">API reference</a> for detailed documentation.</p>
+<p>To view the example, run <code>pub global run webdev serve example</code> from the root directory of this project.</p>
+      </section>
+      
+        <section class="summary">
+            <h2>Libraries</h2>
+          <dl>
+            <dt id="dygraph">
+              <span class="name"><a href="dygraph/dygraph-library.html">dygraph</a></span>             
+            </dt>
+            <dd>
+              The JS interop library itself. 
+            </dd>
+          </dl>
+        </section>
+
+  </div> <!-- /.main-content -->
+
+  <div id="dartdoc-sidebar-right" class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div>
+
+</main>
+
+<footer>
+  <span class="no-break">
+    dygraph
+      0.1.1
+  </span>
+
+</footer>
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/app/test/dartdoc/golden/dygraph_0.1.1_index.latest.diff
+++ b/app/test/dartdoc/golden/dygraph_0.1.1_index.latest.diff
@@ -1,0 +1,6 @@
+-     <meta name="robots" content="noindex"/>
+-     <link rel="alternate" href="/documentation/dygraph/latest/"/>
+-           <a href="/packages/dygraph/versions/0.1.1">dygraph package</a>
++           <a href="/packages/dygraph">dygraph package</a>
+-             <a href="/packages/dygraph/versions/0.1.1">dygraph package</a>
++             <a href="/packages/dygraph">dygraph package</a>

--- a/app/test/dartdoc/golden/dygraph_0.1.1_index.out.html
+++ b/app/test/dartdoc/golden/dygraph_0.1.1_index.out.html
@@ -1,0 +1,168 @@
+<html lang="en">
+  <head>
+    <meta name="robots" content="noindex"/>
+    <script async="async" src="https://www.googletagmanager.com/gtag/js?id=UA-26406144-13"/>
+    <script src="/static/js/gtag.js"/>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+    <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1, user-scalable=no"/>
+    <meta name="generator" content="made with love by dartdoc 0.32.1"/>
+    <meta name="description" content="dygraph API docs, for the Dart programming language."/>
+    <title>dygraph - Dart API docs</title>
+    <link rel="stylesheet" type="text/css" href="/static/css/github-markdown.css?hash=t2ti0tfkd3q7dsh5njovil42c3bnhf5s"/>
+    <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet"/>
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet"/>
+    <link rel="stylesheet" href="static-assets/github.css"/>
+    <link rel="stylesheet" href="static-assets/styles.css"/>
+    <link rel="icon" href="static-assets/favicon.png"/>
+    <link rel="alternate" href="/documentation/dygraph/latest/"/>
+  </head>
+  <body data-base-href="" data-using-base-href="false">
+    <div id="overlay-under-drawer"/>
+    <header id="title">
+      <button id="sidenav-left-toggle" type="button"></button>
+      <a class="hidden-xs" href="/">
+        <img src="/static/img/dart-logo.svg?hash=gqea88bp2ii6tqf5rn5p8jtg22mma809" style="height: 30px; margin-right: 1em;"/>
+      </a>
+      <ol class="breadcrumbs gt-separated dark hidden-xs">
+        <li>
+          <a href="/packages/dygraph/versions/0.1.1">dygraph package</a>
+        </li>
+        <li class="self-crumb">documentation</li>
+      </ol>
+      <div class="self-name">dygraph</div>
+      <form class="search navbar-right" role="search">
+        <input type="text" id="search-box" autocomplete="off" disabled="" class="form-control typeahead" placeholder="Loading search..."/>
+      </form>
+    </header>
+    <main>
+      <div id="dartdoc-sidebar-left" class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+        <header id="header-search-sidebar" class="hidden-l">
+          <form class="search-sidebar" role="search">
+            <input type="text" id="search-sidebar" autocomplete="off" disabled="" class="form-control typeahead" placeholder="Loading search..."/>
+          </form>
+        </header>
+        <ol class="breadcrumbs gt-separated dark hidden-l" id="sidebar-nav">
+          <li>
+            <a href="/packages/dygraph/versions/0.1.1">dygraph package</a>
+          </li>
+          <li class="self-crumb">documentation</li>
+        </ol>
+        <h5 class="hidden-xs">
+          <span class="package-name">dygraph</span>
+          <span class="package-kind">package</span>
+        </h5>
+        <ol>
+          <li class="section-title">Libraries</li>
+          <li>
+            <a href="dygraph/dygraph-library.html">dygraph</a>
+          </li>
+        </ol>
+      </div>
+      <div id="dartdoc-main-content" class="col-xs-12 col-sm-9 col-md-8 main-content">
+        <section class="desc markdown markdown-body">
+          <h1 id="dygraph-dart">Dygraph (Dart)</h1>
+          <p>Dart JS interop for 
+            <a href="https://github.com/danvk/dygraphs">Dygraph v2+</a> - fast, flexible open source JavaScript charting library.
+          </p>
+          <h2 id="usage">Usage</h2>
+          <ol>
+            <li>
+              <p>Register the Dart package in your 
+                <code>pubspec.yaml</code>:
+              </p>
+              <pre class="language-yaml">
+                <code class="language-yaml"> dependencies:
+   dygraph: ^0.1.0
+</code>
+              </pre>
+            </li>
+            <li>
+              <p>Load the latest Dygraph source (js and css) in your html layout:</p>
+              <pre class="language-html">
+                <code class="language-html"> &lt;link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/dygraph/2.1.0/dygraph.min.css">
+ &lt;script src="https://cdnjs.cloudflare.com/ajax/libs/dygraph/2.1.0/dygraph.min.js">&lt;/script>
+</code>
+              </pre>
+            </li>
+            <li>
+              <p>Create a 
+                <code>Dygraph</code> instance:
+              </p>
+              <pre class="language-dart">
+                <code class="language-dart"> import 'dart:html';
+
+ import 'package:dygraph/dygraph.dart';
+
+ void main() {
+   final el = document.getElementById('chart_container');
+
+   final options = DygraphOptions(
+     labels: ['Index', 'X', 'Y'],
+     colors: ['blue', 'red'],
+   );
+
+   final data = [
+     [1, 10, 100],
+     [2, 20, 80],
+     [3, 50, 60],
+     [4, 70, 80],
+   ];
+
+   Dygraph(el, data, options);
+ }
+</code>
+              </pre>
+            </li>
+          </ol>
+          <blockquote>
+            <p>
+              <strong>Note 1:</strong> Dart DateTime objects need to be converted to native js dates by using 
+              <code>dart:html_common</code> and 
+              <code>convertDartToNative_DateTime()</code>.
+            </p>
+          </blockquote>
+          <blockquote>
+            <p>
+              <strong>Note 2:</strong> When passing a Dart function as a callback, make sure to wrap it with 
+              <code>allowInterop()</code> or 
+              <code>allowInteropCaptureThis()</code>.
+            </p>
+          </blockquote>
+          <p>Check the 
+            <a href="https://pub.dev/documentation/dygraph/latest/">API reference</a> for detailed documentation.
+          </p>
+          <p>To view the example, run 
+            <code>pub global run webdev serve example</code> from the root directory of this project.
+          </p>
+        </section>
+        <section class="summary">
+          <h2>Libraries</h2>
+          <dl>
+            <dt id="dygraph">
+              <span class="name">
+                <a href="dygraph/dygraph-library.html">dygraph</a>
+              </span>
+            </dt>
+            <dd>
+              The JS interop library itself. 
+            </dd>
+          </dl>
+        </section>
+      </div>
+      <!-- /.main-content -->
+      <div id="dartdoc-sidebar-right" class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right"></div>
+    </main>
+    <footer>
+      <span class="no-break">
+    dygraph
+      0.1.1
+  </span>
+    </footer>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"/>
+    <script src="static-assets/typeahead.bundle.min.js"/>
+    <script src="static-assets/highlight.pack.js"/>
+    <script src="static-assets/URI.js"/>
+    <script src="static-assets/script.js"/>
+  </body>
+</html>


### PR DESCRIPTION
- Fixes #3885.
- Wraps customization code in try-catch - a bug in our code should not block documentation creation and publishing.
- Fixed the difference in the HTML output handling, added test for it.