### PR TITLE
Increased dartdoc timeout for latest stable packages.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ AppEngine version, listed here to ease deployment and troubleshooting.
    TODO(deferred): schedule cleanup after this release.
  * NOTE: `PackageVersionPubspec` is no longer used or added.
    TODO(deferred): schedule remove script after this release. 
+ * Dartdoc timeout increased for latest stable versions, no more retry on timeout.
 
 ## `20201222t135400-all`
  * Bumped runtimeVersion to `2020.12.21`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ AppEngine version, listed here to ease deployment and troubleshooting.
  * Run `app/bin/tools/clear_package_properties.dart` after the release got deployed.
    This clears the `download` property in `Package` and `PackageVersion`.
  * Run `app/bin/tools/remove_packageversionpubspec.dart` after the release got deployed.
+ * Dartdoc timeout increased for latest stable versions, no more retry on timeout.
 
 ## `20210111t165700-all`
  * Bumped runtimeVersion to `2021.01.07`.
@@ -13,7 +14,6 @@ AppEngine version, listed here to ease deployment and troubleshooting.
    TODO(deferred): schedule cleanup after this release.
  * NOTE: `PackageVersionPubspec` is no longer used or added.
    TODO(deferred): schedule remove script after this release. 
- * Dartdoc timeout increased for latest stable versions, no more retry on timeout.
 
 ## `20201222t135400-all`
  * Bumped runtimeVersion to `2020.12.21`.


### PR DESCRIPTION
There is only a little chance that the retry with reduced options will complete in the same timeframe. Instead, let's increase the timeout for latest stable versions, and drop the immediate retry. The job scheduler will try to attempt it later anyway.

Closes #4388.