### PR TITLE
Fix profile image for recent sessions

### DIFF
--- a/app/lib/account/models.dart
+++ b/app/lib/account/models.dart
@@ -199,7 +199,13 @@ class UserSessionData {
     }
     // Double the layout size, for better quality on higher dpi displays.
     final imageSize = layoutSize * 2;
-    return '$imageUrl=s$imageSize';
+
+    // Strip existing options from the imageUrl if there is any
+    var u = imageUrl;
+    if (RegExp(r'=(?:[swh]\d+)|[cp](?:-(?:[swh]\d+)|[cp])*$').hasMatch(u)) {
+      u = u.substring(0, u.lastIndexOf('='));
+    }
+    return '$u=s$imageSize';
   }
 }
 

--- a/app/lib/account/models.dart
+++ b/app/lib/account/models.dart
@@ -140,6 +140,11 @@ class UserSession extends db.ExpandoModel<String> {
   bool isExpired() => DateTime.now().isAfter(expires);
 }
 
+/// Pattern for detecting profile image parameters as specified in [1].
+///
+/// [1]: https://developers.google.com/people/image-sizing
+final _imgParamPattern = RegExp(r'=(?:[swh]\d+)|[cp](?:-(?:[swh]\d+)|[cp])*$');
+
 /// The cacheable version of [UserSession].
 @JsonSerializable()
 class UserSessionData {
@@ -202,7 +207,7 @@ class UserSessionData {
 
     // Strip existing options from the imageUrl if there is any
     var u = imageUrl;
-    if (RegExp(r'=(?:[swh]\d+)|[cp](?:-(?:[swh]\d+)|[cp])*$').hasMatch(u)) {
+    if (_imgParamPattern.hasMatch(u)) {
       u = u.substring(0, u.lastIndexOf('='));
     }
     return '$u=s$imageSize';


### PR DESCRIPTION
Currently, if I do a sign-out / sign-in, the profile image is broken.
Probably something changed in auth APIs that started inserting default parameters.
That makes sense, but it breaks when we then add additional parameters.