### PR TITLE
Updated canonical URLs for package pages.

### DIFF
--- a/app/lib/frontend/templates/layout.dart
+++ b/app/lib/frontend/templates/layout.dart
@@ -80,7 +80,7 @@ String renderLayoutPage(
     'main_class': mainClasses.join(' '),
     'no_index': noIndex,
     'favicon': faviconUrl ?? staticUrls.smallDartFavicon,
-    'canonicalUrl': canonicalUrl,
+    'canonical_url': canonicalUrl,
     'share_url': shareUrl,
     'pageDescription': pageDescription == null
         ? _defaultPageDescriptionEscaped

--- a/app/lib/frontend/templates/package.dart
+++ b/app/lib/frontend/templates/package.dart
@@ -249,6 +249,7 @@ String renderPkgShowPage(PackagePageData data) {
       packagePageData: data,
       readmeTab: _readmeTab(data),
     ),
+    pkgSubPage: urls.PkgSubPage.readme,
   );
 }
 
@@ -260,6 +261,7 @@ String renderPkgChangelogPage(PackagePageData data) {
       packagePageData: data,
       changelogTab: _changelogTab(data),
     ),
+    pkgSubPage: urls.PkgSubPage.changelog,
   );
 }
 
@@ -271,6 +273,7 @@ String renderPkgExamplePage(PackagePageData data) {
       packagePageData: data,
       exampleTab: _exampleTab(data),
     ),
+    pkgSubPage: urls.PkgSubPage.example,
   );
 }
 
@@ -282,6 +285,7 @@ String renderPkgInstallPage(PackagePageData data) {
       packagePageData: data,
       installingTab: _installTab(data),
     ),
+    pkgSubPage: urls.PkgSubPage.install,
   );
 }
 
@@ -293,12 +297,14 @@ String renderPkgScorePage(PackagePageData data) {
       packagePageData: data,
       scoreTab: _scoreTab(data),
     ),
+    pkgSubPage: urls.PkgSubPage.score,
   );
 }
 
 String _renderPkgPage({
   @required PackagePageData data,
   @required List<Tab> tabs,
+  @required urls.PkgSubPage pkgSubPage,
 }) {
   final card = data.analysis?.card;
 
@@ -311,19 +317,17 @@ String _renderPkgPage({
   );
 
   final isFlutterPackage = data.version.pubspec.usesFlutter;
-  final isVersionPage = data.package.latestVersion != data.version.version;
-  final packageAndVersion = isVersionPage
-      ? '${data.version.package} ${data.version.version}'
-      : data.version.package;
+  final isLatestStable = data.package.latestVersion == data.version.version;
+  final packageAndVersion = isLatestStable
+      ? data.version.package
+      : '${data.version.package} ${data.version.version}';
   final pageTitle =
       '$packageAndVersion | ${isFlutterPackage ? 'Flutter' : 'Dart'} Package';
-  final canonicalUrl = isVersionPage
-      ? urls.pkgPageUrl(data.package.name, includeHost: true)
-      : null;
-  final shareUrl = urls.pkgPageUrl(
+  final canonicalUrl = urls.pkgPageUrl(
     data.package.name,
-    version: isVersionPage ? data.version.version : null,
+    version: isLatestStable ? null : data.version.version,
     includeHost: true,
+    pkgSubPage: pkgSubPage,
   );
   final noIndex = (card?.isSkipped ?? false) ||
       (card?.grantedPubPoints == 0) ||
@@ -335,7 +339,7 @@ String _renderPkgPage({
     pageDescription: data.version.ellipsizedDescription,
     faviconUrl: isFlutterPackage ? staticUrls.flutterLogo32x32 : null,
     canonicalUrl: canonicalUrl,
-    shareUrl: shareUrl,
+    shareUrl: canonicalUrl,
     noIndex: noIndex,
     pageData: pkgPageData(data.package, data.version),
   );

--- a/app/lib/frontend/templates/package.dart
+++ b/app/lib/frontend/templates/package.dart
@@ -249,7 +249,7 @@ String renderPkgShowPage(PackagePageData data) {
       packagePageData: data,
       readmeTab: _readmeTab(data),
     ),
-    pkgSubPage: urls.PkgSubPage.readme,
+    pkgPageTab: urls.PkgPageTab.readme,
   );
 }
 
@@ -261,7 +261,7 @@ String renderPkgChangelogPage(PackagePageData data) {
       packagePageData: data,
       changelogTab: _changelogTab(data),
     ),
-    pkgSubPage: urls.PkgSubPage.changelog,
+    pkgPageTab: urls.PkgPageTab.changelog,
   );
 }
 
