### PR TITLE
Fix: recently moderated package should not get a pass.

### DIFF
--- a/app/lib/package/name_tracker.dart
+++ b/app/lib/package/name_tracker.dart
@@ -49,6 +49,7 @@ class NameTracker {
   void addReservedName(String name) {
     _reservedNames.add(name);
     _reducedNames.add(reducePackageName(name));
+    _names.remove(name);
   }
 
   /// Whether the package was already added to the tracker.

--- a/app/test/package/upload_test.dart
+++ b/app/test/package/upload_test.dart
@@ -13,6 +13,7 @@ import 'package:yaml/yaml.dart';
 
 import 'package:pub_dev/account/backend.dart';
 import 'package:pub_dev/account/models.dart';
+import 'package:pub_dev/admin/backend.dart';
 import 'package:pub_dev/fake/backend/fake_email_sender.dart';
 import 'package:pub_dev/package/backend.dart';
 import 'package:pub_dev/package/models.dart';
@@ -305,14 +306,25 @@ void main() {
         expect(await fn('ok_name'), isNull);
       });
 
-      testWithServices('conflicting package names are rejected', () async {
-        await nameTracker.scanDatastore();
-        registerAuthenticatedUser(hansUser);
+      testWithProfile('similar package names are rejected', fn: () async {
+        registerAuthenticatedUser(adminUser);
 
-        expect(await fn('hy_drogen'),
+        expect(await fn('ox_ygen'),
             'PackageRejected(400): Package name is too similar to another active or moderated package.');
 
-        expect(await fn('mo_derate'),
+        expect(await fn('ox_y_ge_n'),
+            'PackageRejected(400): Package name is too similar to another active or moderated package.');
+      });
+
+      testWithProfile('moderated package names are rejected', fn: () async {
+        registerAuthenticatedUser(adminUser);
+        await adminBackend.removePackage('neon');
+        await nameTracker.scanDatastore();
+
+        expect(await fn('neon'),
+            'PackageRejected(400): Package name is too similar to another active or moderated package.');
+
+        expect(await fn('ne_on'),
             'PackageRejected(400): Package name is too similar to another active or moderated package.');
       });
 

--- a/app/test/shared/test_models.dart
+++ b/app/test/shared/test_models.dart
@@ -77,9 +77,6 @@ final foobarStablePVKey =
     foobarPkgKey.append(PackageVersion, id: foobarStableVersion);
 final foobarDevPVKey = foobarPkgKey.append(PackageVersion, id: '0.2.0-dev');
 
-final moderatedPkgKey =
-    Key.emptyKey(Partition(null)).append(ModeratedPackage, id: 'mo_derated');
-
 final hansUser = User()
   ..id = 'hans-at-juergen-dot-com'
   ..email = 'hans@juergen.com'
@@ -226,14 +223,6 @@ PackageVersion _clonePackageVersion(PackageVersion original) => PackageVersion()
   ..uploader = original.uploader
   ..libraries = original.libraries
   ..pubspec = original.pubspec;
-
-final moderatedPackage = ModeratedPackage()
-  ..parentKey = moderatedPkgKey
-  ..id = 'mo_derate'
-  ..name = 'mo_derate'
-  ..moderated = DateTime.utc(2014)
-  ..uploaders = [hansUser.userId]
-  ..versions = ['1.0.0'];
 
 final String foobarReadmeContent = '''
 Test Package

--- a/app/test/shared/test_services.dart
+++ b/app/test/shared/test_services.dart
@@ -126,7 +126,6 @@ Future<void> _populateDefaultData() async {
     ...lithium.versions.map(pvModels).expand((m) => m),
     ...lithium.infos,
     ...lithium.assets,
-    moderatedPackage,
     exampleComPublisher,
     exampleComHansAdmin,
   ]);


### PR DESCRIPTION
- Prior to this change, name tracker did not remove the package from the valid names, and the fast-track did allowed the upload of the new version. On a freshly started instance it would get it right the next time though, so the effect was limited.
- Also migrated the related tests and removed the now-obsolete test model instance.