### PR TITLE
Adjust Updated label on package listing page.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Important changes to data-models, configuration and migrations between each
 AppEngine version, listed here to ease deployment and troubleshooting.
 
 ## Next Release (replace with git tag when deployed)
+ * Run `app/bin/tools/backfill_package_fields.dart`.
  * NOTE: `PackageVersionPubspec` is no longer used in dependency graph calculation.
          The next release may remove the use of the entity.
 

--- a/app/lib/frontend/templates/views/pkg/package_list.mustache
+++ b/app/lib/frontend/templates/views/pkg/package_list.mustache
@@ -26,7 +26,7 @@
       <span class="packages-metadata-block">
         v <a href="{{& url}}">{{version}}</a>
         {{#show_prerelease_version}} / <a href="{{& prerelease_version_url}}">{{prerelease_version}}</a>{{/show_prerelease_version}}
-        • Published: <span>{{last_uploaded}}</span>
+        • Updated: <span>{{last_uploaded}}</span>
       </span>
       {{#publisher_id}}
       <span class="packages-metadata-block">

--- a/app/test/frontend/golden/my_packages.html
+++ b/app/test/frontend/golden/my_packages.html
@@ -212,7 +212,7 @@
                         <span class="packages-metadata-block">
                           v
                           <a href="/packages/super_package">1.0.0</a>
-                          • Published:
+                          • Updated:
                           <span>3 Jan 2019</span>
                         </span>
                       </p>
@@ -259,7 +259,7 @@
                           <a href="/packages/another_package">2.0.0</a>
                           /
                           <a href="/packages/another_package/versions/3.0.0-beta2">3.0.0-beta2</a>
-                          • Published:
+                          • Updated:
                           <span>30 Mar 2019</span>
                         </span>
                       </p>

--- a/app/test/frontend/golden/pkg_index_page.html
+++ b/app/test/frontend/golden/pkg_index_page.html
@@ -232,7 +232,7 @@
                 <a href="/packages/foobar_pkg">0.1.1+5</a>
                 /
                 <a href="/packages/foobar_pkg/versions/0.2.0-dev">0.2.0-dev</a>
-                • Published:
+                • Updated:
                 <span>Jan 1, 2014</span>
               </span>
             </p>
@@ -276,7 +276,7 @@
                 <a href="/packages/foobar_pkg">0.1.1+5</a>
                 /
                 <a href="/packages/foobar_pkg/versions/0.2.0-dev">0.2.0-dev</a>
-                • Published:
+                • Updated:
                 <span>Jan 1, 2015</span>
               </span>
             </p>

--- a/app/test/frontend/golden/publisher_packages_page.html
+++ b/app/test/frontend/golden/publisher_packages_page.html
@@ -222,7 +222,7 @@
                         <span class="packages-metadata-block">
                           v
                           <a href="/packages/super_package">1.0.0</a>
-                          • Published:
+                          • Updated:
                           <span>3 Jan 2019</span>
                         </span>
                       </p>
@@ -269,7 +269,7 @@
                           <a href="/packages/another_package">2.0.0</a>
                           /
                           <a href="/packages/another_package/versions/3.0.0-beta2">3.0.0-beta2</a>
-                          • Published:
+                          • Updated:
                           <span>30 Mar 2019</span>
                         </span>
                       </p>

--- a/app/test/frontend/golden/search_page.html
+++ b/app/test/frontend/golden/search_page.html
@@ -234,7 +234,7 @@
                 <a href="/packages/foobar_pkg">0.1.1+5</a>
                 /
                 <a href="/packages/foobar_pkg/versions/0.2.0-dev">0.2.0-dev</a>
-                • Published:
+                • Updated:
                 <span>Jan 1, 2014</span>
               </span>
             </p>
@@ -289,7 +289,7 @@
                 <a href="/packages/foobar_pkg">0.1.1+5</a>
                 /
                 <a href="/packages/foobar_pkg/versions/0.2.0-dev">0.2.0-dev</a>
-                • Published:
+                • Updated:
                 <span>Jan 1, 2015</span>
               </span>
             </p>


### PR DESCRIPTION
- #4338
- Added changelog entry for backfilling the `latestPublished` and `latestPrereleasePublished` properties for later use here.