### PR TITLE
Show and use includeLegacy search option only when the SDK is 'any'.

### DIFF
--- a/app/lib/frontend/templates/listing.dart
+++ b/app/lib/frontend/templates/listing.dart
@@ -151,7 +151,8 @@ String renderPkgIndexPage(
     'has_packages': packages.isNotEmpty,
     'pagination': renderPagination(links),
     'include_unlisted': includeUnlisted,
-    'legacy_search_enabled': includeLegacy,
+    'show_legacy_checkbox': SdkTagValue.isAny(sdk),
+    'include_legacy': includeLegacy,
   };
   final content = templateCache.renderTemplate('pkg/index', values);
 

--- a/app/lib/frontend/templates/views/pkg/index.mustache
+++ b/app/lib/frontend/templates/views/pkg/index.mustache
@@ -36,10 +36,12 @@
           <input id="-search-unlisted-checkbox" type="checkbox" name="unlisted" {{#include_unlisted}} checked="checked"{{/include_unlisted}} />
           <label for="-search-unlisted-checkbox">Include unlisted packages</label>
         </div>
+        {{#show_legacy_checkbox}}
         <div class="search-controls-checkbox">
-          <input id="-search-legacy-checkbox" type="checkbox" name="legacy" {{#legacy_search_enabled}} checked="checked"{{/legacy_search_enabled}} />
+          <input id="-search-legacy-checkbox" type="checkbox" name="legacy" {{#include_legacy}} checked="checked"{{/include_legacy}} />
           <label for="-search-legacy-checkbox">Include Dart 1.x results</label>
         </div>
+        {{/show_legacy_checkbox}}
       </div>
     </div>
   </div>

--- a/app/lib/search/search_service.dart
+++ b/app/lib/search/search_service.dart
@@ -277,7 +277,7 @@ class FrontendSearchQuery {
     final q = _stringToNull(query?.trim());
     tagsPredicate ??= TagsPredicate();
     final requiredTags = <String>[];
-    if (sdk != null && sdk != SdkTagValue.any) {
+    if (SdkTagValue.isNotAny(sdk)) {
       requiredTags.add('sdk:$sdk');
     }
     DartSdkRuntime.decodeQueryValues(runtimes)
@@ -318,7 +318,7 @@ class FrontendSearchQuery {
     if (sdk != null) {
       tagsPredicate ??= this.tagsPredicate ?? TagsPredicate();
       tagsPredicate = tagsPredicate.removePrefix('sdk:');
-      if (sdk != SdkTagValue.any) {
+      if (SdkTagValue.isNotAny(sdk)) {
         tagsPredicate = tagsPredicate
             .appendPredicate(TagsPredicate(requiredTags: ['sdk:$sdk']));
       }
@@ -425,7 +425,7 @@ class FrontendSearchQuery {
     if (includeUnlisted) {
       params['unlisted'] = '1';
     }
-    if (includeLegacy) {
+    if (includeLegacy && SdkTagValue.isAny(sdk)) {
       params['legacy'] = '1';
     }
     if (page != null && page > 1) {
@@ -966,7 +966,7 @@ FrontendSearchQuery parseFrontendSearchQuery(
     offset: offset,
     limit: resultsPerPage,
     includeUnlisted: queryParameters['unlisted'] == '1',
-    includeLegacy: queryParameters['legacy'] == '1',
+    includeLegacy: queryParameters['legacy'] == '1' && SdkTagValue.isAny(sdk),
     tagsPredicate: tagsPredicate,
   );
 }

--- a/app/lib/shared/tags.dart
+++ b/app/lib/shared/tags.dart
@@ -61,6 +61,9 @@ abstract class SdkTagValue {
   static const String dart = 'dart';
   static const String flutter = 'flutter';
   static const String any = 'any';
+
+  static bool isAny(String value) => value == null || value == any;
+  static bool isNotAny(String value) => !isAny(value);
 }
 
 /// Collection of Dart SDK runtime tags (with prefix and value).


### PR DESCRIPTION
Fixes #3777.