### PR TITLE
Search tuning with text-match and popularity ranking

### DIFF
--- a/app/lib/search/mem_index.dart
+++ b/app/lib/search/mem_index.dart
@@ -382,7 +382,7 @@ class InMemoryPackageIndex implements PackageIndex {
       final points = (doc.grantedPoints ?? 0) / math.max(1, doc.maxPoints ?? 0);
       final overall = popularity * 0.5 + points * 0.5;
       // don't multiply with zero.
-      return 0.3 + 0.7 * overall;
+      return 0.5 + 0.5 * overall;
     });
     return Score(values);
   }

--- a/app/lib/search/token_index.dart
+++ b/app/lib/search/token_index.dart
@@ -281,7 +281,6 @@ class TokenIndex {
   Map<String, double> scoreDocs(TokenMatch tokenMatch,
       {double weight = 1.0, int wordCount = 1, Set<String> limitToIds}) {
     // Summarize the scores for the documents.
-    final queryWeight = tokenMatch.maxWeight;
     final Map<String, double> docScores = <String, double>{};
     for (String token in tokenMatch.tokens) {
       final docWeights = _inverseIds[token];
@@ -304,7 +303,7 @@ class TokenIndex {
       if (wordCount > 1) {
         docSize = math.pow(docSize, wordSizeExponent).toDouble();
       }
-      docScores[id] = weight * docScores[id] / queryWeight / docSize;
+      docScores[id] = weight * docScores[id] / docSize;
     }
     return docScores;
   }

--- a/app/test/search/api_doc_page_test.dart
+++ b/app/test/search/api_doc_page_test.dart
@@ -82,7 +82,7 @@ void main() {
         'packages': [
           {
             'package': 'other_with_api',
-            'score': closeTo(0.265, 0.001), // find serveWebPages
+            'score': closeTo(0.221, 0.001), // find serveWebPages
             'apiPages': [
               {'title': null, 'path': 'serve.html'},
             ],

--- a/app/test/search/bluetooth_test.dart
+++ b/app/test/search/bluetooth_test.dart
@@ -39,7 +39,7 @@ void main() {
         'packages': [
           {
             'package': 'flutter_blue',
-            'score': closeTo(0.99, 0.01),
+            'score': closeTo(0.89, 0.01),
           },
         ],
       });

--- a/app/test/search/exact_name_test.dart
+++ b/app/test/search/exact_name_test.dart
@@ -47,11 +47,11 @@ void main() {
         'packages': [
           {
             'package': 'build_config',
-            'score': closeTo(0.612, 0.001),
+            'score': closeTo(0.535, 0.001),
           },
           {
             'package': 'build',
-            'score': closeTo(0.606, 0.001),
+            'score': closeTo(0.429, 0.001),
           },
         ],
       });

--- a/app/test/search/handlers_test.dart
+++ b/app/test/search/handlers_test.dart
@@ -49,7 +49,7 @@ void main() {
           'packages': [
             {
               'package': 'pkg_foo',
-              'score': closeTo(0.32, 0.01),
+              'score': closeTo(0.51, 0.01),
             }
           ],
         });
@@ -63,7 +63,7 @@ void main() {
           'packages': [
             {
               'package': 'pkg_foo',
-              'score': closeTo(0.28, 0.01),
+              'score': closeTo(0.45, 0.01),
             }
           ],
         });
@@ -78,7 +78,7 @@ void main() {
               'packages': [
                 {
                   'package': 'pkg_foo',
-                  'score': closeTo(0.28, 0.01),
+                  'score': closeTo(0.45, 0.01),
                 }
               ],
             });
@@ -92,7 +92,7 @@ void main() {
           'packages': [
             {
               'package': 'pkg_foo',
-              'score': closeTo(0.4, 0.1),
+              'score': closeTo(0.51, 0.01),
             }
           ],
         });

