### PR TITLE
Advanced search option for prerelease null-safe packages.

### DIFF
--- a/app/lib/frontend/templates/layout.dart
+++ b/app/lib/frontend/templates/layout.dart
@@ -6,6 +6,7 @@ import 'dart:convert';
 
 import 'package:client_data/page_data.dart';
 import 'package:meta/meta.dart';
+import 'package:pub_dev/frontend/request_context.dart';
 
 import '../../account/backend.dart';
 import '../../search/search_form.dart';
@@ -187,6 +188,8 @@ String _renderSearchBanner({
     'include_discontinued': searchForm?.includeDiscontinued ?? false,
     'include_unlisted': searchForm?.includeUnlisted ?? false,
     'legacy_search_enabled': searchForm?.includeLegacy ?? false,
+    'prerelease_null_safe': requestContext.isNullSafetyDisplayed &&
+        (searchForm?.prereleaseNullSafe ?? false),
     'hidden_inputs': hiddenInputs,
   });
 }

--- a/app/lib/frontend/templates/listing.dart
+++ b/app/lib/frontend/templates/listing.dart
@@ -134,6 +134,8 @@ String renderPkgIndexPage(
   final includeDiscontinued = searchForm?.includeDiscontinued ?? false;
   final includeUnlisted = searchForm?.includeUnlisted ?? false;
   final includeLegacy = searchForm?.includeLegacy ?? false;
+  final prereleaseNullSafe = requestContext.isNullSafetyDisplayed &&
+      (searchForm?.prereleaseNullSafe ?? false);
   final subSdkTabsAdvanced =
       renderSubSdkTabsHtml(searchForm: searchForm, onlyAdvanced: true);
   // TODO: There should be a more efficient way to calculate this
@@ -142,7 +144,8 @@ String renderPkgIndexPage(
   final hasActiveAdvanced = includeDiscontinued ||
       includeUnlisted ||
       includeLegacy ||
-      hasActiveSubSdkAdvanced;
+      hasActiveSubSdkAdvanced ||
+      prereleaseNullSafe;
   final values = {
     'has_active_advanced': hasActiveAdvanced,
     'sdk_tabs_html': renderSdkTabs(searchForm: searchForm),
@@ -163,6 +166,8 @@ String renderPkgIndexPage(
     'include_discontinued': includeDiscontinued,
     'include_unlisted': includeUnlisted,
     'show_legacy_checkbox': SdkTagValue.isAny(sdk),
+    'show_prerelease_null_safe_checkbox': requestContext.isNullSafetyDisplayed,
+    'prerelease_null_safe': prereleaseNullSafe,
     'include_legacy': includeLegacy,
   };
   final content = templateCache.renderTemplate('pkg/index', values);

--- a/app/lib/frontend/templates/views/pkg/index.mustache
+++ b/app/lib/frontend/templates/views/pkg/index.mustache
@@ -46,6 +46,12 @@
           <label for="-search-legacy-checkbox">Include Dart 1.x results</label>
         </div>
         {{/show_legacy_checkbox}}
+        {{#show_prerelease_null_safe_checkbox}}
+        <div class="search-controls-checkbox">
+          <input id="-search-prerelease-null-safe-checkbox" type="checkbox" name="prerelease-null-safe" {{#prerelease_null_safe}} checked="checked"{{/prerelease_null_safe}} />
+          <label for="-search-prerelease-null-safe-checkbox">Prerelease version is null-safe</label>
+        </div>
+        {{/show_prerelease_null_safe_checkbox}}
       </div>
     </div>
   </div>

--- a/app/lib/frontend/templates/views/shared/search_banner.mustache
+++ b/app/lib/frontend/templates/views/shared/search_banner.mustache
@@ -15,6 +15,7 @@
   <input id="-search-discontinued-field" type="hidden" name="discontinued" value="1"{{^include_discontinued}} disabled="disabled"{{/include_discontinued}} />
   <input id="-search-unlisted-field" type="hidden" name="unlisted" value="1"{{^include_unlisted}} disabled="disabled"{{/include_unlisted}} />
   <input id="-search-legacy-field" type="hidden" name="legacy" value="1"{{^legacy_search_enabled}} disabled="disabled"{{/legacy_search_enabled}} />
+  <input id="-search-prerelease-null-safe-field" type="hidden" name="prerelease-null-safe" value="1"{{^prerelease_null_safe}} disabled="disabled"{{/prerelease_null_safe}} />
   {{#hidden_inputs}}
   <input type="hidden" name="{{name}}" value="{{value}}" />
   {{/hidden_inputs}}

--- a/app/lib/search/search_form.dart
+++ b/app/lib/search/search_form.dart
@@ -44,6 +44,9 @@ class SearchForm {
   /// True, if packages which only support dart 1.x should be included.
   final bool includeLegacy;
 
+  /// True, if null safe prerelease package should be listed.
+  final bool prereleaseNullSafe;
+
   SearchForm._({
     this.query,
     TagsPredicate tagsPredicate,
@@ -55,6 +58,7 @@ class SearchForm {
     this.includeDiscontinued,
     this.includeUnlisted,
     this.includeLegacy,
+    this.prereleaseNullSafe,
   })  : parsedQuery = ParsedQueryText.parse(query),
         tagsPredicate = tagsPredicate ?? TagsPredicate(),
         uploaderOrPublishers = _listToNull(uploaderOrPublishers),
@@ -74,6 +78,7 @@ class SearchForm {
     bool includeDiscontinued = false,
     bool includeUnlisted = false,
     bool includeLegacy = false,
+    bool prereleaseNullSafe = false,
   }) {
     currentPage ??= 1;
     pageSize ??= resultsPerPage;
@@ -105,6 +110,7 @@ class SearchForm {
       includeDiscontinued: includeDiscontinued,
       includeUnlisted: includeUnlisted,
       includeLegacy: includeLegacy,
+      prereleaseNullSafe: prereleaseNullSafe,
     );
   }
 
@@ -137,6 +143,7 @@ class SearchForm {
       includeDiscontinued: includeDiscontinued,
       includeUnlisted: includeUnlisted,
       includeLegacy: includeLegacy,
+      prereleaseNullSafe: prereleaseNullSafe,
     );
   }
 
@@ -153,6 +160,12 @@ class SearchForm {
     if (includeLegacy &&
         tagsPredicate.isProhibitedTag(PackageVersionTags.isLegacy)) {
       tagsPredicate = tagsPredicate.withoutTag(PackageVersionTags.isLegacy);
+    }
+    if (prereleaseNullSafe) {
+      tagsPredicate =
+          tagsPredicate.appendPredicate(TagsPredicate(requiredTags: [
+        PackageTags.convertToPrereleaseTag(PackageVersionTags.isNullSafe),
+      ]));
     }
     return ServiceSearchQuery.parse(
       query: query,
@@ -216,6 +229,9 @@ class SearchForm {
     if (includeLegacy && SdkTagValue.isAny(sdk)) {
       params['legacy'] = '1';
     }
+    if (prereleaseNullSafe) {
+      params['prerelease-null-safe'] = '1';
+    }
     if (page != null && page > 1) {
       params['page'] = page.toString();
     }
@@ -261,6 +277,7 @@ SearchForm parseFrontendSearchForm(
     includeDiscontinued: queryParameters['discontinued'] == '1',
     includeUnlisted: queryParameters['unlisted'] == '1',
     includeLegacy: queryParameters['legacy'] == '1' && SdkTagValue.isAny(sdk),
+    prereleaseNullSafe: queryParameters['prerelease-null-safe'] == '1',
     tagsPredicate: tagsPredicate,
   );
 }

--- a/app/test/frontend/golden/error_page.html
+++ b/app/test/frontend/golden/error_page.html
@@ -110,6 +110,7 @@
           <input id="-search-discontinued-field" type="hidden" name="discontinued" value="1" disabled="disabled"/>
           <input id="-search-unlisted-field" type="hidden" name="unlisted" value="1" disabled="disabled"/>
           <input id="-search-legacy-field" type="hidden" name="legacy" value="1" disabled="disabled"/>
+          <input id="-search-prerelease-null-safe-field" type="hidden" name="prerelease-null-safe" value="1" disabled="disabled"/>
         </form>
       </div>
     </div>

--- a/app/test/frontend/golden/landing_page.html
+++ b/app/test/frontend/golden/landing_page.html
@@ -109,6 +109,7 @@
           <input id="-search-discontinued-field" type="hidden" name="discontinued" value="1" disabled="disabled"/>
           <input id="-search-unlisted-field" type="hidden" name="unlisted" value="1" disabled="disabled"/>
           <input id="-search-legacy-field" type="hidden" name="legacy" value="1" disabled="disabled"/>
+          <input id="-search-prerelease-null-safe-field" type="hidden" name="prerelease-null-safe" value="1" disabled="disabled"/>
         </form>
         <p class="text">
           Find and use packages to build

--- a/app/test/frontend/golden/my_liked_packages.html
+++ b/app/test/frontend/golden/my_liked_packages.html
@@ -111,6 +111,7 @@
           <input id="-search-discontinued-field" type="hidden" name="discontinued" value="1" disabled="disabled"/>
           <input id="-search-unlisted-field" type="hidden" name="unlisted" value="1" disabled="disabled"/>
           <input id="-search-legacy-field" type="hidden" name="legacy" value="1" disabled="disabled"/>
+          <input id="-search-prerelease-null-safe-field" type="hidden" name="prerelease-null-safe" value="1" disabled="disabled"/>
         </form>
       </div>
     </div>

--- a/app/test/frontend/golden/my_packages.html
+++ b/app/test/frontend/golden/my_packages.html
@@ -111,6 +111,7 @@
           <input id="-search-discontinued-field" type="hidden" name="discontinued" value="1" disabled="disabled"/>
           <input id="-search-unlisted-field" type="hidden" name="unlisted" value="1" disabled="disabled"/>
           <input id="-search-legacy-field" type="hidden" name="legacy" value="1" disabled="disabled"/>
+          <input id="-search-prerelease-null-safe-field" type="hidden" name="prerelease-null-safe" value="1" disabled="disabled"/>
         </form>
       </div>
     </div>

--- a/app/test/frontend/golden/my_publishers.html
+++ b/app/test/frontend/golden/my_publishers.html
@@ -111,6 +111,7 @@
           <input id="-search-discontinued-field" type="hidden" name="discontinued" value="1" disabled="disabled"/>
           <input id="-search-unlisted-field" type="hidden" name="unlisted" value="1" disabled="disabled"/>
           <input id="-search-legacy-field" type="hidden" name="legacy" value="1" disabled="disabled"/>
+          <input id="-search-prerelease-null-safe-field" type="hidden" name="prerelease-null-safe" value="1" disabled="disabled"/>
         </form>
       </div>
     </div>

--- a/app/test/frontend/golden/pkg_index_page.html
+++ b/app/test/frontend/golden/pkg_index_page.html
@@ -116,6 +116,7 @@
           <input id="-search-discontinued-field" type="hidden" name="discontinued" value="1" disabled="disabled"/>
           <input id="-search-unlisted-field" type="hidden" name="unlisted" value="1" disabled="disabled"/>
           <input id="-search-legacy-field" type="hidden" name="legacy" value="1" disabled="disabled"/>
+          <input id="-search-prerelease-null-safe-field" type="hidden" name="prerelease-null-safe" value="1" disabled="disabled"/>
         </form>
       </div>
     </div>

--- a/app/test/frontend/golden/publisher_list_page.html
+++ b/app/test/frontend/golden/publisher_list_page.html
@@ -114,6 +114,7 @@
           <input id="-search-discontinued-field" type="hidden" name="discontinued" value="1" disabled="disabled"/>
           <input id="-search-unlisted-field" type="hidden" name="unlisted" value="1" disabled="disabled"/>
           <input id="-search-legacy-field" type="hidden" name="legacy" value="1" disabled="disabled"/>
+          <input id="-search-prerelease-null-safe-field" type="hidden" name="prerelease-null-safe" value="1" disabled="disabled"/>
         </form>
       </div>
     </div>

--- a/app/test/frontend/golden/publisher_packages_page.html
+++ b/app/test/frontend/golden/publisher_packages_page.html
@@ -112,6 +112,7 @@
           <input id="-search-discontinued-field" type="hidden" name="discontinued" value="1" disabled="disabled"/>
           <input id="-search-unlisted-field" type="hidden" name="unlisted" value="1" disabled="disabled"/>
           <input id="-search-legacy-field" type="hidden" name="legacy" value="1" disabled="disabled"/>
+          <input id="-search-prerelease-null-safe-field" type="hidden" name="prerelease-null-safe" value="1" disabled="disabled"/>
         </form>
       </div>
     </div>

--- a/app/test/frontend/golden/search_page.html
+++ b/app/test/frontend/golden/search_page.html
@@ -117,6 +117,7 @@
           <input id="-search-discontinued-field" type="hidden" name="discontinued" value="1" disabled="disabled"/>
           <input id="-search-unlisted-field" type="hidden" name="unlisted" value="1" disabled="disabled"/>
           <input id="-search-legacy-field" type="hidden" name="legacy" value="1" disabled="disabled"/>
+          <input id="-search-prerelease-null-safe-field" type="hidden" name="prerelease-null-safe" value="1" disabled="disabled"/>
         </form>
       </div>
     </div>

--- a/pkg/web_app/lib/src/search.dart
+++ b/pkg/web_app/lib/src/search.dart
@@ -80,6 +80,8 @@ void _setEventForCheckboxChanges() {
       '-search-unlisted-field', '-search-unlisted-checkbox');
   _setEventForHiddenCheckboxField(
       '-search-discontinued-field', '-search-discontinued-checkbox');
+  _setEventForHiddenCheckboxField('-search-prerelease-null-safe-field',
+      '-search-prerelease-null-safe-checkbox');
 }
 
 void _setEventForHiddenCheckboxField(


### PR DESCRIPTION
- #4182
- #3745 (the same option can be used to search for latest stable with a small update)
- It is behind the experimental flag.