### PR TITLE
More audit log records.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,14 @@ AppEngine version, listed here to ease deployment and troubleshooting.
 
 ## Next Release (replace with git tag when deployed)
  * Bumped runtimeVersion to `2021.01.29`.
+ * NOTE: the release starts to create `AuditLogRecord`s for all the existing
+         `History` entries. `History` entries could be removed after this release.
 
 ## `20210129t103600-all`
  * Bumped runtimeVersion to `2021.01.26`.
  * Upgraded Flutter to `1.25.0-8.3.pre` (beta).
  * NOTE: the release starts to populate preview version fields and runs
          a periodic task to update it.
- * NOTE: the release starts to create `AuditLogRecord`s for all the existing
-         `History` entries. `History` entries could be removed after this release.
 
 ## `20210119t122300-all`
  * Bumped runtimeVersion to `2021.01.18`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ AppEngine version, listed here to ease deployment and troubleshooting.
  * Upgraded Flutter to `1.25.0-8.3.pre` (beta).
  * NOTE: the release starts to populate preview version fields and runs
          a periodic task to update it.
+ * NOTE: the release starts to create `AuditLogRecord`s for all the existing
+         `History` entries. `History` entries could be removed after this release.
 
 ## `20210119t122300-all`
  * Bumped runtimeVersion to `2021.01.18`.

--- a/app/lib/audit/models.dart
+++ b/app/lib/audit/models.dart
@@ -124,6 +124,24 @@ class AuditLogRecord extends db.ExpandoModel<String> {
     dataJson = json.encode(value);
   }
 
