### PR TITLE
Extended publisher list with caching

### DIFF
--- a/app/build.yaml
+++ b/app/build.yaml
@@ -11,6 +11,7 @@ targets:
       - 'lib/frontend/handlers/redirects.dart'
       - 'lib/history/models.dart'
       - 'lib/package/models.dart'
+      - 'lib/publisher/models.dart'
       - 'lib/scorecard/models.dart'
       - 'lib/search/backend.dart'
       - 'lib/search/search_service.dart'

--- a/app/lib/account/backend.dart
+++ b/app/lib/account/backend.dart
@@ -222,7 +222,7 @@ class AccountBackend {
       tx.queueMutations(inserts: [p, newLike]);
       return newLike;
     });
-    await cache.userPackageLikes(user.userId).purge();
+    await purgeAccountCache(userId: user.userId);
     return res;
   }
 
@@ -541,4 +541,14 @@ class AccountBackend {
       await cache.userSessionData(session.sessionId).purge();
     }
   }
+}
+
+/// Purge [cache] entries for given [userId].
+Future<void> purgeAccountCache({
+  @required String userId,
+}) async {
+  await Future.wait([
+    cache.userPackageLikes(userId).purge(),
+    cache.publisherPage(userId).purge(),
+  ]);
 }

--- a/app/lib/frontend/handlers/account.dart
+++ b/app/lib/frontend/handlers/account.dart
@@ -204,13 +204,13 @@ Future<shelf.Response> accountPackagesPageHandler(shelf.Request request) async {
     return redirectResponse(request.requestedUri.path);
   }
 
-  final publishers =
+  final page =
       await publisherBackend.listPublishersForUser(userSessionData.userId);
   final searchForm = parseFrontendSearchForm(
     request.requestedUri.queryParameters,
     uploaderOrPublishers: [
       userSessionData.email,
-      ...publishers.map((p) => p.publisherId),
+      ...page.publishers.map((p) => p.publisherId),
     ],
     tagsPredicate: TagsPredicate.allPackages(),
   );
@@ -255,12 +255,12 @@ Future<shelf.Response> accountPublishersPageHandler(
     return htmlResponse(renderUnauthenticatedPage());
   }
 
-  final publishers =
+  final page =
       await publisherBackend.listPublishersForUser(userSessionData.userId);
   final content = renderAccountPublishersPage(
     user: await accountBackend.lookupUserById(userSessionData.userId),
     userSessionData: userSessionData,
-    publishers: publishers,
+    publishers: page.publishers,
   );
   return htmlResponse(content);
 }

--- a/app/lib/frontend/handlers/misc.dart
+++ b/app/lib/frontend/handlers/misc.dart
@@ -6,7 +6,6 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:http_parser/http_parser.dart';
-import 'package:logging/logging.dart';
 import 'package:path/path.dart' as path;
 import 'package:shelf/shelf.dart' as shelf;
 
@@ -20,8 +19,6 @@ import '../../shared/urls.dart' as urls;
 import '../request_context.dart';
 import '../static_files.dart';
 import '../templates/misc.dart';
