### PR TITLE
Display [unlisted] label

### DIFF
--- a/app/lib/frontend/templates/listing.dart
+++ b/app/lib/frontend/templates/listing.dart
@@ -74,7 +74,7 @@ String renderPackageList(
       'publisher_id': view.publisherId,
       'publisher_url':
           view.publisherId == null ? null : urls.publisherUrl(view.publisherId),
-      'tags_html': renderTags(package: view, searchQuery: searchQuery),
+      'tags_html': renderTags(package: view),
       'labeled_scores_html': renderLabeledScores(view),
       'has_api_pages': hasApiPages,
       'has_more_api_pages': hasMoreThanOneApiPages,

--- a/app/lib/frontend/templates/misc.dart
+++ b/app/lib/frontend/templates/misc.dart
@@ -198,7 +198,11 @@ String renderTags({@required PackageView package}) {
       'status': 'unlisted',
       'text': 'unlisted',
       'has_href': false,
-      'title': 'Package was unlisted.',
+      'title': 'Package is unlisted, this means that while the package is still '
+          'publicly available the author has decided that it should not appear '
+          'in search results with default search filters. This is typically '
+          'done because this package is meant to support another package, '
+          'rather than being consumed directly.',
     });
   }
   if (package.isObsolete) {

--- a/app/lib/frontend/templates/misc.dart
+++ b/app/lib/frontend/templates/misc.dart
@@ -188,7 +188,7 @@ String renderTags({@required PackageView package}) {
   if (package.isDiscontinued) {
     tagValues.add({
       'status': 'discontinued',
-      'text': '[discontinued]',
+      'text': 'discontinued',
       'has_href': false,
       'title': 'Package was discontinued.',
     });
@@ -196,7 +196,7 @@ String renderTags({@required PackageView package}) {
   if (package.tags.contains(PackageTags.isUnlisted)) {
     tagValues.add({
       'status': 'unlisted',
-      'text': '[unlisted]',
+      'text': 'unlisted',
       'has_href': false,
       'title': 'Package was unlisted.',
     });
@@ -204,7 +204,7 @@ String renderTags({@required PackageView package}) {
   if (package.isObsolete) {
     tagValues.add({
       'status': 'missing',
-      'text': '[outdated]',
+      'text': 'outdated',
       'has_href': false,
       'title': 'Package version too old, check latest stable.',
     });

--- a/app/lib/frontend/templates/misc.dart
+++ b/app/lib/frontend/templates/misc.dart
@@ -8,7 +8,6 @@ import 'package:meta/meta.dart';
 
 import 'package:path/path.dart' as p;
 import '../../package/models.dart';
-import '../../search/search_service.dart' show SearchQuery;
 import '../../shared/markdown.dart';
 import '../../shared/tags.dart';
 import '../../shared/urls.dart' as urls;
@@ -181,45 +180,95 @@ String renderMiniList(List<PackageView> packages) {
 }
 
 /// Renders the tags using the pkg/tags template.
-String renderTags({
-  @required PackageView package,
-  @required SearchQuery searchQuery,
-}) {
+String renderTags({@required PackageView package}) {
   final tags = package.tags;
   final sdkTags = tags.where((s) => s.startsWith('sdk:')).toSet().toList();
-  final List<Map> tagValues = <Map>[];
+  final tagValues = <Map>[];
   final tagBadges = <Map>[];
-  if (package.isExternal) {
-    // no tags added
-  } else if (package.isAwaiting) {
-    tagValues.add({
-      'status': 'missing',
-      'text': '[awaiting]',
-      'has_href': false,
-      'title': 'Analysis should be ready soon.',
-    });
-  } else if (package.isDiscontinued) {
+  if (package.isDiscontinued) {
     tagValues.add({
       'status': 'discontinued',
       'text': '[discontinued]',
       'has_href': false,
       'title': 'Package was discontinued.',
     });
-  } else if (package.isObsolete) {
+  }
+  if (package.tags.contains(PackageTags.isUnlisted)) {
+    tagValues.add({
+      'status': 'unlisted',
+      'text': '[unlisted]',
+      'has_href': false,
+      'title': 'Package was unlisted.',
+    });
+  }
+  if (package.isObsolete) {
     tagValues.add({
       'status': 'missing',
       'text': '[outdated]',
       'has_href': false,
       'title': 'Package version too old, check latest stable.',
     });
-  } else if (package.isLegacy) {
+  }
+  if (package.isLegacy) {
     tagValues.add({
       'status': 'legacy',
       'text': 'Dart 2 incompatible',
       'has_href': false,
       'title': 'Package does not support Dart 2.',
     });
-  } else if (sdkTags.isEmpty) {
+  }
+  // We only display first-class platform/runtimes
+  if (sdkTags.contains(SdkTag.sdkDart)) {
+    tagBadges.add({
+      'sdk': 'Dart',
+      'title': 'Packages compatible with Dart SDK',
+      'sub_tags': [
+        if (tags.contains(DartSdkTag.runtimeNativeJit))
+          {
+            'text': 'native',
+            'title':
+                'Packages compatible with Dart running on a native platform (JIT/AOT)',
+          },
+        if (tags.contains(DartSdkTag.runtimeWeb))
+          {
+            'text': 'js',
+            'title': 'Packages compatible with Dart compiled for the web',
+          },
+      ],
+    });
+  }
+  if (sdkTags.contains(SdkTag.sdkFlutter)) {
+    tagBadges.add({
+      'sdk': 'Flutter',
+      'title': 'Packages compatible with Flutter SDK',
+      'sub_tags': [
+        if (tags.contains(FlutterSdkTag.platformAndroid))
+          {
+            'text': 'Android',
+            'title': 'Packages compatible with Flutter on the Android platform',
+          },
+        if (tags.contains(FlutterSdkTag.platformIos))
+          {
+            'text': 'iOS',
+            'title': 'Packages compatible with Flutter on the iOS platform'
+          },
+        if (tags.contains(FlutterSdkTag.platformWeb))
+          {
+            'text': 'web',
+            'title': 'Packages compatible with Flutter on the Web platform',
+          },
+      ],
+    });
+  }
+  if (tagBadges.isEmpty && package.isAwaiting) {
+    tagValues.add({
+      'status': 'missing',
+      'text': '[awaiting]',
+      'has_href': false,
+      'title': 'Analysis should be ready soon.',
+    });
+  }
+  if (!package.isExternal && tagValues.isEmpty && tagBadges.isEmpty) {
     tagValues.add({
       'status': 'unidentified',
       'text': '[unidentified]',
@@ -227,51 +276,6 @@ String renderTags({
       'has_href': true,
       'href': urls.pkgScoreUrl(package.name),
     });
-  } else {
-    // We only display first-class platform/runtimes
-    if (sdkTags.contains(SdkTag.sdkDart)) {
-      tagBadges.add({
-        'sdk': 'Dart',
-        'title': 'Packages compatible with Dart SDK',
-        'sub_tags': [
-          if (tags.contains(DartSdkTag.runtimeNativeJit))
-            {
-              'text': 'native',
-              'title':
-                  'Packages compatible with Dart running on a native platform (JIT/AOT)',
-            },
-          if (tags.contains(DartSdkTag.runtimeWeb))
-            {
-              'text': 'js',
-              'title': 'Packages compatible with Dart compiled for the web',
-            },
-        ],
-      });
-    }
-    if (sdkTags.contains(SdkTag.sdkFlutter)) {
-      tagBadges.add({
-        'sdk': 'Flutter',
-        'title': 'Packages compatible with Flutter SDK',
-        'sub_tags': [
-          if (tags.contains(FlutterSdkTag.platformAndroid))
-            {
-              'text': 'Android',
-              'title':
-                  'Packages compatible with Flutter on the Android platform',
-            },
-          if (tags.contains(FlutterSdkTag.platformIos))
-            {
-              'text': 'iOS',
-              'title': 'Packages compatible with Flutter on the iOS platform'
-            },
-          if (tags.contains(FlutterSdkTag.platformWeb))
-            {
-              'text': 'web',
-              'title': 'Packages compatible with Flutter on the Web platform',
-            },
-        ],
-      });
-    }
   }
   return templateCache.renderTemplate('pkg/tags', {
     'tags': tagValues,

--- a/app/lib/frontend/templates/package.dart
+++ b/app/lib/frontend/templates/package.dart
@@ -232,7 +232,7 @@ String renderPkgHeader(PackagePageData data) {
     isFlutterFavorite:
         (package.assignedTags ?? []).contains(PackageTags.isFlutterFavorite),
     metadataHtml: metadataHtml,
-    tagsHtml: renderTags(package: pkgView, searchQuery: null),
+    tagsHtml: renderTags(package: pkgView),
     isLoose: true,
   );
 }

--- a/app/test/frontend/golden/pkg_admin_page_outdated.html
+++ b/app/test/frontend/golden/pkg_admin_page_outdated.html
@@ -130,7 +130,7 @@ Published
                 </div>
                 <div class="detail-tags-and-like">
                   <div class="detail-tags">
-                    <span class="package-tag missing" title="Package version too old, check latest stable.">[outdated]</span>
+                    <span class="package-tag missing" title="Package version too old, check latest stable.">outdated</span>
                   </div>
                   <div class="detail-like">
                     <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-hidden="true" aria-pressed="true">

--- a/app/test/frontend/golden/pkg_show_page_discontinued.html
+++ b/app/test/frontend/golden/pkg_show_page_discontinued.html
@@ -131,7 +131,7 @@ Published
                 </div>
                 <div class="detail-tags-and-like">
                   <div class="detail-tags">
-                    <span class="package-tag discontinued" title="Package was discontinued.">[discontinued]</span>
+                    <span class="package-tag discontinued" title="Package was discontinued.">discontinued</span>
                   </div>
                   <div class="detail-like">
                     <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-hidden="true" aria-pressed="true">

--- a/app/test/frontend/golden/pkg_show_page_outdated.html
+++ b/app/test/frontend/golden/pkg_show_page_outdated.html
@@ -131,7 +131,7 @@ Published
                 </div>
                 <div class="detail-tags-and-like">
                   <div class="detail-tags">
-                    <span class="package-tag missing" title="Package version too old, check latest stable.">[outdated]</span>
+                    <span class="package-tag missing" title="Package version too old, check latest stable.">outdated</span>
                   </div>
                   <div class="detail-like">
                     <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-hidden="true" aria-pressed="true">

--- a/app/test/frontend/golden/pkg_versions_page.html
+++ b/app/test/frontend/golden/pkg_versions_page.html
@@ -130,7 +130,12 @@ Published
                 </div>
                 <div class="detail-tags-and-like">
                   <div class="detail-tags">
-                    <span class="package-tag missing" title="Analysis should be ready soon.">[awaiting]</span>
+                    <div class="-pub-tag-badge">
+                      <span class="tag-badge-main" title="Packages compatible with Dart SDK">Dart</span>
+                    </div>
+                    <div class="-pub-tag-badge">
+                      <span class="tag-badge-main" title="Packages compatible with Flutter SDK">Flutter</span>
+                    </div>
                   </div>
                   <div class="detail-like">
                     <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-hidden="true" aria-pressed="true">

--- a/pkg/web_css/lib/src/_tags.scss
+++ b/pkg/web_css/lib/src/_tags.scss
@@ -17,14 +17,14 @@
     color: #555;
   }
 
-  &.unidentified {
+  &.unidentified,
+  &.unlisted {
     background: #fff0f0;
     color: #555;
   }
 
   &.legacy,
-  &.discontinued,
-  &.unlisted {
+  &.discontinued {
     background: #c0392b;
     color: #f8f8f8;
   }

--- a/pkg/web_css/lib/src/_tags.scss
+++ b/pkg/web_css/lib/src/_tags.scss
@@ -23,7 +23,8 @@
   }
 
   &.legacy,
-  &.discontinued {
+  &.discontinued,
+  &.unlisted {
     background: #c0392b;
     color: #f8f8f8;
   }


### PR DESCRIPTION
- https://github.com/dart-lang/pub-dev/issues/4044
- We no longer have a "single" label (e.g. either discontinued or having an SDK), rather we have multiple labels, and adjusted the label selection logic accordingly.
- Unlisted package with SDK information:
  <img width="763" alt="Screenshot 2020-09-22 at 13 36 03" src="https://user-images.githubusercontent.com/4778111/93877576-f1516400-fcd8-11ea-9f5c-80ca012e04ba.png">
  same on the listing page:
  <img width="1135" alt="Screenshot 2020-09-22 at 13 36 18" src="https://user-images.githubusercontent.com/4778111/93877582-f3b3be00-fcd8-11ea-9fe5-b4c261a049c7.png">

- Unlisted + discontinued package:
  <img width="779" alt="Screenshot 2020-09-22 at 13 36 25" src="https://user-images.githubusercontent.com/4778111/93877600-f7474500-fcd8-11ea-96e5-4d4eb2069564.png">

