### PR TITLE
Fix linking of dependencies.

### DIFF
--- a/app/lib/frontend/handlers/documentation.dart
+++ b/app/lib/frontend/handlers/documentation.dart
@@ -28,8 +28,8 @@ Future<shelf.Response> documentationHandler(shelf.Request request) async {
   if (docFilePath == null) {
     return notFoundHandler(request);
   }
-  if (redirectDartdocPages.containsKey(docFilePath.package)) {
-    return redirectResponse(redirectDartdocPages[docFilePath.package]);
+  if (redirectPackageUrls.containsKey(docFilePath.package)) {
+    return redirectResponse(redirectPackageUrls[docFilePath.package]);
   }
   if (!await packageBackend.isPackageVisible(docFilePath.package)) {
     return notFoundHandler(request);

--- a/app/lib/frontend/handlers/package.dart
+++ b/app/lib/frontend/handlers/package.dart
@@ -182,8 +182,8 @@ Future<shelf.Response> _handlePackagePage({
   @required FutureOr Function(PackagePageData data) renderFn,
   Entry<String> cacheEntry,
 }) async {
-  if (redirectPackagePages.containsKey(packageName)) {
-    return redirectResponse(redirectPackagePages[packageName]);
+  if (redirectPackageUrls.containsKey(packageName)) {
+    return redirectResponse(redirectPackageUrls[packageName]);
   }
   final Stopwatch sw = Stopwatch()..start();
   String cachedPage;

--- a/app/lib/frontend/templates/package.dart
+++ b/app/lib/frontend/templates/package.dart
@@ -12,7 +12,8 @@ import 'package:pub_dev/shared/handlers.dart';
 import '../../analyzer/analyzer_client.dart';
 import '../../package/model_properties.dart';
 import '../../package/models.dart';
-import '../../package/overrides.dart' show devDependencyPackages;
+import '../../package/overrides.dart'
+    show devDependencyPackages, redirectPackageUrls;
 import '../../scorecard/models.dart';
 import '../../search/search_form.dart';
 import '../../shared/email.dart' show EmailAddress;
@@ -49,9 +50,13 @@ String _renderDependencyList(Pubspec pubspec) {
   if (pubspec == null) return null;
   final packages = pubspec.dependencies.toList()..sort();
   if (packages.isEmpty) return null;
-  return packages
-      .map((p) => '<a href="${urls.pkgPageUrl(p)}">$p</a>')
-      .join(', ');
+  return packages.map((p) {
+    var href = redirectPackageUrls[p];
+    if (href == null && pubspec.isHostedDependency(p)) {
+      href = urls.pkgPageUrl(p);
+    }
+    return href == null ? p : '<a href="$href">$p</a>';
+  }).join(', ');
 }
 
 String _renderInstallTab(PackageVersion selectedVersion, List<String> tags) {

--- a/app/lib/package/model_properties.dart
+++ b/app/lib/package/model_properties.dart
@@ -7,7 +7,8 @@ library pub_dartlang_org.model_properties;
 import 'dart:convert';
 
 import 'package:pana/pana.dart' show SdkConstraintStatus;
-import 'package:pubspec_parse/pubspec_parse.dart' as pubspek show Pubspec;
+import 'package:pubspec_parse/pubspec_parse.dart' as pubspek
+    show HostedDependency, Pubspec;
 import 'package:yaml/yaml.dart';
 
 import '../shared/datastore.dart';
@@ -57,6 +58,11 @@ class Pubspec {
   }
 
   Iterable<String> get dependencies => _inner.dependencies.keys;
+
+  bool isHostedDependency(String package) {
+    final d = _inner.dependencies[package];
+    return d is pubspek.HostedDependency;
+  }
 
   Iterable<String> get devDependencies => _inner.devDependencies.keys;
 

--- a/app/lib/package/overrides.dart
+++ b/app/lib/package/overrides.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import '../shared/urls.dart' as urls;
-
 /// 'internal' packages are developed by the Dart team, and they are allowed to
 /// point their URLs to *.dartlang.org (others would get a penalty for it).
 const internalPackageNames = <String>[
@@ -11,12 +9,18 @@ const internalPackageNames = <String>[
   'angular_components',
 ];
 
-const redirectPackagePages = <String, String>{
-  'flutter': '${urls.siteRoot}/flutter',
-};
-
-const redirectDartdocPages = <String, String>{
-  'flutter': 'https://docs.flutter.io/',
+const redirectPackageUrls = <String, String>{
+  'flutter': 'https://api.flutter.dev/',
+  'flutter_driver':
+      'https://api.flutter.dev/flutter/flutter_driver/flutter_driver-library.html',
+  'flutter_driver_extension':
+      'https://api.flutter.dev/flutter/flutter_driver_extension/flutter_driver_extension-library.html',
+  'flutter_localizations':
+      'https://api.flutter.dev/flutter/flutter_localizations/flutter_localizations-library.html',
+  'flutter_test':
+      'https://api.flutter.dev/flutter/flutter_test/flutter_test-library.html',
+  'flutter_web_plugins':
+      'https://api.flutter.dev/flutter/package-flutter_web_plugins_flutter_web_plugins/package-flutter_web_plugins_flutter_web_plugins-library.html',
 };
 
 /// Known packages that should be put in `dev_dependencies`
@@ -49,4 +53,4 @@ String overrideIssueTrackerUrl(String url) {
 /// A package is soft-removed when we keep it in the archives and index, but we
 /// won't serve the package or the documentation page, or any data about it.
 bool isSoftRemoved(String packageName) =>
-    redirectPackagePages.containsKey(packageName);
+    redirectPackageUrls.containsKey(packageName);

--- a/app/test/frontend/handlers/documentation_test.dart
+++ b/app/test/frontend/handlers/documentation_test.dart
@@ -74,14 +74,14 @@ void main() {
     testWithServices('/documentation/flutter redirect', () async {
       await expectRedirectResponse(
         await issueGet('/documentation/flutter'),
-        'https://docs.flutter.io/',
+        'https://api.flutter.dev/',
       );
     });
 
     testWithServices('/documentation/flutter/version redirect', () async {
       await expectRedirectResponse(
         await issueGet('/documentation/flutter/version'),
-        'https://docs.flutter.io/',
+        'https://api.flutter.dev/',
       );
     });
 

--- a/app/test/frontend/handlers/redirects_test.dart
+++ b/app/test/frontend/handlers/redirects_test.dart
@@ -97,14 +97,14 @@ void main() {
     testWithServices('/packages/flutter - redirect', () async {
       await expectRedirectResponse(
         await issueGet('/packages/flutter'),
-        '$siteRoot/flutter',
+        'https://api.flutter.dev/',
       );
     });
 
     testWithServices('/packages/flutter/versions/* - redirect', () async {
       await expectRedirectResponse(
         await issueGet('/packages/flutter/versions/0.20'),
-        '$siteRoot/flutter',
+        'https://api.flutter.dev/',
       );
     });
   });


### PR DESCRIPTION
- Fixes #4325.
- No need to have two separate overrides for package and documentation page.
- Only hosted dependencies are displayed with a link to the package page.
- Overrides are applied at the rendered dependency list.
- Updated list of overrides.