+  factory AuditLogRecord.packageOptionsUpdated({
+    @required String package,
+    @required User user,
+  }) {
+    return AuditLogRecord._init()
+      ..kind = AuditLogRecordKind.packageOptionsUpdated
+      ..agent = user.userId
+      ..summary = '`${user.email}` updated package `$package`.'
+      ..data = {
+        'package': package,
+        'user': user.email,
+      }
+      ..users = [user.userId]
+      ..packages = [package]
+      ..packageVersions = []
+      ..publishers = [];
+  }
+
   factory AuditLogRecord.packagePublished({
     @required User uploader,
     @required String package,
@@ -182,6 +200,29 @@ class AuditLogRecord extends db.ExpandoModel<String> {
       ];
   }
 
+  factory AuditLogRecord.publisherContactInviteAccepted({
+    @required User user,
+    @required String publisherId,
+    @required String contactEmail,
+  }) {
+    return AuditLogRecord._init()
+      ..kind = AuditLogRecordKind.publisherContactInviteAccepted
+      ..agent = user.userId
+      ..summary = [
+        '`${user.email}` accepted `$contactEmail` ',
+        'to be contact email for publisher `$publisherId`.',
+      ].join()
+      ..data = {
+        'publisherId': publisherId,
+        'contactEmail': contactEmail,
+        'user': user.email,
+      }
+      ..users = [user.userId]
+      ..packages = []
+      ..packageVersions = []
+      ..publishers = [publisherId];
+  }
+
   factory AuditLogRecord.publisherContactInvited({
     @required User user,
     @required String publisherId,
@@ -197,6 +238,24 @@ class AuditLogRecord extends db.ExpandoModel<String> {
       ..data = {
         'publisherId': publisherId,
         'contactEmail': contactEmail,
+        'user': user.email,
+      }
+      ..users = [user.userId]
+      ..packages = []
+      ..packageVersions = []
+      ..publishers = [publisherId];
+  }
+
+  factory AuditLogRecord.publisherCreated({
+    @required User user,
+    @required String publisherId,
+  }) {
+    return AuditLogRecord._init()
+      ..kind = AuditLogRecordKind.publisherCreated
+      ..agent = user.userId
+      ..summary = '`${user.email}` created publisher `$publisherId`.'
+      ..data = {
+        'publisherId': publisherId,
         'user': user.email,
       }
       ..users = [user.userId]
@@ -228,6 +287,66 @@ class AuditLogRecord extends db.ExpandoModel<String> {
       ..publishers = [publisherId];
   }
 
+  factory AuditLogRecord.publisherMemberInviteAccepted({
+    @required User user,
+    @required String publisherId,
+  }) {
+    return AuditLogRecord._init()
+      ..kind = AuditLogRecordKind.publisherMemberInviteAccepted
+      ..agent = user.userId
+      ..summary =
+          '`${user.email}` accepted member invite for publisher `$publisherId`.'
+      ..data = {
+        'publisherId': publisherId,
+        'user': user.email,
+      }
+      ..users = [user.userId]
+      ..packages = []
+      ..packageVersions = []
+      ..publishers = [publisherId];
+  }
+
+  factory AuditLogRecord.publisherMemberRemoved({
+    @required User activeUser,
+    @required String publisherId,
+    @required User memberToRemove,
+  }) {
+    return AuditLogRecord._init()
+      ..kind = AuditLogRecordKind.publisherMemberRemoved
+      ..agent = activeUser.userId
+      ..summary = [
+        '`${activeUser.email}` removed `${memberToRemove.email}` ',
+        'from publisher `$publisherId`.',
+      ].join()
+      ..data = {
+        'publisherId': publisherId,
+        'memberEmail': memberToRemove.email,
+        'user': activeUser.email,
+      }
+      ..users = [activeUser.userId, memberToRemove.userId]
+      ..packages = []
+      ..packageVersions = []
+      ..publishers = [publisherId];
+  }
+
+  factory AuditLogRecord.publisherUpdated({
+    @required User user,
+    @required String publisherId,
+  }) {
+    return AuditLogRecord._init()
+      ..kind = AuditLogRecordKind.publisherUpdated
+      ..agent = user.userId
+      ..summary = '`${user.email}` updated publisher `$publisherId`.'
+      ..data = {
+        'publisherId': publisherId,
+        'user': user.email,
+      }
+      ..users = [user.userId]
+      ..packages = []
+      ..packageVersions = []
+      ..publishers = [publisherId];
+  }
+
   factory AuditLogRecord.uploaderInvited({
     @required User user,
     @required String package,
@@ -250,9 +369,55 @@ class AuditLogRecord extends db.ExpandoModel<String> {
       ..packageVersions = []
       ..publishers = [];
   }
+
+  factory AuditLogRecord.uploaderInviteAccepted({
+    @required User user,
+    @required String package,
+  }) {
+    return AuditLogRecord._init()
+      ..kind = AuditLogRecordKind.uploaderInviteAccepted
+      ..agent = user.userId
+      ..summary = [
+        '`${user.email}` accepted uploader invite for package `$package`.',
+      ].join()
+      ..data = {
+        'package': package,
+        'user': user.email,
+      }
+      ..users = [user.userId]
+      ..packages = [package]
+      ..packageVersions = []
+      ..publishers = [];
+  }
+
+  factory AuditLogRecord.uploaderRemoved({
+    @required User activeUser,
+    @required String package,
+    @required User uploaderUser,
+  }) {
+    return AuditLogRecord._init()
+      ..kind = AuditLogRecordKind.uploaderRemoved
+      ..agent = activeUser.userId
+      ..summary = [
+        '`${activeUser.email}` removed `${uploaderUser.email}` ',
+        'from the uploaders of package `$package`.',
+      ].join()
+      ..data = {
+        'package': package,
+        'uploaderEmail': uploaderUser.email,
+        'user': activeUser.email,
+      }
+      ..users = [activeUser.userId, uploaderUser.userId]
+      ..packages = [package]
+      ..packageVersions = []
+      ..publishers = [];
+  }
 }
 
 abstract class AuditLogRecordKind {
+  /// Event that a package was updated with new options
+  static const packageOptionsUpdated = 'package-options-updated';
+
   /// Event that a package was published.
   ///
   /// This can be an entirely new package or just a new version to an existing package.
@@ -264,20 +429,40 @@ abstract class AuditLogRecordKind {
   /// Event that an e-mail was invited to be a publisher contact.
   static const publisherContactInvited = 'publisher-contact-invited';
 
+  /// Event that an e-mail consent was accepted to become a publisher contact.
+  static const publisherContactInviteAccepted =
+      'publisher-contact-invite-accepted';
+
+  /// Event that a publisher was created.
+  static const publisherCreated = 'publisher-created';
+
   /// Event that an e-mail was invited to be a publisher member.
   static const publisherMemberInvited = 'publisher-member-invited';
+
+  /// Event that a user has accepted the invite to become member of a publisher.
+  static const publisherMemberInviteAccepted =
+      'publisher-member-invite-accepted';
+
+  /// Event that a publisher member was removed.
+  static const publisherMemberRemoved = 'publisher-member-removed';
+
+  /// Event that a publisher was updated.
+  static const publisherUpdated = 'publisher-updated';
 
   /// Event that an uploader was invited to a package.
   static const uploadedInvited = 'uploader-invited';
 
+  /// Event that an uploader accepted the invite for a package.
+  static const uploaderInviteAccepted = 'uploader-invite-accepted';
+
+  /// Event that an uploader was removed from a package.
+  static const uploaderRemoved = 'uploader-removed';
+
 // TODO: implement further kinds
-  // uploader-invite-accepted/added
+  // uploader-invite-expired
   // uploader-invite-rejected
-  // uploader-removed
-  // publisher-created
-  // publisher-updated
-  // publisher-contact-changed
-  // publisher-member-invite-accepted/added
+  // publisher-contact-invite-expired
+  // publisher-contact-invite-rejected
+  // publisher-member-invite-expired
   // publisher-member-invite-rejected
-  // publisher-member-removed
 }

--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -411,6 +411,10 @@ class PackageBackend {
           isUnlisted: options.isUnlisted,
         ),
       ));
+      tx.insert(AuditLogRecord.packageOptionsUpdated(
+        package: p.name,
+        user: user,
+      ));
     });
     await purgePackageCache(package);
     await analyzerClient.triggerAnalysis(package, latestVersion, <String>{});
@@ -922,6 +926,10 @@ class PackageBackend {
         addedUploaderIds: [uploader.userId],
         addedUploaderEmails: [uploader.email],
       )));
