### PR TITLE
Canonical URL checks in HTML validation.

### DIFF
--- a/app/lib/dartdoc/customization.dart
+++ b/app/lib/dartdoc/customization.dart
@@ -79,15 +79,6 @@ class DartdocCustomizer {
     if (href != null && href.endsWith('/index.html')) {
       href = href.substring(0, href.length - 'index.html'.length);
     }
-    if (href != null) {
-      // Since the <base /> tag removal, dartdoc calculates the canonical URL
-      // with extra `../../` segments. Removing them as a temporary fix.
-      // https://github.com/dart-lang/dartdoc/issues/2122
-      // TODO: Remove this after the dartdoc issue is fixed
-      href = href.replaceAll('../', '');
-
-      elem.attributes['href'] = href;
-    }
   }
 
   void _addAlternateUrl(Element head, Element canonical) {


### PR DESCRIPTION
- #4136
- Removed custom fix which had been addressed in `dartdoc`.
- Added a check for it in HTML validation to catch it if it re-emerges somewhere else.