### PR TITLE
Updated API text search

### DIFF
--- a/app/test/search/api_doc_page_test.dart
+++ b/app/test/search/api_doc_page_test.dart
@@ -120,7 +120,7 @@ void main() {
         'packages': [
           {
             'package': 'foo',
-            'score': closeTo(0.165, 0.001), // find WebPageGenerator
+            'score': closeTo(0.025, 0.001), // find WebPageGenerator
             'apiPages': [
               {'title': null, 'path': 'generator.html'},
             ],

--- a/app/test/search/in_app_payments_test.dart
+++ b/app/test/search/in_app_payments_test.dart
@@ -50,7 +50,7 @@ Add _In-App Payments_ to your Flutter app with this plugin.''')));
         'packages': [
           {
             'package': 'flutter_iap',
-            'score': closeTo(0.60, 0.01),
+            'score': closeTo(0.41, 0.01),
           },
         ],
       });

--- a/app/test/search/json_tool_test.dart
+++ b/app/test/search/json_tool_test.dart
@@ -68,7 +68,7 @@ void main() {
         'packages': [
           {'package': 'jsontool', 'score': 1.0},
           {'package': 'json2entity', 'score': closeTo(0.79, 0.01)},
-          {'package': 'json_to_model', 'score': closeTo(0.66, 0.01)},
+          {'package': 'json_to_model', 'score': closeTo(0.55, 0.01)},
         ],
       });
     });

--- a/app/test/search/mem_index_test.dart
+++ b/app/test/search/mem_index_test.dart
@@ -135,7 +135,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'packages': [
           {
             'package': 'chrome_net',
-            'score': closeTo(0.36, 0.01),
+            'score': closeTo(0.29, 0.01),
           },
         ]
       });
@@ -469,7 +469,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'indexUpdated': isNotNull,
         'totalCount': 1,
         'packages': [
-          {'package': 'http', 'score': closeTo(0.65, 0.01)},
+          {'package': 'http', 'score': closeTo(0.54, 0.01)},
         ],
       });
     });


### PR DESCRIPTION
- #3994 and #4050
- Better structure for cutoff: words are evaluated in one go in a sub-index, timeouts are checked between those.
- Dartdoc API documentation search is done only when there was no reasonable result in the core results nor in the API symbols.
- Reduced the low-value results by 1-15% depending on the search query used.
