### PR TITLE
Package.replacedBy on admin UI + infobox

### DIFF
--- a/app/lib/frontend/templates/package.dart
+++ b/app/lib/frontend/templates/package.dart
@@ -182,6 +182,9 @@ String renderPkgInfoBox(
     'meta_links': metaLinks,
     'has_doc_links': docLinks.isNotEmpty,
     'doc_links': docLinks,
+    'replaced_by': package.replacedBy,
+    'replaced_by_link':
+        package.replacedBy == null ? null : urls.pkgPageUrl(package.replacedBy),
     'publisher_id': package.publisherId,
     'publisher_link': package.publisherId == null
         ? null

--- a/app/lib/frontend/templates/package_admin.dart
+++ b/app/lib/frontend/templates/package_admin.dart
@@ -24,6 +24,9 @@ String renderPkgAdminPage(
         'pkg_has_publisher': data.package.publisherId != null,
         'publisher_id': data.package.publisherId,
         'is_discontinued': data.package.isDiscontinued,
+        'show_replaced_by': data.package.isDiscontinued,
+        'replaced_by': data.package.replacedBy,
+        'show_unlisted': !data.package.isDiscontinued,
         'is_unlisted': data.package.isUnlisted,
         'user_has_publisher': userPublishers.isNotEmpty,
         'user_publishers': userPublishers

--- a/app/lib/frontend/templates/views/pkg/admin_page.mustache
+++ b/app/lib/frontend/templates/views/pkg/admin_page.mustache
@@ -51,12 +51,12 @@
 <h2>Package Options</h2>
 
 <h3>Discontinued</h3>
-<div>
+<p>
   A package can be marked as <a href="https://dart.dev/tools/pub/publishing#discontinue">discontinued</a>
   to inform users that the package is no longer maintained.
   <i>Discontinued packages</i> remain available to package users, but they don't appear
   in search results on pub.dev unless the user specifies advanced search options.
-</div>
+</p>
 <div class="mdc-form-field">
   <div class="mdc-checkbox">
     <input type="checkbox"
@@ -75,19 +75,36 @@
   <label for="-admin-is-discontinued-checkbox">Mark "discontinued"</label>
 </div>
 
+{{#show_replaced_by}}
+<h3>Replaced by</h3>
+<div class="-pub-form-row">
+  <div class="mdc-text-field mdc-text-field--outlined" data-mdc-auto-init="MDCTextField">
+    <input type="text" id="-package-replaced-by" class="mdc-text-field__input" value="{{ replaced_by }}" />
+    <div class="mdc-notched-outline">
+      <div class="mdc-notched-outline__leading"></div>
+      <div class="mdc-notched-outline__trailing"></div>
+    </div>
+  </div>
+  <button
+      id="-package-replaced-by-button"
+      class="mdc-button mdc-button--raised"
+      data-mdc-auto-init="MDCRipple">Update "replaced by"</button>
+</div>
+{{/show_replaced_by}}
+
+{{#show_unlisted}}
 <h3>Unlisted</h3>
-<div>
+<p>
   A package that's marked as <i>unlisted</i> doesn't normally appear in search results on pub.dev.
   Unlisted packages remain publicly available, and users can search for them
   using advanced search options.
-</div>
+</p>
 <div class="mdc-form-field">
   <div class="mdc-checkbox">
     <input type="checkbox"
            class="mdc-checkbox__native-control"
            id="-admin-is-unlisted-checkbox"
            {{#is_unlisted}}checked="checked"{{/is_unlisted}}
-           {{#is_discontinued}}disabled="disabled"{{/is_discontinued}}
     />
     <div class="mdc-checkbox__background">
       <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
@@ -99,3 +116,4 @@
   </div>
   <label for="-admin-is-unlisted-checkbox">Mark "unlisted"</label>
 </div>
+{{/show_unlisted}}

--- a/app/lib/frontend/templates/views/pkg/admin_page.mustache
+++ b/app/lib/frontend/templates/views/pkg/admin_page.mustache
@@ -76,7 +76,16 @@
 </div>
 
 {{#show_replaced_by}}
-<h3>Replaced by</h3>
+<h3>Suggested replacement</h3>
+<p>
+  When a package is <i>discontinued</i> the author may designate a
+  <i>suggested replacement package</i>. Package users will be suggested
+  to consider using the designated replacement package.
+</p>
+<p>
+  Designating a replacement package is optional, and only serves to
+  guide existing package users.
+</p>
 <div class="-pub-form-row">
   <div class="mdc-text-field mdc-text-field--outlined" data-mdc-auto-init="MDCTextField">
     <input type="text" id="-package-replaced-by" class="mdc-text-field__input" value="{{ replaced_by }}" />
@@ -88,7 +97,7 @@
   <button
       id="-package-replaced-by-button"
       class="mdc-button mdc-button--raised"
-      data-mdc-auto-init="MDCRipple">Update "replaced by"</button>
+      data-mdc-auto-init="MDCRipple">Update "suggested replacement"</button>
 </div>
 {{/show_replaced_by}}
 

--- a/app/lib/frontend/templates/views/pkg/info_box.mustache
+++ b/app/lib/frontend/templates/views/pkg/info_box.mustache
@@ -5,7 +5,7 @@
 {{& labeled_scores_html }}
 
 {{#replaced_by}}
-<h3 class="title">Replaced by</h3>
+<h3 class="title">Suggested replacement</h3>
 <p>
   <a href="{{& replaced_by_link }}">{{ replaced_by }}</a>
 </p>

--- a/app/lib/frontend/templates/views/pkg/info_box.mustache
+++ b/app/lib/frontend/templates/views/pkg/info_box.mustache
@@ -7,7 +7,7 @@
 {{#replaced_by}}
 <h3 class="title">Suggested replacement</h3>
 <p>
-  <a href="{{& replaced_by_link }}">{{ replaced_by }}</a>
+  <a href="{{& replaced_by_link }}" title="This package is discontinued, but author has suggested package:{{ replaced_by }} as a replacement">{{ replaced_by }}</a>
 </p>
 {{/replaced_by}}
 

--- a/app/lib/frontend/templates/views/pkg/info_box.mustache
+++ b/app/lib/frontend/templates/views/pkg/info_box.mustache
@@ -4,6 +4,13 @@
 
 {{& labeled_scores_html }}
 
+{{#replaced_by}}
+<h3 class="title">Replaced by</h3>
+<p>
+  <a href="{{& replaced_by_link }}">{{ replaced_by }}</a>
+</p>
+{{/replaced_by}}
+
 {{#publisher_id}}
 <h3 class="title">Publisher</h3>
 <p>

--- a/app/test/frontend/golden/pkg_admin_page_outdated.html
+++ b/app/test/frontend/golden/pkg_admin_page_outdated.html
@@ -207,13 +207,13 @@
                   </div>
                   <h2>Package Options</h2>
                   <h3>Discontinued</h3>
-                  <div>
+                  <p>
                     A package can be marked as
                     <a href="https://dart.dev/tools/pub/publishing#discontinue">discontinued</a>
                     to inform users that the package is no longer maintained.
                     <i>Discontinued packages</i>
                     remain available to package users, but they don't appear in search results on pub.dev unless the user specifies advanced search options.
-                  </div>
+                  </p>
                   <div class="mdc-form-field">
                     <div class="mdc-checkbox">
                       <input type="checkbox" class="mdc-checkbox__native-control" id="-admin-is-discontinued-checkbox"/>
@@ -228,11 +228,11 @@
                     <label for="-admin-is-discontinued-checkbox">Mark "discontinued"</label>
                   </div>
                   <h3>Unlisted</h3>
-                  <div>
+                  <p>
                     A package that's marked as
                     <i>unlisted</i>
                     doesn't normally appear in search results on pub.dev. Unlisted packages remain publicly available, and users can search for them using advanced search options.
-                  </div>
+                  </p>
                   <div class="mdc-form-field">
                     <div class="mdc-checkbox">
                       <input type="checkbox" class="mdc-checkbox__native-control" id="-admin-is-unlisted-checkbox"/>

--- a/app/test/frontend/golden/pkg_show_page_discontinued.html
+++ b/app/test/frontend/golden/pkg_show_page_discontinued.html
@@ -219,6 +219,10 @@
                 <div class="packages-score-label">popularity</div>
               </div>
             </a>
+            <h3 class="title">Replaced by</h3>
+            <p>
+              <a href="/packages/helium">helium</a>
+            </p>
             <h3 class="title pkg-infobox-metadata">Metadata</h3>
             <p>my package description</p>
             <p>
@@ -268,6 +272,10 @@
               <div class="packages-score-label">popularity</div>
             </div>
           </a>
+          <h3 class="title">Replaced by</h3>
+          <p>
+            <a href="/packages/helium">helium</a>
+          </p>
           <h3 class="title pkg-infobox-metadata">Metadata</h3>
           <p>my package description</p>
           <p>

--- a/app/test/frontend/golden/pkg_show_page_discontinued.html
+++ b/app/test/frontend/golden/pkg_show_page_discontinued.html
@@ -219,7 +219,7 @@
                 <div class="packages-score-label">popularity</div>
               </div>
             </a>
-            <h3 class="title">Replaced by</h3>
+            <h3 class="title">Suggested replacement</h3>
             <p>
               <a href="/packages/helium">helium</a>
             </p>
@@ -272,7 +272,7 @@
               <div class="packages-score-label">popularity</div>
             </div>
           </a>
-          <h3 class="title">Replaced by</h3>
+          <h3 class="title">Suggested replacement</h3>
           <p>
             <a href="/packages/helium">helium</a>
           </p>

--- a/app/test/frontend/golden/pkg_show_page_discontinued.html
+++ b/app/test/frontend/golden/pkg_show_page_discontinued.html
@@ -221,7 +221,7 @@
             </a>
             <h3 class="title">Suggested replacement</h3>
             <p>
-              <a href="/packages/helium">helium</a>
+              <a href="/packages/helium" title="This package is discontinued, but author has suggested package:helium as a replacement">helium</a>
             </p>
             <h3 class="title pkg-infobox-metadata">Metadata</h3>
             <p>my package description</p>
@@ -274,7 +274,7 @@
           </a>
           <h3 class="title">Suggested replacement</h3>
           <p>
-            <a href="/packages/helium">helium</a>
+            <a href="/packages/helium" title="This package is discontinued, but author has suggested package:helium as a replacement">helium</a>
           </p>
           <h3 class="title pkg-infobox-metadata">Metadata</h3>
           <p>my package description</p>

--- a/app/test/shared/test_models.dart
+++ b/app/test/shared/test_models.dart
@@ -108,7 +108,8 @@ final Package foobarPackage = createFoobarPackage();
 final foobarUploaderEmails = [hansUser.email];
 
 final Package discontinuedPackage = createFoobarPackage()
-  ..isDiscontinued = true;
+  ..isDiscontinued = true
+  ..replacedBy = 'helium';
 
 final PackageVersion foobarStablePV = PackageVersion()
   ..parentKey = foobarStablePVKey.parent

--- a/pkg/web_app/lib/src/account.dart
+++ b/pkg/web_app/lib/src/account.dart
@@ -179,6 +179,8 @@ class _PkgAdminWidget {
   SelectElement _setPublisherInput;
   Element _setPublisherButton;
   InputElement _discontinuedCheckbox;
+  InputElement _replacedByInput;
+  Element _replacedByButton;
   InputElement _unlistedCheckbox;
 
   void init() {
@@ -191,6 +193,10 @@ class _PkgAdminWidget {
     _discontinuedCheckbox = document
         .getElementById('-admin-is-discontinued-checkbox') as InputElement;
     _discontinuedCheckbox?.onChange?.listen((_) => _toogleDiscontinued());
+    _replacedByInput =
+        document.getElementById('-package-replaced-by') as InputElement;
+    _replacedByButton = document.getElementById('-package-replaced-by-button');
+    _replacedByButton?.onClick?.listen((_) => _updateReplacedBy());
     _unlistedCheckbox =
         document.getElementById('-admin-is-unlisted-checkbox') as InputElement;
     _unlistedCheckbox?.onChange?.listen((_) => _toggleUnlisted());
@@ -209,16 +215,33 @@ class _PkgAdminWidget {
             ));
         return rs.isDiscontinued;
       },
-      successMessage: text('"discontinued" status changed.'),
+      successMessage:
+          text('"discontinued" status changed. The page will reload.'),
+      onSuccess: (_) => window.location.reload(),
       onError: (err) => null,
     );
-    if (newValue == null) {
+    if (newValue == null || newValue == oldValue) {
       _discontinuedCheckbox.checked = oldValue;
-    } else {
-      _discontinuedCheckbox.defaultChecked = newValue;
-      _discontinuedCheckbox.checked = newValue;
-      _unlistedCheckbox?.disabled = newValue;
     }
+  }
+
+  Future<void> _updateReplacedBy() async {
+    await rpc(
+      confirmQuestion: text(
+          'Are you sure you want change the "replaced by" field of the package?'),
+      fn: () async {
+        final rs = await client.setPackageOptions(
+            pageData.pkgData.package,
+            PkgOptions(
+              isDiscontinued: true,
+              replacedBy: _replacedByInput?.value,
+            ));
+        return rs.isDiscontinued;
+      },
+      successMessage:
+          text('"replaced by" status changed. The page will reload.'),
+      onSuccess: (_) => window.location.reload(),
+    );
   }
 
   Future<void> _toggleUnlisted() async {

--- a/pkg/web_app/lib/src/account.dart
+++ b/pkg/web_app/lib/src/account.dart
@@ -228,7 +228,7 @@ class _PkgAdminWidget {
   Future<void> _updateReplacedBy() async {
     await rpc(
       confirmQuestion: text(
-          'Are you sure you want change the "replaced by" field of the package?'),
+          'Are you sure you want change the "suggested replacement" field of the package?'),
       fn: () async {
         final rs = await client.setPackageOptions(
             pageData.pkgData.package,
@@ -239,7 +239,7 @@ class _PkgAdminWidget {
         return rs.isDiscontinued;
       },
       successMessage:
-          text('"replaced by" status changed. The page will reload.'),
+          text('"suggested replacement" field changed. The page will reload.'),
       onSuccess: (_) => window.location.reload(),
     );
   }


### PR DESCRIPTION
- Added further checks + tests: do not specify self, and do not specify another discontinued package.
- Minimal admin UI:
  <img width="766" alt="Screenshot 2020-10-14 at 12 59 53" src="https://user-images.githubusercontent.com/4778111/95980393-610cc780-0e1d-11eb-9b63-bc209e4a341d.png">

- Minimal exposure on InfoBox:
  <img width="207" alt="Screenshot 2020-10-14 at 12 59 45" src="https://user-images.githubusercontent.com/4778111/95980404-679b3f00-0e1d-11eb-8fac-3073544b42e3.png">
