### PR TITLE
Audit log messages for invite consents.

### DIFF
--- a/app/lib/audit/models.dart
+++ b/app/lib/audit/models.dart
@@ -181,6 +181,75 @@ class AuditLogRecord extends db.ExpandoModel<String> {
         toPublisherId,
       ];
   }
+
+  factory AuditLogRecord.publisherContactInvited({
+    @required User user,
+    @required String publisherId,
+    @required String contactEmail,
+  }) {
+    return AuditLogRecord._init()
+      ..kind = AuditLogRecordKind.publisherContactInvited
+      ..agent = user.userId
+      ..summary = [
+        '`${user.email}` invited `$contactEmail` ',
+        'to be contact email for publisher `$publisherId`.',
+      ].join()
+      ..data = {
+        'publisherId': publisherId,
+        'contactEmail': contactEmail,
+        'user': user.email,
+      }
+      ..users = [user.userId]
+      ..packages = []
+      ..packageVersions = []
+      ..publishers = [publisherId];
+  }
+
+  factory AuditLogRecord.publisherMemberInvited({
+    @required User user,
+    @required String publisherId,
+    @required String memberEmail,
+  }) {
+    return AuditLogRecord._init()
+      ..kind = AuditLogRecordKind.publisherMemberInvited
+      ..agent = user.userId
+      ..summary = [
+        '`${user.email}` invited `$memberEmail` ',
+        'to be a member for publisher `$publisherId`.',
+      ].join()
+      ..data = {
+        'publisherId': publisherId,
+        'memberEmail': memberEmail,
+        'user': user.email,
+      }
+      ..users = [user.userId]
+      ..packages = []
+      ..packageVersions = []
+      ..publishers = [publisherId];
+  }
+
+  factory AuditLogRecord.uploaderInvited({
+    @required User user,
+    @required String package,
+    @required String uploaderEmail,
+  }) {
+    return AuditLogRecord._init()
+      ..kind = AuditLogRecordKind.uploadedInvited
+      ..agent = user.userId
+      ..summary = [
+        '`${user.email}` invited `$uploaderEmail` ',
+        'to be an uploader for package `$package`.',
+      ].join()
+      ..data = {
+        'package': package,
+        'uploaderEmail': uploaderEmail,
+        'user': user.email,
+      }
+      ..users = [user.userId]
+      ..packages = [package]
+      ..packageVersions = []
+      ..publishers = [];
+  }
 }
 
 abstract class AuditLogRecordKind {
@@ -192,15 +261,22 @@ abstract class AuditLogRecordKind {
   /// Event that a package has transferred to a (new) publisher.
   static const packageTransferred = 'package-transferred';
 
-  // TODO: implement further kinds
-  // uploader-invited
+  /// Event that an e-mail was invited to be a publisher contact.
+  static const publisherContactInvited = 'publisher-contact-invited';
+
+  /// Event that an e-mail was invited to be a publisher member.
+  static const publisherMemberInvited = 'publisher-member-invited';
+
+  /// Event that an uploader was invited to a package.
+  static const uploadedInvited = 'uploader-invited';
+
+// TODO: implement further kinds
   // uploader-invite-accepted/added
   // uploader-invite-rejected
   // uploader-removed
   // publisher-created
   // publisher-updated
   // publisher-contact-changed
-  // publisher-member-invited
   // publisher-member-invite-accepted/added
   // publisher-member-invite-rejected
   // publisher-member-removed

--- a/app/test/account/consent_backend_test.dart
+++ b/app/test/account/consent_backend_test.dart
@@ -3,61 +3,93 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:gcloud/db.dart';
-import 'package:pub_dev/account/backend.dart';
 import 'package:test/test.dart';
 
+import 'package:pub_dev/account/backend.dart';
 import 'package:pub_dev/account/consent_backend.dart';
 import 'package:pub_dev/account/models.dart';
+import 'package:pub_dev/audit/backend.dart';
+import 'package:pub_dev/audit/models.dart';
 
 import '../shared/test_models.dart';
 import '../shared/test_services.dart';
 
 void main() {
   group('Uploader invite', () {
-    testWithServices('Uploader invite', () async {
-      registerAuthenticatedUser(hansUser);
-      final status = await consentBackend.invitePackageUploader(
-        uploaderEmail: joeUser.email,
-        packageName: hydrogen.packageName,
-      );
-      expect(status.emailSent, isTrue);
+    testWithProfile('Uploader invite', fn: () async {
+      await accountBackend.withBearerToken(adminAtPubDevAuthToken, () async {
+        final status = await consentBackend.invitePackageUploader(
+          uploaderEmail: 'user@pub.dev',
+          packageName: 'oxygen',
+        );
+        expect(status.emailSent, isTrue);
+      });
 
-      final consentRow = await dbService.query<Consent>().run().single;
-      final consent =
-          await consentBackend.getConsent(consentRow.consentId, joeUser);
-      expect(consent.descriptionHtml, contains('/packages/hydrogen'));
-      expect(consent.descriptionHtml, contains('publish new versions'));
+      await accountBackend.withBearerToken(userAtPubDevAuthToken, () async {
+        final consentRow = await dbService.query<Consent>().run().single;
+        final consent = await consentBackend.getConsent(
+            consentRow.consentId, await requireAuthenticatedUser());
+        expect(consent.descriptionHtml, contains('/packages/oxygen'));
+        expect(consent.descriptionHtml, contains('publish new versions'));
+      });
+
+      final auditLogRecords =
+          await auditBackend.listRecordsForPackage('oxygen');
+      final auditLog = auditLogRecords
+          .firstWhere((e) => e.kind == AuditLogRecordKind.uploadedInvited);
+      expect(auditLog.summary,
+          '`admin@pub.dev` invited `user@pub.dev` to be an uploader for package `oxygen`.');
     });
 
-    testWithServices('Publisher contact', () async {
-      registerAuthenticatedUser(hansUser);
-      final status = await consentBackend.invitePublisherContact(
-        publisherId: exampleComPublisher.publisherId,
-        contactEmail: joeUser.email,
-      );
-      expect(status.emailSent, isTrue);
+    testWithProfile('Publisher contact', fn: () async {
+      await accountBackend.withBearerToken(adminAtPubDevAuthToken, () async {
+        final status = await consentBackend.invitePublisherContact(
+          publisherId: exampleComPublisher.publisherId,
+          contactEmail: 'info@example.com',
+        );
+        expect(status.emailSent, isTrue);
+      });
 
-      final consentRow = await dbService.query<Consent>().run().single;
-      final consent =
-          await consentBackend.getConsent(consentRow.consentId, joeUser);
-      expect(consent.descriptionHtml, contains('/publishers/example.com'));
-      expect(consent.descriptionHtml, contains('contact email means'));
+      await accountBackend.withBearerToken(userAtPubDevAuthToken, () async {
+        final consentRow = await dbService.query<Consent>().run().single;
+        final consent = await consentBackend.getConsent(
+            consentRow.consentId, await requireAuthenticatedUser());
+        expect(consent.descriptionHtml, contains('/publishers/example.com'));
+        expect(consent.descriptionHtml, contains('contact email means'));
+      });
+
+      final auditLogRecords = await auditBackend
+          .listRecordsForPublisher(exampleComPublisher.publisherId);
+      final auditLog = auditLogRecords.firstWhere(
+          (e) => e.kind == AuditLogRecordKind.publisherContactInvited);
+      expect(auditLog.summary,
+          '`admin@pub.dev` invited `info@example.com` to be contact email for publisher `example.com`.');
     });
 
-    testWithServices('Publisher member', () async {
-      registerAuthenticatedUser(hansUser);
-      final status = await consentBackend.invitePublisherMember(
-        publisherId: exampleComPublisher.publisherId,
-        invitedUserEmail: joeUser.email,
-      );
-      expect(status.emailSent, isTrue);
+    testWithProfile('Publisher member', fn: () async {
+      await accountBackend.withBearerToken(adminAtPubDevAuthToken, () async {
+        final status = await consentBackend.invitePublisherMember(
+          publisherId: exampleComPublisher.publisherId,
+          invitedUserEmail: 'user@pub.dev',
+        );
+        expect(status.emailSent, isTrue);
+      });
 
-      final consentRow = await dbService.query<Consent>().run().single;
-      final consent =
-          await consentBackend.getConsent(consentRow.consentId, joeUser);
-      expect(consent.descriptionHtml, contains('/publishers/example.com'));
-      expect(
-          consent.descriptionHtml, contains('perform administrative actions'));
+      await accountBackend.withBearerToken(userAtPubDevAuthToken, () async {
+        final consentRow = await dbService.query<Consent>().run().single;
+        final consent = await consentBackend.getConsent(
+            consentRow.consentId, await requireAuthenticatedUser());
+        expect(consent.descriptionHtml, contains('/publishers/example.com'));
+        expect(consent.descriptionHtml,
+            contains('perform administrative actions'));
+      });
+
+      final auditLogRecords = await auditBackend
+          .listRecordsForPublisher(exampleComPublisher.publisherId);
+      final auditLog = auditLogRecords.firstWhere(
+          (e) => e.kind == AuditLogRecordKind.publisherMemberInvited);
+      expect(auditLog.summary,
+          '`admin@pub.dev` invited `user@pub.dev` to be a member for publisher `example.com`.');
     });
   });
 }


### PR DESCRIPTION
- #4386, #1018, #2687
- Also migrated the test to use test profile + token scopes instead of specifying a user instance.