### PR TITLE
Store current timestamp in search result.

### DIFF
--- a/app/lib/package/search_adapter.dart
+++ b/app/lib/package/search_adapter.dart
@@ -122,6 +122,7 @@ class SearchAdapter {
     final totalCount = scores.length;
     scores = scores.skip(query.offset ?? 0).take(query.limit ?? 10).toList();
     return PackageSearchResult(
+        timestamp: DateTime.now().toUtc(),
         packages: scores,
         totalCount: totalCount,
         message:

--- a/app/lib/search/mem_index.dart
+++ b/app/lib/search/mem_index.dart
@@ -308,8 +308,9 @@ class InMemoryPackageIndex implements PackageIndex {
 
     return PackageSearchResult(
       totalCount: totalCount,
-      indexUpdated: _lastUpdated?.toIso8601String(),
+      indexUpdated: _lastUpdated,
       packages: results,
+      timestamp: DateTime.now().toUtc(),
     );
   }
 

--- a/app/lib/search/result_combiner.dart
+++ b/app/lib/search/result_combiner.dart
@@ -60,6 +60,7 @@ class SearchResultCombiner {
 
     return PackageSearchResult(
       indexUpdated: primaryResult.indexUpdated,
+      timestamp: primaryResult.timestamp,
       totalCount: allPackages.length,
       packages: packages,
     );

--- a/app/lib/search/search_client.dart
+++ b/app/lib/search/search_client.dart
@@ -34,9 +34,7 @@ class SearchClient {
     // check validity first
     final validity = query.evaluateValidity();
     if (validity.isRejected) {
-      return PackageSearchResult(
-        totalCount: 0,
-        packages: [],
+      return PackageSearchResult.empty(
         message: 'Search query rejected. ${validity.rejectReason}',
       );
     }

--- a/app/lib/search/search_service.dart
+++ b/app/lib/search/search_service.dart
@@ -721,7 +721,8 @@ class ParsedQuery {
 @JsonSerializable(includeIfNull: false)
 class PackageSearchResult {
   /// The last update of the search index.
-  final String indexUpdated;
+  final DateTime indexUpdated;
+  final DateTime timestamp;
   final int totalCount;
   final List<PackageScore> packages;
 
@@ -731,6 +732,7 @@ class PackageSearchResult {
 
   PackageSearchResult({
     this.indexUpdated,
+    @required this.timestamp,
     this.totalCount,
     List<PackageScore> packages,
     this.message,
@@ -738,6 +740,7 @@ class PackageSearchResult {
 
   PackageSearchResult.empty({this.message})
       : indexUpdated = null,
+        timestamp = DateTime.now().toUtc(),
         totalCount = 0,
         packages = [];
 

--- a/app/lib/search/search_service.g.dart
+++ b/app/lib/search/search_service.g.dart
@@ -76,7 +76,12 @@ Map<String, dynamic> _$ApiDocPageToJson(ApiDocPage instance) =>
 
 PackageSearchResult _$PackageSearchResultFromJson(Map<String, dynamic> json) {
   return PackageSearchResult(
-    indexUpdated: json['indexUpdated'] as String,
+    indexUpdated: json['indexUpdated'] == null
+        ? null
+        : DateTime.parse(json['indexUpdated'] as String),
+    timestamp: json['timestamp'] == null
+        ? null
+        : DateTime.parse(json['timestamp'] as String),
     totalCount: json['totalCount'] as int,
     packages: (json['packages'] as List)
         ?.map((e) =>
@@ -95,7 +100,8 @@ Map<String, dynamic> _$PackageSearchResultToJson(PackageSearchResult instance) {
     }
   }
 
-  writeNotNull('indexUpdated', instance.indexUpdated);
+  writeNotNull('indexUpdated', instance.indexUpdated?.toIso8601String());
+  writeNotNull('timestamp', instance.timestamp?.toIso8601String());
   writeNotNull('totalCount', instance.totalCount);
   writeNotNull('packages', instance.packages);
   writeNotNull('message', instance.message);

--- a/app/test/search/angular_test.dart
+++ b/app/test/search/angular_test.dart
@@ -34,6 +34,7 @@ void main() {
           .search(SearchQuery.parse(query: 'angular', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
+        'timestamp': isNotNull,
         'totalCount': 2,
         'packages': [
           {

--- a/app/test/search/api_doc_page_test.dart
+++ b/app/test/search/api_doc_page_test.dart
@@ -55,6 +55,7 @@ void main() {
           .search(SearchQuery.parse(query: 'foo', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
+        'timestamp': isNotNull,
         'totalCount': 2,
         'packages': [
           {
@@ -78,6 +79,7 @@ void main() {
           .search(SearchQuery.parse(query: 'serve', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
+        'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
           {
@@ -97,6 +99,7 @@ void main() {
           SearchQuery.parse(query: 'page generator', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
+        'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
           {
@@ -116,6 +119,7 @@ void main() {
           SearchQuery.parse(query: 'web page', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
+        'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
           {
@@ -136,6 +140,7 @@ void main() {
           SearchQuery.parse(query: 'goal fancy', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
+        'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
           {

--- a/app/test/search/bluetooth_test.dart
+++ b/app/test/search/bluetooth_test.dart
@@ -35,6 +35,7 @@ void main() {
           SearchQuery.parse(query: 'bluetooth', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
+        'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
           {

--- a/app/test/search/exact_name_test.dart
+++ b/app/test/search/exact_name_test.dart
@@ -43,6 +43,7 @@ void main() {
           SearchQuery.parse(query: 'build_config', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
+        'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
           {

--- a/app/test/search/flutter_95_test.dart
+++ b/app/test/search/flutter_95_test.dart
@@ -30,6 +30,7 @@ void main() {
           SearchQuery.parse(query: 'flutter 95', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
+        'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
           {

--- a/app/test/search/flutter_iap_test.dart
+++ b/app/test/search/flutter_iap_test.dart
@@ -53,6 +53,7 @@ void main() {
           SearchQuery.parse(query: 'flutter iap', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
+        'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
           {
@@ -68,6 +69,7 @@ void main() {
           SearchQuery.parse(query: 'flutter_iap', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
+        'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
           {

--- a/app/test/search/handlers_test.dart
+++ b/app/test/search/handlers_test.dart
@@ -45,6 +45,7 @@ void main() {
         await setUpInServiceScope();
         await expectJsonResponse(await issueGet('/search?q=pkg_foo'), body: {
           'indexUpdated': isNotNull,
+          'timestamp': isNotNull,
           'totalCount': 1,
           'packages': [
             {
@@ -59,6 +60,7 @@ void main() {
         await setUpInServiceScope();
         await expectJsonResponse(await issueGet('/search?q=json'), body: {
           'indexUpdated': isNotNull,
+          'timestamp': isNotNull,
           'totalCount': 1,
           'packages': [
             {
@@ -74,6 +76,7 @@ void main() {
         await expectJsonResponse(await issueGet('/search?q=json&pkg-prefix=pk'),
             body: {
               'indexUpdated': isNotNull,
+              'timestamp': isNotNull,
               'totalCount': 1,
               'packages': [
                 {
@@ -88,6 +91,7 @@ void main() {
         await setUpInServiceScope();
         await expectJsonResponse(await issueGet('/search?q=package:pk'), body: {
           'indexUpdated': isNotNull,
+          'timestamp': isNotNull,
           'totalCount': 1,
           'packages': [
             {
@@ -103,6 +107,7 @@ void main() {
         await expectJsonResponse(await issueGet('/search?q=json+package:foo'),
             body: {
               'indexUpdated': isNotNull,
+              'timestamp': isNotNull,
               'totalCount': 0,
               'packages': [],
             });

--- a/app/test/search/haversine_test.dart
+++ b/app/test/search/haversine_test.dart
@@ -381,6 +381,7 @@ MIT'''),
           SearchQuery.parse(query: 'haversine', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
+        'timestamp': isNotNull,
         'totalCount': 3,
         'packages': [
           {
@@ -407,6 +408,7 @@ MIT'''),
           SearchQuery.parse(query: 'hoversine', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
+        'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
           {

--- a/app/test/search/in_app_payments_test.dart
+++ b/app/test/search/in_app_payments_test.dart
@@ -31,6 +31,7 @@ Add _In-App Payments_ to your Flutter app with this plugin.''')));
           .search(SearchQuery.parse(query: 'IAP', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
+        'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
           {
@@ -46,6 +47,7 @@ Add _In-App Payments_ to your Flutter app with this plugin.''')));
           SearchQuery.parse(query: 'in app payments', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
+        'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
           {

--- a/app/test/search/json_tool_test.dart
+++ b/app/test/search/json_tool_test.dart
@@ -26,6 +26,7 @@ void main() {
           SearchQuery.parse(query: 'json_tool', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
+        'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
           {'package': 'jsontool', 'score': 1.0},
@@ -64,6 +65,7 @@ void main() {
           SearchQuery.parse(query: 'json_tool', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
+        'timestamp': isNotNull,
         'totalCount': 3,
         'packages': [
           {'package': 'jsontool', 'score': 1.0},

--- a/app/test/search/lombok_test.dart
+++ b/app/test/search/lombok_test.dart
@@ -27,6 +27,7 @@ void main() {
           .search(SearchQuery.parse(query: 'lombock', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
+        'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
           {

--- a/app/test/search/maps_test.dart
+++ b/app/test/search/maps_test.dart
@@ -25,6 +25,7 @@ void main() {
           .search(SearchQuery.parse(query: 'maps', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
+        'timestamp': isNotNull,
         'totalCount': 2,
         'packages': [
           {'package': 'maps', 'score': 1.0},
@@ -38,6 +39,7 @@ void main() {
           .search(SearchQuery.parse(query: 'map', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
+        'timestamp': isNotNull,
         'totalCount': 2,
         'packages': [
           {'package': 'maps', 'score': 1.0},

--- a/app/test/search/mem_index_test.dart
+++ b/app/test/search/mem_index_test.dart
@@ -101,6 +101,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
           await index.search(SearchQuery.parse(query: 'async'));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
+        'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
           {
@@ -116,6 +117,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
           await index.search(SearchQuery.parse(query: 'composable'));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
+        'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
           {
@@ -131,6 +133,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
           await index.search(SearchQuery.parse(query: 'chrome.sockets'));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
+        'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
           {
@@ -146,6 +149,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
           await index.search(SearchQuery.parse(query: '"utility"'));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
+        'timestamp': isNotNull,
         'totalCount': 2,
         'packages': [
           {'package': 'http', 'score': closeTo(0.70, 0.01)},
@@ -159,6 +163,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
           await index.search(SearchQuery.parse(query: '"once on demand."'));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
+        'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
           {'package': 'async', 'score': closeTo(0.29, 0.01)},
@@ -171,6 +176,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
           await index.search(SearchQuery.parse(query: 'package:chrome'));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
+        'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
           {
@@ -186,6 +192,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
           .search(SearchQuery.parse(query: 't', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
+        'timestamp': isNotNull,
         'totalCount': 2,
         'packages': [
           {'package': 'http', 'score': 0.5},
@@ -199,6 +206,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
           await index.search(SearchQuery.parse(order: SearchOrder.created));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
+        'timestamp': isNotNull,
         'totalCount': 3,
         'packages': [
           {'package': 'async'},
@@ -213,6 +221,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
           .search(SearchQuery.parse(query: '', order: SearchOrder.updated));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
+        'timestamp': isNotNull,
         'totalCount': 3,
         'packages': [
           {'package': 'http'},
@@ -227,6 +236,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
           .search(SearchQuery.parse(query: 'http', order: SearchOrder.updated));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
+        'timestamp': isNotNull,
         'totalCount': 2,
         'packages': [
           {'package': 'http'},
@@ -243,6 +253,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
       ));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
+        'timestamp': isNotNull,
         'totalCount': 2,
         'packages': [
           {'package': 'http'},
@@ -256,6 +267,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
           await index.search(SearchQuery.parse(order: SearchOrder.popularity));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
+        'timestamp': isNotNull,
         'totalCount': 3,
         'packages': [
           {'package': 'async', 'score': 0.8},
@@ -270,6 +282,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
           await index.search(SearchQuery.parse(order: SearchOrder.like));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
+        'timestamp': isNotNull,
         'totalCount': 3,
         'packages': [
           {'package': 'http', 'score': 10.0},
@@ -284,6 +297,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
           await index.search(SearchQuery.parse(order: SearchOrder.points));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
+        'timestamp': isNotNull,
         'totalCount': 3,
         'packages': [
           {'package': 'http', 'score': 110.0},
@@ -298,6 +312,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
           await index.search(SearchQuery.parse(query: 'dependency:test'));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
+        'timestamp': isNotNull,
         'totalCount': 2,
         'packages': [
           {'package': 'http', 'score': closeTo(0.96, 0.01)},
@@ -311,6 +326,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
           await index.search(SearchQuery.parse(query: 'dependency:foo'));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
+        'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
           {'package': 'chrome_net', 'score': closeTo(0.54, 0.01)},
@@ -323,6 +339,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
           await index.search(SearchQuery.parse(query: 'dependency*:foo'));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
+        'timestamp': isNotNull,
         'totalCount': 2,
         'packages': [
           {'package': 'http', 'score': closeTo(0.96, 0.01)},
@@ -336,6 +353,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
           .search(SearchQuery.parse(query: 'composable dependency:test'));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
+        'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
           {'package': 'http', 'score': closeTo(0.85, 0.01)},
@@ -348,6 +366,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
           .search(SearchQuery.parse(query: 'dependency:async dependency:test'));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
+        'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
           {'package': 'http', 'score': closeTo(0.96, 0.01)},
@@ -360,6 +379,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
           .search(SearchQuery.parse(query: 'publisher:other-domain.com'));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
+        'timestamp': isNotNull,
         'totalCount': 0,
         'packages': [],
       });
@@ -370,6 +390,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
           await index.search(SearchQuery.parse(query: 'publisher:dart.dev'));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
+        'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
           {'package': 'async', 'score': closeTo(0.70, 0.01)},
@@ -382,6 +403,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
           SearchQuery.parse(uploaderOrPublishers: ['other-domain.com']));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
+        'timestamp': isNotNull,
         'totalCount': 0,
         'packages': [],
       });
@@ -392,6 +414,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
           .search(SearchQuery.parse(uploaderOrPublishers: ['dart.dev']));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
+        'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
           {'package': 'async', 'score': closeTo(0.70, 0.01)},
@@ -407,6 +430,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
       ]));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
+        'timestamp': isNotNull,
         'totalCount': 2,
         'packages': [
           {'package': 'http', 'score': closeTo(0.96, 0.01)},
@@ -420,6 +444,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
           await index.search(SearchQuery.parse(query: 'email:some@other.com'));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
+        'timestamp': isNotNull,
         'totalCount': 0,
         'packages': [],
       });
@@ -430,6 +455,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
           .search(SearchQuery.parse(query: 'email:user1@example.com'));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
+        'timestamp': isNotNull,
         'totalCount': 2,
         'packages': [
           {'package': 'http', 'score': closeTo(0.96, 0.01)},
@@ -443,6 +469,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
           SearchQuery.parse(query: 'composable', order: SearchOrder.text));
       expect(json.decode(json.encode(composable)), {
         'indexUpdated': isNotNull,
+        'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
           {'package': 'http', 'score': closeTo(0.88, 0.01)},
@@ -453,6 +480,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
           .search(SearchQuery.parse(query: 'library', order: SearchOrder.text));
       expect(json.decode(json.encode(library)), {
         'indexUpdated': isNotNull,
+        'timestamp': isNotNull,
         'totalCount': 3,
         'packages': [
           {'package': 'chrome_net', 'score': closeTo(0.88, 0.01)},
@@ -467,6 +495,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
           query: 'composable library', order: SearchOrder.text));
       expect(json.decode(json.encode(both)), {
         'indexUpdated': isNotNull,
+        'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
           {'package': 'http', 'score': closeTo(0.54, 0.01)},

--- a/app/test/search/rest_api_test.dart
+++ b/app/test/search/rest_api_test.dart
@@ -52,6 +52,7 @@ Recent versions (0.3.x and 0.4.x) of this plugin require [extensible codec funct
           SearchQuery.parse(query: 'rest api', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
+        'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
           {

--- a/app/test/search/result_combiner_test.dart
+++ b/app/test/search/result_combiner_test.dart
@@ -49,6 +49,7 @@ void main() {
           .search(SearchQuery.parse(order: SearchOrder.popularity));
       expect(json.decode(json.encode(results.toJson())), {
         'indexUpdated': isNotNull,
+        'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
           {'package': 'stringutils', 'score': 0.4},
@@ -61,6 +62,7 @@ void main() {
           .search(SearchQuery.parse(query: 'email:foo@example.com'));
       expect(json.decode(json.encode(results.toJson())), {
         'indexUpdated': isNotNull,
+        'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
           {'package': 'stringutils', 'score': closeTo(0.8, 0.01)},
@@ -73,6 +75,7 @@ void main() {
           await combiner.search(SearchQuery.parse(query: 'substring'));
       expect(json.decode(json.encode(results.toJson())), {
         'indexUpdated': isNotNull,
+        'timestamp': isNotNull,
         'totalCount': 2,
         'packages': [
           {
@@ -100,6 +103,7 @@ void main() {
           await combiner.search(SearchQuery.parse(query: 'stringutils'));
       expect(json.decode(json.encode(results.toJson())), {
         'indexUpdated': isNotNull,
+        'timestamp': isNotNull,
         'totalCount': 2,
         'packages': [
           {'package': 'stringutils', 'score': closeTo(0.80, 0.01)},

--- a/app/test/search/scope_specificity_test.dart
+++ b/app/test/search/scope_specificity_test.dart
@@ -65,6 +65,7 @@ void main() {
           await index.search(SearchQuery.parse(query: 'json'));
       expect(json.decode(json.encode(withoutPlatform)), {
         'indexUpdated': isNotNull,
+        'timestamp': isNotNull,
         'totalCount': 4,
         'packages': [
           {
@@ -95,6 +96,7 @@ void main() {
       ));
       expect(json.decode(json.encode(withPlatform)), {
         'indexUpdated': isNotNull,
+        'timestamp': isNotNull,
         'totalCount': 2,
         'packages': [
           {

--- a/app/test/search/stack_trace_test.dart
+++ b/app/test/search/stack_trace_test.dart
@@ -33,6 +33,7 @@ void main() {
           SearchQuery.parse(query: 'stacktrace', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
+        'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
           {

--- a/app/test/search/tags_test.dart
+++ b/app/test/search/tags_test.dart
@@ -21,6 +21,7 @@ void main() {
       ));
       expect(rs.toJson(), {
         'indexUpdated': isNotEmpty,
+        'timestamp': isNotNull,
         'totalCount': 0,
         'packages': [],
       });
@@ -36,6 +37,7 @@ void main() {
       ));
       expect(json.decode(json.encode(rs.toJson())), {
         'indexUpdated': isNotEmpty,
+        'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
           {'package': 'pkg1', 'score': isNotNull},
@@ -54,6 +56,7 @@ void main() {
       ));
       expect(json.decode(json.encode(rs.toJson())), {
         'indexUpdated': isNotEmpty,
+        'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
           {'package': 'pkg2', 'score': isNotNull},
@@ -72,6 +75,7 @@ void main() {
       ));
       expect(json.decode(json.encode(rs.toJson())), {
         'indexUpdated': isNotEmpty,
+        'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
           {'package': 'pkg1', 'score': isNotNull},
@@ -92,6 +96,7 @@ void main() {
       ));
       expect(json.decode(json.encode(rs.toJson())), {
         'indexUpdated': isNotEmpty,
+        'timestamp': isNotNull,
         'totalCount': 2,
         'packages': [
           {'package': 'pkg1', 'score': isNotNull},
@@ -113,6 +118,7 @@ void main() {
       ));
       expect(json.decode(json.encode(rs.toJson())), {
         'indexUpdated': isNotEmpty,
+        'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
           {'package': 'pkg2', 'score': isNotNull},
@@ -133,6 +139,7 @@ void main() {
       ));
       expect(json.decode(json.encode(rs.toJson())), {
         'indexUpdated': isNotEmpty,
+        'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
           {'package': 'pkg1', 'score': isNotNull},
@@ -150,6 +157,7 @@ void main() {
       final rs = await index.search(SearchQuery.parse(query: 'is:b -is:a'));
       expect(json.decode(json.encode(rs.toJson())), {
         'indexUpdated': isNotEmpty,
+        'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
           {'package': 'pkg2', 'score': isNotNull},
@@ -169,6 +177,7 @@ void main() {
           query: 'is:a is:b'));
       expect(json.decode(json.encode(rs.toJson())), {
         'indexUpdated': isNotEmpty,
+        'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
           {'package': 'pkg1', 'score': isNotNull},

--- a/app/test/search/travis_test.dart
+++ b/app/test/search/travis_test.dart
@@ -56,6 +56,7 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor i
           .search(SearchQuery.parse(query: 'travis', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
+        'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
           {


### PR DESCRIPTION
This will be used to re-populate cache when landing-page results are close to their TTL age.