--- a/app/test/search/haversine_test.dart
+++ b/app/test/search/haversine_test.dart
@@ -416,15 +416,15 @@ MIT'''),
         'packages': [
           {
             'package': 'haversine',
-            'score': closeTo(0.99, 0.01),
+            'score': closeTo(0.45, 0.01),
           },
           {
             'package': 'great_circle_distance',
-            'score': closeTo(0.72, 0.01),
+            'score': closeTo(0.31, 0.01),
           },
           {
             'package': 'latlong',
-            'score': closeTo(0.71, 0.01),
+            'score': closeTo(0.31, 0.01),
           },
         ]
       });

--- a/app/test/search/lombok_test.dart
+++ b/app/test/search/lombok_test.dart
@@ -31,7 +31,7 @@ void main() {
         'packages': [
           {
             'package': 'lombok',
-            'score': closeTo(0.99, 0.01),
+            'score': closeTo(0.33, 0.01),
           },
         ],
       });

--- a/app/test/search/mem_index_test.dart
+++ b/app/test/search/mem_index_test.dart
@@ -106,7 +106,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'packages': [
           {
             'package': 'async',
-            'score': closeTo(0.59, 0.01),
+            'score': closeTo(0.71, 0.01),
           },
         ]
       });
@@ -121,7 +121,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'packages': [
           {
             'package': 'http',
-            'score': closeTo(0.83, 0.01),
+            'score': closeTo(0.85, 0.01),
           },
         ]
       });
@@ -136,7 +136,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'packages': [
           {
             'package': 'chrome_net',
-            'score': closeTo(0.26, 0.01),
+            'score': closeTo(0.39, 0.01),
           },
         ]
       });
@@ -149,8 +149,8 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'indexUpdated': isNotNull,
         'totalCount': 2,
         'packages': [
-          {'package': 'http', 'score': closeTo(0.68, 0.01)},
-          {'package': 'async', 'score': closeTo(0.52, 0.01)},
+          {'package': 'http', 'score': closeTo(0.36, 0.01)},
+          {'package': 'async', 'score': closeTo(0.32, 0.01)},
         ]
       });
     });
@@ -172,8 +172,8 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'indexUpdated': isNotNull,
         'totalCount': 2,
         'packages': [
-          {'package': 'http', 'score': closeTo(0.68, 0.01)},
-          {'package': 'async', 'score': closeTo(0.52, 0.01)},
+          {'package': 'http', 'score': closeTo(0.70, 0.01)},
+          {'package': 'async', 'score': closeTo(0.62, 0.01)},
         ],
       });
     });
@@ -185,7 +185,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'indexUpdated': isNotNull,
         'totalCount': 1,
         'packages': [
-          {'package': 'async', 'score': closeTo(0.24, 0.01)},
+          {'package': 'async', 'score': closeTo(0.29, 0.01)},
         ],
       });
     });
@@ -199,7 +199,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'packages': [
           {
             'package': 'chrome_net',
-            'score': closeTo(0.36, 0.1),
+            'score': closeTo(0.54, 0.1),
           },
         ]
       });
@@ -324,8 +324,8 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'indexUpdated': isNotNull,
         'totalCount': 2,
         'packages': [
-          {'package': 'http', 'score': closeTo(0.95, 0.01)},
-          {'package': 'async', 'score': closeTo(0.59, 0.01)},
+          {'package': 'http', 'score': closeTo(0.96, 0.01)},
+          {'package': 'async', 'score': closeTo(0.70, 0.01)},
         ],
       });
     });
@@ -337,7 +337,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'indexUpdated': isNotNull,
         'totalCount': 1,
         'packages': [
-          {'package': 'chrome_net', 'score': closeTo(0.36, 0.01)},
+          {'package': 'chrome_net', 'score': closeTo(0.54, 0.01)},
         ],
       });
     });
@@ -349,8 +349,8 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'indexUpdated': isNotNull,
         'totalCount': 2,
         'packages': [
-          {'package': 'http', 'score': closeTo(0.95, 0.01)},
-          {'package': 'chrome_net', 'score': closeTo(0.36, 0.01)},
+          {'package': 'http', 'score': closeTo(0.96, 0.01)},
+          {'package': 'chrome_net', 'score': closeTo(0.54, 0.01)},
         ],
       });
     });
@@ -362,7 +362,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'indexUpdated': isNotNull,
         'totalCount': 1,
         'packages': [
-          {'package': 'http', 'score': closeTo(0.83, 0.01)},
+          {'package': 'http', 'score': closeTo(0.85, 0.01)},
         ],
       });
     });
@@ -374,7 +374,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'indexUpdated': isNotNull,
         'totalCount': 1,
         'packages': [
-          {'package': 'http', 'score': closeTo(0.95, 0.01)},
+          {'package': 'http', 'score': closeTo(0.96, 0.01)},
         ],
       });
     });
@@ -396,7 +396,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'indexUpdated': isNotNull,
         'totalCount': 1,
         'packages': [
-          {'package': 'async', 'score': closeTo(0.59, 0.01)},
+          {'package': 'async', 'score': closeTo(0.70, 0.01)},
         ],
       });
     });
@@ -418,7 +418,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'indexUpdated': isNotNull,
         'totalCount': 1,
         'packages': [
-          {'package': 'async', 'score': closeTo(0.59, 0.01)},
+          {'package': 'async', 'score': closeTo(0.70, 0.01)},
         ],
       });
     });
@@ -433,8 +433,8 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'indexUpdated': isNotNull,
         'totalCount': 2,
         'packages': [
-          {'package': 'http', 'score': closeTo(0.95, 0.01)},
-          {'package': 'async', 'score': closeTo(0.59, 0.01)},
+          {'package': 'http', 'score': closeTo(0.96, 0.01)},
+          {'package': 'async', 'score': closeTo(0.70, 0.01)},
         ],
       });
     });
@@ -456,8 +456,8 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'indexUpdated': isNotNull,
         'totalCount': 2,
         'packages': [
-          {'package': 'http', 'score': closeTo(0.95, 0.01)},
-          {'package': 'async', 'score': closeTo(0.59, 0.01)},
+          {'package': 'http', 'score': closeTo(0.96, 0.01)},
+          {'package': 'async', 'score': closeTo(0.70, 0.01)},
         ],
       });
     });

--- a/app/test/search/result_combiner_test.dart
+++ b/app/test/search/result_combiner_test.dart
@@ -63,7 +63,7 @@ void main() {
         'indexUpdated': isNotNull,
         'totalCount': 1,
         'packages': [
-          {'package': 'stringutils', 'score': closeTo(0.72, 0.01)},
+          {'package': 'stringutils', 'score': closeTo(0.8, 0.01)},
         ],
       });
     });
@@ -90,7 +90,7 @@ void main() {
               },
             ],
           },
-          {'package': 'stringutils', 'score': closeTo(0.53, 0.01)},
+          {'package': 'stringutils', 'score': closeTo(0.59, 0.01)},
         ],
       });
     });
@@ -102,10 +102,10 @@ void main() {
         'indexUpdated': isNotNull,
         'totalCount': 2,
         'packages': [
-          {'package': 'stringutils', 'score': closeTo(0.72, 0.01)},
+          {'package': 'stringutils', 'score': closeTo(0.80, 0.01)},
           {
             'package': 'dart:core',
-            'score': closeTo(0.89, 0.01),
+            'score': closeTo(0.69, 0.01),
             'url':
                 'https://api.dartlang.org/stable/2.0.0/dart-core/String-class.html',
             'description': 'Dart core utils',

--- a/app/test/search/scope_specificity_test.dart
+++ b/app/test/search/scope_specificity_test.dart
@@ -69,19 +69,19 @@ void main() {
         'packages': [
           {
             'package': 'json_0',
-            'score': closeTo(0.29, 0.01),
+            'score': closeTo(0.49, 0.01),
           },
           {
             'package': 'json_1',
-            'score': closeTo(0.29, 0.01),
+            'score': closeTo(0.49, 0.01),
           },
           {
             'package': 'json_2',
-            'score': closeTo(0.29, 0.01),
+            'score': closeTo(0.49, 0.01),
           },
           {
             'package': 'json_3',
-            'score': closeTo(0.29, 0.01),
+            'score': closeTo(0.49, 0.01),
           },
         ],
       });
@@ -99,11 +99,11 @@ void main() {
         'packages': [
           {
             'package': 'json_1',
-            'score': closeTo(0.2967, 0.0001),
+            'score': closeTo(0.49, 0.01),
           },
           {
             'package': 'json_3',
-            'score': closeTo(0.2671, 0.0001),
+            'score': closeTo(0.45, 0.01),
           },
         ],
       });

--- a/app/test/search/token_index_test.dart
+++ b/app/test/search/token_index_test.dart
@@ -39,7 +39,7 @@ void main() {
         'queue': closeTo(0.29, 0.01),
       });
       expect(index.search('unmodifiab'), {
-        'unmodifiable': closeTo(0.47, 0.01),
+        'unmodifiable': closeTo(0.39, 0.01),
       });
       expect(index.search('unmodifiable'), {
         'unmodifiable': closeTo(0.47, 0.01),
@@ -70,6 +70,13 @@ void main() {
       expect(index.tokenCount, 2);
       index.remove('url2');
       expect(index.tokenCount, 1);
+    });
+
+    test('Do not overweight partial matches', () {
+      final index = TokenIndex()..add('flutter_qr_reader', 'flutter_qr_reader');
+      final data = index.search('ByteDataReader');
+      // The partial match should not return more than 0.5 as score.
+      expect(data, {'flutter_qr_reader': lessThan(0.5)});
     });
   });
 


### PR DESCRIPTION
- Score fix: partial text matches are no longer normalized to the token group they are part of. This normalization resulted a text match score of 0.97 for the document text `flutter_qr_reader` against the query of `ByteDataReader`. The common substring `reader` should not gain more than 0.5 of the score (the current value will be around 0.44).

- Ranking tuning: decreases the weight multiplier of popularity score from 0.7 -> 0.5. In effect, this prioritizes text match over use/popularity a slightly bit more. Normal listing is not affected, and it improves a few hand-checked results where a typo allowed a totally unrelated but popular package to rise to the top of the results.

- Adjusted scores in tests - the score decrease in the typo of `hoversine/haversine` was a bit unexpected, but checking the live site it is already something we don't serve too well.
