### PR TITLE
Upgrade package:sanitize_html and use addLinkRel for <a> tags.

### DIFF
--- a/app/lib/shared/markdown.dart
+++ b/app/lib/shared/markdown.dart
@@ -201,12 +201,6 @@ class _UnsafeUrlFilter implements m.NodeVisitor {
       element.attributes.remove(attr);
       return true;
     }
-
-    /// <img src=""> elements are not covered by package:sanitize_html.
-    /// TODO: decide to remove from here or add it to sanitize_html.
-    if (tag == 'img' && uri.shouldIndicateUgc) {
-      element.attributes['rel'] = 'ugc';
-    }
     return false;
   }
 }

--- a/app/lib/shared/markdown.dart
+++ b/app/lib/shared/markdown.dart
@@ -116,6 +116,13 @@ String _renderSafeHtml(
       if (cn.startsWith('language-')) return true;
       return _whitelistedClassNames.contains(cn);
     },
+    addLinkRel: (String url) {
+      final uri = Uri.tryParse(url);
+      if (uri == null || uri.isInvalid) return ['nofollow'];
+      return <String>[
+        if (uri.shouldIndicateUgc) 'ugc',
+      ];
+    },
   );
   return inlineOnly ? html : '$html\n';
 }
@@ -194,7 +201,10 @@ class _UnsafeUrlFilter implements m.NodeVisitor {
       element.attributes.remove(attr);
       return true;
     }
