### PR TITLE
Update DartdocEntry's latest version flag

### DIFF
--- a/app/lib/dartdoc/backend.dart
+++ b/app/lib/dartdoc/backend.dart
@@ -19,6 +19,7 @@ import 'package:retry/retry.dart';
 import 'package:pub_dartdoc_data/pub_dartdoc_data.dart';
 
 import '../dartdoc/models.dart' show DartdocEntry;
+import '../package/backend.dart';
 import '../package/models.dart' show Package, PackageVersion;
 import '../scorecard/backend.dart';
 import '../shared/redis_cache.dart' show cache;
@@ -76,13 +77,6 @@ class DartdocBackend {
   /// Schedules the delete of old data files.
   void scheduleOldDataGC() {
     _sdkStorage.scheduleOldDataGC();
-  }
-
-  /// Returns the latest stable version of a package.
-  Future<String> getLatestVersion(String package) async {
-    final list = await _db.lookup([_db.emptyKey.append(Package, id: package)]);
-    final p = list.single as Package;
-    return p?.latestVersion;
   }
 
   Future<List<String>> getLatestVersions(String package,
@@ -230,7 +224,7 @@ class DartdocBackend {
     if (version != 'latest') {
       entry = await loadVersion(version);
     } else {
-      final latestVersion = await dartdocBackend.getLatestVersion(package);
+      final latestVersion = await packageBackend.getLatestVersion(package);
       if (latestVersion == null) {
         return null;
       }

--- a/app/lib/dartdoc/dartdoc_runner.dart
+++ b/app/lib/dartdoc/dartdoc_runner.dart
@@ -16,6 +16,7 @@ import 'package:pub_dartdoc_data/pub_dartdoc_data.dart';
 import '../frontend/static_files.dart';
 import '../job/backend.dart';
 import '../job/job.dart';
+import '../package/backend.dart';
 import '../scorecard/backend.dart';
 import '../scorecard/models.dart';
 import '../shared/configuration.dart';
@@ -159,7 +160,7 @@ class DartdocJobProcessor extends JobProcessor {
     final toolEnvRef = await getOrCreateToolEnvRef();
 
     final latestVersion =
-        await dartdocBackend.getLatestVersion(job.packageName);
+        await packageBackend.getLatestVersion(job.packageName);
     final bool isLatestStable = latestVersion == job.packageVersion;
     bool depsResolved = false;
     DartdocResult dartdocResult;

--- a/app/lib/frontend/handlers/documentation.dart
+++ b/app/lib/frontend/handlers/documentation.dart
@@ -7,6 +7,7 @@ import 'dart:io';
 
 import 'package:http_parser/http_parser.dart';
 import 'package:path/path.dart' as p;
+import 'package:pub_dev/package/backend.dart';
 // ignore: implementation_imports
 import 'package:pub_package_reader/src/names.dart';
 import 'package:pub_semver/pub_semver.dart';
@@ -43,8 +44,11 @@ Future<shelf.Response> documentationHandler(shelf.Request request) async {
     return redirectResponse(pkgVersionsUrl(docFilePath.package));
   }
   if (entry.isLatest == true && docFilePath.version != 'latest') {
-    return redirectResponse(pkgDocUrl(docFilePath.package,
-        isLatest: true, relativePath: docFilePath.path));
+    final version = await packageBackend.getLatestVersion(entry.packageName);
+    if (version == docFilePath.version) {
+      return redirectResponse(pkgDocUrl(docFilePath.package,
+          isLatest: true, relativePath: docFilePath.path));
+    }
   }
   if (requestMethod == 'HEAD') {
     if (!entry.hasContent && docFilePath.path.endsWith('.html')) {

--- a/app/lib/shared/redis_cache.dart
+++ b/app/lib/shared/redis_cache.dart
@@ -122,6 +122,11 @@ class CachePatterns {
       .withPrefix('api-package-data-by-uri')
       .withTTL(Duration(minutes: 10))['$package'];
 
+  Entry<String> packageLatestVersion(String package) => _cache
+      .withPrefix('package-latest-version')
+      .withTTL(Duration(minutes: 60))
+      .withCodec(utf8)[package];
+
   Entry<PackageView> packageView(String package) => _cache
       .withPrefix('package-view')
       .withTTL(Duration(minutes: 60))


### PR DESCRIPTION
- Addresses issues uncovered in #2762.
- redirect to `/documentations/<package>/latest/` happens only when the version is indeed the latest
- latest version is stored in cache (and purged when package is updated)
- trigger a documentation update for the previous latest version: updates the flag and also the canonical version urls