### PR TITLE
Prepare search result listing + cache to handle non-latest-stable versions

### DIFF
--- a/app/bin/tools/uploader.dart
+++ b/app/bin/tools/uploader.dart
@@ -34,11 +34,13 @@ Future main(List<String> arguments) async {
     if (command == 'list') {
       await listUploaders(package);
     } else if (command == 'add') {
-      await addUploader(package, uploader);
-      await purgePackageCache(package);
+      final p = await addUploader(package, uploader);
+      await purgePackageCache(package,
+          versions: [p.latestVersion, p.latestPrereleaseVersion]);
     } else if (command == 'remove') {
-      await removeUploader(package, uploader);
-      await purgePackageCache(package);
+      final p = await removeUploader(package, uploader);
+      await purgePackageCache(package,
+          versions: [p.latestVersion, p.latestPrereleaseVersion]);
     }
   });
 
@@ -59,7 +61,7 @@ Future listUploaders(String packageName) async {
   });
 }
 
-Future addUploader(String packageName, String uploaderEmail) async {
+Future<Package> addUploader(String packageName, String uploaderEmail) async {
   return dbService.withTransaction((Transaction T) async {
     final package =
         (await T.lookup([dbService.emptyKey.append(Package, id: packageName)]))
@@ -87,10 +89,11 @@ Future addUploader(String packageName, String uploaderEmail) async {
       currentUserEmail: pubDartlangOrgEmail,
       addedUploaderEmails: [uploaderEmail],
     ));
+    return package;
   });
 }
 
-Future removeUploader(String packageName, String uploaderEmail) async {
+Future<Package> removeUploader(String packageName, String uploaderEmail) async {
   return dbService.withTransaction((Transaction T) async {
     final package =
         (await T.lookup([dbService.emptyKey.append(Package, id: packageName)]))
@@ -122,5 +125,6 @@ Future removeUploader(String packageName, String uploaderEmail) async {
       currentUserEmail: pubDartlangOrgEmail,
       removedUploaderEmails: [uploaderEmail],
     ));
+    return package;
   });
 }

