### PR TITLE
Reduce race conditions in Job processing

### DIFF
--- a/app/lib/job/job.dart
+++ b/app/lib/job/job.dart
@@ -133,7 +133,6 @@ class JobMaintenance {
           task.package,
           version: task.version,
           updated: task.updated,
-          isHighPriority: true,
         );
       } catch (e, st) {
         _logger.info('Head sync failed for $task', e, st);


### PR DESCRIPTION
Should help with #3954:
- change check ignores timestamps that are earlier than currently known (== repeated trigger)
- change check ignores larger priority values
- job selection does not treat priority 0 as preferential (which increased race conditions)
- job completion accepts successful completions when race happened (no retry)
- new version scanning doesn't trigger the high-priority flag
