### PR TITLE
Fine-tuning Job priority, selection and lock periods

### DIFF
--- a/app/lib/analyzer/pana_runner.dart
+++ b/app/lib/analyzer/pana_runner.dart
@@ -21,11 +21,9 @@ class AnalyzerJobProcessor extends JobProcessor {
   final _urlChecker = UrlChecker();
 
   AnalyzerJobProcessor({
-    Duration lockDuration,
     @required AliveCallback aliveCallback,
   }) : super(
           service: JobService.analyzer,
-          lockDuration: lockDuration,
           aliveCallback: aliveCallback,
         );
 

--- a/app/lib/dartdoc/dartdoc_runner.dart
+++ b/app/lib/dartdoc/dartdoc_runner.dart
@@ -42,11 +42,9 @@ final _pkgPubDartdocDir =
 
 class DartdocJobProcessor extends JobProcessor {
   DartdocJobProcessor({
-    Duration lockDuration,
     @required AliveCallback aliveCallback,
   }) : super(
           service: JobService.dartdoc,
-          lockDuration: lockDuration,
           aliveCallback: aliveCallback,
         );
 

--- a/app/lib/job/job.dart
+++ b/app/lib/job/job.dart
@@ -35,6 +35,7 @@ abstract class JobProcessor {
 
   JobProcessor({
     @required this.service,
+
     /// [JobProcessor] calls this to indicate that it is still alive and working.
     /// It is expected to be called between jobs.
     AliveCallback aliveCallback,
@@ -54,8 +55,7 @@ abstract class JobProcessor {
       final sw = Stopwatch()..start();
       var statEvent = 'failed';
       try {
-        final job =
-            await jobBackend.lockAvailable(service);
+        final job = await jobBackend.lockAvailable(service);
         if (job != null) {
           jobDescription = '${job.packageName} ${job.packageVersion}';
           _logger.info('$_serviceAsString job started: $jobDescription');

--- a/app/lib/job/job.dart
+++ b/app/lib/job/job.dart
@@ -29,15 +29,12 @@ typedef AliveCallback = Function();
 
 abstract class JobProcessor {
   final JobService service;
-  final Duration lockDuration;
   final String _serviceAsString;
   final AliveCallback _aliveCallback;
   final _trackers = <String, DurationTracker>{};
 
   JobProcessor({
     @required this.service,
-    this.lockDuration,
-
     /// [JobProcessor] calls this to indicate that it is still alive and working.
     /// It is expected to be called between jobs.
     AliveCallback aliveCallback,
@@ -58,7 +55,7 @@ abstract class JobProcessor {
       var statEvent = 'failed';
       try {
         final job =
-            await jobBackend.lockAvailable(service, lockDuration: lockDuration);
+            await jobBackend.lockAvailable(service);
         if (job != null) {
           jobDescription = '${job.packageName} ${job.packageVersion}';
           _logger.info('$_serviceAsString job started: $jobDescription');

--- a/app/lib/job/model.dart
+++ b/app/lib/job/model.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:math' as math;
-
 import 'package:gcloud/db.dart';
 import 'package:pub_semver/pub_semver.dart';
 
@@ -110,25 +108,22 @@ class Job extends ExpandoModel<String> {
     final age = now.difference(packageVersionUpdated).abs();
     priority += age.inDays;
 
-    // popular packages first
-    if (isLatestStable &&
+    // popular packages first - except fresh uploads which are not pushed back
+    // based on their popularity.
+    if (age.inHours >= 8 &&
         popularity != null &&
         popularity >= 0.0 &&
         popularity <= 1.0) {
-      priority += ((1 - popularity) * 1000).round();
-    } else {
-      priority += 2000;
+      priority += ((1 - popularity) * 2000).round();
     }
 
     // non-latest stable versions get pushed back in the queue
     if (!isLatestStable) {
       priority += 100000;
-      priority +=
-          math.max(0, age.inDays - 180) * 100; // penalty for older versions
     }
 
     // errors encountered, pushing it back in the queue
-    priority += math.min(errorCount, 100) * 1000 + errorCount;
+    priority += errorCount * 100;
   }
 }
 

--- a/app/lib/service/entrypoint/dartdoc.dart
+++ b/app/lib/service/entrypoint/dartdoc.dart
@@ -81,7 +81,6 @@ Future _workerMain(WorkerEntryMessage message) async {
     await popularityStorage.init();
 
     final jobProcessor = DartdocJobProcessor(
-      lockDuration: const Duration(minutes: 30),
       aliveCallback: () => message.aliveSendPort.send(null),
     );
     await jobProcessor.generateDocsForSdk();


### PR DESCRIPTION
- Fixes #3954. (The issue seems to be resolved, and the following fine-tuning will improve things a bit)
- Removed dartdoc's `lockDuration` value because it was lower than the default.
- Removed the now-unused `lockDuration` parameters.
- Added a long-term lock extension period for Jobs that completed successfully and for Jobs that keep failing repeatedly.  This will lower the number of Datastore updates.
- Updated Job priority calculation: simpler logic, new uploads get slightly higher priority.
- Job selections random distribution is now biased towards the lower values.
