### PR TITLE
Copy icon for "package: ^version" pattern in package title.

### DIFF
--- a/app/lib/frontend/templates/detail_page.dart
+++ b/app/lib/frontend/templates/detail_page.dart
@@ -27,7 +27,8 @@ String renderDetailHeader({
   /// Set true for more whitespace in the header.
   bool isLoose = false,
 }) {
-  if ((title == null && titleHtml == null) || (title != null && titleHtml != null)) {
+  if ((title == null && titleHtml == null) ||
+      (title != null && titleHtml != null)) {
     throw ArgumentError(
         'Exactly one of `title` and `titleHtml` must be specified.');
   }

--- a/app/lib/frontend/templates/detail_page.dart
+++ b/app/lib/frontend/templates/detail_page.dart
@@ -15,7 +15,8 @@ final wideHeaderDetailPageClassName = '-wide-header-detail-page';
 ///
 /// The like button in the header will not be displayed when [isLiked] is null.
 String renderDetailHeader({
-  @required String title,
+  String title,
+  String titleHtml,
   String imageUrl,
   int packageLikes,
   bool isLiked,
@@ -26,9 +27,13 @@ String renderDetailHeader({
   /// Set true for more whitespace in the header.
   bool isLoose = false,
 }) {
+  if ((title == null && titleHtml == null) || (title != null && titleHtml != null)) {
+    throw ArgumentError(
+        'Exactly one of `title` and `titleHtml` must be specified.');
+  }
   return templateCache.renderTemplate('shared/detail/header', {
     'is_loose': isLoose,
-    'title': title,
+    'title_html': titleHtml ?? htmlEscape.convert(title),
     'metadata_html': metadataHtml,
     'tags_html': tagsHtml,
     'like_count': _formatPackageLikes(packageLikes),

--- a/app/lib/frontend/templates/package.dart
+++ b/app/lib/frontend/templates/package.dart
@@ -231,7 +231,7 @@ String renderPkgHeader(PackagePageData data) {
   });
   final pkgView = data.toPackageView();
   return renderDetailHeader(
-    title: '${package.name} ${data.version.version}',
+    titleHtml: _renderPkgTitleContent(data),
     packageLikes: package.likes,
     isLiked: data.isLiked,
     isFlutterFavorite:
@@ -240,6 +240,13 @@ String renderPkgHeader(PackagePageData data) {
     tagsHtml: renderTags(package: pkgView),
     isLoose: true,
   );
+}
+
+String _renderPkgTitleContent(PackagePageData data) {
+  return templateCache.renderTemplate('pkg/title_content', {
+    'package': data.package.name,
+    'version': data.version.version,
+  });
 }
 
 /// Renders the package detail page.

--- a/app/lib/frontend/templates/views/pkg/title_content.mustache
+++ b/app/lib/frontend/templates/views/pkg/title_content.mustache
@@ -1,0 +1,12 @@
+{{! Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+    for details. All rights reserved. Use of this source code is governed by a
+    BSD-style license that can be found in the LICENSE file. }}
+
+{{ package }} {{ version }}
+
+<span class="pkg-page-title-copy-hoverable hoverable">
+  <img class="pkg-page-title-copy-icon" src="{{& static_assets.img__content-copy-icon_svg }}" />
+  <div class="pkg-page-title-copy-dropdown">
+    <div class="pkg-page-title-copy-item">{{ package }}: ^{{ version }}</div>
+  </div>
+</span>

--- a/app/lib/frontend/templates/views/shared/detail/header.mustache
+++ b/app/lib/frontend/templates/views/shared/detail/header.mustache
@@ -26,7 +26,7 @@
       </div>
       {{/has_image_url}}
       <div class="detail-header-content-block">
-        <h1 class="title">{{ title }}</h1>
+        <h1 class="title">{{& title_html }}</h1>
         <div class="metadata">{{& metadata_html}}</div>
         <div class="detail-tags-and-like">
           <div class="detail-tags">{{& tags_html}}</div>

--- a/app/test/frontend/golden/pkg_admin_page_outdated.html
+++ b/app/test/frontend/golden/pkg_admin_page_outdated.html
@@ -115,7 +115,15 @@
           <div class="detail-container">
             <div class="detail-header-outer-block">
               <div class="detail-header-content-block">
-                <h1 class="title">foobar_pkg 0.1.1+5</h1>
+                <h1 class="title">
+                  foobar_pkg 0.1.1+5
+                  <span class="pkg-page-title-copy-hoverable hoverable">
+                    <img class="pkg-page-title-copy-icon" src="/static/img/content-copy-icon.svg?hash=mocked_hash_1005735992"/>
+                    <div class="pkg-page-title-copy-dropdown">
+                      <div class="pkg-page-title-copy-item">foobar_pkg: ^0.1.1+5</div>
+                    </div>
+                  </span>
+                </h1>
                 <div class="metadata">
                   Published
                   <span>Jan 1, 2014</span>

--- a/app/test/frontend/golden/pkg_changelog_page.html
+++ b/app/test/frontend/golden/pkg_changelog_page.html
@@ -117,7 +117,15 @@
           <div class="detail-container">
             <div class="detail-header-outer-block">
               <div class="detail-header-content-block">
-                <h1 class="title">foobar_pkg 0.1.1+5</h1>
+                <h1 class="title">
+                  foobar_pkg 0.1.1+5
+                  <span class="pkg-page-title-copy-hoverable hoverable">
+                    <img class="pkg-page-title-copy-icon" src="/static/img/content-copy-icon.svg?hash=mocked_hash_1005735992"/>
+                    <div class="pkg-page-title-copy-dropdown">
+                      <div class="pkg-page-title-copy-item">foobar_pkg: ^0.1.1+5</div>
+                    </div>
+                  </span>
+                </h1>
                 <div class="metadata">
                   Published
                   <span>Jan 1, 2014</span>

--- a/app/test/frontend/golden/pkg_example_page.html
+++ b/app/test/frontend/golden/pkg_example_page.html
@@ -117,7 +117,15 @@
           <div class="detail-container">
             <div class="detail-header-outer-block">
               <div class="detail-header-content-block">
-                <h1 class="title">foobar_pkg 0.1.1+5</h1>
+                <h1 class="title">
+                  foobar_pkg 0.1.1+5
+                  <span class="pkg-page-title-copy-hoverable hoverable">
+                    <img class="pkg-page-title-copy-icon" src="/static/img/content-copy-icon.svg?hash=mocked_hash_1005735992"/>
+                    <div class="pkg-page-title-copy-dropdown">
+                      <div class="pkg-page-title-copy-item">foobar_pkg: ^0.1.1+5</div>
+                    </div>
+                  </span>
+                </h1>
                 <div class="metadata">
                   Published
                   <span>Jan 1, 2014</span>

--- a/app/test/frontend/golden/pkg_install_page.html
+++ b/app/test/frontend/golden/pkg_install_page.html
@@ -117,7 +117,15 @@
           <div class="detail-container">
             <div class="detail-header-outer-block">
               <div class="detail-header-content-block">
-                <h1 class="title">foobar_pkg 0.1.1+5</h1>
+                <h1 class="title">
+                  foobar_pkg 0.1.1+5
+                  <span class="pkg-page-title-copy-hoverable hoverable">
+                    <img class="pkg-page-title-copy-icon" src="/static/img/content-copy-icon.svg?hash=mocked_hash_1005735992"/>
+                    <div class="pkg-page-title-copy-dropdown">
+                      <div class="pkg-page-title-copy-item">foobar_pkg: ^0.1.1+5</div>
+                    </div>
+                  </span>
+                </h1>
                 <div class="metadata">
                   Published
                   <span>Jan 1, 2014</span>

--- a/app/test/frontend/golden/pkg_score_page.html
+++ b/app/test/frontend/golden/pkg_score_page.html
@@ -117,7 +117,15 @@
           <div class="detail-container">
             <div class="detail-header-outer-block">
               <div class="detail-header-content-block">
-                <h1 class="title">foobar_pkg 0.1.1+5</h1>
+                <h1 class="title">
+                  foobar_pkg 0.1.1+5
+                  <span class="pkg-page-title-copy-hoverable hoverable">
+                    <img class="pkg-page-title-copy-icon" src="/static/img/content-copy-icon.svg?hash=mocked_hash_1005735992"/>
+                    <div class="pkg-page-title-copy-dropdown">
+                      <div class="pkg-page-title-copy-item">foobar_pkg: ^0.1.1+5</div>
+                    </div>
+                  </span>
+                </h1>
                 <div class="metadata">
                   Published
                   <span>Jan 1, 2014</span>

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -117,7 +117,15 @@
           <div class="detail-container">
             <div class="detail-header-outer-block">
               <div class="detail-header-content-block">
-                <h1 class="title">foobar_pkg 0.1.1+5</h1>
+                <h1 class="title">
+                  foobar_pkg 0.1.1+5
+                  <span class="pkg-page-title-copy-hoverable hoverable">
+                    <img class="pkg-page-title-copy-icon" src="/static/img/content-copy-icon.svg?hash=mocked_hash_1005735992"/>
+                    <div class="pkg-page-title-copy-dropdown">
+                      <div class="pkg-page-title-copy-item">foobar_pkg: ^0.1.1+5</div>
+                    </div>
+                  </span>
+                </h1>
                 <div class="metadata">
                   Published
                   <span>Jan 1, 2014</span>

--- a/app/test/frontend/golden/pkg_show_page_discontinued.html
+++ b/app/test/frontend/golden/pkg_show_page_discontinued.html
@@ -117,7 +117,15 @@
           <div class="detail-container">
             <div class="detail-header-outer-block">
               <div class="detail-header-content-block">
-                <h1 class="title">foobar_pkg 0.1.1+5</h1>
+                <h1 class="title">
+                  foobar_pkg 0.1.1+5
+                  <span class="pkg-page-title-copy-hoverable hoverable">
+                    <img class="pkg-page-title-copy-icon" src="/static/img/content-copy-icon.svg?hash=mocked_hash_1005735992"/>
+                    <div class="pkg-page-title-copy-dropdown">
+                      <div class="pkg-page-title-copy-item">foobar_pkg: ^0.1.1+5</div>
+                    </div>
+                  </span>
+                </h1>
                 <div class="metadata">
                   Published
                   <span>Jan 1, 2014</span>

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -117,7 +117,15 @@
           <div class="detail-container">
             <div class="detail-header-outer-block">
               <div class="detail-header-content-block">
-                <h1 class="title">foobar_pkg 0.1.1+5</h1>
+                <h1 class="title">
+                  foobar_pkg 0.1.1+5
+                  <span class="pkg-page-title-copy-hoverable hoverable">
+                    <img class="pkg-page-title-copy-icon" src="/static/img/content-copy-icon.svg?hash=mocked_hash_1005735992"/>
+                    <div class="pkg-page-title-copy-dropdown">
+                      <div class="pkg-page-title-copy-item">foobar_pkg: ^0.1.1+5</div>
+                    </div>
+                  </span>
+                </h1>
                 <div class="metadata">
                   Published
                   <span>Jan 1, 2015</span>

--- a/app/test/frontend/golden/pkg_show_page_legacy.html
+++ b/app/test/frontend/golden/pkg_show_page_legacy.html
@@ -117,7 +117,15 @@
           <div class="detail-container">
             <div class="detail-header-outer-block">
               <div class="detail-header-content-block">
-                <h1 class="title">foobar_pkg 0.1.1+5</h1>
+                <h1 class="title">
+                  foobar_pkg 0.1.1+5
+                  <span class="pkg-page-title-copy-hoverable hoverable">
+                    <img class="pkg-page-title-copy-icon" src="/static/img/content-copy-icon.svg?hash=mocked_hash_1005735992"/>
+                    <div class="pkg-page-title-copy-dropdown">
+                      <div class="pkg-page-title-copy-item">foobar_pkg: ^0.1.1+5</div>
+                    </div>
+                  </span>
+                </h1>
                 <div class="metadata">
                   Published
                   <span>Jan 1, 2014</span>

--- a/app/test/frontend/golden/pkg_show_page_outdated.html
+++ b/app/test/frontend/golden/pkg_show_page_outdated.html
@@ -117,7 +117,15 @@
           <div class="detail-container">
             <div class="detail-header-outer-block">
               <div class="detail-header-content-block">
-                <h1 class="title">foobar_pkg 0.1.1+5</h1>
+                <h1 class="title">
+                  foobar_pkg 0.1.1+5
+                  <span class="pkg-page-title-copy-hoverable hoverable">
+                    <img class="pkg-page-title-copy-icon" src="/static/img/content-copy-icon.svg?hash=mocked_hash_1005735992"/>
+                    <div class="pkg-page-title-copy-dropdown">
+                      <div class="pkg-page-title-copy-item">foobar_pkg: ^0.1.1+5</div>
+                    </div>
+                  </span>
+                </h1>
                 <div class="metadata">
                   Published
                   <span>Jan 1, 2014</span>

--- a/app/test/frontend/golden/pkg_show_page_publisher.html
+++ b/app/test/frontend/golden/pkg_show_page_publisher.html
@@ -117,7 +117,15 @@
           <div class="detail-container">
             <div class="detail-header-outer-block">
               <div class="detail-header-content-block">
-                <h1 class="title">lithium 5.8.6</h1>
+                <h1 class="title">
+                  lithium 5.8.6
+                  <span class="pkg-page-title-copy-hoverable hoverable">
+                    <img class="pkg-page-title-copy-icon" src="/static/img/content-copy-icon.svg?hash=mocked_hash_1005735992"/>
+                    <div class="pkg-page-title-copy-dropdown">
+                      <div class="pkg-page-title-copy-item">lithium: ^5.8.6</div>
+                    </div>
+                  </span>
+                </h1>
                 <div class="metadata">
                   Published
                   <span>Mar 5, 2014</span>

--- a/app/test/frontend/golden/pkg_show_version_page.html
+++ b/app/test/frontend/golden/pkg_show_version_page.html
@@ -117,7 +117,15 @@
           <div class="detail-container">
             <div class="detail-header-outer-block">
               <div class="detail-header-content-block">
-                <h1 class="title">foobar_pkg 0.2.0-dev</h1>
+                <h1 class="title">
+                  foobar_pkg 0.2.0-dev
+                  <span class="pkg-page-title-copy-hoverable hoverable">
+                    <img class="pkg-page-title-copy-icon" src="/static/img/content-copy-icon.svg?hash=mocked_hash_1005735992"/>
+                    <div class="pkg-page-title-copy-dropdown">
+                      <div class="pkg-page-title-copy-item">foobar_pkg: ^0.2.0-dev</div>
+                    </div>
+                  </span>
+                </h1>
                 <div class="metadata">
                   Published
                   <span>Jan 1, 2014</span>

--- a/app/test/frontend/golden/pkg_versions_page.html
+++ b/app/test/frontend/golden/pkg_versions_page.html
@@ -116,7 +116,15 @@
           <div class="detail-container">
             <div class="detail-header-outer-block">
               <div class="detail-header-content-block">
-                <h1 class="title">foobar_pkg 0.1.1+5</h1>
+                <h1 class="title">
+                  foobar_pkg 0.1.1+5
+                  <span class="pkg-page-title-copy-hoverable hoverable">
+                    <img class="pkg-page-title-copy-icon" src="/static/img/content-copy-icon.svg?hash=mocked_hash_1005735992"/>
+                    <div class="pkg-page-title-copy-dropdown">
+                      <div class="pkg-page-title-copy-item">foobar_pkg: ^0.1.1+5</div>
+                    </div>
+                  </span>
+                </h1>
                 <div class="metadata">
                   Published
                   <span>Jan 1, 2014</span>

--- a/app/test/frontend/handlers/package_test.dart
+++ b/app/test/frontend/handlers/package_test.dart
@@ -22,7 +22,7 @@ void main() {
       await expectHtmlResponse(
         await issueGet('/packages/foobar_pkg'),
         present: [
-          ' class="title">foobar_pkg 0.1.1+5</',
+          'foobar_pkg 0.1.1+5',
           '<a href="/packages/foobar_pkg">0.1.1+5</a>',
           '<a href="/packages/foobar_pkg/versions/0.2.0-dev">0.2.0-dev</a>',
         ],
@@ -55,7 +55,7 @@ void main() {
       await expectHtmlResponse(
         await issueGet('/packages/foobar_pkg/versions'),
         present: [
-          ' class="title">foobar_pkg 0.1.1+5</',
+          'foobar_pkg 0.1.1+5',
           '<a href="/packages/foobar_pkg">0.1.1+5</a>',
           '<a href="/packages/foobar_pkg/versions/0.2.0-dev">0.2.0-dev</a>',
         ],
@@ -74,7 +74,7 @@ void main() {
       await expectHtmlResponse(
         await issueGet('/packages/foobar_pkg/versions/0.1.1+5'),
         present: [
-          ' class="title">foobar_pkg 0.1.1+5</',
+          'foobar_pkg 0.1.1+5',
           '<a href="/packages/foobar_pkg">0.1.1+5</a>',
           '<a href="/packages/foobar_pkg/versions/0.2.0-dev">0.2.0-dev</a>',
         ],
@@ -86,7 +86,7 @@ void main() {
       await expectHtmlResponse(
         await issueGet('/packages/foobar_pkg/versions/0.1.1%2B5'),
         present: [
-          ' class="title">foobar_pkg 0.1.1+5</',
+          'foobar_pkg 0.1.1+5',
           '<a href="/packages/foobar_pkg">0.1.1+5</a>',
           '<a href="/packages/foobar_pkg/versions/0.2.0-dev">0.2.0-dev</a>',
         ],

--- a/pkg/pub_integration/lib/script/dev_version.dart
+++ b/pkg/pub_integration/lib/script/dev_version.dart
@@ -45,7 +45,7 @@ class DevVersionScript {
         _expectContent(
           await _pubHttpClient.getLatestVersionPage('_dummy_pkg'),
           present: [
-            ' class="title">_dummy_pkg 0.9.0</',
+            '_dummy_pkg 0.9.0',
           ],
           absent: [
             '<a href="/packages/_dummy_pkg">0.9.0</a>',
@@ -58,7 +58,7 @@ class DevVersionScript {
         _expectContent(
           await _pubHttpClient.getLatestVersionPage('_dummy_pkg'),
           present: [
-            ' class="title">_dummy_pkg 1.0.0-beta</',
+            '_dummy_pkg 1.0.0-beta',
           ],
           absent: [
             '<a href="/packages/_dummy_pkg">1.0.0-beta</a>',
@@ -73,7 +73,7 @@ class DevVersionScript {
       _expectContent(
         await _pubHttpClient.getLatestVersionPage('_dummy_pkg'),
         present: [
-          ' class="title">_dummy_pkg 0.9.0</',
+          '_dummy_pkg 0.9.0',
           '<a href="/packages/_dummy_pkg">0.9.0</a>',
           '<a href="/packages/_dummy_pkg/versions/1.0.0-beta">1.0.0-beta</a>',
         ],
@@ -89,7 +89,7 @@ class DevVersionScript {
       _expectContent(
         await _pubHttpClient.getLatestVersionPage('_dummy_pkg'),
         present: [
-          ' class="title">_dummy_pkg 0.9.1</',
+          '_dummy_pkg 0.9.1',
           '<a href="/packages/_dummy_pkg">0.9.1</a>',
           '<a href="/packages/_dummy_pkg/versions/1.0.0-beta">1.0.0-beta</a>',
         ],
@@ -106,7 +106,7 @@ class DevVersionScript {
       _expectContent(
         await _pubHttpClient.getLatestVersionPage('_dummy_pkg'),
         present: [
-          ' class="title">_dummy_pkg 0.9.1</',
+          '_dummy_pkg 0.9.1',
           '<a href="/packages/_dummy_pkg">0.9.1</a>',
           '<a href="/packages/_dummy_pkg/versions/1.0.0-gamma">1.0.0-gamma</a>',
         ],
@@ -125,7 +125,7 @@ class DevVersionScript {
       _expectContent(
         await _pubHttpClient.getLatestVersionPage('_dummy_pkg'),
         present: [
-          ' class="title">_dummy_pkg 1.0.0</',
+          '_dummy_pkg 1.0.0',
         ],
         absent: [
           '<a href="/packages/_dummy_pkg">0.9.0</a>',
@@ -145,7 +145,7 @@ class DevVersionScript {
       _expectContent(
         await _pubHttpClient.getLatestVersionPage('_dummy_pkg'),
         present: [
-          ' class="title">_dummy_pkg 1.0.0</',
+          '_dummy_pkg 1.0.0',
           '<a href="/packages/_dummy_pkg">1.0.0</a>',
           '<a href="/packages/_dummy_pkg/versions/1.1.0-dev">1.1.0-dev</a>',
         ],

--- a/pkg/pub_integration/test/browser_test.dart
+++ b/pkg/pub_integration/test/browser_test.dart
@@ -119,7 +119,7 @@ void main() {
             final headerTitle = await page.$('h1.title');
             final headerTitleText =
                 await (await headerTitle.property('textContent')).jsonValue;
-            expect(headerTitleText, 'retry 2.0.1');
+            expect(headerTitleText, contains('retry 2.0.1'));
           }
 
           await checkHeaderTitle();

--- a/pkg/web_app/lib/src/hoverable.dart
+++ b/pkg/web_app/lib/src/hoverable.dart
@@ -6,6 +6,7 @@ import 'dart:html';
 
 void setupHoverable() {
   _setEventForHoverable();
+  _setEventForPackageTitleCopyToClipboard();
 }
 
 Element _activeHover;
@@ -48,4 +49,33 @@ void registerHoverable(Element h) {
       deactivateHover(e);
     }
   });
+}
+
+void _setEventForPackageTitleCopyToClipboard() {
+  final root = document.querySelector('.pkg-page-title-copy-hoverable');
+  root?.querySelectorAll('.pkg-page-title-copy-item')?.forEach((elem) {
+    elem.onClick.listen((e) async {
+      _copyToClipboard(elem.text.trim());
+
+      // remove hover style on parent
+      deactivateHover(null);
+
+      // prevent re-adding hover style on parent
+      e.stopPropagation();
+
+      // force unhover in case :hover was the trigger
+      root.classes.add('unhover');
+      await window.animationFrame;
+      root.classes.remove('unhover');
+    });
+  });
+}
+
+void _copyToClipboard(String text) {
+  final ta = TextAreaElement();
+  ta.value = text;
+  document.body.append(ta);
+  ta.select();
+  document.execCommand('copy');
+  ta.remove();
 }

--- a/pkg/web_css/lib/src/_pkg.scss
+++ b/pkg/web_css/lib/src/_pkg.scss
@@ -262,7 +262,12 @@
     display: block;
     width: 20px;
     height: 20px;
-    opacity: 0.5;
+    opacity: 0.1;
+    transition: opacity 0.3s;
+
+    h1.title:hover & {
+      opacity: 0.5;
+    }
   }
 
   .pkg-page-title-copy-dropdown {

--- a/pkg/web_css/lib/src/_pkg.scss
+++ b/pkg/web_css/lib/src/_pkg.scss
@@ -250,3 +250,54 @@
     }
   }
 }
+
+.pkg-page-title-copy-hoverable {
+  position: relative;
+  display: inline-block;
+  height: 20px;
+  width: 20px;
+  margin-left: 12px;
+
+  .pkg-page-title-copy-icon {
+    display: block;
+    width: 20px;
+    height: 20px;
+    opacity: 0.5;
+  }
+
+  .pkg-page-title-copy-dropdown {
+    display: none;
+    position: absolute;
+    top: 20px;
+    right: 2px;
+    box-shadow: 0px 0px 2px 0px rgba(0, 0, 0, 0.3);
+    white-space: nowrap;
+    z-index: $z-index-nav-mask;
+
+    .pkg-page-title-copy-item {
+      padding: 8px 12px;
+      cursor: copy;
+      font-family: $font-family-roboto-mono;
+      font-size: 14px;
+      font-weight: 400;
+      background: white;
+
+      &:hover {
+        background: #fafafa;
+      }
+    }
+  }
+
+  &.hover,
+  &:hover {
+    .pkg-page-title-copy-dropdown {
+      display: block;
+    }
+
+    &.unhover {
+      .pkg-page-title-copy-dropdown {
+        display: none;
+      }
+    }
+  }
+}

--- a/static/img/content-copy-icon.svg
+++ b/static/img/content-copy-icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="black" width="18px" height="18px"><path d="M0 0h24v24H0z" fill="none"/><path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"/></svg>


### PR DESCRIPTION
- Fixes #4198.
- Extensible for future multi-value dropdown.

<img width="204" alt="Screenshot 2020-10-30 at 10 57 46" src="https://user-images.githubusercontent.com/4778111/97691800-20f54800-1a9f-11eb-93a1-ab0accf17591.png">
