### PR TITLE
Copy code blocks to clipboard.

### DIFF
--- a/pkg/web_css/lib/src/_base.scss
+++ b/pkg/web_css/lib/src/_base.scss
@@ -165,6 +165,61 @@ pre {
   }
 }
 
+.-pub-pre-copy-container {
+  position: relative;
+
+  &:hover {
+    .-pub-pre-copy-button {
+      opacity: 0.35;
+    }
+  }
+
+  .-pub-pre-copy-button {
+    position: absolute;
+    top: 4px;
+    right: 4px;
+    width: 20px;
+    height: 20px;
+    background: url("/static/img/content-copy-icon.svg?hash=fg6h81ph6ii0740g39jkvci8jiqi2j4p");
+    background-position: center;
+    background-repeat: no-repeat;
+    background-size: 16px 16px;
+
+    cursor: copy;
+
+    opacity: 0.15;
+    transition: opacity 0.5s;
+
+    &:hover {
+      opacity: 1;
+    }
+  }
+
+  .-pub-pre-copy-feedback {
+    display: none;
+
+    position: absolute;
+    top: 32px;
+    right: 4px;
+
+    font-size: 11px;
+    padding: 8px;
+    background: #fafaff;
+    box-shadow: 0px 0px 2px 2px rgba(0, 0, 0, 0.05);
+
+    white-space: nowrap;
+    transition: opacity $copy-feedback-transition-opacity-delay;
+
+    &.visible {
+      display: block;
+    }
+
+    &.fadeout {
+      opacity: 0;
+    }
+  }
+}
+
 .markdown-body {
   p {
     margin-top: 8px; /* overrides github-markdown.css */

--- a/pkg/web_css/lib/src/_pkg.scss
+++ b/pkg/web_css/lib/src/_pkg.scss
@@ -283,8 +283,7 @@
 
     opacity: 1;
     display: none;
-    // NOTE: keep in sync with hoverable.dart 900ms delay
-    transition: opacity 0.9s;
+    transition: opacity $copy-feedback-transition-opacity-delay;
 
     >.code {
       font-family: $font-family-roboto-mono;

--- a/pkg/web_css/lib/src/_variables.scss
+++ b/pkg/web_css/lib/src/_variables.scss
@@ -32,3 +32,6 @@ $color-searchbar-dark-link: #0175c2;
 $color-input-primary: #0175C2;
 $color-input-danger: #ff4242;
 $color-link: $color-input-primary;
+
+// NOTE: keep in sync with hoverable.dart 900ms delay
+$copy-feedback-transition-opacity-delay: 0.9s;


### PR DESCRIPTION
- Fixes #4356.
- I wanted to implement it without the DOM-modification hack, but turns out that `relative-absolute` positioning and horizontal scrolling do need one extra level of DOM Element there. Instead of making the markdown-postprocessing more complex (and even more custom), I think this in-place modification is at an acceptable level of added complexity.
- The icon has three levels of opacity: default is very light, hovering over the `<pre>` block makes it visible, and hovering over the icon has full opacity.
- Has the same feedback as the copy of the package version.

<img width="759" alt="Screenshot 2021-01-14 at 18 37 09" src="https://user-images.githubusercontent.com/4778111/104627709-abf5df80-5697-11eb-8249-083116d6755e.png">
