### PR TITLE
Fake token authentication UI for local development.

### DIFF
--- a/app/lib/shared/configuration.dart
+++ b/app/lib/shared/configuration.dart
@@ -29,6 +29,10 @@ void registerActiveConfiguration(Configuration configuration) {
 const _pubClientAudience =
     '818368855108-8grd2eg9tj9f38os6f1urbcvsq399u8n.apps.googleusercontent.com';
 
+/// Special value to indicate that the site is running in fake mode, and the
+/// client side authentication should use the fake authentication tokens.
+const _fakeSiteAudience = 'fake-site-audience';
+
 /// Class describing the configuration of running the pub site.
 ///
 /// The configuration define the location of the Datastore with the
@@ -274,7 +278,7 @@ class Configuration {
       searchServicePrefix: 'http://localhost:$searchPort',
       storageBaseUrl: storageBaseUrl,
       pubClientAudience: null,
-      pubSiteAudience: null,
+      pubSiteAudience: _fakeSiteAudience,
       adminAudience: null,
       gmailRelayServiceAccount: null, // disable email sending
       gmailRelayImpersonatedGSuiteUser: null, // disable email sending

--- a/pkg/web_app/lib/src/account.dart
+++ b/pkg/web_app/lib/src/account.dart
@@ -58,8 +58,15 @@ void setupAccount() {
   final metaElem =
       document.querySelector('meta[name="google-signin-client_id"]');
   final clientId = metaElem == null ? null : metaElem.attributes['content'];
+
+  // Handle missing clientId by not allowing the sign-in button at all.
   if (clientId == null || clientId.isEmpty) {
-    // pub is running in a fake server or test mode
+    _initFailed();
+    return;
+  }
+
+  // Special value to use fake token authentication.
+  if (clientId == 'fake-site-audience') {
     setupFakeTokenAuthenticationProxy(onUpdated: () => _updateSession());
     _initWidgets();
     return;

--- a/pkg/web_app/lib/src/account.dart
+++ b/pkg/web_app/lib/src/account.dart
@@ -60,9 +60,8 @@ void setupAccount() {
   final clientId = metaElem == null ? null : metaElem.attributes['content'];
   if (clientId == null || clientId.isEmpty) {
     // pub is running in a fake server or test mode
-    // TODO: implement fake login flow
-    setupFakeUser(accessToken: null, idToken: null);
-    _signInNotAvailable();
+    setupFakeTokenAuthenticationProxy(onUpdated: () => _updateSession());
+    _initWidgets();
     return;
   }
 
@@ -72,7 +71,7 @@ void setupAccount() {
   context['pubAuthInit'] = () {
     load('auth2', allowInterop(() {
       init(JsObject.jsify({'client_id': clientId})).then(
-        allowInterop((_) => _init()), // success
+        allowInterop((_) => _initGoogleAuthAndWidgets()), // success
         allowInterop((_) => _initFailed()), // failure
       );
     }));
@@ -97,12 +96,16 @@ void _signInNotAvailable() {
   });
 }
 
-void _init() {
+void _initGoogleAuthAndWidgets() {
   setupGoogleAuthenticationProxy(
     onUpdated: () async {
       await _updateSession();
     },
   );
+  _initWidgets();
+}
+
+void _initWidgets() {
   document
       .getElementById('-account-login')
       ?.onClick


### PR DESCRIPTION
- stores token in the browser's local storage
- the sign-in button is reused for asking for the token
- the sign-out button works as expected
- follows the same session update mechanism as the normal google auth
- leaves out a few nice-to-haves (e.g. fake profile picture that doesn't brake layout), but function-wise completes the missing piece for #4105