### PR TITLE
API for name completion data.

### DIFF
--- a/app/lib/frontend/handlers/custom_api.dart
+++ b/app/lib/frontend/handlers/custom_api.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:client_data/package_api.dart';
@@ -23,6 +22,7 @@ import '../../shared/exceptions.dart';
 import '../../shared/handlers.dart';
 import '../../shared/redis_cache.dart' show cache;
 import '../../shared/urls.dart' as urls;
+import '../../shared/utils.dart' show jsonUtf8Encoder;
 
 /// Handles requests for /api/documentation/<package>
 Future<shelf.Response> apiDocumentationHandler(
@@ -113,9 +113,9 @@ Future<shelf.Response> apiPackageNameCompletionDataHandler(
       skipCache: true,
     );
 
-    return gzip.encode(utf8.encode(json.encode({
+    return gzip.encode(jsonUtf8Encoder.convert({
       'packages': rs.packages.map((p) => p.package).toList(),
-    })));
+    }));
   });
 
   return shelf.Response(200, body: bytes, headers: {

--- a/app/lib/frontend/handlers/custom_api.dart
+++ b/app/lib/frontend/handlers/custom_api.dart
@@ -96,9 +96,7 @@ Future<shelf.Response> apiPackageNamesHandler(shelf.Request request) async {
 Future<shelf.Response> apiPackageNameCompletionDataHandler(
     shelf.Request request) async {
   // only accept requests which allow gzip content encoding
-  final acceptsEncoding =
-      request.headers[HttpHeaders.acceptEncodingHeader] ?? '*';
-  if (!acceptsEncoding.contains('*') && !acceptsEncoding.contains('gzip')) {
+  if (!request.acceptsEncoding('gzip')) {
     throw NotAcceptableException('Client must accept gzip content.');
   }
 

--- a/app/lib/frontend/handlers/pubapi.client.dart
+++ b/app/lib/frontend/handlers/pubapi.client.dart
@@ -247,6 +247,13 @@ class PubApiClient {
     );
   }
 
+  Future<List<int>> packageNameCompletionData() async {
+    return await _client.requestBytes(
+      verb: 'get',
+      path: '/api/package-name-completion-data',
+    );
+  }
+
   Future<List<int>> packageMetrics(String package) async {
     return await _client.requestBytes(
       verb: 'get',

--- a/app/lib/frontend/handlers/pubapi.dart
+++ b/app/lib/frontend/handlers/pubapi.dart
@@ -316,6 +316,11 @@ class PubApi {
     return apiPackageNamesHandler(request);
   }
 
+  @EndPoint.get('/api/package-name-completion-data')
+  Future<Response> packageNameCompletionData(Request request) async {
+    return apiPackageNameCompletionDataHandler(request);
+  }
+
   @EndPoint.get('/api/packages/<package>/metrics')
   Future<Response> packageMetrics(Request request, String package) =>
       apiPackageMetricsHandler(request, package);

--- a/app/lib/frontend/handlers/pubapi.g.dart
+++ b/app/lib/frontend/handlers/pubapi.g.dart
@@ -437,6 +437,19 @@ Router _$PubApiRouter(PubApi service) {
       return $utilities.unhandledError(e, st);
     }
   });
+  router.add('GET', r'/api/package-name-completion-data',
+      (Request request) async {
+    try {
+      final _$result = await service.packageNameCompletionData(
+        request,
+      );
+      return _$result;
+    } on ApiResponseException catch (e) {
+      return e.asApiResponse();
+    } catch (e, st) {
+      return $utilities.unhandledError(e, st);
+    }
+  });
   router.add('GET', r'/api/packages/<package>/metrics',
       (Request request, String package) async {
     try {

--- a/app/lib/shared/exceptions.dart
+++ b/app/lib/shared/exceptions.dart
@@ -32,6 +32,12 @@ class NotFoundException extends ResponseException {
       : super._(404, 'NotFound', 'Could not find `$resource`.');
 }
 
+/// Thrown when request is not acceptable.
+class NotAcceptableException extends ResponseException {
+  NotAcceptableException(String message)
+      : super._(406, 'NotAcceptable', message);
+}
+
 /// Thrown when request input is invalid, bad payload, wrong querystring, etc.
 class InvalidInputException extends ResponseException {
   InvalidInputException._(String message)

--- a/app/lib/shared/handlers.dart
+++ b/app/lib/shared/handlers.dart
@@ -197,3 +197,16 @@ bool isNotModified(shelf.Request request, DateTime lastModified, String etag) {
 
   return false;
 }
+
+extension RequestExt on shelf.Request {
+  /// Returns true if the current request declares that it accepts the [encoding].
+  ///
+  /// NOTE: the method does not parses the header, only checks whether the String
+  ///       value is present (or everything is accepted).
+  bool acceptsEncoding(String encoding) {
+    final accepting = headers[HttpHeaders.acceptEncodingHeader];
+    return accepting == null ||
+        accepting.contains('*') ||
+        accepting.contains(encoding);
+  }
+}

--- a/app/lib/shared/handlers.dart
+++ b/app/lib/shared/handlers.dart
@@ -27,6 +27,12 @@ const staticShortCache = Duration(minutes: 5);
 /// and it matches the etag.
 const staticLongCache = Duration(days: 7);
 
+/// The default header values for JSON responses.
+const jsonResponseHeaders = <String, String>{
+  'content-type': 'application/json; charset="utf-8"',
+  'x-content-type-options': 'nosniff',
+};
+
 final _logger = Logger('pub.shared.handler');
 final _prettyJson = JsonUtf8Encoder('  ');
 
@@ -49,9 +55,8 @@ shelf.Response jsonResponse(
     status,
     body: body,
     headers: {
+      ...jsonResponseHeaders,
       if (headers != null) ...headers,
-      'content-type': 'application/json; charset="utf-8"',
-      'x-content-type-options': 'nosniff',
     },
   );
 }

--- a/app/lib/shared/redis_cache.dart
+++ b/app/lib/shared/redis_cache.dart
@@ -221,6 +221,10 @@ class CachePatterns {
       .withTTL(Duration(hours: 12))
       .withCodec(utf8)[requestedUri];
 
+  Entry<List<int>> packageNameCompletitionDataJsonGz() => _cache
+      .withPrefix('api-package-name-completition-data-json-gz')
+      .withTTL(Duration(hours: 8))['-'];
+
   Entry<PublisherPage> allPublishersPage() => publisherPage('-');
 
   Entry<PublisherPage> publisherPage(String userId) => _cache

--- a/pkg/pub_integration/lib/script/public_pages.dart
+++ b/pkg/pub_integration/lib/script/public_pages.dart
@@ -23,6 +23,9 @@ class PublicPagesScript {
     assert(_pubClient == null);
     _pubClient = PubHttpClient(pubHostedUrl);
     try {
+      if (!expectLiveSite) {
+        await _pubClient.forceSearchUpdate();
+      }
       await _landingPage();
       await _helpPages();
       await _securityPage();
@@ -84,6 +87,11 @@ class PublicPagesScript {
     final packageNames = await _pubClient.apiPackageNames();
     if (packageNames == null || !packageNames.contains('retry')) {
       throw Exception('Expected "retry" in the list of package names.');
+    }
+
+    final completitionData = await _pubClient.apiPackageNameCompletionData();
+    if (completitionData == null || !completitionData.contains('retry')) {
+      throw Exception('Expected "retry" in the package name completion data.');
     }
   }
 

--- a/pkg/pub_integration/lib/src/pub_http_client.dart
+++ b/pkg/pub_integration/lib/src/pub_http_client.dart
@@ -224,6 +224,18 @@ class PubHttpClient {
     return packages;
   }
 
+  /// Returns the list of packages from `/api/package-name-completion-data` endpoint.
+  Future<List<String>> apiPackageNameCompletionData() async {
+    final rs =
+        await _http.get('$pubHostedUrl/api/package-name-completion-data');
+    if (rs.statusCode != 200) {
+      throw Exception('Unexpected status code: ${rs.statusCode}');
+    }
+    final map = json.decode(rs.body) as Map<String, dynamic>;
+    final packages = (map['packages'] as List).cast<String>();
+    return packages;
+  }
+
   /// Free resources.
   Future<void> close() async {
     _http.close();

--- a/pkg/web_app/lib/src/pubapi.client.dart
+++ b/pkg/web_app/lib/src/pubapi.client.dart
@@ -247,6 +247,13 @@ class PubApiClient {
     );
   }
 
+  Future<List<int>> packageNameCompletionData() async {
+    return await _client.requestBytes(
+      verb: 'get',
+      path: '/api/package-name-completion-data',
+    );
+  }
+
   Future<List<int>> packageMetrics(String package) async {
     return await _client.requestBytes(
       verb: 'get',


### PR DESCRIPTION
- #4302
- Tested search responses on staging: 400-600 ms on the search instance to serve the content, a 200-500 ms more on the frontend instance to parse, transform and cache it. If we were to use a binary protocol for search, this could be reduced by about 50-150 ms.
- The uncompressed size is about 280k, the compressed is about 80k with the default gzip settings.
- Caching the gzipped content for 8 hours seems to be a good balance.
- Clients that do not accept gzip encoding are rejected with HTTP 406.
- Added to integration test (also checks on post-deployment) - as long as `retry` is a popular package, it won't fail :).