### PR TITLE
SearchForm should operate with currentPage instead of offset.

### DIFF
--- a/app/lib/frontend/handlers/account.dart
+++ b/app/lib/frontend/handlers/account.dart
@@ -217,8 +217,7 @@ Future<shelf.Response> accountPackagesPageHandler(shelf.Request request) async {
 
   final searchResult = await searchAdapter.search(searchForm);
   final int totalCount = searchResult.totalCount;
-  final links =
-      PageLinks(searchForm.offset, totalCount, searchForm: searchForm);
+  final links = PageLinks(searchForm, totalCount);
 
   final html = renderAccountPackagesPage(
     user: await accountBackend.lookupUserById(userSessionData.userId),

--- a/app/lib/frontend/handlers/custom_api.dart
+++ b/app/lib/frontend/handlers/custom_api.dart
@@ -252,7 +252,7 @@ Future<shelf.Response> apiSearchHandler(shelf.Request request) async {
   );
   final sr = await searchClient.search(searchForm.toServiceQuery());
   final packages = sr.packages.map((ps) => {'package': ps.package}).toList();
-  final hasNextPage = sr.totalCount > searchForm.limit + searchForm.offset;
+  final hasNextPage = sr.totalCount > searchForm.pageSize + searchForm.offset;
   final result = <String, dynamic>{
     'packages': packages,
     if (sr.message != null) 'message': sr.message,
@@ -260,8 +260,7 @@ Future<shelf.Response> apiSearchHandler(shelf.Request request) async {
   if (hasNextPage) {
     final newParams =
         Map<String, dynamic>.from(request.requestedUri.queryParameters);
-    final nextPageIndex = (searchForm.offset ~/ searchForm.limit) + 2;
-    newParams['page'] = nextPageIndex.toString();
+    newParams['page'] = (searchForm.currentPage + 1).toString();
     final nextPageUrl =
         request.requestedUri.replace(queryParameters: newParams).toString();
     result['next'] = nextPageUrl;

--- a/app/lib/frontend/handlers/listing.dart
+++ b/app/lib/frontend/handlers/listing.dart
@@ -88,8 +88,7 @@ Future<shelf.Response> _packagesHandlerHtmlCore(
   final searchResult = await searchAdapter.search(searchForm);
   final int totalCount = searchResult.totalCount;
 
-  final links =
-      PageLinks(searchForm.offset, totalCount, searchForm: searchForm);
+  final links = PageLinks(searchForm, totalCount);
   final result = htmlResponse(
     renderPkgIndexPage(
       searchResult.packages,

--- a/app/lib/frontend/handlers/publisher.dart
+++ b/app/lib/frontend/handlers/publisher.dart
@@ -80,8 +80,7 @@ Future<shelf.Response> publisherPackagesPageHandler(
 
   final searchResult = await searchAdapter.search(searchForm);
   final int totalCount = searchResult.totalCount;
-  final links =
-      PageLinks(searchForm.offset, totalCount, searchForm: searchForm);
+  final links = PageLinks(searchForm, totalCount);
 
   final html = renderPublisherPackagesPage(
     publisher: publisher,

--- a/app/lib/frontend/templates/listing.dart
+++ b/app/lib/frontend/templates/listing.dart
@@ -181,7 +181,7 @@ String renderPkgIndexPage(
     title: pageTitle,
     sdk: sdk,
     searchForm: searchForm,
-    canonicalUrl: searchForm.toSearchLink(page: links.currentPage),
+    canonicalUrl: searchForm.toSearchLink(),
     noIndex: true,
     searchPlaceHolder: searchPlaceholder,
     mainClasses: [],
@@ -245,25 +245,22 @@ String renderSortControl(SearchForm form) {
 }
 
 class PageLinks {
-  final int offset;
+  final SearchForm searchForm;
   final int count;
-  final SearchForm _searchForm;
 
-  PageLinks(this.offset, this.count, {SearchForm searchForm})
-      : _searchForm = searchForm;
+  PageLinks(this.searchForm, this.count);
 
   PageLinks.empty()
-      : offset = 1,
-        count = 1,
-        _searchForm = null;
+      : searchForm = SearchForm.parse(),
+        count = 1;
 
-  int get leftmostPage => max(currentPage - maxPages ~/ 2, 1);
+  int get leftmostPage => max(currentPage - maxPageLinks ~/ 2, 1);
 
-  int get currentPage => 1 + offset ~/ resultsPerPage;
+  int get currentPage => searchForm.currentPage;
 
   int get rightmostPage {
-    final int fromSymmetry = currentPage + maxPages ~/ 2;
-    final int fromCount = 1 + ((count - 1) ~/ resultsPerPage);
+    final int fromSymmetry = currentPage + maxPageLinks ~/ 2;
+    final int fromCount = 1 + ((count - 1) ~/ searchForm.pageSize);
     return min(fromSymmetry, max(currentPage, fromCount));
   }
 
@@ -275,7 +272,8 @@ class PageLinks {
       'active': false,
       'disabled': !hasPrevious,
       'render_link': hasPrevious,
-      'href': htmlAttrEscape.convert(formatHref(currentPage - 1)),
+      'href': htmlAttrEscape
+          .convert(searchForm.toSearchLink(page: currentPage - 1)),
       'text': '&laquo;',
       'rel_prev': true,
       'rel_next': false,
@@ -287,7 +285,7 @@ class PageLinks {
         'active': isCurrent,
         'disabled': false,
         'render_link': !isCurrent,
-        'href': htmlAttrEscape.convert(formatHref(page)),
+        'href': htmlAttrEscape.convert(searchForm.toSearchLink(page: page)),
         'text': '$page',
         'rel_prev': currentPage == page + 1,
         'rel_next': currentPage == page - 1,
@@ -299,7 +297,8 @@ class PageLinks {
       'active': false,
       'disabled': !hasNext,
       'render_link': hasNext,
-      'href': htmlAttrEscape.convert(formatHref(currentPage + 1)),
+      'href': htmlAttrEscape
+          .convert(searchForm.toSearchLink(page: currentPage + 1)),
       'text': '&raquo;',
       'rel_prev': false,
       'rel_next': true,
@@ -309,13 +308,5 @@ class PageLinks {
     assert(!results
         .any((map) => map['disabled'] == true && map['active'] == true));
     return results;
-  }
-
-  String formatHref(int page) {
-    if (_searchForm == null) {
-      return urls.searchUrl(page: page);
-    } else {
-      return _searchForm.toSearchLink(page: page);
-    }
   }
 }

--- a/app/lib/frontend/templates/publisher.dart
+++ b/app/lib/frontend/templates/publisher.dart
@@ -131,7 +131,7 @@ String renderPublisherPackagesPage({
     ),
     publisherId: publisher.publisherId,
     searchForm: searchForm,
-    canonicalUrl: searchForm.toSearchLink(page: pageLinks.currentPage),
+    canonicalUrl: searchForm.toSearchLink(),
     // index only the first page, if it has packages displayed without search query
     noIndex: packages.isEmpty || isSearch || pageLinks.currentPage > 1,
     mainClasses: [wideHeaderDetailPageClassName],

--- a/app/lib/package/search_adapter.dart
+++ b/app/lib/package/search_adapter.dart
@@ -44,7 +44,7 @@ class SearchAdapter {
     SearchOrder order,
   }) async {
     final form = SearchForm.parse(
-      limit: 100,
+      pageSize: 100,
       tagsPredicate: TagsPredicate.advertisement(requiredTags: requiredTags),
       order: order,
     );
@@ -127,7 +127,7 @@ class SearchAdapter {
     scores.sort((a, b) => -a.score.compareTo(b.score));
 
     final totalCount = scores.length;
-    scores = scores.skip(form.offset ?? 0).take(form.limit ?? 10).toList();
+    scores = scores.skip(form.offset).take(form.pageSize).toList();
     return PackageSearchResult(
         timestamp: DateTime.now().toUtc(),
         packages: scores,

--- a/app/lib/search/search_service.dart
+++ b/app/lib/search/search_service.dart
@@ -22,7 +22,7 @@ const int resultsPerPage = 10;
 
 /// The number of page links we display, e.g. on page 10, we display direct
 /// links from page 5 to page 15.
-const int maxPages = 10;
+const int maxPageLinks = 10;
 
 /// The maximum length of the search query's text phrase that we'll try to serve.
 const _maxQueryLength = 256;

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -554,7 +554,7 @@ void main() {
             ),
           ),
         ],
-        PageLinks(0, 50, searchForm: searchForm),
+        PageLinks(searchForm, 50),
         searchForm: searchForm,
         totalCount: 2,
       );
@@ -640,7 +640,7 @@ void main() {
         ],
         totalCount: 2,
         searchForm: searchForm,
-        pageLinks: PageLinks(0, 10, searchForm: searchForm),
+        pageLinks: PageLinks(searchForm, 10),
         isAdmin: true,
         messageFromBackend: null,
       );
@@ -672,7 +672,7 @@ void main() {
             tags: ['sdk:flutter', 'platform:android'],
           ),
         ],
-        pageLinks: PageLinks(0, 10, searchForm: searchForm),
+        pageLinks: PageLinks(searchForm, 10),
         searchForm: searchForm,
         totalCount: 2,
         messageFromBackend: null,
@@ -723,17 +723,19 @@ void main() {
     });
 
     scopedTest('pagination: in the middle', () {
-      final String html = renderPagination(PageLinks(90, 299));
+      final String html =
+          renderPagination(PageLinks(SearchForm.parse(currentPage: 10), 299));
       expectGoldenFile(html, 'pagination_middle.html', isFragment: true);
     });
 
     scopedTest('pagination: at first page', () {
-      final String html = renderPagination(PageLinks(0, 600));
+      final String html = renderPagination(PageLinks(SearchForm.parse(), 600));
       expectGoldenFile(html, 'pagination_first.html', isFragment: true);
     });
 
     scopedTest('pagination: at last page', () {
-      final String html = renderPagination(PageLinks(90, 91));
+      final String html =
+          renderPagination(PageLinks(SearchForm.parse(currentPage: 10), 91));
       expectGoldenFile(html, 'pagination_last.html', isFragment: true);
     });
 
@@ -761,28 +763,28 @@ void main() {
     });
 
     scopedTest('one', () {
-      final links = PageLinks(0, 1);
+      final links = PageLinks(SearchForm.parse(), 1);
       expect(links.currentPage, 1);
       expect(links.leftmostPage, 1);
       expect(links.rightmostPage, 1);
     });
 
     scopedTest('PageLinks.RESULTS_PER_PAGE - 1', () {
-      final links = PageLinks(0, resultsPerPage - 1);
+      final links = PageLinks(SearchForm.parse(), resultsPerPage - 1);
       expect(links.currentPage, 1);
       expect(links.leftmostPage, 1);
       expect(links.rightmostPage, 1);
     });
 
     scopedTest('PageLinks.RESULTS_PER_PAGE', () {
-      final links = PageLinks(0, resultsPerPage);
+      final links = PageLinks(SearchForm.parse(), resultsPerPage);
       expect(links.currentPage, 1);
       expect(links.leftmostPage, 1);
       expect(links.rightmostPage, 1);
     });
 
     scopedTest('PageLinks.RESULTS_PER_PAGE + 1', () {
-      final links = PageLinks(0, resultsPerPage + 1);
+      final links = PageLinks(SearchForm.parse(), resultsPerPage + 1);
       expect(links.currentPage, 1);
       expect(links.leftmostPage, 1);
       expect(links.rightmostPage, 2);
@@ -791,54 +793,42 @@ void main() {
     final int page2Offset = resultsPerPage;
 
     scopedTest('page=2 + one item', () {
-      final links = PageLinks(page2Offset, page2Offset + 1);
+      final links =
+          PageLinks(SearchForm.parse(currentPage: 2), page2Offset + 1);
       expect(links.currentPage, 2);
       expect(links.leftmostPage, 1);
       expect(links.rightmostPage, 2);
     });
 
     scopedTest('page=2 + PageLinks.RESULTS_PER_PAGE - 1', () {
-      final links = PageLinks(page2Offset, page2Offset + resultsPerPage - 1);
+      final links = PageLinks(
+          SearchForm.parse(currentPage: 2), page2Offset + resultsPerPage - 1);
       expect(links.currentPage, 2);
       expect(links.leftmostPage, 1);
       expect(links.rightmostPage, 2);
     });
 
     scopedTest('page=2 + PageLinks.RESULTS_PER_PAGE', () {
-      final links = PageLinks(page2Offset, page2Offset + resultsPerPage);
+      final links = PageLinks(
+          SearchForm.parse(currentPage: 2), page2Offset + resultsPerPage);
       expect(links.currentPage, 2);
       expect(links.leftmostPage, 1);
       expect(links.rightmostPage, 2);
     });
 
     scopedTest('page=2 + PageLinks.RESULTS_PER_PAGE + 1', () {
-      final links = PageLinks(page2Offset, page2Offset + resultsPerPage + 1);
+      final links = PageLinks(
+          SearchForm.parse(currentPage: 2), page2Offset + resultsPerPage + 1);
       expect(links.currentPage, 2);
       expect(links.leftmostPage, 1);
       expect(links.rightmostPage, 3);
     });
 
     scopedTest('deep in the middle', () {
-      final links = PageLinks(200, 600);
+      final links = PageLinks(SearchForm.parse(currentPage: 21), 600);
       expect(links.currentPage, 21);
       expect(links.leftmostPage, 16);
       expect(links.rightmostPage, 26);
-    });
-  });
-
-  group('URLs', () {
-    scopedTest('PageLinks defaults', () {
-      final query = SearchForm.parse(query: 'web framework');
-      final PageLinks links = PageLinks(0, 100, searchForm: query);
-      expect(links.formatHref(1), '/packages?q=web+framework');
-      expect(links.formatHref(2), '/packages?q=web+framework&page=2');
-    });
-
-    scopedTest('PageLinks with platform', () {
-      final query = SearchForm.parse(query: 'some framework', sdk: 'flutter');
-      final PageLinks links = PageLinks(0, 100, searchForm: query);
-      expect(links.formatHref(1), '/flutter/packages?q=some+framework');
-      expect(links.formatHref(2), '/flutter/packages?q=some+framework&page=2');
     });
   });
 }

--- a/app/test/search/search_form_test.dart
+++ b/app/test/search/search_form_test.dart
@@ -1,0 +1,41 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test/test.dart';
+
+import 'package:pub_dev/search/search_form.dart';
+
+void main() {
+  group('SearchForm', () {
+    test('query with defaults', () {
+      final form = SearchForm.parse(query: 'web framework');
+      expect(form.toSearchLink(), '/packages?q=web+framework');
+      expect(form.toSearchLink(page: 1), '/packages?q=web+framework');
+      expect(form.toSearchLink(page: 2), '/packages?q=web+framework&page=2');
+    });
+
+    test('query with defaults on page 1', () {
+      final form = SearchForm.parse(query: 'web framework', currentPage: 1);
+      expect(form.toSearchLink(), '/packages?q=web+framework');
+      expect(form.toSearchLink(page: 1), '/packages?q=web+framework');
+      expect(form.toSearchLink(page: 2), '/packages?q=web+framework&page=2');
+    });
+
+    test('query with defaults on page 3', () {
+      final form = SearchForm.parse(query: 'web framework', currentPage: 3);
+      expect(form.toSearchLink(), '/packages?q=web+framework&page=3');
+      expect(form.toSearchLink(page: 1), '/packages?q=web+framework');
+      expect(form.toSearchLink(page: 2), '/packages?q=web+framework&page=2');
+      expect(form.toSearchLink(page: 3), '/packages?q=web+framework&page=3');
+    });
+
+    test('query with with sdk', () {
+      final form = SearchForm.parse(query: 'some framework', sdk: 'flutter');
+      expect(form.toSearchLink(), '/flutter/packages?q=some+framework');
+      expect(form.toSearchLink(page: 1), '/flutter/packages?q=some+framework');
+      expect(form.toSearchLink(page: 2),
+          '/flutter/packages?q=some+framework&page=2');
+    });
+  });
+}


### PR DESCRIPTION
This also removes repeated functions from `PageLinks` and reduces it to its core function.