### PR TITLE
Use Datastore transactions only with retry.

### DIFF
--- a/app/lib/history/backend.dart
+++ b/app/lib/history/backend.dart
@@ -3,16 +3,12 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
 
 import 'package:gcloud/db.dart';
 import 'package:gcloud/service_scope.dart' as ss;
-import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
 
 import 'models.dart';
-
-final _logger = Logger('pub.history.backend');
 
 /// Sets the history backend.
 void registerHistoryBackend(HistoryBackend backend) =>
@@ -25,25 +21,13 @@ HistoryBackend get historyBackend =>
 /// Stores and queries [History] entries.
 class HistoryBackend {
   final DatastoreDB _db;
-  final bool _enabled = Platform.environment['HISTORY_ENABLED'] != '0';
   HistoryBackend(this._db);
-
-  /// Whether the storing of the entries is enabled.
-  bool get isEnabled => _enabled;
 
   /// Store a history [event]. When storing is not enabled, this will only log
   /// the method call, and not store the entry in Datastore.
   Future<String> storeEvent(HistoryEvent event) async {
     final history = History.entry(event);
-    if (!_enabled) {
-      _logger.info('History is not enabled, store aborted: '
-          '${history.packageName} ${history.packageVersion} ${history.eventType}');
-      return null;
-    }
-    await _db.withTransaction((tx) async {
-      tx.queueMutations(inserts: [history]);
-      await tx.commit();
-    });
+    await _db.commit(inserts: [history]);
     return history.id;
   }
 

--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -691,7 +691,11 @@ class PackageBackend {
     final user = await requireAuthenticatedUser();
     await withRetryTransaction(db, (tx) async {
       final packageKey = db.emptyKey.append(Package, id: packageName);
-      final package = await tx.lookupValue<Package>(packageKey);
+      final package =
+          await tx.lookupValue<Package>(packageKey, orElse: () => null);
+      if (package == null) {
+        throw NotFoundException.resource('package: $packageName');
+      }
 
       await _validatePackageUploader(packageName, package, user.userId);
 

--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -186,7 +186,7 @@ class PackageBackend {
 
     final pkgKey = db.emptyKey.append(Package, id: package);
     String latestVersion;
-    await withTransaction(db, (tx) async {
+    await withRetryTransaction(db, (tx) async {
       final p = await tx.lookupOrNull<Package>(pkgKey);
       if (p == null) {
         throw NotFoundException.resource(package);
@@ -294,14 +294,15 @@ class PackageBackend {
     final key = db.emptyKey.append(Package, id: packageName);
     await requirePackageAdmin(packageName, user.userId);
     await requirePublisherAdmin(request.publisherId, user.userId);
-    final rs = await db.withTransaction<api.PackagePublisherInfo>((tx) async {
+    final rs = await withRetryTransaction(db, (tx) async {
       final package = (await db.lookup<Package>([key])).single;
       final fromPublisherId = package.publisherId;
       package.publisherId = request.publisherId;
       package.uploaders.clear();
       package.updated = DateTime.now().toUtc();
 
-      final history = History.entry(
+      tx.insert(package);
+      tx.insert(History.entry(
         PackageTransferred(
           packageName: package.name,
           fromPublisherId: fromPublisherId,
@@ -309,10 +310,8 @@ class PackageBackend {
           userId: user.userId,
           userEmail: user.email,
         ),
-      );
+      ));
 
-      tx.queueMutations(inserts: [package, history]);
-      await tx.commit();
       return _asPackagePublisherInfo(package);
     });
     await purgePublisherCache(publisherId: request.publisherId);
@@ -647,20 +646,13 @@ class PackageBackend {
       fromUserId = user.userId;
     }
     assert(fromUserId != null);
-    return db.withTransaction((Transaction tx) async {
+    await withRetryTransaction(db, (tx) async {
       final packageKey = db.emptyKey.append(Package, id: packageName);
       final package = (await tx.lookup([packageKey])).first as Package;
 
-      try {
-        await _validatePackageUploader(packageName, package, fromUserId);
-      } catch (_) {
-        await tx.rollback();
-        rethrow;
-      }
-
+      await _validatePackageUploader(packageName, package, fromUserId);
       if (package.containsUploader(uploader.userId)) {
         // The requested uploaderEmail is already part of the uploaders.
-        await tx.rollback();
         return;
       }
 
@@ -668,22 +660,16 @@ class PackageBackend {
       package.addUploader(uploader.userId);
       package.updated = DateTime.now().toUtc();
 
-      final inserts = <Model>[package];
-      if (historyBackend.isEnabled) {
-        final history = History.entry(UploaderChanged(
-          packageName: packageName,
-          currentUserId: fromUserId,
-          currentUserEmail: fromUserEmail,
-          addedUploaderIds: [uploader.userId],
-          addedUploaderEmails: [uploader.email],
-        ));
-        inserts.add(history);
-      }
-
-      tx.queueMutations(inserts: inserts);
-      await tx.commit();
-      await purgePackageCache(package.name);
+      tx.insert(package);
+      tx.insert(History.entry(UploaderChanged(
+        packageName: packageName,
+        currentUserId: fromUserId,
+        currentUserEmail: fromUserEmail,
+        addedUploaderIds: [uploader.userId],
+        addedUploaderEmails: [uploader.email],
+      )));
     });
+    await purgePackageCache(packageName);
   }
 
   Future<void> _validatePackageUploader(
@@ -703,23 +689,21 @@ class PackageBackend {
       String packageName, String uploaderEmail) async {
     uploaderEmail = uploaderEmail.toLowerCase();
     final user = await requireAuthenticatedUser();
-    await db.withTransaction((Transaction T) async {
+    await withRetryTransaction(db, (tx) async {
       final packageKey = db.emptyKey.append(Package, id: packageName);
-      final package = (await T.lookup([packageKey])).first as Package;
+      final package = await tx.lookupValue<Package>(packageKey);
 
       await _validatePackageUploader(packageName, package, user.userId);
 
       // Fail if the uploader we want to remove does not exist.
       final uploader = await accountBackend.lookupUserByEmail(uploaderEmail);
       if (uploader == null || !package.containsUploader(uploader.userId)) {
-        await T.rollback();
         throw NotFoundException.resource('uploader: $uploaderEmail');
       }
 
       // We cannot have 0 uploaders, if we would remove the last one, we
       // fail with an error.
       if (package.uploaderCount <= 1) {
-        await T.rollback();
         throw OperationForbiddenException.lastUploaderRemoveError();
       }
 
@@ -727,7 +711,6 @@ class PackageBackend {
       // are able to authenticate. To prevent accidentally losing the control
       // of a package, we don't allow self-removal.
       if (user.email == uploader.email || user.userId == uploader.userId) {
-        await T.rollback();
         throw OperationForbiddenException.selfRemovalNotAllowed();
       }
 
@@ -735,22 +718,16 @@ class PackageBackend {
       package.removeUploader(uploader.userId);
       package.updated = DateTime.now().toUtc();
 
-      final inserts = <Model>[package];
-      if (historyBackend.isEnabled) {
-        final history = History.entry(UploaderChanged(
-          packageName: packageName,
-          currentUserId: user.userId,
-          currentUserEmail: user.email,
-          removedUploaderIds: [uploader.userId],
-          removedUploaderEmails: [uploader.email],
-        ));
-        inserts.add(history);
-      }
-
-      T.queueMutations(inserts: inserts);
-      await T.commit();
-      await purgePackageCache(package.name);
+      tx.insert(package);
+      tx.insert(History.entry(UploaderChanged(
+        packageName: packageName,
+        currentUserId: user.userId,
+        currentUserEmail: user.email,
+        removedUploaderIds: [uploader.userId],
+        removedUploaderEmails: [uploader.email],
+      )));
     });
+    await purgePackageCache(packageName);
     return api.SuccessMessage(
         success: api.Message(
             message:

--- a/app/lib/shared/datastore_helper.dart
+++ b/app/lib/shared/datastore_helper.dart
@@ -48,7 +48,7 @@ class TransactionWrapper {
 
 /// Call [fn] with a [TransactionWrapper] that is either committed or
 /// rolled back when [fn] returns.
-Future<T> withTransaction<T>(
+Future<T> _withTransaction<T>(
   DatastoreDB db,
   Future<T> Function(TransactionWrapper tx) fn,
 ) async {
@@ -109,7 +109,7 @@ Future<T> withRetryTransaction<T>(
   Future<T> Function(TransactionWrapper tx) fn,
 ) =>
     _transactionRetrier.retry<T>(
-      () => withTransaction<T>(db, fn),
+      () => _withTransaction<T>(db, fn),
       // TODO(jonasfj): Over time we want reduce the number exceptions on which
       //                we retry. The following is a list of exceptions we know
       //                we want to retry:


### PR DESCRIPTION
- Fixes #3904.
- Also migrated a few calls to use `lookupValue` around the transaction blocks.