### PR TITLE
Use only HTTP endpoints in test_profile importer.

### DIFF
--- a/app/lib/fake/tool/init_data_file.dart
+++ b/app/lib/fake/tool/init_data_file.dart
@@ -15,7 +15,6 @@ import 'package:pub_dev/dartdoc/dartdoc_runner.dart';
 import 'package:pub_dev/frontend/static_files.dart';
 import 'package:pub_dev/job/job.dart';
 import 'package:pub_dev/service/services.dart';
-import 'package:pub_dev/shared/configuration.dart';
 import 'package:pub_dev/tool/test_profile/import_source.dart';
 import 'package:pub_dev/tool/test_profile/importer.dart';
 import 'package:pub_dev/tool/test_profile/models.dart';
@@ -65,7 +64,6 @@ class FakeInitDataFileCommand extends Command {
     final state = LocalServerState();
 
     await withFakeServices(
-        configuration: Configuration.test(),
         datastore: state.datastore,
         storage: state.storage,
         fn: () async {

--- a/app/lib/frontend/handlers/pubapi.client.dart
+++ b/app/lib/frontend/handlers/pubapi.client.dart
@@ -62,6 +62,13 @@ class PubApiClient {
     ));
   }
 
+  Future<_i3.SuccessMessage> finishPackageUpload(String uploadId) async {
+    return _i3.SuccessMessage.fromJson(await _client.requestJson(
+      verb: 'get',
+      path: '/api/packages/versions/newUploadFinish/$uploadId',
+    ));
+  }
+
   Future<_i3.SuccessMessage> addUploader(String package) async {
     return _i3.SuccessMessage.fromJson(await _client.requestJson(
       verb: 'post',

--- a/app/lib/frontend/handlers/pubapi.dart
+++ b/app/lib/frontend/handlers/pubapi.dart
@@ -110,8 +110,16 @@ class PubApi {
   ///     }
   @EndPoint.get('/api/packages/versions/newUploadFinish')
   Future<SuccessMessage> packageUploadCallback(Request request) async {
-    await packageBackend
-        .publishUploadedBlob(_replaceHost(request.requestedUri));
+    final uploadId = request.requestedUri.queryParameters['upload_id'];
+    await packageBackend.publishUploadedBlob(uploadId);
+    return SuccessMessage(
+        success: Message(message: 'Successfully uploaded package.'));
+  }
+
+  @EndPoint.get('/api/packages/versions/newUploadFinish/<uploadId>')
+  Future<SuccessMessage> finishPackageUpload(
+      Request request, String uploadId) async {
+    await packageBackend.publishUploadedBlob(uploadId);
     return SuccessMessage(
         success: Message(message: 'Successfully uploaded package.'));
   }

--- a/app/lib/frontend/handlers/pubapi.g.dart
+++ b/app/lib/frontend/handlers/pubapi.g.dart
@@ -93,6 +93,20 @@ Router _$PubApiRouter(PubApi service) {
       return $utilities.unhandledError(e, st);
     }
   });
+  router.add('GET', r'/api/packages/versions/newUploadFinish/<uploadId>',
+      (Request request, String uploadId) async {
+    try {
+      final _$result = await service.finishPackageUpload(
+        request,
+        uploadId,
+      );
+      return $utilities.jsonResponse(_$result.toJson());
+    } on ApiResponseException catch (e) {
+      return e.asApiResponse();
+    } catch (e, st) {
+      return $utilities.unhandledError(e, st);
+    }
+  });
   router.add('POST', r'/api/packages/<package>/uploaders',
       (Request request, String package) async {
     try {

--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -522,11 +522,7 @@ class PackageBackend {
     _logger.info('Starting semi-async upload (uuid: $guid)');
     final object = _storage.tempObjectName(guid);
     await data.pipe(_storage.bucket.write(object));
-    final finishUri = Uri(
-      path: '/api/packages/versions/newUploadFinish',
-      queryParameters: {'upload_id': guid},
-    );
-    return await publishUploadedBlob(finishUri);
+    return await publishUploadedBlob(guid);
   }
 
   Future<api.UploadInfo> startUpload(Uri redirectUrl) async {
@@ -555,13 +551,12 @@ class PackageBackend {
   }
 
   /// Finishes the upload of a package.
-  Future<PackageVersion> publishUploadedBlob(Uri uri) async {
+  Future<PackageVersion> publishUploadedBlob(String guid) async {
     final restriction = await getUploadRestrictionStatus();
     if (restriction == UploadRestrictionStatus.noUploads) {
       throw PackageRejectedException.uploadRestricted();
     }
     final user = await requireAuthenticatedUser();
-    final guid = uri.queryParameters['upload_id'];
     _logger.info('Finishing async upload (uuid: $guid)');
     _logger.info('Reading tarball from cloud storage.');
 

--- a/app/lib/shared/configuration.dart
+++ b/app/lib/shared/configuration.dart
@@ -294,7 +294,7 @@ class Configuration {
   }
 
   /// Configuration for tests.
-  factory Configuration.test() {
+  factory Configuration.test({String storageBaseUrl}) {
     return Configuration(
       projectId: 'dartlang-pub-test',
       packageBucketName: 'fake-bucket-pub',
@@ -303,7 +303,7 @@ class Configuration {
       searchSnapshotBucketName: 'fake-bucket-search',
       backupSnapshotBucketName: 'fake-bucket-backup',
       searchServicePrefix: 'http://localhost:0',
-      storageBaseUrl: 'http://localhost:0',
+      storageBaseUrl: storageBaseUrl ?? 'http://localhost:0',
       pubClientAudience: null,
       pubSiteAudience: null,
       adminAudience: null,

--- a/app/lib/tool/utils/http_client_to_shelf_handler.dart
+++ b/app/lib/tool/utils/http_client_to_shelf_handler.dart
@@ -1,0 +1,64 @@
+// Copyright (c) 2021, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:gcloud/service_scope.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart' as http_testing;
+import 'package:logging/logging.dart';
+import 'package:shelf/shelf.dart' as shelf;
+
+import '../../frontend/handlers.dart';
+import '../../shared/handler_helpers.dart';
+import '../../tool/utils/http.dart';
+
+/// Returns a HTTP client that bridges HTTP requests and shelf handlers without
+/// the actual HTTP transport layer.
+///
+/// If [handler] is not specified, it will use the default frontend handler.
+http.Client httpClientToShelfHandler({
+  shelf.Handler handler,
+  String authToken,
+}) {
+  handler ??= createAppHandler();
+  handler = wrapHandler(
+    Logger.detached('test'),
+    handler,
+    sanitize: true,
+  );
+  return httpClientWithAuthorization(
+    tokenProvider: () async => authToken,
+    client: http_testing.MockClient(_wrapShelfHandler(handler)),
+  );
+}
+
+String _removeLeadingSlashes(String path) {
+  while (path.startsWith('/')) {
+    path = path.substring(1);
+  }
+  return path;
+}
+
+http_testing.MockClientHandler _wrapShelfHandler(shelf.Handler handler) {
+  return (rq) async {
+    final shelfRq = shelf.Request(
+      rq.method,
+      rq.url.replace(path: _removeLeadingSlashes(rq.url.path)),
+      body: rq.body,
+      headers: rq.headers,
+      url: Uri(path: _removeLeadingSlashes(rq.url.path), query: rq.url.query),
+      handlerPath: '',
+    );
+    shelf.Response rs;
+    // Need to fork a service scope to create a separate RequestContext in the
+    // search service handler.
+    await fork(() async {
+      rs = await handler(shelfRq);
+    });
+    return http.Response(
+      await rs.readAsString(),
+      rs.statusCode,
+      headers: rs.headers,
+    );
+  };
+}

--- a/app/lib/tool/utils/pub_api_client.dart
+++ b/app/lib/tool/utils/pub_api_client.dart
@@ -1,0 +1,42 @@
+// Copyright (c) 2021, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:meta/meta.dart';
+
+import '../../frontend/handlers/pubapi.client.dart';
+
+import 'http.dart';
+import 'http_client_to_shelf_handler.dart';
+
+/// Creates local, non-HTTP-based API client with [authToken].
+PubApiClient createLocalPubApiClient({String authToken}) =>
+    PubApiClient('http://localhost:0/',
+        client: httpClientToShelfHandler(authToken: authToken));
+
+/// Creates a pub.dev API client and executes [fn], making sure that the HTTP
+/// resources are freed after the callback finishes.
+///
+/// If [bearerToken] is specified, the Authorization HTTP header will be sent
+/// with a Bearer token.
+///
+/// If [pubHostedUrl] is specified, the HTTP client will connect to this
+/// endpoint, otherwise only local API calls will be made.
+Future<R> withPubApiClient<R>({
+  String bearerToken,
+  String pubHostedUrl,
+  @required Future<R> Function(PubApiClient client) fn,
+}) async {
+  final httpClient = pubHostedUrl == null
+      ? httpClientToShelfHandler(authToken: bearerToken)
+      : httpClientWithAuthorization(tokenProvider: () async => bearerToken);
+  try {
+    final apiClient = PubApiClient(
+      pubHostedUrl ?? 'http://localhost:0/',
+      client: httpClient,
+    );
+    return await fn(apiClient);
+  } finally {
+    httpClient.close();
+  }
+}

--- a/app/test/package/backend_test.dart
+++ b/app/test/package/backend_test.dart
@@ -158,13 +158,13 @@ void main() {
       testWithServices('no escape needed', () async {
         final url = await packageBackend.downloadUrl('hydrogen', '2.0.8');
         expect(url.toString(),
-            'http://localhost:0/fake-bucket-pub/packages/hydrogen-2.0.8.tar.gz');
+            contains('/fake-bucket-pub/packages/hydrogen-2.0.8.tar.gz'));
       });
 
       testWithServices('version escape needed', () async {
         final url = await packageBackend.downloadUrl('hydrogen', '2.0.8+5');
         expect(url.toString(),
-            'http://localhost:0/fake-bucket-pub/packages/hydrogen-2.0.8%2B5.tar.gz');
+            contains('/fake-bucket-pub/packages/hydrogen-2.0.8%2B5.tar.gz'));
       });
     });
   });

--- a/app/test/package/upload_test.dart
+++ b/app/test/package/upload_test.dart
@@ -51,16 +51,15 @@ void main() {
     });
 
     group('packageBackend.publishUploadedBlob', () {
-      final Uri redirectUri =
-          Uri.parse('http://blobstore.com/upload?upload_id=my-uuid');
+      final uploadId = 'my-uuid';
 
       testWithServices('uploaded zero-length file', () async {
         registerAuthenticatedUser(hansUser);
 
         // create empty file
-        await tarballStorage.bucket.write('tmp/my-uuid').close();
+        await tarballStorage.bucket.write('tmp/$uploadId').close();
 
-        final rs = packageBackend.publishUploadedBlob(redirectUri);
+        final rs = packageBackend.publishUploadedBlob(uploadId);
         await expectLater(
           rs,
           throwsA(
@@ -82,11 +81,11 @@ void main() {
         // Add one more byte than allowed.
         bigTarball.add([1]);
 
-        final sink = tarballStorage.bucket.write('tmp/my-uuid');
+        final sink = tarballStorage.bucket.write('tmp/$uploadId');
         bigTarball.forEach(sink.add);
         await sink.close();
 
-        final rs = packageBackend.publishUploadedBlob(redirectUri);
+        final rs = packageBackend.publishUploadedBlob(uploadId);
         await expectLater(
           rs,
           throwsA(
@@ -101,10 +100,10 @@ void main() {
 
         final dateBeforeTest = DateTime.now().toUtc();
         final pubspecContent = generatePubspecYaml('new_package', '1.2.3');
-        await tarballStorage.bucket.writeBytes('tmp/my-uuid',
+        await tarballStorage.bucket.writeBytes('tmp/$uploadId',
             await packageArchiveBytes(pubspecContent: pubspecContent));
 
-        final version = await packageBackend.publishUploadedBlob(redirectUri);
+        final version = await packageBackend.publishUploadedBlob(uploadId);
         expect(version.package, 'new_package');
         expect(version.version, '1.2.3');
 
@@ -171,10 +170,10 @@ void main() {
 
         final dateBeforeTest = DateTime.now().toUtc();
         final pubspecContent = generatePubspecYaml('lithium', '7.0.0');
-        await tarballStorage.bucket.writeBytes('tmp/my-uuid',
+        await tarballStorage.bucket.writeBytes('tmp/$uploadId',
             await packageArchiveBytes(pubspecContent: pubspecContent));
 
-        final version = await packageBackend.publishUploadedBlob(redirectUri);
+        final version = await packageBackend.publishUploadedBlob(uploadId);
         expect(version.package, 'lithium');
         expect(version.version, '7.0.0');
 

--- a/app/test/package/upload_test.dart
+++ b/app/test/package/upload_test.dart
@@ -42,7 +42,8 @@ void main() {
         final Uri redirectUri = Uri.parse('http://blobstore.com/upload');
         registerAuthenticatedUser(hansUser);
         final info = await packageBackend.startUpload(redirectUri);
-        expect(info.url, startsWith('http://localhost:0/fake-bucket-pub/tmp/'));
+        expect(info.url, startsWith('http://localhost:'));
+        expect(info.url, contains('/fake-bucket-pub/tmp/'));
         expect(info.fields, {
           'key': startsWith('fake-bucket-pub/tmp/'),
           'success_action_redirect': startsWith('$redirectUri?upload_id='),

--- a/pkg/web_app/lib/src/pubapi.client.dart
+++ b/pkg/web_app/lib/src/pubapi.client.dart
@@ -62,6 +62,13 @@ class PubApiClient {
     ));
   }
 
+  Future<_i3.SuccessMessage> finishPackageUpload(String uploadId) async {
+    return _i3.SuccessMessage.fromJson(await _client.requestJson(
+      verb: 'get',
+      path: '/api/packages/versions/newUploadFinish/$uploadId',
+    ));
+  }
+
   Future<_i3.SuccessMessage> addUploader(String package) async {
     return _i3.SuccessMessage.fromJson(await _client.requestJson(
       verb: 'post',


### PR DESCRIPTION
- Moved http->shelf->http adapter from test to lib.
- Added callback wrapper for API client with HTTP endpoint and auth bearer token.
- Unit tests will create a local HTTP server that receives the uploaded archive files. That caused a bit of complexity in the initialization sequence of `Configuration`.
- Added a new API endpoint for finishing the upload (until API generator has support for query parameters).