-
-final _logger = Logger('handlers.misc');
 
 /// Handles requests for /help
 Future<shelf.Response> helpPageHandler(shelf.Request request) async {
@@ -119,13 +116,9 @@ Future<shelf.Response> sitemapPublishersTxtHandler(
     shelf.Request request) async {
   final uri = request.requestedUri;
   final content = await cache.sitemap(uri.toString()).get(() async {
-    final list = await publisherBackend.listPublishers(limit: 1000);
-    if (list.length == 1000) {
-      _logger.shout(
-          'Number of publishers reached backend query limit, do implement paging.');
-    }
+    final page = await publisherBackend.listPublishers();
 
-    return list
+    return page.publishers
         .map((p) => urls.publisherUrl(p.publisherId))
         .map((s) => uri.replace(path: s).toString())
         .join('\n');

--- a/app/lib/frontend/handlers/package.dart
+++ b/app/lib/frontend/handlers/package.dart
@@ -239,10 +239,10 @@ Future<shelf.Response> packageAdminHandler(
       if (!data.isAdmin) {
         return htmlResponse(renderUnauthorizedPage());
       }
-      final publishers =
+      final page =
           await publisherBackend.listPublishersForUser(userSessionData.userId);
       return renderPkgAdminPage(
-          data, publishers.map((p) => p.publisherId).toList());
+          data, page.publishers.map((p) => p.publisherId).toList());
     },
   );
 }

--- a/app/lib/frontend/handlers/publisher.dart
+++ b/app/lib/frontend/handlers/publisher.dart
@@ -32,15 +32,15 @@ Future<shelf.Response> createPublisherPageHandler(shelf.Request request) async {
 Future<shelf.Response> publisherListHandler(shelf.Request request) async {
   if (requestContext.uiCacheEnabled) {
     final content = await cache.uiPublisherListPage().get(() async {
-      final publishers = await publisherBackend.listPublishers(limit: 1000);
-      return renderPublisherListPage(publishers);
+      final page = await publisherBackend.listPublishers();
+      return renderPublisherListPage(page.publishers);
     });
     return htmlResponse(content);
   }
 
   // no caching for logged-in user
-  final publishers = await publisherBackend.listPublishers(limit: 1000);
-  final content = renderPublisherListPage(publishers);
+  final page = await publisherBackend.listPublishers();
+  final content = renderPublisherListPage(page.publishers);
   return htmlResponse(content);
 }
 

--- a/app/lib/frontend/templates/admin.dart
+++ b/app/lib/frontend/templates/admin.dart
@@ -8,7 +8,7 @@ import 'package:meta/meta.dart';
 
 import '../../account/models.dart' show LikeData, User, UserSessionData;
 import '../../package/models.dart' show PackageView;
-import '../../publisher/models.dart' show Publisher;
+import '../../publisher/models.dart' show PublisherSummary;
 import '../../search/search_form.dart' show SearchForm;
 import '../../shared/urls.dart' as urls;
 import '../../shared/utils.dart' show shortDateFormat;
@@ -123,7 +123,7 @@ String renderMyLikedPackagesPage({
 String renderAccountPublishersPage({
   @required User user,
   @required UserSessionData userSessionData,
-  @required List<Publisher> publishers,
+  @required List<PublisherSummary> publishers,
 }) {
   final publisherListHtml = renderPublisherList(publishers, isGlobal: false);
 

--- a/app/lib/frontend/templates/publisher.dart
+++ b/app/lib/frontend/templates/publisher.dart
@@ -8,7 +8,7 @@ import 'package:meta/meta.dart';
 import 'package:pub_dev/shared/markdown.dart';
 
 import '../../package/models.dart' show PackageView;
-import '../../publisher/models.dart' show Publisher;
+import '../../publisher/models.dart' show Publisher, PublisherSummary;
 import '../../search/search_form.dart' show SearchForm;
 import '../../shared/urls.dart' as urls;
 import '../../shared/utils.dart' show shortDateFormat;
@@ -30,7 +30,7 @@ String renderCreatePublisherPage() {
 }
 
 /// Renders the `views/publisher/publisher_list.mustache` template
-String renderPublisherList(List<Publisher> publishers,
+String renderPublisherList(List<PublisherSummary> publishers,
     {@required bool isGlobal}) {
   final noPublisherHtml = isGlobal
       ? 'No publisher has been registered.'
@@ -55,7 +55,7 @@ String renderPublisherList(List<Publisher> publishers,
 
 /// Renders the `views/publisher/publisher_list.mustache` template on a standard
 /// layout.
-String renderPublisherListPage(List<Publisher> publishers) {
+String renderPublisherListPage(List<PublisherSummary> publishers) {
   final content = renderPublisherList(publishers, isGlobal: true);
   return renderLayoutPage(
     PageType.listing,

--- a/app/lib/publisher/backend.dart
+++ b/app/lib/publisher/backend.dart
@@ -208,6 +208,7 @@ class PublisherBackend {
       ]);
     });
     await purgeAccountCache(userId: user.userId);
+    await cache.allPublishersPage().purge();
 
     // Return publisher as it was created
     final key = _db.emptyKey.append(Publisher, id: publisherId);

--- a/app/lib/publisher/models.dart
+++ b/app/lib/publisher/models.dart
@@ -2,7 +2,12 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:json_annotation/json_annotation.dart';
+import 'package:meta/meta.dart';
+
 import '../shared/datastore.dart' as db;
+
+part 'models.g.dart';
 
 /// Canonical publisher data.
 @db.Kind(name: 'Publisher', idType: db.IdType.String)
@@ -117,4 +122,32 @@ class PublisherMember extends db.ExpandoModel<String> {
       ..updated = updated
       ..role = role;
   }
+}
+
+@JsonSerializable()
+class PublisherPage {
+  final List<PublisherSummary> publishers;
+
+  PublisherPage({
+    @required this.publishers,
+  });
+
+  factory PublisherPage.fromJson(Map<String, dynamic> json) =>
+      _$PublisherPageFromJson(json);
+  Map<String, dynamic> toJson() => _$PublisherPageToJson(this);
+}
+
+@JsonSerializable()
+class PublisherSummary {
+  final String publisherId;
+  final DateTime created;
+
+  PublisherSummary({
+    @required this.publisherId,
+    @required this.created,
+  });
+
+  factory PublisherSummary.fromJson(Map<String, dynamic> json) =>
+      _$PublisherSummaryFromJson(json);
+  Map<String, dynamic> toJson() => _$PublisherSummaryToJson(this);
 }

--- a/app/lib/publisher/models.g.dart
+++ b/app/lib/publisher/models.g.dart
@@ -1,0 +1,37 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'models.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+PublisherPage _$PublisherPageFromJson(Map<String, dynamic> json) {
+  return PublisherPage(
+    publishers: (json['publishers'] as List)
+        ?.map((e) => e == null
+            ? null
+            : PublisherSummary.fromJson(e as Map<String, dynamic>))
+        ?.toList(),
+  );
+}
+
+Map<String, dynamic> _$PublisherPageToJson(PublisherPage instance) =>
+    <String, dynamic>{
+      'publishers': instance.publishers,
+    };
+
+PublisherSummary _$PublisherSummaryFromJson(Map<String, dynamic> json) {
+  return PublisherSummary(
+    publisherId: json['publisherId'] as String,
+    created: json['created'] == null
+        ? null
+        : DateTime.parse(json['created'] as String),
+  );
+}
+
+Map<String, dynamic> _$PublisherSummaryToJson(PublisherSummary instance) =>
+    <String, dynamic>{
+      'publisherId': instance.publisherId,
+      'created': instance.created?.toIso8601String(),
+    };

--- a/app/lib/shared/redis_cache.dart
+++ b/app/lib/shared/redis_cache.dart
@@ -18,6 +18,7 @@ import 'package:client_data/package_api.dart' show VersionScore;
 import '../account/models.dart' show LikeData, UserSessionData;
 import '../dartdoc/models.dart' show DartdocEntry, FileInfo;
 import '../package/models.dart' show PackageView;
+import '../publisher/models.dart' show PublisherPage;
 import '../scorecard/models.dart' show ScoreCardData;
 import '../search/search_service.dart' show PackageSearchResult;
 import '../service/secret/backend.dart';
@@ -219,6 +220,18 @@ class CachePatterns {
       .withPrefix('sitemap')
       .withTTL(Duration(hours: 12))
       .withCodec(utf8)[requestedUri];
+
+  Entry<PublisherPage> allPublishersPage() => publisherPage('-');
+
+  Entry<PublisherPage> publisherPage(String userId) => _cache
+      .withPrefix('publisher-page')
+      .withTTL(Duration(hours: 4))
+      .withCodec(utf8)
+      .withCodec(json)
+      .withCodec(wrapAsCodec(
+        encode: (PublisherPage list) => list.toJson(),
+        decode: (data) => PublisherPage.fromJson(data as Map<String, dynamic>),
+      ))['$userId'];
 }
 
 /// The active cache.

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -613,19 +613,14 @@ void main() {
     scopedTest('publisher list page', () {
       final html = renderPublisherListPage(
         [
-          Publisher()
-            ..id = 'example.com'
-            ..contactEmail = 'hello@example.com'
-            ..description = 'This is our little software developer shop.\n\n'
-                'We develop full-stack in Dart, and happy about it.'
-            ..websiteUrl = 'https://example.com/'
-            ..created = DateTime(2019, 09, 13),
-          Publisher()
-            ..id = 'other-domain.com'
-            ..contactEmail = 'hello@other-domain.com'
-            ..description = 'We do software.'
-            ..websiteUrl = 'https://other-domain.com/'
-            ..created = DateTime(2019, 09, 19),
+          PublisherSummary(
+            publisherId: 'example.com',
+            created: DateTime(2019, 09, 13),
+          ),
+          PublisherSummary(
+            publisherId: 'other-domain.com',
+            created: DateTime(2019, 09, 19),
+          ),
         ],
       );
       expectGoldenFile(html, 'publisher_list_page.html');
@@ -723,7 +718,10 @@ void main() {
         user: hansUser,
         userSessionData: hansUserSessionData,
         publishers: [
-          exampleComPublisher,
+          PublisherSummary(
+            publisherId: exampleComPublisher.publisherId,
+            created: exampleComPublisher.created,
+          ),
         ],
       );
       expectGoldenFile(html, 'my_publishers.html');


### PR DESCRIPTION
- Fixes #3598.
- Caches the list of publishers + their created timestamp for returning in various APIs and internal calls.