### PR TITLE
Split SearchQuery: Frontend* and Service*

### DIFF
--- a/app/lib/frontend/templates/admin.dart
+++ b/app/lib/frontend/templates/admin.dart
@@ -9,7 +9,7 @@ import 'package:meta/meta.dart';
 import '../../account/models.dart' show LikeData, User, UserSessionData;
 import '../../package/models.dart' show PackageView;
 import '../../publisher/models.dart' show Publisher;
-import '../../search/search_service.dart' show SearchQuery;
+import '../../search/search_service.dart' show FrontendSearchQuery;
 import '../../shared/urls.dart' as urls;
 import '../../shared/utils.dart' show shortDateFormat;
 
@@ -33,7 +33,7 @@ String renderAccountPackagesPage({
   @required List<PackageView> packages,
   @required String messageFromBackend,
   @required PageLinks pageLinks,
-  @required SearchQuery searchQuery,
+  @required FrontendSearchQuery searchQuery,
   @required int totalCount,
 }) {
   final isSearch = searchQuery.hasQuery;

--- a/app/lib/frontend/templates/layout.dart
+++ b/app/lib/frontend/templates/layout.dart
@@ -48,7 +48,7 @@ String renderLayoutPage(
   String shareUrl,
   String sdk,
   String publisherId,
-  SearchQuery searchQuery,
+  FrontendSearchQuery searchQuery,
   bool noIndex = false,
   PageData pageData,
   String searchPlaceHolder,
@@ -132,7 +132,7 @@ String _renderSiteHeader(PageType pageType) {
 String _renderSearchBanner({
   @required PageType type,
   @required String publisherId,
-  @required SearchQuery searchQuery,
+  @required FrontendSearchQuery searchQuery,
   String searchPlaceholder,
 }) {
   final sdk = searchQuery?.sdk ?? SdkTagValue.any;
@@ -150,19 +150,20 @@ String _renderSearchBanner({
   }
   String searchFormUrl;
   if (publisherId != null) {
-    searchFormUrl = SearchQuery.parse(publisherId: publisherId).toSearchLink();
+    searchFormUrl =
+        FrontendSearchQuery.parse(publisherId: publisherId).toSearchLink();
   } else if (type == PageType.account) {
     searchFormUrl = urls.myPackagesUrl();
   } else if (searchQuery != null) {
     searchFormUrl = searchQuery.toSearchFormPath();
   } else {
-    searchFormUrl = SearchQuery.parse().toSearchFormPath();
+    searchFormUrl = FrontendSearchQuery.parse().toSearchFormPath();
   }
   final searchSort = searchQuery?.order == null
       ? null
       : serializeSearchOrder(searchQuery.order);
   final hiddenInputs = includePreferencesAsHiddenFields
-      ? (searchQuery ?? SearchQuery.parse())
+      ? (searchQuery ?? FrontendSearchQuery.parse())
           .tagsPredicate
           .asSearchLinkParams()
           .entries
@@ -186,7 +187,7 @@ String _renderSearchBanner({
 }
 
 String renderSdkTabs({
-  SearchQuery searchQuery,
+  FrontendSearchQuery searchQuery,
 }) {
   final currentSdk = searchQuery?.sdk ?? SdkTagValue.any;
   SearchTab sdkTabData(String label, String tabSdk, String title) {
@@ -240,7 +241,7 @@ class _FilterOption {
 }
 
 String renderSubSdkTabsHtml({
-  @required SearchQuery searchQuery,
+  @required FrontendSearchQuery searchQuery,
   bool detectAdvanced = false,
   bool onlyAdvanced = false,
 }) {
@@ -324,7 +325,7 @@ String renderSubSdkTabsHtml({
 }
 
 String _renderFilterTabs({
-  @required SearchQuery searchQuery,
+  @required FrontendSearchQuery searchQuery,
   @required List<_FilterOption> options,
 }) {
   if (options.isEmpty) return null;

--- a/app/lib/frontend/templates/listing.dart
+++ b/app/lib/frontend/templates/listing.dart
@@ -34,7 +34,7 @@ String renderPagination(PageLinks pageLinks) {
 /// Renders the `views/pkg/package_list.mustache` template.
 String renderPackageList(
   List<PackageView> packages, {
-  SearchQuery searchQuery,
+  FrontendSearchQuery searchQuery,
 }) {
   final packagesJson = [];
   for (int i = 0; i < packages.length; i++) {
@@ -117,7 +117,7 @@ String renderPkgIndexPage(
   PageLinks links, {
   String sdk,
   String title,
-  SearchQuery searchQuery,
+  FrontendSearchQuery searchQuery,
   int totalCount,
   String searchPlaceholder,
   String messageFromBackend,
@@ -177,7 +177,7 @@ String renderPkgIndexPage(
 
 /// Renders the `views/shared/listing_info.mustache` template.
 String renderListingInfo({
-  @required SearchQuery searchQuery,
+  @required FrontendSearchQuery searchQuery,
   @required int totalCount,
   String title,
   String ownedBy,
@@ -197,7 +197,7 @@ String renderListingInfo({
   });
 }
 
-String _subSdkLabel(SearchQuery sq) {
+String _subSdkLabel(FrontendSearchQuery sq) {
   if (sq?.sdk == SdkTagValue.dart) {
     return 'Runtime';
   } else if (sq?.sdk == SdkTagValue.flutter) {
@@ -208,7 +208,7 @@ String _subSdkLabel(SearchQuery sq) {
 }
 
 /// Renders the `views/shared/sort_control.mustache` template.
-String renderSortControl(SearchQuery query) {
+String renderSortControl(FrontendSearchQuery query) {
   final isSearch = query != null && query.hasQuery;
   final options = getSortDicts(isSearch);
   final selectedValue = serializeSearchOrder(query?.order) ??
@@ -234,9 +234,9 @@ String renderSortControl(SearchQuery query) {
 class PageLinks {
   final int offset;
   final int count;
-  final SearchQuery _searchQuery;
+  final FrontendSearchQuery _searchQuery;
 
-  PageLinks(this.offset, this.count, {SearchQuery searchQuery})
+  PageLinks(this.offset, this.count, {FrontendSearchQuery searchQuery})
       : _searchQuery = searchQuery;
 
   PageLinks.empty()

--- a/app/lib/frontend/templates/package.dart
+++ b/app/lib/frontend/templates/package.dart
@@ -433,7 +433,8 @@ String _getAuthorsHtml(List<String> authors) {
     if (author.email != null) {
       final escapedEmail = htmlAttrEscape.convert(author.email);
       final emailSearchUrl = htmlAttrEscape.convert(
-          SearchQuery.parse(query: 'email:${author.email}').toSearchLink());
+          FrontendSearchQuery.parse(query: 'email:${author.email}')
+              .toSearchLink());
       final text =
           '<a href="$emailSearchUrl" title="Search packages from $escapedName" rel="nofollow">'
           '$escapedEmail'

--- a/app/lib/frontend/templates/publisher.dart
+++ b/app/lib/frontend/templates/publisher.dart
@@ -9,7 +9,7 @@ import 'package:pub_dev/shared/markdown.dart';
 
 import '../../package/models.dart' show PackageView;
 import '../../publisher/models.dart' show Publisher;
-import '../../search/search_service.dart' show SearchQuery;
+import '../../search/search_service.dart' show FrontendSearchQuery;
 import '../../shared/urls.dart' as urls;
 import '../../shared/utils.dart' show shortDateFormat;
 
@@ -80,7 +80,7 @@ String renderPublisherPackagesPage({
   @required List<PackageView> packages,
   @required String messageFromBackend,
   @required PageLinks pageLinks,
-  @required SearchQuery searchQuery,
+  @required FrontendSearchQuery searchQuery,
   @required int totalCount,
   @required bool isAdmin,
 }) {

--- a/app/lib/package/search_adapter.dart
+++ b/app/lib/package/search_adapter.dart
@@ -42,7 +42,7 @@ class SearchAdapter {
     int count = 6,
     SearchOrder order,
   }) async {
-    final query = SearchQuery.parse(
+    final query = FrontendSearchQuery.parse(
       limit: 100,
       tagsPredicate: TagsPredicate.advertisement(requiredTags: requiredTags),
       order: order,
@@ -76,14 +76,14 @@ class SearchAdapter {
   ///
   /// When the `search` service fails, it falls back to use the name tracker to
   /// provide package names and perform search in that set.
-  Future<SearchResultPage> search(SearchQuery query) async {
+  Future<SearchResultPage> search(FrontendSearchQuery query) async {
     final result = await _searchOrFallback(query, true);
     return SearchResultPage(query, result.totalCount,
         await getPackageViews(result.packages), result.message);
   }
 
   Future<PackageSearchResult> _searchOrFallback(
-    SearchQuery query,
+    FrontendSearchQuery query,
     bool fallbackToNames, {
     Duration ttl,
     Duration updateCacheAfter,
@@ -103,7 +103,7 @@ class SearchAdapter {
 
   /// Search over the package names as a fallback, in the absence of the
   /// `search` service.
-  Future<PackageSearchResult> _fallbackSearch(SearchQuery query) async {
+  Future<PackageSearchResult> _fallbackSearch(FrontendSearchQuery query) async {
     // Some search queries must not be served with the fallback search.
     if (query.uploaderOrPublishers != null || query.publisherId != null) {
       return PackageSearchResult.empty(
@@ -209,7 +209,7 @@ class SearchAdapter {
 /// The results of a search via the Custom Search API.
 class SearchResultPage {
   /// The query used for the search.
-  final SearchQuery query;
+  final FrontendSearchQuery query;
 
   /// The total number of results available for the search.
   final int totalCount;
@@ -223,6 +223,6 @@ class SearchResultPage {
 
   SearchResultPage(this.query, this.totalCount, this.packages, this.message);
 
-  factory SearchResultPage.empty(SearchQuery query, {String message}) =>
+  factory SearchResultPage.empty(FrontendSearchQuery query, {String message}) =>
       SearchResultPage(query, 0, [], message);
 }

--- a/app/lib/search/handlers.dart
+++ b/app/lib/search/handlers.dart
@@ -63,7 +63,7 @@ Future<shelf.Response> _searchHandler(shelf.Request request) async {
         status: searchIndexNotReadyCode);
   }
   final Stopwatch sw = Stopwatch()..start();
-  final SearchQuery query = SearchQuery.fromServiceUrl(request.requestedUri);
+  final query = ServiceSearchQuery.fromServiceUrl(request.requestedUri);
   final combiner = SearchResultCombiner(
       primaryIndex: packageIndex, dartSdkIndex: dartSdkIndex);
   final result = await combiner.search(query);
@@ -71,7 +71,7 @@ Future<shelf.Response> _searchHandler(shelf.Request request) async {
   if (elapsed > _slowSearchThreshold) {
     _logger.info(
         '[pub-slow-search-query] Slow search: handler exceeded ${_slowSearchThreshold.inMilliseconds} ms: '
-        '${query.toServiceQueryParameters()}');
+        '${query.toUriQueryParameters()}');
   }
 
   return jsonResponse(result.toJson());

--- a/app/lib/search/mem_index.dart
+++ b/app/lib/search/mem_index.dart
@@ -10,7 +10,6 @@ import 'package:logging/logging.dart';
 import 'package:pana/pana.dart' show DependencyTypes;
 import 'package:path/path.dart' as p;
 
-import '../shared/tags.dart';
 import '../shared/utils.dart' show boundedList;
 
 import 'scope_specificity.dart';
@@ -126,7 +125,7 @@ class InMemoryPackageIndex implements PackageIndex {
   }
 
   @override
-  Future<PackageSearchResult> search(SearchQuery query) async {
+  Future<PackageSearchResult> search(ServiceSearchQuery query) async {
     final Set<String> packages = Set.from(_packages.keys);
 
     // filter on package prefix
@@ -201,13 +200,6 @@ class InMemoryPackageIndex implements PackageIndex {
         }
         return true;
       });
-    }
-
-    // Remove legacy packages, if not included in the query.
-    // TODO: remove after next release, as the flag should be always true with that
-    if (!query.includeLegacy) {
-      packages.removeWhere(
-          (p) => _packages[p].tags.contains(PackageVersionTags.isLegacy));
     }
 
     // do text matching
@@ -316,7 +308,7 @@ class InMemoryPackageIndex implements PackageIndex {
   }
 
   Map<String, double> _scopeSpecificityScore(
-      SearchQuery query, Iterable<String> packages) {
+      ServiceSearchQuery query, Iterable<String> packages) {
     final scopeSpecificity = <String, double>{};
     packages.forEach((String package) {
       final PackageDocument doc = _packages[package];

--- a/app/lib/search/result_combiner.dart
+++ b/app/lib/search/result_combiner.dart
@@ -21,7 +21,7 @@ class SearchResultCombiner {
     @required this.dartSdkIndex,
   });
 
-  Future<PackageSearchResult> search(SearchQuery query) async {
+  Future<PackageSearchResult> search(ServiceSearchQuery query) async {
     final includeSdkResults = shouldIncludeSdkResults(query);
     if (!includeSdkResults) {
       return primaryIndex.search(query);
@@ -68,7 +68,7 @@ class SearchResultCombiner {
 }
 
 /// Whether the results for the query should include SDK results.
-bool shouldIncludeSdkResults(SearchQuery query) {
+bool shouldIncludeSdkResults(ServiceSearchQuery query) {
   // No reason to display SDK packages if:
   // - there is no text query
   // - the query is about a filter (e.g. dependency or package-prefix)

--- a/app/lib/search/search_client.dart
+++ b/app/lib/search/search_client.dart
@@ -39,7 +39,7 @@ class SearchClient {
   /// than the specified value, the client will do a non-cached request to the
   /// search service and update the cached value.
   Future<PackageSearchResult> search(
-    SearchQuery query, {
+    FrontendSearchQuery query, {
     Duration ttl,
     Duration updateCacheAfter,
   }) async {
@@ -52,8 +52,8 @@ class SearchClient {
     }
 
     final String httpHostPort = activeConfiguration.searchServicePrefix;
-    final String serviceUrlParams =
-        Uri(queryParameters: query.toServiceQueryParameters()).toString();
+    final serviceUrlParams =
+        Uri(queryParameters: query.toServiceQuery().toUriQueryParameters());
     final String serviceUrl = '$httpHostPort/search$serviceUrlParams';
 
     Future<PackageSearchResult> searchFn() async {

--- a/app/lib/shared/urls.dart
+++ b/app/lib/shared/urls.dart
@@ -5,7 +5,7 @@
 import 'package:path/path.dart' as p;
 
 import '../package/overrides.dart';
-import '../search/search_service.dart' show SearchOrder, SearchQuery;
+import '../search/search_service.dart' show SearchOrder, FrontendSearchQuery;
 
 export '../search/search_service.dart' show SearchOrder;
 
@@ -101,7 +101,7 @@ String pkgDocUrl(
 
 String publisherUrl(String publisherId) => '/publishers/$publisherId';
 String publisherPackagesUrl(String publisherId) =>
-    SearchQuery.parse(publisherId: publisherId).toSearchLink();
+    FrontendSearchQuery.parse(publisherId: publisherId).toSearchLink();
 String publisherAdminUrl(String publisherId) =>
     '/publishers/$publisherId/admin';
 
@@ -113,7 +113,7 @@ String searchUrl({
   int page,
   SearchOrder order,
 }) {
-  final query = SearchQuery.parse(
+  final query = FrontendSearchQuery.parse(
     sdk: sdk,
     runtimes: runtimes,
     platforms: platforms,

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -528,7 +528,7 @@ void main() {
 
     scopedTest('package index page with search', () {
       final searchQuery =
-          SearchQuery.parse(query: 'foobar', order: SearchOrder.top);
+          FrontendSearchQuery.parse(query: 'foobar', order: SearchOrder.top);
       final String html = renderPkgIndexPage(
         [
           PackageView.fromModel(
@@ -605,7 +605,7 @@ void main() {
     });
 
     scopedTest('publisher packages page', () {
-      final searchQuery = SearchQuery.parse(publisherId: 'example.com');
+      final searchQuery = FrontendSearchQuery.parse(publisherId: 'example.com');
       final html = renderPublisherPackagesPage(
         publisher: Publisher()
           ..id = 'example.com'
@@ -644,7 +644,7 @@ void main() {
 
     scopedTest('/my-packages page', () {
       final searchQuery =
-          SearchQuery.parse(uploaderOrPublishers: [hansUser.email]);
+          FrontendSearchQuery.parse(uploaderOrPublishers: [hansUser.email]);
       final String html = renderAccountPackagesPage(
         user: hansUser,
         userSessionData: hansUserSessionData,
@@ -739,7 +739,7 @@ void main() {
 
     scopedTest('platform tabs: search', () {
       final String html = renderSdkTabs(
-          searchQuery: SearchQuery.parse(
+          searchQuery: FrontendSearchQuery.parse(
         query: 'foo',
         sdk: 'flutter',
       ));
@@ -823,14 +823,15 @@ void main() {
 
   group('URLs', () {
     scopedTest('PageLinks defaults', () {
-      final query = SearchQuery.parse(query: 'web framework');
+      final query = FrontendSearchQuery.parse(query: 'web framework');
       final PageLinks links = PageLinks(0, 100, searchQuery: query);
       expect(links.formatHref(1), '/packages?q=web+framework');
       expect(links.formatHref(2), '/packages?q=web+framework&page=2');
     });
 
     scopedTest('PageLinks with platform', () {
-      final query = SearchQuery.parse(query: 'some framework', sdk: 'flutter');
+      final query =
+          FrontendSearchQuery.parse(query: 'some framework', sdk: 'flutter');
       final PageLinks links = PageLinks(0, 100, searchQuery: query);
       expect(links.formatHref(1), '/flutter/packages?q=some+framework');
       expect(links.formatHref(2), '/flutter/packages?q=some+framework&page=2');

--- a/app/test/search/angular_test.dart
+++ b/app/test/search/angular_test.dart
@@ -30,8 +30,8 @@ void main() {
     });
 
     test('angular', () async {
-      final PackageSearchResult result = await index
-          .search(SearchQuery.parse(query: 'angular', order: SearchOrder.text));
+      final PackageSearchResult result = await index.search(
+          ServiceSearchQuery.parse(query: 'angular', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
         'timestamp': isNotNull,

--- a/app/test/search/api_doc_page_test.dart
+++ b/app/test/search/api_doc_page_test.dart
@@ -51,8 +51,8 @@ void main() {
     });
 
     test('foo', () async {
-      final PackageSearchResult result = await index
-          .search(SearchQuery.parse(query: 'foo', order: SearchOrder.text));
+      final PackageSearchResult result = await index.search(
+          ServiceSearchQuery.parse(query: 'foo', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
         'timestamp': isNotNull,
@@ -75,8 +75,8 @@ void main() {
     });
 
     test('serve', () async {
-      final PackageSearchResult result = await index
-          .search(SearchQuery.parse(query: 'serve', order: SearchOrder.text));
+      final PackageSearchResult result = await index.search(
+          ServiceSearchQuery.parse(query: 'serve', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
         'timestamp': isNotNull,
@@ -96,7 +96,8 @@ void main() {
 
     test('page generator', () async {
       final PackageSearchResult result = await index.search(
-          SearchQuery.parse(query: 'page generator', order: SearchOrder.text));
+          ServiceSearchQuery.parse(
+              query: 'page generator', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
         'timestamp': isNotNull,
@@ -116,7 +117,7 @@ void main() {
 
     test('web page', () async {
       final PackageSearchResult result = await index.search(
-          SearchQuery.parse(query: 'web page', order: SearchOrder.text));
+          ServiceSearchQuery.parse(query: 'web page', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
         'timestamp': isNotNull,
@@ -137,7 +138,8 @@ void main() {
 
     test('text block', () async {
       final PackageSearchResult result = await index.search(
-          SearchQuery.parse(query: 'goal fancy', order: SearchOrder.text));
+          ServiceSearchQuery.parse(
+              query: 'goal fancy', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
         'timestamp': isNotNull,

--- a/app/test/search/bluetooth_test.dart
+++ b/app/test/search/bluetooth_test.dart
@@ -32,7 +32,8 @@ void main() {
 
     test('bluetooth', () async {
       final PackageSearchResult result = await index.search(
-          SearchQuery.parse(query: 'bluetooth', order: SearchOrder.text));
+          ServiceSearchQuery.parse(
+              query: 'bluetooth', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
         'timestamp': isNotNull,

--- a/app/test/search/exact_name_test.dart
+++ b/app/test/search/exact_name_test.dart
@@ -40,7 +40,8 @@ void main() {
 
     test('build_config', () async {
       final PackageSearchResult result = await index.search(
-          SearchQuery.parse(query: 'build_config', order: SearchOrder.text));
+          ServiceSearchQuery.parse(
+              query: 'build_config', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
         'timestamp': isNotNull,

--- a/app/test/search/flutter_95_test.dart
+++ b/app/test/search/flutter_95_test.dart
@@ -27,7 +27,8 @@ void main() {
 
     test('flutter 95', () async {
       final PackageSearchResult result = await index.search(
-          SearchQuery.parse(query: 'flutter 95', order: SearchOrder.text));
+          ServiceSearchQuery.parse(
+              query: 'flutter 95', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
         'timestamp': isNotNull,

--- a/app/test/search/flutter_iap_test.dart
+++ b/app/test/search/flutter_iap_test.dart
@@ -50,7 +50,8 @@ void main() {
 
     test('flutter iap', () async {
       final PackageSearchResult result = await index.search(
-          SearchQuery.parse(query: 'flutter iap', order: SearchOrder.text));
+          ServiceSearchQuery.parse(
+              query: 'flutter iap', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
         'timestamp': isNotNull,
@@ -66,7 +67,8 @@ void main() {
 
     test('flutter_iap', () async {
       final PackageSearchResult result = await index.search(
-          SearchQuery.parse(query: 'flutter_iap', order: SearchOrder.text));
+          ServiceSearchQuery.parse(
+              query: 'flutter_iap', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
         'timestamp': isNotNull,

--- a/app/test/search/haversine_test.dart
+++ b/app/test/search/haversine_test.dart
@@ -378,7 +378,8 @@ MIT'''),
 
     test('haversine', () async {
       final PackageSearchResult result = await index.search(
-          SearchQuery.parse(query: 'haversine', order: SearchOrder.text));
+          ServiceSearchQuery.parse(
+              query: 'haversine', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
         'timestamp': isNotNull,
@@ -405,7 +406,8 @@ MIT'''),
 
     test('type: hoversine', () async {
       final PackageSearchResult result = await index.search(
-          SearchQuery.parse(query: 'hoversine', order: SearchOrder.text));
+          ServiceSearchQuery.parse(
+              query: 'hoversine', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
         'timestamp': isNotNull,

--- a/app/test/search/in_app_payments_test.dart
+++ b/app/test/search/in_app_payments_test.dart
@@ -27,8 +27,8 @@ Add _In-App Payments_ to your Flutter app with this plugin.''')));
     });
 
     test('IAP', () async {
-      final PackageSearchResult result = await index
-          .search(SearchQuery.parse(query: 'IAP', order: SearchOrder.text));
+      final PackageSearchResult result = await index.search(
+          ServiceSearchQuery.parse(query: 'IAP', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
         'timestamp': isNotNull,
@@ -44,7 +44,8 @@ Add _In-App Payments_ to your Flutter app with this plugin.''')));
 
     test('in app payments', () async {
       final PackageSearchResult result = await index.search(
-          SearchQuery.parse(query: 'in app payments', order: SearchOrder.text));
+          ServiceSearchQuery.parse(
+              query: 'in app payments', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
         'timestamp': isNotNull,

--- a/app/test/search/json_tool_test.dart
+++ b/app/test/search/json_tool_test.dart
@@ -23,7 +23,8 @@ void main() {
 
     test('json_tool', () async {
       final PackageSearchResult result = await index.search(
-          SearchQuery.parse(query: 'json_tool', order: SearchOrder.text));
+          ServiceSearchQuery.parse(
+              query: 'json_tool', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
         'timestamp': isNotNull,
@@ -62,7 +63,8 @@ void main() {
 
     test('json_tool', () async {
       final PackageSearchResult result = await index.search(
-          SearchQuery.parse(query: 'json_tool', order: SearchOrder.text));
+          ServiceSearchQuery.parse(
+              query: 'json_tool', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
         'timestamp': isNotNull,

--- a/app/test/search/lombok_test.dart
+++ b/app/test/search/lombok_test.dart
@@ -23,8 +23,8 @@ void main() {
     });
 
     test('lombock', () async {
-      final PackageSearchResult result = await index
-          .search(SearchQuery.parse(query: 'lombock', order: SearchOrder.text));
+      final PackageSearchResult result = await index.search(
+          ServiceSearchQuery.parse(query: 'lombock', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
         'timestamp': isNotNull,

--- a/app/test/search/maps_test.dart
+++ b/app/test/search/maps_test.dart
@@ -21,8 +21,8 @@ void main() {
     });
 
     test('maps', () async {
-      final PackageSearchResult result = await index
-          .search(SearchQuery.parse(query: 'maps', order: SearchOrder.text));
+      final PackageSearchResult result = await index.search(
+          ServiceSearchQuery.parse(query: 'maps', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
         'timestamp': isNotNull,
@@ -35,8 +35,8 @@ void main() {
     });
 
     test('map', () async {
-      final PackageSearchResult result = await index
-          .search(SearchQuery.parse(query: 'map', order: SearchOrder.text));
+      final PackageSearchResult result = await index.search(
+          ServiceSearchQuery.parse(query: 'map', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
         'timestamp': isNotNull,

--- a/app/test/search/mem_index_test.dart
+++ b/app/test/search/mem_index_test.dart
@@ -98,7 +98,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
 
     test('package name match: async', () async {
       final PackageSearchResult result =
-          await index.search(SearchQuery.parse(query: 'async'));
+          await index.search(ServiceSearchQuery.parse(query: 'async'));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
         'timestamp': isNotNull,
@@ -114,7 +114,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
 
     test('description match: composable', () async {
       final PackageSearchResult result =
-          await index.search(SearchQuery.parse(query: 'composable'));
+          await index.search(ServiceSearchQuery.parse(query: 'composable'));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
         'timestamp': isNotNull,
@@ -130,7 +130,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
 
     test('readme match: chrome.sockets', () async {
       final PackageSearchResult result =
-          await index.search(SearchQuery.parse(query: 'chrome.sockets'));
+          await index.search(ServiceSearchQuery.parse(query: 'chrome.sockets'));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
         'timestamp': isNotNull,
@@ -146,7 +146,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
 
     test('exact phrase match: utility', () async {
       final PackageSearchResult result =
-          await index.search(SearchQuery.parse(query: '"utility"'));
+          await index.search(ServiceSearchQuery.parse(query: '"utility"'));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
         'timestamp': isNotNull,
@@ -159,8 +159,8 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
     });
 
     test('exact phrase with dot: "once on demand."', () async {
-      final result =
-          await index.search(SearchQuery.parse(query: '"once on demand."'));
+      final result = await index
+          .search(ServiceSearchQuery.parse(query: '"once on demand."'));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
         'timestamp': isNotNull,
@@ -173,7 +173,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
 
     test('package prefix: chrome', () async {
       final PackageSearchResult result =
-          await index.search(SearchQuery.parse(query: 'package:chrome'));
+          await index.search(ServiceSearchQuery.parse(query: 'package:chrome'));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
         'timestamp': isNotNull,
@@ -188,8 +188,8 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
     });
 
     test('order by text: single-letter t', () async {
-      final PackageSearchResult result = await index
-          .search(SearchQuery.parse(query: 't', order: SearchOrder.text));
+      final PackageSearchResult result = await index.search(
+          ServiceSearchQuery.parse(query: 't', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
         'timestamp': isNotNull,
@@ -202,8 +202,8 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
     });
 
     test('order by created: no filter', () async {
-      final PackageSearchResult result =
-          await index.search(SearchQuery.parse(order: SearchOrder.created));
+      final PackageSearchResult result = await index
+          .search(ServiceSearchQuery.parse(order: SearchOrder.created));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
         'timestamp': isNotNull,
@@ -217,8 +217,8 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
     });
 
     test('order by updated: no filter', () async {
-      final PackageSearchResult result = await index
-          .search(SearchQuery.parse(query: '', order: SearchOrder.updated));
+      final PackageSearchResult result = await index.search(
+          ServiceSearchQuery.parse(query: '', order: SearchOrder.updated));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
         'timestamp': isNotNull,
@@ -232,8 +232,8 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
     });
 
     test('order by updated: query text filter', () async {
-      final PackageSearchResult result = await index
-          .search(SearchQuery.parse(query: 'http', order: SearchOrder.updated));
+      final PackageSearchResult result = await index.search(
+          ServiceSearchQuery.parse(query: 'http', order: SearchOrder.updated));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
         'timestamp': isNotNull,
@@ -246,11 +246,13 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
     });
 
     test('order by updated: runtime filter', () async {
-      final PackageSearchResult result = await index.search(SearchQuery.parse(
-        sdk: 'dart',
-        order: SearchOrder.updated,
-        runtimes: ['native'],
-      ));
+      final result = await index.search(
+        FrontendSearchQuery.parse(
+          sdk: 'dart',
+          order: SearchOrder.updated,
+          runtimes: ['native'],
+        ).toServiceQuery(),
+      );
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
         'timestamp': isNotNull,
@@ -263,8 +265,8 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
     });
 
     test('order by popularity', () async {
-      final PackageSearchResult result =
-          await index.search(SearchQuery.parse(order: SearchOrder.popularity));
+      final PackageSearchResult result = await index
+          .search(ServiceSearchQuery.parse(order: SearchOrder.popularity));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
         'timestamp': isNotNull,
@@ -279,7 +281,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
 
     test('order by like count', () async {
       final PackageSearchResult result =
-          await index.search(SearchQuery.parse(order: SearchOrder.like));
+          await index.search(ServiceSearchQuery.parse(order: SearchOrder.like));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
         'timestamp': isNotNull,
@@ -293,8 +295,8 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
     });
 
     test('order by pub points', () async {
-      final PackageSearchResult result =
-          await index.search(SearchQuery.parse(order: SearchOrder.points));
+      final PackageSearchResult result = await index
+          .search(ServiceSearchQuery.parse(order: SearchOrder.points));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
         'timestamp': isNotNull,
@@ -308,8 +310,8 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
     });
 
     test('filter by one dependency', () async {
-      final PackageSearchResult result =
-          await index.search(SearchQuery.parse(query: 'dependency:test'));
+      final PackageSearchResult result = await index
+          .search(ServiceSearchQuery.parse(query: 'dependency:test'));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
         'timestamp': isNotNull,
@@ -323,7 +325,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
 
     test('filter by foo as direct/dev dependency', () async {
       final PackageSearchResult result =
-          await index.search(SearchQuery.parse(query: 'dependency:foo'));
+          await index.search(ServiceSearchQuery.parse(query: 'dependency:foo'));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
         'timestamp': isNotNull,
@@ -335,8 +337,8 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
     });
 
     test('filter by foo as transitive dependency', () async {
-      final PackageSearchResult result =
-          await index.search(SearchQuery.parse(query: 'dependency*:foo'));
+      final PackageSearchResult result = await index
+          .search(ServiceSearchQuery.parse(query: 'dependency*:foo'));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
         'timestamp': isNotNull,
@@ -349,8 +351,8 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
     });
 
     test('filter by text and dependency', () async {
-      final PackageSearchResult result = await index
-          .search(SearchQuery.parse(query: 'composable dependency:test'));
+      final PackageSearchResult result = await index.search(
+          ServiceSearchQuery.parse(query: 'composable dependency:test'));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
         'timestamp': isNotNull,
@@ -362,8 +364,8 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
     });
 
     test('filter by two dependencies', () async {
-      final PackageSearchResult result = await index
-          .search(SearchQuery.parse(query: 'dependency:async dependency:test'));
+      final PackageSearchResult result = await index.search(
+          ServiceSearchQuery.parse(query: 'dependency:async dependency:test'));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
         'timestamp': isNotNull,
@@ -375,8 +377,8 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
     });
 
     test('no results via publisher', () async {
-      final PackageSearchResult result = await index
-          .search(SearchQuery.parse(query: 'publisher:other-domain.com'));
+      final PackageSearchResult result = await index.search(
+          ServiceSearchQuery.parse(query: 'publisher:other-domain.com'));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
         'timestamp': isNotNull,
@@ -386,8 +388,8 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
     });
 
     test('filter by publisher', () async {
-      final PackageSearchResult result =
-          await index.search(SearchQuery.parse(query: 'publisher:dart.dev'));
+      final PackageSearchResult result = await index
+          .search(ServiceSearchQuery.parse(query: 'publisher:dart.dev'));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
         'timestamp': isNotNull,
@@ -400,7 +402,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
 
     test('no results via owners', () async {
       final PackageSearchResult result = await index.search(
-          SearchQuery.parse(uploaderOrPublishers: ['other-domain.com']));
+          ServiceSearchQuery.parse(uploaderOrPublishers: ['other-domain.com']));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
         'timestamp': isNotNull,
@@ -411,7 +413,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
 
     test('filter by a single owner', () async {
       final PackageSearchResult result = await index
-          .search(SearchQuery.parse(uploaderOrPublishers: ['dart.dev']));
+          .search(ServiceSearchQuery.parse(uploaderOrPublishers: ['dart.dev']));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
         'timestamp': isNotNull,
@@ -424,7 +426,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
 
     test('filter by multiple owners', () async {
       final PackageSearchResult result =
-          await index.search(SearchQuery.parse(uploaderOrPublishers: [
+          await index.search(ServiceSearchQuery.parse(uploaderOrPublishers: [
         'dart.dev',
         'user1@example.com',
       ]));
@@ -440,8 +442,8 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
     });
 
     test('no results via email', () async {
-      final PackageSearchResult result =
-          await index.search(SearchQuery.parse(query: 'email:some@other.com'));
+      final PackageSearchResult result = await index
+          .search(ServiceSearchQuery.parse(query: 'email:some@other.com'));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
         'timestamp': isNotNull,
@@ -452,7 +454,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
 
     test('filter by email', () async {
       final PackageSearchResult result = await index
-          .search(SearchQuery.parse(query: 'email:user1@example.com'));
+          .search(ServiceSearchQuery.parse(query: 'email:user1@example.com'));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
         'timestamp': isNotNull,
@@ -466,7 +468,8 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
 
     test('multiword query: implicit AND', () async {
       final PackageSearchResult composable = await index.search(
-          SearchQuery.parse(query: 'composable', order: SearchOrder.text));
+          ServiceSearchQuery.parse(
+              query: 'composable', order: SearchOrder.text));
       expect(json.decode(json.encode(composable)), {
         'indexUpdated': isNotNull,
         'timestamp': isNotNull,
@@ -476,8 +479,8 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         ],
       });
 
-      final PackageSearchResult library = await index
-          .search(SearchQuery.parse(query: 'library', order: SearchOrder.text));
+      final PackageSearchResult library = await index.search(
+          ServiceSearchQuery.parse(query: 'library', order: SearchOrder.text));
       expect(json.decode(json.encode(library)), {
         'indexUpdated': isNotNull,
         'timestamp': isNotNull,
@@ -491,8 +494,9 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
 
       // Without the implicit AND, the end result would be close to the result
       // of the `library` search.
-      final PackageSearchResult both = await index.search(SearchQuery.parse(
-          query: 'composable library', order: SearchOrder.text));
+      final PackageSearchResult both = await index.search(
+          ServiceSearchQuery.parse(
+              query: 'composable library', order: SearchOrder.text));
       expect(json.decode(json.encode(both)), {
         'indexUpdated': isNotNull,
         'timestamp': isNotNull,
@@ -504,13 +508,13 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
     });
 
     test('non-word query with default order', () async {
-      final rs = await index.search(SearchQuery.parse(query: '='));
+      final rs = await index.search(ServiceSearchQuery.parse(query: '='));
       expect(rs.packages, isEmpty);
     });
 
     test('non-word query with text order', () async {
-      final rs = await index
-          .search(SearchQuery.parse(query: '=', order: SearchOrder.text));
+      final rs = await index.search(
+          ServiceSearchQuery.parse(query: '=', order: SearchOrder.text));
       expect(rs.packages, isEmpty);
     });
   });
@@ -524,14 +528,14 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
       await index.addPackage(PackageDocument(
         package: 'apps',
       ));
-      final match = await index
-          .search(SearchQuery.parse(query: 'app', order: SearchOrder.text));
+      final match = await index.search(
+          ServiceSearchQuery.parse(query: 'app', order: SearchOrder.text));
       expect(match.packages.map((e) => e.toJson()), [
         {'package': 'app', 'score': 1.0},
         {'package': 'apps', 'score': 1.0},
       ]);
-      final match2 = await index
-          .search(SearchQuery.parse(query: 'apps', order: SearchOrder.text));
+      final match2 = await index.search(
+          ServiceSearchQuery.parse(query: 'apps', order: SearchOrder.text));
       expect(match2.packages.map((e) => e.toJson()), [
         {'package': 'app', 'score': 1.0},
         {'package': 'apps', 'score': 1.0},
@@ -546,14 +550,14 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
       await index.addPackage(PackageDocument(
         package: 'appz',
       ));
-      final match = await index
-          .search(SearchQuery.parse(query: 'app', order: SearchOrder.text));
+      final match = await index.search(
+          ServiceSearchQuery.parse(query: 'app', order: SearchOrder.text));
       expect(match.packages.map((e) => e.toJson()), [
         {'package': 'app', 'score': 1.0},
         {'package': 'appz', 'score': 0.75},
       ]);
-      final match2 = await index
-          .search(SearchQuery.parse(query: 'appz', order: SearchOrder.text));
+      final match2 = await index.search(
+          ServiceSearchQuery.parse(query: 'appz', order: SearchOrder.text));
       expect(match2.packages.map((e) => e.toJson()), [
         {'package': 'appz', 'score': 1.0},
         // would be nice if `app` would show up here

--- a/app/test/search/rest_api_test.dart
+++ b/app/test/search/rest_api_test.dart
@@ -49,7 +49,7 @@ Recent versions (0.3.x and 0.4.x) of this plugin require [extensible codec funct
 
     test('REST API', () async {
       final PackageSearchResult result = await index.search(
-          SearchQuery.parse(query: 'rest api', order: SearchOrder.text));
+          ServiceSearchQuery.parse(query: 'rest api', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
         'timestamp': isNotNull,

--- a/app/test/search/result_combiner_test.dart
+++ b/app/test/search/result_combiner_test.dart
@@ -46,7 +46,7 @@ void main() {
 
     test('non-text ranking', () async {
       final results = await combiner
-          .search(SearchQuery.parse(order: SearchOrder.popularity));
+          .search(ServiceSearchQuery.parse(order: SearchOrder.popularity));
       expect(json.decode(json.encode(results.toJson())), {
         'indexUpdated': isNotNull,
         'timestamp': isNotNull,
@@ -59,7 +59,7 @@ void main() {
 
     test('no actual text query', () async {
       final results = await combiner
-          .search(SearchQuery.parse(query: 'email:foo@example.com'));
+          .search(ServiceSearchQuery.parse(query: 'email:foo@example.com'));
       expect(json.decode(json.encode(results.toJson())), {
         'indexUpdated': isNotNull,
         'timestamp': isNotNull,
@@ -72,7 +72,7 @@ void main() {
 
     test('search: substring', () async {
       final results =
-          await combiner.search(SearchQuery.parse(query: 'substring'));
+          await combiner.search(ServiceSearchQuery.parse(query: 'substring'));
       expect(json.decode(json.encode(results.toJson())), {
         'indexUpdated': isNotNull,
         'timestamp': isNotNull,
@@ -100,7 +100,7 @@ void main() {
 
     test('exact name match: stringutils', () async {
       final results =
-          await combiner.search(SearchQuery.parse(query: 'stringutils'));
+          await combiner.search(ServiceSearchQuery.parse(query: 'stringutils'));
       expect(json.decode(json.encode(results.toJson())), {
         'indexUpdated': isNotNull,
         'timestamp': isNotNull,

--- a/app/test/search/scope_specificity_test.dart
+++ b/app/test/search/scope_specificity_test.dart
@@ -62,7 +62,7 @@ void main() {
 
     test('text search without platform', () async {
       final PackageSearchResult withoutPlatform =
-          await index.search(SearchQuery.parse(query: 'json'));
+          await index.search(ServiceSearchQuery.parse(query: 'json'));
       expect(json.decode(json.encode(withoutPlatform)), {
         'indexUpdated': isNotNull,
         'timestamp': isNotNull,
@@ -89,11 +89,12 @@ void main() {
     });
 
     test('text search with platform', () async {
-      final PackageSearchResult withPlatform =
-          await index.search(SearchQuery.parse(
-        query: 'json',
-        sdk: 'flutter',
-      ));
+      final withPlatform = await index.search(
+        FrontendSearchQuery.parse(
+          query: 'json',
+          sdk: 'flutter',
+        ).toServiceQuery(),
+      );
       expect(json.decode(json.encode(withPlatform)), {
         'indexUpdated': isNotNull,
         'timestamp': isNotNull,

--- a/app/test/search/search_service_test.dart
+++ b/app/test/search/search_service_test.dart
@@ -24,13 +24,14 @@ void main() {
 
   group('ParsedQuery', () {
     test('trim', () {
-      expect(SearchQuery.parse(query: 'text').parsedQuery.text, 'text');
-      expect(SearchQuery.parse(query: ' text ').query, 'text');
-      expect(SearchQuery.parse(query: ' text ').parsedQuery.text, 'text');
+      expect(FrontendSearchQuery.parse(query: 'text').parsedQuery.text, 'text');
+      expect(FrontendSearchQuery.parse(query: ' text ').query, 'text');
+      expect(
+          FrontendSearchQuery.parse(query: ' text ').parsedQuery.text, 'text');
     });
 
     test('no dependency', () {
-      final query = SearchQuery.parse(query: 'text');
+      final query = FrontendSearchQuery.parse(query: 'text');
       expect(query.parsedQuery.text, 'text');
       expect(query.parsedQuery.refDependencies, []);
       expect(query.parsedQuery.allDependencies, []);
@@ -38,7 +39,7 @@ void main() {
     });
 
     test('only one dependency', () {
-      final query = SearchQuery.parse(query: 'dependency:pkg');
+      final query = FrontendSearchQuery.parse(query: 'dependency:pkg');
       expect(query.parsedQuery.text, isNull);
       expect(query.parsedQuery.refDependencies, ['pkg']);
       expect(query.parsedQuery.allDependencies, []);
@@ -46,7 +47,7 @@ void main() {
     });
 
     test('only one dependency*', () {
-      final query = SearchQuery.parse(query: 'dependency*:pkg');
+      final query = FrontendSearchQuery.parse(query: 'dependency*:pkg');
       expect(query.parsedQuery.text, isNull);
       expect(query.parsedQuery.refDependencies, []);
       expect(query.parsedQuery.allDependencies, ['pkg']);
@@ -54,7 +55,7 @@ void main() {
     });
 
     test('two dependencies with text blocks', () {
-      final query = SearchQuery.parse(
+      final query = FrontendSearchQuery.parse(
           query: 'text1 dependency:pkg1 text2 dependency:pkg2');
       expect(query.parsedQuery.text, 'text1 text2');
       expect(query.parsedQuery.refDependencies, ['pkg1', 'pkg2']);
@@ -63,7 +64,7 @@ void main() {
     });
 
     test('two mixed dependencies with text blocks', () {
-      final query = SearchQuery.parse(
+      final query = FrontendSearchQuery.parse(
           query: 'text1 dependency:pkg1 text2 dependency*:pkg2');
       expect(query.parsedQuery.text, 'text1 text2');
       expect(query.parsedQuery.refDependencies, ['pkg1']);
@@ -72,33 +73,34 @@ void main() {
     });
 
     test('only publisher', () {
-      final query = SearchQuery.parse(query: 'publisher:example.com');
+      final query = FrontendSearchQuery.parse(query: 'publisher:example.com');
       expect(query.parsedQuery.text, isNull);
       expect(query.parsedQuery.publisher, 'example.com');
     });
 
     test('only email', () {
-      final query = SearchQuery.parse(query: 'email:user@domain.com');
+      final query = FrontendSearchQuery.parse(query: 'email:user@domain.com');
       expect(query.parsedQuery.text, isNull);
       expect(query.parsedQuery.emails, ['user@domain.com']);
     });
 
     test('known tag', () {
-      final query = SearchQuery.parse(query: 'is:legacy');
+      final query = FrontendSearchQuery.parse(query: 'is:legacy');
       expect(query.parsedQuery.text, isNull);
       expect(
           query.parsedQuery.tagsPredicate.toQueryParameters(), ['is:legacy']);
     });
 
     test('forbidden known tag', () {
-      final query = SearchQuery.parse(query: '-is:legacy');
+      final query = FrontendSearchQuery.parse(query: '-is:legacy');
       expect(query.parsedQuery.text, isNull);
       expect(
           query.parsedQuery.tagsPredicate.toQueryParameters(), ['-is:legacy']);
     });
 
     test('known tag + package prefix + search text', () {
-      final query = SearchQuery.parse(query: 'json is:legacy package:foo_');
+      final query =
+          FrontendSearchQuery.parse(query: 'json is:legacy package:foo_');
       expect(query.parsedQuery.text, 'json');
       expect(
           query.parsedQuery.tagsPredicate.toQueryParameters(), ['is:legacy']);
@@ -106,7 +108,7 @@ void main() {
     });
 
     test('publisher + email + text + dependency', () {
-      final query = SearchQuery.parse(
+      final query = FrontendSearchQuery.parse(
           query:
               'publisher:example.com email:user@domain.com text dependency:pkg1');
       expect(query.parsedQuery.text, 'text');
@@ -119,27 +121,27 @@ void main() {
 
   group('Search URLs', () {
     test('empty', () {
-      final query = SearchQuery.parse();
+      final query = FrontendSearchQuery.parse();
       expect(query.parsedQuery.text, isNull);
       expect(query.parsedQuery.packagePrefix, isNull);
       expect(query.toSearchLink(), '/packages');
     });
 
     test('platform: flutter', () {
-      final query = SearchQuery.parse(sdk: 'flutter');
+      final query = FrontendSearchQuery.parse(sdk: 'flutter');
       expect(query.parsedQuery.text, isNull);
       expect(query.parsedQuery.packagePrefix, isNull);
       expect(query.toSearchLink(), '/flutter/packages');
     });
 
     test('Flutter favorites', () {
-      final query = SearchQuery.parse(
+      final query = FrontendSearchQuery.parse(
           tagsPredicate: TagsPredicate(requiredTags: ['is:flutter-favorite']));
       expect(query.toSearchLink(page: 2), '/flutter/favorites?page=2');
     });
 
     test('publisher: example.com', () {
-      final query = SearchQuery.parse(publisherId: 'example.com');
+      final query = FrontendSearchQuery.parse(publisherId: 'example.com');
       expect(query.toSearchLink(), '/publishers/example.com/packages');
       expect(query.toSearchLink(page: 2),
           '/publishers/example.com/packages?page=2');
@@ -147,21 +149,21 @@ void main() {
 
     test('publisher: example.com with query', () {
       final query =
-          SearchQuery.parse(publisherId: 'example.com', query: 'json');
+          FrontendSearchQuery.parse(publisherId: 'example.com', query: 'json');
       expect(query.toSearchLink(), '/publishers/example.com/packages?q=json');
       expect(query.toSearchLink(page: 2),
           '/publishers/example.com/packages?q=json&page=2');
     });
 
     test('package prefix: angular', () {
-      final query = SearchQuery.parse(query: 'package:angular');
+      final query = FrontendSearchQuery.parse(query: 'package:angular');
       expect(query.parsedQuery.text, isNull);
       expect(query.parsedQuery.packagePrefix, 'angular');
       expect(query.toSearchLink(), '/packages?q=package%3Aangular');
     });
 
     test('complex search', () {
-      final query = SearchQuery.parse(
+      final query = FrontendSearchQuery.parse(
           query: 'package:angular widget', order: SearchOrder.top);
       expect(query.parsedQuery.text, 'widget');
       expect(query.parsedQuery.packagePrefix, 'angular');

--- a/app/test/search/stack_trace_test.dart
+++ b/app/test/search/stack_trace_test.dart
@@ -30,7 +30,8 @@ void main() {
     // should find full word
     test('stacktrace', () async {
       final PackageSearchResult result = await index.search(
-          SearchQuery.parse(query: 'stacktrace', order: SearchOrder.text));
+          ServiceSearchQuery.parse(
+              query: 'stacktrace', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
         'timestamp': isNotNull,

--- a/app/test/search/tags_test.dart
+++ b/app/test/search/tags_test.dart
@@ -10,13 +10,13 @@ import 'package:pub_dev/search/mem_index.dart';
 import 'package:pub_dev/search/search_service.dart';
 
 void main() {
-  group('SearchQuery.tags', () {
+  group('ServiceSearchQuery.tags', () {
     test('No tags in documents: positive tag match', () async {
       final index = InMemoryPackageIndex();
       await index.addPackage(PackageDocument(package: 'pkg1'));
       await index.markReady();
 
-      final rs = await index.search(SearchQuery.parse(
+      final rs = await index.search(ServiceSearchQuery.parse(
         tagsPredicate: TagsPredicate(requiredTags: ['is:a']),
       ));
       expect(rs.toJson(), {
@@ -32,7 +32,7 @@ void main() {
       await index.addPackage(PackageDocument(package: 'pkg1'));
       await index.markReady();
 
-      final rs = await index.search(SearchQuery.parse(
+      final rs = await index.search(ServiceSearchQuery.parse(
         tagsPredicate: TagsPredicate(prohibitedTags: ['is:a']),
       ));
       expect(json.decode(json.encode(rs.toJson())), {
@@ -51,7 +51,7 @@ void main() {
       await index.addPackage(PackageDocument(package: 'pkg2', tags: ['is:b']));
       await index.markReady();
 
-      final rs = await index.search(SearchQuery.parse(
+      final rs = await index.search(ServiceSearchQuery.parse(
         tagsPredicate: TagsPredicate(prohibitedTags: ['is:a']),
       ));
       expect(json.decode(json.encode(rs.toJson())), {
@@ -70,7 +70,7 @@ void main() {
       await index.addPackage(PackageDocument(package: 'pkg2', tags: ['is:b']));
       await index.markReady();
 
-      final rs = await index.search(SearchQuery.parse(
+      final rs = await index.search(ServiceSearchQuery.parse(
         tagsPredicate: TagsPredicate.parseQueryValues(['is:a']),
       ));
       expect(json.decode(json.encode(rs.toJson())), {
@@ -91,7 +91,7 @@ void main() {
           PackageDocument(package: 'pkg2', tags: ['is:b', 'is:dart1']));
       await index.markReady();
 
-      final rs = await index.search(SearchQuery.parse(
+      final rs = await index.search(ServiceSearchQuery.parse(
         tagsPredicate: TagsPredicate.parseQueryValues(['is:dart1']),
       ));
       expect(json.decode(json.encode(rs.toJson())), {
@@ -113,7 +113,7 @@ void main() {
           PackageDocument(package: 'pkg2', tags: ['is:b', 'is:dart1']));
       await index.markReady();
 
-      final rs = await index.search(SearchQuery.parse(
+      final rs = await index.search(ServiceSearchQuery.parse(
         tagsPredicate: TagsPredicate.parseQueryValues(['is:dart1', 'is:b']),
       ));
       expect(json.decode(json.encode(rs.toJson())), {
@@ -134,7 +134,7 @@ void main() {
           PackageDocument(package: 'pkg2', tags: ['is:b', 'is:dart1']));
       await index.markReady();
 
-      final rs = await index.search(SearchQuery.parse(
+      final rs = await index.search(ServiceSearchQuery.parse(
         tagsPredicate: TagsPredicate.parseQueryValues(['is:dart1', '-is:b']),
       ));
       expect(json.decode(json.encode(rs.toJson())), {
@@ -154,7 +154,8 @@ void main() {
       await index.addPackage(PackageDocument(package: 'pkg2', tags: ['is:b']));
       await index.markReady();
 
-      final rs = await index.search(SearchQuery.parse(query: 'is:b -is:a'));
+      final rs =
+          await index.search(ServiceSearchQuery.parse(query: 'is:b -is:a'));
       expect(json.decode(json.encode(rs.toJson())), {
         'indexUpdated': isNotEmpty,
         'timestamp': isNotNull,
@@ -172,7 +173,7 @@ void main() {
       await index.addPackage(PackageDocument(package: 'pkg2', tags: ['is:a']));
       await index.markReady();
 
-      final rs = await index.search(SearchQuery.parse(
+      final rs = await index.search(ServiceSearchQuery.parse(
           tagsPredicate: TagsPredicate(prohibitedTags: ['is:b']),
           query: 'is:a is:b'));
       expect(json.decode(json.encode(rs.toJson())), {

--- a/app/test/search/travis_test.dart
+++ b/app/test/search/travis_test.dart
@@ -52,8 +52,8 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor i
     });
 
     test('travis', () async {
-      final PackageSearchResult result = await index
-          .search(SearchQuery.parse(query: 'travis', order: SearchOrder.text));
+      final PackageSearchResult result = await index.search(
+          ServiceSearchQuery.parse(query: 'travis', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
         'timestamp': isNotNull,

--- a/app/test/shared/urls_test.dart
+++ b/app/test/shared/urls_test.dart
@@ -4,7 +4,7 @@
 
 import 'package:test/test.dart';
 
-import 'package:pub_dev/search/search_service.dart' show SearchQuery;
+import 'package:pub_dev/search/search_service.dart' show FrontendSearchQuery;
 import 'package:pub_dev/shared/urls.dart';
 
 void main() {
@@ -205,7 +205,7 @@ void main() {
         '/dart/packages?runtime=native',
       );
       expect(
-        SearchQuery.parse(runtimes: ['native'])
+        FrontendSearchQuery.parse(runtimes: ['native'])
             .tagsPredicate
             .toQueryParameters(),
         ['runtime:native-jit'],
@@ -218,7 +218,7 @@ void main() {
         '/dart/packages?runtime=native',
       );
       expect(
-        SearchQuery.parse(runtimes: ['native-jit'])
+        FrontendSearchQuery.parse(runtimes: ['native-jit'])
             .tagsPredicate
             .toQueryParameters(),
         ['runtime:native-jit'],
@@ -231,7 +231,9 @@ void main() {
         '/dart/packages?runtime=js',
       );
       expect(
-        SearchQuery.parse(runtimes: ['web']).tagsPredicate.toQueryParameters(),
+        FrontendSearchQuery.parse(runtimes: ['web'])
+            .tagsPredicate
+            .toQueryParameters(),
         ['runtime:web'],
       );
     });
@@ -242,7 +244,9 @@ void main() {
         '/dart/packages?runtime=js',
       );
       expect(
-        SearchQuery.parse(runtimes: ['js']).tagsPredicate.toQueryParameters(),
+        FrontendSearchQuery.parse(runtimes: ['js'])
+            .tagsPredicate
+            .toQueryParameters(),
         ['runtime:web'],
       );
     });
@@ -253,7 +257,9 @@ void main() {
         '/dart/packages?runtime=xxy',
       );
       expect(
-        SearchQuery.parse(runtimes: ['xxy']).tagsPredicate.toQueryParameters(),
+        FrontendSearchQuery.parse(runtimes: ['xxy'])
+            .tagsPredicate
+            .toQueryParameters(),
         ['runtime:xxy'],
       );
     });


### PR DESCRIPTION
- Removed unused methods and fields from each.
- Removed the use of `includeLegacy` from search index.
- Other migrations postponed to follow-up PRs (filtering publisher with tag, handle frontend query without tags predicate).
