### PR TITLE
Updated HTML validation: pkg/pub_validations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,10 @@ jobs:
       os: linux
       script: "pub global activate mono_repo 3.0.0 && pub global run mono_repo travis --validate"
     - stage: smoke_test
-      name: "SDK: 2.10.0; PKGS: app, pkg/_popularity, pkg/api_builder, pkg/client_data, pkg/fake_gcloud, pkg/fake_pub_server, pkg/pub_dartdoc, pkg/pub_dartdoc_data, pkg/pub_package_reader, pkg/web_app, pkg/web_css; TASKS: [`dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos --fatal-warnings .`]"
+      name: "SDK: 2.10.0; PKGS: app, pkg/_popularity, pkg/api_builder, pkg/client_data, pkg/fake_gcloud, pkg/fake_pub_server, pkg/pub_dartdoc, pkg/pub_dartdoc_data, pkg/pub_package_reader, pkg/pub_validations, pkg/web_app, pkg/web_css; TASKS: [`dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos --fatal-warnings .`]"
       dart: "2.10.0"
       os: linux
-      env: PKGS="app pkg/_popularity pkg/api_builder pkg/client_data pkg/fake_gcloud pkg/fake_pub_server pkg/pub_dartdoc pkg/pub_dartdoc_data pkg/pub_package_reader pkg/web_app pkg/web_css"
+      env: PKGS="app pkg/_popularity pkg/api_builder pkg/client_data pkg/fake_gcloud pkg/fake_pub_server pkg/pub_dartdoc pkg/pub_dartdoc_data pkg/pub_package_reader pkg/pub_validations pkg/web_app pkg/web_css"
       script: tool/travis.sh dartfmt dartanalyzer_0
     - stage: smoke_test
       name: "SDK: 2.10.0; PKG: pkg/pub_integration; TASKS: [`dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos --fatal-warnings bin/ lib/`]"
@@ -134,6 +134,12 @@ jobs:
       dart: "2.10.0"
       os: linux
       env: PKGS="pkg/pub_package_reader"
+      script: tool/travis.sh test_07
+    - stage: unit_test
+      name: "SDK: 2.10.0; PKG: pkg/pub_validations; TASKS: `pub run test --run-skipped`"
+      dart: "2.10.0"
+      os: linux
+      env: PKGS="pkg/pub_validations"
       script: tool/travis.sh test_07
     - stage: unit_test
       name: "SDK: 2.10.0; PKG: pkg/web_app; TASKS: `pub run test --run-skipped`"

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -519,6 +519,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.4.4"
+  pub_validations:
+    dependency: "direct dev"
+    description:
+      path: "../pkg/pub_validations"
+      relative: true
+    source: path
+    version: "0.0.0"
   pubspec_parse:
     dependency: "direct main"
     description:
@@ -758,4 +765,4 @@ packages:
     source: hosted
     version: "2.2.1"
 sdks:
-  dart: ">=2.10.0-93.0.dev <3.0.0"
+  dart: ">=2.10.0 <3.0.0"

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -59,6 +59,8 @@ dev_dependencies:
   build_verify: ^1.1.1
   coverage: any # test already depends on it
   json_serializable: '^3.0.0'
+  pub_validations:
+    path: ../pkg/pub_validations
   shelf_router_generator: ^0.7.2+3
   source_gen: '^0.9.0'
   test: ^1.2.0

--- a/app/test/dartdoc/customization_test.dart
+++ b/app/test/dartdoc/customization_test.dart
@@ -11,7 +11,7 @@ import 'package:xml/xml.dart';
 
 import 'package:pub_dev/dartdoc/customization.dart';
 import 'package:pub_dev/frontend/static_files.dart';
-import 'package:pub_dev/tool/html/html_validation.dart';
+import 'package:pub_validations/html/html_validation.dart';
 
 const String goldenDir = 'test/dartdoc/golden';
 

--- a/app/test/frontend/handlers/_utils.dart
+++ b/app/test/frontend/handlers/_utils.dart
@@ -14,7 +14,7 @@ import 'package:test/test.dart';
 import 'package:pub_dev/frontend/handlers.dart';
 import 'package:pub_dev/shared/handler_helpers.dart';
 import 'package:pub_dev/shared/urls.dart';
-import 'package:pub_dev/tool/html/html_validation.dart';
+import 'package:pub_validations/html/html_validation.dart';
 
 import '../../shared/utils.dart';
 

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -31,7 +31,7 @@ import 'package:pub_dev/scorecard/models.dart';
 import 'package:pub_dev/search/search_form.dart';
 import 'package:pub_dev/search/search_service.dart';
 import 'package:pub_dev/shared/versions.dart';
-import 'package:pub_dev/tool/html/html_validation.dart';
+import 'package:pub_validations/html/html_validation.dart';
 
 import '../shared/test_models.dart';
 import '../shared/utils.dart';

