### PR TITLE
Update LICENSE file handling

### DIFF
--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -980,6 +980,15 @@ DerivedPackageVersionEntities derivePackageVersionEntities({
         path: archive.examplePath,
         textContent: archive.exampleContent,
       ),
+    if (archive.licensePath != null)
+      PackageVersionAsset.init(
+        package: key.package,
+        version: key.version,
+        kind: AssetKind.license,
+        versionCreated: versionCreated,
+        path: archive.licensePath,
+        textContent: archive.licenseContent,
+      ),
   ];
 
   final versionInfo = PackageVersionInfo()

--- a/app/lib/package/models.dart
+++ b/app/lib/package/models.dart
@@ -423,6 +423,7 @@ abstract class AssetKind {
   static const readme = 'readme';
   static const changelog = 'changelog';
   static const example = 'example';
+  static const license = 'license';
 }
 
 /// A derived entity that holds extracted asset of a [PackageVersion] archive.

--- a/app/test/package/backend_test_utils.dart
+++ b/app/test/package/backend_test_utils.dart
@@ -24,10 +24,12 @@ Future<List<int>> packageArchiveBytes({String pubspecContent}) async {
     final readme = File('$tmp/README.md');
     final changelog = File('$tmp/CHANGELOG.md');
     final pubspec = File('$tmp/pubspec.yaml');
+    final license = File('$tmp/LICENSE');
 
     await readme.writeAsString(foobarReadmeContent);
     await changelog.writeAsString(foobarChangelogContent);
     await pubspec.writeAsString(pubspecContent ?? foobarStablePubspec);
+    await license.writeAsString('BSD LICENSE 2.0');
 
     await Directory('$tmp/lib').create();
     await File('$tmp/lib/test_library.dart')
@@ -36,6 +38,7 @@ Future<List<int>> packageArchiveBytes({String pubspecContent}) async {
     final files = [
       'README.md',
       'CHANGELOG.md',
+      'LICENSE',
       'pubspec.yaml',
       'lib/test_library.dart'
     ];

--- a/pkg/pub_package_reader/lib/pub_package_reader.dart
+++ b/pkg/pub_package_reader/lib/pub_package_reader.dart
@@ -442,7 +442,7 @@ Iterable<ArchiveIssue> requireNonEmptyLicense(
     yield ArchiveIssue('LICENSE file `$path` has no content.');
     return;
   }
-  if (content.contains('TODO: Add your license here.')) {
+  if (content.toLowerCase().contains('todo: add your license here.')) {
     yield ArchiveIssue('LICENSE file `$path` contains generic TODO.');
     return;
   }

--- a/pkg/pub_package_reader/lib/src/file_names.dart
+++ b/pkg/pub_package_reader/lib/src/file_names.dart
@@ -32,3 +32,9 @@ List<String> exampleFileCandidates(String package) {
     ...textFileNameCandidates('example/readme'),
   ];
 }
+
+final licenseFileNames = <String>[
+  ...textFileNameCandidates('LICENSE'),
+  ...textFileNameCandidates('COPYING'),
+  ...textFileNameCandidates('UNLICENSE'),
+];

--- a/pkg/pub_package_reader/test/package_archive_test.dart
+++ b/pkg/pub_package_reader/test/package_archive_test.dart
@@ -462,4 +462,25 @@ $dependencies
       expect(requireIosFolderOrFlutter2_20(pubspec, ['ios/']), isEmpty);
     });
   });
+
+  group('require license content', () {
+    test('no license file', () {
+      expect(requireNonEmptyLicense(null, null), isNotEmpty);
+    });
+
+    test('empty file', () {
+      expect(requireNonEmptyLicense('LICENSE', ''), isNotEmpty);
+      expect(requireNonEmptyLicense('LICENSE', '\n  \n'), isNotEmpty);
+    });
+
+    test('generic TODO', () {
+      expect(
+          requireNonEmptyLicense('LICENSE', 'TODO: Add your license here.\n'),
+          isNotEmpty);
+    });
+
+    test('valid-looking license', () {
+      expect(requireNonEmptyLicense('LICENSE', 'BSD license'), isEmpty);
+    });
+  });
 }


### PR DESCRIPTION
- Empty license file is no longer accepted. fixes #3449 - although there would be more patterns that we can filter on, let's start with the trivial one.
- Storing license file as an asset, to eventually display it as a tab (#2226).