### PR TITLE
Move contentType header check outside of fake-pub-server.

### DIFF
--- a/pkg/fake_pub_server/lib/fake_pub_server.dart
+++ b/pkg/fake_pub_server/lib/fake_pub_server.dart
@@ -58,13 +58,7 @@ class FakePubServer {
           final server = await IOServer.bind('localhost', port);
           serveRequests(server.server, (request) async {
             return await ss.fork(() async {
-              final rs = await extraHandler(request) ?? await handler(request);
-              try {
-                return await _validateAndWrapResponse(request, rs) ?? rs;
-              } catch (e, st) {
-                _logger.severe('Response validation failed', e, st);
-                return shelf.Response.internalServerError();
-              }
+              return await extraHandler(request) ?? await handler(request);
             }) as shelf.Response;
           });
           _logger.info('running on port $port');
@@ -77,18 +71,4 @@ class FakePubServer {
         });
     _logger.info('closed');
   }
-}
-
-// Normally this method could be just void, however reading the shelf.Response's
-// body forces us to return a new instance of the response.
-Future<shelf.Response> _validateAndWrapResponse(
-    shelf.Request rq, shelf.Response rs) async {
-  if (rs == null) return null;
-
-  final ct = rs.headers[HttpHeaders.contentTypeHeader];
-  if (ct == null || ct.isEmpty) {
-    // TODO: force headers everywhere and throw exception instead of logging
-    _logger.warning('Content type header is missing for ${rq.requestedUri}.');
-  }
-  return null;
 }

--- a/pkg/pub_integration/lib/src/headless_env.dart
+++ b/pkg/pub_integration/lib/src/headless_env.dart
@@ -129,9 +129,11 @@ class HeadlessEnv {
       }
 
       final contentType = rs.headers[HttpHeaders.contentTypeHeader];
-      if (rs.status == 200 &&
-          contentType != null &&
-          contentType.contains('text/html')) {
+      if (contentType == null || contentType.isEmpty) {
+        serverErrors
+            .add('Content type header is missing for ${rs.request.url}.');
+      }
+      if (rs.status == 200 && contentType.contains('text/html')) {
         try {
           parseAndValidateHtml(await rs.text);
         } catch (e) {

--- a/pkg/pub_integration/lib/src/pub_http_client.dart
+++ b/pkg/pub_integration/lib/src/pub_http_client.dart
@@ -240,9 +240,11 @@ class _HtmlVerifierHttpClient extends BaseClient {
   Future<StreamedResponse> send(BaseRequest request) async {
     final rs = await _delegate.send(request);
     final contentType = rs.headers[HttpHeaders.contentTypeHeader];
-    if (rs.statusCode == 200 &&
-        contentType != null &&
-        contentType.contains('text/html')) {
+    if (contentType == null || contentType.isEmpty) {
+      throw FormatException(
+          'Content type header is missing for ${request.url}.');
+    }
+    if (rs.statusCode == 200 && contentType.contains('text/html')) {
       final body = await rs.stream.bytesToString();
       parseAndValidateHtml(body);
       return StreamedResponse(


### PR DESCRIPTION
Integration tests will verify it on each request instead (also against the production server in post-deployment test).