### PR TITLE
Fused json-utf8 converters in JSON API and Datastore blobs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ AppEngine version, listed here to ease deployment and troubleshooting.
 
 ## Next Release (replace with git tag when deployed)
  * Bumped runtimeVersion to `2020.11.27`.
+ * Using fused json-utf8 converters in JSON API responses and binary
+   serialization of JSON blobs in Datastore entities.
  * NOTE: `PanaReport` has deprecated `pkgDependencies`.
          The field can be removed after this release is stable.
  * NOTE: added `Package`'s `latestPublished` and `latestPrereleasePublished`.

--- a/app/lib/dartdoc/models.dart
+++ b/app/lib/dartdoc/models.dart
@@ -3,11 +3,11 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:convert';
 
 import 'package:json_annotation/json_annotation.dart';
 import 'package:meta/meta.dart';
 
+import '../shared/utils.dart' show jsonUtf8Encoder, utf8JsonDecoder;
 import '../shared/versions.dart' as versions;
 import 'storage_path.dart' as storage_path;
 
@@ -81,7 +81,7 @@ class DartdocEntry {
       _$DartdocEntryFromJson(json);
 
   factory DartdocEntry.fromBytes(List<int> bytes) => DartdocEntry.fromJson(
-      json.decode(utf8.decode(bytes)) as Map<String, dynamic>);
+      utf8JsonDecoder.convert(bytes) as Map<String, dynamic>);
 
   static Future<DartdocEntry> fromStream(Stream<List<int>> stream) async {
     final bytes =
@@ -147,7 +147,7 @@ class DartdocEntry {
     }
   }
 
