### PR TITLE
Upgrade pana

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Important changes to data-models, configuration and migrations between each
 AppEngine version, listed here to ease deployment and troubleshooting.
 
 ## Next Release (replace with git tag when deployed)
+ * Bumped runtimeVersion to `2021.01.07`.
+ * Upgraded pana to `0.14.10`.
  * NOTE: `downloads` property in `Package` and `PackageVersion` is no longer populated.
    TODO(deferred): schedule cleanup after this release.
  * NOTE: `PackageVersionPubspec` is no longer used or added.

--- a/app/lib/shared/versions.dart
+++ b/app/lib/shared/versions.dart
@@ -21,9 +21,9 @@ final RegExp runtimeVersionPattern = RegExp(r'^\d{4}\.\d{2}\.\d{2}$');
 /// Make sure that at least two versions are kept here as the next candidates
 /// when the version switch happens.
 const acceptedRuntimeVersions = <String>[
-  '2020.12.21', // The current [runtimeVersion].
+  '2021.01.07', // The current [runtimeVersion].
+  '2020.12.21',
   '2020.12.09',
-  '2020.11.25',
 ];
 
 /// Represents a combined version of the overall toolchain and processing,

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -14,7 +14,7 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "11.0.0"
+    version: "13.0.0"
   _popularity:
     dependency: "direct main"
     description:
@@ -28,7 +28,7 @@ packages:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.40.4"
+    version: "0.41.0"
   api_builder:
     dependency: "direct main"
     description:
@@ -91,7 +91,7 @@ packages:
       name: build
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.0"
+    version: "1.5.2"
   build_config:
     dependency: transitive
     description:
@@ -112,7 +112,7 @@ packages:
       name: build_resolvers
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.3"
+    version: "1.4.4"
   build_runner:
     dependency: "direct dev"
     description:
@@ -224,7 +224,7 @@ packages:
       name: dart_style
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.9"
+    version: "1.3.10"
   dartis:
     dependency: transitive
     description:
@@ -378,7 +378,7 @@ packages:
       name: json_serializable
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.5.0"
+    version: "3.5.1"
   logging:
     dependency: "direct main"
     description:
@@ -469,7 +469,7 @@ packages:
       name: pana
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.14.9"
+    version: "0.14.10"
   path:
     dependency: "direct main"
     description:
@@ -602,7 +602,7 @@ packages:
       name: shelf_router_generator
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.7.2+3"
+    version: "0.7.2+4"
   shelf_static:
     dependency: transitive
     description:
@@ -623,7 +623,7 @@ packages:
       name: source_gen
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.7+1"
+    version: "0.9.10+1"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -686,21 +686,21 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.4"
+    version: "1.15.7"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.18"
+    version: "0.2.18+1"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.11+1"
+    version: "0.3.11+4"
   timing:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -44,7 +44,7 @@ dependencies:
   watcher: ^0.9.7
   yaml: '^2.1.12'
   # pana version to be pinned
-  pana: '0.14.9'
+  pana: '0.14.10'
   # 3rd-party packages with pinned versions
   archive: '2.0.11'
   buffer: '1.0.7'


### PR DESCRIPTION
This was blocked on `shelf_router_generator`, and it also upgraded other packages.