### PR TITLE
Allow symlinks that point to existing files inside the archive.

### DIFF
--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -15,6 +15,7 @@ import 'package:gcloud/storage.dart';
 import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
 import 'package:pana/pana.dart' show runProc;
+import 'package:path/path.dart' as p;
 import 'package:pub_package_reader/pub_package_reader.dart';
 
 import '../account/backend.dart';
@@ -824,21 +825,36 @@ Future<void> _verifyTarball(String filename) async {
 // is any symlink in the archive.
 @visibleForTesting
 Future<void> verifyTarGzSymlinks(String filename) async {
-  // Check if the file has any symlink.
-  final pr = await runProc('tar', ['-tvf', filename]);
-  if (pr.exitCode != 0) {
-    _logger.info('Rejecting package: tar returned with ${pr.exitCode}\n'
-        '${pr.stdout}\n${pr.stderr}');
-    throw PackageRejectedException.invalidTarGz();
+  Future<List<String>> listFiles(bool verbose) async {
+    final pr = await runProc(
+      'tar',
+      [verbose ? '-tvf' : '-tf', filename],
+    );
+    if (pr.exitCode != 0) {
+      _logger.info('Rejecting package: tar returned with ${pr.exitCode}\n'
+          '${pr.stdout}\n${pr.stderr}');
+      throw PackageRejectedException.invalidTarGz();
+    }
+    return pr.stdout.toString().split('\n');
   }
-  final lines = pr.stdout.toString().split('\n');
-  for (final line in lines) {
+
+  final fileNames = (await listFiles(false)).toSet();
+  final verboseLines = await listFiles(true);
+  // Check if the file has any symlink.
+  for (final line in verboseLines) {
     if (line.startsWith('l')) {
       // report only the source path
       // if output is non-standard for any reason, this reports the full line
       final parts = line.split(' -> ');
       final source = parts.first.split(' ').last;
-      throw PackageRejectedException.containsSymlink(source);
+      final target = parts.last;
+      if (p.isAbsolute(target)) {
+        throw PackageRejectedException.brokenSymlink(source, target);
+      }
+      final resolvedPath = p.normalize(Uri(path: source).resolve(target).path);
+      if (!fileNames.contains(resolvedPath)) {
+        throw PackageRejectedException.brokenSymlink(source, target);
+      }
     }
   }
 }

--- a/app/lib/shared/exceptions.dart
+++ b/app/lib/shared/exceptions.dart
@@ -185,10 +185,11 @@ class PackageRejectedException extends ResponseException {
       : super._(400, 'PackageRejected',
             'Package archive is not a valid `.tar.gz`.');
 
-  /// The package archive file contains a symlink.
-  PackageRejectedException.containsSymlink(String source)
+  /// The package archive file contains a broken symlink (outside of the archive
+  /// or file does not exists).
+  PackageRejectedException.brokenSymlink(String source, String target)
       : super._(400, 'PackageRejected',
-            'Package archive contains a symlink: `$source`.');
+            'Package archive contains a broken symlink: `$source` -> `$target`.');
 
   /// The [package] name is reserved.
   PackageRejectedException.nameReserved(String package)

--- a/app/test/package/upload_test.dart
+++ b/app/test/package/upload_test.dart
@@ -365,24 +365,75 @@ void main() {
       });
     });
 
