### PR TITLE
Fix fallback runtimeVersion

### DIFF
--- a/app/lib/shared/versions.dart
+++ b/app/lib/shared/versions.dart
@@ -22,8 +22,8 @@ final RegExp runtimeVersionPattern = RegExp(r'^\d{4}\.\d{2}\.\d{2}$');
 /// when the version switch happens.
 const acceptedRuntimeVersions = <String>[
   '2021.01.29', // The current [runtimeVersion].
+  '2021.01.26',
   '2021.01.18',
-  '2021.01.07',
 ];
 
 /// Represents a combined version of the overall toolchain and processing,


### PR DESCRIPTION
Fixing #4454, as it should have pushed down the prior version, instead it did an override.