### PR TITLE
Render null-safe badge on package page + refactoring.

### DIFF
--- a/app/lib/frontend/templates/listing.dart
+++ b/app/lib/frontend/templates/listing.dart
@@ -22,7 +22,7 @@ import '_cache.dart';
 import '_consts.dart';
 import '_utils.dart';
 import 'layout.dart';
-import 'misc.dart';
+import 'package_misc.dart';
 
 /// Renders the `views/shared/pagination.mustache` template.
 String renderPagination(PageLinks pageLinks) {
@@ -55,6 +55,13 @@ String renderPackageList(
         ?.toList();
     final hasApiPages = apiPages != null && apiPages.isNotEmpty;
     final hasMoreThanOneApiPages = hasApiPages && apiPages.length > 1;
+    final flutterFavoriteBadgeHtml =
+        view.tags.contains(PackageTags.isFlutterFavorite)
+            ? renderFlutterFavoriteBadge()
+            : null;
+    final isNullSafe = requestContext.isNullSafetyDisplayed &&
+        view.tags.contains(PackageVersionTags.isNullSafe);
+    final nullSafeBadgeHtml = isNullSafe ? renderNullSafeBadge() : null;
     packagesJson.add({
       'url': view.url ?? urls.pkgPageUrl(view.name),
       'name': view.name,
@@ -69,9 +76,8 @@ String renderPackageList(
       'added_x_ago': addedXAgo,
       'last_uploaded': view.shortUpdated,
       'desc': view.ellipsizedDescription,
-      'is_flutter_favorite': view.tags.contains(PackageTags.isFlutterFavorite),
-      'is_null_safe': requestContext.isNullSafetyDisplayed &&
-          view.tags.contains(PackageVersionTags.isNullSafe),
+      'flutter_favorite_badge_html': flutterFavoriteBadgeHtml,
+      'null_safe_badge_html': nullSafeBadgeHtml,
       'publisher_id': view.publisherId,
       'publisher_url':
           view.publisherId == null ? null : urls.publisherUrl(view.publisherId),

--- a/app/lib/frontend/templates/misc.dart
+++ b/app/lib/frontend/templates/misc.dart
@@ -4,12 +4,10 @@
 
 import 'dart:io' as io;
 
-import 'package:meta/meta.dart';
-
 import 'package:path/path.dart' as p;
+
 import '../../package/models.dart';
 import '../../shared/markdown.dart';
-import '../../shared/tags.dart';
 import '../../shared/urls.dart' as urls;
 import '../static_files.dart' as static_files;
 
@@ -177,144 +175,4 @@ String renderMiniList(List<PackageView> packages) {
     }).toList(),
   };
   return templateCache.renderTemplate('pkg/mini_list', values);
-}
-
-/// Renders the tags using the pkg/tags template.
-String renderTags({@required PackageView package}) {
-  final tags = package.tags;
-  final sdkTags = tags.where((s) => s.startsWith('sdk:')).toSet().toList();
-  final tagValues = <Map>[];
-  final tagBadges = <Map>[];
-  if (package.isDiscontinued) {
-    tagValues.add({
-      'status': 'discontinued',
-      'text': 'discontinued',
-      'has_href': false,
-      'title': 'Package was discontinued.',
-    });
-  }
-  // Display unlisted tag only for packages that are not discontinued.
-  if (!package.isDiscontinued &&
-      package.tags.contains(PackageTags.isUnlisted)) {
-    tagValues.add({
-      'status': 'unlisted',
-      'text': 'unlisted',
-      'has_href': false,
-      'title': 'Package is unlisted, this means that while the package is still '
-          'publicly available the author has decided that it should not appear '
-          'in search results with default search filters. This is typically '
-          'done because this package is meant to support another package, '
-          'rather than being consumed directly.',
-    });
-  }
-  if (package.isObsolete) {
-    tagValues.add({
-      'status': 'missing',
-      'text': 'outdated',
-      'has_href': false,
-      'title': 'Package version too old, check latest stable.',
-    });
-  }
-  if (package.isLegacy) {
-    tagValues.add({
-      'status': 'legacy',
-      'text': 'Dart 2 incompatible',
-      'has_href': false,
-      'title': 'Package does not support Dart 2.',
-    });
-  }
-  // We only display first-class platform/runtimes
-  if (sdkTags.contains(SdkTag.sdkDart)) {
-    tagBadges.add({
-      'sdk': 'Dart',
-      'title': 'Packages compatible with Dart SDK',
-      'sub_tags': [
-        if (tags.contains(DartSdkTag.runtimeNativeJit))
-          {
-            'text': 'native',
-            'title':
-                'Packages compatible with Dart running on a native platform (JIT/AOT)',
-          },
-        if (tags.contains(DartSdkTag.runtimeWeb))
-          {
-            'text': 'js',
-            'title': 'Packages compatible with Dart compiled for the web',
-          },
-      ],
-    });
-  }
-  if (sdkTags.contains(SdkTag.sdkFlutter)) {
-    tagBadges.add({
-      'sdk': 'Flutter',
-      'title': 'Packages compatible with Flutter SDK',
-      'sub_tags': [
-        if (tags.contains(FlutterSdkTag.platformAndroid))
-          {
-            'text': 'Android',
-            'title': 'Packages compatible with Flutter on the Android platform',
-          },
-        if (tags.contains(FlutterSdkTag.platformIos))
-          {
-            'text': 'iOS',
-            'title': 'Packages compatible with Flutter on the iOS platform'
-          },
-        if (tags.contains(FlutterSdkTag.platformWeb))
-          {
-            'text': 'web',
-            'title': 'Packages compatible with Flutter on the Web platform',
-          },
-      ],
-    });
-  }
-  if (tagBadges.isEmpty && package.isAwaiting) {
-    tagValues.add({
-      'status': 'missing',
-      'text': '[awaiting]',
-      'has_href': false,
-      'title': 'Analysis should be ready soon.',
-    });
-  }
-  if (!package.isExternal && tagValues.isEmpty && tagBadges.isEmpty) {
-    tagValues.add({
-      'status': 'unidentified',
-      'text': '[unidentified]',
-      'title': 'Check the scores tab for further details.',
-      'has_href': true,
-      'href': urls.pkgScoreUrl(package.name),
-    });
-  }
-  return templateCache.renderTemplate('pkg/tags', {
-    'tags': tagValues,
-    'tag_badges': tagBadges,
-  });
-}
-
-/// Renders the `views/pkg/labeled_scores.mustache` template.
-String renderLabeledScores(PackageView view) {
-  return templateCache.renderTemplate('pkg/labeled_scores', {
-    'pkg_score_url': urls.pkgScoreUrl(view.name),
-    'like_score_html': _renderLabeledScore('likes', view.likes, ''),
-    'pub_points_html':
-        _renderLabeledScore('pub points', view.grantedPubPoints, ''),
-    'popularity_score_html':
-        _renderLabeledScore('popularity', view.popularity, '%'),
-  });
-}
-
-/// Renders the `views/pkg/labeled_score.mustache` template.
-String _renderLabeledScore(String label, int value, String sign) {
-  return templateCache.renderTemplate('pkg/labeled_score', {
-    'label': label,
-    'has_value': value != null,
-    'value': value ?? '--',
-    'sign': sign,
-  });
-}
-
-/// Formats the score from [0.0 - 1.0] range to [0 - 100] or '--'.
-String formatScore(double value) {
-  if (value == null) return '--';
-  if (value <= 0.0) return '0';
-  if (value >= 1.0) return '100';
-  return (value * 100.0).round().toString();
 }

--- a/app/lib/frontend/templates/package.dart
+++ b/app/lib/frontend/templates/package.dart
@@ -18,6 +18,7 @@ import '../../shared/email.dart' show EmailAddress;
 import '../../shared/tags.dart';
 import '../../shared/urls.dart' as urls;
 
+import '../request_context.dart';
 import '../static_files.dart';
 
 import '_cache.dart';
@@ -26,6 +27,7 @@ import 'detail_page.dart';
 import 'layout.dart';
 import 'misc.dart';
 import 'package_analysis.dart';
+import 'package_misc.dart';
 
 String _renderLicense(String baseUrl, LicenseFile license) {
   if (license == null) return null;
@@ -208,11 +210,16 @@ String renderPkgHeader(PackagePageData data) {
   final bool showUpdated =
       selectedVersion.version != package.latestVersion || showPrereleaseVersion;
 
+  final isNullSafe = requestContext.isNullSafetyDisplayed &&
+      data.toPackageView().tags.contains(PackageVersionTags.isNullSafe);
+  final nullSafeBadgeHtml = isNullSafe ? renderNullSafeBadge() : null;
+
   final metadataHtml = templateCache.renderTemplate('pkg/header', {
     'publisher_id': package.publisherId,
     'publisher_url': package.publisherId == null
         ? null
         : urls.publisherUrl(package.publisherId),
+    'null_safe_badge_html': nullSafeBadgeHtml,
     'latest': {
       'show_updated': showUpdated,
       'show_prerelease_version': showPrereleaseVersion,

--- a/app/lib/frontend/templates/package_analysis.dart
+++ b/app/lib/frontend/templates/package_analysis.dart
@@ -14,7 +14,7 @@ import '../../shared/utils.dart';
 import '../static_files.dart';
 
 import '_cache.dart';
-import 'misc.dart';
+import 'package_misc.dart';
 
 /// Renders the `views/pkg/analysis/tab.mustache` template.
 String renderAnalysisTab(

--- a/app/lib/frontend/templates/package_misc.dart
+++ b/app/lib/frontend/templates/package_misc.dart
@@ -1,0 +1,182 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:meta/meta.dart';
+
+import '../../package/models.dart';
+import '../../shared/tags.dart';
+import '../../shared/urls.dart' as urls;
+
+import '../static_files.dart';
+
+import '_cache.dart';
+
+/// Renders the Flutter Favorite badge, used by package listing.
+String renderFlutterFavoriteBadge() {
+  return _renderPackageBadge(
+    label: 'Flutter Favorite',
+    icon: staticUrls.flutterLogo32x32,
+  );
+}
+
+/// Renders the null-safe badge used by package listing and package page.
+String renderNullSafeBadge() {
+  return _renderPackageBadge(
+    label: 'Null safety',
+    title: 'Supports the null safety language feature.',
+  );
+}
+
+/// Renders the package badge using the pkg/badge template.
+String _renderPackageBadge({
+  @required String label,
+  String title,
+  String icon,
+}) {
+  return templateCache.renderTemplate('pkg/badge', {
+    'label': label,
+    'title': title,
+    'icon': icon,
+  });
+}
+
+/// Renders the tags using the pkg/tags template.
+String renderTags({@required PackageView package}) {
+  final tags = package.tags;
+  final sdkTags = tags.where((s) => s.startsWith('sdk:')).toSet().toList();
+  final tagValues = <Map>[];
+  final tagBadges = <Map>[];
+  if (package.isDiscontinued) {
+    tagValues.add({
+      'status': 'discontinued',
+      'text': 'discontinued',
+      'has_href': false,
+      'title': 'Package was discontinued.',
+    });
+  }
+  // Display unlisted tag only for packages that are not discontinued.
+  if (!package.isDiscontinued &&
+      package.tags.contains(PackageTags.isUnlisted)) {
+    tagValues.add({
+      'status': 'unlisted',
+      'text': 'unlisted',
+      'has_href': false,
+      'title': 'Package is unlisted, this means that while the package is still '
+          'publicly available the author has decided that it should not appear '
+          'in search results with default search filters. This is typically '
+          'done because this package is meant to support another package, '
+          'rather than being consumed directly.',
+    });
+  }
+  if (package.isObsolete) {
+    tagValues.add({
+      'status': 'missing',
+      'text': 'outdated',
+      'has_href': false,
+      'title': 'Package version too old, check latest stable.',
+    });
+  }
+  if (package.isLegacy) {
+    tagValues.add({
+      'status': 'legacy',
+      'text': 'Dart 2 incompatible',
+      'has_href': false,
+      'title': 'Package does not support Dart 2.',
+    });
+  }
+  // We only display first-class platform/runtimes
+  if (sdkTags.contains(SdkTag.sdkDart)) {
+    tagBadges.add({
+      'sdk': 'Dart',
+      'title': 'Packages compatible with Dart SDK',
+      'sub_tags': [
+        if (tags.contains(DartSdkTag.runtimeNativeJit))
+          {
+            'text': 'native',
+            'title':
+                'Packages compatible with Dart running on a native platform (JIT/AOT)',
+          },
+        if (tags.contains(DartSdkTag.runtimeWeb))
+          {
+            'text': 'js',
+            'title': 'Packages compatible with Dart compiled for the web',
+          },
+      ],
+    });
+  }
+  if (sdkTags.contains(SdkTag.sdkFlutter)) {
+    tagBadges.add({
+      'sdk': 'Flutter',
+      'title': 'Packages compatible with Flutter SDK',
+      'sub_tags': [
+        if (tags.contains(FlutterSdkTag.platformAndroid))
+          {
+            'text': 'Android',
+            'title': 'Packages compatible with Flutter on the Android platform',
+          },
+        if (tags.contains(FlutterSdkTag.platformIos))
+          {
+            'text': 'iOS',
+            'title': 'Packages compatible with Flutter on the iOS platform'
+          },
+        if (tags.contains(FlutterSdkTag.platformWeb))
+          {
+            'text': 'web',
+            'title': 'Packages compatible with Flutter on the Web platform',
+          },
+      ],
+    });
+  }
+  if (tagBadges.isEmpty && package.isAwaiting) {
+    tagValues.add({
+      'status': 'missing',
+      'text': '[awaiting]',
+      'has_href': false,
+      'title': 'Analysis should be ready soon.',
+    });
+  }
+  if (!package.isExternal && tagValues.isEmpty && tagBadges.isEmpty) {
+    tagValues.add({
+      'status': 'unidentified',
+      'text': '[unidentified]',
+      'title': 'Check the scores tab for further details.',
+      'has_href': true,
+      'href': urls.pkgScoreUrl(package.name),
+    });
+  }
+  return templateCache.renderTemplate('pkg/tags', {
+    'tags': tagValues,
+    'tag_badges': tagBadges,
+  });
+}
+
+/// Renders the `views/pkg/labeled_scores.mustache` template.
+String renderLabeledScores(PackageView view) {
+  return templateCache.renderTemplate('pkg/labeled_scores', {
+    'pkg_score_url': urls.pkgScoreUrl(view.name),
+    'like_score_html': _renderLabeledScore('likes', view.likes, ''),
+    'pub_points_html':
+        _renderLabeledScore('pub points', view.grantedPubPoints, ''),
+    'popularity_score_html':
+        _renderLabeledScore('popularity', view.popularity, '%'),
+  });
+}
+
+/// Renders the `views/pkg/labeled_score.mustache` template.
+String _renderLabeledScore(String label, int value, String sign) {
+  return templateCache.renderTemplate('pkg/labeled_score', {
+    'label': label,
+    'has_value': value != null,
+    'value': value ?? '--',
+    'sign': sign,
+  });
+}
+
+/// Formats the score from [0.0 - 1.0] range to [0 - 100] or '--'.
+String formatScore(double value) {
+  if (value == null) return '--';
+  if (value <= 0.0) return '0';
+  if (value >= 1.0) return '100';
+  return (value * 100.0).round().toString();
+}

--- a/app/lib/frontend/templates/views/pkg/badge.mustache
+++ b/app/lib/frontend/templates/views/pkg/badge.mustache
@@ -1,0 +1,10 @@
+{{! Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+    for details. All rights reserved. Use of this source code is governed by a
+    BSD-style license that can be found in the LICENSE file. }}
+
+<span class="package-badge"{{#title}} title="{{ title }}"{{/title}}>
+  {{#icon}}
+  <img class="package-badge-icon" src="{{ icon }}" />
+  {{/icon}}
+  {{ label }}
+</span>

--- a/app/lib/frontend/templates/views/pkg/header.mustache
+++ b/app/lib/frontend/templates/views/pkg/header.mustache
@@ -10,6 +10,8 @@ Published <span>{{short_created}}</span>
           src="/static/img/verified-publisher-blue.svg" />{{publisher_id}}</a>
 {{/publisher_id}}
 
+{{& null_safe_badge_html }}
+
 {{#latest.show_updated}}
   &bull; Latest:
   <span><a href="{{& latest.stable_url}}">{{latest.stable_version}}</a></span>

--- a/app/lib/frontend/templates/views/pkg/package_list.mustache
+++ b/app/lib/frontend/templates/views/pkg/package_list.mustache
@@ -30,21 +30,14 @@
       </span>
       {{#publisher_id}}
       <span class="packages-metadata-block">
-        <img class="packages-vp-icon"
+        <img class="package-vp-icon"
            src="{{& static_assets.img__verified-publisher-icon_svg}}"
            title="Published by a pub.dev verified publisher" />
         <a href="/publishers/{{publisher_id}}">{{publisher_id}}</a>
       </span>
       {{/publisher_id}}
-      {{#is_flutter_favorite}}
-      <span class="package-badge">
-        <img class="package-badge-icon" src="{{static_assets.img__flutter-logo-32x32_png}}" />
-        Flutter Favorite
-      </span>
-      {{/is_flutter_favorite}}
-      {{#is_null_safe}}
-      <span class="package-badge" title="Supports the null safety language feature.">Null safety</span>
-      {{/is_null_safe}}
+      {{& flutter_favorite_badge_html }}
+      {{& null_safe_badge_html }}
     </p>
     {{/is_external}}
     <div>{{& tags_html}}</div>

--- a/pkg/web_css/lib/src/_list.scss
+++ b/pkg/web_css/lib/src/_list.scss
@@ -316,33 +316,6 @@
     margin: 0 8px 0 0;
   }
 
-  .package-badge {
-    display: inline-block;
-    background: white;
-    border: 1px solid $color-input-primary;
-    border-radius: 20px;
-    color: $color-input-primary;
-
-    font-size: 12px;
-    padding: 1px 6px;
-    margin: 0 8px 0 0;
-
-    .package-badge-icon {
-      max-width: 13px;
-      max-height: 13px;
-      position: relative;
-      top: 2px;
-    }
-  }
-
-  .packages-vp-icon {
-    display: inline-block;
-    height: 14px;
-    position: relative;
-    top: 3px;
-    opacity: 0.5;
-  }
-
   .packages-api {
     color: #3c4043;
     font-size: 12px;
@@ -360,10 +333,6 @@
     .-rest {
       padding-left: 16px;
     }
-  }
-
-  .score-box {
-    float: none;
   }
 
   &.-compact {

--- a/pkg/web_css/lib/src/_pkg.scss
+++ b/pkg/web_css/lib/src/_pkg.scss
@@ -2,6 +2,33 @@
    for details. All rights reserved. Use of this source code is governed by a
    BSD-style license that can be found in the LICENSE file. */
 
+.package-badge {
+  display: inline-block;
+  background: white;
+  border: 1px solid $color-input-primary;
+  border-radius: 20px;
+  color: $color-input-primary;
+
+  font-size: 12px;
+  padding: 1px 6px;
+  margin: 0 8px 0 0;
+
+  .package-badge-icon {
+    max-width: 13px;
+    max-height: 13px;
+    position: relative;
+    top: 2px;
+  }
+}
+
+.package-vp-icon {
+  display: inline-block;
+  height: 14px;
+  position: relative;
+  top: 3px;
+  opacity: 0.5;
+}
+
 .version-table {
   width: 100%;
   border-spacing: 0;

--- a/pkg/web_css/lib/src/_scores.scss
+++ b/pkg/web_css/lib/src/_scores.scss
@@ -2,50 +2,6 @@
    for details. All rights reserved. Use of this source code is governed by a
    BSD-style license that can be found in the LICENSE file. */
 
-.score-circle {
-  width: 40px;
-  height: 40px;
-  background: white;
-  border-radius: 50%;
-  position: relative;
-
-  .score-circle-outline,
-  .score-circle-arc,
-  .score-circle-label {
-    position: absolute;
-    top: 0;
-    left: 0;
-    bottom: 0;
-    right: 0;
-    border-radius: 50%;
-  }
-
-  .score-circle-arc {
-    background: $score-circle-outline;
-    stroke: $score-circle-stroke;
-  }
-
-  .score-circle-label {
-    margin: 10%;
-    background: white;
-
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-  }
-
-  .score-circle-primary-label {
-    color: $score-circle-label;
-    font-size: 16px;
-    font-weight: 500;
-  }
-
-  .score-circle-secondary-label {
-    /* Uses the defaults. */
-  }
-}
-
 .packages-scores {
   display: flex;
   align-items: center;

--- a/pkg/web_css/lib/src/_variables.scss
+++ b/pkg/web_css/lib/src/_variables.scss
@@ -20,11 +20,6 @@ $device-tablet-max-width: 979px;
 
 $z-index-nav-mask: 1000;
 
-$score-circle-outline: #f0f0f0;
-$score-circle-stroke: #168afd;
-$score-circle-stroke: #168afd;
-$score-circle-label: $score-circle-stroke;
-
 $site-max-width: 1096px;
 $color-footer-dark-bg: #27323a;
 $color-footer-dark-fg: #f8f9fa;


### PR DESCRIPTION
- Fixes #4163 (badge is rendered after the publisher in the header).
- Extracted badge rendering into its own template + provided helper methods for badges.
- Extracted badge and icon styles from the listing SCSS.
- Also moved tag rendering alongside the badges (they seem to belong together).
- Removed unused CSS styles (score-circle, score-box).