### PR TITLE
Locally cache test-profile archives in pkg/fake_pub_server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -161,4 +161,4 @@ branches:
 cache:
   directories:
     - "$HOME/.pub-cache"
-    - "pkg/fake_pub_server/.test-profile"
+    - "pkg/fake_pub_server/.dart_tool/pub-test-profile"

--- a/.travis.yml
+++ b/.travis.yml
@@ -161,3 +161,4 @@ branches:
 cache:
   directories:
     - "$HOME/.pub-cache"
+    - "pkg/fake_pub_server/.test-profile"

--- a/app/lib/frontend/static_files.dart
+++ b/app/lib/frontend/static_files.dart
@@ -38,7 +38,7 @@ String resolveAppDir() {
   if (Platform.script.path.contains('bin/server.dart')) {
     return Platform.script.resolve('../').toFilePath();
   }
-  if (Platform.script.path.contains('bin/fake_pub_server.dart')) {
+  if (Platform.script.path.contains('/fake_pub_server')) {
     return Platform.script.resolve('../../../app').toFilePath();
   }
   if (Platform.script.path.contains('app/test')) {
@@ -73,6 +73,12 @@ String resolvePubDartdocDirPath() {
 /// Returns the path of /doc on the local filesystem.
 String resolveDocDirPath() {
   return path.join(resolveAppDir(), '../doc');
+}
+
+/// Returns the path of pkg/fake_pub_server on the local filesystem.
+String resolveFakePubServerDirPath() {
+  return Directory(path.join(resolveAppDir(), '../pkg/fake_pub_server'))
+      .resolveSymbolicLinksSync();
 }
 
 String _resolveRootDirPath() =>

--- a/pkg/fake_pub_server/bin/init_data_file.dart
+++ b/pkg/fake_pub_server/bin/init_data_file.dart
@@ -29,8 +29,12 @@ Future<void> main(List<String> args) async {
     normalize: true,
   );
 
-  final archiveCachePath =
-      p.join(resolveFakePubServerDirPath(), '.test-profile', 'archives');
+  final archiveCachePath = p.join(
+    resolveFakePubServerDirPath(),
+    '.dart_tool',
+    'pub-test-profile',
+    'archives',
+  );
 
   final state = LocalServerState(path: argv['data-file'] as String);
 

--- a/pkg/fake_pub_server/bin/init_data_file.dart
+++ b/pkg/fake_pub_server/bin/init_data_file.dart
@@ -10,15 +10,16 @@ import 'package:gcloud/service_scope.dart';
 import 'package:gcloud/storage.dart';
 import 'package:path/path.dart' as p;
 
-import 'package:fake_pub_server/local_server_state.dart';
+import 'package:pub_dev/frontend/static_files.dart';
 import 'package:pub_dev/service/services.dart';
 import 'package:pub_dev/shared/configuration.dart';
 import 'package:pub_dev/tool/test_profile/importer.dart';
 import 'package:pub_dev/tool/test_profile/models.dart';
 
+import 'package:fake_pub_server/local_server_state.dart';
+
 final _argParser = ArgParser()
   ..addOption('test-profile', help: 'The file to read the test profile from.')
-  ..addOption('cache-dir', help: 'The directory to cache the downloaded files.')
   ..addOption('data-file', help: 'The file to store the local state.');
 
 Future<void> main(List<String> args) async {
@@ -28,9 +29,8 @@ Future<void> main(List<String> args) async {
     normalize: true,
   );
 
-  final cacheDirArg = argv['cache-dir'] as String;
-  final cacheDir = cacheDirArg ?? Directory.systemTemp.createTempSync().path;
-  await Directory(cacheDir).create(recursive: true);
+  final archiveCachePath =
+      p.join(resolveFakePubServerDirPath(), '.test-profile', 'archives');
 
   final state = LocalServerState(path: argv['data-file'] as String);
 
@@ -40,13 +40,8 @@ Future<void> main(List<String> args) async {
     registerActiveConfiguration(Configuration.test());
     await withPubServices(() async {
       // ignore: invalid_use_of_visible_for_testing_member
-      await importProfile(
-          profile: profile, archiveCachePath: p.join(cacheDir, 'archives'));
+      await importProfile(profile: profile, archiveCachePath: archiveCachePath);
     });
   });
   await state.save();
-
-  if (cacheDirArg == null) {
-    await Directory(cacheDir).delete(recursive: true);
-  }
 }

--- a/pkg/fake_pub_server/mono_pkg.yaml
+++ b/pkg/fake_pub_server/mono_pkg.yaml
@@ -9,3 +9,7 @@ stages:
         - dartanalyzer: --fatal-infos --fatal-warnings .
 #  - unit_test:
 #    - test: --run-skipped
+
+cache:
+  directories:
+    - ".test-profile"

--- a/pkg/fake_pub_server/mono_pkg.yaml
+++ b/pkg/fake_pub_server/mono_pkg.yaml
@@ -12,4 +12,4 @@ stages:
 
 cache:
   directories:
-    - ".test-profile"
+    - ".dart_tool/pub-test-profile"


### PR DESCRIPTION
This is useful for local development, and it also should work with CI tests.