### PR TITLE
Stronger landing page to survive search outages.

### DIFF
--- a/app/lib/frontend/handlers/landing.dart
+++ b/app/lib/frontend/handlers/landing.dart
@@ -47,20 +47,19 @@ Future<shelf.Response> indexLandingHandler(shelf.Request request) async {
   }
 
   Future<String> _render() async {
-    final ffPackages = await topFeaturedPackages(
+    final ffPackages = await searchAdapter.topFeatured(
       requiredTags: [PackageTags.isFlutterFavorite],
       count: 4,
-      emptyFallback: true,
     );
 
     final mostPopularPackages =
-        await topFeaturedPackages(order: SearchOrder.popularity);
+        await searchAdapter.topFeatured(order: SearchOrder.popularity);
 
     final topFlutterPackages =
-        await topFeaturedPackages(requiredTags: [SdkTag.sdkFlutter]);
+        await searchAdapter.topFeatured(requiredTags: [SdkTag.sdkFlutter]);
 
     final topDartPackages =
-        await topFeaturedPackages(requiredTags: [SdkTag.sdkDart]);
+        await searchAdapter.topFeatured(requiredTags: [SdkTag.sdkDart]);
 
     return renderLandingPage(
       ffPackages: ffPackages,

--- a/app/lib/search/search_client.dart
+++ b/app/lib/search/search_client.dart
@@ -33,7 +33,7 @@ class SearchClient {
 
   SearchClient([http.Client client]) : _httpClient = client ?? http.Client();
 
-  Future<PackageSearchResult> search(SearchQuery query) async {
+  Future<PackageSearchResult> search(SearchQuery query, {Duration ttl}) async {
     final String httpHostPort = activeConfiguration.searchServicePrefix;
     final String serviceUrlParams =
         Uri(queryParameters: query.toServiceQueryParameters()).toString();
@@ -75,7 +75,9 @@ class SearchClient {
     if (query.randomize) {
       return await searchFn();
     } else {
-      return await cache.packageSearchResult(serviceUrl).get(searchFn);
+      return await cache
+          .packageSearchResult(serviceUrl, ttl: ttl)
+          .get(searchFn);
     }
   }
 

--- a/app/lib/search/search_service.dart
+++ b/app/lib/search/search_service.dart
@@ -238,11 +238,11 @@ class SearchQuery {
   /// True, if the result list should be a random sample of packages matching
   /// this [SearchQuery]. The range, method and weights of the random sampling
   /// is up to the index implementation.
+  /// TODO: remove when 2020.08.12 is no longer accepted runtimeVersion.
   final bool randomize;
 
   SearchQuery._({
     this.query,
-    String platform,
     TagsPredicate tagsPredicate,
     List<String> uploaderOrPublishers,
     String publisherId,
@@ -327,7 +327,6 @@ class SearchQuery {
 
   SearchQuery change({
     String query,
-    String platform,
     String sdk,
     TagsPredicate tagsPredicate,
     List<String> uploaderOrPublishers,

--- a/app/lib/service/services.dart
+++ b/app/lib/service/services.dart
@@ -112,6 +112,7 @@ Future<void> withPubServices(FutureOr<void> Function() fn) async {
     registerScopeExitCallback(authProvider.close);
     registerScopeExitCallback(dartdocClient.close);
     registerScopeExitCallback(searchClient.close);
+    registerScopeExitCallback(searchAdapter.close);
 
     return await withCache(fn);
   });

--- a/app/lib/shared/redis_cache.dart
+++ b/app/lib/shared/redis_cache.dart
@@ -142,15 +142,19 @@ class CachePatterns {
         decode: (obj) => obj as Map<String, dynamic>,
       ))['$page'];
 
-  Entry<PackageSearchResult> packageSearchResult(String url) => _cache
-      .withPrefix('search-result')
-      .withTTL(Duration(minutes: 10))
-      .withCodec(utf8)
-      .withCodec(json)
-      .withCodec(wrapAsCodec(
-        encode: (PackageSearchResult r) => r.toJson(),
-        decode: (d) => PackageSearchResult.fromJson(d as Map<String, dynamic>),
-      ))[url];
+  Entry<PackageSearchResult> packageSearchResult(String url, {Duration ttl}) {
+    ttl ??= const Duration(minutes: 10);
+    return _cache
+        .withPrefix('search-result')
+        .withTTL(ttl)
+        .withCodec(utf8)
+        .withCodec(json)
+        .withCodec(wrapAsCodec(
+          encode: (PackageSearchResult r) => r.toJson(),
+          decode: (d) =>
+              PackageSearchResult.fromJson(d as Map<String, dynamic>),
+        ))[url];
+  }
 
   Entry<ScoreCardData> scoreCardData(String package, String version) => _cache
       .withPrefix('scorecarddata')

--- a/app/lib/shared/versions.dart
+++ b/app/lib/shared/versions.dart
@@ -21,7 +21,7 @@ final RegExp runtimeVersionPattern = RegExp(r'^\d{4}\.\d{2}\.\d{2}$');
 /// Make sure that at least two versions are kept here as the next candidates
 /// when the version switch happens.
 const acceptedRuntimeVersions = <String>[
-  // TODO: when removing, also remove SearchQuery.randomize
+  // TODO: when removing '2020.08.24', also remove SearchQuery.randomize
   '2020.08.24', // The current [runtimeVersion].
   '2020.08.12',
   // TODO: when removing, also remove PanaReport.licenses

--- a/app/lib/shared/versions.dart
+++ b/app/lib/shared/versions.dart
@@ -21,6 +21,7 @@ final RegExp runtimeVersionPattern = RegExp(r'^\d{4}\.\d{2}\.\d{2}$');
 /// Make sure that at least two versions are kept here as the next candidates
 /// when the version switch happens.
 const acceptedRuntimeVersions = <String>[
+  // TODO: when removing, also remove SearchQuery.randomize
   '2020.08.24', // The current [runtimeVersion].
   '2020.08.12',
   // TODO: when removing, also remove PanaReport.licenses

--- a/app/test/frontend/handlers/landing_test.dart
+++ b/app/test/frontend/handlers/landing_test.dart
@@ -39,9 +39,7 @@ void main() {
       await expectHtmlResponse(
         rs,
         present: [
-          '/packages/http',
-          '/packages/event_bus',
-          'lightweight library for parsing',
+          'Find and use packages to build',
         ],
         absent: [
           '/packages/helium',

--- a/pkg/pub_integration/lib/pub_integration.dart
+++ b/pkg/pub_integration/lib/pub_integration.dart
@@ -13,7 +13,7 @@ Future verifyPub({
   @required String credentialsFileContent,
   @required String invitedEmail,
   @required InviteCompleterFn inviteCompleterFn,
-  bool omitDocumentationPage = false,
+  bool expectLiveSite = true,
   String clientSdkDir,
 }) async {
   final pubToolScript = PublishingScript(
@@ -22,10 +22,13 @@ Future verifyPub({
     credentialsFileContent,
     invitedEmail,
     inviteCompleterFn,
-    omitDocumentationPage,
+    expectLiveSite,
   );
   await pubToolScript.verify();
 
-  final publicPagesScript = PublicPagesScript(pubHostedUrl);
+  final publicPagesScript = PublicPagesScript(
+    pubHostedUrl,
+    expectLiveSite: expectLiveSite,
+  );
   await publicPagesScript.verify();
 }

--- a/pkg/pub_integration/lib/script/public_pages.dart
+++ b/pkg/pub_integration/lib/script/public_pages.dart
@@ -2,15 +2,21 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:meta/meta.dart';
+
 import '../src/pub_http_client.dart';
 
 /// A single object to execute integration script and verification tests querying
 /// public pages on the pub.dev site (or on a test site).
 class PublicPagesScript {
   final String pubHostedUrl;
+  final bool expectLiveSite;
   PubHttpClient _pubClient;
 
-  PublicPagesScript(this.pubHostedUrl);
+  PublicPagesScript(
+    this.pubHostedUrl, {
+    @required this.expectLiveSite,
+  });
 
   /// Verify public pages.
   Future<void> verify() async {
@@ -31,8 +37,11 @@ class PublicPagesScript {
 
   Future<void> _landingPage() async {
     final html = await _pubClient.getContent('/');
-    _contains(html, 'Top packages');
-    _contains(html, 'View all');
+    _contains(html, 'Find and use packages');
+    if (expectLiveSite) {
+      _contains(html, 'Top packages');
+      _contains(html, 'View all');
+    }
   }
 
   Future<void> _helpPages() async {

--- a/pkg/pub_integration/lib/script/publishing.dart
+++ b/pkg/pub_integration/lib/script/publishing.dart
@@ -25,7 +25,7 @@ class PublishingScript {
   final String credentialsFileContent;
   final String invitedEmail;
   final InviteCompleterFn inviteCompleterFn;
-  final bool omitDocumentationPage;
+  final bool expectLiveSite;
   PubHttpClient _pubHttpClient;
   PubToolClient _pubToolClient;
 
@@ -43,7 +43,7 @@ class PublishingScript {
     this.credentialsFileContent,
     this.invitedEmail,
     this.inviteCompleterFn,
-    this.omitDocumentationPage,
+    this.expectLiveSite,
   );
 
   /// Verify all integration steps.
@@ -94,7 +94,7 @@ class PublishingScript {
       await _pubToolClient.removeUploader(_dummyDir.path, invitedEmail);
       await _verifyDummyPkg(matchInvited: false);
 
-      if (!omitDocumentationPage) {
+      if (expectLiveSite) {
         await _verifyDummyDocumentation();
       }
     } finally {

--- a/pkg/pub_integration/test/pub_integration_test.dart
+++ b/pkg/pub_integration/test/pub_integration_test.dart
@@ -66,7 +66,7 @@ void main() {
         invitedEmail: 'dev@example.org',
         inviteCompleterFn: inviteCompleterFn,
         clientSdkDir: Platform.environment['PUB_INTEGRATION_CLIENT_SDK_DIR'],
-        omitDocumentationPage: true,
+        expectLiveSite: false,
       );
     });
   }, timeout: Timeout.factor(testTimeoutFactor));


### PR DESCRIPTION
- no more hardcoded fallback lists - if both search and cache is unavailable, the sections are not displayed
- 6 hours of caching for each of the top sections should be enough - based on the search outages we've had in the past
- local random selection will pick the first package from the top 20