### PR TITLE
Reduce PackageVersion's exposure in rendering PackagePageData.

### DIFF
--- a/app/lib/frontend/handlers/package.dart
+++ b/app/lib/frontend/handlers/package.dart
@@ -97,7 +97,7 @@ Future<shelf.Response> packageChangelogHandler(
     packageName: packageName,
     versionName: versionName,
     renderFn: (data) {
-      if (data.version.changelog == null) {
+      if (!data.hasChangelog) {
         return redirectResponse(
             urls.pkgPageUrl(packageName, version: versionName));
       }
@@ -117,7 +117,7 @@ Future<shelf.Response> packageExampleHandler(
     packageName: packageName,
     versionName: versionName,
     renderFn: (data) {
-      if (data.version.example == null) {
+      if (!data.hasExample) {
         return redirectResponse(
             urls.pkgPageUrl(packageName, version: versionName));
       }

--- a/app/lib/frontend/templates/package_admin.dart
+++ b/app/lib/frontend/templates/package_admin.dart
@@ -16,7 +16,7 @@ String renderPkgAdminPage(
   List<String> userPublishers,
 ) {
   final tabs = buildPackageTabs(
-    packagePageData: data,
+    data: data,
     adminTab: Tab.withContent(
       id: 'admin',
       title: 'Admin',

--- a/app/lib/frontend/templates/package_versions.dart
+++ b/app/lib/frontend/templates/package_versions.dart
@@ -64,7 +64,7 @@ String renderPkgVersionsPage(
   }
 
   final tabs = buildPackageTabs(
-    packagePageData: data,
+    data: data,
     versionsTab: Tab.withContent(
       id: 'versions',
       title: 'Versions',

--- a/app/lib/package/models.dart
+++ b/app/lib/package/models.dart
@@ -819,13 +819,12 @@ class PackagePageData {
 
   PackagePageData({
     @required this.package,
-    this.moderatedPackage,
     @required this.version,
     @required this.analysis,
     @required this.uploaderEmails,
     @required this.isAdmin,
     @required this.isLiked,
-  });
+  }) : moderatedPackage = null;
 
   PackagePageData.missing({
     @required this.package,
@@ -835,6 +834,12 @@ class PackagePageData {
         uploaderEmails = null,
         isAdmin = null,
         isLiked = null;
+
+  bool get hasReadme => version.readme != null;
+  bool get hasChangelog => version.changelog != null;
+  bool get hasExample => version.example != null;
+
+  bool get isLatestStable => version.version == package.latestVersion;
 
   PackageView toPackageView() {
     return _view ??= PackageView.fromModel(


### PR DESCRIPTION
- Removed a few `final version = data.version;` call to better uncover the use of the methods.
- Using `package.name`, instead of `version.package`.
- Using `toPackageView()` instead of creating a new one.
- Extracted `hasXyz` methods which will be handled later by using `PackageVersionInfo.assets`.