-  List<int> asBytes() => utf8.encode(json.encode(toJson()));
+  List<int> asBytes() => jsonUtf8Encoder.convert(toJson());
 
   bool isRegression(DartdocEntry oldEntry) {
     if (oldEntry == null) {
@@ -186,10 +186,10 @@ class FileInfo {
   factory FileInfo.fromJson(Map<String, dynamic> json) =>
       _$FileInfoFromJson(json);
 
-  factory FileInfo.fromBytes(List<int> bytes) => FileInfo.fromJson(
-      json.decode(utf8.decode(bytes)) as Map<String, dynamic>);
+  factory FileInfo.fromBytes(List<int> bytes) =>
+      FileInfo.fromJson(utf8JsonDecoder.convert(bytes) as Map<String, dynamic>);
 
-  List<int> asBytes() => utf8.encode(json.encode(toJson()));
+  List<int> asBytes() => jsonUtf8Encoder.convert(toJson());
 
   Map<String, dynamic> toJson() => _$FileInfoToJson(this);
 }

--- a/app/lib/frontend/handlers/package.dart
+++ b/app/lib/frontend/handlers/package.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:convert';
 
 import 'package:meta/meta.dart';
 import 'package:neat_cache/neat_cache.dart';
@@ -307,7 +306,7 @@ Future<shelf.Response> listVersionsHandler(
     shelf.Request request, Uri baseUri, String package) async {
   final body = await cache.packageData(package).get(() async {
     final data = await packageBackend.listVersions(baseUri, package);
-    return utf8.encode(json.encode(data.toJson()));
+    return jsonUtf8Encoder.convert(data.toJson());
   });
   return shelf.Response(200, body: body, headers: {
     'content-type': 'application/json; charset="utf-8"',

--- a/app/lib/package/upload_signer_service.dart
+++ b/app/lib/package/upload_signer_service.dart
@@ -18,6 +18,7 @@ import 'package:http/http.dart' as http;
 import 'package:client_data/package_api.dart';
 
 import '../shared/configuration.dart';
+import '../shared/utils.dart' show jsonUtf8Encoder;
 
 /// The registered [UploadSignerService] object.
 UploadSignerService get uploadSigner =>
@@ -81,7 +82,7 @@ abstract class UploadSignerService {
       'conditions': conditions,
     };
 
-    final policyString = base64.encode(utf8.encode(json.encode(policyMap)));
+    final policyString = base64.encode(jsonUtf8Encoder.convert(policyMap));
     final SigningResult result = await sign(ascii.encode(policyString));
     final signatureString = base64.encode(result.bytes);
 

--- a/app/lib/scorecard/models.dart
+++ b/app/lib/scorecard/models.dart
@@ -2,18 +2,18 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:json_annotation/json_annotation.dart';
 import 'package:meta/meta.dart';
 import 'package:pana/models.dart'
     show LicenseFile, PanaRuntimeInfo, PkgDependency, Report, ReportSection;
-import 'package:pub_dev/dartdoc/models.dart';
 import 'package:pub_semver/pub_semver.dart';
 
+import '../dartdoc/models.dart';
 import '../shared/datastore.dart' as db;
 import '../shared/model_properties.dart';
+import '../shared/utils.dart' show jsonUtf8Encoder, utf8JsonDecoder;
 import '../shared/versions.dart' as versions;
 
 import 'helpers.dart';
@@ -207,7 +207,7 @@ class ScoreCardReport extends db.ExpandoModel<String> {
 
   Map<String, dynamic> get reportJson {
     if (reportJsonGz == null) return null;
-    return json.decode(utf8.decode(_gzipCodec.decode(reportJsonGz)))
+    return utf8JsonDecoder.convert(_gzipCodec.decode(reportJsonGz))
         as Map<String, dynamic>;
   }
 
@@ -215,7 +215,7 @@ class ScoreCardReport extends db.ExpandoModel<String> {
     if (map == null) {
       reportJsonGz = null;
     } else {
-      reportJsonGz = _gzipCodec.encode(utf8.encode(json.encode(map)));
+      reportJsonGz = _gzipCodec.encode(jsonUtf8Encoder.convert(map));
     }
   }
 

--- a/app/lib/shared/handlers.dart
+++ b/app/lib/shared/handlers.dart
@@ -13,7 +13,7 @@ import '../frontend/request_context.dart';
 import 'popularity_storage.dart';
 import 'scheduler_stats.dart';
 import 'urls.dart' as urls;
-import 'utils.dart' show eventLoopLatencyTracker;
+import 'utils.dart' show eventLoopLatencyTracker, jsonUtf8Encoder;
 import 'versions.dart';
 
 const String default400BadRequest = '400 Bad Request';
@@ -28,7 +28,7 @@ const staticShortCache = Duration(minutes: 5);
 const staticLongCache = Duration(days: 7);
 
 final _logger = Logger('pub.shared.handler');
-final _prettyJson = JsonEncoder.withIndent('  ');
+final _prettyJson = JsonUtf8Encoder('  ');
 
 shelf.Response redirectResponse(String url) => shelf.Response.seeOther(url);
 
@@ -42,9 +42,9 @@ shelf.Response jsonResponse(
   bool indentJson = false,
   Map<String, String> headers,
 }) {
-  final String body = (indentJson || requestContext.indentJson)
+  final body = (indentJson || requestContext.indentJson)
       ? _prettyJson.convert(map)
-      : json.encode(map);
+      : jsonUtf8Encoder.convert(map);
   return shelf.Response(
     status,
     body: body,

--- a/app/lib/shared/storage.dart
+++ b/app/lib/shared/storage.dart
@@ -14,7 +14,7 @@ import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
 import 'package:pool/pool.dart';
 
-import 'utils.dart' show contentType, retryAsync;
+import 'utils.dart' show contentType, jsonUtf8Encoder, retryAsync;
 import 'versions.dart' as versions;
 
 final _gzip = GZipCodec();
@@ -146,7 +146,7 @@ class VersionedJsonStorage {
   /// Upload the current data to the storage bucket.
   Future<void> uploadDataAsJsonMap(Map<String, dynamic> map) async {
     final objectName = _objectName();
-    final bytes = _gzip.encode(utf8.encode(json.encode(map)));
+    final bytes = _gzip.encode(jsonUtf8Encoder.convert(map));
     try {
       await uploadBytesWithRetry(_bucket, objectName, bytes);
     } catch (e, st) {

--- a/app/lib/shared/utils.dart
+++ b/app/lib/shared/utils.dart
@@ -6,6 +6,7 @@ library pub_dartlang_org.utils;
 
 import 'dart:async';
 import 'dart:collection';
+import 'dart:convert';
 import 'dart:io';
 import 'dart:math';
 
@@ -42,6 +43,9 @@ final Logger _logger = Logger('pub.utils');
 final _random = Random.secure();
 
 final DateFormat shortDateFormat = DateFormat.yMMMd();
+
+final jsonUtf8Encoder = JsonUtf8Encoder();
+final utf8JsonDecoder = utf8.decoder.fuse(json.decoder);
 
 Future<T> withTempDirectory<T>(Future<T> Function(Directory dir) func,
     {String prefix = 'dart-tempdir'}) {


### PR DESCRIPTION
- Microbenchmarking confirmed that `JsonUtf8Encoder` has better performance than doing it separately.
- I've reviewed our code and found a few places where we could use it instead the un-fused version, or in the case of API JSON response convert straight to List<int> instead of `String`.