### PR TITLE
Upgrade pana

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@ Important changes to data-models, configuration and migrations between each
 AppEngine version, listed here to ease deployment and troubleshooting.
 
 ## Next Release (replace with git tag when deployed)
- * Bumped runtimeVersion to `2020.08.07`.
+ * Bumped runtimeVersion to `2020.08.11`.
  * Upgraded runtime Dart SDK to `2.9.0`.
  * Upgraded Flutter to `1.20.1`.
  * Upgraded dartdoc to `0.32.3`.
+ * Upgraded pana to `0.14.0`.
  * Potential memory consumption changes:
    * the SDK seems to consume more memory
    * the `search` index no longer stores the combined text, should need less memory

--- a/app/lib/analyzer/analyzer_client.dart
+++ b/app/lib/analyzer/analyzer_client.dart
@@ -90,7 +90,8 @@ class AnalysisView {
 
   List<String> get derivedTags => _card?.derivedTags ?? const <String>[];
 
-  List<LicenseFile> get licenses => _pana?.licenses;
+  List<LicenseFile> get licenses =>
+      _pana?.licenseFile == null ? null : [_pana?.licenseFile];
 
   List<PkgDependency> get directDependencies =>
       _getDependencies(DependencyTypes.direct);

--- a/app/lib/analyzer/pana_runner.dart
+++ b/app/lib/analyzer/pana_runner.dart
@@ -134,13 +134,15 @@ class AnalyzerJobProcessor extends JobProcessor {
 PanaReport panaReportFromSummary(Summary summary, {List<String> flags}) {
   final reportStatus =
       summary == null ? ReportStatus.aborted : ReportStatus.success;
+  final licenses = summary?.licenseFile == null ? null : [summary.licenseFile];
   return PanaReport(
     timestamp: DateTime.now().toUtc(),
     panaRuntimeInfo: summary?.runtimeInfo,
     reportStatus: reportStatus,
     derivedTags: summary?.tags,
     pkgDependencies: summary?.pkgResolution?.dependencies,
-    licenses: summary?.licenses,
+    licenses: licenses,
+    licenseFile: summary?.licenseFile,
     report: summary?.report,
     flags: flags,
   );

--- a/app/lib/scorecard/models.dart
+++ b/app/lib/scorecard/models.dart
@@ -336,7 +336,10 @@ class PanaReport implements ReportData {
 
   final List<PkgDependency> pkgDependencies;
 
+  // TODO: remove after `2020.08.05` release is no longer accepted.
   final List<LicenseFile> licenses;
+
+  final LicenseFile licenseFile;
 
   @JsonKey(includeIfNull: false)
   final Report report;
@@ -352,10 +355,14 @@ class PanaReport implements ReportData {
     @required this.reportStatus,
     @required this.derivedTags,
     @required this.pkgDependencies,
-    @required this.licenses,
+    List<LicenseFile> licenses,
+    @required LicenseFile licenseFile,
     @required this.report,
     @required this.flags,
-  });
+  })  : licenses = licenses,
+        // when reading older reports: populate field from the list of licenses
+        licenseFile = licenseFile ??
+            (licenses == null || licenses.isEmpty ? null : licenses.first);
 
   factory PanaReport.fromJson(Map<String, dynamic> json) =>
       _$PanaReportFromJson(json);

--- a/app/lib/scorecard/models.g.dart
+++ b/app/lib/scorecard/models.g.dart
@@ -69,6 +69,9 @@ PanaReport _$PanaReportFromJson(Map<String, dynamic> json) {
         ?.map((e) =>
             e == null ? null : LicenseFile.fromJson(e as Map<String, dynamic>))
         ?.toList(),
+    licenseFile: json['licenseFile'] == null
+        ? null
+        : LicenseFile.fromJson(json['licenseFile'] as Map<String, dynamic>),
     report: json['report'] == null
         ? null
         : Report.fromJson(json['report'] as Map<String, dynamic>),
@@ -84,6 +87,7 @@ Map<String, dynamic> _$PanaReportToJson(PanaReport instance) {
     'derivedTags': instance.derivedTags,
     'pkgDependencies': instance.pkgDependencies,
     'licenses': instance.licenses,
+    'licenseFile': instance.licenseFile,
   };
 
   void writeNotNull(String key, dynamic value) {

--- a/app/lib/shared/versions.dart
+++ b/app/lib/shared/versions.dart
@@ -21,7 +21,8 @@ final RegExp runtimeVersionPattern = RegExp(r'^\d{4}\.\d{2}\.\d{2}$');
 /// Make sure that at least two versions are kept here as the next candidates
 /// when the version switch happens.
 const acceptedRuntimeVersions = <String>[
-  '2020.08.07', // The current [runtimeVersion].
+  '2020.08.11', // The current [runtimeVersion].
+  // TODO: when removing, also remove PanaReport.licenses
   '2020.08.05',
   '2020.08.03',
 ];

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -462,7 +462,7 @@ packages:
       name: pana
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.16"
+    version: "0.14.0"
   path:
     dependency: "direct main"
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -42,7 +42,7 @@ dependencies:
   watcher: ^0.9.7
   yaml: '^2.1.12'
   # pana version to be pinned
-  pana: '0.13.16'
+  pana: '0.14.0'
   # 3rd-party packages with pinned versions
   archive: '2.0.11'
   mailer: '3.0.4'

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -170,7 +170,7 @@ void main() {
                 errors: null,
               )
             ],
-            licenses: [LicenseFile('LICENSE.txt', 'BSD')],
+            licenseFile: LicenseFile('LICENSE.txt', 'BSD'),
             report: Report(sections: <ReportSection>[]),
             flags: null),
         dartdocReport: DartdocReport(
@@ -257,7 +257,7 @@ void main() {
                   errors: null,
                 )
               ],
-              licenses: [LicenseFile('LICENSE.txt', 'BSD')],
+              licenseFile: LicenseFile('LICENSE.txt', 'BSD'),
               report: Report(sections: <ReportSection>[]),
               flags: null),
           dartdocReport: null,
