### PR TITLE
Removing Consent.userId

### DIFF
--- a/app/bin/tools/create_publisher.dart
+++ b/app/bin/tools/create_publisher.dart
@@ -39,16 +39,26 @@ Future main(List<String> args) async {
   }
 
   await withToolRuntime(() async {
-    final user = await accountBackend.lookupUserByEmail(userEmail);
-    if (user == null) {
+    final users = await accountBackend.lookupUsersByEmail(userEmail);
+    if (users.isEmpty) {
       print('ERROR: unknown user: $userEmail');
       return;
     }
-    final admin = await accountBackend.lookupUserByEmail(adminEmail);
-    if (admin == null) {
+    if (users.length > 1) {
+      print('ERROR: more than one user: $userEmail');
+      return;
+    }
+    final user = users.single;
+    final admins = await accountBackend.lookupUsersByEmail(adminEmail);
+    if (admins.isEmpty) {
       print('ERROR: unknown user: $adminEmail');
       return;
     }
+    if (admins.length > 1) {
+      print('ERROR: more than one user: $adminEmail');
+      return;
+    }
+    final admin = admins.single;
 
     // Create the publisher
     final now = DateTime.now().toUtc();

--- a/app/bin/tools/set_package_withheld.dart
+++ b/app/bin/tools/set_package_withheld.dart
@@ -67,11 +67,13 @@ Future main(List<String> args) async {
       }
     } else if (lookupKey == 'email') {
       for (final email in argv.rest) {
-        final user = await accountBackend.lookupUserByEmail(email);
-        if (user == null) {
+        final users = await accountBackend.lookupUsersByEmail(email);
+        if (users.isEmpty) {
           throw Exception('Email lookup failed: $email');
         }
-        await loadPackages('uploaders', user.userId);
+        for (final u in users) {
+          await loadPackages('uploaders', u.userId);
+        }
       }
     } else {
       throw Exception('Lookup not recognized: $lookupKey');

--- a/app/bin/tools/set_user_blocked.dart
+++ b/app/bin/tools/set_user_blocked.dart
@@ -25,19 +25,23 @@ Future main(List<String> args) async {
   final blockedStatus = _parseValue(valueAsString);
 
   await withToolRuntime(() async {
-    final user = await accountBackend.lookupUserById(idOrEmail) ??
-        await accountBackend.lookupUserByEmail(idOrEmail);
-    if (user == null) {
+    final userById = await accountBackend.lookupUserById(idOrEmail);
+    final users = userById != null
+        ? [userById]
+        : await accountBackend.lookupUsersByEmail(idOrEmail);
+    if (users.isEmpty) {
       print('No user found.');
       return;
     }
-    if (blockedStatus == null) {
-      print('userId: ${user.userId}');
-      print('email: ${user.email}');
-      print('isBlocked: ${user.isBlocked}');
-      return;
+    for (final user in users) {
+      if (blockedStatus == null) {
+        print('userId: ${user.userId}');
+        print('email: ${user.email}');
+        print('isBlocked: ${user.isBlocked}');
+        return;
+      }
+      await accountBackend.updateBlockedFlag(user.userId, blockedStatus);
     }
-    await accountBackend.updateBlockedFlag(user.userId, blockedStatus);
   });
 }
 

--- a/app/lib/account/backend.dart
+++ b/app/lib/account/backend.dart
@@ -136,20 +136,12 @@ class AccountBackend {
     return result;
   }
 
-  /// Returns the `User` entry for the [email] or null if it does not exists.
-  ///
-  /// Throws Exception if more then one `User` entry exists.
-  Future<User> lookupUserByEmail(String email) async {
+  /// Returns the list of `User` entries for the [email] or empty list if it
+  /// does not exists.
+  Future<List<User>> lookupUsersByEmail(String email) async {
     email = email.toLowerCase();
     final query = _db.query<User>()..filter('email =', email);
-    final list = await query.run().toList();
-    if (list.length > 1) {
-      throw Exception('More than one User exists for email: $email');
-    }
-    if (list.length == 1) {
-      return list.single;
-    }
-    return null;
+    return await query.run().toList();
   }
 
   /// Returns the `User` entry for the [email] or creates a new one if it does
@@ -158,11 +150,12 @@ class AccountBackend {
   /// Throws Exception if more then one `User` entry exists.
   Future<User> lookupOrCreateUserByEmail(String email) async {
     email = email.toLowerCase();
-    User user = await lookupUserByEmail(email);
-    if (user != null) {
-      return user;
+    final users = await lookupUsersByEmail(email);
+    if (users.length > 1) {
+      throw Exception('More than one User exists for email: $email');
     }
-    user = User()
+    if (users.isNotEmpty) return users.single;
+    final user = User()
       ..parentKey = _db.emptyKey
       ..id = createUuid()
       ..email = email

--- a/app/lib/account/consent_backend.dart
+++ b/app/lib/account/consent_backend.dart
@@ -79,23 +79,17 @@ class ConsentBackend {
   /// Resolves the consent.
   Future<api.ConsentResult> resolveConsent(
       String consentId, api.ConsentResult result) async {
-    try {
-      InvalidInputException.checkUlid(consentId, 'consentId');
-      final user = await requireAuthenticatedUser();
+    InvalidInputException.checkUlid(consentId, 'consentId');
+    final user = await requireAuthenticatedUser();
 
-      final c = await _lookupAndCheck(consentId, user);
-      InvalidInputException.checkNotNull(result.granted, 'granted');
-      if (result.granted) {
-        await _accept(c);
-        return api.ConsentResult(granted: true);
-      } else {
-        await _delete(c);
-        return api.ConsentResult(granted: false);
-      }
-    } catch (e, st) {
-      print(e);
-      print(st);
-      rethrow;
+    final c = await _lookupAndCheck(consentId, user);
+    InvalidInputException.checkNotNull(result.granted, 'granted');
+    if (result.granted) {
+      await _accept(c);
+      return api.ConsentResult(granted: true);
+    } else {
+      await _delete(c);
+      return api.ConsentResult(granted: false);
     }
   }
 

--- a/app/lib/account/consent_backend.dart
+++ b/app/lib/account/consent_backend.dart
@@ -79,17 +79,23 @@ class ConsentBackend {
   /// Resolves the consent.
   Future<api.ConsentResult> resolveConsent(
       String consentId, api.ConsentResult result) async {
-    InvalidInputException.checkUlid(consentId, 'consentId');
-    final user = await requireAuthenticatedUser();
+    try {
+      InvalidInputException.checkUlid(consentId, 'consentId');
+      final user = await requireAuthenticatedUser();
 
-    final c = await _lookupAndCheck(consentId, user);
-    InvalidInputException.checkNotNull(result.granted, 'granted');
-    if (result.granted) {
-      await _accept(c);
-      return api.ConsentResult(granted: true);
-    } else {
-      await _delete(c);
-      return api.ConsentResult(granted: false);
+      final c = await _lookupAndCheck(consentId, user);
+      InvalidInputException.checkNotNull(result.granted, 'granted');
+      if (result.granted) {
+        await _accept(c);
+        return api.ConsentResult(granted: true);
+      } else {
+        await _delete(c);
+        return api.ConsentResult(granted: false);
+      }
+    } catch (e, st) {
+      print(e);
+      print(st);
+      rethrow;
     }
   }
 
@@ -97,7 +103,6 @@ class ConsentBackend {
   /// - if it already exists, re-send the notification, or
   /// - if it was sent recently, do nothing.
   Future<api.InviteStatus> _invite({
-    @required String userId,
     @required String email,
     @required String kind,
     @required List<String> args,
@@ -107,7 +112,6 @@ class ConsentBackend {
       // First check for existing consents with identical dedupId.
       final dedupId = consentDedupId(
         fromUserId: activeUser.userId,
-        userId: userId,
         email: email,
         kind: kind,
         args: args,
@@ -130,7 +134,6 @@ class ConsentBackend {
       // Create a new entry.
       final consent = Consent.init(
         fromUserId: activeUser.userId,
-        userId: userId,
         email: email,
         kind: kind,
         args: args,
@@ -143,11 +146,9 @@ class ConsentBackend {
   /// Invites a new uploader to the package.
   Future<api.InviteStatus> invitePackageUploader({
     @required String packageName,
-    @required String uploaderUserId,
     @required String uploaderEmail,
   }) async {
     return await _invite(
-      userId: uploaderUserId,
       email: uploaderEmail,
       kind: ConsentKind.packageUploader,
       args: [packageName],
@@ -160,7 +161,6 @@ class ConsentBackend {
     @required String contactEmail,
   }) async {
     return await _invite(
-      userId: null,
       email: contactEmail,
       kind: ConsentKind.publisherContact,
       args: [publisherId, contactEmail],
@@ -170,11 +170,9 @@ class ConsentBackend {
   /// Invites a new member for the publisher.
   Future<api.InviteStatus> invitePublisherMember({
     @required String publisherId,
-    @required String invitedUserId,
     @required String invitedUserEmail,
   }) async {
     return await _invite(
-      userId: invitedUserId,
       email: invitedUserEmail,
       kind: ConsentKind.publisherMember,
       args: [publisherId],
@@ -183,8 +181,7 @@ class ConsentBackend {
 
   Future<api.InviteStatus> _sendNotification(
       String activeUserEmail, Consent consent) async {
-    final invitedEmail =
-        consent.email ?? await accountBackend.getEmailOfUserId(consent.userId);
+    final invitedEmail = consent.email;
     final action = _actions[consent.kind];
     await emailSender.sendMessage(createInviteEmail(
       invitedEmail: invitedEmail,
@@ -219,26 +216,19 @@ class ConsentBackend {
   /// Returns the [Consent] for [consentId] and checks if it is for [user].
   Future<Consent> _lookupAndCheck(String consentId, User user) async {
     final key = _db.emptyKey.append(Consent, id: consentId);
-    return await withRetryTransaction(_db, (tx) async {
-      final c = await tx.lookupOrNull<Consent>(key);
-      if (c == null) {
-        throw NotFoundException.resource('consent: $consentId');
-      }
-      if (c.userId == null && c.email == user.email) {
-        c.userId = user.userId;
-        tx.insert(c);
-      }
-
-      // Checking that consent is for the current user.
-      InvalidInputException.check(c.userId == null || c.userId == user.userId,
+    final c = await _db.lookupValue<Consent>(key, orElse: () => null);
+    if (c == null) {
+      throw NotFoundException.resource('consent: $consentId');
+    }
+    // Checking that consent is for the current user.
+    InvalidInputException.check(c.userId == null || c.userId == user.userId,
+        'This invitation is not for the user account currently logged in.');
+    final action = _actions[c.kind];
+    if (!action.permitConfirmationWithOtherEmail && c.email != null) {
+      InvalidInputException.check(c.email == user.email,
           'This invitation is not for the user account currently logged in.');
-      final action = _actions[c.kind];
-      if (!action.permitConfirmationWithOtherEmail && c.email != null) {
-        InvalidInputException.check(c.email == user.email,
-            'This invitation is not for the user account currently logged in.');
-      }
-      return c;
-    });
+    }
+    return c;
   }
 
   Future<void> _accept(Consent consent) async {
@@ -314,17 +304,14 @@ class _PackageUploaderAction extends ConsentAction {
     final packageName = consent.args[0];
     final fromUserEmail =
         await accountBackend.getEmailOfUserId(consent.fromUserId);
-    final uploader = consent.userId != null
-        ? await accountBackend.lookupUserById(consent.userId)
-        : await accountBackend.lookupUserByEmail(consent.email);
-    if (uploader == null) {
-      // NOTE: This should never happen because `userId` of the consent entity
-      //       will be set when it is loaded.
-      throw AuthenticationException.userNotFound();
+    final currentUser = await requireAuthenticatedUser();
+    if (currentUser.email != consent.email) {
+      throw NotAcceptableException(
+          'Current user and consent user does not match.');
     }
 
     await packageBackend.confirmUploader(
-        consent.fromUserId, fromUserEmail, packageName, uploader);
+        consent.fromUserId, fromUserEmail, packageName, currentUser);
   }
 
   @override
@@ -415,20 +402,12 @@ class _PublisherMemberAction extends ConsentAction {
   @override
   Future<void> onAccept(Consent consent) async {
     final publisherId = consent.args[0];
-    // consent.userId will be set in `ConsentBackend._lookupAndCheck` if it's not already set
-    // when the invite is created.
-    if (consent.userId == null) {
-      throw AssertionError(
-          'Expected a non-null `userId` for publisher invite for '
-          '`$publisherId` to `${consent.email}`.');
+    final currentUser = await requireAuthenticatedUser();
+    if (consent.email != currentUser.email) {
+      throw NotAcceptableException('Consent is not for the current user.');
     }
-    final member = await accountBackend.lookupUserById(consent.userId);
-    if (member == null) {
-      // NOTE: This should never happen because `userId` of the consent entity
-      //       will be set when it is loaded.
-      throw AuthenticationException.userNotFound();
-    }
-    await publisherBackend.inviteConsentGranted(publisherId, member.userId);
+    await publisherBackend.inviteConsentGranted(
+        publisherId, currentUser.userId);
   }
 
   @override

--- a/app/lib/account/consent_backend.dart
+++ b/app/lib/account/consent_backend.dart
@@ -220,9 +220,6 @@ class ConsentBackend {
     if (c == null) {
       throw NotFoundException.resource('consent: $consentId');
     }
-    // Checking that consent is for the current user.
-    InvalidInputException.check(c.userId == null || c.userId == user.userId,
-        'This invitation is not for the user account currently logged in.');
     final action = _actions[c.kind];
     if (!action.permitConfirmationWithOtherEmail && c.email != null) {
       InvalidInputException.check(c.email == user.email,

--- a/app/lib/account/models.dart
+++ b/app/lib/account/models.dart
@@ -244,7 +244,8 @@ class Consent extends db.Model {
   @db.StringProperty()
   String userId;
 
-  @db.StringProperty()
+  /// The email that this consent is for.
+  @db.StringProperty(required: true)
   String email;
 
   /// A [Uri.path]-like concatenation of identifiers from [kind] and [args].
@@ -277,7 +278,6 @@ class Consent extends db.Model {
 
   Consent.init({
     @required this.fromUserId,
-    @required this.userId,
     @required this.email,
     @required this.kind,
     @required this.args,
@@ -286,7 +286,6 @@ class Consent extends db.Model {
     id = Ulid().toString();
     dedupId = consentDedupId(
       fromUserId: fromUserId,
-      userId: userId,
       email: email,
       kind: kind,
       args: args,
@@ -311,12 +310,11 @@ class Consent extends db.Model {
 /// Calculates the dedupId of a consent request.
 String consentDedupId({
   @required String fromUserId,
-  @required String userId,
   @required String email,
   @required String kind,
   @required List<String> args,
 }) =>
-    [fromUserId, userId, email, kind, ...args]
+    [fromUserId, email, kind, ...args]
         .where((s) => s != null)
         .map(Uri.encodeComponent)
         .join('/');

--- a/app/lib/account/models.dart
+++ b/app/lib/account/models.dart
@@ -232,17 +232,11 @@ class UserInfo extends db.ExpandoModel<String> {
 }
 
 /// An active consent request sent to a recipient.
-///
-/// When [userId] or [email] is specified, the accepting user is matched against
-/// these values on accepting the consent.
+/// Users are identified by their e-mail address, and not by their userId.
 @db.Kind(name: 'Consent', idType: db.IdType.String)
 class Consent extends db.Model {
   /// The consent id.
   String get consentId => id as String;
-
-  /// The user that this consent is for.
-  @db.StringProperty()
-  String userId;
 
   /// The email that this consent is for.
   @db.StringProperty(required: true)

--- a/app/lib/shared/user_merger.dart
+++ b/app/lib/shared/user_merger.dart
@@ -130,23 +130,6 @@ class UserMerger {
       },
     );
 
-    // Consent's userId attribute
-    await _processConcurrently(
-      _db.query<Consent>()..filter('userId =', fromUserId),
-      (Consent m) async {
-        if (m?.parentKey?.id != null) {
-          throw StateError('Old Consent entity: ${m.consentId}.');
-        }
-        await withRetryTransaction(_db, (tx) async {
-          final consent = await tx.lookupValue<Consent>(m.key);
-          if (consent.userId == fromUserId) {
-            consent.userId = toUserId;
-            tx.insert(consent);
-          }
-        });
-      },
-    );
-
     // Consent's fromUserId attribute
     await _processConcurrently(
       _db.query<Consent>()..filter('fromUserId =', fromUserId),

--- a/app/test/account/consent_backend_test.dart
+++ b/app/test/account/consent_backend_test.dart
@@ -17,7 +17,6 @@ void main() {
     testWithServices('Uploader invite', () async {
       registerAuthenticatedUser(hansUser);
       final status = await consentBackend.invitePackageUploader(
-        uploaderUserId: joeUser.userId,
         uploaderEmail: joeUser.email,
         packageName: hydrogen.packageName,
       );
@@ -49,7 +48,6 @@ void main() {
       registerAuthenticatedUser(hansUser);
       final status = await consentBackend.invitePublisherMember(
         publisherId: exampleComPublisher.publisherId,
-        invitedUserId: joeUser.userId,
         invitedUserEmail: joeUser.email,
       );
       expect(status.emailSent, isTrue);

--- a/app/test/publisher/api_test.dart
+++ b/app/test/publisher/api_test.dart
@@ -310,16 +310,14 @@ void main() {
     });
 
     group('Invite a new member', () {
-      Future<List<Map>> queryConstents({String userId, String email}) async {
+      Future<List<Map>> queryConstents({String email}) async {
         final query = dbService.query<Consent>();
         return await query
             .run()
-            .where((c) => c.userId == null || c.userId == userId || userId == null)
             .where((c) => c.email == email || email == null)
             .map((c) => {
                   'id': c.consentId,
                   'fromUserId': c.fromUserId,
-                  'userId': c.userId,
                   'email': c.email,
                   'kind': c.kind,
                   'args': c.args,
@@ -371,7 +369,6 @@ void main() {
           {
             'id': isNotNull,
             'fromUserId': hansUser.userId,
-            'userId': null,
             'email': testUserA.email,
             'kind': 'PublisherMember',
             'args': ['example.com'],
@@ -399,7 +396,6 @@ void main() {
           {
             'id': isNotNull,
             'fromUserId': hansUser.userId,
-            'userId': isNull, // no user has been created
             'email': 'newuser@example.com',
             'kind': 'PublisherMember',
             'args': ['example.com'],
@@ -417,7 +413,6 @@ void main() {
           {
             'id': isNotNull,
             'fromUserId': hansUser.userId,
-            'userId': null,
             'email': testUserA.email,
             'kind': 'PublisherMember',
             'args': ['example.com'],

--- a/app/test/publisher/api_test.dart
+++ b/app/test/publisher/api_test.dart
@@ -245,9 +245,9 @@ void main() {
         expect(updated.contactEmail, 'not-registered@example.com');
 
         // no User entity created
-        final user = await accountBackend
-            .lookupUserByEmail('not-registered@example.com');
-        expect(user, isNull);
+        final users = await accountBackend
+            .lookupUsersByEmail('not-registered@example.com');
+        expect(users, isEmpty);
       });
 
       testWithServices('User is not a member', () async {
@@ -314,7 +314,7 @@ void main() {
         final query = dbService.query<Consent>();
         return await query
             .run()
-            .where((c) => c.userId == userId || userId == null)
+            .where((c) => c.userId == null || c.userId == userId || userId == null)
             .where((c) => c.email == email || email == null)
             .map((c) => {
                   'id': c.consentId,
@@ -356,7 +356,6 @@ void main() {
       testWithServices('Pending with Consent, sending new e-mail', () async {
         final consent = Consent.init(
           fromUserId: hansUser.userId,
-          userId: testUserA.userId,
           email: testUserA.email,
           kind: 'PublisherMember',
           args: ['example.com'],
@@ -372,7 +371,7 @@ void main() {
           {
             'id': isNotNull,
             'fromUserId': hansUser.userId,
-            'userId': testUserA.userId,
+            'userId': null,
             'email': testUserA.email,
             'kind': 'PublisherMember',
             'args': ['example.com'],
@@ -418,7 +417,7 @@ void main() {
           {
             'id': isNotNull,
             'fromUserId': hansUser.userId,
-            'userId': testUserA.userId,
+            'userId': null,
             'email': testUserA.email,
             'kind': 'PublisherMember',
             'args': ['example.com'],

--- a/app/test/shared/user_merger_test.dart
+++ b/app/test/shared/user_merger_test.dart
@@ -100,20 +100,17 @@ void main() {
 
   testWithServices('new consent', () async {
     final target1 = Consent.init(
-        userId: hansUser.userId,
-        email: null,
+        email: hansUser.email,
         kind: 'k1',
         args: ['1'],
         fromUserId: adminUser.userId);
     final target2 = Consent.init(
-        userId: adminUser.userId,
-        email: null,
+        email: adminUser.email,
         kind: 'k2',
         args: ['2'],
         fromUserId: hansUser.userId);
     final control = Consent.init(
-        userId: adminUser.userId,
-        email: null,
+        email: adminUser.email,
         kind: 'k3',
         args: ['3'],
         fromUserId: adminUser.userId);
@@ -126,11 +123,8 @@ void main() {
     final updated2 = list.firstWhere((c) => c.id == target2.id);
     final updated3 = list.firstWhere((c) => c.id == control.id);
 
-    expect(updated1.userId, joeUser.userId);
     expect(updated1.fromUserId, adminUser.userId);
-    expect(updated2.userId, adminUser.userId);
     expect(updated2.fromUserId, joeUser.userId);
-    expect(updated3.userId, adminUser.userId);
     expect(updated3.fromUserId, adminUser.userId);
   });
 


### PR DESCRIPTION
- #4360
- It was a non-required field for a while now, with code checking for null, no risk for backwards-compatibility.
- Migrated code that relied on getting a single `User` for an email address. Some use-case still throws if multiple users are returned, otherwise they are adopted to handle multiple users.
- Consent is now identified primarily via the `email` field instead of the `userId` (now: `required`). It was always set, but making sure it keeps doing the same in the future.
