### PR TITLE
Tracking version published timestamps in Package.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ AppEngine version, listed here to ease deployment and troubleshooting.
  * Bumped runtimeVersion to `2020.11.27`.
  * NOTE: `PanaReport` has deprecated `pkgDependencies`.
          The field can be removed after this release is stable.
+ * NOTE: added `Package`'s `latestPublished` and `latestPrereleasePublished`.
+         TODO(deferred): schedule backfill after this release.
 
 ## `20201126t141046-all`
  * Bumped runtimeVersion to `2020.11.25`.

--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -1048,7 +1048,9 @@ Package _newPackageFromVersion(
     ..updated = now
     ..downloads = 0
     ..latestVersionKey = version.key
+    ..latestPublished = now
     ..latestPrereleaseVersionKey = version.key
+    ..latestPrereleasePublished = now
     ..uploaders = [userId]
     ..likes = 0
     ..isDiscontinued = false

--- a/app/lib/package/models.dart
+++ b/app/lib/package/models.dart
@@ -66,8 +66,14 @@ class Package extends db.ExpandoModel<String> {
   @db.ModelKeyProperty(propertyName: 'latest_version', required: true)
   db.Key latestVersionKey;
 
+  @db.DateTimeProperty()
+  DateTime latestPublished;
+
   @db.ModelKeyProperty(propertyName: 'latest_dev_version')
   db.Key latestPrereleaseVersionKey;
+
+  @db.DateTimeProperty()
+  DateTime latestPrereleasePublished;
 
   /// The publisher id (null, if the package does not have a publisher).
   @db.StringProperty()
@@ -179,12 +185,14 @@ class Package extends db.ExpandoModel<String> {
     if (latestVersionKey == null ||
         isNewer(latestSemanticVersion, newVersion, pubSorted: true)) {
       latestVersionKey = pv.key;
+      latestPublished = pv.created;
     }
 
     if (latestPrereleaseVersionKey == null ||
         isNewer(latestPrereleaseSemanticVersion, newVersion,
             pubSorted: false)) {
       latestPrereleaseVersionKey = pv.key;
+      latestPrereleasePublished = pv.created;
     }
   }
 

--- a/app/lib/package/models.dart
+++ b/app/lib/package/models.dart
@@ -63,15 +63,24 @@ class Package extends db.ExpandoModel<String> {
   @db.IntProperty(required: true)
   int likes;
 
+  /// Key referencing the [PackageVersion] for the latest version of this package, ordered by priority order of
+  /// semantic versioning, hence, deprioritizing prereleases.
   @db.ModelKeyProperty(propertyName: 'latest_version', required: true)
   db.Key latestVersionKey;
 
+  /// [DateTime] when the [PackageVersion] in [latestVersionKey] was published.
   @db.DateTimeProperty()
   DateTime latestPublished;
 
+  /// Reference to latest version of this package ordered by semantic versioning, including
+  /// prerelease versions of this package.
+  ///
+  /// Note. This is **not** the _latest prerelease version_, it is the _latest version_ without deprioritization of
+  /// prereleases. Hence, this might not be a prerelease version, if a newer non-prerelease exists.
   @db.ModelKeyProperty(propertyName: 'latest_dev_version')
   db.Key latestPrereleaseVersionKey;
 
+  /// DateTime at which point the `PackageVersion` referenced in [latestPrereleaseVersionKey] was published.
   @db.DateTimeProperty()
   DateTime latestPrereleasePublished;
 


### PR DESCRIPTION
- #4113
- added backfill
- fields are updated the same way the key references are updated