### PR TITLE
Fix code coverage

### DIFF
--- a/pkg/code_coverage/build.sh
+++ b/pkg/code_coverage/build.sh
@@ -8,7 +8,6 @@ ALL_TEST_NAME="_all_tests.dart"
 APP_ALL_TEST_PATH="${APP_DIR}/test/${ALL_TEST_NAME}"
 PUB_INTEGRATION_DIR="${PROJECT_DIR}/pkg/pub_integration"
 PUB_INTEGRATION_ALL_TEST_PATH="${PUB_INTEGRATION_DIR}/test/${ALL_TEST_NAME}"
-FAKE_PUB_SERVER_DIR="${PROJECT_DIR}/pkg/fake_pub_server"
 
 OUTPUT_DIR="${CODE_COVERAGE_DIR}/build"
 
@@ -73,7 +72,7 @@ ls -1 "${PUB_INTEGRATION_DIR}/test" | grep .dart$ | xargs -n 1 -I ZZZ dart \
   --package "${PUB_INTEGRATION_DIR}" \
   --test test/ZZZ \
   --prefix ZZZ \
-  --fake-pub-server "${FAKE_PUB_SERVER_DIR}"
+  --app-dir "${APP_DIR}"
 
 ## Processing coverage
 

--- a/pkg/code_coverage/lib/test_runner.dart
+++ b/pkg/code_coverage/lib/test_runner.dart
@@ -16,7 +16,7 @@ final _argParser = ArgParser()
   ..addOption('package', help: 'The package directory.')
   ..addOption('test', help: 'The relative path inside the package directory.')
   ..addOption('prefix', help: 'The file name prefix to use.')
-  ..addOption('fake-pub-server', help: 'The directory of pkg/fake_pub_server.');
+  ..addOption('app-dir', help: 'The directory of app/.');
 
 Future<void> main(List<String> args) async {
   final buildDir = '${Directory.current.path}/build';
@@ -25,7 +25,7 @@ Future<void> main(List<String> args) async {
   final packageDir = argv['package'] as String;
   final testPath = argv['test'] as String;
   final outputPrefix = argv['prefix'] as String;
-  final fakePubServerDir = argv['fake-pub-server'] as String;
+  final appDir = argv['app-dir'] as String;
 
   ArgumentError.checkNotNull(packageDir);
   ArgumentError.checkNotNull(testPath);
@@ -69,7 +69,7 @@ Future<void> main(List<String> args) async {
   for (final file in files) {
     final name = file.path.split('/').last;
     await _convertToLcov(
-      name.contains('fake-pub-server') ? fakePubServerDir : packageDir,
+      name.contains('fake-pub-server') ? appDir : packageDir,
       '$buildDir/raw/$name',
       '$buildDir/lcov/$name.info',
     );
@@ -125,10 +125,11 @@ Future<void> _convertToLcov(
       '-i',
       inputFile,
       '--base-directory',
-      '../../',
+      packageDir.contains('/app') ? '../' : '../../',
       '--lcov',
       '--out',
       outputFile,
     ],
+    workingDirectory: packageDir,
   );
 }

--- a/pkg/code_coverage/pubspec.lock
+++ b/pkg/code_coverage/pubspec.lock
@@ -56,7 +56,7 @@ packages:
       name: coverage
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.14.1"
+    version: "0.14.2"
   crypto:
     dependency: transitive
     description:

--- a/pkg/code_coverage/pubspec.yaml
+++ b/pkg/code_coverage/pubspec.yaml
@@ -6,7 +6,7 @@ environment:
 
 dependencies:
   args: ^1.5.0
-  coverage: ^0.14.1
+  coverage: ^0.14.2
   lcov: ^6.0.0
   path: ^1.0.0
   source_maps: ^0.10.8


### PR DESCRIPTION
- Updating `package:coverage` to reduce the flakiness around collect.
- Updating the post-processing that was broken after #4313.
- Now coverage report is around 72%, spot-checking the details seems to be about right.