@@ -273,7 +273,7 @@ String renderPkgExamplePage(PackagePageData data) {
       packagePageData: data,
       exampleTab: _exampleTab(data),
     ),
-    pkgSubPage: urls.PkgSubPage.example,
+    pkgPageTab: urls.PkgPageTab.example,
   );
 }
 
@@ -285,7 +285,7 @@ String renderPkgInstallPage(PackagePageData data) {
       packagePageData: data,
       installingTab: _installTab(data),
     ),
-    pkgSubPage: urls.PkgSubPage.install,
+    pkgPageTab: urls.PkgPageTab.install,
   );
 }
 
@@ -297,14 +297,14 @@ String renderPkgScorePage(PackagePageData data) {
       packagePageData: data,
       scoreTab: _scoreTab(data),
     ),
-    pkgSubPage: urls.PkgSubPage.score,
+    pkgPageTab: urls.PkgPageTab.score,
   );
 }
 
 String _renderPkgPage({
   @required PackagePageData data,
   @required List<Tab> tabs,
-  @required urls.PkgSubPage pkgSubPage,
+  @required urls.PkgPageTab pkgPageTab,
 }) {
   final card = data.analysis?.card;
 
@@ -327,7 +327,7 @@ String _renderPkgPage({
     data.package.name,
     version: isLatestStable ? null : data.version.version,
     includeHost: true,
-    pkgSubPage: pkgSubPage,
+    pkgPageTab: pkgPageTab,
   );
   final noIndex = (card?.isSkipped ?? false) ||
       (card?.grantedPubPoints == 0) ||

--- a/app/lib/frontend/templates/package_versions.dart
+++ b/app/lib/frontend/templates/package_versions.dart
@@ -81,7 +81,7 @@ String renderPkgVersionsPage(
   );
 
   final canonicalUrl = urls.pkgPageUrl(data.package.name,
-      includeHost: true, pkgSubPage: urls.PkgSubPage.versions);
+      includeHost: true, pkgPageTab: urls.PkgPageTab.versions);
   return renderLayoutPage(
     PageType.package,
     content,

--- a/app/lib/frontend/templates/package_versions.dart
+++ b/app/lib/frontend/templates/package_versions.dart
@@ -80,11 +80,14 @@ String renderPkgVersionsPage(
     footerHtml: renderPackageSchemaOrgHtml(data),
   );
 
+  final canonicalUrl = urls.pkgPageUrl(data.package.name,
+      includeHost: true, pkgSubPage: urls.PkgSubPage.versions);
   return renderLayoutPage(
     PageType.package,
     content,
     title: '${data.package.name} package - All Versions',
-    canonicalUrl: urls.pkgPageUrl(data.package.name, includeHost: true),
+    canonicalUrl: canonicalUrl,
+    shareUrl: canonicalUrl,
     pageData: pkgPageData(data.package, data.version),
     noIndex: data.package.isDiscontinued,
   );

--- a/app/lib/frontend/templates/views/shared/layout.mustache
+++ b/app/lib/frontend/templates/views/shared/layout.mustache
@@ -43,9 +43,9 @@
   <link rel="shortcut icon" href="{{{favicon}}}" />
   {{/favicon}}
   <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="{{{static_assets.osd_xml}}}" />
-  {{#canonicalUrl}}
-  <link rel="canonical" href="{{{canonicalUrl}}}"/>
-  {{/canonicalUrl}}
+  {{#canonical_url}}
+  <link rel="canonical" href="{{{canonical_url}}}"/>
+  {{/canonical_url}}
   <meta name="description" content="{{& pageDescription}}" />
   <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom" />
   <link href="{{{static_assets.material__material-components-web_min_css}}}" rel="stylesheet" type="text/css" />

--- a/app/lib/shared/urls.dart
+++ b/app/lib/shared/urls.dart
@@ -32,7 +32,8 @@ const _trustedTargetHost = [
 final _siteRootUri = Uri.parse('$siteRoot/');
 final _pathRootUri = Uri(path: '/');
 
-enum PkgSubPage {
+/// The list of available tabs on the package page.
+enum PkgPageTab {
   readme,
   changelog,
   example,
@@ -42,23 +43,23 @@ enum PkgSubPage {
   admin,
 }
 
-const _pkgSubPageSegments = <PkgSubPage, String>{
-  PkgSubPage.readme: '',
-  PkgSubPage.changelog: 'changelog',
-  PkgSubPage.example: 'example',
-  PkgSubPage.install: 'install',
-  PkgSubPage.versions: 'versions',
-  PkgSubPage.score: 'score',
-  PkgSubPage.admin: 'admin',
+const _pkgPageTabSegments = <PkgPageTab, String>{
+  PkgPageTab.readme: '',
+  PkgPageTab.changelog: 'changelog',
+  PkgPageTab.example: 'example',
+  PkgPageTab.install: 'install',
+  PkgPageTab.versions: 'versions',
+  PkgPageTab.score: 'score',
+  PkgPageTab.admin: 'admin',
 };
 
 String pkgPageUrl(
   String package, {
   String version,
   bool includeHost = false,
-  PkgSubPage pkgSubPage,
+  PkgPageTab pkgPageTab,
 }) {
-  final subPageSegment = _pkgSubPageSegments[pkgSubPage ?? PkgSubPage.readme];
+  final subPageSegment = _pkgPageTabSegments[pkgPageTab ?? PkgPageTab.readme];
   final segments = <String>[
     'packages',
     package,
@@ -73,22 +74,22 @@ String pkgReadmeUrl(String package, {String version}) =>
     pkgPageUrl(package, version: version);
 
 String pkgChangelogUrl(String package, {String version}) =>
-    pkgPageUrl(package, version: version, pkgSubPage: PkgSubPage.changelog);
+    pkgPageUrl(package, version: version, pkgPageTab: PkgPageTab.changelog);
 
 String pkgExampleUrl(String package, {String version}) =>
-    pkgPageUrl(package, version: version, pkgSubPage: PkgSubPage.example);
+    pkgPageUrl(package, version: version, pkgPageTab: PkgPageTab.example);
 
 String pkgInstallUrl(String package, {String version}) =>
-    pkgPageUrl(package, version: version, pkgSubPage: PkgSubPage.install);
+    pkgPageUrl(package, version: version, pkgPageTab: PkgPageTab.install);
 
 String pkgVersionsUrl(String package) =>
-    pkgPageUrl(package, pkgSubPage: PkgSubPage.versions);
+    pkgPageUrl(package, pkgPageTab: PkgPageTab.versions);
 
 String pkgScoreUrl(String package, {String version}) =>
-    pkgPageUrl(package, version: version, pkgSubPage: PkgSubPage.score);
+    pkgPageUrl(package, version: version, pkgPageTab: PkgPageTab.score);
 
 String pkgAdminUrl(String package) =>
-    pkgPageUrl(package, pkgSubPage: PkgSubPage.admin);
+    pkgPageUrl(package, pkgPageTab: PkgPageTab.admin);
 
 String pkgArchiveDownloadUrl(String package, String version, {Uri baseUri}) {
   final path =

--- a/app/lib/shared/urls.dart
+++ b/app/lib/shared/urls.dart
@@ -32,42 +32,63 @@ const _trustedTargetHost = [
 final _siteRootUri = Uri.parse('$siteRoot/');
 final _pathRootUri = Uri(path: '/');
 
+enum PkgSubPage {
+  readme,
+  changelog,
+  example,
+  install,
+  versions,
+  score,
+  admin,
+}
+
+const _pkgSubPageSegments = <PkgSubPage, String>{
+  PkgSubPage.readme: '',
+  PkgSubPage.changelog: 'changelog',
+  PkgSubPage.example: 'example',
+  PkgSubPage.install: 'install',
+  PkgSubPage.versions: 'versions',
+  PkgSubPage.score: 'score',
+  PkgSubPage.admin: 'admin',
+};
+
 String pkgPageUrl(
   String package, {
   String version,
   bool includeHost = false,
-  String fragment,
+  PkgSubPage pkgSubPage,
 }) {
+  final subPageSegment = _pkgSubPageSegments[pkgSubPage ?? PkgSubPage.readme];
   final segments = <String>[
     'packages',
     package,
-    if (version != null) 'versions',
-    if (version != null) version,
+    if (version != null) ...['versions', version],
+    if (subPageSegment != null && subPageSegment.isNotEmpty) subPageSegment,
   ];
   final baseUri = includeHost ? _siteRootUri : _pathRootUri;
-  return baseUri
-      .resolveUri(Uri(pathSegments: segments, fragment: fragment))
-      .toString();
+  return baseUri.resolveUri(Uri(pathSegments: segments)).toString();
 }
 
 String pkgReadmeUrl(String package, {String version}) =>
     pkgPageUrl(package, version: version);
 
 String pkgChangelogUrl(String package, {String version}) =>
-    pkgPageUrl(package, version: version) + '/changelog';
+    pkgPageUrl(package, version: version, pkgSubPage: PkgSubPage.changelog);
 
 String pkgExampleUrl(String package, {String version}) =>
-    pkgPageUrl(package, version: version) + '/example';
+    pkgPageUrl(package, version: version, pkgSubPage: PkgSubPage.example);
 
 String pkgInstallUrl(String package, {String version}) =>
-    pkgPageUrl(package, version: version) + '/install';
+    pkgPageUrl(package, version: version, pkgSubPage: PkgSubPage.install);
 
-String pkgVersionsUrl(String package) => pkgPageUrl(package) + '/versions';
+String pkgVersionsUrl(String package) =>
+    pkgPageUrl(package, pkgSubPage: PkgSubPage.versions);
 
 String pkgScoreUrl(String package, {String version}) =>
-    pkgPageUrl(package, version: version) + '/score';
+    pkgPageUrl(package, version: version, pkgSubPage: PkgSubPage.score);
 
-String pkgAdminUrl(String package) => pkgPageUrl(package) + '/admin';
+String pkgAdminUrl(String package) =>
+    pkgPageUrl(package, pkgSubPage: PkgSubPage.admin);
 
 String pkgArchiveDownloadUrl(String package, String version, {Uri baseUri}) {
   final path =

--- a/app/test/frontend/golden/pkg_changelog_page.html
+++ b/app/test/frontend/golden/pkg_changelog_page.html
@@ -18,12 +18,13 @@
     <meta property="og:title" content="foobar_pkg | Dart Package"/>
     <meta property="og:description" content="my package description"/>
     <meta property="og:image" content="https://pub.dev/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
-    <meta property="og:url" content="https://pub.dev/packages/foobar_pkg"/>
+    <meta property="og:url" content="https://pub.dev/packages/foobar_pkg/changelog"/>
     <title>foobar_pkg | Dart Package</title>
     <link href="https://fonts.googleapis.com/css?family=Google+Sans:300,400,500|Google+Sans+Display:400|Roboto:300,400,500,700|Roboto+Mono:300,400,700" rel="stylesheet"/>
     <meta content="/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
     <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
     <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/osd.xml?hash=mocked_hash_869379763"/>
+    <link rel="canonical" href="https://pub.dev/packages/foobar_pkg/changelog"/>
     <meta name="description" content="my package description"/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
     <link href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842" rel="stylesheet" type="text/css"/>

--- a/app/test/frontend/golden/pkg_example_page.html
+++ b/app/test/frontend/golden/pkg_example_page.html
@@ -18,12 +18,13 @@
     <meta property="og:title" content="foobar_pkg | Dart Package"/>
     <meta property="og:description" content="my package description"/>
     <meta property="og:image" content="https://pub.dev/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
-    <meta property="og:url" content="https://pub.dev/packages/foobar_pkg"/>
+    <meta property="og:url" content="https://pub.dev/packages/foobar_pkg/example"/>
     <title>foobar_pkg | Dart Package</title>
     <link href="https://fonts.googleapis.com/css?family=Google+Sans:300,400,500|Google+Sans+Display:400|Roboto:300,400,500,700|Roboto+Mono:300,400,700" rel="stylesheet"/>
     <meta content="/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
     <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
     <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/osd.xml?hash=mocked_hash_869379763"/>
+    <link rel="canonical" href="https://pub.dev/packages/foobar_pkg/example"/>
     <meta name="description" content="my package description"/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
     <link href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842" rel="stylesheet" type="text/css"/>

--- a/app/test/frontend/golden/pkg_install_page.html
+++ b/app/test/frontend/golden/pkg_install_page.html
@@ -18,12 +18,13 @@
     <meta property="og:title" content="foobar_pkg | Dart Package"/>
     <meta property="og:description" content="my package description"/>
     <meta property="og:image" content="https://pub.dev/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
-    <meta property="og:url" content="https://pub.dev/packages/foobar_pkg"/>
+    <meta property="og:url" content="https://pub.dev/packages/foobar_pkg/install"/>
     <title>foobar_pkg | Dart Package</title>
     <link href="https://fonts.googleapis.com/css?family=Google+Sans:300,400,500|Google+Sans+Display:400|Roboto:300,400,500,700|Roboto+Mono:300,400,700" rel="stylesheet"/>
     <meta content="/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
     <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
     <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/osd.xml?hash=mocked_hash_869379763"/>
+    <link rel="canonical" href="https://pub.dev/packages/foobar_pkg/install"/>
     <meta name="description" content="my package description"/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
     <link href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842" rel="stylesheet" type="text/css"/>

--- a/app/test/frontend/golden/pkg_score_page.html
+++ b/app/test/frontend/golden/pkg_score_page.html
@@ -18,12 +18,13 @@
     <meta property="og:title" content="foobar_pkg | Dart Package"/>
     <meta property="og:description" content="my package description"/>
     <meta property="og:image" content="https://pub.dev/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
-    <meta property="og:url" content="https://pub.dev/packages/foobar_pkg"/>
+    <meta property="og:url" content="https://pub.dev/packages/foobar_pkg/score"/>
     <title>foobar_pkg | Dart Package</title>
     <link href="https://fonts.googleapis.com/css?family=Google+Sans:300,400,500|Google+Sans+Display:400|Roboto:300,400,500,700|Roboto+Mono:300,400,700" rel="stylesheet"/>
     <meta content="/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
     <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
     <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/osd.xml?hash=mocked_hash_869379763"/>
+    <link rel="canonical" href="https://pub.dev/packages/foobar_pkg/score"/>
     <meta name="description" content="my package description"/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
     <link href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842" rel="stylesheet" type="text/css"/>

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -24,6 +24,7 @@
     <meta content="/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
     <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
     <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/osd.xml?hash=mocked_hash_869379763"/>
+    <link rel="canonical" href="https://pub.dev/packages/foobar_pkg"/>
     <meta name="description" content="my package description"/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
     <link href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842" rel="stylesheet" type="text/css"/>

--- a/app/test/frontend/golden/pkg_show_page_discontinued.html
+++ b/app/test/frontend/golden/pkg_show_page_discontinued.html
@@ -24,6 +24,7 @@
     <meta content="/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
     <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
     <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/osd.xml?hash=mocked_hash_869379763"/>
+    <link rel="canonical" href="https://pub.dev/packages/foobar_pkg"/>
     <meta name="description" content="my package description"/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
     <link href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842" rel="stylesheet" type="text/css"/>

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -24,6 +24,7 @@
     <meta content="/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
     <link rel="shortcut icon" href="/static/img/flutter-logo-32x32.png?hash=mocked_hash_318836230"/>
     <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/osd.xml?hash=mocked_hash_869379763"/>
+    <link rel="canonical" href="https://pub.dev/packages/foobar_pkg"/>
     <meta name="description" content="my package description"/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
     <link href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842" rel="stylesheet" type="text/css"/>

--- a/app/test/frontend/golden/pkg_show_page_legacy.html
+++ b/app/test/frontend/golden/pkg_show_page_legacy.html
@@ -24,6 +24,7 @@
     <meta content="/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
     <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
     <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/osd.xml?hash=mocked_hash_869379763"/>
+    <link rel="canonical" href="https://pub.dev/packages/foobar_pkg"/>
     <meta name="description" content="my package description"/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
     <link href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842" rel="stylesheet" type="text/css"/>

--- a/app/test/frontend/golden/pkg_show_page_outdated.html
+++ b/app/test/frontend/golden/pkg_show_page_outdated.html
@@ -24,6 +24,7 @@
     <meta content="/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
     <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
     <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/osd.xml?hash=mocked_hash_869379763"/>
+    <link rel="canonical" href="https://pub.dev/packages/foobar_pkg"/>
     <meta name="description" content="my package description"/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
     <link href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842" rel="stylesheet" type="text/css"/>

--- a/app/test/frontend/golden/pkg_show_page_publisher.html
+++ b/app/test/frontend/golden/pkg_show_page_publisher.html
@@ -24,6 +24,7 @@
     <meta content="/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
     <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
     <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/osd.xml?hash=mocked_hash_869379763"/>
+    <link rel="canonical" href="https://pub.dev/packages/lithium"/>
     <meta name="description" content="lithium is a Dart package"/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
     <link href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842" rel="stylesheet" type="text/css"/>

--- a/app/test/frontend/golden/pkg_show_version_page.html
+++ b/app/test/frontend/golden/pkg_show_version_page.html
@@ -24,7 +24,7 @@
     <meta content="/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
     <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
     <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/osd.xml?hash=mocked_hash_869379763"/>
-    <link rel="canonical" href="https://pub.dev/packages/foobar_pkg"/>
+    <link rel="canonical" href="https://pub.dev/packages/foobar_pkg/versions/0.2.0-dev"/>
     <meta name="description" content="my package description"/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
     <link href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842" rel="stylesheet" type="text/css"/>

--- a/app/test/frontend/golden/pkg_versions_page.html
+++ b/app/test/frontend/golden/pkg_versions_page.html
@@ -17,12 +17,13 @@
     <meta property="og:title" content="foobar_pkg package - All Versions"/>
     <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <meta property="og:image" content="https://pub.dev/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta property="og:url" content="https://pub.dev/packages/foobar_pkg/versions"/>
     <title>foobar_pkg package - All Versions</title>
     <link href="https://fonts.googleapis.com/css?family=Google+Sans:300,400,500|Google+Sans+Display:400|Roboto:300,400,500,700|Roboto+Mono:300,400,700" rel="stylesheet"/>
     <meta content="/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
     <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
     <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/osd.xml?hash=mocked_hash_869379763"/>
-    <link rel="canonical" href="https://pub.dev/packages/foobar_pkg"/>
+    <link rel="canonical" href="https://pub.dev/packages/foobar_pkg/versions"/>
     <meta name="description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
     <link href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842" rel="stylesheet" type="text/css"/>

--- a/app/test/shared/urls_test.dart
+++ b/app/test/shared/urls_test.dart
@@ -13,8 +13,6 @@ void main() {
       expect(pkgPageUrl('foo_bar'), '/packages/foo_bar');
       expect(pkgPageUrl('foo_bar', version: '1.0.0'),
           '/packages/foo_bar/versions/1.0.0');
-      expect(pkgPageUrl('foo_bar', version: '1.0.0', fragment: 'hash'),
-          '/packages/foo_bar/versions/1.0.0#hash');
     });
 
     test('with host', () {


### PR DESCRIPTION
- #4136
- All package pages should have canonical url.
- The share url should be the same as the canonical url.
- I've create`PkgSubPage` because I think it will be useful in other parts of the package page rendering.