### PR TITLE
Separate the file path where fake server's state is loaded from vs. saved to.

### DIFF
--- a/pkg/fake_pub_server/bin/fake_pub_server.dart
+++ b/pkg/fake_pub_server/bin/fake_pub_server.dart
@@ -40,6 +40,7 @@ Future main(List<String> args) async {
   final analyzerPort = int.parse(argv['analyzer-port'] as String);
   final dartdocPort = int.parse(argv['dartdoc-port'] as String);
   final readOnly = argv['read-only'] == true;
+  final dataFile = argv['data-file'] as String;
 
   Logger.root.onRecord.listen((r) {
     print([
@@ -50,8 +51,10 @@ Future main(List<String> args) async {
     ].where((e) => e != null).join(' '));
   });
 
-  final state = LocalServerState(path: argv['data-file'] as String);
-  await state.load();
+  final state = LocalServerState();
+  if (dataFile != null) {
+    await state.loadIfExists(dataFile);
+  }
 
   final storage = state.storage;
   final datastore = state.datastore;
@@ -123,8 +126,8 @@ Future main(List<String> args) async {
     eagerError: true,
   );
 
-  if (!readOnly) {
-    await state.save();
+  if (!readOnly && dataFile != null) {
+    await state.save(dataFile);
   }
   print('Server processes completed.');
 }

--- a/pkg/fake_pub_server/bin/init_data_file.dart
+++ b/pkg/fake_pub_server/bin/init_data_file.dart
@@ -39,6 +39,7 @@ Future<void> main(List<String> args) async {
 
   final argv = _argParser.parse(args);
   final analyze = argv['analyze'] as bool;
+  final dataFile = argv['data-file'] as String;
   final profile = TestProfile.fromYaml(
     await File(argv['test-profile'] as String).readAsString(),
   );
@@ -50,7 +51,7 @@ Future<void> main(List<String> args) async {
     'archives',
   );
 
-  final state = LocalServerState(path: argv['data-file'] as String);
+  final state = LocalServerState();
 
   await withFakeServices(
       configuration: Configuration.test(),
@@ -67,7 +68,7 @@ Future<void> main(List<String> args) async {
           await _analyze();
         }
       });
-  await state.save();
+  await state.save(dataFile);
 }
 
 Future<void> _analyze() async {


### PR DESCRIPTION
This can later enable better fake-specific API to control what to do with the state.