### PR TITLE
Fix paging 404 in /api/packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ AppEngine version, listed here to ease deployment and troubleshooting.
  * Bumped runtimeVersion to `2020.10.26`.
  * Upgraded pana to `0.14.5`.
  * Package page is rendered using `PackageVersionInfo` and `PackageVersionAsset`.
+ * `/api/packages` API no longer returns incorrect 404 (#4192).
 
 ## `20201020t163909-all`
  * Bumped runtimeVersion to `2020.10.19`.

--- a/app/lib/frontend/handlers/custom_api.dart
+++ b/app/lib/frontend/handlers/custom_api.dart
@@ -147,19 +147,15 @@ Future<shelf.Response> apiPackagesHandler(shelf.Request request) async {
 
     if (!pkgPage.isLast) {
       json['next_url'] = '${uri.resolve('/api/packages?page=${page + 1}')}';
+    } else {
+      // Set the last page in cache, if not already there with a lower number.
+      final lastPage = await lastPageCacheEntry.get();
+      if (lastPage == null || lastPage['page'] as int > page) {
+        await lastPageCacheEntry.set({'page': page});
+      }
     }
     return json;
   });
-
-  // Return 400, if there is no packages on this page.
-  if (data['packages'].length == 0) {
-    // Set the last page in cache, if not already there with a lower number.
-    final lastPage = await lastPageCacheEntry.get();
-    if (lastPage == null || lastPage['page'] as int > page) {
-      await lastPageCacheEntry.set({'page': page});
-    }
-    return jsonResponse({'message': 'no content'}, status: 400);
-  }
 
   return jsonResponse(data);
 }


### PR DESCRIPTION
The root cause was: we were updating the cache based on the list of packages and not on the `isLast` flag.