--- a/app/lib/frontend/templates/listing.dart
+++ b/app/lib/frontend/templates/listing.dart
@@ -60,10 +60,13 @@ String renderPackageList(
       'is_external': view.isExternal,
       'external_type': externalType,
       'version': view.version,
-      'show_prerelease_version': view.prereleaseVersion != null,
-      'prerelease_version': view.prereleaseVersion,
+      'stable_version': view.latestStableVersion ?? view.version,
+      'stable_version_url': urls.pkgPageUrl(view.name),
+      'show_prerelease_version': view.latestPrereleaseVersion != null &&
+          view.latestStableVersion != view.latestPrereleaseVersion,
+      'prerelease_version': view.latestPrereleaseVersion,
       'prerelease_version_url':
-          urls.pkgPageUrl(view.name, version: view.prereleaseVersion),
+          urls.pkgPageUrl(view.name, version: view.latestPrereleaseVersion),
       'is_new': addedXAgo != null,
       'added_x_ago': addedXAgo,
       'last_uploaded': view.shortUpdated,

--- a/app/lib/frontend/templates/views/pkg/package_list.mustache
+++ b/app/lib/frontend/templates/views/pkg/package_list.mustache
@@ -24,7 +24,7 @@
     {{^is_external}}
     <p class="packages-metadata">
       <span class="packages-metadata-block">
-        v <a href="{{& url}}">{{version}}</a>
+        v <a href="{{& stable_version_url }}">{{ stable_version }}</a>
         {{#show_prerelease_version}} / <a href="{{& prerelease_version_url}}">{{prerelease_version}}</a>{{/show_prerelease_version}}
         • Published: <span>{{last_uploaded}}</span>
       </span>

--- a/app/lib/package/models.dart
+++ b/app/lib/package/models.dart
@@ -157,14 +157,10 @@ class Package extends db.ExpandoModel<String> {
     return <String>[
       // TODO(jonasfj): Remove the if (assignedTags != null) condition, we only
       //                need this until we've done backfill_package_fields.dart
-      if (assignedTags != null)
-        ...assignedTags,
-      if (isDiscontinued)
-        PackageTags.isDiscontinued,
-      if (isNewPackage())
-        PackageTags.isRecent,
-      if (doNotAdvertise)
-        PackageTags.isNotAdvertized,
+      if (assignedTags != null) ...assignedTags,
+      if (isDiscontinued) PackageTags.isDiscontinued,
+      if (isNewPackage()) PackageTags.isRecent,
+      if (doNotAdvertise) PackageTags.isNotAdvertized,
       // TODO: publisher:<publisherId>
       // TODO: uploader:<...>
     ];

--- a/app/lib/package/models.dart
+++ b/app/lib/package/models.dart
@@ -157,10 +157,14 @@ class Package extends db.ExpandoModel<String> {
     return <String>[
       // TODO(jonasfj): Remove the if (assignedTags != null) condition, we only
       //                need this until we've done backfill_package_fields.dart
-      if (assignedTags != null) ...assignedTags,
-      if (isDiscontinued) PackageTags.isDiscontinued,
-      if (isNewPackage()) PackageTags.isRecent,
-      if (doNotAdvertise) PackageTags.isNotAdvertized,
+      if (assignedTags != null)
+        ...assignedTags,
+      if (isDiscontinued)
+        PackageTags.isDiscontinued,
+      if (isNewPackage())
+        PackageTags.isRecent,
+      if (doNotAdvertise)
+        PackageTags.isNotAdvertized,
       // TODO: publisher:<publisherId>
       // TODO: uploader:<...>
     ];
@@ -564,9 +568,8 @@ class PackageView extends Object with FlagMixin {
   final String url;
   final String name;
   final String version;
-
-  // Not null only if there is a difference compared to the [version].
-  final String prereleaseVersion;
+  final String latestStableVersion;
+  final String latestPrereleaseVersion;
   final String ellipsizedDescription;
 
   /// The date when the package was first published.
@@ -599,7 +602,8 @@ class PackageView extends Object with FlagMixin {
     this.url,
     this.name,
     this.version,
-    this.prereleaseVersion,
+    this.latestStableVersion,
+    this.latestPrereleaseVersion,
     this.ellipsizedDescription,
     this.created,
     this.shortUpdated,
@@ -623,10 +627,6 @@ class PackageView extends Object with FlagMixin {
     ScoreCardData scoreCard,
     List<ApiPageRef> apiPages,
   }) {
-    final prereleaseVersion = package != null &&
-            package.latestVersion != package.latestPrereleaseVersion
-        ? package.latestPrereleaseVersion
-        : null;
     final hasPanaReport = scoreCard?.reportTypes != null &&
         scoreCard.reportTypes.contains(ReportType.pana);
     final isAwaiting =
@@ -640,7 +640,8 @@ class PackageView extends Object with FlagMixin {
     return PackageView(
       name: version?.package ?? package?.name,
       version: version?.version ?? package?.latestVersion,
-      prereleaseVersion: prereleaseVersion,
+      latestStableVersion: package?.latestVersion,
+      latestPrereleaseVersion: package?.latestPrereleaseVersion,
       ellipsizedDescription: version?.ellipsizedDescription,
       created: package.created,
       shortUpdated: version?.shortCreated ?? package?.shortUpdated,
@@ -668,7 +669,8 @@ class PackageView extends Object with FlagMixin {
       url: url,
       name: name,
       version: version,
-      prereleaseVersion: prereleaseVersion,
+      latestStableVersion: latestStableVersion,
+      latestPrereleaseVersion: latestPrereleaseVersion,
       ellipsizedDescription: ellipsizedDescription,
       created: created,
       shortUpdated: shortUpdated,

--- a/app/lib/package/models.g.dart
+++ b/app/lib/package/models.g.dart
@@ -12,7 +12,8 @@ PackageView _$PackageViewFromJson(Map<String, dynamic> json) {
     url: json['url'] as String,
     name: json['name'] as String,
     version: json['version'] as String,
-    prereleaseVersion: json['prereleaseVersion'] as String,
+    latestStableVersion: json['latestStableVersion'] as String,
+    latestPrereleaseVersion: json['latestPrereleaseVersion'] as String,
     ellipsizedDescription: json['ellipsizedDescription'] as String,
     created: json['created'] == null
         ? null
@@ -46,7 +47,8 @@ Map<String, dynamic> _$PackageViewToJson(PackageView instance) {
   writeNotNull('url', instance.url);
   writeNotNull('name', instance.name);
   writeNotNull('version', instance.version);
-  writeNotNull('prereleaseVersion', instance.prereleaseVersion);
+  writeNotNull('latestStableVersion', instance.latestStableVersion);
+  writeNotNull('latestPrereleaseVersion', instance.latestPrereleaseVersion);
   writeNotNull('ellipsizedDescription', instance.ellipsizedDescription);
   writeNotNull('created', instance.created?.toIso8601String());
   writeNotNull('shortUpdated', instance.shortUpdated);

--- a/app/lib/scorecard/backend.dart
+++ b/app/lib/scorecard/backend.dart
@@ -241,8 +241,9 @@ class ScoreCardBackend {
     await Future.wait([
       cache.scoreCardData(packageName, packageVersion).purge(),
       cache.uiPackagePage(packageName, packageVersion).purge(),
+      cache.packageView(packageName, packageVersion).purge(),
       if (isLatest) cache.uiPackagePage(packageName, null).purge(),
-      if (isLatest) cache.packageView(packageName).purge(),
+      if (isLatest) cache.packageView(packageName, null).purge(),
     ]);
   }
 

--- a/app/lib/search/backend.dart
+++ b/app/lib/search/backend.dart
@@ -113,6 +113,7 @@ class SearchBackend {
     return PackageDocument(
       package: pv.package,
       version: p.latestVersion,
+      isLatestStable: p.latestVersion == pv.version,
       tags: tags,
       description: compactDescription(pv.pubspec.description),
       created: p.created,
@@ -161,6 +162,7 @@ class SearchBackend {
       yield PackageDocument(
         package: p.name,
         version: p.latestVersion,
+        isLatestStable: true,
         tags: p.getTags(),
         created: p.created,
         updated: p.updated,

--- a/app/lib/search/mem_index.dart
+++ b/app/lib/search/mem_index.dart
@@ -476,8 +476,13 @@ class InMemoryPackageIndex implements PackageIndex {
   List<PackageScore> _rankWithValues(Map<String, double> values) {
     final List<PackageScore> list = values.keys
         .map((package) {
+          final doc = _packages[package];
           final score = values[package];
-          return PackageScore(package: package, score: score);
+          return PackageScore(
+            package: package,
+            version: doc.isLatestStable == false ? doc.version : null,
+            score: score,
+          );
         })
         .where((ps) => ps != null)
         .toList();
@@ -492,9 +497,13 @@ class InMemoryPackageIndex implements PackageIndex {
 
   List<PackageScore> _rankWithComparator(Set<String> packages,
       int Function(PackageDocument a, PackageDocument b) compare) {
-    final List<PackageScore> list = packages
-        .map((package) => PackageScore(package: _packages[package].package))
-        .toList();
+    final List<PackageScore> list = packages.map((package) {
+      final doc = _packages[package];
+      return PackageScore(
+        package: package,
+        version: doc.isLatestStable == false ? doc.version : null,
+      );
+    }).toList();
     list.sort((a, b) => compare(_packages[a.package], _packages[b.package]));
     return list;
   }

--- a/app/lib/search/search_service.dart
+++ b/app/lib/search/search_service.dart
@@ -74,6 +74,7 @@ abstract class PackageIndex {
 class PackageDocument {
   final String package;
   final String version;
+  final bool isLatestStable;
   final String description;
   final DateTime created;
   final DateTime updated;
@@ -103,6 +104,7 @@ class PackageDocument {
   PackageDocument({
     this.package,
     this.version,
+    this.isLatestStable,
     this.description,
     this.created,
     this.updated,
@@ -724,7 +726,7 @@ class PackageScore {
 
   PackageScore onlyPackageName() => PackageScore(package: package);
 
-  bool get isExternal => url != null && version != null && description != null;
+  bool get isExternal => url != null && description != null;
 
   Map<String, dynamic> toJson() => _$PackageScoreToJson(this);
 }

--- a/app/lib/search/search_service.g.dart
+++ b/app/lib/search/search_service.g.dart
@@ -10,6 +10,7 @@ PackageDocument _$PackageDocumentFromJson(Map<String, dynamic> json) {
   return PackageDocument(
     package: json['package'] as String,
     version: json['version'] as String,
+    isLatestStable: json['isLatestStable'] as bool,
     description: json['description'] as String,
     created: json['created'] == null
         ? null
@@ -43,6 +44,7 @@ Map<String, dynamic> _$PackageDocumentToJson(PackageDocument instance) =>
     <String, dynamic>{
       'package': instance.package,
       'version': instance.version,
+      'isLatestStable': instance.isLatestStable,
       'description': instance.description,
       'created': instance.created?.toIso8601String(),
       'updated': instance.updated?.toIso8601String(),

--- a/app/lib/shared/redis_cache.dart
+++ b/app/lib/shared/redis_cache.dart
@@ -122,7 +122,7 @@ class CachePatterns {
       .withPrefix('api-package-data-by-uri')
       .withTTL(Duration(minutes: 10))['$package'];
 
-  Entry<PackageView> packageView(String package) => _cache
+  Entry<PackageView> packageView(String package, String version) => _cache
       .withPrefix('package-view')
       .withTTL(Duration(minutes: 60))
       .withCodec(utf8)
@@ -130,7 +130,7 @@ class CachePatterns {
       .withCodec(wrapAsCodec(
         encode: (PackageView pv) => pv.toJson(),
         decode: (d) => PackageView.fromJson(d as Map<String, dynamic>),
-      ))[package];
+      ))['$package-$version'];
 
   Entry<Map<String, dynamic>> apiPackagesListPage(int page) => _cache
       .withPrefix('api-packages-list')

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -626,7 +626,8 @@ void main() {
           PackageView(
             name: 'another_package',
             version: '2.0.0',
-            prereleaseVersion: '3.0.0-beta2',
+            latestStableVersion: '2.0.0',
+            latestPrereleaseVersion: '3.0.0-beta2',
             ellipsizedDescription: 'Camera plugin.',
             created: DateTime.utc(2019, 03, 30),
             shortUpdated: '30 Mar 2019',
@@ -660,7 +661,8 @@ void main() {
           PackageView(
             name: 'another_package',
             version: '2.0.0',
-            prereleaseVersion: '3.0.0-beta2',
+            latestStableVersion: '2.0.0',
+            latestPrereleaseVersion: '3.0.0-beta2',
             ellipsizedDescription: 'Camera plugin.',
             created: DateTime.utc(2019, 03, 30),
             shortUpdated: '30 Mar 2019',


### PR DESCRIPTION
- `PackageView` is used (among other things) to display the search results (ideally from cache).
  - Updated cache handling to use versions (if specified).
  - Storing latest stable and prerelease versions on it separately.
- `search` returns `version` if it is explicitly not the latest stable (will be used later when the index stores prerelease versions too)
- SDK index's `isExternal` flag is updated to care only about whether the `url` and the `description` is provided.