### PR TITLE
Slightly simpler canonical URLs.

### DIFF
--- a/app/lib/frontend/templates/layout.dart
+++ b/app/lib/frontend/templates/layout.dart
@@ -55,6 +55,10 @@ String renderLayoutPage(
   String searchPlaceHolder,
   List<String> mainClasses,
 }) {
+  // normalize canonical URL
+  if (canonicalUrl != null && canonicalUrl.startsWith('/')) {
+    canonicalUrl = '${urls.siteRoot}$canonicalUrl';
+  }
   mainClasses ??= ['container'];
   final isRoot = type == PageType.landing && sdk == null;
   final pageDataEncoded = pageData == null

--- a/app/lib/frontend/templates/listing.dart
+++ b/app/lib/frontend/templates/listing.dart
@@ -181,8 +181,7 @@ String renderPkgIndexPage(
     title: pageTitle,
     sdk: sdk,
     searchForm: searchForm,
-    canonicalUrl:
-        searchForm.toSearchLink(page: links.currentPage, includeHost: true),
+    canonicalUrl: searchForm.toSearchLink(page: links.currentPage),
     noIndex: true,
     searchPlaceHolder: searchPlaceholder,
     mainClasses: [],

--- a/app/lib/frontend/templates/publisher.dart
+++ b/app/lib/frontend/templates/publisher.dart
@@ -131,8 +131,7 @@ String renderPublisherPackagesPage({
     ),
     publisherId: publisher.publisherId,
     searchForm: searchForm,
-    canonicalUrl:
-        searchForm.toSearchLink(page: pageLinks.currentPage, includeHost: true),
+    canonicalUrl: searchForm.toSearchLink(page: pageLinks.currentPage),
     // index only the first page, if it has packages displayed without search query
     noIndex: packages.isEmpty || isSearch || pageLinks.currentPage > 1,
     mainClasses: [wideHeaderDetailPageClassName],
@@ -181,8 +180,7 @@ String renderPublisherAdminPage({
         publisherId: publisher.publisherId,
       ),
     ),
-    canonicalUrl:
-        urls.publisherAdminUrl(publisher.publisherId, includeHost: true),
+    canonicalUrl: urls.publisherAdminUrl(publisher.publisherId),
     noIndex: true,
     mainClasses: [wideHeaderDetailPageClassName],
   );

--- a/app/lib/search/search_form.dart
+++ b/app/lib/search/search_form.dart
@@ -186,7 +186,7 @@ class SearchForm {
 
   /// Converts the query to a user-facing link that (after frontend parsing) will
   /// re-create an identical search query object.
-  String toSearchLink({int page, bool includeHost = false}) {
+  String toSearchLink({int page}) {
     final params = <String, dynamic>{};
     if (query != null && query.isNotEmpty) {
       params['q'] = query;
@@ -211,7 +211,7 @@ class SearchForm {
     final uri = Uri(
         path: toSearchFormPath(),
         queryParameters: params.isEmpty ? null : params);
-    return includeHost ? '$siteRoot$uri' : uri.toString();
+    return uri.toString();
   }
 }
 

--- a/app/lib/shared/urls.dart
+++ b/app/lib/shared/urls.dart
@@ -138,10 +138,8 @@ String publisherUrl(String publisherId) => '/publishers/$publisherId';
 String publisherPackagesUrl(String publisherId) =>
     SearchForm.parse(publisherId: publisherId).toSearchLink();
 
-String publisherAdminUrl(String publisherId, {bool includeHost = false}) {
-  final baseUri = includeHost ? _siteRootUri : _pathRootUri;
-  return baseUri.resolve('/publishers/$publisherId/admin').toString();
-}
+String publisherAdminUrl(String publisherId) =>
+    publisherUrl(publisherId) + '/admin';
 
 String searchUrl({
   String sdk,

--- a/app/test/frontend/handlers/_utils.dart
+++ b/app/test/frontend/handlers/_utils.dart
@@ -15,6 +15,7 @@ import 'package:pub_dev/frontend/handlers.dart';
 import 'package:pub_dev/shared/handler_helpers.dart';
 import 'package:pub_dev/shared/urls.dart';
 
+import '../../shared/html_validation.dart';
 import '../../shared/utils.dart';
 
 const pageSize = 10;
@@ -45,6 +46,7 @@ Future<String> expectHtmlResponse(
   expect(response.statusCode, status);
   expect(response.headers['content-type'], 'text/html; charset="utf-8"');
   final content = await response.readAsString();
+  parseAndValidateHtml(content);
   expect(content, contains('<!DOCTYPE html>'));
   expect(content, contains('</html>'));
   for (Pattern p in present) {

--- a/app/test/frontend/handlers/account_test.dart
+++ b/app/test/frontend/handlers/account_test.dart
@@ -4,6 +4,8 @@
 
 import 'package:test/test.dart';
 
+import 'package:pub_dev/frontend/static_files.dart';
+
 import '../../shared/test_services.dart';
 
 import '_utils.dart';
@@ -16,6 +18,8 @@ void main() {
   });
 
   group('pub client authorization landing page', () {
+    setUpAll(() => updateLocalBuiltFilesIfNeeded());
+
     testWithServices('/authorized', () async {
       await expectHtmlResponse(await issueGet('/authorized'));
     });

--- a/app/test/shared/html_validation.dart
+++ b/app/test/shared/html_validation.dart
@@ -5,9 +5,14 @@
 import 'dart:convert';
 
 import 'package:html/dom.dart';
+import 'package:html/parser.dart' as parser;
 import 'package:test/test.dart';
 
-void validateHtml(root) {
+void parseAndValidateHtml(String html) {
+  validateHtml(parser.parse(html));
+}
+
+void validateHtml(Node root) {
   List<Element> elements;
   List<Element> links;
   List<Element> scripts;


### PR DESCRIPTION
- It seems that most URLs don't need site prefix, only at the canonical URL meta field, let's set it only there.
- Slightly related change: I've added generic HTML verification to the handlers test (no change in tests otherwise), and planning to refactor it to (a) include check for canonical URL and (b) also do it for integration tests.