### PR TITLE
Switch profile image to input tag to allow users to tab to it

### DIFF
--- a/app/lib/frontend/templates/views/shared/site_header.mustache
+++ b/app/lib/frontend/templates/views/shared/site_header.mustache
@@ -83,11 +83,11 @@
     </div>
     {{#is_logged_in}}
     <div class="nav-container nav-profile-container hoverable">
-      <img class="nav-profile-img nav-profile-image-desktop" src="{{& user_session.image_url}}" />
+      <input type="image" class="nav-profile-img nav-profile-image-desktop" src="{{& user_session.image_url}}" alt="Profile Image" />
       <div class="nav-hover-popup">
         <div class="nav-table-column">
           <div class="nav-account-title-mobile">
-            <img class="nav-profile-img nav-profile-img-mobile" src="{{& user_session.image_url}}" />
+            <img class="nav-profile-img nav-profile-img-mobile" src="{{& user_session.image_url}}" alt="Profile Image" />
             <div class="nav-account-title">
               {{#user_session.has_name}}<div class="nav-account-name">{{user_session.name}}</div>{{/user_session.has_name}}
               <div class="nav-account-email" id="-account-profile-email">{{user_session.email}}</div>


### PR DESCRIPTION
Previously users could not tab to the profile image, so they perhaps could not easily see that information or log out.

This switches the tag to an image input so the user can tab to the element and open its dropdown just like the other navigation buttons. 

I also added alt labels to the profile image elements.

After the change:
![image](https://user-images.githubusercontent.com/18372958/103717577-752f1380-4f8b-11eb-97ed-a3e19d20ee53.png)
