### PR TITLE
Slight change for null-safe badge CSS

### DIFF
--- a/pkg/web_css/lib/src/_pkg.scss
+++ b/pkg/web_css/lib/src/_pkg.scss
@@ -20,6 +20,10 @@
     top: 2px;
   }
 
+  /*
+    NOTE: This changes the side margins for the badge(s) on the package page,
+          while subsequent badges still have 8px between them.
+  */
   .detail-header-content-block .metadata & {
     margin-left: 4px;
     margin-right: 4px;

--- a/pkg/web_css/lib/src/_pkg.scss
+++ b/pkg/web_css/lib/src/_pkg.scss
@@ -19,6 +19,11 @@
     position: relative;
     top: 2px;
   }
+
+  .detail-header-content-block .metadata & {
+    margin-left: 4px;
+    margin-right: 4px;
+  }
 }
 
 .package-vp-icon {


### PR DESCRIPTION
- Fixes #4475.
- Unfortunately, the metadata structure depends a lot on the current state of the package, and the left margin can be near either to a publisher id or some other label. Using 4-4px seems to be a good compromise between the different layouts.