### PR TITLE
Refactor HTTP-client tools into a separate library.

### DIFF
--- a/app/lib/account/google_oauth2.dart
+++ b/app/lib/account/google_oauth2.dart
@@ -11,7 +11,7 @@ import 'package:logging/logging.dart';
 import 'package:retry/retry.dart' show retry;
 
 import '../shared/email.dart' show looksLikeEmail;
-import '../shared/utils.dart' show httpRetryClient;
+import '../tool/utils/http.dart' show httpRetryClient;
 import 'auth_provider.dart';
 
 final _logger = Logger('pub.account.google_auth2');

--- a/app/lib/search/search_client.dart
+++ b/app/lib/search/search_client.dart
@@ -13,6 +13,7 @@ import '../scorecard/backend.dart';
 import '../shared/configuration.dart';
 import '../shared/redis_cache.dart' show cache;
 import '../shared/utils.dart';
+import '../tool/utils/http.dart';
 
 import 'search_service.dart';
 

--- a/app/lib/service/services.dart
+++ b/app/lib/service/services.dart
@@ -43,8 +43,8 @@ import '../shared/popularity_storage.dart';
 import '../shared/redis_cache.dart' show withCache;
 import '../shared/storage.dart';
 import '../shared/urls.dart';
-import '../shared/utils.dart' show httpRetryClient;
 import '../shared/versions.dart';
+import '../tool/utils/http.dart';
 
 import 'announcement/backend.dart';
 import 'secret/backend.dart';

--- a/app/lib/shared/utils.dart
+++ b/app/lib/shared/utils.dart
@@ -11,8 +11,6 @@ import 'dart:io';
 import 'dart:math';
 
 import 'package:appengine/appengine.dart';
-import 'package:http/http.dart' as http;
-import 'package:http_retry/http_retry.dart';
 import 'package:intl/intl.dart';
 import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
@@ -386,28 +384,6 @@ String createUuid([List<int> bytes]) {
     bytes.sublist(8, 10).map(formatByte).join(),
     bytes.sublist(10).map(formatByte).join(),
   ].join('-');
-}
-
-final _transientStatusCodes = {
-  // See: https://cloud.google.com/storage/docs/xml-api/reference-status
-  429,
-  500,
-  503,
-};
-
-/// Creates a HTTP client that retries transient status codes.
-http.Client httpRetryClient({
-  http.Client innerClient,
-  int retries,
-}) {
-  return RetryClient(
-    innerClient ?? http.Client(),
-    when: (r) => _transientStatusCodes.contains(r.statusCode),
-    // TOOD: Consider implementing whenError and handle DNS + handshake errors.
-    //       These are safe, retrying after partially sending data is more
-    //       sketchy, but probably safe in our application.
-    retries: retries ?? 5,
-  );
 }
 
 /// Returns a header map when appengine context's is active and traceId is set.

--- a/app/lib/tool/utils/http.dart
+++ b/app/lib/tool/utils/http.dart
@@ -1,0 +1,66 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:http/http.dart' as http;
+import 'package:http_retry/http_retry.dart';
+import 'package:meta/meta.dart';
+
+final _transientStatusCodes = {
+  // See: https://cloud.google.com/storage/docs/xml-api/reference-status
+  429,
+  500,
+  503,
+};
+
+/// Creates a HTTP client that retries transient status codes.
+http.Client httpRetryClient({
+  http.Client innerClient,
+  int retries,
+}) {
+  return RetryClient(
+    innerClient ?? http.Client(),
+    when: (r) => _transientStatusCodes.contains(r.statusCode),
+    // TOOD: Consider implementing whenError and handle DNS + handshake errors.
+    //       These are safe, retrying after partially sending data is more
+    //       sketchy, but probably safe in our application.
+    retries: retries ?? 5,
+  );
+}
+
+/// Returns an [http.Client] which sends a `Bearer` token as `Authorization`
+/// header for each request.
+http.Client httpClientWithAuthorization({
+  @required String bearerToken,
+  http.Client client,
+}) {
+  return _AuthenticatedClient(
+    bearerToken,
+    client ?? http.Client(),
+    client == null,
+  );
+}
+
+/// An [http.Client] which sends a `Bearer` token as `Authorization` header for
+/// each request.
+class _AuthenticatedClient extends http.BaseClient {
+  final String _bearerToken;
+  final http.Client _client;
+  final bool _closeInnerClient;
+
+  _AuthenticatedClient(this._bearerToken, this._client, this._closeInnerClient);
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) async {
+    request.headers['Authorization'] = 'Bearer $_bearerToken';
+    return await _client.send(request);
+  }
+
+  @override
+  void close() {
+    if (_closeInnerClient) {
+      _client.close();
+    }
+    super.close();
+  }
+}

--- a/app/lib/tool/utils/http.dart
+++ b/app/lib/tool/utils/http.dart
@@ -31,11 +31,11 @@ http.Client httpRetryClient({
 /// Returns an [http.Client] which sends a `Bearer` token as `Authorization`
 /// header for each request.
 http.Client httpClientWithAuthorization({
-  @required Future<String> Function() bearerTokenFn,
+  @required Future<String> Function() tokenProvider,
   http.Client client,
 }) {
   return _AuthenticatedClient(
-    bearerTokenFn,
+    tokenProvider,
     client ?? http.Client(),
     client == null,
   );
@@ -44,16 +44,16 @@ http.Client httpClientWithAuthorization({
 /// An [http.Client] which sends a `Bearer` token as `Authorization` header for
 /// each request.
 class _AuthenticatedClient extends http.BaseClient {
-  final Future<String> Function() _bearerTokenFn;
+  final Future<String> Function() _tokenProvider;
   final http.Client _client;
   final bool _closeInnerClient;
 
   _AuthenticatedClient(
-      this._bearerTokenFn, this._client, this._closeInnerClient);
+      this._tokenProvider, this._client, this._closeInnerClient);
 
   @override
   Future<http.StreamedResponse> send(http.BaseRequest request) async {
-    final token = await _bearerTokenFn();
+    final token = await _tokenProvider();
     if (token != null) {
       request.headers['Authorization'] = 'Bearer $token';
     }

--- a/app/test/shared/test_services.dart
+++ b/app/test/shared/test_services.dart
@@ -165,7 +165,7 @@ http.Client _httpClient({
     sanitize: true,
   );
   return httpClientWithAuthorization(
-    bearerToken: authToken,
+    bearerTokenFn: () async => authToken,
     client: http_testing.MockClient(_wrapShelfHandler(handler)),
   );
 }

--- a/app/test/shared/test_services.dart
+++ b/app/test/shared/test_services.dart
@@ -165,7 +165,7 @@ http.Client _httpClient({
     sanitize: true,
   );
   return httpClientWithAuthorization(
-    bearerTokenFn: () async => authToken,
+    tokenProvider: () async => authToken,
     client: http_testing.MockClient(_wrapShelfHandler(handler)),
   );
 }


### PR DESCRIPTION
I wanted to add `httpClientWithAuthorization` but `shared/utils.dart` seems to be overcrowded, let's create a new library for these. It is a component that the test-profile importer will use - eventually.