### PR TITLE
Simpler test-profile normalizer

### DIFF
--- a/app/lib/tool/test_profile/models.dart
+++ b/app/lib/tool/test_profile/models.dart
@@ -8,8 +8,6 @@ import 'package:json_annotation/json_annotation.dart';
 import 'package:meta/meta.dart';
 import 'package:yaml/yaml.dart' as yaml;
 
-import 'normalizer.dart';
-
 part 'models.g.dart';
 
 /// The configuration to use when creating a local (partial) mirror of pub.dev
@@ -32,24 +30,12 @@ class TestProfile {
         publishers = publishers ?? <TestPublisher>[],
         users = users ?? <TestUser>[];
 
-  factory TestProfile.fromJson(Map<String, dynamic> json,
-      {bool normalize = false}) {
-    final mc = _$TestProfileFromJson(json);
-    if (normalize) {
-      return TestProfileNormalizer().normalize(mc);
-    } else {
-      return mc;
-    }
-  }
+  factory TestProfile.fromJson(Map<String, dynamic> json) =>
+      _$TestProfileFromJson(json);
 
-  factory TestProfile.fromYaml(String source, {bool normalize = false}) {
+  factory TestProfile.fromYaml(String source) {
     final map = json.decode(json.encode(yaml.loadYaml(source)));
-    final mc = TestProfile.fromJson(map as Map<String, dynamic>);
-    if (normalize) {
-      return TestProfileNormalizer().normalize(mc);
-    } else {
-      return mc;
-    }
+    return TestProfile.fromJson(map as Map<String, dynamic>);
   }
 
   Map<String, dynamic> toJson() => _$TestProfileToJson(this);

--- a/app/lib/tool/test_profile/normalizer.dart
+++ b/app/lib/tool/test_profile/normalizer.dart
@@ -6,95 +6,91 @@ import 'package:meta/meta.dart';
 
 import 'models.dart';
 
-class TestProfileNormalizer {
-  String oauthUserIdFromEmail(String email) =>
-      email.replaceAll('.', '-dot-').replaceAll('@', '-at-');
+/// Creates a new TestProfile with the missing entities (e.g. users or publishers)
+/// created.
+TestProfile normalize(TestProfile profile) {
+  final users = <String, TestUser>{};
+  final publishers = <String, TestPublisher>{};
+  final packages = <String, TestPackage>{};
 
-  TestProfile normalize(TestProfile profile) {
-    final users = <String, TestUser>{};
-    final publishers = <String, TestPublisher>{};
-    final packages = <String, TestPackage>{};
-
-    profile.users?.forEach((user) {
-      users[user.email] = user;
-    });
-    if (profile.defaultUser != null) {
-      _createUserIfNeeded(users, profile.defaultUser);
-    }
-
-    profile.publishers?.forEach((publisher) {
-      publishers[publisher.name] = publisher;
-      publisher.members?.forEach((member) {
-        _createUserIfNeeded(users, member.email);
-      });
-    });
-
-    profile.packages?.forEach((package) {
-      packages[package.name] = package;
-      package.uploaders?.forEach((uploader) {
-        _createUserIfNeeded(users, uploader);
-      });
-    });
-
-    final defaultUser = profile.defaultUser ?? users.keys.first;
-
-    profile.packages?.forEach((package) {
-      if (package.publisher != null) {
-        _createPublisherIfNeeded(
-          publishers,
-          package.publisher,
-          memberEmail: defaultUser,
-        );
-      } else if (package.uploaders == null || package.uploaders.isEmpty) {
-        packages[package.name] = package.change(uploaders: [defaultUser]);
-      }
-    });
-
-    return TestProfile(
-      defaultUser: defaultUser,
-      users: users.values.toList(),
-      publishers: publishers.values.toList(),
-      packages: packages.values.toList(),
-    );
+  profile.users?.forEach((user) {
+    users[user.email] = user;
+  });
+  if (profile.defaultUser != null) {
+    _createUserIfNeeded(users, profile.defaultUser);
   }
 
-  TestUser _createUserIfNeeded(Map<String, TestUser> users, String email) {
-    return users.putIfAbsent(
-      email,
-      () => TestUser(
-        email: email,
-        oauthUserId: oauthUserIdFromEmail(email),
-        created: DateTime.now().toUtc(),
-        isDeleted: false,
-        likes: <String>[],
-      ),
-    );
-  }
+  profile.publishers?.forEach((publisher) {
+    publishers[publisher.name] = publisher;
+    publisher.members?.forEach((member) {
+      _createUserIfNeeded(users, member.email);
+    });
+  });
 
-  TestPublisher _createPublisherIfNeeded(
-    Map<String, TestPublisher> publishers,
-    String publisherId, {
-    @required String memberEmail,
-    DateTime created,
-    DateTime updated,
-  }) {
-    return publishers.putIfAbsent(publisherId, () {
-      final now = DateTime.now().toUtc();
-      final publisherCreated = created ?? now;
-      final publisherUpdated = updated ?? publisherCreated;
-      return TestPublisher(
-        name: publisherId,
-        created: publisherCreated,
-        updated: publisherUpdated,
-        members: <TestMember>[
-          TestMember(
-            email: memberEmail,
-            role: 'admin',
-            created: publisherUpdated,
-            updated: publisherUpdated,
-          ),
-        ],
+  profile.packages?.forEach((package) {
+    packages[package.name] = package;
+    package.uploaders?.forEach((uploader) {
+      _createUserIfNeeded(users, uploader);
+    });
+  });
+
+  final defaultUser = profile.defaultUser ?? users.keys.first;
+
+  profile.packages?.forEach((package) {
+    if (package.publisher != null) {
+      _createPublisherIfNeeded(
+        publishers,
+        package.publisher,
+        memberEmail: defaultUser,
       );
-    });
-  }
+    } else if (package.uploaders == null || package.uploaders.isEmpty) {
+      packages[package.name] = package.change(uploaders: [defaultUser]);
+    }
+  });
+
+  return TestProfile(
+    defaultUser: defaultUser,
+    users: users.values.toList(),
+    publishers: publishers.values.toList(),
+    packages: packages.values.toList(),
+  );
+}
+
+TestUser _createUserIfNeeded(Map<String, TestUser> users, String email) {
+  return users.putIfAbsent(
+    email,
+    () => TestUser(
+      email: email,
+      created: DateTime.now().toUtc(),
+      isDeleted: false,
+      likes: <String>[],
+    ),
+  );
+}
+
+TestPublisher _createPublisherIfNeeded(
+  Map<String, TestPublisher> publishers,
+  String publisherId, {
+  @required String memberEmail,
+  DateTime created,
+  DateTime updated,
+}) {
+  return publishers.putIfAbsent(publisherId, () {
+    final now = DateTime.now().toUtc();
+    final publisherCreated = created ?? now;
+    final publisherUpdated = updated ?? publisherCreated;
+    return TestPublisher(
+      name: publisherId,
+      created: publisherCreated,
+      updated: publisherUpdated,
+      members: <TestMember>[
+        TestMember(
+          email: memberEmail,
+          role: 'admin',
+          created: publisherUpdated,
+          updated: publisherUpdated,
+        ),
+      ],
+    );
+  });
 }

--- a/app/test/tool/test_profile/importer_test.dart
+++ b/app/test/tool/test_profile/importer_test.dart
@@ -20,7 +20,7 @@ void main() {
     testWithServices(
       'a few entities',
       () async {
-        final profile = TestProfileNormalizer().normalize(TestProfile(
+        final profile = normalize(TestProfile(
           defaultUser: 'dev@example.com',
           packages: [
             TestPackage(

--- a/app/test/tool/test_profile/model_normalization_test.dart
+++ b/app/test/tool/test_profile/model_normalization_test.dart
@@ -5,12 +5,13 @@
 import 'package:test/test.dart';
 
 import 'package:pub_dev/tool/test_profile/models.dart';
+import 'package:pub_dev/tool/test_profile/normalizer.dart';
 
 void main() {
   group('normalization tests', () {
     test('a package with a publisher', () {
       expect(
-        TestProfile.fromYaml(
+        normalize(TestProfile.fromYaml(
           '''
 defaultUser: user@domain.com
 packages:
@@ -18,8 +19,7 @@ packages:
     publisher: example.com
     versions: ['1.0.0', '2.0.0']
 ''',
-          normalize: true,
-        ).toJson(),
+        )).toJson(),
         {
           'packages': [
             {
@@ -46,7 +46,6 @@ packages:
           'users': [
             {
               'email': 'user@domain.com',
-              'oauthUserId': 'user-at-domain-dot-com',
               'created': isNotEmpty,
               'isDeleted': false,
               'likes': [],
@@ -59,15 +58,14 @@ packages:
 
     test('a package without publisher', () {
       expect(
-        TestProfile.fromYaml(
+        normalize(TestProfile.fromYaml(
           '''
 defaultUser: user@domain.com
 packages:
   - name: foo
     versions: ['1.0.0', '2.0.0']
 ''',
-          normalize: true,
-        ).toJson(),
+        )).toJson(),
         {
           'packages': [
             {
@@ -80,7 +78,6 @@ packages:
           'users': [
             {
               'email': 'user@domain.com',
-              'oauthUserId': 'user-at-domain-dot-com',
               'created': isNotEmpty,
               'isDeleted': false,
               'likes': [],

--- a/app/test/tool/test_profile/resolve_test.dart
+++ b/app/test/tool/test_profile/resolve_test.dart
@@ -10,7 +10,7 @@ import 'package:pub_dev/tool/test_profile/resolver.dart';
 
 void main() {
   Future<List<ResolvedVersion>> _resolve(List<TestPackage> packages) async {
-    final profile = TestProfileNormalizer().normalize(TestProfile(
+    final profile = normalize(TestProfile(
       publishers: [],
       packages: packages,
       users: [],

--- a/pkg/fake_pub_server/bin/init_data_file.dart
+++ b/pkg/fake_pub_server/bin/init_data_file.dart
@@ -15,6 +15,7 @@ import 'package:pub_dev/service/services.dart';
 import 'package:pub_dev/shared/configuration.dart';
 import 'package:pub_dev/tool/test_profile/importer.dart';
 import 'package:pub_dev/tool/test_profile/models.dart';
+import 'package:pub_dev/tool/test_profile/normalizer.dart';
 
 final _argParser = ArgParser()
   ..addOption('test-profile', help: 'The file to read the test profile from.')
@@ -23,10 +24,9 @@ final _argParser = ArgParser()
 
 Future<void> main(List<String> args) async {
   final argv = _argParser.parse(args);
-  final profile = TestProfile.fromYaml(
+  final profile = normalize(TestProfile.fromYaml(
     await File(argv['test-profile'] as String).readAsString(),
-    normalize: true,
-  );
+  ));
 
   final cacheDirArg = argv['cache-dir'] as String;
   final cacheDir = cacheDirArg ?? Directory.systemTemp.createTempSync().path;


### PR DESCRIPTION
- removes `oauthUserId` setter from the generic normalizer
- removes `normalize` parameter from the `TestProfile` constructors
- keeps only the `normalize` method, instead of the class, as I plan to make this non-configurable (importer should configure the `oauthUserId`), only filling in the missing defaults
- in a follow-up PR I expect this to also use the `ResolvedVersion` to create entries for the resolved packages.