-    test('has a symlink', () async {
-      await withTempDirectory((tempDir) async {
+    Future<void> runArchiveVerification({
+      Future<void> Function(String pkgDirPath) setupDir,
+      String expectedErrorMessage,
+    }) async {
+      return await withTempDirectory((tempDir) async {
         final archiveFile = File(p.join(tempDir, 'with-symlink.tar.gz'));
         final pkgDir = Directory(p.join(tempDir, 'pkg'));
         await pkgDir.create(recursive: true);
-        await Link(p.join(tempDir, 'pkg', 'README.md')).create('../README.md');
-        final pr = await runProc('tar', ['-czvf', archiveFile.path, 'pkg'],
+        await setupDir(pkgDir.path);
+        final pr = await runProc(
+            'tar', ['--strip-components=1', '-czvf', archiveFile.path, 'pkg'],
             workingDirectory: tempDir);
         expect(pr.exitCode, 0);
         final rs = verifyTarGzSymlinks(archiveFile.path);
-        await expectLater(
-            rs,
-            throwsA(isA<PackageRejectedException>().having(
-              (e) => '$e',
-              'text',
-              contains('Package archive contains a symlink: `pkg/README.md`.'),
-            )));
+        if (expectedErrorMessage != null) {
+          await expectLater(
+              rs,
+              throwsA(isA<PackageRejectedException>().having(
+                (e) => '$e',
+                'text',
+                contains(expectedErrorMessage),
+              )));
+        } else {
+          await rs;
+        }
       });
+    }
+
+    test('has a relative symlink outside of archive', () async {
+      await runArchiveVerification(
+        setupDir: (pkgDir) async {
+          await Link(p.join(pkgDir, 'README.md')).create('../README.md');
+        },
+        expectedErrorMessage:
+            'Package archive contains a broken symlink: `README.md` -> `../README.md`.',
+      );
+    });
+
+    test('has an absolute symlink', () async {
+      await runArchiveVerification(
+        setupDir: (pkgDir) async {
+          await Link(p.join(pkgDir, 'README.md')).create('/README.md');
+        },
+        expectedErrorMessage:
+            'Package archive contains a broken symlink: `README.md` -> `/README.md`.',
+      );
+    });
+
+    // This test-case should fail, but it for simplicity it is accepted by pub.
+    // TODO: fix verification to detect circular links
+    test('has symlink(s) with circular links', () async {
+      // TODO: this use case should fail instead
+      await runArchiveVerification(
+        setupDir: (pkgDir) async {
+          await Link(p.join(pkgDir, 'README.md')).create('./README.md');
+        },
+      );
+    });
+
+    test('valid symlink to another file', () async {
+      await runArchiveVerification(
+        setupDir: (pkgDir) async {
+          await Directory(p.join(pkgDir, 'a')).create();
+          await Directory(p.join(pkgDir, 'b')).create();
+          await File(p.join(pkgDir, 'a', 'existing.txt')).writeAsString('');
+          await Link(p.join(pkgDir, 'b', 'link.txt'))
+              .create('../a/existing.txt');
+        },
+      );
     });
   });
 }

--- a/app/test/package/upload_test.dart
+++ b/app/test/package/upload_test.dart
@@ -374,8 +374,7 @@ void main() {
         final pkgDir = Directory(p.join(tempDir, 'pkg'));
         await pkgDir.create(recursive: true);
         await setupDir(pkgDir.path);
-        final pr = await runProc(
-            'tar', ['--strip-components=1', '-czvf', archiveFile.path, 'pkg'],
+        final pr = await runProc('tar', ['-czvf', archiveFile.path, 'pkg'],
             workingDirectory: tempDir);
         expect(pr.exitCode, 0);
         final rs = verifyTarGzSymlinks(archiveFile.path);
@@ -396,10 +395,10 @@ void main() {
     test('has a relative symlink outside of archive', () async {
       await runArchiveVerification(
         setupDir: (pkgDir) async {
-          await Link(p.join(pkgDir, 'README.md')).create('../README.md');
+          await Link(p.join(pkgDir, 'README.md')).create('../../README.md');
         },
         expectedErrorMessage:
-            'Package archive contains a broken symlink: `README.md` -> `../README.md`.',
+            'Package archive contains a broken symlink: `pkg/README.md` -> `../../README.md`.',
       );
     });
 
@@ -409,7 +408,7 @@ void main() {
           await Link(p.join(pkgDir, 'README.md')).create('/README.md');
         },
         expectedErrorMessage:
-            'Package archive contains a broken symlink: `README.md` -> `/README.md`.',
+            'Package archive contains a broken symlink: `pkg/README.md` -> `/README.md`.',
       );
     });
 


### PR DESCRIPTION
- #3971
- This will read the list of files two times from the archive: first it will get the files without attributes, then the files with all the attributes and the link pointing to a new file.
- Symlinks are accepted when they point to existing files inside the archive.
- Circular links are not detected (yet).
