### PR TITLE
Fix: unnecessary scope exit call

### DIFF
--- a/app/lib/shared/storage_retry.dart
+++ b/app/lib/shared/storage_retry.dart
@@ -42,7 +42,6 @@ Future<void> withStorageRetry(FutureOr<void> Function() fn) async {
       client,
       activeConfiguration.projectId,
     ));
-    ss.registerScopeExitCallback(() async => client.close());
 
     await fn();
   });


### PR DESCRIPTION
This was added in #3981 and it was a mistake.