### PR TITLE
Remove unused styles + detect them in test.

### DIFF
--- a/pkg/web_css/lib/src/_base.scss
+++ b/pkg/web_css/lib/src/_base.scss
@@ -231,10 +231,6 @@ pre {
   }
 }
 
-.overflow-x {
-  overflow-x: auto;
-}
-
 .-pub-publisher-shield {
   vertical-align: middle;
   margin: -1px 2px 0 0;
@@ -257,42 +253,6 @@ pre {
 
 .center {
   text-align: center;
-}
-
-.pub-modal {
-  position: fixed;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  top: 0;
-  background: rgba(0, 0, 0, 0.7);
-
-  >.pub-modal-panel {
-    background: white;
-    border: 1px solid #666;
-    border-radius: 24px;
-    padding: 24px;
-
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    min-width: 300px;
-    max-width: 600px;
-
-    >.pub-modal-content {
-      margin-bottom: 24px;
-    }
-
-    >.pub-modal-buttons {
-      text-align: center;
-
-      .pub-button {
-        margin-left: 20px;
-        margin-right: 20px;
-      }
-    }
-  }
 }
 
 /******************************************************

--- a/pkg/web_css/pubspec.lock
+++ b/pkg/web_css/pubspec.lock
@@ -85,6 +85,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.5"
+  csslib:
+    dependency: "direct dev"
+    description:
+      name: csslib
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.16.2"
   glob:
     dependency: transitive
     description:

--- a/pkg/web_css/pubspec.yaml
+++ b/pkg/web_css/pubspec.yaml
@@ -8,4 +8,5 @@ dependencies:
   sass: ^1.19.0
 
 dev_dependencies:
+  csslib: ^0.16.2
   test: ^1.15.0

--- a/pkg/web_css/test/expression_test.dart
+++ b/pkg/web_css/test/expression_test.dart
@@ -1,0 +1,112 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:csslib/parser.dart';
+import 'package:csslib/visitor.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('build + check rules', () {
+    final file = File('../../static/css/style.css');
+
+    setUpAll(() async {
+      if (!file.existsSync()) {
+        final pr = await Process.run('/bin/sh', ['build.sh']);
+        if (pr.exitCode != 0) {
+          throw Exception('Build process failed. ${pr.stdout}');
+        }
+      }
+    });
+
+    test('Check if all expressions are referenced in source files.', () async {
+      final styles = parse(await file.readAsString());
+      final visitor = _Visitor();
+      styles.visit(visitor);
+
+      // Sanity checks
+      // TODO: figure out how to find more expressions
+      expect(visitor.elements, isNotEmpty);
+
+      // TODO: figure out why no element selector has been found
+      // expect(visitor.ids, isNotEmpty);
+
+      expect(visitor.classes, isNotEmpty);
+      // TODO: figure out why 'unlisted' is not present, while it is in `_tags.scss`
+      // expect(visitor.classes, contains('unlisted'));
+
+      expect(visitor.selectors, isNotEmpty);
+
+      final expressions = <String>{
+        ...visitor.elements,
+        ...visitor.ids,
+        ...visitor.classes,
+        ...visitor.selectors,
+      };
+
+      // These expressions are extracted from the CSS file, but they shouldn't
+      // have been.
+      expressions.removeAll(<String>[
+        'site-font-color',
+        'keyframes',
+        'nth-child',
+      ]);
+
+      final files = <File>[
+        ...await Directory('../../app/lib')
+            .list(recursive: true)
+            .where((f) => f is File)
+            .cast<File>()
+            .toList(),
+        ...await Directory('../web_app/lib')
+            .list(recursive: true)
+            .where((f) => f is File)
+            .cast<File>()
+            .toList()
+      ];
+
+      for (final file in files) {
+        if (expressions.isEmpty) break;
+        final content = await file.readAsString();
+        final matched = expressions.where(content.contains).toList();
+        expressions.removeAll(matched);
+      }
+
+      expect(expressions, isEmpty);
+    });
+  });
+}
+
+class _Visitor extends Visitor {
+  final ids = <String>{};
+  final elements = <String>{};
+  final classes = <String>{};
+  final selectors = <String>{};
+
+  @override
+  void visitSelector(Selector node) {
+    selectors
+        .addAll(node.simpleSelectorSequences.map((e) => e.simpleSelector.name));
+    return super.visitSelector(node);
+  }
+
+  @override
+  void visitClassSelector(ClassSelector node) {
+    classes.add(node.name);
+    return super.visitClassSelector(node);
+  }
+
+  @override
+  void visitIdSelector(IdSelector node) {
+    ids.add(node.name);
+    return super.visitIdSelector(node);
+  }
+
+  @override
+  void visitElementSelector(ElementSelector node) {
+    elements.add(node.name);
+    return super.visitElementSelector(node);
+  }
+}


### PR DESCRIPTION
The detection is sub-optional (looking for sources whether they contain the specific string without any context), but the worse part is `csslib` doesn't return all of the selector parts. I'm deferring that part for a later time, it is a good first version that can be improved upon.