### PR TITLE
Fix UserSession query filter and remove userIdKey

### DIFF
--- a/app/lib/account/backend.dart
+++ b/app/lib/account/backend.dart
@@ -437,8 +437,6 @@ class AccountBackend {
     final now = DateTime.now().toUtc();
     final session = UserSession()
       ..id = createUuid()
-      // ignore: deprecated_member_use_from_same_package
-      ..userIdKey = user.key
       ..userId = user.userId
       ..email = user.email
       ..name = name
@@ -519,7 +517,7 @@ class AccountBackend {
 
   // expire all sessions of a given user from datastore and cache
   Future<void> _expireAllSessions(String userId) async {
-    final query = _db.query<UserSession>()..filter('userId = ', userId);
+    final query = _db.query<UserSession>()..filter('userId =', userId);
     final sessionsToDelete = await query.run().toList();
     for (final session in sessionsToDelete) {
       await _db.commit(deletes: [session.key]);

--- a/app/lib/account/models.dart
+++ b/app/lib/account/models.dart
@@ -117,17 +117,8 @@ class UserSession extends db.ExpandoModel<String> {
   /// This is a v4 (random) UUID String.
   String get sessionId => id;
 
-  @Deprecated('Prefer userId')
-  @db.ModelKeyProperty(required: true)
-  db.Key userIdKey;
-
-  // TODO: set `required: true` once this is expected to be the only userId property.
-  @db.StringProperty()
+  @db.StringProperty(required: true)
   String userId;
-
-  // TODO: remove once only `userId` is used.
-  // ignore: deprecated_member_use_from_same_package
-  String get userIdValue => userId ?? userIdKey.id as String;
 
   @db.StringProperty(required: true)
   String email;
@@ -186,7 +177,7 @@ class UserSessionData {
   factory UserSessionData.fromModel(UserSession session) {
     return UserSessionData(
       sessionId: session.sessionId,
-      userId: session.userIdValue,
+      userId: session.userId,
       email: session.email,
       name: session.name,
       imageUrl: session.imageUrl,

--- a/app/lib/shared/user_merger.dart
+++ b/app/lib/shared/user_merger.dart
@@ -117,17 +117,13 @@ class UserMerger {
 
     // UserSession
     final fromUserKey = _db.emptyKey.append(User, id: fromUserId);
-    final toUserKey = _db.emptyKey.append(User, id: toUserId);
     await _processConcurrently(
-      _db.query<UserSession>()..filter('userIdKey =', fromUserKey),
+      _db.query<UserSession>()..filter('userId =', fromUserId),
       (UserSession m) async {
         await withRetryTransaction(_db, (tx) async {
           final session = await tx.lookupValue<UserSession>(m.key);
-          if (session.userIdValue == fromUserId) {
-            session
-              // ignore: deprecated_member_use_from_same_package
-              ..userIdKey = toUserKey
-              ..userId = toUserId;
+          if (session.userId == fromUserId) {
+            session.userId = toUserId;
             tx.insert(session);
           }
         });

--- a/app/test/shared/user_merger_test.dart
+++ b/app/test/shared/user_merger_test.dart
@@ -74,16 +74,12 @@ void main() {
     await dbService.commit(inserts: [
       UserSession()
         ..id = 'target'
-        // ignore: deprecated_member_use_from_same_package
-        ..userIdKey = hansUser.key
         ..userId = hansUser.userId
         ..email = 'target@domain.com'
         ..created = DateTime.now()
         ..expires = DateTime.now(),
       UserSession()
         ..id = 'control'
-        // ignore: deprecated_member_use_from_same_package
-        ..userIdKey = adminUser.key
         ..userId = adminUser.userId
         ..email = 'control@domain.com'
         ..created = DateTime.now()
@@ -96,8 +92,8 @@ void main() {
       dbService.emptyKey.append(UserSession, id: 'target'),
       dbService.emptyKey.append(UserSession, id: 'control'),
     ]);
-    expect(list[0].userIdValue, joeUser.userId);
-    expect(list[1].userIdValue, adminUser.userId);
+    expect(list[0].userId, joeUser.userId);
+    expect(list[1].userId, adminUser.userId);
   });
 
   testWithServices('new consent', () async {


### PR DESCRIPTION
- Confirmed on staging: the query issue was the extra space at the end of the filter expression.
- Removed `userIdKey` as we no longer use it and `UserSession` entries have `userId` for more than 14 days.