### PR TITLE
Refactored service initialization: explicit fake services.

### DIFF
--- a/app/lib/shared/configuration.dart
+++ b/app/lib/shared/configuration.dart
@@ -117,10 +117,6 @@ class Configuration {
   /// The identifier of admins.
   final List<AdminId> admins;
 
-  /// Whether the current environment uses the pkg/fake_gcloud package instead
-  /// of the real AppEngine environment.
-  final bool usesFakeGcloud;
-
   /// Create a configuration for production deployment.
   ///
   /// This will use the Datastore from the cloud project and the Cloud Storage
@@ -165,7 +161,6 @@ class Configuration {
           permissions: {AdminPermission.removePackage},
         )
       ],
-      usesFakeGcloud: false,
     );
   }
 
@@ -214,7 +209,6 @@ class Configuration {
           permissions: {AdminPermission.manageAssignedTags},
         )
       ],
-      usesFakeGcloud: false,
     );
   }
 
@@ -237,7 +231,6 @@ class Configuration {
     @required this.primaryApiUri,
     @required this.primarySiteUri,
     @required this.admins,
-    @required this.usesFakeGcloud,
   });
 
   /// Create a configuration based on the environment variables.
@@ -282,7 +275,6 @@ class Configuration {
           permissions: AdminPermission.values,
         ),
       ],
-      usesFakeGcloud: true,
     );
   }
 
@@ -313,7 +305,6 @@ class Configuration {
           permissions: AdminPermission.values,
         ),
       ],
-      usesFakeGcloud: true,
     );
   }
 }

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -226,7 +226,7 @@ packages:
     source: hosted
     version: "0.3.0"
   fake_gcloud:
-    dependency: "direct dev"
+    dependency: "direct main"
     description:
       path: "../pkg/fake_gcloud"
       relative: true

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -14,6 +14,8 @@ dependencies:
     path: ../pkg/client_data
   convert: '^2.0.0'
   crypto: '^2.0.2'
+  fake_gcloud:
+    path: ../pkg/fake_gcloud
   gcloud: '^0.7.3'
   googleapis: '^0.55.0'
   googleapis_auth: ^0.2.4
@@ -56,8 +58,6 @@ dev_dependencies:
   build_runner: '^1.0.0'
   build_verify: ^1.1.1
   coverage: any # test already depends on it
-  fake_gcloud:
-    path: ../pkg/fake_gcloud
   json_serializable: '^3.0.0'
   shelf_router_generator: ^0.7.2+3
   source_gen: '^0.9.0'

--- a/pkg/fake_pub_server/bin/init_data_file.dart
+++ b/pkg/fake_pub_server/bin/init_data_file.dart
@@ -7,7 +7,6 @@ import 'dart:io';
 import 'package:args/args.dart';
 import 'package:gcloud/db.dart';
 import 'package:gcloud/service_scope.dart';
-import 'package:gcloud/storage.dart';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
 
@@ -52,19 +51,19 @@ Future<void> main(List<String> args) async {
 
   final state = LocalServerState(path: argv['data-file'] as String);
 
-  await fork(() async {
-    registerDbService(DatastoreDB(state.datastore));
-    registerStorageService(state.storage);
-    registerActiveConfiguration(Configuration.test());
-    await withPubServices(() async {
-      // ignore: invalid_use_of_visible_for_testing_member
-      await importProfile(profile: profile, archiveCachePath: archiveCachePath);
+  await withFakeServices(
+      configuration: Configuration.test(),
+      datastore: state.datastore,
+      storage: state.storage,
+      fn: () async {
+        // ignore: invalid_use_of_visible_for_testing_member
+        await importProfile(
+            profile: profile, archiveCachePath: archiveCachePath);
 
-      if (analyze) {
-        await _analyze();
-      }
-    });
-  });
+        if (analyze) {
+          await _analyze();
+        }
+      });
   await state.save();
 }
 

--- a/pkg/fake_pub_server/lib/fake_analyzer_service.dart
+++ b/pkg/fake_pub_server/lib/fake_analyzer_service.dart
@@ -9,7 +9,6 @@ import 'package:fake_gcloud/mem_datastore.dart';
 import 'package:fake_gcloud/mem_storage.dart';
 import 'package:gcloud/db.dart';
 import 'package:gcloud/service_scope.dart' as ss;
-import 'package:gcloud/storage.dart';
 import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
 import 'package:shelf/shelf.dart' as shelf;
