### PR TITLE
Update null safety Advanced search string

### DIFF
--- a/app/lib/frontend/templates/views/pkg/index.mustache
+++ b/app/lib/frontend/templates/views/pkg/index.mustache
@@ -49,7 +49,7 @@
         {{#show_prerelease_null_safe_checkbox}}
         <div class="search-controls-checkbox">
           <input id="-search-prerelease-null-safe-checkbox" type="checkbox" name="prerelease-null-safe" {{#prerelease_null_safe}} checked="checked"{{/prerelease_null_safe}} />
-          <label for="-search-prerelease-null-safe-checkbox">Supports null-safety</label>
+          <label for="-search-prerelease-null-safe-checkbox">Supports null safety</label>
         </div>
         {{/show_prerelease_null_safe_checkbox}}
       </div>


### PR DESCRIPTION
Per @kwalrath: You only add the hyphen if it comes before the noun, to make the string of words easier to parse, e.g. "supports the null-safety feature" but "supports null safety" or "is null safe"

