### PR TITLE
Fix the remaining parts of code coverage.

### DIFF
--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -191,7 +191,7 @@ packages:
     source: hosted
     version: "2.1.1"
   coverage:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: coverage
       url: "https://pub.dartlang.org"

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -55,6 +55,7 @@ dependencies:
 dev_dependencies:
   build_runner: '^1.0.0'
   build_verify: ^1.1.1
+  coverage: any # test already depends on it
   fake_gcloud:
     path: ../pkg/fake_gcloud
   json_serializable: '^3.0.0'

--- a/pkg/code_coverage/build.sh
+++ b/pkg/code_coverage/build.sh
@@ -13,8 +13,9 @@ FAKE_PUB_SERVER_DIR="${PROJECT_DIR}/pkg/fake_pub_server"
 OUTPUT_DIR="${CODE_COVERAGE_DIR}/build"
 
 rm -rf ${OUTPUT_DIR}
-mkdir -p "${OUTPUT_DIR}/raw"
+mkdir -p "${OUTPUT_DIR}/lcov"
 mkdir -p "${OUTPUT_DIR}/puppeteer"
+mkdir -p "${OUTPUT_DIR}/raw"
 
 cd "${CODE_COVERAGE_DIR}"
 pub get
@@ -56,8 +57,7 @@ echo "Delete ${APP_ALL_TEST_PATH}..."
 rm ${APP_ALL_TEST_PATH}
 
 echo "Exporting to LCOV"
-cd "${CODE_COVERAGE_DIR}"
-mkdir -p "${OUTPUT_DIR}/lcov"
+cd "${APP_DIR}"
 pub run coverage:format_coverage \
   --packages "${APP_DIR}/.packages" \
   -i "${OUTPUT_DIR}/raw/app_unit.json" \
@@ -67,6 +67,7 @@ pub run coverage:format_coverage \
 
 ## Collect coverage for integration tests.
 
+cd "${CODE_COVERAGE_DIR}"
 ls -1 "${PUB_INTEGRATION_DIR}/test" | grep .dart$ | xargs -n 1 -I ZZZ dart \
   lib/test_runner.dart \
   --package "${PUB_INTEGRATION_DIR}" \

--- a/pkg/pub_integration/pubspec.yaml
+++ b/pkg/pub_integration/pubspec.yaml
@@ -14,5 +14,5 @@ dependencies:
   puppeteer: ^1.13.0
 
 dev_dependencies:
-  coverage: ^0.14.1
+  coverage: any # test already depends on it
   test: ^1.6.3


### PR DESCRIPTION
- `package:coverage`'s collect now needs to be run from the directory where the `.packages` files points to, otherwise it misses the packages' own `lib/` directory. (may be a bug, will report)
- added a few formatted text in the report for easier copy-paste
- kept our all-tests-in-one-go approach, `package:test`'s `--coverage` required `-j 1` execution and took almost 25 minutes on my machine to complete.
