### PR TITLE
Remove use of PackageVersionPubspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Important changes to data-models, configuration and migrations between each
 AppEngine version, listed here to ease deployment and troubleshooting.
 
 ## Next Release (replace with git tag when deployed)
+ * NOTE: `PackageVersionPubspec` is no longer used in dependency graph calculation.
+         The next release may remove the use of the entity.
 
 ## `20201210t173100-all`
  * Bumped runtimeVersion to `2020.12.09`.

--- a/app/lib/package/deps_graph.dart
+++ b/app/lib/package/deps_graph.dart
@@ -106,10 +106,10 @@ class PackageDependencyBuilder {
       try {
         // We scan from oldest to newest and therefore keep [_lastTs] always
         // increasing.
-        final query = _db.query<PackageVersionPubspec>()..order('updated');
-        await for (PackageVersionPubspec pv in query.run()) {
+        final query = _db.query<PackageVersion>()..order('created');
+        await for (PackageVersion pv in query.run()) {
           addPackageVersion(pv);
-          _lastTs = pv.updated;
+          _lastTs = pv.created;
         }
       } catch (e, s) {
         _logger.severe(e, s);
@@ -126,11 +126,11 @@ class PackageDependencyBuilder {
     _logger.info('Monitoring new package uploads.');
     for (;;) {
       try {
-        final query = _db.query<PackageVersionPubspec>()
-          ..filter('updated >', _lastTs)
-          ..order('updated');
+        final query = _db.query<PackageVersion>()
+          ..filter('created >', _lastTs)
+          ..order('created');
         var updated = false;
-        await for (PackageVersionPubspec pv in query.run()) {
+        await for (PackageVersion pv in query.run()) {
           addPackageVersion(pv);
           updated = true;
 
@@ -149,7 +149,7 @@ class PackageDependencyBuilder {
             }
           }
 
-          _lastTs = pv.updated;
+          _lastTs = pv.created;
         }
         if (updated) {
           _reverseDeps._logStats();
@@ -161,7 +161,7 @@ class PackageDependencyBuilder {
     }
   }
 
-  void addPackageVersion(PackageVersionPubspec pv) {
+  void addPackageVersion(PackageVersion pv) {
     final Set<String> depsSet = Set<String>.from(pv.pubspec.dependencies);
     final Set<String> devDepsSet = Set<String>.from(pv.pubspec.devDependencies);
 


### PR DESCRIPTION
- Dependency graph can use `PackageVersion` instead of `PackageVersionPubspec`, since the content-heavy fields were removed from `PackageVersion`.
- A future release could remove `PackageVersionPubspec`.