+      tx.insert(AuditLogRecord.uploaderInviteAccepted(
+        user: uploader,
+        package: packageName,
+      ));
     });
     await purgePackageCache(packageName);
   }
@@ -995,6 +1003,11 @@ class PackageBackend {
         removedUploaderIds: [uploader.userId],
         removedUploaderEmails: [uploader.email],
       )));
+      tx.insert(AuditLogRecord.uploaderRemoved(
+        activeUser: user,
+        package: packageName,
+        uploaderUser: uploader,
+      ));
     });
     await purgePackageCache(packageName);
     return api.SuccessMessage(

--- a/app/test/account/consent_backend_test.dart
+++ b/app/test/account/consent_backend_test.dart
@@ -5,11 +5,13 @@
 import 'package:gcloud/db.dart';
 import 'package:test/test.dart';
 
+import 'package:client_data/account_api.dart' as account_api;
 import 'package:pub_dev/account/backend.dart';
 import 'package:pub_dev/account/consent_backend.dart';
 import 'package:pub_dev/account/models.dart';
 import 'package:pub_dev/audit/backend.dart';
 import 'package:pub_dev/audit/models.dart';
+import 'package:pub_dev/tool/utils/pub_api_client.dart';
 
 import '../shared/test_models.dart';
 import '../shared/test_services.dart';
@@ -25,20 +27,35 @@ void main() {
         expect(status.emailSent, isTrue);
       });
 
+      String consentId;
       await accountBackend.withBearerToken(userAtPubDevAuthToken, () async {
         final consentRow = await dbService.query<Consent>().run().single;
         final consent = await consentBackend.getConsent(
             consentRow.consentId, await requireAuthenticatedUser());
         expect(consent.descriptionHtml, contains('/packages/oxygen'));
         expect(consent.descriptionHtml, contains('publish new versions'));
+        consentId = consentRow.consentId;
       });
 
-      final auditLogRecords =
-          await auditBackend.listRecordsForPackage('oxygen');
-      final auditLog = auditLogRecords
+      final records1 = await auditBackend.listRecordsForPackage('oxygen');
+      final r1 = records1
           .firstWhere((e) => e.kind == AuditLogRecordKind.uploadedInvited);