@@ -34,14 +33,11 @@ class FakeAnalyzerService {
     int port = 8083,
     @required Configuration configuration,
   }) async {
-    await ss.fork(() async {
-      final db = DatastoreDB(_datastore);
-      registerDbService(db);
-      registerStorageService(_storage);
-      registerActiveConfiguration(configuration);
-
-      await withPubServices(() async {
-        await ss.fork(() async {
+    await withFakeServices(
+        configuration: configuration,
+        datastore: _datastore,
+        storage: _storage,
+        fn: () async {
           final jobProcessor = AnalyzerJobProcessor(aliveCallback: null);
           final jobMaintenance = JobMaintenance(dbService, jobProcessor);
 
@@ -67,8 +63,6 @@ class FakeAnalyzerService {
           await server.close();
           _logger.info('closing');
         });
-      });
-    });
     _logger.info('closed');
   }
 }

--- a/pkg/fake_pub_server/lib/fake_dartdoc_service.dart
+++ b/pkg/fake_pub_server/lib/fake_dartdoc_service.dart
@@ -9,7 +9,6 @@ import 'package:fake_gcloud/mem_datastore.dart';
 import 'package:fake_gcloud/mem_storage.dart';
 import 'package:gcloud/db.dart';
 import 'package:gcloud/service_scope.dart' as ss;
-import 'package:gcloud/storage.dart';
 import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
 import 'package:shelf/shelf.dart' as shelf;
@@ -34,14 +33,11 @@ class FakeDartdocService {
     int port = 8084,
     @required Configuration configuration,
   }) async {
-    await ss.fork(() async {
-      final db = DatastoreDB(_datastore);
-      registerDbService(db);
-      registerStorageService(_storage);
-      registerActiveConfiguration(configuration);
-
-      await withPubServices(() async {
-        await ss.fork(() async {
+    await withFakeServices(
+        configuration: configuration,
+        datastore: _datastore,
+        storage: _storage,
+        fn: () async {
           final jobProcessor = DartdocJobProcessor(aliveCallback: null);
           final jobMaintenance = JobMaintenance(dbService, jobProcessor);
 
@@ -67,8 +63,6 @@ class FakeDartdocService {
           await server.close();
           _logger.info('closing');
         });
-      });
-    });
     _logger.info('closed');
   }
 }

--- a/pkg/fake_pub_server/lib/fake_pub_server.dart
+++ b/pkg/fake_pub_server/lib/fake_pub_server.dart
@@ -7,9 +7,7 @@ import 'dart:io';
 
 import 'package:fake_gcloud/mem_datastore.dart';
 import 'package:fake_gcloud/mem_storage.dart';
-import 'package:gcloud/db.dart';
 import 'package:gcloud/service_scope.dart' as ss;
-import 'package:gcloud/storage.dart';
 import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
 import 'package:shelf/shelf.dart' as shelf;
@@ -42,14 +40,11 @@ class FakePubServer {
     @required Configuration configuration,
     shelf.Handler extraHandler,
   }) async {
-    await ss.fork(() async {
-      final db = DatastoreDB(_datastore);
-      registerDbService(db);
-      registerStorageService(_storage);
-      registerActiveConfiguration(configuration);
-
-      await withPubServices(() async {
-        await ss.fork(() async {
+    await withFakeServices(
+        configuration: configuration,
+        datastore: _datastore,
+        storage: _storage,
+        fn: () async {
           registerAuthProvider(FakeAuthProvider(port));
           registerDomainVerifier(FakeDomainVerifier());
           registerUploadSigner(
@@ -81,8 +76,6 @@ class FakePubServer {
           await server.close();
           _logger.info('closing');
         });
-      });
-    });
     _logger.info('closed');
   }
 }

--- a/pkg/fake_pub_server/lib/fake_search_service.dart
+++ b/pkg/fake_pub_server/lib/fake_search_service.dart
@@ -7,9 +7,7 @@ import 'dart:io';
 
 import 'package:fake_gcloud/mem_datastore.dart';
 import 'package:fake_gcloud/mem_storage.dart';
-import 'package:gcloud/db.dart';
 import 'package:gcloud/service_scope.dart' as ss;
-import 'package:gcloud/storage.dart';
 import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
 import 'package:shelf/shelf.dart' as shelf;
@@ -33,14 +31,11 @@ class FakeSearchService {
     int port = 8082,
     @required Configuration configuration,
   }) async {
-    await ss.fork(() async {
-      final db = DatastoreDB(_datastore);
-      registerDbService(db);
-      registerStorageService(_storage);
-      registerActiveConfiguration(configuration);
-
-      await withPubServices(() async {
-        await ss.fork(() async {
+    await withFakeServices(
+        configuration: configuration,
+        datastore: _datastore,
+        storage: _storage,
+        fn: () async {
           final handler = wrapHandler(_logger, searchServiceHandler);
           final server = await IOServer.bind('localhost', port);
           serveRequests(server.server, (request) async {
@@ -63,8 +58,6 @@ class FakeSearchService {
           await server.close();
           _logger.info('closing');
         });
-      });
-    });
     _logger.info('closed');
   }
 }


### PR DESCRIPTION
- This is a follow-up to https://github.com/dart-lang/pub-dev/pull/4204
- I'm not sure if/how a single method for both would be beneficial, keeping them separate for now. It also makes the `usesFakeGcloud` flag obsolete, removing it for now.