### PR TITLE
Reduced test profile and scoped importer.

### DIFF
--- a/app/lib/tool/test_profile/importer.dart
+++ b/app/lib/tool/test_profile/importer.dart
@@ -2,19 +2,15 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:convert';
-
-import 'package:crypto/crypto.dart';
 import 'package:gcloud/service_scope.dart';
 import 'package:meta/meta.dart';
 
 import 'package:client_data/package_api.dart';
+import 'package:client_data/publisher_api.dart';
 
 import '../../account/backend.dart';
-import '../../account/models.dart';
 import '../../package/backend.dart';
-import '../../publisher/models.dart';
-import '../../shared/datastore.dart';
+import '../../publisher/backend.dart';
 
 import 'import_source.dart';
 import 'models.dart';
@@ -32,51 +28,29 @@ Future<void> importProfile({
   // expand profile with resolved version information
   profile = normalize(profile, resolvedVersions: resolvedVersions);
 
-  // create users
-  for (final u in profile.users) {
-    // The default oauthUserId is following the same pattern as we have in
-    // `fake_auth_provider.dart`.
-    final oauthUserId =
-        u.oauthUserId ?? u.email.replaceAll('.', '-').replaceAll('@', '-');
-    final userId = _userIdFromEmail(u.email);
-    await dbService.commit(inserts: [
-      User()
-        ..id = userId
-        ..oauthUserId = oauthUserId
-        ..email = u.email
-        ..created = u.created ?? DateTime.now().toUtc()
-        ..isDeleted = u.isDeleted ?? false
-        ..isBlocked = u.isBlocked ?? false,
-      OAuthUserID()
-        ..id = oauthUserId
-        ..userIdKey = dbService.emptyKey.append(User, id: userId),
-    ]);
+  if (profile.packages
+      .any((p) => p.uploaders != null && p.uploaders.length > 1)) {
+    throw UnimplementedError('More than one uploader is not implemented.');
   }
 
   // create publishers
   for (final p in profile.publishers) {
-    await dbService.commit(inserts: [
-      Publisher()
-        ..id = p.name
-        ..contactEmail = p.members.isEmpty ? null : p.members.first.email
-        ..websiteUrl = 'https://${p.name}/'
-        ..created = p.created ?? DateTime.now().toUtc()
-        ..updated = p.updated ?? DateTime.now().toUtc()
-        ..isAbandoned = false,
-      ...p.members.map(
-        (m) => PublisherMember()
-          ..parentKey = dbService.emptyKey.append(Publisher, id: p.name)
-          ..id = _userIdFromEmail(m.email)
-          ..userId = _userIdFromEmail(m.email)
-          ..created = m.created ?? DateTime.now().toUtc()
-          ..updated = m.updated ?? DateTime.now().toUtc()
-          ..role = PublisherMemberRole.admin,
-      )
-    ]);
+    final firstMemberEmail = p.members.first.email;
+    final token = _fakeToken(firstMemberEmail);
+    await _withAuthorizationToken(token, () async {
+      await publisherBackend.createPublisher(
+          p.name, CreatePublisherRequest(accessToken: token));
+
+      for (final _ in p.members.skip(1)) {
+        // TODO: explore implementation options how to add this
+        throw UnimplementedError(
+            'More than one publisher members is not implemented (${p.name}).');
+      }
+    });
   }
 
   // last active uploader
-  final lastActiveUploaders = <String, User>{};
+  final lastActiveUploaderEmails = <String, String>{};
 
   // create versions
   for (final rv in resolvedVersions) {
@@ -84,13 +58,9 @@ Future<void> importProfile({
     final uploaderEmails = _potentialActiveEmails(profile, rv.package);
     final uploaderEmail =
         uploaderEmails[rv.version.hashCode.abs() % uploaderEmails.length];
-    final activeUser =
-        await accountBackend.lookupUserById(_userIdFromEmail(uploaderEmail));
-    lastActiveUploaders[rv.package] = activeUser;
+    lastActiveUploaderEmails[rv.package] = uploaderEmail;
 
-    // upload package in the name of the active user
-    await fork(() async {
-      registerAuthenticatedUser(activeUser);
+    await _withAuthorizationToken(_fakeToken(uploaderEmail), () async {
       // ignore: invalid_use_of_visible_for_testing_member
       await packageBackend.upload(Stream<List<int>>.fromFuture(
           source.getArchiveBytes(rv.package, rv.version)));
@@ -98,11 +68,9 @@ Future<void> importProfile({
   }
   for (final testPackage in profile.packages) {
     final packageName = testPackage.name;
-    final activeUser = lastActiveUploaders[packageName];
+    final activeEmail = lastActiveUploaderEmails[packageName];
 
-    // update package info
-    await fork(() async {
-      registerAuthenticatedUser(activeUser);
+    await _withAuthorizationToken(_fakeToken(activeEmail), () async {
       // update publisher
       if (testPackage.publisher != null) {
         await packageBackend.setPublisher(
@@ -124,18 +92,16 @@ Future<void> importProfile({
 
   // create likes
   for (final u in profile.users) {
-    if (u.likes == null || u.likes.isEmpty) continue;
-    final userId = _userIdFromEmail(u.email);
-    await dbService.commit(inserts: [
-      ...u.likes.map(
-        (p) => Like()
-          ..parentKey = dbService.emptyKey.append(User, id: userId)
-          ..id = p
-          // TODO: support via [TestProfile]
-          ..created = DateTime.now().toUtc()
-          ..packageName = p,
-      )
-    ]);
+    // create user
+    await _withAuthorizationToken(_fakeToken(u.email), () async {});
+
+    if (u.likes != null && u.likes.isNotEmpty) {
+      await _withAuthorizationToken(_fakeToken(u.email), () async {
+        for (final p in u.likes) {
+          await accountBackend.likePackage(await requireAuthenticatedUser(), p);
+        }
+      });
+    }
   }
 
   await source.close();
@@ -154,15 +120,16 @@ List<String> _potentialActiveEmails(TestProfile profile, String packageName) {
   return members.map((m) => m.email).toList();
 }
 
-String _userIdFromEmail(String email) {
-  final hash = sha1.convert(utf8.encode('email-$email')).toString();
-  return hash.substring(0, 8) +
-      '-' +
-      hash.substring(8, 12) +
-      '-' +
-      hash.substring(12, 16) +
-      '-' +
-      hash.substring(16, 20) +
-      '-' +
-      hash.substring(20, 32);
+String _fakeToken(String email) =>
+    email.replaceAll('@', '-at-').replaceAll('.', '-dot-');
+
+Future<R> _withAuthorizationToken<R>(
+    String token, Future<R> Function() fn) async {
+  return await fork(() async {
+    final user = await accountBackend.authenticateWithBearerToken(token);
+    if (user != null) {
+      registerAuthenticatedUser(user);
+    }
+    return await fn();
+  }) as R;
 }

--- a/app/lib/tool/test_profile/models.dart
+++ b/app/lib/tool/test_profile/models.dart
@@ -82,14 +82,10 @@ class TestPackage {
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
 class TestPublisher {
   final String name;
-  final DateTime created;
-  final DateTime updated;
   final List<TestMember> members;
 
   TestPublisher({
     @required this.name,
-    this.created,
-    this.updated,
     @required List<TestMember> members,
   }) : members = members ?? <TestMember>[];
 
@@ -103,14 +99,10 @@ class TestPublisher {
 class TestMember {
   final String email;
   final String role;
-  final DateTime created;
-  final DateTime updated;
 
   TestMember({
     @required this.email,
     @required this.role,
-    this.created,
-    this.updated,
   });
 
   factory TestMember.fromJson(Map<String, dynamic> json) =>
@@ -122,20 +114,12 @@ class TestMember {
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
 class TestUser {
   final String email;
-  final String oauthUserId;
-  final DateTime created;
-  final bool isDeleted;
-  final bool isBlocked;
 
   /// The list of package names that the user liked.
   final List<String> likes;
 
   TestUser({
     @required this.email,
-    this.oauthUserId,
-    this.created,
-    this.isDeleted,
-    this.isBlocked,
     @required List<String> likes,
   }) : likes = likes ?? <String>[];
 

--- a/app/lib/tool/test_profile/models.g.dart
+++ b/app/lib/tool/test_profile/models.g.dart
@@ -77,12 +77,6 @@ Map<String, dynamic> _$TestPackageToJson(TestPackage instance) {
 TestPublisher _$TestPublisherFromJson(Map<String, dynamic> json) {
   return TestPublisher(
     name: json['name'] as String,
-    created: json['created'] == null
-        ? null
-        : DateTime.parse(json['created'] as String),
-    updated: json['updated'] == null
-        ? null
-        : DateTime.parse(json['updated'] as String),
     members: (json['members'] as List)
         ?.map((e) =>
             e == null ? null : TestMember.fromJson(e as Map<String, dynamic>))
@@ -100,8 +94,6 @@ Map<String, dynamic> _$TestPublisherToJson(TestPublisher instance) {
   }
 
   writeNotNull('name', instance.name);
-  writeNotNull('created', instance.created?.toIso8601String());
-  writeNotNull('updated', instance.updated?.toIso8601String());
   writeNotNull('members', instance.members?.map((e) => e?.toJson())?.toList());
   return val;
 }
@@ -110,12 +102,6 @@ TestMember _$TestMemberFromJson(Map<String, dynamic> json) {
   return TestMember(
     email: json['email'] as String,
     role: json['role'] as String,
-    created: json['created'] == null
-        ? null
-        : DateTime.parse(json['created'] as String),
-    updated: json['updated'] == null
-        ? null
-        : DateTime.parse(json['updated'] as String),
   );
 }
 
@@ -130,20 +116,12 @@ Map<String, dynamic> _$TestMemberToJson(TestMember instance) {
 
   writeNotNull('email', instance.email);
   writeNotNull('role', instance.role);
-  writeNotNull('created', instance.created?.toIso8601String());
-  writeNotNull('updated', instance.updated?.toIso8601String());
   return val;
 }
 
 TestUser _$TestUserFromJson(Map<String, dynamic> json) {
   return TestUser(
     email: json['email'] as String,
-    oauthUserId: json['oauthUserId'] as String,
-    created: json['created'] == null
-        ? null
-        : DateTime.parse(json['created'] as String),
-    isDeleted: json['isDeleted'] as bool,
-    isBlocked: json['isBlocked'] as bool,
     likes: (json['likes'] as List)?.map((e) => e as String)?.toList(),
   );
 }
@@ -158,10 +136,6 @@ Map<String, dynamic> _$TestUserToJson(TestUser instance) {
   }
 
   writeNotNull('email', instance.email);
-  writeNotNull('oauthUserId', instance.oauthUserId);
-  writeNotNull('created', instance.created?.toIso8601String());
-  writeNotNull('isDeleted', instance.isDeleted);
-  writeNotNull('isBlocked', instance.isBlocked);
   writeNotNull('likes', instance.likes);
   return val;
 }

--- a/app/lib/tool/test_profile/normalizer.dart
+++ b/app/lib/tool/test_profile/normalizer.dart
@@ -86,8 +86,6 @@ TestUser _createUserIfNeeded(Map<String, TestUser> users, String email) {
     email,
     () => TestUser(
       email: email,
-      created: DateTime.now().toUtc(),
-      isDeleted: false,
       likes: <String>[],
     ),
   );
@@ -97,23 +95,14 @@ TestPublisher _createPublisherIfNeeded(
   Map<String, TestPublisher> publishers,
   String publisherId, {
   @required String memberEmail,
-  DateTime created,
-  DateTime updated,
 }) {
   return publishers.putIfAbsent(publisherId, () {
-    final now = DateTime.now().toUtc();
-    final publisherCreated = created ?? now;
-    final publisherUpdated = updated ?? publisherCreated;
     return TestPublisher(
       name: publisherId,
-      created: publisherCreated,
-      updated: publisherUpdated,
       members: <TestMember>[
         TestMember(
           email: memberEmail,
           role: 'admin',
-          created: publisherUpdated,
-          updated: publisherUpdated,
         ),
       ],
     );

--- a/app/test/tool/test_profile/importer_test.dart
+++ b/app/test/tool/test_profile/importer_test.dart
@@ -30,7 +30,7 @@ void main() {
       importSource: ImportSource.fromPubDev(),
       fn: () async {
         final users = await dbService.query<User>().run().toList();
-        expect(users.single.userId, '0378792c-a778-8b8d-b689-64e531ae52bc');
+        expect(users.single.userId, hasLength(36));
         expect(users.single.oauthUserId, 'dev-example-com');
 
         final packages = await dbService.query<Package>().run().toList();
@@ -40,14 +40,13 @@ void main() {
 
         final versions = await dbService.query<PackageVersion>().run().toList();
         expect(versions.single.version, '2.0.0');
-        expect(
-            versions.single.uploader, '0378792c-a778-8b8d-b689-64e531ae52bc');
+        expect(versions.single.uploader, users.single.userId);
 
         final publishers = await dbService.query<Publisher>().run().toList();
         expect(publishers.single.publisherId, 'example.com');
 
         final members = await dbService.query<PublisherMember>().run().toList();
-        expect(members.single.userId, '0378792c-a778-8b8d-b689-64e531ae52bc');
+        expect(members.single.userId, users.single.userId);
         expect(members.single.role, 'admin');
       },
     );
@@ -62,7 +61,7 @@ void main() {
       importSource: ImportSource.fromPubDev(),
       fn: () async {
         final users = await dbService.query<User>().run().toList();
-        expect(users.single.userId, '0378792c-a778-8b8d-b689-64e531ae52bc');
+        expect(users.single.userId, hasLength(36));
         expect(users.single.oauthUserId, 'dev-example-com');
 
         final packages = await dbService.query<Package>().run().toList();
@@ -89,7 +88,7 @@ void main() {
       ),
       fn: () async {
         final users = await dbService.query<User>().run().toList();
-        expect(users.single.userId, '0378792c-a778-8b8d-b689-64e531ae52bc');
+        expect(users.single.userId, hasLength(36));
         expect(users.single.oauthUserId, 'dev-example-com');
 
         final packages = await dbService.query<Package>().run().toList();
@@ -99,8 +98,7 @@ void main() {
 
         final versions = await dbService.query<PackageVersion>().run().toList();
         expect(versions.single.version, '1.2.7');
-        expect(
-            versions.single.uploader, '0378792c-a778-8b8d-b689-64e531ae52bc');
+        expect(versions.single.uploader, users.single.userId);
 
         final publishers = await dbService.query<Publisher>().run().toList();
         expect(publishers, isEmpty);

--- a/app/test/tool/test_profile/model_normalization_test.dart
+++ b/app/test/tool/test_profile/model_normalization_test.dart
@@ -31,14 +31,10 @@ packages:
           'publishers': [
             {
               'name': 'example.com',
-              'created': isNotEmpty,
-              'updated': isNotEmpty,
               'members': [
                 {
                   'email': 'user@domain.com',
                   'role': 'admin',
-                  'created': isNotEmpty,
-                  'updated': isNotEmpty,
                 }
               ]
             }
@@ -46,8 +42,6 @@ packages:
           'users': [
             {
               'email': 'user@domain.com',
-              'created': isNotEmpty,
-              'isDeleted': false,
               'likes': [],
             }
           ],
@@ -78,8 +72,6 @@ packages:
           'users': [
             {
               'email': 'user@domain.com',
-              'created': isNotEmpty,
-              'isDeleted': false,
               'likes': [],
             }
           ],
@@ -116,8 +108,6 @@ packages:
           'users': [
             {
               'email': 'user@domain.com',
-              'created': isNotEmpty,
-              'isDeleted': false,
               'likes': [],
             }
           ],


### PR DESCRIPTION
- This is an intermediate step towards an importer that communicates only through the APIs. The auth token wrapper shows us the blocks where we need to use a certain kind of user token.
- Removed `created` and `updated` fields, as they are not available through the API.
- Removed `TestUser`'s `isBlocked` and `isDeleted` fields (for now).
- Setting more than one uploader or publisher member throws an exception (for now).