--- a/pkg/fake_pub_server/lib/fake_pub_server.dart
+++ b/pkg/fake_pub_server/lib/fake_pub_server.dart
@@ -25,7 +25,6 @@ import 'package:pub_dev/service/services.dart';
 import 'package:pub_dev/service/spam/backend.dart';
 import 'package:pub_dev/shared/configuration.dart';
 import 'package:pub_dev/shared/handler_helpers.dart';
-import 'package:pub_dev/tool/html/html_validation.dart';
 
 final _logger = Logger('fake_server');
 
@@ -90,10 +89,6 @@ Future<shelf.Response> _validateAndWrapResponse(
   if (ct == null || ct.isEmpty) {
     // TODO: force headers everywhere and throw exception instead of logging
     _logger.warning('Content type header is missing for ${rq.requestedUri}.');
-  } else if (ct.contains('text/html')) {
-    final body = await rs.readAsString();
-    parseAndValidateHtml(body);
-    return rs.change(body: body);
   }
   return null;
 }

--- a/pkg/pub_integration/pubspec.yaml
+++ b/pkg/pub_integration/pubspec.yaml
@@ -11,6 +11,8 @@ dependencies:
   meta: ^1.0.0
   path: ^1.0.0
   pub_semver: ^1.4.2
+  pub_validations:
+    path: ../pub_validations
   puppeteer: ^1.13.0
 
 dev_dependencies:

--- a/pkg/pub_validations/lib/html/html_validation.dart
+++ b/pkg/pub_validations/lib/html/html_validation.dart
@@ -15,7 +15,10 @@ import 'package:html/parser.dart' as parser;
 /// - `<script> tags have no `src` attribute or have content (except `ld+json`
 ///   meta content).
 void parseAndValidateHtml(String html) {
-  validateHtml(parser.parse(html));
+  if (html.startsWith('<html>')) {
+    html = '<!DOCTYPE html>\n$html';
+  }
+  validateHtml(parser.HtmlParser(html, strict: true).parse());
 }
 
 /// Validates the parsed HTML content and throws ArgumentError if any of the
