### PR TITLE
Use Google Tag Manager for analytics

### DIFF
--- a/app/lib/frontend/templates/views/shared/layout.mustache
+++ b/app/lib/frontend/templates/views/shared/layout.mustache
@@ -4,8 +4,15 @@
 <!DOCTYPE html>
 <html lang="en-us">
 <head>
+  {{#is_experimental}}
+  <script async="async" src="https://www.googletagmanager.com/gtm.js?id=GTM-MX6DBN9"></script>
+  <script src="{{{static_assets.js__gtm_js}}}"></script>
+  {{/is_experimental}}
+  {{^is_experimental}}
   <script async="async" src="https://www.googletagmanager.com/gtag/js?id=UA-26406144-13"></script>
   <script src="{{{static_assets.js__gtag_js}}}"></script>
+  {{/is_experimental}}
+
   <meta charset="utf-8" />
   <meta http-equiv="x-ua-compatible" content="ie=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -54,6 +61,13 @@
   {{/page_data_encoded}}
 </head>
 <body class="{{& body_class}}">
+{{#is_experimental}}
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MX6DBN9"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
+{{/is_experimental}}
+
 {{& site_header_html}}
 
 <div id="banner-container">

--- a/static/js/gtag.js
+++ b/static/js/gtag.js
@@ -1,3 +1,7 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 window.dataLayer = window.dataLayer || [];
 function gtag() { dataLayer.push(arguments); }
 gtag('js', new Date());
@@ -19,7 +23,7 @@ window.addEventListener('DOMContentLoaded', function () {
     // https://support.google.com/analytics/answer/7478520?hl=en
     if (elem.hasAttribute('href')) {
       var updated = false;
-      var callbackFn = function() {
+      var callbackFn = function () {
         if (updated) return;
         updated = true;
         document.location = elem.href;

--- a/static/js/gtm.js
+++ b/static/js/gtm.js
@@ -1,3 +1,7 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 window.dataLayer = window.dataLayer || [];
 window.dataLayer.push({
   'gtm.start': new Date().getTime(),

--- a/static/js/gtm.js
+++ b/static/js/gtm.js
@@ -1,0 +1,47 @@
+window.dataLayer = window.dataLayer || [];
+window.dataLayer.push({
+  'gtm.start': new Date().getTime(),
+  event: 'gtm.js'
+});
+
+function gtag() { dataLayer.push(arguments); }
+
+// Setup listening to send Google Analytics events when any element
+// with a 'data-ga-click-event' attribute is clicked.
+window.addEventListener('DOMContentLoaded', function () {
+  function sendEvent(e) {
+    var elem = e.currentTarget;
+
+    var data = {
+      'event_category': 'click',
+      'event_label': 'path:' + window.location.pathname,
+      'value': 1
+    };
+
+    // Events on links should be sent via beacon, see:
+    // https://support.google.com/analytics/answer/7478520?hl=en
+    if (elem.hasAttribute('href')) {
+      var updated = false;
+      var callbackFn = function () {
+        if (updated) return;
+        updated = true;
+        document.location = elem.href;
+      };
+      data.event_callback = callbackFn;
+      data.transport_type = 'beacon';
+      e.preventDefault();
+
+      // Fallback location change in case the Google Tag Manager is blocked.
+      setTimeout(callbackFn, 100);
+    }
+
+    gtag('event', elem.dataset.gaClickEvent, data);
+  }
+  function addListeners() {
+    var elements = document.querySelectorAll('[data-ga-click-event]');
+    for (var i = 0; i < elements.length; i++) {
+      elements[i].addEventListener('click', sendEvent);
+    }
+  }
+  addListeners();
+});


### PR DESCRIPTION
We probably still need to migrate the generated dartdoc, but
I don't think we can make that migration experimental.