### PR TITLE
Update markdown in web_app to match app

### DIFF
--- a/pkg/web_app/pubspec.lock
+++ b/pkg/web_app/pubspec.lock
@@ -238,7 +238,7 @@ packages:
       name: markdown
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.8"
+    version: "3.0.0"
   matcher:
     dependency: transitive
     description:

--- a/pkg/web_app/pubspec.yaml
+++ b/pkg/web_app/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
     path: ../client_data
   http: ^0.12.0
   js: ^0.6.1
-  markdown: ^2.1.0
+  markdown: ^3.0.0
   intl: ^0.16.0
 
 dev_dependencies:


### PR DESCRIPTION
The root level `app` already updated to 3.0.0 but `web_app` had not.