### PR TITLE
Fail instead of redirect when accessing non-existing version.

### DIFF
--- a/app/lib/frontend/handlers/package.dart
+++ b/app/lib/frontend/handlers/package.dart
@@ -197,15 +197,14 @@ Future<shelf.Response> _handlePackagePage({
     final data =
         await _loadPackagePageData(packageName, versionName, assetKind);
     _packageDataLoadLatencyTracker.add(serviceSw.elapsed);
-    if (data.package == null || data.package.isNotVisible) {
+    if (data.package == null ||
+        data.package.isNotVisible ||
+        data.version == null) {
       if (data.moderatedPackage != null) {
         final content = renderModeratedPackagePage(packageName);
         return htmlResponse(content, status: 404);
       }
       return formattedNotFoundHandler(request);
-    }
-    if (data.version == null) {
-      return redirectResponse(urls.pkgVersionsUrl(packageName));
     }
     final renderedResult = await renderFn(data);
     if (renderedResult is String) {

--- a/app/test/frontend/handlers/package_test.dart
+++ b/app/test/frontend/handlers/package_test.dart
@@ -96,18 +96,16 @@ void main() {
     testWithServices(
       '/packages/foobar_pkg/versions/0.1.2 - not found',
       () async {
-        await expectRedirectResponse(
-            await issueGet('/packages/foobar_pkg/versions/0.1.2'),
-            '/packages/foobar_pkg/versions');
+        await expectNotFoundResponse(
+            await issueGet('/packages/foobar_pkg/versions/0.1.2'));
       },
     );
 
     testWithServices(
       '/packages/foobar_pkg/versions/xyz - bad version',
       () async {
-        await expectRedirectResponse(
-            await issueGet('/packages/foobar_pkg/versions/xyz'),
-            '/packages/foobar_pkg/versions');
+        await expectNotFoundResponse(
+            await issueGet('/packages/foobar_pkg/versions/xyz'));
       },
     );
 


### PR DESCRIPTION
#4272