### PR TITLE
Fix latest-stable calculation with prerelease bypass.

### DIFF
--- a/app/lib/package/models.dart
+++ b/app/lib/package/models.dart
@@ -222,10 +222,11 @@ class Package extends db.ExpandoModel<String> {
     @required Version dartSdkVersion,
   }) {
     final newVersion = pv.semanticVersion;
+    final isOnStableSdk = !pv.pubspec.isPreviewForCurrentSdk(dartSdkVersion);
 
     if (latestVersionKey == null ||
         (isNewer(latestSemanticVersion, newVersion, pubSorted: true) &&
-            !pv.pubspec.isPreviewForCurrentSdk(dartSdkVersion))) {
+            (latestSemanticVersion.isPreRelease || isOnStableSdk))) {
       latestVersionKey = pv.key;
       latestPublished = pv.created;
     }


### PR DESCRIPTION
- #4404 
- This is a bypass for packages that have only prerelease versions: in such case there is no latest stable version (preview SDK or not), and we should default to the latest prerelease version.