### PR TITLE
typed ResolvedVersion in test_profile

### DIFF
--- a/app/lib/tool/test_profile/importer.dart
+++ b/app/lib/tool/test_profile/importer.dart
@@ -5,7 +5,6 @@
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:basics/basics.dart';
 import 'package:crypto/crypto.dart';
 import 'package:gcloud/service_scope.dart';
 import 'package:http/http.dart';
@@ -28,7 +27,7 @@ import 'resolver.dart';
 @visibleForTesting
 Future<void> importProfile({
   @required TestProfile profile,
-  List<String> resolvedVersions,
+  List<ResolvedVersion> resolvedVersions,
   @required String archiveCachePath,
 }) async {
   // resolve versions if they are not yet resolved
@@ -84,12 +83,9 @@ Future<void> importProfile({
   final archiveCacheDir = Directory(archiveCachePath);
   await archiveCacheDir.create(recursive: true);
   for (final rv in resolvedVersions) {
-    final parts = rv.partition(':');
-    final packageName = parts.first;
-    final versionName = parts.last;
-
-    final fileName = rv.replaceAll(':', '-') + '.tar.gz';
-    final file = File(p.join(archiveCacheDir.path, fileName));
+    final packageName = rv.package;
+    final versionName = rv.version;
+    final file = File(p.join(archiveCacheDir.path, rv.archiveName));
     // download package archive if not already in the cache
     if (!await file.exists()) {
       client ??= Client();

--- a/app/lib/tool/test_profile/models.dart
+++ b/app/lib/tool/test_profile/models.dart
@@ -160,3 +160,31 @@ class TestUser {
 
   Map<String, dynamic> toJson() => _$TestUserToJson(this);
 }
+
+@JsonSerializable(explicitToJson: true, includeIfNull: false)
+class ResolvedVersion implements Comparable<ResolvedVersion> {
+  final String package;
+  final String version;
+
+  ResolvedVersion({
+    @required this.package,
+    @required this.version,
+  });
+
+  factory ResolvedVersion.fromJson(Map<String, dynamic> json) =>
+      _$ResolvedVersionFromJson(json);
+
+  Map<String, dynamic> toJson() => _$ResolvedVersionToJson(this);
+
+  String get archiveName => '$package-$version.tar.gz';
+
+  @override
+  int compareTo(ResolvedVersion other) {
+    final p = package.compareTo(other.package);
+    if (p != 0) return p;
+    // We could sort by semantic version, but it is only needed for consistent,
+    // but not necessarily semantically consistent ordering. A simple string
+    // comparison will do it.
+    return version.compareTo(other.version);
+  }
+}

--- a/app/lib/tool/test_profile/models.g.dart
+++ b/app/lib/tool/test_profile/models.g.dart
@@ -165,3 +165,24 @@ Map<String, dynamic> _$TestUserToJson(TestUser instance) {
   writeNotNull('likes', instance.likes);
   return val;
 }
+
+ResolvedVersion _$ResolvedVersionFromJson(Map<String, dynamic> json) {
+  return ResolvedVersion(
+    package: json['package'] as String,
+    version: json['version'] as String,
+  );
+}
+
+Map<String, dynamic> _$ResolvedVersionToJson(ResolvedVersion instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('package', instance.package);
+  writeNotNull('version', instance.version);
+  return val;
+}

--- a/app/lib/tool/test_profile/resolver.dart
+++ b/app/lib/tool/test_profile/resolver.dart
@@ -5,6 +5,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:basics/basics.dart';
 import 'package:path/path.dart' as p;
 import 'package:pub_dev/shared/utils.dart';
 
@@ -14,8 +15,9 @@ import 'models.dart';
 /// - latest versions of the packages that are without specific versions
 /// - direct or transitive dependencies of the packages
 ///
-/// The resulting list contains <package>:<version> pairs.
-Future<List<String>> resolveVersions(TestProfile profile) async {
+/// The resulting list contains all the resolved versions (may be more packages
+/// than the profile originally specified).
+Future<List<ResolvedVersion>> resolveVersions(TestProfile profile) async {
   return await withTempDirectory((temp) async {
     final pubCacheDir = Directory(p.join(temp.path, 'pub-cache'));
     await pubCacheDir.create();
@@ -55,8 +57,10 @@ Future<List<String>> resolveVersions(TestProfile profile) async {
         .whereType<Directory>()
         .map((d) => p.basename(d.path))
         .where((v) => v.contains('-'))
-        .map((v) => v.replaceFirst('-', ':'))
-        .toList()
+        .map((v) {
+      final parts = v.partition('-');
+      return ResolvedVersion(package: parts.first, version: parts.last);
+    }).toList()
           ..sort();
   });
 }

--- a/app/test/tool/test_profile/resolve_test.dart
+++ b/app/test/tool/test_profile/resolve_test.dart
@@ -9,7 +9,7 @@ import 'package:pub_dev/tool/test_profile/models.dart';
 import 'package:pub_dev/tool/test_profile/resolver.dart';
 
 void main() {
-  Future<List<String>> _resolve(List<TestPackage> packages) async {
+  Future<List<ResolvedVersion>> _resolve(List<TestPackage> packages) async {
     final profile = TestProfileNormalizer().normalize(TestProfile(
       publishers: [],
       packages: packages,
@@ -23,7 +23,7 @@ void main() {
     test('latest version', () async {
       final pvs = await _resolve([TestPackage(name: 'retry')]);
       expect(pvs, hasLength(1));
-      expect(pvs.first, startsWith('retry:'));
+      expect(pvs.first.package, 'retry');
     });
 
     test('dependencies', () async {
@@ -34,8 +34,9 @@ void main() {
         )
       ]);
       expect(pvs, hasLength(2));
-      expect(pvs[0], startsWith('retry:'));
-      expect(pvs[1], 'safe_url_check:1.0.0');
+      expect(pvs[0].package, 'retry');
+      expect(pvs[1].package, 'safe_url_check');
+      expect(pvs[1].version, '1.0.0');
     });
   });
 }


### PR DESCRIPTION
We can still fall back to use the `package:version` format if needed (we are not using neither), however, I may want to use the verbose format in the future.