-    if (uri.shouldIndicateUgc) {
+
+    /// <img src=""> elements are not covered by package:sanitize_html.
+    /// TODO: decide to remove from here or add it to sanitize_html.
+    if (tag == 'img' && uri.shouldIndicateUgc) {
       element.attributes['rel'] = 'ugc';
     }
     return false;

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -560,7 +560,7 @@ packages:
       name: sanitize_html
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.1"
   shelf:
     dependency: "direct main"
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -46,7 +46,7 @@ dependencies:
   # 3rd-party packages with pinned versions
   archive: '2.0.11'
   mailer: '3.2.1'
-  sanitize_html: '1.3.0'
+  sanitize_html: '1.4.1'
   ulid: '1.1.0'
   http_retry: '0.1.1+3'
   api_builder:

--- a/app/test/shared/markdown_test.dart
+++ b/app/test/shared/markdown_test.dart
@@ -229,7 +229,7 @@ void main() {
     test('a', () {
       expect(
         markdownToHtml('<a href="https://google.com">link</a>'),
-        '<p><a href="https://google.com">link</a></p>\n',
+        '<p><a href="https://google.com" rel="ugc">link</a></p>\n',
       );
     });
 

--- a/app/test/shared/markdown_test.dart
+++ b/app/test/shared/markdown_test.dart
@@ -96,15 +96,15 @@ void main() {
 
     test('absolute image URL', () {
       expect(markdownToHtml('![text](http://dartlang.org/image.png)'),
-          '<p><img src="http://dartlang.org/image.png" alt="text" rel="ugc" /></p>\n');
+          '<p><img src="http://dartlang.org/image.png" alt="text" /></p>\n');
       expect(
           markdownToHtml('![text](http://dartlang.org/image.png)',
               baseUrl: baseUrl),
-          '<p><img src="http://dartlang.org/image.png" alt="text" rel="ugc" /></p>\n');
+          '<p><img src="http://dartlang.org/image.png" alt="text" /></p>\n');
       expect(
           markdownToHtml('![text](http://dartlang.org/image.png)',
               baseUrl: '$baseUrl/'),
-          '<p><img src="http://dartlang.org/image.png" alt="text" rel="ugc" /></p>\n');
+          '<p><img src="http://dartlang.org/image.png" alt="text" /></p>\n');
     });
 
     test('sibling link within site', () {
@@ -120,9 +120,9 @@ void main() {
       expect(markdownToHtml('![text](image.png)'),
           '<p><img src="image.png" alt="text" /></p>\n');
       expect(markdownToHtml('![text](image.png)', baseUrl: baseUrl),
-          '<p><img src="https://github.com/example/project/raw/master/image.png" alt="text" rel="ugc" /></p>\n');
+          '<p><img src="https://github.com/example/project/raw/master/image.png" alt="text" /></p>\n');
       expect(markdownToHtml('![text](image.png)', baseUrl: '$baseUrl/'),
-          '<p><img src="https://github.com/example/project/raw/master/image.png" alt="text" rel="ugc" /></p>\n');
+          '<p><img src="https://github.com/example/project/raw/master/image.png" alt="text" /></p>\n');
     });
 
     test('sibling image inside a relative directory', () {
@@ -131,11 +131,11 @@ void main() {
       expect(
           markdownToHtml('![text](image.png)',
               baseUrl: baseUrl, baseDir: 'example'),
-          '<p><img src="https://github.com/example/project/raw/master/example/image.png" alt="text" rel="ugc" /></p>\n');
+          '<p><img src="https://github.com/example/project/raw/master/example/image.png" alt="text" /></p>\n');
       expect(
           markdownToHtml('![text](img/image.png)',
               baseUrl: '$baseUrl/', baseDir: 'example'),
-          '<p><img src="https://github.com/example/project/raw/master/example/img/image.png" alt="text" rel="ugc" /></p>\n');
+          '<p><img src="https://github.com/example/project/raw/master/example/img/image.png" alt="text" /></p>\n');
     });
 
     test('sibling link plus relative link', () {
@@ -160,9 +160,9 @@ void main() {
       expect(markdownToHtml('![text](example/image.png)'),
           '<p><img src="example/image.png" alt="text" /></p>\n');
       expect(markdownToHtml('![text](example/image.png)', baseUrl: baseUrl),
-          '<p><img src="https://github.com/example/project/raw/master/example/image.png" alt="text" rel="ugc" /></p>\n');
+          '<p><img src="https://github.com/example/project/raw/master/example/image.png" alt="text" /></p>\n');
       expect(markdownToHtml('![text](example/image.png)', baseUrl: '$baseUrl/'),
-          '<p><img src="https://github.com/example/project/raw/master/example/image.png" alt="text" rel="ugc" /></p>\n');
+          '<p><img src="https://github.com/example/project/raw/master/example/image.png" alt="text" /></p>\n');
     });
 
     test('root link within site', () {
@@ -178,10 +178,10 @@ void main() {
       expect(markdownToHtml('![text](/image.png)'),
           '<p><img src="/image.png" alt="text" /></p>\n');
       expect(markdownToHtml('![text](/example/image.png)', baseUrl: baseUrl),
-          '<p><img src="https://github.com/example/image.png" alt="text" rel="ugc" /></p>\n');
+          '<p><img src="https://github.com/example/image.png" alt="text" /></p>\n');
       expect(
           markdownToHtml('![text](/example/image.png)', baseUrl: '$baseUrl/'),
-          '<p><img src="https://github.com/example/image.png" alt="text" rel="ugc" /></p>\n');
+          '<p><img src="https://github.com/example/image.png" alt="text" /></p>\n');
     });
 
     test('email', () {
@@ -244,7 +244,7 @@ void main() {
       expect(
           markdownToHtml(
               '![text](https://github.com/rcpassos/progress_hud/blob/master/progress_hud.gif)'),
-          '<p><img src="https://github.com/rcpassos/progress_hud/raw/master/progress_hud.gif" alt="text" rel="ugc" /></p>\n');
+          '<p><img src="https://github.com/rcpassos/progress_hud/raw/master/progress_hud.gif" alt="text" /></p>\n');
     });
 
     test('root path: /[..]/blob/master/[path].gif', () {
@@ -252,14 +252,14 @@ void main() {
           markdownToHtml(
               '![text](/rcpassos/progress_hud/blob/master/progress_hud.gif)',
               baseUrl: 'https://github.com/rcpassos/progress_hud'),
-          '<p><img src="https://github.com/rcpassos/progress_hud/raw/master/progress_hud.gif" alt="text" rel="ugc" /></p>\n');
+          '<p><img src="https://github.com/rcpassos/progress_hud/raw/master/progress_hud.gif" alt="text" /></p>\n');
     });
 
     test('relative path: [path].gif', () {
       expect(
           markdownToHtml('![text](progress_hud.gif)',
               baseUrl: 'https://github.com/rcpassos/progress_hud'),
-          '<p><img src="https://github.com/rcpassos/progress_hud/raw/master/progress_hud.gif" alt="text" rel="ugc" /></p>\n');
+          '<p><img src="https://github.com/rcpassos/progress_hud/raw/master/progress_hud.gif" alt="text" /></p>\n');
     });
   });
 


### PR DESCRIPTION
- `<img>` elements do not have `rel` attribute, removing that from the customization.
- this improves our sanitization coverage by handling the whitelisted inline `<a>` elements.