### PR TITLE
Remove unnecessary null check in cookie parsing.

### DIFF
--- a/app/lib/account/session_cookie.dart
+++ b/app/lib/account/session_cookie.dart
@@ -44,8 +44,6 @@ Map<String, String> createSessionCookie(UserSessionData session) {
 ///
 /// The [cookieString] is the value of the `cookie:` request header.
 String parseSessionCookie(String cookieString) {
-  ArgumentError.checkNotNull(cookieString, 'cookieString');
-
   final sessionId = parseCookieHeader(cookieString)['$_pubSessionCookieName'];
   // An empty sessionId cookie is the result of reseting the cookie.
   // Browser usually won't send this, but let's make sure we handle the case.


### PR DESCRIPTION
- Root cause by #4112.
- Fixes #4131.
- Check can be removed as the subsequent `parseCookieHeader` handles `null` value (and has test for it).