### PR TITLE
Upgrade package:shelf_router_generator.

### DIFF
--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -23,7 +23,7 @@ packages:
     source: path
     version: "0.0.0"
   analyzer:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
@@ -84,7 +84,7 @@ packages:
       name: build
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.5.0"
   build_config:
     dependency: transitive
     description:
@@ -105,21 +105,21 @@ packages:
       name: build_resolvers
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.11"
+    version: "1.4.3"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.1"
+    version: "1.10.4"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.1"
+    version: "6.0.3"
   build_verify:
     dependency: "direct dev"
     description:
@@ -217,7 +217,7 @@ packages:
       name: dart_style
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.6"
+    version: "1.3.9"
   dartis:
     dependency: transitive
     description:
@@ -588,7 +588,7 @@ packages:
       name: shelf_router_generator
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.7.2+2"
+    version: "0.7.2+3"
   shelf_static:
     dependency: transitive
     description:
@@ -758,4 +758,4 @@ packages:
     source: hosted
     version: "2.2.1"
 sdks:
-  dart: ">=2.8.0 <3.0.0"
+  dart: ">=2.10.0-93.0.dev <3.0.0"

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -59,11 +59,7 @@ dev_dependencies:
   fake_gcloud:
     path: ../pkg/fake_gcloud
   json_serializable: '^3.0.0'
-  shelf_router_generator: ^0.7.0
+  shelf_router_generator: ^0.7.2+3
   source_gen: '^0.9.0'
   test: ^1.2.0
   xml: ^4.5.0
-
-dependency_overrides:
-  # TODO: remove override once shelf_router and shelf_router_generator is upgraded
-  analyzer: 0.40.4


### PR DESCRIPTION
Allows us to remove the `dependency_overrides` block.