### PR TITLE
TestProfile import calls normalize internally.

### DIFF
--- a/app/lib/tool/test_profile/models.dart
+++ b/app/lib/tool/test_profile/models.dart
@@ -23,8 +23,8 @@ class TestProfile {
 
   TestProfile({
     @required List<TestPackage> packages,
-    @required List<TestPublisher> publishers,
-    @required List<TestUser> users,
+    List<TestPublisher> publishers,
+    List<TestUser> users,
     this.defaultUser,
   })  : packages = packages ?? <TestPackage>[],
         publishers = publishers ?? <TestPublisher>[],
@@ -39,11 +39,6 @@ class TestProfile {
   }
 
   Map<String, dynamic> toJson() => _$TestProfileToJson(this);
-
-  /// Returns the [TestPackage] object or null if none was specified.
-  TestPackage getTestPackage(String name) {
-    return packages.firstWhere((p) => p.name == name, orElse: () => null);
-  }
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
@@ -71,12 +66,15 @@ class TestPackage {
 
   Map<String, dynamic> toJson() => _$TestPackageToJson(this);
 
-  TestPackage change({List<String> uploaders}) {
+  TestPackage change({
+    List<String> uploaders,
+    List<String> versions,
+  }) {
     return TestPackage(
       name: name,
       uploaders: uploaders ?? this.uploaders,
       publisher: publisher,
-      versions: versions,
+      versions: versions ?? this.versions,
     );
   }
 }
@@ -161,8 +159,6 @@ class ResolvedVersion implements Comparable<ResolvedVersion> {
       _$ResolvedVersionFromJson(json);
 
   Map<String, dynamic> toJson() => _$ResolvedVersionToJson(this);
-
-  String get archiveName => '$package-$version.tar.gz';
 
   @override
   int compareTo(ResolvedVersion other) {

--- a/app/test/tool/test_profile/model_normalization_test.dart
+++ b/app/test/tool/test_profile/model_normalization_test.dart
@@ -87,5 +87,39 @@ packages:
         },
       );
     });
+
+    test('resolved versions', () {
+      expect(
+        normalize(
+          TestProfile.fromYaml('''
+defaultUser: user@domain.com
+packages:
+  - name: foo
+'''),
+          resolvedVersions: [
+            ResolvedVersion(package: 'foo', version: '1.1.0'),
+          ],
+        ).toJson(),
+        {
+          'packages': [
+            {
+              'name': 'foo',
+              'uploaders': ['user@domain.com'],
+              'versions': ['1.1.0']
+            }
+          ],
+          'publishers': [],
+          'users': [
+            {
+              'email': 'user@domain.com',
+              'created': isNotEmpty,
+              'isDeleted': false,
+              'likes': [],
+            }
+          ],
+          'defaultUser': 'user@domain.com',
+        },
+      );
+    });
   });
 }

--- a/pkg/fake_pub_server/bin/init_data_file.dart
+++ b/pkg/fake_pub_server/bin/init_data_file.dart
@@ -15,7 +15,6 @@ import 'package:pub_dev/service/services.dart';
 import 'package:pub_dev/shared/configuration.dart';
 import 'package:pub_dev/tool/test_profile/importer.dart';
 import 'package:pub_dev/tool/test_profile/models.dart';
-import 'package:pub_dev/tool/test_profile/normalizer.dart';
 
 import 'package:fake_pub_server/local_server_state.dart';
 
@@ -25,9 +24,9 @@ final _argParser = ArgParser()
 
 Future<void> main(List<String> args) async {
   final argv = _argParser.parse(args);
-  final profile = normalize(TestProfile.fromYaml(
+  final profile = TestProfile.fromYaml(
     await File(argv['test-profile'] as String).readAsString(),
-  ));
+  );
 
   final archiveCachePath = p.join(
     resolveFakePubServerDirPath(),


### PR DESCRIPTION
- Reduces the ambiguity in the importer, it doesn't need to handle cases where the resolved package was not present in the profile.
- Fewer things to care for when using profile in tests.
- Separated publisher / options updated from package upload, executing them only once.