### PR TITLE
Formal paging for last updated packages.

### DIFF
--- a/app/lib/frontend/handlers/listing.dart
+++ b/app/lib/frontend/handlers/listing.dart
@@ -8,7 +8,6 @@ import 'package:shelf/shelf.dart' as shelf;
 
 import '../../package/backend.dart';
 import '../../package/models.dart';
-import '../../package/overrides.dart';
 import '../../package/search_adapter.dart';
 import '../../search/search_service.dart';
 import '../../shared/handlers.dart';
@@ -127,15 +126,12 @@ Future<shelf.Response> _packagesHandlerJson(
   final pageSize = 50;
 
   final offset = pageSize * (page - 1);
-  final limit = pageSize + 1;
 
-  final packages =
-      await packageBackend.latestPackages(offset: offset, limit: limit);
-  packages.removeWhere((p) => isSoftRemoved(p.name));
-  final bool lastPage = packages.length < limit;
+  final pkgPage =
+      await packageBackend.latestPackages(offset: offset, limit: pageSize);
 
   Uri nextPageUrl;
-  if (!lastPage) {
+  if (!pkgPage.isLast) {
     nextPageUrl =
         request.requestedUri.resolve('/packages.json?page=${page + 1}');
   }
@@ -148,7 +144,7 @@ Future<shelf.Response> _packagesHandlerJson(
   }
 
   final json = {
-    'packages': packages.take(pageSize).map(toUrl).toList(),
+    'packages': pkgPage.packages.map(toUrl).toList(),
     'next': nextPageUrl != null ? '$nextPageUrl' : null,
 
     // NOTE: We're not returning the following entry:

--- a/app/test/package/backend_test.dart
+++ b/app/test/package/backend_test.dart
@@ -25,8 +25,8 @@ void main() {
   group('backend', () {
     group('Backend.latestPackages', () {
       testWithServices('default packages', () async {
-        final list = await packageBackend.latestPackages();
-        expect(list.map((p) => p.name), [
+        final page = await packageBackend.latestPackages();
+        expect(page.packages.map((p) => p.name), [
           'foobar_pkg',
           'lithium',
           'helium',
@@ -37,8 +37,8 @@ void main() {
       testWithServices('default packages with withheld', () async {
         final pkg = await dbService.lookupValue<Package>(foobarPackage.key);
         await dbService.commit(inserts: [pkg..isWithheld = true]);
-        final list = await packageBackend.latestPackages();
-        expect(list.map((p) => p.name), [
+        final page = await packageBackend.latestPackages();
+        expect(page.packages.map((p) => p.name), [
           'lithium',
           'helium',
           'hydrogen',
@@ -50,8 +50,8 @@ void main() {
             (await dbService.lookup<Package>([helium.package.key])).single;
         h.updated = DateTime(2010);
         await dbService.commit(inserts: [h]);
-        final list = await packageBackend.latestPackages();
-        expect(list.last.name, 'helium');
+        final page = await packageBackend.latestPackages();
+        expect(page.packages.last.name, 'helium');
       });
 
       testWithServices('default packages, extra later', () async {
@@ -59,18 +59,18 @@ void main() {
             (await dbService.lookup<Package>([helium.package.key])).single;
         h.updated = DateTime(2030);
         await dbService.commit(inserts: [h]);
-        final list = await packageBackend.latestPackages();
-        expect(list.first.name, 'helium');
+        final page = await packageBackend.latestPackages();
+        expect(page.packages.first.name, 'helium');
       });
 
       testWithServices('default packages, offset: 2', () async {
-        final list = await packageBackend.latestPackages(offset: 2);
-        expect(list.map((p) => p.name), ['helium', 'hydrogen']);
+        final page = await packageBackend.latestPackages(offset: 2);
+        expect(page.packages.map((p) => p.name), ['helium', 'hydrogen']);
       });
 
       testWithServices('default packages, offset: 1, limit: 1', () async {
-        final list = await packageBackend.latestPackages(offset: 1, limit: 1);
-        expect(list.map((p) => p.name), ['lithium']);
+        final page = await packageBackend.latestPackages(offset: 1, limit: 1);
+        expect(page.packages.map((p) => p.name), ['lithium']);
       });
     });
 

--- a/app/test/package/upload_test.dart
+++ b/app/test/package/upload_test.dart
@@ -386,9 +386,9 @@ void main() {
         expect(email.bodyText,
             contains('https://pub.dev/packages/foobar_pkg/versions/1.2.3\n'));
 
-        final packages = await packageBackend.latestPackages();
-        expect(packages.first.name, foobarPackage.name);
-        expect(packages.first.latestVersion, '1.2.3');
+        final pkgPage = await packageBackend.latestPackages();
+        expect(pkgPage.packages.first.name, foobarPackage.name);
+        expect(pkgPage.packages.first.latestVersion, '1.2.3');
 
         final stream =
             await packageBackend.download(foobarPackage.name, '1.2.3');


### PR DESCRIPTION
- Fixes the null pointer in #4104. In the future we should rather use `offset=<num>` or better `next=<token>` in such APIs.
- Slightly related to #4113.