### PR TITLE
Classify min SDK prereleases as dev channel.

### DIFF
--- a/app/lib/package/model_properties.dart
+++ b/app/lib/package/model_properties.dart
@@ -187,6 +187,8 @@ class MinSdkVersion {
         channel = 'dev';
       } else if (str.endsWith('.beta')) {
         channel = 'beta';
+      } else if (min.isPreRelease) {
+        channel = 'dev';
       }
       return MinSdkVersion(min, channel);
     }

--- a/app/test/package/models_test.dart
+++ b/app/test/package/models_test.dart
@@ -134,6 +134,40 @@ version: 1.0.9
       });
     });
   });
+
+  group('MinSdkVersion', () {
+    test('dev only', () {
+      final msd =
+          MinSdkVersion.tryParse(VersionConstraint.parse('>=2.12.0-0 <2.12.0'));
+      expect(msd.major, 2);
+      expect(msd.minor, 12);
+      expect(msd.channel, 'dev');
+    });
+
+    test('dev', () {
+      final msd = MinSdkVersion.tryParse(
+          VersionConstraint.parse('>=2.12.0-29.10.dev <3.0.0'));
+      expect(msd.major, 2);
+      expect(msd.minor, 12);
+      expect(msd.channel, 'dev');
+    });
+
+    test('beta', () {
+      final msd = MinSdkVersion.tryParse(
+          VersionConstraint.parse('>=2.12.0-29.10.beta <3.0.0'));
+      expect(msd.major, 2);
+      expect(msd.minor, 12);
+      expect(msd.channel, 'beta');
+    });
+
+    test('stable', () {
+      final msd =
+          MinSdkVersion.tryParse(VersionConstraint.parse('>=2.12.0 <3.0.0'));
+      expect(msd.major, 2);
+      expect(msd.minor, 12);
+      expect(msd.channel, isNull);
+    });
+  });
 }
 
 class _PublishSequence {


### PR DESCRIPTION
Fixes #4457.