### PR TITLE
Fix SDK links on Flutter Favorites listing page.

### DIFF
--- a/app/lib/frontend/templates/layout.dart
+++ b/app/lib/frontend/templates/layout.dart
@@ -197,11 +197,12 @@ String _renderSearchBanner({
 String renderSdkTabs({
   SearchForm searchForm,
 }) {
-  final currentSdk = searchForm?.sdk ?? SdkTagValue.any;
+  final isff = searchForm?.isFlutterFavorite ?? false;
+  final currentSdk = isff ? null : searchForm?.sdk ?? SdkTagValue.any;
   SearchTab sdkTabData(String label, String tabSdk, String title) {
     String url;
     if (searchForm != null) {
-      url = searchForm.change(sdk: tabSdk).toSearchLink();
+      url = searchForm.change(sdk: tabSdk, currentPage: 1).toSearchLink();
     } else {
       url = urls.searchUrl(sdk: tabSdk);
     }

--- a/app/lib/search/search_form.dart
+++ b/app/lib/search/search_form.dart
@@ -126,7 +126,9 @@ class SearchForm {
   }) {
     if (sdk != null) {
       tagsPredicate ??= this.tagsPredicate ?? TagsPredicate();
-      tagsPredicate = tagsPredicate.removePrefix('sdk:');
+      tagsPredicate = tagsPredicate
+          .removePrefix('sdk:')
+          .withoutTag(PackageTags.isFlutterFavorite);
       if (SdkTagValue.isNotAny(sdk)) {
         tagsPredicate = tagsPredicate
             .appendPredicate(TagsPredicate(requiredTags: ['sdk:$sdk']));
@@ -188,6 +190,10 @@ class SearchForm {
     return values.isEmpty ? null : values.first;
   }
 
+  /// Returns whether the search is on Flutter Favorites.
+  bool get isFlutterFavorite =>
+      tagsPredicate.isRequiredTag(PackageTags.isFlutterFavorite);
+
   /// Converts the query to a user-facing link that the search form can use as
   /// the base path of its `action` parameter.
   String toSearchFormPath() {
@@ -195,7 +201,7 @@ class SearchForm {
     if (sdk != null) {
       path = '/$sdk/packages';
     }
-    if (tagsPredicate.isRequiredTag('is:flutter-favorite')) {
+    if (isFlutterFavorite) {
       path = '/flutter/favorites';
     }
     if (publisherId != null && publisherId.isNotEmpty) {

--- a/pkg/web_css/lib/src/_list.scss
+++ b/pkg/web_css/lib/src/_list.scss
@@ -86,6 +86,7 @@
     .list-filters {
 
       .filter {
+        border-bottom: 2px solid transparent;
         color: #555555;
         display: inline-block;
         margin-right: 18px;


### PR DESCRIPTION
- Fixes #4226.
- On a Flutter favorite page `Any` doesn't become active.
- With the SDK change there is also a reset to the page number.
- Non-active SDK tabs do have a transparent bottom border.