### PR TITLE
Remove unused field from search response.

### DIFF
--- a/app/lib/search/mem_index.dart
+++ b/app/lib/search/mem_index.dart
@@ -301,7 +301,6 @@ class InMemoryPackageIndex implements PackageIndex {
 
     return PackageSearchResult(
       totalCount: totalCount,
-      indexUpdated: _lastUpdated,
       packages: results,
       timestamp: DateTime.now().toUtc(),
     );

--- a/app/lib/search/result_combiner.dart
+++ b/app/lib/search/result_combiner.dart
@@ -59,7 +59,6 @@ class SearchResultCombiner {
         boundedList(allPackages, offset: query.offset, limit: query.limit);
 
     return PackageSearchResult(
-      indexUpdated: primaryResult.indexUpdated,
       timestamp: primaryResult.timestamp,
       totalCount: allPackages.length,
       packages: packages,

--- a/app/lib/search/search_client.dart
+++ b/app/lib/search/search_client.dart
@@ -76,11 +76,6 @@ class SearchClient {
       final result = PackageSearchResult.fromJson(
         json.decode(response.body) as Map<String, dynamic>,
       );
-      if (!result.isLegit) {
-        // Search request before the service initialization completed.
-        // TODO: retry request, maybe another search instance will be able to serve it
-        return null;
-      }
       return result;
     }
 

--- a/app/lib/search/search_service.dart
+++ b/app/lib/search/search_service.dart
@@ -609,8 +609,6 @@ class ParsedQueryText {
 
 @JsonSerializable(includeIfNull: false)
 class PackageSearchResult {
-  /// The last update of the search index.
-  final DateTime indexUpdated;
   final DateTime timestamp;
   final int totalCount;
   final List<PackageScore> packages;
@@ -620,7 +618,6 @@ class PackageSearchResult {
   final String message;
 
   PackageSearchResult({
-    this.indexUpdated,
     @required this.timestamp,
     this.totalCount,
     List<PackageScore> packages,
@@ -628,8 +625,7 @@ class PackageSearchResult {
   }) : packages = packages ?? [];
 
   PackageSearchResult.empty({this.message})
-      : indexUpdated = null,
-        timestamp = DateTime.now().toUtc(),
+      : timestamp = DateTime.now().toUtc(),
         totalCount = 0,
         packages = [];
 
@@ -637,9 +633,6 @@ class PackageSearchResult {
       _$PackageSearchResultFromJson(json);
 
   Duration get age => DateTime.now().difference(timestamp);
-
-  /// Whether the search service has already updated its index after a startup.
-  bool get isLegit => indexUpdated != null;
 
   Map<String, dynamic> toJson() => _$PackageSearchResultToJson(this);
 }

--- a/app/lib/search/search_service.g.dart
+++ b/app/lib/search/search_service.g.dart
@@ -76,9 +76,6 @@ Map<String, dynamic> _$ApiDocPageToJson(ApiDocPage instance) =>
 
 PackageSearchResult _$PackageSearchResultFromJson(Map<String, dynamic> json) {
   return PackageSearchResult(
-    indexUpdated: json['indexUpdated'] == null
-        ? null
-        : DateTime.parse(json['indexUpdated'] as String),
     timestamp: json['timestamp'] == null
         ? null
         : DateTime.parse(json['timestamp'] as String),
@@ -100,7 +97,6 @@ Map<String, dynamic> _$PackageSearchResultToJson(PackageSearchResult instance) {
     }
   }
 
-  writeNotNull('indexUpdated', instance.indexUpdated?.toIso8601String());
   writeNotNull('timestamp', instance.timestamp?.toIso8601String());
   writeNotNull('totalCount', instance.totalCount);
   writeNotNull('packages', instance.packages);

--- a/app/test/search/angular_test.dart
+++ b/app/test/search/angular_test.dart
@@ -33,7 +33,6 @@ void main() {
       final PackageSearchResult result = await index.search(
           ServiceSearchQuery.parse(query: 'angular', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
-        'indexUpdated': isNotNull,
         'timestamp': isNotNull,
         'totalCount': 2,
         'packages': [

--- a/app/test/search/api_doc_page_test.dart
+++ b/app/test/search/api_doc_page_test.dart
@@ -54,7 +54,6 @@ void main() {
       final PackageSearchResult result = await index.search(
           ServiceSearchQuery.parse(query: 'foo', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
-        'indexUpdated': isNotNull,
         'timestamp': isNotNull,
         'totalCount': 2,
         'packages': [
@@ -78,7 +77,6 @@ void main() {
       final PackageSearchResult result = await index.search(
           ServiceSearchQuery.parse(query: 'serve', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
-        'indexUpdated': isNotNull,
         'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
@@ -99,7 +97,6 @@ void main() {
           ServiceSearchQuery.parse(
               query: 'page generator', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
-        'indexUpdated': isNotNull,
         'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
@@ -119,7 +116,6 @@ void main() {
       final PackageSearchResult result = await index.search(
           ServiceSearchQuery.parse(query: 'web page', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
-        'indexUpdated': isNotNull,
         'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
@@ -141,7 +137,6 @@ void main() {
           ServiceSearchQuery.parse(
               query: 'goal fancy', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
-        'indexUpdated': isNotNull,
         'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [

--- a/app/test/search/bluetooth_test.dart
+++ b/app/test/search/bluetooth_test.dart
@@ -35,7 +35,6 @@ void main() {
           ServiceSearchQuery.parse(
               query: 'bluetooth', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
-        'indexUpdated': isNotNull,
         'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [

--- a/app/test/search/exact_name_test.dart
+++ b/app/test/search/exact_name_test.dart
@@ -43,7 +43,6 @@ void main() {
           ServiceSearchQuery.parse(
               query: 'build_config', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
-        'indexUpdated': isNotNull,
         'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [

--- a/app/test/search/flutter_95_test.dart
+++ b/app/test/search/flutter_95_test.dart
@@ -30,7 +30,6 @@ void main() {
           ServiceSearchQuery.parse(
               query: 'flutter 95', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
-        'indexUpdated': isNotNull,
         'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [

--- a/app/test/search/flutter_iap_test.dart
+++ b/app/test/search/flutter_iap_test.dart
@@ -53,7 +53,6 @@ void main() {
           ServiceSearchQuery.parse(
               query: 'flutter iap', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
-        'indexUpdated': isNotNull,
         'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
@@ -70,7 +69,6 @@ void main() {
           ServiceSearchQuery.parse(
               query: 'flutter_iap', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
-        'indexUpdated': isNotNull,
         'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [

--- a/app/test/search/handlers_test.dart
+++ b/app/test/search/handlers_test.dart
@@ -44,7 +44,6 @@ void main() {
       scopedTest('Finds package by name', () async {
         await setUpInServiceScope();
         await expectJsonResponse(await issueGet('/search?q=pkg_foo'), body: {
-          'indexUpdated': isNotNull,
           'timestamp': isNotNull,
           'totalCount': 1,
           'packages': [
@@ -59,7 +58,6 @@ void main() {
       scopedTest('Finds text in description or readme', () async {
         await setUpInServiceScope();
         await expectJsonResponse(await issueGet('/search?q=json'), body: {
-          'indexUpdated': isNotNull,
           'timestamp': isNotNull,
           'totalCount': 1,
           'packages': [
@@ -75,7 +73,6 @@ void main() {
         await setUpInServiceScope();
         await expectJsonResponse(await issueGet('/search?q=json&pkg-prefix=pk'),
             body: {
-              'indexUpdated': isNotNull,
               'timestamp': isNotNull,
               'totalCount': 1,
               'packages': [
@@ -90,7 +87,6 @@ void main() {
       scopedTest('Finds package by package-prefix search only', () async {
         await setUpInServiceScope();
         await expectJsonResponse(await issueGet('/search?q=package:pk'), body: {
-          'indexUpdated': isNotNull,
           'timestamp': isNotNull,
           'totalCount': 1,
           'packages': [
@@ -106,7 +102,6 @@ void main() {
         await setUpInServiceScope();
         await expectJsonResponse(await issueGet('/search?q=json+package:foo'),
             body: {
-              'indexUpdated': isNotNull,
               'timestamp': isNotNull,
               'totalCount': 0,
               'packages': [],

--- a/app/test/search/haversine_test.dart
+++ b/app/test/search/haversine_test.dart
@@ -381,7 +381,6 @@ MIT'''),
           ServiceSearchQuery.parse(
               query: 'haversine', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
-        'indexUpdated': isNotNull,
         'timestamp': isNotNull,
         'totalCount': 3,
         'packages': [
@@ -409,7 +408,6 @@ MIT'''),
           ServiceSearchQuery.parse(
               query: 'hoversine', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
-        'indexUpdated': isNotNull,
         'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [

--- a/app/test/search/in_app_payments_test.dart
+++ b/app/test/search/in_app_payments_test.dart
@@ -30,7 +30,6 @@ Add _In-App Payments_ to your Flutter app with this plugin.''')));
       final PackageSearchResult result = await index.search(
           ServiceSearchQuery.parse(query: 'IAP', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
-        'indexUpdated': isNotNull,
         'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
@@ -47,7 +46,6 @@ Add _In-App Payments_ to your Flutter app with this plugin.''')));
           ServiceSearchQuery.parse(
               query: 'in app payments', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
-        'indexUpdated': isNotNull,
         'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [

--- a/app/test/search/json_tool_test.dart
+++ b/app/test/search/json_tool_test.dart
@@ -26,7 +26,6 @@ void main() {
           ServiceSearchQuery.parse(
               query: 'json_tool', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
-        'indexUpdated': isNotNull,
         'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
@@ -66,7 +65,6 @@ void main() {
           ServiceSearchQuery.parse(
               query: 'json_tool', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
-        'indexUpdated': isNotNull,
         'timestamp': isNotNull,
         'totalCount': 3,
         'packages': [

--- a/app/test/search/lombok_test.dart
+++ b/app/test/search/lombok_test.dart
@@ -26,7 +26,6 @@ void main() {
       final PackageSearchResult result = await index.search(
           ServiceSearchQuery.parse(query: 'lombock', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
-        'indexUpdated': isNotNull,
         'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [

--- a/app/test/search/maps_test.dart
+++ b/app/test/search/maps_test.dart
@@ -24,7 +24,6 @@ void main() {
       final PackageSearchResult result = await index.search(
           ServiceSearchQuery.parse(query: 'maps', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
-        'indexUpdated': isNotNull,
         'timestamp': isNotNull,
         'totalCount': 2,
         'packages': [
@@ -38,7 +37,6 @@ void main() {
       final PackageSearchResult result = await index.search(
           ServiceSearchQuery.parse(query: 'map', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
-        'indexUpdated': isNotNull,
         'timestamp': isNotNull,
         'totalCount': 2,
         'packages': [

--- a/app/test/search/mem_index_test.dart
+++ b/app/test/search/mem_index_test.dart
@@ -101,7 +101,6 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
       final PackageSearchResult result =
           await index.search(ServiceSearchQuery.parse(query: 'async'));
       expect(json.decode(json.encode(result)), {
-        'indexUpdated': isNotNull,
         'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
@@ -117,7 +116,6 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
       final PackageSearchResult result =
           await index.search(ServiceSearchQuery.parse(query: 'composable'));
       expect(json.decode(json.encode(result)), {
-        'indexUpdated': isNotNull,
         'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
@@ -133,7 +131,6 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
       final PackageSearchResult result =
           await index.search(ServiceSearchQuery.parse(query: 'chrome.sockets'));
       expect(json.decode(json.encode(result)), {
-        'indexUpdated': isNotNull,
         'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
@@ -149,7 +146,6 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
       final PackageSearchResult result =
           await index.search(ServiceSearchQuery.parse(query: '"utility"'));
       expect(json.decode(json.encode(result)), {
-        'indexUpdated': isNotNull,
         'timestamp': isNotNull,
         'totalCount': 2,
         'packages': [
@@ -163,7 +159,6 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
       final result = await index
           .search(ServiceSearchQuery.parse(query: '"once on demand."'));
       expect(json.decode(json.encode(result)), {
-        'indexUpdated': isNotNull,
         'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
@@ -176,7 +171,6 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
       final PackageSearchResult result =
           await index.search(ServiceSearchQuery.parse(query: 'package:chrome'));
       expect(json.decode(json.encode(result)), {
-        'indexUpdated': isNotNull,
         'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
@@ -192,7 +186,6 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
       final PackageSearchResult result = await index.search(
           ServiceSearchQuery.parse(query: 't', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
-        'indexUpdated': isNotNull,
         'timestamp': isNotNull,
         'totalCount': 2,
         'packages': [
@@ -206,7 +199,6 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
       final PackageSearchResult result = await index
           .search(ServiceSearchQuery.parse(order: SearchOrder.created));
       expect(json.decode(json.encode(result)), {
-        'indexUpdated': isNotNull,
         'timestamp': isNotNull,
         'totalCount': 3,
         'packages': [
@@ -221,7 +213,6 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
       final PackageSearchResult result = await index.search(
           ServiceSearchQuery.parse(query: '', order: SearchOrder.updated));
       expect(json.decode(json.encode(result)), {
-        'indexUpdated': isNotNull,
         'timestamp': isNotNull,
         'totalCount': 3,
         'packages': [
@@ -236,7 +227,6 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
       final PackageSearchResult result = await index.search(
           ServiceSearchQuery.parse(query: 'http', order: SearchOrder.updated));
       expect(json.decode(json.encode(result)), {
-        'indexUpdated': isNotNull,
         'timestamp': isNotNull,
         'totalCount': 2,
         'packages': [
@@ -255,7 +245,6 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         ).toServiceQuery(),
       );
       expect(json.decode(json.encode(result)), {
-        'indexUpdated': isNotNull,
         'timestamp': isNotNull,
         'totalCount': 2,
         'packages': [
@@ -269,7 +258,6 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
       final PackageSearchResult result = await index
           .search(ServiceSearchQuery.parse(order: SearchOrder.popularity));
       expect(json.decode(json.encode(result)), {
-        'indexUpdated': isNotNull,
         'timestamp': isNotNull,
         'totalCount': 3,
         'packages': [
@@ -284,7 +272,6 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
       final PackageSearchResult result =
           await index.search(ServiceSearchQuery.parse(order: SearchOrder.like));
       expect(json.decode(json.encode(result)), {
-        'indexUpdated': isNotNull,
         'timestamp': isNotNull,
         'totalCount': 3,
         'packages': [
@@ -299,7 +286,6 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
       final PackageSearchResult result = await index
           .search(ServiceSearchQuery.parse(order: SearchOrder.points));
       expect(json.decode(json.encode(result)), {
-        'indexUpdated': isNotNull,
         'timestamp': isNotNull,
         'totalCount': 3,
         'packages': [
@@ -314,7 +300,6 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
       final PackageSearchResult result = await index
           .search(ServiceSearchQuery.parse(query: 'dependency:test'));
       expect(json.decode(json.encode(result)), {
-        'indexUpdated': isNotNull,
         'timestamp': isNotNull,
         'totalCount': 2,
         'packages': [
@@ -328,7 +313,6 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
       final PackageSearchResult result =
           await index.search(ServiceSearchQuery.parse(query: 'dependency:foo'));
       expect(json.decode(json.encode(result)), {
-        'indexUpdated': isNotNull,
         'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
@@ -341,7 +325,6 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
       final PackageSearchResult result = await index
           .search(ServiceSearchQuery.parse(query: 'dependency*:foo'));
       expect(json.decode(json.encode(result)), {
-        'indexUpdated': isNotNull,
         'timestamp': isNotNull,
         'totalCount': 2,
         'packages': [
@@ -355,7 +338,6 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
       final PackageSearchResult result = await index.search(
           ServiceSearchQuery.parse(query: 'composable dependency:test'));
       expect(json.decode(json.encode(result)), {
-        'indexUpdated': isNotNull,
         'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
@@ -368,7 +350,6 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
       final PackageSearchResult result = await index.search(
           ServiceSearchQuery.parse(query: 'dependency:async dependency:test'));
       expect(json.decode(json.encode(result)), {
-        'indexUpdated': isNotNull,
         'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
@@ -381,7 +362,6 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
       final PackageSearchResult result = await index.search(
           ServiceSearchQuery.parse(query: 'publisher:other-domain.com'));
       expect(json.decode(json.encode(result)), {
-        'indexUpdated': isNotNull,
         'timestamp': isNotNull,
         'totalCount': 0,
         'packages': [],
@@ -392,7 +372,6 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
       final PackageSearchResult result = await index
           .search(ServiceSearchQuery.parse(query: 'publisher:dart.dev'));
       expect(json.decode(json.encode(result)), {
-        'indexUpdated': isNotNull,
         'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
@@ -405,7 +384,6 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
       final PackageSearchResult result = await index.search(
           ServiceSearchQuery.parse(uploaderOrPublishers: ['other-domain.com']));
       expect(json.decode(json.encode(result)), {
-        'indexUpdated': isNotNull,
         'timestamp': isNotNull,
         'totalCount': 0,
         'packages': [],
@@ -416,7 +394,6 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
       final PackageSearchResult result = await index
           .search(ServiceSearchQuery.parse(uploaderOrPublishers: ['dart.dev']));
       expect(json.decode(json.encode(result)), {
-        'indexUpdated': isNotNull,
         'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
@@ -432,7 +409,6 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'user1@example.com',
       ]));
       expect(json.decode(json.encode(result)), {
-        'indexUpdated': isNotNull,
         'timestamp': isNotNull,
         'totalCount': 2,
         'packages': [
@@ -446,7 +422,6 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
       final PackageSearchResult result = await index
           .search(ServiceSearchQuery.parse(query: 'email:some@other.com'));
       expect(json.decode(json.encode(result)), {
-        'indexUpdated': isNotNull,
         'timestamp': isNotNull,
         'totalCount': 0,
         'packages': [],
@@ -457,7 +432,6 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
       final PackageSearchResult result = await index
           .search(ServiceSearchQuery.parse(query: 'email:user1@example.com'));
       expect(json.decode(json.encode(result)), {
-        'indexUpdated': isNotNull,
         'timestamp': isNotNull,
         'totalCount': 2,
         'packages': [
@@ -472,7 +446,6 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
           ServiceSearchQuery.parse(
               query: 'composable', order: SearchOrder.text));
       expect(json.decode(json.encode(composable)), {
-        'indexUpdated': isNotNull,
         'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
@@ -483,7 +456,6 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
       final PackageSearchResult library = await index.search(
           ServiceSearchQuery.parse(query: 'library', order: SearchOrder.text));
       expect(json.decode(json.encode(library)), {
-        'indexUpdated': isNotNull,
         'timestamp': isNotNull,
         'totalCount': 3,
         'packages': [
@@ -499,7 +471,6 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
           ServiceSearchQuery.parse(
               query: 'composable library', order: SearchOrder.text));
       expect(json.decode(json.encode(both)), {
-        'indexUpdated': isNotNull,
         'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [

--- a/app/test/search/rest_api_test.dart
+++ b/app/test/search/rest_api_test.dart
@@ -51,7 +51,6 @@ Recent versions (0.3.x and 0.4.x) of this plugin require [extensible codec funct
       final PackageSearchResult result = await index.search(
           ServiceSearchQuery.parse(query: 'rest api', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
-        'indexUpdated': isNotNull,
         'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [

--- a/app/test/search/result_combiner_test.dart
+++ b/app/test/search/result_combiner_test.dart
@@ -48,7 +48,6 @@ void main() {
       final results = await combiner
           .search(ServiceSearchQuery.parse(order: SearchOrder.popularity));
       expect(json.decode(json.encode(results.toJson())), {
-        'indexUpdated': isNotNull,
         'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
@@ -61,7 +60,6 @@ void main() {
       final results = await combiner
           .search(ServiceSearchQuery.parse(query: 'email:foo@example.com'));
       expect(json.decode(json.encode(results.toJson())), {
-        'indexUpdated': isNotNull,
         'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
@@ -74,7 +72,6 @@ void main() {
       final results =
           await combiner.search(ServiceSearchQuery.parse(query: 'substring'));
       expect(json.decode(json.encode(results.toJson())), {
-        'indexUpdated': isNotNull,
         'timestamp': isNotNull,
         'totalCount': 2,
         'packages': [
@@ -102,7 +99,6 @@ void main() {
       final results =
           await combiner.search(ServiceSearchQuery.parse(query: 'stringutils'));
       expect(json.decode(json.encode(results.toJson())), {
-        'indexUpdated': isNotNull,
         'timestamp': isNotNull,
         'totalCount': 2,
         'packages': [

--- a/app/test/search/scope_specificity_test.dart
+++ b/app/test/search/scope_specificity_test.dart
@@ -65,7 +65,6 @@ void main() {
       final PackageSearchResult withoutPlatform =
           await index.search(ServiceSearchQuery.parse(query: 'json'));
       expect(json.decode(json.encode(withoutPlatform)), {
-        'indexUpdated': isNotNull,
         'timestamp': isNotNull,
         'totalCount': 4,
         'packages': [
@@ -97,7 +96,6 @@ void main() {
         ).toServiceQuery(),
       );
       expect(json.decode(json.encode(withPlatform)), {
-        'indexUpdated': isNotNull,
         'timestamp': isNotNull,
         'totalCount': 2,
         'packages': [

--- a/app/test/search/stack_trace_test.dart
+++ b/app/test/search/stack_trace_test.dart
@@ -33,7 +33,6 @@ void main() {
           ServiceSearchQuery.parse(
               query: 'stacktrace', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
-        'indexUpdated': isNotNull,
         'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [

--- a/app/test/search/tags_test.dart
+++ b/app/test/search/tags_test.dart
@@ -20,7 +20,6 @@ void main() {
         tagsPredicate: TagsPredicate(requiredTags: ['is:a']),
       ));
       expect(rs.toJson(), {
-        'indexUpdated': isNotEmpty,
         'timestamp': isNotNull,
         'totalCount': 0,
         'packages': [],
@@ -36,7 +35,6 @@ void main() {
         tagsPredicate: TagsPredicate(prohibitedTags: ['is:a']),
       ));
       expect(json.decode(json.encode(rs.toJson())), {
-        'indexUpdated': isNotEmpty,
         'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
@@ -55,7 +53,6 @@ void main() {
         tagsPredicate: TagsPredicate(prohibitedTags: ['is:a']),
       ));
       expect(json.decode(json.encode(rs.toJson())), {
-        'indexUpdated': isNotEmpty,
         'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
@@ -74,7 +71,6 @@ void main() {
         tagsPredicate: TagsPredicate.parseQueryValues(['is:a']),
       ));
       expect(json.decode(json.encode(rs.toJson())), {
-        'indexUpdated': isNotEmpty,
         'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
@@ -95,7 +91,6 @@ void main() {
         tagsPredicate: TagsPredicate.parseQueryValues(['is:dart1']),
       ));
       expect(json.decode(json.encode(rs.toJson())), {
-        'indexUpdated': isNotEmpty,
         'timestamp': isNotNull,
         'totalCount': 2,
         'packages': [
@@ -117,7 +112,6 @@ void main() {
         tagsPredicate: TagsPredicate.parseQueryValues(['is:dart1', 'is:b']),
       ));
       expect(json.decode(json.encode(rs.toJson())), {
-        'indexUpdated': isNotEmpty,
         'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
@@ -138,7 +132,6 @@ void main() {
         tagsPredicate: TagsPredicate.parseQueryValues(['is:dart1', '-is:b']),
       ));
       expect(json.decode(json.encode(rs.toJson())), {
-        'indexUpdated': isNotEmpty,
         'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
@@ -157,7 +150,6 @@ void main() {
       final rs =
           await index.search(ServiceSearchQuery.parse(query: 'is:b -is:a'));
       expect(json.decode(json.encode(rs.toJson())), {
-        'indexUpdated': isNotEmpty,
         'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
@@ -177,7 +169,6 @@ void main() {
           tagsPredicate: TagsPredicate(prohibitedTags: ['is:b']),
           query: 'is:a is:b'));
       expect(json.decode(json.encode(rs.toJson())), {
-        'indexUpdated': isNotEmpty,
         'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [

--- a/app/test/search/travis_test.dart
+++ b/app/test/search/travis_test.dart
@@ -55,7 +55,6 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor i
       final PackageSearchResult result = await index.search(
           ServiceSearchQuery.parse(query: 'travis', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
-        'indexUpdated': isNotNull,
         'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [


### PR DESCRIPTION
At one point `indexUpdated` was used to detect incomplete index state, however, since appengine uses readiness checks and we use `IndexInfo.isReady`, it is no longer required. On top of that, we also use status code to indicate when index was not ready and it is being checked in `search_client.dart`.