### PR TITLE
Click indicator for <summary> element.

### DIFF
--- a/pkg/web_css/lib/src/_base.scss
+++ b/pkg/web_css/lib/src/_base.scss
@@ -55,8 +55,18 @@ img {
   --mdc-theme-primary: #0175C2;
 }
 
-summary:focus {
-  outline: 0;
+summary {
+  cursor: pointer;
+  background: transparent;
+  transition: background-color 0.3s;
+
+  &:hover {
+    background: lighten($color-link, 55%);
+  }
+
+  &:focus {
+    outline: 0;
+  }
 }
 
 button {


### PR DESCRIPTION
- Fixes #4211.
- Uses click mouse pointer.
- Uses a lighter shade of the link color as a background + quick animation:

<img width="725" alt="Screenshot 2020-11-04 at 16 21 56" src="https://user-images.githubusercontent.com/4778111/98130107-306afb80-1eba-11eb-80d6-86dd17bc781d.png">