-      expect(auditLog.summary,
+      expect(r1.summary,
           '`admin@pub.dev` invited `user@pub.dev` to be an uploader for package `oxygen`.');
+
+      await withPubApiClient(
+          bearerToken: userAtPubDevAuthToken,
+          fn: (client) async {
+            final rs = await client.resolveConsent(
+                consentId, account_api.ConsentResult(granted: true));
+            expect(rs.granted, true);
+          });
+
+      final records2 = await auditBackend.listRecordsForPackage('oxygen');
+      final r2 = records2.firstWhere(
+          (e) => e.kind == AuditLogRecordKind.uploaderInviteAccepted);
+      expect(r2.summary,
+          '`user@pub.dev` accepted uploader invite for package `oxygen`.');
     });
 
     testWithProfile('Publisher contact', fn: () async {
@@ -50,20 +67,37 @@ void main() {
         expect(status.emailSent, isTrue);
       });
 
+      String consentId;
       await accountBackend.withBearerToken(userAtPubDevAuthToken, () async {
         final consentRow = await dbService.query<Consent>().run().single;
         final consent = await consentBackend.getConsent(
             consentRow.consentId, await requireAuthenticatedUser());
         expect(consent.descriptionHtml, contains('/publishers/example.com'));
         expect(consent.descriptionHtml, contains('contact email means'));
+        consentId = consentRow.consentId;
       });
 
-      final auditLogRecords = await auditBackend
-          .listRecordsForPublisher(exampleComPublisher.publisherId);
-      final auditLog = auditLogRecords.firstWhere(
+      final records1 =
+          await auditBackend.listRecordsForPublisher('example.com');
+      final r1 = records1.firstWhere(
           (e) => e.kind == AuditLogRecordKind.publisherContactInvited);
-      expect(auditLog.summary,
+      expect(r1.summary,
           '`admin@pub.dev` invited `info@example.com` to be contact email for publisher `example.com`.');
+
+      await withPubApiClient(
+          bearerToken: adminAtPubDevAuthToken,
+          fn: (client) async {
+            final rs = await client.resolveConsent(
+                consentId, account_api.ConsentResult(granted: true));
+            expect(rs.granted, true);
+          });
+
+      final records2 =
+          await auditBackend.listRecordsForPublisher('example.com');
+      final r2 = records2.firstWhere(
+          (e) => e.kind == AuditLogRecordKind.publisherContactInviteAccepted);
+      expect(r2.summary,
+          '`admin@pub.dev` accepted `info@example.com` to be contact email for publisher `example.com`.');
     });
 
     testWithProfile('Publisher member', fn: () async {
@@ -75,6 +109,7 @@ void main() {
         expect(status.emailSent, isTrue);
       });
 
+      String consentId;
       await accountBackend.withBearerToken(userAtPubDevAuthToken, () async {
         final consentRow = await dbService.query<Consent>().run().single;
         final consent = await consentBackend.getConsent(
@@ -82,14 +117,30 @@ void main() {
         expect(consent.descriptionHtml, contains('/publishers/example.com'));
         expect(consent.descriptionHtml,
             contains('perform administrative actions'));
+        consentId = consentRow.consentId;
       });
 
-      final auditLogRecords = await auditBackend
-          .listRecordsForPublisher(exampleComPublisher.publisherId);
-      final auditLog = auditLogRecords.firstWhere(
+      final records1 =
+          await auditBackend.listRecordsForPublisher('example.com');
+      final r1 = records1.firstWhere(
           (e) => e.kind == AuditLogRecordKind.publisherMemberInvited);
-      expect(auditLog.summary,
+      expect(r1.summary,
           '`admin@pub.dev` invited `user@pub.dev` to be a member for publisher `example.com`.');
+
+      await withPubApiClient(
+          bearerToken: userAtPubDevAuthToken,
+          fn: (client) async {
+            final rs = await client.resolveConsent(
+                consentId, account_api.ConsentResult(granted: true));
+            expect(rs.granted, true);
+          });
+
+      final records2 =
+          await auditBackend.listRecordsForPublisher('example.com');
+      final r2 = records2.firstWhere(
+          (e) => e.kind == AuditLogRecordKind.publisherMemberInviteAccepted);
+      expect(r2.summary,
+          '`user@pub.dev` accepted member invite for publisher `example.com`.');
     });
   });
 }


### PR DESCRIPTION
- #4386
- `AuditLogRecord` is now a superset of `History` entries.
- The remaining ones require a bit refactoring in the consent backend, postponed to a followup-PR.