@@ -286,7 +286,7 @@ void main() {
               reportStatus: ReportStatus.success,
               derivedTags: ['sdk:flutter', 'platform:android'],
               pkgDependencies: null,
-              licenses: null,
+              licenseFile: null,
               report: Report(sections: <ReportSection>[]),
               flags: null),
         ),
@@ -429,7 +429,7 @@ void main() {
                 errors: null,
               ),
             ],
-            licenses: null,
+            licenseFile: null,
             report: Report(sections: <ReportSection>[]),
             flags: null),
       );
@@ -458,7 +458,7 @@ void main() {
             reportStatus: ReportStatus.aborted,
             derivedTags: null,
             pkgDependencies: null,
-            licenses: null,
+            licenseFile: null,
             report: Report(sections: <ReportSection>[]),
             flags: null,
           ),

--- a/app/test/shared/test_models.dart
+++ b/app/test/shared/test_models.dart
@@ -396,7 +396,7 @@ PanaReport generatePanaReport({List<String> derivedTags}) {
     reportStatus: ReportStatus.success,
     derivedTags: derivedTags ?? <String>[],
     pkgDependencies: null,
-    licenses: null,
+    licenseFile: null,
     flags: null,
     report: Report(sections: <ReportSection>[]),
   );

--- a/app/test/shared/versions_test.dart
+++ b/app/test/shared/versions_test.dart
@@ -33,7 +33,7 @@ void main() {
     // This test is a reminder that if pana, the SDK or any of the above
     // versions change, we should also adjust the [runtimeVersion]. Before
     // updating the hash value, double-check if it is being updated.
-    expect(hash, 944089068);
+    expect(hash, 491059909);
   });
 
   test('accepted runtime versions should be lexicographically ordered', () {


### PR DESCRIPTION
Changed `PanaReport` to also store a single licenseFile (and for the time being store the list too). This list of licenses can be removed after a the currently live runtimeVersion is no longer accepted.