### PR TITLE
'package: ^version' copyable title pattern on package page.

### DIFF
--- a/app/lib/frontend/templates/detail_page.dart
+++ b/app/lib/frontend/templates/detail_page.dart
@@ -27,12 +27,9 @@ String renderDetailHeader({
   /// Set true for more whitespace in the header.
   bool isLoose = false,
 }) {
-  if (title == null && titleHtml == null) {
-    throw ArgumentError('One of `title` and `titleHtml` must be specified.');
-  }
-  if (title != null && titleHtml != null) {
+  if ((title == null && titleHtml == null) || (title != null && titleHtml != null)) {
     throw ArgumentError(
-        'Only one of `title` and `titleHtml` must be specified.');
+        'Exactly one of `title` and `titleHtml` must be specified.');
   }
   return templateCache.renderTemplate('shared/detail/header', {
     'is_loose': isLoose,

--- a/app/lib/frontend/templates/detail_page.dart
+++ b/app/lib/frontend/templates/detail_page.dart
@@ -15,7 +15,8 @@ final wideHeaderDetailPageClassName = '-wide-header-detail-page';
 ///
 /// The like button in the header will not be displayed when [isLiked] is null.
 String renderDetailHeader({
-  @required String title,
+  String title,
+  String titleHtml,
   String imageUrl,
   int packageLikes,
   bool isLiked,
@@ -26,9 +27,16 @@ String renderDetailHeader({
   /// Set true for more whitespace in the header.
   bool isLoose = false,
 }) {
+  if (title == null && titleHtml == null) {
+    throw ArgumentError('One of `title` and `titleHtml` must be specified.');
+  }
+  if (title != null && titleHtml != null) {
+    throw ArgumentError(
+        'Only one of `title` and `titleHtml` must be specified.');
+  }
   return templateCache.renderTemplate('shared/detail/header', {
     'is_loose': isLoose,
-    'title': title,
+    'title_html': titleHtml ?? htmlEscape.convert(title),
     'metadata_html': metadataHtml,
     'tags_html': tagsHtml,
     'like_count': _formatPackageLikes(packageLikes),

--- a/app/lib/frontend/templates/package.dart
+++ b/app/lib/frontend/templates/package.dart
@@ -231,7 +231,9 @@ String renderPkgHeader(PackagePageData data) {
   });
   final pkgView = data.toPackageView();
   return renderDetailHeader(
-    title: '${package.name} ${data.version.version}',
+    titleHtml: '${htmlEscape.convert(package.name)}'
+        '<span class="pkg-page-title-colon">: ^</span>'
+        '${htmlEscape.convert(data.version.version)}',
     packageLikes: package.likes,
     isLiked: data.isLiked,
     isFlutterFavorite:

--- a/app/lib/frontend/templates/views/shared/detail/header.mustache
+++ b/app/lib/frontend/templates/views/shared/detail/header.mustache
@@ -26,7 +26,7 @@
       </div>
       {{/has_image_url}}
       <div class="detail-header-content-block">
-        <h1 class="title">{{ title }}</h1>
+        <h1 class="title">{{& title_html }}</h1>
         <div class="metadata">{{& metadata_html}}</div>
         <div class="detail-tags-and-like">
           <div class="detail-tags">{{& tags_html}}</div>

--- a/app/test/frontend/golden/pkg_admin_page_outdated.html
+++ b/app/test/frontend/golden/pkg_admin_page_outdated.html
@@ -115,7 +115,11 @@
           <div class="detail-container">
             <div class="detail-header-outer-block">
               <div class="detail-header-content-block">
-                <h1 class="title">foobar_pkg 0.1.1+5</h1>
+                <h1 class="title">
+                  foobar_pkg
+                  <span class="pkg-page-title-colon">: ^</span>
+                  0.1.1+5
+                </h1>
                 <div class="metadata">
                   Published
                   <span>Jan 1, 2014</span>

--- a/app/test/frontend/golden/pkg_changelog_page.html
+++ b/app/test/frontend/golden/pkg_changelog_page.html
@@ -117,7 +117,11 @@
           <div class="detail-container">
             <div class="detail-header-outer-block">
               <div class="detail-header-content-block">
-                <h1 class="title">foobar_pkg 0.1.1+5</h1>
+                <h1 class="title">
+                  foobar_pkg
+                  <span class="pkg-page-title-colon">: ^</span>
+                  0.1.1+5
+                </h1>
                 <div class="metadata">
                   Published
                   <span>Jan 1, 2014</span>

--- a/app/test/frontend/golden/pkg_example_page.html
+++ b/app/test/frontend/golden/pkg_example_page.html
@@ -117,7 +117,11 @@
           <div class="detail-container">
             <div class="detail-header-outer-block">
               <div class="detail-header-content-block">
-                <h1 class="title">foobar_pkg 0.1.1+5</h1>
+                <h1 class="title">
+                  foobar_pkg
+                  <span class="pkg-page-title-colon">: ^</span>
+                  0.1.1+5
+                </h1>
                 <div class="metadata">
                   Published
                   <span>Jan 1, 2014</span>

--- a/app/test/frontend/golden/pkg_install_page.html
+++ b/app/test/frontend/golden/pkg_install_page.html
@@ -117,7 +117,11 @@
           <div class="detail-container">
             <div class="detail-header-outer-block">
               <div class="detail-header-content-block">
-                <h1 class="title">foobar_pkg 0.1.1+5</h1>
+                <h1 class="title">
+                  foobar_pkg
+                  <span class="pkg-page-title-colon">: ^</span>
+                  0.1.1+5
+                </h1>
                 <div class="metadata">
                   Published
                   <span>Jan 1, 2014</span>

--- a/app/test/frontend/golden/pkg_score_page.html
+++ b/app/test/frontend/golden/pkg_score_page.html
@@ -117,7 +117,11 @@
           <div class="detail-container">
             <div class="detail-header-outer-block">
               <div class="detail-header-content-block">
-                <h1 class="title">foobar_pkg 0.1.1+5</h1>
+                <h1 class="title">
+                  foobar_pkg
+                  <span class="pkg-page-title-colon">: ^</span>
+                  0.1.1+5
+                </h1>
                 <div class="metadata">
                   Published
                   <span>Jan 1, 2014</span>

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -117,7 +117,11 @@
           <div class="detail-container">
             <div class="detail-header-outer-block">
               <div class="detail-header-content-block">
-                <h1 class="title">foobar_pkg 0.1.1+5</h1>
+                <h1 class="title">
+                  foobar_pkg
+                  <span class="pkg-page-title-colon">: ^</span>
+                  0.1.1+5
+                </h1>
                 <div class="metadata">
                   Published
                   <span>Jan 1, 2014</span>

--- a/app/test/frontend/golden/pkg_show_page_discontinued.html
+++ b/app/test/frontend/golden/pkg_show_page_discontinued.html
@@ -117,7 +117,11 @@
           <div class="detail-container">
             <div class="detail-header-outer-block">
               <div class="detail-header-content-block">
-                <h1 class="title">foobar_pkg 0.1.1+5</h1>
+                <h1 class="title">
+                  foobar_pkg
+                  <span class="pkg-page-title-colon">: ^</span>
+                  0.1.1+5
+                </h1>
                 <div class="metadata">
                   Published
                   <span>Jan 1, 2014</span>

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -117,7 +117,11 @@
           <div class="detail-container">
             <div class="detail-header-outer-block">
               <div class="detail-header-content-block">
-                <h1 class="title">foobar_pkg 0.1.1+5</h1>
+                <h1 class="title">
+                  foobar_pkg
+                  <span class="pkg-page-title-colon">: ^</span>
+                  0.1.1+5
+                </h1>
                 <div class="metadata">
                   Published
                   <span>Jan 1, 2015</span>

--- a/app/test/frontend/golden/pkg_show_page_legacy.html
+++ b/app/test/frontend/golden/pkg_show_page_legacy.html
@@ -117,7 +117,11 @@
           <div class="detail-container">
             <div class="detail-header-outer-block">
               <div class="detail-header-content-block">
-                <h1 class="title">foobar_pkg 0.1.1+5</h1>
+                <h1 class="title">
+                  foobar_pkg
+                  <span class="pkg-page-title-colon">: ^</span>
+                  0.1.1+5
+                </h1>
                 <div class="metadata">
                   Published
                   <span>Jan 1, 2014</span>

--- a/app/test/frontend/golden/pkg_show_page_outdated.html
+++ b/app/test/frontend/golden/pkg_show_page_outdated.html
@@ -117,7 +117,11 @@
           <div class="detail-container">
             <div class="detail-header-outer-block">
               <div class="detail-header-content-block">
-                <h1 class="title">foobar_pkg 0.1.1+5</h1>
+                <h1 class="title">
+                  foobar_pkg
+                  <span class="pkg-page-title-colon">: ^</span>
+                  0.1.1+5
+                </h1>
                 <div class="metadata">
                   Published
                   <span>Jan 1, 2014</span>

--- a/app/test/frontend/golden/pkg_show_page_publisher.html
+++ b/app/test/frontend/golden/pkg_show_page_publisher.html
@@ -117,7 +117,11 @@
           <div class="detail-container">
             <div class="detail-header-outer-block">
               <div class="detail-header-content-block">
-                <h1 class="title">lithium 5.8.6</h1>
+                <h1 class="title">
+                  lithium
+                  <span class="pkg-page-title-colon">: ^</span>
+                  5.8.6
+                </h1>
                 <div class="metadata">
                   Published
                   <span>Mar 5, 2014</span>

--- a/app/test/frontend/golden/pkg_show_version_page.html
+++ b/app/test/frontend/golden/pkg_show_version_page.html
@@ -117,7 +117,11 @@
           <div class="detail-container">
             <div class="detail-header-outer-block">
               <div class="detail-header-content-block">
-                <h1 class="title">foobar_pkg 0.2.0-dev</h1>
+                <h1 class="title">
+                  foobar_pkg
+                  <span class="pkg-page-title-colon">: ^</span>
+                  0.2.0-dev
+                </h1>
                 <div class="metadata">
                   Published
                   <span>Jan 1, 2014</span>

--- a/app/test/frontend/golden/pkg_versions_page.html
+++ b/app/test/frontend/golden/pkg_versions_page.html
@@ -116,7 +116,11 @@
           <div class="detail-container">
             <div class="detail-header-outer-block">
               <div class="detail-header-content-block">
-                <h1 class="title">foobar_pkg 0.1.1+5</h1>
+                <h1 class="title">
+                  foobar_pkg
+                  <span class="pkg-page-title-colon">: ^</span>
+                  0.1.1+5
+                </h1>
                 <div class="metadata">
                   Published
                   <span>Jan 1, 2014</span>

--- a/app/test/frontend/handlers/package_test.dart
+++ b/app/test/frontend/handlers/package_test.dart
@@ -22,7 +22,7 @@ void main() {
       await expectHtmlResponse(
         await issueGet('/packages/foobar_pkg'),
         present: [
-          ' class="title">foobar_pkg 0.1.1+5</',
+          ' class="title">foobar_pkg<span class="pkg-page-title-colon">: ^</span>0.1.1+5</',
           '<a href="/packages/foobar_pkg">0.1.1+5</a>',
           '<a href="/packages/foobar_pkg/versions/0.2.0-dev">0.2.0-dev</a>',
         ],
@@ -55,7 +55,7 @@ void main() {
       await expectHtmlResponse(
         await issueGet('/packages/foobar_pkg/versions'),
         present: [
-          ' class="title">foobar_pkg 0.1.1+5</',
+          ' class="title">foobar_pkg<span class="pkg-page-title-colon">: ^</span>0.1.1+5</',
           '<a href="/packages/foobar_pkg">0.1.1+5</a>',
           '<a href="/packages/foobar_pkg/versions/0.2.0-dev">0.2.0-dev</a>',
         ],
@@ -74,7 +74,7 @@ void main() {
       await expectHtmlResponse(
         await issueGet('/packages/foobar_pkg/versions/0.1.1+5'),
         present: [
-          ' class="title">foobar_pkg 0.1.1+5</',
+          ' class="title">foobar_pkg<span class="pkg-page-title-colon">: ^</span>0.1.1+5</',
           '<a href="/packages/foobar_pkg">0.1.1+5</a>',
           '<a href="/packages/foobar_pkg/versions/0.2.0-dev">0.2.0-dev</a>',
         ],
@@ -86,7 +86,7 @@ void main() {
       await expectHtmlResponse(
         await issueGet('/packages/foobar_pkg/versions/0.1.1%2B5'),
         present: [
-          ' class="title">foobar_pkg 0.1.1+5</',
+          ' class="title">foobar_pkg<span class="pkg-page-title-colon">: ^</span>0.1.1+5</',
           '<a href="/packages/foobar_pkg">0.1.1+5</a>',
           '<a href="/packages/foobar_pkg/versions/0.2.0-dev">0.2.0-dev</a>',
         ],

--- a/pkg/web_css/lib/src/_pkg.scss
+++ b/pkg/web_css/lib/src/_pkg.scss
@@ -250,3 +250,17 @@
     }
   }
 }
+
+h1.title {
+  .pkg-page-title-colon {
+    letter-spacing: -3.0px;
+    opacity: 0;
+    transition: opacity 0.5s;
+  }
+
+  &:hover {
+    .pkg-page-title-colon {
+      opacity: 0.15;
+    }
+  }
+}


### PR DESCRIPTION
- The most requested part of #3336.

- with selection:
  <img width="224" alt="Screenshot 2020-10-29 at 10 11 31" src="https://user-images.githubusercontent.com/4778111/97548434-6a766200-19cf-11eb-882f-e104dcb5412f.png">

- only hover:
  <img width="217" alt="Screenshot 2020-10-29 at 10 10 59" src="https://user-images.githubusercontent.com/4778111/97548421-677b7180-19cf-11eb-89d4-00626c1ace31.png">

- without hover:
  <img width="210" alt="Screenshot 2020-10-29 at 10 11 06" src="https://user-images.githubusercontent.com/4778111/97548429-69453500-19cf-11eb-9400-d87a05668ac1.png">

