### PR TITLE
Reduce the direct model surface in tests.

### DIFF
--- a/app/test/account/consent_backend_test.dart
+++ b/app/test/account/consent_backend_test.dart
@@ -19,7 +19,7 @@ void main() {
       final status = await consentBackend.invitePackageUploader(
         uploaderUserId: joeUser.userId,
         uploaderEmail: joeUser.email,
-        packageName: hydrogen.package.name,
+        packageName: hydrogen.packageName,
       );
       expect(status.emailSent, isTrue);
 

--- a/app/test/account/like_test.dart
+++ b/app/test/account/like_test.dart
@@ -12,32 +12,32 @@ void main() {
   group('/api/account/likes', () {
     testWithServices('Like package', () async {
       final client = createPubApiClient(authToken: hansUser.userId);
-      final rs = await client.getLikePackage(hydrogen.package.name);
-      expect(rs.package, hydrogen.package.name);
+      final rs = await client.getLikePackage(hydrogen.packageName);
+      expect(rs.package, hydrogen.packageName);
       expect(rs.liked, false);
 
-      final rs2 = await client.likePackage(hydrogen.package.name);
-      expect(rs2.package, hydrogen.package.name);
+      final rs2 = await client.likePackage(hydrogen.packageName);
+      expect(rs2.package, hydrogen.packageName);
       expect(rs2.liked, true);
 
-      final rs3 = await client.getLikePackage(hydrogen.package.name);
-      expect(rs3.package, hydrogen.package.name);
+      final rs3 = await client.getLikePackage(hydrogen.packageName);
+      expect(rs3.package, hydrogen.packageName);
       expect(rs3.liked, true);
     });
 
     testWithServices('Like already liked package', () async {
       final client = createPubApiClient(authToken: hansUser.userId);
 
-      final rs = await client.likePackage(hydrogen.package.name);
-      expect(rs.package, hydrogen.package.name);
+      final rs = await client.likePackage(hydrogen.packageName);
+      expect(rs.package, hydrogen.packageName);
       expect(rs.liked, true);
 
-      final rs2 = await client.likePackage(hydrogen.package.name);
-      expect(rs2.package, hydrogen.package.name);
+      final rs2 = await client.likePackage(hydrogen.packageName);
+      expect(rs2.package, hydrogen.packageName);
       expect(rs2.liked, true);
 
-      final rs3 = await client.getLikePackage(hydrogen.package.name);
-      expect(rs3.package, hydrogen.package.name);
+      final rs3 = await client.getLikePackage(hydrogen.packageName);
+      expect(rs3.package, hydrogen.packageName);
       expect(rs3.liked, true);
     });
 
@@ -52,20 +52,20 @@ void main() {
       final rs = await client.listPackageLikes();
       expect(rs.likedPackages.isEmpty, true);
 
-      final rs2 = await client.likePackage(hydrogen.package.name);
-      expect(rs2.package, hydrogen.package.name);
+      final rs2 = await client.likePackage(hydrogen.packageName);
+      expect(rs2.package, hydrogen.packageName);
       expect(rs2.liked, true);
 
-      final rs3 = await client.likePackage(helium.package.name);
-      expect(rs3.package, helium.package.name);
+      final rs3 = await client.likePackage(helium.packageName);
+      expect(rs3.package, helium.packageName);
       expect(rs3.liked, true);
 
       final rs4 = await client.listPackageLikes();
       expect(rs4.likedPackages.length, 2);
       expect(rs4.likedPackages.map((e) => e.package),
-          contains(hydrogen.package.name));
+          contains(hydrogen.packageName));
       expect(rs4.likedPackages.map((e) => e.package),
-          contains(helium.package.name));
+          contains(helium.packageName));
       expect(rs4.likedPackages[0].liked, true);
       expect(rs4.likedPackages[1].liked, true);
     });
@@ -75,12 +75,12 @@ void main() {
       final rs = await client.listPackageLikes();
       expect(rs.likedPackages.isEmpty, true);
 
-      final rs2 = await client.likePackage(hydrogen.package.name);
-      expect(rs2.package, hydrogen.package.name);
+      final rs2 = await client.likePackage(hydrogen.packageName);
+      expect(rs2.package, hydrogen.packageName);
       expect(rs2.liked, true);
 
-      final rs3 = await client.likePackage(helium.package.name);
-      expect(rs3.package, helium.package.name);
+      final rs3 = await client.likePackage(helium.packageName);
+      expect(rs3.package, helium.packageName);
       expect(rs3.liked, true);
 
       final rs4 = await client.listPackageLikes();
@@ -88,15 +88,15 @@ void main() {
       expect(rs4.likedPackages[0].liked, true);
       expect(rs4.likedPackages[1].liked, true);
 
-      await client.unlikePackage(hydrogen.package.name);
+      await client.unlikePackage(hydrogen.packageName);
 
-      final rs5 = await client.getLikePackage(hydrogen.package.name);
-      expect(rs5.package, hydrogen.package.name);
+      final rs5 = await client.getLikePackage(hydrogen.packageName);
+      expect(rs5.package, hydrogen.packageName);
       expect(rs5.liked, false);
 
       final rs6 = await client.listPackageLikes();
       expect(rs6.likedPackages.length, 1);
-      expect(rs6.likedPackages[0].package, helium.package.name);
+      expect(rs6.likedPackages[0].package, helium.packageName);
     });
 
     testWithServices('Unlike non-existing package', () async {
@@ -116,8 +116,8 @@ void main() {
       final rs1 = await client2.listPackageLikes();
       expect(rs1.likedPackages.isEmpty, true);
 
-      final rs2 = await client.likePackage(hydrogen.package.name);
-      expect(rs2.package, hydrogen.package.name);
+      final rs2 = await client.likePackage(hydrogen.packageName);
+      expect(rs2.package, hydrogen.packageName);
       expect(rs2.liked, true);
 
       final rs3 = await client2.listPackageLikes();
@@ -129,45 +129,45 @@ void main() {
       final client = createPubApiClient(authToken: hansUser.userId);
       final client2 = createPubApiClient(authToken: joeUser.userId);
 
-      final rs = await client.getPackageLikes(hydrogen.package.name);
+      final rs = await client.getPackageLikes(hydrogen.packageName);
       expect(rs.likes, 0);
-      final rs2 = await client2.getPackageLikes(hydrogen.package.name);
+      final rs2 = await client2.getPackageLikes(hydrogen.packageName);
       expect(rs2.likes, 0);
 
-      await client.likePackage(hydrogen.package.name);
+      await client.likePackage(hydrogen.packageName);
 
-      final rs3 = await client.getPackageLikes(hydrogen.package.name);
+      final rs3 = await client.getPackageLikes(hydrogen.packageName);
       expect(rs3.likes, 1);
-      final rs4 = await client2.getPackageLikes(hydrogen.package.name);
+      final rs4 = await client2.getPackageLikes(hydrogen.packageName);
       expect(rs4.likes, 1);
 
-      await client2.likePackage(hydrogen.package.name);
+      await client2.likePackage(hydrogen.packageName);
 
-      final rs5 = await client.getPackageLikes(hydrogen.package.name);
+      final rs5 = await client.getPackageLikes(hydrogen.packageName);
       expect(rs5.likes, 2);
-      final rs6 = await client2.getPackageLikes(hydrogen.package.name);
+      final rs6 = await client2.getPackageLikes(hydrogen.packageName);
       expect(rs6.likes, 2);
 
-      await client.unlikePackage(hydrogen.package.name);
+      await client.unlikePackage(hydrogen.packageName);
 
-      final rs7 = await client.getPackageLikes(hydrogen.package.name);
+      final rs7 = await client.getPackageLikes(hydrogen.packageName);
       expect(rs7.likes, 1);
-      final rs8 = await client2.getPackageLikes(hydrogen.package.name);
+      final rs8 = await client2.getPackageLikes(hydrogen.packageName);
       expect(rs8.likes, 1);
 
       /// Unliking already unliked package doesn't cause decrement
-      await client.unlikePackage(hydrogen.package.name);
+      await client.unlikePackage(hydrogen.packageName);
 
-      final rs9 = await client.getPackageLikes(hydrogen.package.name);
+      final rs9 = await client.getPackageLikes(hydrogen.packageName);
       expect(rs9.likes, 1);
-      final rs10 = await client2.getPackageLikes(hydrogen.package.name);
+      final rs10 = await client2.getPackageLikes(hydrogen.packageName);
       expect(rs10.likes, 1);
 
-      await client2.unlikePackage(hydrogen.package.name);
+      await client2.unlikePackage(hydrogen.packageName);
 
-      final rs11 = await client.getPackageLikes(hydrogen.package.name);
+      final rs11 = await client.getPackageLikes(hydrogen.packageName);
       expect(rs11.likes, 0);
-      final rs12 = await client2.getPackageLikes(hydrogen.package.name);
+      final rs12 = await client2.getPackageLikes(hydrogen.packageName);
       expect(rs12.likes, 0);
     });
 
@@ -181,14 +181,14 @@ void main() {
         'Get number of likes for client without authorization header.',
         () async {
       final client = createPubApiClient();
-      final rs = await client.getPackageLikes(hydrogen.package.name);
+      final rs = await client.getPackageLikes(hydrogen.packageName);
       expect(rs.likes, 0);
 
       final authenticatedClient =
           createPubApiClient(authToken: hansUser.userId);
-      await authenticatedClient.likePackage(hydrogen.package.name);
+      await authenticatedClient.likePackage(hydrogen.packageName);
 
-      final rs1 = await client.getPackageLikes(hydrogen.package.name);
+      final rs1 = await client.getPackageLikes(hydrogen.packageName);
       expect(rs1.likes, 1);
     });
   });

--- a/app/test/admin/api_test.dart
+++ b/app/test/admin/api_test.dart
@@ -164,13 +164,13 @@ void main() {
 
     group('Delete package', () {
       _testNotAdmin(
-          (client) => client.adminRemovePackage(hydrogen.package.name));
+          (client) => client.adminRemovePackage(hydrogen.packageName));
 
       testWithServices('OK', () async {
         final client = createPubApiClient(authToken: adminUser.userId);
 
         final pkgKey =
-            dbService.emptyKey.append(Package, id: hydrogen.package.name);
+            dbService.emptyKey.append(Package, id: hydrogen.packageName);
         final package = await dbService.lookupValue<Package>(pkgKey);
         expect(package, isNotNull);
 
@@ -181,23 +181,23 @@ void main() {
         expect(versions.map((v) => v.version), expectedVersions);
 
         final hansClient = createPubApiClient(authToken: hansUser.userId);
-        await hansClient.likePackage(hydrogen.package.name);
+        await hansClient.likePackage(hydrogen.packageName);
 
         final likeKey = dbService.emptyKey
             .append(User, id: hansUser.userId)
-            .append(Like, id: hydrogen.package.name);
+            .append(Like, id: hydrogen.packageName);
         final like =
             await dbService.lookupValue<Like>(likeKey, orElse: () => null);
         expect(like, isNotNull);
 
         final moderatedPkgKey = dbService.emptyKey
-            .append(ModeratedPackage, id: hydrogen.package.name);
+            .append(ModeratedPackage, id: hydrogen.packageName);
         ModeratedPackage moderatedPkg = await dbService
             .lookupValue<ModeratedPackage>(moderatedPkgKey, orElse: () => null);
         expect(moderatedPkg, isNull);
 
         final timeBeforeRemoval = DateTime.now().toUtc();
-        final rs = await client.adminRemovePackage(hydrogen.package.name);
+        final rs = await client.adminRemovePackage(hydrogen.packageName);
 
         expect(utf8.decode(rs), '{"status":"OK"}');
 
@@ -225,14 +225,14 @@ void main() {
 
     group('Delete package version', () {
       _testNotAdmin((client) => client.adminRemovePackageVersion(
-          hydrogen.package.name, hydrogen.package.latestVersion));
+          hydrogen.packageName, hydrogen.latestVersion));
 
       testWithServices('OK', () async {
         final client = createPubApiClient(authToken: adminUser.userId);
-        final removeVersion = hydrogen.package.latestVersion;
+        final removeVersion = hydrogen.latestVersion;
 
         final pkgKey =
-            dbService.emptyKey.append(Package, id: hydrogen.package.name);
+            dbService.emptyKey.append(Package, id: hydrogen.packageName);
         final package = await dbService.lookupValue<Package>(pkgKey);
         expect(package, isNotNull);
 
@@ -243,24 +243,24 @@ void main() {
         expect(versions.map((v) => v.version), expectedVersions);
 
         final hansClient = createPubApiClient(authToken: hansUser.userId);
-        await hansClient.likePackage(hydrogen.package.name);
+        await hansClient.likePackage(hydrogen.packageName);
 
         final likeKey = dbService.emptyKey
             .append(User, id: hansUser.userId)
-            .append(Like, id: hydrogen.package.name);
+            .append(Like, id: hydrogen.packageName);
         final like =
             await dbService.lookupValue<Like>(likeKey, orElse: () => null);
         expect(like, isNotNull);
 
         final moderatedPkgKey = dbService.emptyKey
-            .append(ModeratedPackage, id: hydrogen.package.name);
+            .append(ModeratedPackage, id: hydrogen.packageName);
         ModeratedPackage moderatedPkg = await dbService
             .lookupValue<ModeratedPackage>(moderatedPkgKey, orElse: () => null);
         expect(moderatedPkg, isNull);
 
         final timeBeforeRemoval = DateTime.now().toUtc();
         final rs = await client.adminRemovePackageVersion(
-            hydrogen.package.name, removeVersion);
+            hydrogen.packageName, removeVersion);
 
         expect(utf8.decode(rs), '{"status":"OK"}');
 
@@ -321,14 +321,14 @@ void main() {
         final client = createPubApiClient(authToken: adminUser.userId);
         final hansClient = createPubApiClient(authToken: hansUser.userId);
 
-        await hansClient.likePackage(helium.package.name);
+        await hansClient.likePackage(helium.packageName);
 
-        final r2 = await client.getPackageLikes(helium.package.name);
+        final r2 = await client.getPackageLikes(helium.packageName);
         expect(r2.likes, 1);
 
         final likeKey = dbService.emptyKey
             .append(User, id: hansUser.userId)
-            .append(Like, id: helium.package.name);
+            .append(Like, id: helium.packageName);
 
         Like like =
             await dbService.lookupValue<Like>(likeKey, orElse: () => null);
@@ -336,7 +336,7 @@ void main() {
 
         await client.adminRemoveUser(hansUser.userId);
 
-        final r3 = await client.getPackageLikes(helium.package.name);
+        final r3 = await client.getPackageLikes(helium.packageName);
         expect(r3.likes, 0);
 
         like = await dbService.lookupValue<Like>(likeKey, orElse: () => null);

--- a/app/test/dartdoc/dartdoc_report_test.dart
+++ b/app/test/dartdoc/dartdoc_report_test.dart
@@ -16,14 +16,14 @@ void main() {
   group('ScoreCard dartdoc report', () {
     testWithServices('write and read dartdoc reports', () async {
       await scoreCardBackend.updateReport(
-          hydrogen.package.name,
-          hydrogen.latestStableVersion.version,
+          hydrogen.packageName,
+          hydrogen.latestVersion,
           DartdocReport(
             reportStatus: ReportStatus.success,
             dartdocEntry: DartdocEntry(
               uuid: 'report-uuid-1',
-              packageName: hydrogen.package.name,
-              packageVersion: hydrogen.latestStableVersion.version,
+              packageName: hydrogen.packageName,
+              packageVersion: hydrogen.latestVersion,
               runtimeVersion: runtimeVersion,
               flutterVersion: flutterVersion,
               dartdocVersion: dartdocVersion,
@@ -42,8 +42,8 @@ void main() {
           ));
 
       final reports = await scoreCardBackend.loadReportForAllVersions(
-        hydrogen.package.name,
-        [hydrogen.latestStableVersion.version, '0.1.2'],
+        hydrogen.packageName,
+        [hydrogen.latestVersion, '0.1.2'],
         reportType: ReportType.dartdoc,
       );
 
@@ -54,8 +54,8 @@ void main() {
       expect(report.dartdocEntry.totalSize, 121212);
 
       final entries = await dartdocBackend.getEntriesForVersions(
-        hydrogen.package.name,
-        [hydrogen.latestStableVersion.version, '0.1.2'],
+        hydrogen.packageName,
+        [hydrogen.latestVersion, '0.1.2'],
       );
 
       expect(entries.first, isNotNull);

--- a/app/test/frontend/handlers/documentation_test.dart
+++ b/app/test/frontend/handlers/documentation_test.dart
@@ -116,7 +116,7 @@ void main() {
     });
 
     testWithServices('withheld package gets rejected', () async {
-      final pkg = await dbService.lookupValue<Package>(foobarPackage.key);
+      final pkg = await dbService.lookupValue<Package>(foobarPkgKey);
       await dbService.commit(inserts: [pkg..isWithheld = true]);
       await expectNotFoundResponse(
           await issueGet('/documentation/foobar_pkg/latest/'));

--- a/app/test/frontend/handlers/package_test.dart
+++ b/app/test/frontend/handlers/package_test.dart
@@ -33,7 +33,7 @@ void main() {
     });
 
     testWithServices('withheld package - not found', () async {
-      final pkg = await dbService.lookupValue<Package>(foobarPackage.key);
+      final pkg = await dbService.lookupValue<Package>(foobarPkgKey);
       await dbService.commit(inserts: [pkg..isWithheld = true]);
       await expectNotFoundResponse(await issueGet('/packages/foobar_pkg'));
       await expectNotFoundResponse(

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -181,8 +181,8 @@ void main() {
               reportStatus: ReportStatus.success,
               dartdocEntry: DartdocEntry(
                 uuid: '1234-5678-dartdocentry-90ab',
-                packageName: foobarStablePV.package,
-                packageVersion: foobarStablePV.version,
+                packageName: foobarPkgName,
+                packageVersion: foobarStableVersion,
                 isLatest: true,
                 isObsolete: false,
                 usesFlutter: false,

--- a/app/test/package/backend_test.dart
+++ b/app/test/package/backend_test.dart
@@ -35,7 +35,7 @@ void main() {
       });
 
       testWithServices('default packages with withheld', () async {
-        final pkg = await dbService.lookupValue<Package>(foobarPackage.key);
+        final pkg = await dbService.lookupValue<Package>(foobarPkgKey);
         await dbService.commit(inserts: [pkg..isWithheld = true]);
         final page = await packageBackend.latestPackages();
         expect(page.packages.map((p) => p.name), [
@@ -46,8 +46,7 @@ void main() {
       });
 
       testWithServices('default packages, extra earlier', () async {
-        final h =
-            (await dbService.lookup<Package>([helium.package.key])).single;
+        final h = (await dbService.lookup<Package>([helium.packageKey])).single;
         h.updated = DateTime(2010);
         await dbService.commit(inserts: [h]);
         final page = await packageBackend.latestPackages();
@@ -55,8 +54,7 @@ void main() {
       });
 
       testWithServices('default packages, extra later', () async {
-        final h =
-            (await dbService.lookup<Package>([helium.package.key])).single;
+        final h = (await dbService.lookup<Package>([helium.packageKey])).single;
         h.updated = DateTime(2030);
         await dbService.commit(inserts: [h]);
         final page = await packageBackend.latestPackages();
@@ -171,13 +169,13 @@ void main() {
   group('backend.repository', () {
     group('add uploader', () {
       testWithServices('not logged in', () async {
-        final pkg = foobarPackage.name;
+        final pkg = foobarPkgName;
         final rs = packageBackend.addUploader(pkg, 'a@b.com');
         await expectLater(rs, throwsA(isA<AuthenticationException>()));
       });
 
       testWithServices('not authorized', () async {
-        final pkg = foobarPackage.name;
+        final pkg = foobarPkgName;
         registerAuthenticatedUser(User()
           ..id = 'uuid-foo-at-bar-dot-com'
           ..email = 'foo@bar.com'
@@ -191,7 +189,7 @@ void main() {
         final user = await dbService.lookupValue<User>(hansUser.key);
         await dbService.commit(inserts: [user..isBlocked = true]);
         registerAuthenticatedUser(user);
-        final rs = packageBackend.addUploader(foobarPackage.name, 'a@b.com');
+        final rs = packageBackend.addUploader(foobarPkgName, 'a@b.com');
         await expectLater(rs, throwsA(isA<AuthorizationException>()));
       });
 
@@ -209,7 +207,7 @@ void main() {
           ...bundle.versions.map(pvModels).expand((m) => m),
         ]);
         await packageBackend.addUploader(pkg, newUploader);
-        final list = await dbService.lookup<Package>([bundle.package.key]);
+        final list = await dbService.lookup<Package>([bundle.packageKey]);
         final p = list.single;
         expect(p.uploaders, uploaders.map((u) => u.userId));
       }
@@ -228,7 +226,7 @@ void main() {
 
         final newUploader = 'somebody@example.com';
         final rs =
-            packageBackend.addUploader(hydrogen.package.name, newUploader);
+            packageBackend.addUploader(hydrogen.packageName, newUploader);
         await expectLater(
             rs,
             throwsA(isException.having(
@@ -238,7 +236,7 @@ void main() {
                     "They'll be added as an uploader after they accept the invitation.")));
 
         // uploaders do not change yet
-        final list = await dbService.lookup<Package>([hydrogen.package.key]);
+        final list = await dbService.lookup<Package>([hydrogen.packageKey]);
         final p = list.single;
         expect(p.uploaders, [hansUser.userId]);
 
@@ -258,14 +256,14 @@ void main() {
 
     group('invite uploader', () {
       testWithServices('not logged in', () async {
-        final pkg = foobarPackage.name;
+        final pkg = foobarPkgName;
         final rs = packageBackend.inviteUploader(
             pkg, InviteUploaderRequest(email: 'a@b.com'));
         await expectLater(rs, throwsA(isA<AuthenticationException>()));
       });
 
       testWithServices('not authorized', () async {
-        final pkg = foobarPackage.name;
+        final pkg = foobarPkgName;
         registerAuthenticatedUser(User()
           ..id = 'uuid-foo-at-bar-dot-com'
           ..email = 'foo@bar.com'
@@ -281,7 +279,7 @@ void main() {
         await dbService.commit(inserts: [user..isBlocked = true]);
         registerAuthenticatedUser(user);
         final rs = packageBackend.inviteUploader(
-            foobarPackage.name, InviteUploaderRequest(email: 'a@b.com'));
+            foobarPkgName, InviteUploaderRequest(email: 'a@b.com'));
         await expectLater(rs, throwsA(isA<AuthorizationException>()));
       });
 
@@ -324,11 +322,11 @@ void main() {
 
         final newUploader = 'somebody@example.com';
         final rs = await packageBackend.inviteUploader(
-            hydrogen.package.name, InviteUploaderRequest(email: newUploader));
+            hydrogen.packageName, InviteUploaderRequest(email: newUploader));
         expect(rs.emailSent, isTrue);
 
         // uploaders do not change yet
-        final list = await dbService.lookup<Package>([hydrogen.package.key]);
+        final list = await dbService.lookup<Package>([hydrogen.packageKey]);
         final p = list.single;
         expect(p.uploaders, [hansUser.userId]);
 
@@ -355,7 +353,7 @@ void main() {
       testWithServices('not authorized', () async {
         // replace uploader for the scope of this test
         final pkg =
-            (await dbService.lookup<Package>([hydrogen.package.key])).single;
+            (await dbService.lookup<Package>([hydrogen.packageKey])).single;
         pkg.addUploader(testUserA.userId);
         pkg.removeUploader(hansUser.userId);
         await dbService.commit(inserts: [pkg]);
@@ -393,7 +391,7 @@ void main() {
       testWithServices('cannot remove self', () async {
         // adding extra uploader for the scope of this test
         final pkg =
-            (await dbService.lookup<Package>([hydrogen.package.key])).single;
+            (await dbService.lookup<Package>([hydrogen.packageKey])).single;
         pkg.addUploader(testUserA.userId);
         await dbService.commit(inserts: [pkg]);
 
@@ -407,7 +405,7 @@ void main() {
 
       testWithServices('successful1', () async {
         // adding extra uploader for the scope of this test
-        final key = hydrogen.package.key;
+        final key = hydrogen.packageKey;
         final pkg1 = (await dbService.lookup<Package>([key])).single;
         pkg1.addUploader(testUserA.userId);
         await dbService.commit(inserts: [pkg1]);

--- a/app/test/package/package_publisher_test.dart
+++ b/app/test/package/package_publisher_test.dart
@@ -38,14 +38,14 @@ void main() {
         ));
 
     _testNoPublisher((client) => client.setPackagePublisher(
-          hydrogen.package.name,
+          hydrogen.packageName,
           PackagePublisherInfo(publisherId: 'no-domain.net'),
         ));
 
     _testPublisherAdminAuthIssues(
       exampleComPublisher.key,
       (client) => client.setPackagePublisher(
-        hydrogen.package.name,
+        hydrogen.packageName,
         PackagePublisherInfo(publisherId: 'example.com'),
       ),
     );
@@ -57,7 +57,7 @@ void main() {
 
       final client = createPubApiClient(authToken: hansUser.userId);
       final rs = client.setPackagePublisher(
-        hydrogen.package.name,
+        hydrogen.packageName,
         PackagePublisherInfo(publisherId: 'example.com'),
       );
       await expectApiException(rs,
@@ -67,7 +67,7 @@ void main() {
     testWithServices('successful', () async {
       final client = createPubApiClient(authToken: hansUser.userId);
       final rs = await client.setPackagePublisher(
-        hydrogen.package.name,
+        hydrogen.packageName,
         PackagePublisherInfo(publisherId: 'example.com'),
       );
       expect(_json(rs.toJson()), {'publisherId': 'example.com'});
@@ -85,7 +85,7 @@ void main() {
     testWithServices('not an admin', () async {
       final client = createPubApiClient(authToken: hansUser.userId);
       await client.setPackagePublisher(
-        hydrogen.package.name,
+        hydrogen.packageName,
         PackagePublisherInfo(publisherId: 'example.com'),
       );
       await dbService.commit(inserts: [
@@ -104,7 +104,7 @@ void main() {
     testWithServices('successful', () async {
       final client = createPubApiClient(authToken: hansUser.userId);
       await client.setPackagePublisher(
-        hydrogen.package.name,
+        hydrogen.packageName,
         PackagePublisherInfo(publisherId: 'example.com'),
       );
       registerAuthenticatedUser(hansUser);
@@ -118,7 +118,7 @@ void main() {
   group('Move between publishers', () {
     final otherComPublisher = publisher('other.com');
     Future<void> _setup({bool addHans = true}) async {
-      final p = await packageBackend.lookupPackage(hydrogen.package.name);
+      final p = await packageBackend.lookupPackage(hydrogen.packageName);
       p.publisherId = otherComPublisher.publisherId;
       p.uploaders = [];
       final hansMember = publisherMember(hansUser.userId, 'admin',
@@ -144,7 +144,7 @@ void main() {
     _testNoPublisher((client) async {
       await _setup();
       return client.setPackagePublisher(
-        hydrogen.package.name,
+        hydrogen.packageName,
         PackagePublisherInfo(publisherId: 'no-domain.net'),
       );
     });
@@ -152,7 +152,7 @@ void main() {
     _testPublisherAdminAuthIssues(exampleComPublisher.key, (client) async {
       await _setup();
       return client.setPackagePublisher(
-        hydrogen.package.name,
+        hydrogen.packageName,
         PackagePublisherInfo(publisherId: 'example.com'),
       );
     });
@@ -160,7 +160,7 @@ void main() {
     _testPublisherAdminAuthIssues(otherComPublisher.key, (client) async {
       await _setup(addHans: false);
       return client.setPackagePublisher(
-        hydrogen.package.name,
+        hydrogen.packageName,
         PackagePublisherInfo(publisherId: 'example.com'),
       );
     });
@@ -169,7 +169,7 @@ void main() {
       await _setup();
       final client = createPubApiClient(authToken: hansUser.userId);
       final rs = await client.setPackagePublisher(
-        hydrogen.package.name,
+        hydrogen.packageName,
         PackagePublisherInfo(publisherId: 'example.com'),
       );
       expect(_json(rs.toJson()), {'publisherId': 'example.com'});
@@ -185,7 +185,7 @@ void main() {
 
   group('Delete publisher', () {
     Future<void> _setupPackage() async {
-      final p = await packageBackend.lookupPackage(hydrogen.package.name);
+      final p = await packageBackend.lookupPackage(hydrogen.packageName);
       p.publisherId = 'example.com';
       p.uploaders = [];
       await dbService.commit(inserts: [p]);
@@ -198,18 +198,18 @@ void main() {
 
     _testPublisherAdminAuthIssues(exampleComPublisher.key, (client) async {
       await _setupPackage();
-      return client.removePackagePublisher(hydrogen.package.name);
+      return client.removePackagePublisher(hydrogen.packageName);
     });
 
     testWithServices('successful', () async {
       await _setupPackage();
       final client = createPubApiClient(authToken: hansUser.userId);
-      final rs = client.removePackagePublisher(hydrogen.package.name);
+      final rs = client.removePackagePublisher(hydrogen.packageName);
       await expectApiException(rs, status: 501);
 //  Code commented out while we decide if this feature is something we want to
 //  support going forward.
 //
-//      final rs = await client.removePackagePublisher(hydrogen.package.name);
+//      final rs = await client.removePackagePublisher(hydrogen.packageName);
 //      expect(_json(rs.toJson()), {'publisherId': null});
 //
 //      final p = await packageBackend.lookupPackage('hydrogen');

--- a/app/test/package/upload_test.dart
+++ b/app/test/package/upload_test.dart
@@ -195,7 +195,7 @@ void main() {
       testWithServices('not authorized', () async {
         registerAuthenticatedUser(joeUser);
         final tarball = await packageArchiveBytes(
-            pubspecContent: generatePubspecYaml(foobarPackage.name, '0.2.0'));
+            pubspecContent: generatePubspecYaml(foobarPkgName, '0.2.0'));
         final rs = packageBackend.upload(Stream.fromIterable([tarball]));
         await expectLater(rs, throwsA(isA<AuthorizationException>()));
       });
@@ -205,7 +205,7 @@ void main() {
         await dbService.commit(inserts: [user..isBlocked = true]);
         registerAuthenticatedUser(user);
         final tarball = await packageArchiveBytes(
-            pubspecContent: generatePubspecYaml(foobarPackage.name, '1.2.3'));
+            pubspecContent: generatePubspecYaml(foobarPkgName, '1.2.3'));
         final rs = packageBackend.upload(Stream.fromIterable([tarball]));
         await expectLater(rs, throwsA(isA<AuthorizationException>()));
       });
@@ -214,7 +214,7 @@ void main() {
         await secretBackend.update(SecretKey.uploadRestriction, 'no-uploads');
         registerAuthenticatedUser(hansUser);
         final tarball = await packageArchiveBytes(
-            pubspecContent: generatePubspecYaml(foobarPackage.name, '1.2.3'));
+            pubspecContent: generatePubspecYaml(foobarPkgName, '1.2.3'));
         final rs = packageBackend.upload(Stream.fromIterable([tarball]));
         await expectLater(
             rs,
@@ -244,9 +244,9 @@ void main() {
         await secretBackend.update(SecretKey.uploadRestriction, 'only-updates');
         registerAuthenticatedUser(hansUser);
         final tarball = await packageArchiveBytes(
-            pubspecContent: generatePubspecYaml(foobarPackage.name, '1.2.3'));
+            pubspecContent: generatePubspecYaml(foobarPkgName, '1.2.3'));
         final rs = await packageBackend.upload(Stream.fromIterable([tarball]));
-        expect(rs.package, foobarPackage.name);
+        expect(rs.package, foobarPkgName);
       });
 
       testWithServices('versions already exist', () async {
@@ -373,10 +373,10 @@ void main() {
       testWithServices('successful upload + download', () async {
         registerAuthenticatedUser(hansUser);
         final tarball = await packageArchiveBytes(
-            pubspecContent: generatePubspecYaml(foobarPackage.name, '1.2.3'));
+            pubspecContent: generatePubspecYaml(foobarPkgName, '1.2.3'));
         final version =
             await packageBackend.upload(Stream.fromIterable([tarball]));
-        expect(version.package, foobarPackage.name);
+        expect(version.package, foobarPkgName);
         expect(version.version, '1.2.3');
 
         expect(fakeEmailSender.sentMessages, hasLength(1));
@@ -387,11 +387,10 @@ void main() {
             contains('https://pub.dev/packages/foobar_pkg/versions/1.2.3\n'));
 
         final pkgPage = await packageBackend.latestPackages();
-        expect(pkgPage.packages.first.name, foobarPackage.name);
+        expect(pkgPage.packages.first.name, foobarPkgName);
         expect(pkgPage.packages.first.latestVersion, '1.2.3');
 
-        final stream =
-            await packageBackend.download(foobarPackage.name, '1.2.3');
+        final stream = await packageBackend.download(foobarPkgName, '1.2.3');
         final chunks = await stream.toList();
         final bytes = chunks
             .fold<List<int>>(<int>[], (buffer, chunk) => buffer..addAll(chunk));

--- a/app/test/shared/user_merger_test.dart
+++ b/app/test/shared/user_merger_test.dart
@@ -56,14 +56,14 @@ void main() {
     await _corruptAndFix();
 
     final pkgList = await dbService.lookup<Package>([
-      foobarPackage.key,
-      control.package.key,
+      foobarPkgKey,
+      control.packageKey,
     ]);
     expect(pkgList[0].uploaders, [joeUser.userId]);
     expect(pkgList[1].uploaders, [adminUser.userId]);
 
     final pvList = await dbService.lookup<PackageVersion>([
-      foobarStablePV.key,
+      foobarStablePVKey,
       control.versions.single.key,
     ]);
     expect(pvList[0].uploader, joeUser.userId);


### PR DESCRIPTION
- Many of our tests reference a hand-crafted DB entity object. Instead, we should - eventually - use an automatic process that populates the DB based on a test profile or an in-memory archive file.
  - Instead of `<pkg>.name`, we should use `<pkg>Name`.
  - Instead of `<model>.key`, we should use `<model>Key`.
  - Instead of `xy<version>.version`, we should use `xyVersion`.

- Makes some of the helper methods internal.