### PR TITLE
Wrap long titles and API links on listing page

### DIFF
--- a/app/lib/frontend/templates/views/pkg/package_list.mustache
+++ b/app/lib/frontend/templates/views/pkg/package_list.mustache
@@ -52,13 +52,13 @@
     <div class="packages-api">
       {{^has_more_api_pages}}
         <div class="packages-api-label">API result:</div>
-        <div>
+        <div class="packages-api-links">
           <a href="{{& first_api_page.href}}">{{ first_api_page.title }}</a>
         </div>
       {{/has_more_api_pages}}
       {{#has_more_api_pages}}
         <div class="packages-api-label">API results:</div>
-        <details class="packages-api-details">
+        <details class="packages-api-details packages-api-links">
           <summary>
             <a href="{{& first_api_page.href}}">{{ first_api_page.title }}</a>
           </summary>

--- a/app/test/frontend/golden/search_page.html
+++ b/app/test/frontend/golden/search_page.html
@@ -243,7 +243,7 @@
             </div>
             <div class="packages-api">
               <div class="packages-api-label">API results:</div>
-              <details class="packages-api-details">
+              <details class="packages-api-details packages-api-links">
                 <summary>
                   <a href="/documentation/foobar_pkg/latest/some/some-library.html">some/some-library.html</a>
                 </summary>

--- a/pkg/web_css/lib/src/_list.scss
+++ b/pkg/web_css/lib/src/_list.scss
@@ -280,6 +280,7 @@
     font-size: 22px;
     font-weight: 500;
     margin: 0;
+    overflow-wrap: anywhere;
   }
 
   .packages-recent {
@@ -345,6 +346,10 @@
 
     .packages-api-label {
       padding-right: 8px;
+    }
+
+    .packages-api-links {
+      overflow-wrap: anywhere;
     }
 
     .-rest {


### PR DESCRIPTION
Fixes #3836.
<img width="379" alt="Screenshot 2020-07-29 at 14 08 08" src="https://user-images.githubusercontent.com/4778111/88798403-1fb53600-d1a5-11ea-9ca7-e82de3911a51.png">
<img width="441" alt="Screenshot 2020-07-29 at 14 08 19" src="https://user-images.githubusercontent.com/4778111/88798407-217ef980-d1a5-11ea-94e5-ca7c808e18c8.png">
