### PR TITLE
Caching for sitemaps.

### DIFF
--- a/app/lib/frontend/handlers/misc.dart
+++ b/app/lib/frontend/handlers/misc.dart
@@ -12,9 +12,9 @@ import 'package:shelf/shelf.dart' as shelf;
 
 import '../../package/backend.dart';
 import '../../package/name_tracker.dart';
-import '../../package/overrides.dart';
 import '../../publisher/backend.dart';
 import '../../shared/handlers.dart';
+import '../../shared/redis_cache.dart';
 import '../../shared/urls.dart' as urls;
 
 import '../request_context.dart';
@@ -79,43 +79,43 @@ Future<shelf.Response> robotsTxtHandler(shelf.Request request) async {
 }
 
 /// Handles requests for /sitemap.txt
-Future<shelf.Response> siteMapTxtHandler(shelf.Request request) async {
+Future<shelf.Response> sitemapTxtHandler(shelf.Request request) async {
   if (requestContext.blockRobots) {
     return notFoundHandler(request);
   }
 
   final uri = request.requestedUri;
+  final content = cache.sitemap(uri.toString()).get(() async {
+    // Google wants the return page to have < 50,000 entries and be less than
+    // 50MB -  https://support.google.com/webmasters/answer/183668?hl=en
+    // As of 2018-01-01, the return page is ~3,000 entries and ~140KB
+    // By restricting to packages that have been updated in the last two years,
+    // the count is closer to ~1,500
 
-  // Google wants the return page to have < 50,000 entries and be less than
-  // 50MB -  https://support.google.com/webmasters/answer/183668?hl=en
-  // As of 2018-01-01, the return page is ~3,000 entries and ~140KB
-  // By restricting to packages that have been updated in the last two years,
-  // the count is closer to ~1,500
+    final items = <String>[];
+    final pages = [
+      '/',
+      '/help',
+      '/web',
+      '/flutter',
+      '/publishers',
+    ];
+    items.addAll(pages.map((page) => uri.replace(path: page).toString()));
 
-  final items = <String>[];
-  final pages = [
-    '/',
-    '/help',
-    '/web',
-    '/flutter',
-    '/publishers',
-  ];
-  items.addAll(pages.map((page) => uri.replace(path: page).toString()));
+    final stream = packageBackend.sitemapPackageNames();
+    await for (var package in stream) {
+      final pkgPath = urls.pkgPageUrl(package);
+      items.add(uri.replace(path: pkgPath).toString());
 
-  final stream = packageBackend.robotsPackageNames();
-  await for (var package in stream) {
-    if (isSoftRemoved(package)) continue;
+      final docPath = urls.pkgDocUrl(package, isLatest: true);
+      items.add(uri.replace(path: docPath).toString());
+    }
 
-    final pkgPath = urls.pkgPageUrl(package);
-    items.add(uri.replace(path: pkgPath).toString());
+    items.sort();
+    return items.join('\n');
+  });
 
-    final docPath = urls.pkgDocUrl(package, isLatest: true);
-    items.add(uri.replace(path: docPath).toString());
-  }
-
-  items.sort();
-
-  return shelf.Response.ok(items.join('\n'));
+  return shelf.Response.ok(content);
 }
 
 /// Handles requests for /sitemap-2.txt
@@ -126,17 +126,18 @@ Future<shelf.Response> sitemapPublishersTxtHandler(
   }
 
   final uri = request.requestedUri;
+  final content = cache.sitemap(uri.toString()).get(() async {
+    final list = await publisherBackend.listPublishers(limit: 1000);
+    if (list.length == 1000) {
+      _logger.shout(
+          'Number of publishers reached backend query limit, do implement paging.');
+    }
 
-  final list = await publisherBackend.listPublishers(limit: 1000);
-  if (list.length == 1000) {
-    _logger.shout(
-        'Number of publishers reached backend query limit, do implement paging.');
-  }
-
-  final content = list
-      .map((p) => urls.publisherUrl(p.publisherId))
-      .map((s) => uri.replace(path: s).toString())
-      .join('\n');
+    return list
+        .map((p) => urls.publisherUrl(p.publisherId))
+        .map((s) => uri.replace(path: s).toString())
+        .join('\n');
+  });
 
   return shelf.Response.ok(content);
 }

--- a/app/lib/frontend/handlers/routes.dart
+++ b/app/lib/frontend/handlers/routes.dart
@@ -237,7 +237,7 @@ class PubSiteService {
 
   /// Renders the /sitemap.txt page
   @Route.get('/sitemap.txt')
-  Future<Response> sitemapTxt(Request request) => siteMapTxtHandler(request);
+  Future<Response> sitemapTxt(Request request) => sitemapTxtHandler(request);
 
   /// Renders the /sitemap-2.txt page
   @Route.get('/sitemap-2.txt')

--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -104,8 +104,8 @@ class PackageBackend {
     );
   }
 
-  /// Retrieves the names of all packages that need to be included in robots.txt.
-  Stream<String> robotsPackageNames() {
+  /// Retrieves the names of all packages that need to be included in sitemap.txt.
+  Stream<String> sitemapPackageNames() {
     final query = db.query<Package>()
       ..filter(
           'updated >', DateTime.now().toUtc().subtract(robotsVisibilityMaxAge));
@@ -113,6 +113,7 @@ class PackageBackend {
         .run()
         .where((p) => p.isVisible)
         .where((p) => p.isIncludedInRobots)
+        .where((p) => !isSoftRemoved(p.name))
         .map((p) => p.name);
   }
 

--- a/app/lib/shared/redis_cache.dart
+++ b/app/lib/shared/redis_cache.dart
@@ -214,6 +214,11 @@ class CachePatterns {
       .withPrefix('secret-value')
       .withTTL(Duration(minutes: 60))
       .withCodec(utf8)[secretId];
+
+  Entry<String> sitemap(String requestedUri) => _cache
+      .withPrefix('sitemap')
+      .withTTL(Duration(hours: 12))
+      .withCodec(utf8)[requestedUri];
 }
 
 /// The active cache.


### PR DESCRIPTION
- moved `isSoftRemoved` from the handler to the backend
- added cache for both package and publisher sitemap