@@ -95,7 +98,7 @@ void _validateHead(Element head) {
       .querySelectorAll('link')
       .where((e) => e.attributes['rel'] == 'canonical')
       .toList();
-  if (canonicalLinks.length > 2) {
+  if (canonicalLinks.length > 1) {
     throw ArgumentError('More than one canonical link was specified.');
   }
   if (canonicalLinks.length == 1) {

--- a/pkg/pub_validations/mono_pkg.yaml
+++ b/pkg/pub_validations/mono_pkg.yaml
@@ -1,0 +1,11 @@
+# See https://pub.dev/packages/mono_repo for details on this file
+dart:
+  - 2.10.0
+
+stages:
+  - smoke_test:
+    - group:
+        - dartfmt
+        - dartanalyzer: --fatal-infos --fatal-warnings .
+  - unit_test:
+    - test: --run-skipped

--- a/pkg/pub_validations/pubspec.lock
+++ b/pkg/pub_validations/pubspec.lock
@@ -7,23 +7,16 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0"
+    version: "12.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.39.8"
-  archive:
-    dependency: transitive
-    description:
-      name: archive
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.13"
+    version: "0.40.6"
   args:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: args
       url: "https://pub.dartlang.org"
@@ -35,7 +28,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.1"
+    version: "2.4.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -50,13 +43,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.3"
+  cli_util:
+    dependency: transitive
+    description:
+      name: cli_util
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.2.0"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.12"
+    version: "1.14.13"
   convert:
     dependency: transitive
     description:
@@ -65,26 +65,26 @@ packages:
     source: hosted
     version: "2.1.1"
   coverage:
-    dependency: "direct dev"
+    dependency: transitive
     description:
       name: coverage
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.14.1"
+    version: "0.14.2"
   crypto:
     dependency: transitive
     description:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.4"
+    version: "2.1.5"
   csslib:
     dependency: transitive
     description:
       name: csslib
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.16.1"
+    version: "0.16.2"
   glob:
     dependency: transitive
     description:
@@ -93,19 +93,19 @@ packages:
     source: hosted
     version: "1.2.0"
   html:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: html
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.14.0+3"
+    version: "0.14.0+4"
   http:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: http
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.1"
+    version: "0.12.2"
   http_multi_server:
     dependency: transitive
     description:
@@ -133,7 +133,7 @@ packages:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.1+1"
+    version: "0.6.2"
   logging:
     dependency: transitive
     description:
@@ -154,35 +154,35 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.8"
+    version: "1.2.3"
   mime:
     dependency: transitive
     description:
       name: mime
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.6+3"
+    version: "0.9.7"
   node_interop:
     dependency: transitive
     description:
       name: node_interop
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.3"
+    version: "1.2.0"
   node_io:
     dependency: transitive
     description:
       name: node_io
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1+2"
+    version: "1.1.1"
   node_preamble:
     dependency: transitive
     description:
       name: node_preamble
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.8"
+    version: "1.4.12"
   package_config:
     dependency: transitive
     description:
@@ -191,7 +191,7 @@ packages:
     source: hosted
     version: "1.9.3"
   path:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
@@ -203,14 +203,7 @@ packages:
       name: pedantic
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.0"
-  petitparser:
-    dependency: transitive
-    description:
-      name: petitparser
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "3.0.2"
+    version: "1.9.2"
   pool:
     dependency: transitive
     description:
@@ -219,33 +212,19 @@ packages:
     source: hosted
     version: "1.4.0"
   pub_semver:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: pub_semver
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.4.4"
-  pub_validations:
-    dependency: "direct main"
-    description:
-      path: "../pub_validations"
-      relative: true
-    source: path
-    version: "0.0.0"
-  puppeteer:
-    dependency: "direct main"
-    description:
-      name: puppeteer
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.17.0"
   shelf:
     dependency: transitive
     description:
       name: shelf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.7.5"
+    version: "0.7.9"
   shelf_packages_handler:
     dependency: transitive
     description:
@@ -294,7 +273,7 @@ packages:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.3"
+    version: "1.9.6"
   stream_channel:
     dependency: transitive
     description:
@@ -322,35 +301,35 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.4"
+    version: "1.15.5"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.18"
+    version: "0.2.18+1"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.11+1"
+    version: "0.3.11+2"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.6"
+    version: "1.2.0"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.2"
+    version: "4.2.0"
   watcher:
     dependency: transitive
     description:
@@ -371,7 +350,7 @@ packages:
       name: webkit_inspection_protocol
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.5.2"
+    version: "0.7.4"
   yaml:
     dependency: transitive
     description:

--- a/pkg/pub_validations/pubspec.yaml
+++ b/pkg/pub_validations/pubspec.yaml
@@ -1,0 +1,13 @@
+name: pub_validations
+description: Shared validation for pub.dev
+publish_to: none
+
+environment:
+  sdk: '>=2.10.0 <3.0.0'
+
+dependencies:
+  html: ^0.14.0
+  meta: ^1.0.0
+
+dev_dependencies:
+  test: ^1.5.1

--- a/pkg/pub_validations/test/html/html_validation_test.dart
+++ b/pkg/pub_validations/test/html/html_validation_test.dart
@@ -1,0 +1,78 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test/test.dart';
+
+import 'package:pub_validations/html/html_validation.dart';
+
+void main() {
+  void expectException(String html) {
+    expect(() => parseAndValidateHtml(html), throwsA(isA<Exception>()));
+  }
+
+  void expectError(String html) {
+    expect(() => parseAndValidateHtml(html), throwsA(isA<Error>()));
+  }
+
+  group('invalid html', () {
+    test('bad tag', () {
+      expectException('<html></htm>');
+      expectException('<html><head><body></head></body></html>');
+    });
+
+    test('bad attribute quotes', () {
+      expectException('<html><head></head><body attr="x\'></body></html>');
+    });
+  });
+
+  group('pub restrictions', () {
+    test('no onclick or other inline JS calls', () {
+      expectError('<html><head></head><body onclick="x"></body></html>');
+      expectError('<html><head></head><body onblur="x"></body></html>');
+      expectError('<html><head></head><body onxyz="x"></body></html>');
+    });
+
+    test('target="_blank" with rel="noopener"', () {
+      expectError(
+          '<html><head></head><body><a href="x" target="_blank"></a></body></html>');
+      expectError(
+          '<html><head></head><body><a href="x" target="_blank" rel="noopen"></a></body></html>');
+    });
+
+    test('script with src only', () {
+      expectError('<html><head></head><body><script></script></body></html>');
+      expectError(
+          '<html><head></head><body><script>window.alert("!");</script></body></html>');
+      expectError(
+          '<html><head></head><body><script src="x.js">window.alert("!");</script></body></html>');
+    });
+
+    test('more than one canonical url', () {
+      expectError('<html><head><link rel="canonical" href="https://pub.dev/" />'
+          '<link rel="canonical" href="https://pub.dev/x" /></head><body></body></html>');
+    });
+
+    test('canonical url on a different domain', () {
+      expectError(
+          '<html><head><link rel="canonical" href="https://example.com/" /></head></html>');
+    });
+  });
+
+  group('valid html', () {
+    test('minimal', () {
+      parseAndValidateHtml('<html><head></head><body></body></html>');
+    });
+
+    test('pub restrictions used correctly', () {
+      parseAndValidateHtml(
+          '<html><head></head><body><a href="x" target="_blank" rel="x noopener y"></a></body></html>');
+      parseAndValidateHtml(
+          '<html><head></head><body><script src="x.js"></script></body></html>');
+      parseAndValidateHtml(
+          '<html><head></head><body><script type="application/ld+json">{}</script></body></html>');
+      parseAndValidateHtml(
+          '<html><head><link rel="canonical" href="https://pub.dev/" /></head><body></body></html>');
+    });
+  });
+}


### PR DESCRIPTION
- Moved `html_validation` into `pkg/pub_validations`.
- Added tests for `html_validation`, which led to fixing a bad check with canonical urls.
- Using strict HTML parsing in `html_validation`.
- Removed `html_validation` from the output of `fake_pub_server`.
- Always checking for valid HTMLs in integrations tests: both in the HTTP client and in the puppeteer tests.