### PR TITLE
Strengthen robots.txt and non-primary domain handling.

### DIFF
--- a/app/lib/frontend/handlers.dart
+++ b/app/lib/frontend/handlers.dart
@@ -29,6 +29,7 @@ void _logPubHeaders(shelf.Request request) {
 shelf.Handler createAppHandler() {
   final legacyDartdocHandler = LegacyDartdocService().router.handler;
   final pubDartlangOrgHandler = PubDartlangOrgService().router.handler;
+  final apiPubDevHandler = ApiPubDevService().router.handler;
   final pubSiteHandler = PubSiteService().router.handler;
   return (shelf.Request request) async {
     _logPubHeaders(request);
@@ -37,6 +38,12 @@ shelf.Handler createAppHandler() {
     final host = request.requestedUri.host;
     if (host == 'www.dartdocs.org' || host == 'dartdocs.org') {
       return legacyDartdocHandler(request);
+    }
+
+    // keeping for future use
+    if (host == 'api.pub.dev') {
+      final rs = await apiPubDevHandler(request);
+      return rs ?? notFoundHandler(request);
     }
 
     // do pub.dartlang.org-only routes

--- a/app/lib/frontend/handlers/redirects.dart
+++ b/app/lib/frontend/handlers/redirects.dart
@@ -12,6 +12,15 @@ import '../../shared/urls.dart';
 
 part 'redirects.g.dart';
 
+/// Routes that are processed by api.pub.dev.
+class ApiPubDevService {
+  Router get router => _$ApiPubDevServiceRouter(this);
+
+  @Route.get('/robots.txt')
+  Future<Response> robotsTxt(Request request) async =>
+      rejectRobotsHandler(request);
+}
+
 /// Routes that are only processed by the old pub domain.
 class PubDartlangOrgService {
   Router get router => _$PubDartlangOrgServiceRouter(this);
@@ -44,6 +53,10 @@ class PubDartlangOrgService {
       redirectResponse(request.requestedUri
           .replace(host: primaryHost, path: '/packages')
           .toString());
+
+  @Route.get('/robots.txt')
+  Future<Response> robotsTxt(Request request) async =>
+      rejectRobotsHandler(request);
 }
 
 /// Routes that are only processed by the legacy dartdocs.org domain.
@@ -62,6 +75,10 @@ class LegacyDartdocService {
       redirectResponse(Uri.parse(fullSiteUrl)
           .replace(path: request.requestedUri.path)
           .toString());
+
+  @Route.get('/robots.txt')
+  Future<Response> robotsTxt(Request request) async =>
+      rejectRobotsHandler(request);
 
   @Route.all('/<_|.*>')
   Response catchAll(Request request) => Response.notFound('Not Found.');

--- a/app/lib/frontend/handlers/redirects.dart
+++ b/app/lib/frontend/handlers/redirects.dart
@@ -19,6 +19,9 @@ class ApiPubDevService {
   @Route.get('/robots.txt')
   Future<Response> robotsTxt(Request request) async =>
       rejectRobotsHandler(request);
+
+  @Route.all('/<_|.*>')
+  Response catchAll(Request request) => Response.notFound('Not Found.');
 }
 
 /// Routes that are only processed by the old pub domain.

--- a/app/lib/frontend/handlers/redirects.g.dart
+++ b/app/lib/frontend/handlers/redirects.g.dart
@@ -9,6 +9,7 @@ part of pub_dartlang_org.handlers_redirects;
 Router _$ApiPubDevServiceRouter(ApiPubDevService service) {
   final router = Router();
   router.add('GET', r'/robots.txt', service.robotsTxt);
+  router.all(r'/<_|.*>', service.catchAll);
   return router;
 }
 

--- a/app/lib/frontend/handlers/redirects.g.dart
+++ b/app/lib/frontend/handlers/redirects.g.dart
@@ -6,6 +6,12 @@ part of pub_dartlang_org.handlers_redirects;
 // ShelfRouterGenerator
 // **************************************************************************
 
+Router _$ApiPubDevServiceRouter(ApiPubDevService service) {
+  final router = Router();
+  router.add('GET', r'/robots.txt', service.robotsTxt);
+  return router;
+}
+
 Router _$PubDartlangOrgServiceRouter(PubDartlangOrgService service) {
   final router = Router();
   router.add('GET', r'/doc', service.doc);
@@ -14,6 +20,7 @@ Router _$PubDartlangOrgServiceRouter(PubDartlangOrgService service) {
   router.add('GET', r'/flutter/plugins', service.flutterPlugins);
   router.add('GET', r'/server/packages', service.serverPackages);
   router.add('GET', r'/search', service.search);
+  router.add('GET', r'/robots.txt', service.robotsTxt);
   return router;
 }
 
@@ -22,6 +29,7 @@ Router _$LegacyDartdocServiceRouter(LegacyDartdocService service) {
   router.add('GET', r'/', service.index);
   router.add('GET', r'/documentation', service.documentation);
   router.add('GET', r'/documentation/<path|[^]*>', service.documentation);
+  router.add('GET', r'/robots.txt', service.robotsTxt);
   router.all(r'/<_|.*>', service.catchAll);
   return router;
 }

--- a/app/lib/shared/handler_helpers.dart
+++ b/app/lib/shared/handler_helpers.dart
@@ -84,7 +84,6 @@ shelf.Handler _requestContextWrapper(shelf.Handler handler) {
 
     final host = request.requestedUri.host;
     final isPrimaryHost = host == urls.primaryHost;
-    final isProductionHost = activeConfiguration.productionHosts.contains(host);
 
     final cookies =
         parseCookieHeader(request.headers[HttpHeaders.cookieHeader]);
@@ -92,7 +91,7 @@ shelf.Handler _requestContextWrapper(shelf.Handler handler) {
     final isExperimental = hasExperimentalCookie;
 
     final enableRobots = hasExperimentalCookie ||
-        (!activeConfiguration.blockRobots && isProductionHost);
+        (!activeConfiguration.blockRobots && isPrimaryHost);
     final uiCacheEnabled = //
         isPrimaryHost && // don't cache on non-primary domains
             !hasExperimentalCookie && // don't cache if experimental cookie is enabled


### PR DESCRIPTION
- Fixes #4177.
- `api.pub.dev` no longer serves the same content as `pub.dev` + has a reject `robots.txt`
- `pub.dartlang.org` has a reject `robots.txt`.
- `dartdocs.org` has a reject `robots.txt`.
- `robots.txt` is always rejecting, unless on the primary host (and not on any of the primary host list).