### PR TITLE
Do not require analysis in search updater.

### DIFF
--- a/app/lib/search/backend.dart
+++ b/app/lib/search/backend.dart
@@ -71,11 +71,7 @@ class SearchBackend {
   ///
   /// When a package, or its latest version is missing, the method throws
   /// [RemovedPackageException].
-  ///
-  /// When either the analysis is not completed yet, the method returns with
-  /// null.
-  Future<PackageDocument> loadDocument(String packageName,
-      {bool requireAnalysis = false}) async {
+  Future<PackageDocument> loadDocument(String packageName) async {
     final packageKey = _db.emptyKey.append(Package, id: packageName);
     final p = (await _db.lookup<Package>([packageKey])).single;
     if (p == null) {
@@ -89,9 +85,6 @@ class SearchBackend {
 
     final analysisView =
         await analyzerClient.getAnalysisView(packageName, pv.version);
-    if (requireAnalysis && !analysisView.hasPanaSummary) {
-      throw MissingAnalysisException();
-    }
 
     final tags = <String>[
       ...p.getTags(),

--- a/app/lib/shared/exceptions.dart
+++ b/app/lib/shared/exceptions.dart
@@ -376,12 +376,6 @@ class ConflictException extends ResponseException {
           'A publisher with the domain `$domain` already exists');
 }
 
-/// Thrown when the analysis for a package is not done yet.
-class MissingAnalysisException extends NotFoundException {
-  MissingAnalysisException()
-      : super('Analysis is not ready for the given package.');
-}
-
 /// Thrown when package or versions is missing or has flags indicating that it
 /// should be removed from the search index.
 class RemovedPackageException extends NotFoundException {


### PR DESCRIPTION
I believe this is no longer required, because:
- we have a good fallback mechanism on analysis (ScoreCard + acceptedRuntimeVersions), and
- we do have a daily index update, in the rare case this would cause an issue, the effect is limited to a day
