### PR TITLE
Left-align advanced search options.

### DIFF
--- a/app/lib/frontend/templates/views/pkg/index.mustache
+++ b/app/lib/frontend/templates/views/pkg/index.mustache
@@ -24,23 +24,21 @@
   </div>
   <div class="search-controls-advanced">
     <div class="container">
-      {{#has_subsdk_tabs_advanced_html}}
-      <div class="search-controls-subsdk-advanced search-controls-buttons"
-           title="Prerelease platforms">
-        <span class="search-controls-label">Prerelease platforms</span>
-        {{& subsdk_tabs_advanced_html }}
-      </div>
-      {{/has_subsdk_tabs_advanced_html}}
-      <div>
+      <div class="search-controls-advanced-block">
+        {{#has_subsdk_tabs_advanced_html}}
+        <div class="search-controls-subsdk-advanced search-controls-buttons"
+             title="Prerelease platforms">
+          <span class="search-controls-label">Prerelease platforms</span>
+          {{& subsdk_tabs_advanced_html }}
+        </div>
+        {{/has_subsdk_tabs_advanced_html}}
         <div class="search-controls-checkbox">
           <input id="-search-unlisted-checkbox" type="checkbox" name="unlisted" {{#include_unlisted}} checked="checked"{{/include_unlisted}} />
           <label for="-search-unlisted-checkbox">Include unlisted packages</label>
         </div>
-      </div>
-      <div>
         <div class="search-controls-checkbox">
-          <input id="search-legacy-checkbox" type="checkbox" name="legacy" {{#legacy_search_enabled}} checked="checked"{{/legacy_search_enabled}} />
-          <label for="search-legacy-checkbox">Include Dart 1.x results</label>
+          <input id="-search-legacy-checkbox" type="checkbox" name="legacy" {{#legacy_search_enabled}} checked="checked"{{/legacy_search_enabled}} />
+          <label for="-search-legacy-checkbox">Include Dart 1.x results</label>
         </div>
       </div>
     </div>

--- a/app/lib/frontend/templates/views/shared/search_banner.mustache
+++ b/app/lib/frontend/templates/views/shared/search_banner.mustache
@@ -13,7 +13,7 @@
   {{/show_search_filters_btn}}
   {{#search_sort_param}}<input type="hidden" name="sort" value="{{search_sort_param}}"/>{{/search_sort_param}}
   <input id="-search-unlisted-field" type="hidden" name="unlisted" value="1"{{^include_unlisted}} disabled="disabled"{{/include_unlisted}} />
-  <input id="search-legacy-field" type="hidden" name="legacy" value="1"{{^legacy_search_enabled}} disabled="disabled"{{/legacy_search_enabled}} />
+  <input id="-search-legacy-field" type="hidden" name="legacy" value="1"{{^legacy_search_enabled}} disabled="disabled"{{/legacy_search_enabled}} />
   {{#hidden_inputs}}
   <input type="hidden" name="{{name}}" value="{{value}}" />
   {{/hidden_inputs}}

--- a/app/test/frontend/golden/error_page.html
+++ b/app/test/frontend/golden/error_page.html
@@ -105,7 +105,7 @@
           <input class="input" name="q" placeholder="Search packages" autocomplete="on" autofocus="autofocus"/>
           <button class="icon"></button>
           <input id="-search-unlisted-field" type="hidden" name="unlisted" value="1" disabled="disabled"/>
-          <input id="search-legacy-field" type="hidden" name="legacy" value="1" disabled="disabled"/>
+          <input id="-search-legacy-field" type="hidden" name="legacy" value="1" disabled="disabled"/>
         </form>
       </div>
     </div>

--- a/app/test/frontend/golden/landing_page.html
+++ b/app/test/frontend/golden/landing_page.html
@@ -104,7 +104,7 @@
           <input class="input" name="q" placeholder="Search packages" autocomplete="on" autofocus="autofocus"/>
           <button class="icon"></button>
           <input id="-search-unlisted-field" type="hidden" name="unlisted" value="1" disabled="disabled"/>
-          <input id="search-legacy-field" type="hidden" name="legacy" value="1" disabled="disabled"/>
+          <input id="-search-legacy-field" type="hidden" name="legacy" value="1" disabled="disabled"/>
         </form>
         <p class="text">Find and use packages to build 
           <a target="_blank" rel="noopener" href="https://dart.dev/">Dart</a> and 

--- a/app/test/frontend/golden/my_liked_packages.html
+++ b/app/test/frontend/golden/my_liked_packages.html
@@ -106,7 +106,7 @@
           <input class="input" name="q" placeholder="Search your packages" autocomplete="on" autofocus="autofocus"/>
           <button class="icon"></button>
           <input id="-search-unlisted-field" type="hidden" name="unlisted" value="1" disabled="disabled"/>
-          <input id="search-legacy-field" type="hidden" name="legacy" value="1" disabled="disabled"/>
+          <input id="-search-legacy-field" type="hidden" name="legacy" value="1" disabled="disabled"/>
         </form>
       </div>
     </div>

--- a/app/test/frontend/golden/my_packages.html
+++ b/app/test/frontend/golden/my_packages.html
@@ -106,7 +106,7 @@
           <input class="input" name="q" placeholder="Search your packages" autocomplete="on" autofocus="autofocus"/>
           <button class="icon"></button>
           <input id="-search-unlisted-field" type="hidden" name="unlisted" value="1" disabled="disabled"/>
-          <input id="search-legacy-field" type="hidden" name="legacy" value="1" disabled="disabled"/>
+          <input id="-search-legacy-field" type="hidden" name="legacy" value="1" disabled="disabled"/>
         </form>
       </div>
     </div>

--- a/app/test/frontend/golden/my_publishers.html
+++ b/app/test/frontend/golden/my_publishers.html
@@ -106,7 +106,7 @@
           <input class="input" name="q" placeholder="Search your packages" autocomplete="on" autofocus="autofocus"/>
           <button class="icon"></button>
           <input id="-search-unlisted-field" type="hidden" name="unlisted" value="1" disabled="disabled"/>
-          <input id="search-legacy-field" type="hidden" name="legacy" value="1" disabled="disabled"/>
+          <input id="-search-legacy-field" type="hidden" name="legacy" value="1" disabled="disabled"/>
         </form>
       </div>
     </div>

--- a/app/test/frontend/golden/pkg_index_page.html
+++ b/app/test/frontend/golden/pkg_index_page.html
@@ -110,7 +110,7 @@
             <img class="search-filters-btn search-filters-btn-active" src="/static/img/search-filters-active.svg?hash=mocked_hash_397783636"/>
           </div>
           <input id="-search-unlisted-field" type="hidden" name="unlisted" value="1" disabled="disabled"/>
-          <input id="search-legacy-field" type="hidden" name="legacy" value="1" disabled="disabled"/>
+          <input id="-search-legacy-field" type="hidden" name="legacy" value="1" disabled="disabled"/>
         </form>
       </div>
     </div>
@@ -165,16 +165,14 @@
         </div>
         <div class="search-controls-advanced">
           <div class="container">
-            <div>
+            <div class="search-controls-advanced-block">
               <div class="search-controls-checkbox">
                 <input id="-search-unlisted-checkbox" type="checkbox" name="unlisted"/>
                 <label for="-search-unlisted-checkbox">Include unlisted packages</label>
               </div>
-            </div>
-            <div>
               <div class="search-controls-checkbox">
-                <input id="search-legacy-checkbox" type="checkbox" name="legacy"/>
-                <label for="search-legacy-checkbox">Include Dart 1.x results</label>
+                <input id="-search-legacy-checkbox" type="checkbox" name="legacy"/>
+                <label for="-search-legacy-checkbox">Include Dart 1.x results</label>
               </div>
             </div>
           </div>

--- a/app/test/frontend/golden/publisher_list_page.html
+++ b/app/test/frontend/golden/publisher_list_page.html
@@ -109,7 +109,7 @@
             <img class="search-filters-btn search-filters-btn-active" src="/static/img/search-filters-active.svg?hash=mocked_hash_397783636"/>
           </div>
           <input id="-search-unlisted-field" type="hidden" name="unlisted" value="1" disabled="disabled"/>
-          <input id="search-legacy-field" type="hidden" name="legacy" value="1" disabled="disabled"/>
+          <input id="-search-legacy-field" type="hidden" name="legacy" value="1" disabled="disabled"/>
         </form>
       </div>
     </div>

--- a/app/test/frontend/golden/publisher_packages_page.html
+++ b/app/test/frontend/golden/publisher_packages_page.html
@@ -106,7 +106,7 @@
           <input class="input" name="q" placeholder="Search example.com packages" autocomplete="on" autofocus="autofocus"/>
           <button class="icon"></button>
           <input id="-search-unlisted-field" type="hidden" name="unlisted" value="1" disabled="disabled"/>
-          <input id="search-legacy-field" type="hidden" name="legacy" value="1" disabled="disabled"/>
+          <input id="-search-legacy-field" type="hidden" name="legacy" value="1" disabled="disabled"/>
         </form>
       </div>
     </div>

--- a/app/test/frontend/golden/search_page.html
+++ b/app/test/frontend/golden/search_page.html
@@ -111,7 +111,7 @@
           </div>
           <input type="hidden" name="sort" value="top"/>
           <input id="-search-unlisted-field" type="hidden" name="unlisted" value="1" disabled="disabled"/>
-          <input id="search-legacy-field" type="hidden" name="legacy" value="1" disabled="disabled"/>
+          <input id="-search-legacy-field" type="hidden" name="legacy" value="1" disabled="disabled"/>
         </form>
       </div>
     </div>
@@ -166,16 +166,14 @@
         </div>
         <div class="search-controls-advanced">
           <div class="container">
-            <div>
+            <div class="search-controls-advanced-block">
               <div class="search-controls-checkbox">
                 <input id="-search-unlisted-checkbox" type="checkbox" name="unlisted"/>
                 <label for="-search-unlisted-checkbox">Include unlisted packages</label>
               </div>
-            </div>
-            <div>
               <div class="search-controls-checkbox">
-                <input id="search-legacy-checkbox" type="checkbox" name="legacy"/>
-                <label for="search-legacy-checkbox">Include Dart 1.x results</label>
+                <input id="-search-legacy-checkbox" type="checkbox" name="legacy"/>
+                <label for="-search-legacy-checkbox">Include Dart 1.x results</label>
               </div>
             </div>
           </div>

--- a/pkg/web_app/lib/src/search.dart
+++ b/pkg/web_app/lib/src/search.dart
@@ -75,7 +75,7 @@ void _updateSortField(String value) {
 
 void _setEventForCheckboxChanges() {
   _setEventForHiddenCheckboxField(
-      'search-legacy-field', 'search-legacy-checkbox');
+      '-search-legacy-field', '-search-legacy-checkbox');
   _setEventForHiddenCheckboxField(
       '-search-unlisted-field', '-search-unlisted-checkbox');
 }

--- a/pkg/web_css/lib/src/_list.scss
+++ b/pkg/web_css/lib/src/_list.scss
@@ -22,18 +22,23 @@
   .search-controls-advanced {
     display: none;
 
+    .search-controls-checkbox {
+      display: flex;
+      align-items: center;
+      color: #6d7278;
+    }
+
     @media (min-width: $device-desktop-min-width) {
       background: white;
       border-bottom: 1px solid #d5d5d5;
-      text-align: right;
 
-      .search-controls-checkbox {
-        display: inline-flex;
-        align-items: center;
+      >.container {
+        text-align: right;
+      }
 
-        color: #6d7278;
-        font-size: 14px;
-        text-transform: uppercase;
+      .search-controls-advanced-block {
+        display: inline-block;
+        text-align: left;
       }
     }
   }


### PR DESCRIPTION
- Fixed `-` prefix of the `legacy` checkbox ID
- Left-align the checkboxes and other buttons:
  <img width="381" alt="Screenshot 2020-09-23 at 16 49 05" src="https://user-images.githubusercontent.com/4778111/94029068-b9bbe800-fdbc-11ea-8a40-b21feb656550.png">
