### PR TITLE
Better handling of version canonicalization

### DIFF
--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -898,10 +898,7 @@ Future<_ValidatedUpload> _parseAndValidateUpload(
 
   final packageKey = db.emptyKey.append(Package, id: pubspec.name);
 
-  final versionString = canonicalizeVersion(pubspec.version);
-  if (versionString == null) {
-    throw InvalidInputException.canonicalizeVersionError(pubspec.version);
-  }
+  final versionString = pubspec.canonicalVersion;
 
   final version = PackageVersion()
     ..id = versionString
@@ -936,7 +933,7 @@ DerivedPackageVersionEntities derivePackageVersionEntities({
 }) {
   final pubspec = Pubspec.fromYaml(archive.pubspecContent);
   final key = QualifiedVersionKey(
-      package: pubspec.name, version: canonicalizeVersion(pubspec.version));
+      package: pubspec.name, version: pubspec.canonicalVersion);
 
   final versionPubspec = PackageVersionPubspec()
     ..initFromKey(key)

--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -898,7 +898,11 @@ Future<_ValidatedUpload> _parseAndValidateUpload(
 
   final packageKey = db.emptyKey.append(Package, id: pubspec.name);
 
-  final versionString = pubspec.canonicalVersion;
+  final versionString = canonicalizeVersion(pubspec.nonCanonicalVersion);
+  if (versionString == null) {
+    throw InvalidInputException.canonicalizeVersionError(
+        pubspec.nonCanonicalVersion);
+  }
 
   final version = PackageVersion()
     ..id = versionString

--- a/app/lib/package/model_properties.dart
+++ b/app/lib/package/model_properties.dart
@@ -11,7 +11,6 @@ import 'package:pana/pana.dart' show SdkConstraintStatus;
 import 'package:pubspec_parse/pubspec_parse.dart' as pubspek show Pubspec;
 import 'package:yaml/yaml.dart';
 
-import '../shared/exceptions.dart' show InvalidInputException;
 import '../shared/utils.dart' show canonicalizeVersion;
 
 Map<String, dynamic> _loadYaml(String yamlString) {

--- a/app/lib/package/model_properties.dart
+++ b/app/lib/package/model_properties.dart
@@ -50,8 +50,8 @@ class Pubspec {
     if (_canonicalVersion == null) {
       _canonicalVersion = canonicalizeVersion(nonCanonicalVersion);
       if (_canonicalVersion == null) {
-        throw InvalidInputException.canonicalizeVersionError(
-            nonCanonicalVersion);
+        throw AssertionError(
+            'Unable to canonicalize the version: $nonCanonicalVersion');
       }
     }
     return _canonicalVersion;

--- a/app/lib/package/model_properties.dart
+++ b/app/lib/package/model_properties.dart
@@ -11,6 +11,9 @@ import 'package:pana/pana.dart' show SdkConstraintStatus;
 import 'package:pubspec_parse/pubspec_parse.dart' as pubspek show Pubspec;
 import 'package:yaml/yaml.dart';
 
+import '../shared/exceptions.dart' show InvalidInputException;
+import '../shared/utils.dart' show canonicalizeVersion;
+
 Map<String, dynamic> _loadYaml(String yamlString) {
   final map = loadYaml(yamlString) as Map;
   // TODO: remove this part after yaml returns a proper map
@@ -24,6 +27,7 @@ class Pubspec {
   final pubspek.Pubspec _inner;
   final String jsonString;
   Map<String, dynamic> _json;
+  String _canonicalVersion;
 
   Pubspec._(this._inner, this.jsonString);
 
@@ -41,7 +45,17 @@ class Pubspec {
 
   String get name => _inner.name;
 
-  String get version => _inner.version.toString();
+  String get nonCanonicalVersion => _inner.version.toString();
+  String get canonicalVersion {
+    if (_canonicalVersion == null) {
+      _canonicalVersion = canonicalizeVersion(nonCanonicalVersion);
+      if (_canonicalVersion == null) {
+        throw InvalidInputException.canonicalizeVersionError(
+            nonCanonicalVersion);
+      }
+    }
+    return _canonicalVersion;
+  }
 
   Iterable<String> get dependencies => _inner.dependencies.keys;
 

--- a/app/lib/shared/exceptions.dart
+++ b/app/lib/shared/exceptions.dart
@@ -45,10 +45,6 @@ class InvalidInputException extends ResponseException {
   InvalidInputException.continuationParseError()
       : this._('Parsing the continuation token failed.');
 
-  /// Thrown when the canonicalization of the [version] failed.
-  InvalidInputException.canonicalizeVersionError(String version)
-      : this._('Unable to canonicalize the version: $version');
-
   /// Check [condition] and throw [InvalidInputException] with [message] if
   /// [condition] is `false`.
   static void check(bool condition, String message) {

--- a/app/lib/shared/exceptions.dart
+++ b/app/lib/shared/exceptions.dart
@@ -45,6 +45,10 @@ class InvalidInputException extends ResponseException {
   InvalidInputException.continuationParseError()
       : this._('Parsing the continuation token failed.');
 
+  /// Thrown when the canonicalization of the [version] failed.
+  InvalidInputException.canonicalizeVersionError(String version)
+      : this._('Unable to canonicalize the version: $version');
+
   /// Check [condition] and throw [InvalidInputException] with [message] if
   /// [condition] is `false`.
   static void check(bool condition, String message) {

--- a/app/test/package/models_test.dart
+++ b/app/test/package/models_test.dart
@@ -124,7 +124,7 @@ version: 1.0.9
       final Pubspec p = Pubspec(pubspecBase);
       expect(p.name, 'test_package');
       expect(p.description, 'Test package');
-      expect(p.version, '1.0.9');
+      expect(p.canonicalVersion, '1.0.9');
     });
 
     group('Flutter', () {

--- a/pkg/pub_integration/test/browser_test.dart
+++ b/pkg/pub_integration/test/browser_test.dart
@@ -100,10 +100,24 @@ void main() {
               wait: Until.networkIdle);
 
           // check header with name and version
-          final headerTitle = await page.$('h1.title');
-          final headerTitleText =
-              await (await headerTitle.property('textContent')).jsonValue;
-          expect(headerTitleText, 'retry 2.0.0');
+          Future<void> checkHeaderTitle() async {
+            final headerTitle = await page.$('h1.title');
+            final headerTitleText =
+                await (await headerTitle.property('textContent')).jsonValue;
+            expect(headerTitleText, 'retry 2.0.1');
+          }
+
+          await checkHeaderTitle();
+
+          await page.goto(
+              'http://localhost:${fakePubServerProcess.port}/packages/retry/versions/2.0.1',
+              wait: Until.networkIdle);
+          await checkHeaderTitle();
+
+          await page.goto(
+              'http://localhost:${fakePubServerProcess.port}/packages/retry/versions/2.0.01',
+              wait: Until.networkIdle);
+          await checkHeaderTitle();
 
           // check uncaught exception
           expect(headlessEnv.clientErrors.isEmpty, true);

--- a/pkg/pub_integration/test_data/retry/pubspec.yaml
+++ b/pkg/pub_integration/test_data/retry/pubspec.yaml
@@ -1,5 +1,5 @@
 name: retry
-version: 2.0.0
+version: 2.0.01
 homepage: 'https://github.com/dart-lang/pub-dev'
 description: 'Dummy packages published from pub integration tests.'
 environment:


### PR DESCRIPTION
- explicit `Pubspec.canonicalVersion`
- updated end2end test to use non-canonical input
- #3905