### PR TITLE
Display only a single license on the package page.

### DIFF
--- a/app/bin/tools/package_stats.dart
+++ b/app/bin/tools/package_stats.dart
@@ -30,9 +30,7 @@ Future main(List<String> args) async {
   final List<String> flutterSdks = [];
 
   final homepageScheme = _Counter();
-  final licenseCounts = _Counter();
   final licenseNames = _Counter();
-  final packagesWithMoreThanOneLicense = _Counter();
   final grantedPoints = _Counter();
   final tags = _Counter();
 
@@ -75,14 +73,7 @@ Future main(List<String> args) async {
 
       final analysis =
           await analyzerClient.getAnalysisView(p.name, p.latestVersion);
-      final licenseCount = analysis.licenses?.length ?? 0;
-      licenseCounts.increment(licenseCount);
-      analysis.licenses?.forEach((l) {
-        licenseNames.increment(l.name ?? 'none');
-      });
-      if (licenseCount > 1) {
-        packagesWithMoreThanOneLicense.increment(p.name, licenseCount);
-      }
+      licenseNames.increment(analysis.licenseFile ?? 'none');
       grantedPoints.increment(analysis.report?.grantedPoints ?? 0);
     }
 
@@ -105,11 +96,7 @@ Future main(List<String> args) async {
     },
     'tags': tags.sortedByCounts(),
     'homepage': homepageScheme.sortedByCounts(),
-    'licenses': {
-      'counts': licenseCounts.sortedByKeysAsInt(),
-      'names': licenseNames.sortedByCounts(),
-      'moreThanOne': packagesWithMoreThanOneLicense.sortedByCounts(),
-    },
+    'licenses': licenseNames.sortedByCounts(),
     'points': grantedPoints.sortedByKeysAsInt(),
   };
   final String json = JsonEncoder.withIndent('  ').convert(report);

--- a/app/lib/analyzer/analyzer_client.dart
+++ b/app/lib/analyzer/analyzer_client.dart
@@ -90,8 +90,6 @@ class AnalysisView {
 
   List<String> get derivedTags => _card?.derivedTags ?? const <String>[];
 
-  List<LicenseFile> get licenses =>
-      _pana?.licenseFile == null ? null : [_pana?.licenseFile];
   LicenseFile get licenseFile => _pana?.licenseFile;
 
   List<PkgDependency> get directDependencies =>

--- a/app/lib/analyzer/analyzer_client.dart
+++ b/app/lib/analyzer/analyzer_client.dart
@@ -92,6 +92,7 @@ class AnalysisView {
 
   List<LicenseFile> get licenses =>
       _pana?.licenseFile == null ? null : [_pana?.licenseFile];
+  LicenseFile get licenseFile => _pana?.licenseFile;
 
   List<PkgDependency> get directDependencies =>
       _getDependencies(DependencyTypes.direct);

--- a/app/lib/frontend/templates/package.dart
+++ b/app/lib/frontend/templates/package.dart
@@ -26,22 +26,20 @@ import 'layout.dart';
 import 'misc.dart';
 import 'package_analysis.dart';
 
-String _renderLicenses(String baseUrl, List<LicenseFile> licenses) {
-  if (licenses == null || licenses.isEmpty) return null;
-  return licenses.map((license) {
-    final String escapedName = htmlEscape.convert(license.shortFormatted);
-    String html = escapedName;
+String _renderLicense(String baseUrl, LicenseFile license) {
+  if (license == null) return null;
+  final String escapedName = htmlEscape.convert(license.shortFormatted);
+  String html = escapedName;
 
-    if (license.url != null && license.path != null) {
-      final String escapedLink = htmlAttrEscape.convert(license.url);
-      final String escapedPath = htmlEscape.convert(license.path);
-      html += ' (<a href="$escapedLink">$escapedPath</a>)';
-    } else if (license.path != null) {
-      final String escapedPath = htmlEscape.convert(license.path);
-      html += ' ($escapedPath)';
-    }
-    return html;
-  }).join('<br/>');
+  if (license.url != null && license.path != null) {
+    final String escapedLink = htmlAttrEscape.convert(license.url);
+    final String escapedPath = htmlEscape.convert(license.path);
+    html += ' (<a href="$escapedLink">$escapedPath</a>)';
+  } else if (license.path != null) {
+    final String escapedPath = htmlEscape.convert(license.path);
+    html += ' ($escapedPath)';
+  }
+  return html;
 }
 
 String _renderDependencyList(AnalysisView analysis) {
@@ -189,7 +187,7 @@ String renderPkgInfoBox(
         ? null
         : _getAuthorsHtml(data.uploaderEmails),
     'license_html':
-        _renderLicenses(packageLinks.baseUrl, data.analysis?.licenses),
+        _renderLicense(packageLinks.baseUrl, data.analysis?.licenseFile),
     'dependencies_html': _renderDependencyList(data.analysis),
     'search_deps_link': urls.searchUrl(q: 'dependency:${package.name}'),
     'labeled_scores_html': renderLabeledScores(data.toPackageView()),
@@ -466,11 +464,9 @@ String renderPackageSchemaOrgHtml(PackagePageData data) {
     'image':
         '${urls.siteRoot}${staticUrls.staticPath}/img/pub-dev-icon-cover-image.png'
   };
-  final licenses = data.analysis?.licenses;
-  final firstUrl =
-      licenses?.firstWhere((lf) => lf.url != null, orElse: () => null)?.url;
-  if (firstUrl != null) {
-    map['license'] = firstUrl;
+  final licenseFileUrl = data.analysis?.licenseFile?.url;
+  if (licenseFileUrl != null) {
+    map['license'] = licenseFileUrl;
   }
   // TODO: add http://schema.org/codeRepository for github and gitlab links
   return '<script type="application/ld+json">\n${json.encode(map)}\n</script>\n';


### PR DESCRIPTION
Follows the changes in `pana` to handle only a single license file.