### PR TITLE
Wrapping bearer token parsing in a callback method.

### DIFF
--- a/app/lib/account/backend.dart
+++ b/app/lib/account/backend.dart
@@ -84,28 +84,6 @@ Future<User> requireAuthenticatedUser() async {
   return _authenticatedUser;
 }
 
-/// Authenticates with bearer [token] and populates [_authenticatedUser] with
-/// it, running in a new scope.
-///
-/// The [token] may be an oauth2 `access_token` or an openid-connect
-/// `id_token` (signed JWT).
-///
-/// When no associated User entry exists in Datastore, this method will create
-/// a new one. When the authenticated email of the user changes, the email
-/// field will be updated to the latest one.
-Future<R> withAuthorizationToken<R>(
-    String token, Future<R> Function() fn) async {
-  return await ss.fork(() async {
-    final user = token == null || token.isEmpty
-        ? null
-        : await accountBackend._authenticateWithBearerToken(token);
-    if (user != null) {
-      registerAuthenticatedUser(user);
-    }
-    return await fn();
-  }) as R;
-}
-
 /// Represents the backend for the account handling and authentication.
 class AccountBackend {
   final DatastoreDB _db;
@@ -280,9 +258,13 @@ class AccountBackend {
     }
   }
 
-  /// Authenticates with bearer [token] and returns an `User` object.
+  /// Authenticates with bearer [token] and populates [_authenticatedUser] with
+  /// it, running [fn] in a new scope.
   ///
-  /// The method returns null if [token] is invalid.
+  /// When the token authentication fails, the method throws
+  /// [AuthenticationException].
+  ///
+  /// The method returns with the response of [fn].
   ///
   /// The [token] may be an oauth2 `access_token` or an openid-connect
   /// `id_token` (signed JWT).
@@ -290,19 +272,28 @@ class AccountBackend {
   /// When no associated User entry exists in Datastore, this method will create
   /// a new one. When the authenticated email of the user changes, the email
   /// field will be updated to the latest one.
-  Future<User> _authenticateWithBearerToken(String token) async {
-    final auth = await authProvider.tryAuthenticate(token);
-    if (auth == null) {
-      return null;
+  Future<R> withBearerToken<R>(String token, Future<R> Function() fn) async {
+    if (token == null || token.isEmpty) {
+      throw AuthenticationException.authenticationRequired();
     }
-    final user = await _lookupOrCreateUserByOauthUserId(auth);
-    if (user.isDeleted) {
-      // This can only happen if we have a data inconsistency in the datastore.
-      _logger
-          .severe('Login on deleted account: ${user.userId} / ${user.email}');
-      throw StateError('Account had been deleted, login is not allowed.');
-    }
-    return user;
+    return await ss.fork(() async {
+      final auth = await authProvider.tryAuthenticate(token);
+      if (auth == null) {
+        throw AuthenticationException.authenticationRequired();
+      }
+      final user = await _lookupOrCreateUserByOauthUserId(auth);
+      if (user == null) {
+        throw AuthenticationException.authenticationRequired();
+      }
+      if (user.isDeleted) {
+        // This can only happen if we have a data inconsistency in the datastore.
+        _logger
+            .severe('Login on deleted account: ${user.userId} / ${user.email}');
+        throw StateError('Account had been deleted, login is not allowed.');
+      }
+      registerAuthenticatedUser(user);
+      return await fn();
+    }) as R;
   }
 
   Future<User> _lookupUserByOauthUserId(String oauthUserId) async {

--- a/app/lib/shared/handler_helpers.dart
+++ b/app/lib/shared/handler_helpers.dart
@@ -244,16 +244,18 @@ shelf.Handler _sanitizeRequestWrapper(shelf.Handler handler) {
 /// the user email address and registers it.
 shelf.Handler _userAuthWrapper(shelf.Handler handler) {
   return (shelf.Request request) async {
-    String accessToken;
     final authorization = request.headers['authorization'];
     if (authorization != null) {
+      String accessToken;
       final parts = authorization.split(' ');
       if (parts.length == 2 && parts.first.trim().toLowerCase() == 'bearer') {
         accessToken = parts.last.trim();
       }
+      return await accountBackend.withBearerToken(
+          accessToken, () async => await handler(request));
+    } else {
+      return await handler(request);
     }
-    return await withAuthorizationToken(
-        accessToken, () async => await handler(request));
   };
 }
 

--- a/app/lib/shared/handler_helpers.dart
+++ b/app/lib/shared/handler_helpers.dart
@@ -244,20 +244,16 @@ shelf.Handler _sanitizeRequestWrapper(shelf.Handler handler) {
 /// the user email address and registers it.
 shelf.Handler _userAuthWrapper(shelf.Handler handler) {
   return (shelf.Request request) async {
+    String accessToken;
     final authorization = request.headers['authorization'];
     if (authorization != null) {
       final parts = authorization.split(' ');
       if (parts.length == 2 && parts.first.trim().toLowerCase() == 'bearer') {
-        final accessToken = parts.last.trim();
-
-        final user =
-            await accountBackend.authenticateWithBearerToken(accessToken);
-        if (user != null) {
-          registerAuthenticatedUser(user);
-        }
+        accessToken = parts.last.trim();
       }
     }
-    return await handler(request);
+    return await withAuthorizationToken(
+        accessToken, () async => await handler(request));
   };
 }
 

--- a/app/test/account/backend_test.dart
+++ b/app/test/account/backend_test.dart
@@ -46,10 +46,9 @@ void main() {
     });
 
     testWithServices('Authenticate: token failure', () async {
-      await withAuthorizationToken('', () async {
-        await expectLater(() => requireAuthenticatedUser(),
-            throwsA(isA<AuthenticationException>()));
-      });
+      await expectLater(
+          () => accountBackend.withBearerToken('', () async => null),
+          throwsA(isA<AuthenticationException>()));
     });
 
     testWithServices('Authenticate: pre-created', () async {
@@ -60,7 +59,7 @@ void main() {
           .toList();
       expect(ids1, ['admin-pub-dev']);
 
-      await withAuthorizationToken('a-at-example-dot-com', () async {
+      await accountBackend.withBearerToken('a-at-example-dot-com', () async {
         final u1 = await requireAuthenticatedUser();
         expect(u1.userId, 'a-example-com');
         expect(u1.email, 'a@example.com');
@@ -86,7 +85,7 @@ void main() {
           .toList();
       expect(ids1, ['admin-pub-dev']);
 
-      await withAuthorizationToken('c-at-example-dot-com', () async {
+      await accountBackend.withBearerToken('c-at-example-dot-com', () async {
         final u1 = await requireAuthenticatedUser();
         expect(u1.userId, hasLength(36));
         expect(u1.email, 'c@example.com');


### PR DESCRIPTION
- Pattern copied from #4332.
- I think this wrapper should be used in tests, instead of calling `registerAuthenticatedUser` (eventually all test should be migrated to it). It would decouple the tests one step further from the test models.