### PR TITLE
Consistent but somewhat random-looking ordering for test-profile package versions.

### DIFF
--- a/app/test/frontend/handlers/atom_feed_test.dart
+++ b/app/test/frontend/handlers/atom_feed_test.dart
@@ -11,7 +11,7 @@ import '_utils.dart';
 
 void main() {
   group('feeds', () {
-    testWithServices('/feed.atom', () async {
+    testWithProfile('/feed.atom', fn: () async {
       final content = await expectAtomXmlResponse(await issueGet('/feed.atom'));
 
       // check if content is valid XML
@@ -19,42 +19,40 @@ void main() {
       final feed = root.rootElement;
 
       final entries = feed.findElements('entry').toList();
-      expect(entries.length, 4);
+      expect(entries.length, 2);
       expect(entries.map((e) => e.findElements('title').first.text).toList(), [
-        'v0.1.1+5 of foobar_pkg',
-        'v5.8.6 of lithium',
-        'v2.0.5 of helium',
-        'v2.0.8 of hydrogen',
+        'v1.2.0 of oxygen',
+        'v1.0.0 of neon',
       ]);
 
       expect(
-          entries[0].toXmlString(indent: '  '),
-          '<entry>\n'
-          '          <id>urn:uuid:12c30db4-f5d7-4757-939d-02c81b9e299e</id>\n'
-          '          <title>v0.1.1+5 of foobar_pkg</title>\n'
-          '          <updated>2014-01-01T00:00:00.000Z</updated>\n'
-          '          \n'
-          '          <content type="html">&lt;h1>Test Package&lt;/h1>\n'
-          '&lt;p>This is a readme file.&lt;/p>\n'
-          '&lt;pre>&lt;code class="language-dart">void main() {\n'
-          '}\n'
-          '&lt;/code>&lt;/pre>\n'
-          '</content>\n'
-          '          <link href="https://pub.dev/packages/foobar_pkg" rel="alternate" title="foobar_pkg"/>\n'
-          '        </entry>');
+        entries.first.toXmlString(indent: '  ').split('\n'),
+        [
+          '<entry>',
+          '          <id>urn:uuid:a6a43bff-e1ef-4633-b5ee-e0516b655be9</id>',
+          '          <title>v1.2.0 of oxygen</title>',
+          contains('          <updated>'),
+          '          ',
+          '          <content type="html">&lt;h1>oxygen&lt;/h1>',
+          '&lt;p>Awesome package.&lt;/p>',
+          '</content>',
+          '          <link href="https://pub.dev/packages/oxygen" rel="alternate" title="oxygen"/>',
+          '        </entry>',
+        ],
+      );
 
-      expect(
-          entries[3].toXmlString(indent: '  '),
-          '<entry>\n'
-          '          <id>urn:uuid:41c3131f-9d96-445e-9a55-756a6dd33d79</id>\n'
-          '          <title>v2.0.8 of hydrogen</title>\n'
-          '          <updated>2014-02-08T17:30:00.000</updated>\n'
-          '          \n'
-          '          <content type="html">&lt;h1>hydrogen&lt;/h1>\n'
-          '&lt;p>hydrogen is a Dart package&lt;/p>\n'
-          '</content>\n'
-          '          <link href="https://pub.dev/packages/hydrogen" rel="alternate" title="hydrogen"/>\n'
-          '        </entry>');
+      expect(entries.last.toXmlString(indent: '  ').split('\n'), [
+        '<entry>',
+        '          <id>urn:uuid:5f920595-c067-404a-bb19-2b0918372eb6</id>',
+        '          <title>v1.0.0 of neon</title>',
+        contains('          <updated>'),
+        '          ',
+        '          <content type="html">&lt;h1>neon&lt;/h1>',
+        '&lt;p>Awesome package.&lt;/p>',
+        '</content>',
+        '          <link href="https://pub.dev/packages/neon" rel="alternate" title="neon"/>',
+        '        </entry>',
+      ]);
 
       entries.forEach((e) => e.parent.children.remove(e));
 


### PR DESCRIPTION
I think it is important to have a random-looking order, otherwise tests that order by name or by updated times will be looking exactly the same, unable to differentiate between them.