### PR TITLE
Remove tracking of _originalRequest

### DIFF
--- a/app/lib/frontend/handlers/routes.dart
+++ b/app/lib/frontend/handlers/routes.dart
@@ -163,26 +163,20 @@ class PubSiteService {
   Future<Response> documentation(
           Request request, String package, String version, String path) =>
       // TODO: pass in the [package] and [version] parameters, and maybe also the rest of the path.
-      // TODO: investigate if _originalRequest is still needed
-      documentationHandler(
-          request.context['_originalRequest'] as Request ?? request);
+      documentationHandler(request);
 
   @Route.get('/documentation/<package>/<version>')
   @Route.get('/documentation/<package>/<version>/')
   Future<Response> documentationVersion(
           Request request, String package, String version) =>
       // TODO: pass in the [package] and [version] parameters, and maybe also the rest of the path.
-      // TODO: investigate if _originalRequest is still needed
-      documentationHandler(
-          request.context['_originalRequest'] as Request ?? request);
+      documentationHandler(request);
 
   @Route.get('/documentation/<package>')
   @Route.get('/documentation/<package>/')
   Future<Response> documentationLatest(Request request, String package) =>
       // TODO: pass in the [package] parameter, or do redirect to /latest/ here
-      // TODO: investigate if _originalRequest is still needed
-      documentationHandler(
-          request.context['_originalRequest'] as Request ?? request);
+      documentationHandler(request);
 
   // ****
   // **** Publishers

--- a/app/lib/shared/handler_helpers.dart
+++ b/app/lib/shared/handler_helpers.dart
@@ -321,7 +321,13 @@ shelf.Request _sanitizeRequestedUri(shelf.Request request) {
   final uri = request.requestedUri;
   triggerUriParsingMethods(uri);
   final resource = Uri.decodeFull(uri.path);
-  final normalizedResource = path.normalize(resource);
+  final normalizedPath = path.normalize(resource);
+  // path.normalize removes trailing `/`, but in URLs we need to keep them
+  final normalizedResource = (resource.length > 1 &&
+          resource.endsWith('/') &&
+          !normalizedPath.endsWith('/'))
+      ? '$normalizedPath/'
+      : normalizedPath;
 
   if (uri.path == normalizedResource) {
     return request;
@@ -345,10 +351,6 @@ shelf.Request _sanitizeRequestedUri(shelf.Request request) {
       encoding: request.encoding,
       context: request.context,
     );
-    if (!sanitized.context.containsKey('_originalRequest')) {
-      return sanitized.change(context: {'_originalRequest': request});
-    } else {
-      return sanitized;
-    }
+    return sanitized;
   }
 }

--- a/app/test/frontend/handlers/redirects_test.dart
+++ b/app/test/frontend/handlers/redirects_test.dart
@@ -33,14 +33,14 @@ void main() {
     testWithServices('dartdocs.org redirect', () async {
       await expectRedirectResponse(
         await issueGet('/documentation/pkg/latest/', host: 'dartdocs.org'),
-        '$siteRoot/documentation/pkg/latest',
+        '$siteRoot/documentation/pkg/latest/',
       );
     });
 
     testWithServices('www.dartdocs.org redirect', () async {
       await expectRedirectResponse(
         await issueGet('/documentation/pkg/latest/', host: 'www.dartdocs.org'),
-        '$siteRoot/documentation/pkg/latest',
+        '$siteRoot/documentation/pkg/latest/',
       );
     });
 


### PR DESCRIPTION
I think it is better to be explicit on what the normalization does, and remove the tracking of the original request.