### PR TITLE
Fix auto-refresh for sign-in.

### DIFF
--- a/app/lib/account/backend.dart
+++ b/app/lib/account/backend.dart
@@ -18,6 +18,7 @@ import '../shared/utils.dart';
 
 import 'auth_provider.dart';
 import 'models.dart';
+import 'session_cookie.dart' as session_cookie;
 
 /// The name of the session cookie.
 ///
@@ -447,9 +448,25 @@ class AccountBackend {
     return UserSessionData.fromModel(session);
   }
 
+  /// Parse [cookieString] and lookup session if cookie value is available.
+  ///
+  /// Returns `null` if the session does not exists or any issue is present
+  Future<UserSessionData> parseAndLookupSessionCookie(
+      String cookieString) async {
+    try {
+      final sessionId = session_cookie.parseSessionCookie(cookieString);
+      if (sessionId != null && sessionId.isNotEmpty) {
+        return await _lookupSession(sessionId);
+      }
+    } catch (e, st) {
+      _logger.severe('Unable to process session cookie.', e, st);
+    }
+    return null;
+  }
+
   /// Returns the user session associated with the [sessionId] or null if it
   /// does not exists.
-  Future<UserSessionData> lookupSession(String sessionId) async {
+  Future<UserSessionData> _lookupSession(String sessionId) async {
     ArgumentError.checkNotNull(sessionId, 'sessionId');
 
     final cacheEntry = cache.userSessionData(sessionId);

--- a/app/lib/shared/handler_helpers.dart
+++ b/app/lib/shared/handler_helpers.dart
@@ -225,8 +225,7 @@ shelf.Handler _userSessionWrapper(Logger logger, shelf.Handler handler) {
     // Never read or look for the session cookie on request that try to modify
     // data (non-GET HTTP methods), except for deleting the session cookie.
     final isAllowedForSession = request.method == 'GET' ||
-        (request.method == 'DELETE' &&
-            request.requestedUri.path == '/api/account/session');
+        request.requestedUri.path == '/api/account/session';
     if (isPrimaryHost &&
         isAllowedForSession &&
         request.headers.containsKey(HttpHeaders.cookieHeader)) {

--- a/app/lib/shared/handler_helpers.dart
+++ b/app/lib/shared/handler_helpers.dart
@@ -13,7 +13,6 @@ import 'package:shelf/shelf_io.dart' as shelf_io;
 import 'package:stack_trace/stack_trace.dart';
 
 import '../account/backend.dart';
-import '../account/session_cookie.dart' as session_cookie;
 import '../frontend/request_context.dart';
 import '../frontend/templates/layout.dart';
 
@@ -223,25 +222,15 @@ shelf.Handler _userSessionWrapper(Logger logger, shelf.Handler handler) {
     final isPrimaryHost =
         request.requestedUri.host == activeConfiguration.primarySiteUri.host;
     // Never read or look for the session cookie on request that try to modify
-    // data (non-GET HTTP methods), except for deleting the session cookie.
-    final isAllowedForSession = request.method == 'GET' ||
-        request.requestedUri.path == '/api/account/session';
+    // data (non-GET HTTP methods).
+    final isAllowedForSession = request.method == 'GET';
     if (isPrimaryHost &&
         isAllowedForSession &&
         request.headers.containsKey(HttpHeaders.cookieHeader)) {
-      try {
-        final sessionId = session_cookie.parseSessionCookie(
-          request.headers[HttpHeaders.cookieHeader],
-        );
-        if (sessionId != null && sessionId.isNotEmpty) {
-          final sessionData = await accountBackend.lookupSession(sessionId);
-          if (sessionData != null) {
-            registerUserSessionData(sessionData);
-          }
-        }
-      } catch (e, st) {
-        logger.severe('Unable to process session cookie.', e, st);
-      }
+      final cookieString = request.headers[HttpHeaders.cookieHeader];
+      final sessionData =
+          await accountBackend.parseAndLookupSessionCookie(cookieString);
+      registerUserSessionData(sessionData);
     }
     shelf.Response rs = await handler(request);
     if (userSessionData != null) {


### PR DESCRIPTION
We need to allow both `POST` and `DELETE`, and at that point it is just easier to not check for the http.method. Originates from https://github.com/dart-lang/pub-dev/pull/4068.