### PR TITLE
Refactoring pub-dev's ToolEnvironment cache.

### DIFF
--- a/app/lib/dartdoc/dartdoc_runner.dart
+++ b/app/lib/dartdoc/dartdoc_runner.dart
@@ -158,8 +158,6 @@ class DartdocJobProcessor extends JobProcessor {
     // directories need to be created
     await Directory(outputDir).create(recursive: true);
 
-    final toolEnvRef = await getOrCreateToolEnvRef();
-
     final latestVersion =
         await packageBackend.getLatestVersion(job.packageName);
     final bool isLatestStable = latestVersion == job.packageVersion;
@@ -179,65 +177,71 @@ class DartdocJobProcessor extends JobProcessor {
         destination: pkgPath,
         pubHostedUrl: activeConfiguration.primarySiteUri.toString(),
       );
-      final usesFlutter = await toolEnvRef.toolEnv.detectFlutterUse(pkgPath);
+      await withToolEnv(
+        fn: (toolEnv) async {
+          final usesFlutter = await toolEnv.detectFlutterUse(pkgPath);
 
-      final logFileOutput = StringBuffer();
-      logFileOutput.write('Dartdoc generation for $job\n\n'
-          'runtime: ${versions.runtimeVersion}\n'
-          'toolEnv Dart SDK: ${versions.toolEnvSdkVersion}\n'
-          'runtime Dart SDK: ${versions.runtimeSdkVersion}\n'
-          'pana: ${versions.panaVersion}\n'
-          'dartdoc: ${versions.dartdocVersion}\n'
-          'flutter: ${versions.flutterVersion}\n'
-          'usesFlutter: $usesFlutter\n'
-          'started: ${DateTime.now().toUtc().toIso8601String()}\n\n');
+          final logFileOutput = StringBuffer();
+          logFileOutput.write('Dartdoc generation for $job\n\n'
+              'runtime: ${versions.runtimeVersion}\n'
+              'toolEnv Dart SDK: ${versions.toolEnvSdkVersion}\n'
+              'runtime Dart SDK: ${versions.runtimeSdkVersion}\n'
+              'pana: ${versions.panaVersion}\n'
+              'dartdoc: ${versions.dartdocVersion}\n'
+              'flutter: ${versions.flutterVersion}\n'
+              'usesFlutter: $usesFlutter\n'
+              'started: ${DateTime.now().toUtc().toIso8601String()}\n\n');
 
-      final status = await scoreCardBackend.getPackageStatus(
-          job.packageName, job.packageVersion);
+          final status = await scoreCardBackend.getPackageStatus(
+              job.packageName, job.packageVersion);
 
-      // Resolve dependencies only for non-legacy package versions.
-      if (!status.isLegacy) {
-        depsResolved = await _resolveDependencies(logger, toolEnvRef.toolEnv,
-            job, pkgPath, usesFlutter, logFileOutput);
-      } else {
-        logFileOutput.write(
-            'Package version does not allow current SDK, skipping pub upgrade.\n\n');
-      }
+          // Resolve dependencies only for non-legacy package versions.
+          if (!status.isLegacy) {
+            depsResolved = await _resolveDependencies(
+                logger, toolEnv, job, pkgPath, usesFlutter, logFileOutput);
+          } else {
+            logFileOutput.write(
+                'Package version does not allow current SDK, skipping pub upgrade.\n\n');
+          }
 
-      // Generate docs only for packages that have healthy dependencies.
-      if (depsResolved) {
-        dartdocResult =
-            await _generateDocs(logger, job, pkgPath, outputDir, logFileOutput);
-        hasContent = dartdocResult.hasIndexHtml && dartdocResult.hasIndexJson;
-      } else {
-        abortLog = 'Dependencies were not resolved.';
-        logFileOutput
-            .write('Dependencies were not resolved, skipping dartdoc.\n\n');
-      }
+          // Generate docs only for packages that have healthy dependencies.
+          if (depsResolved) {
+            dartdocResult = await _generateDocs(
+                logger, job, pkgPath, outputDir, logFileOutput);
+            hasContent =
+                dartdocResult.hasIndexHtml && dartdocResult.hasIndexJson;
+          } else {
+            abortLog = 'Dependencies were not resolved.';
+            logFileOutput
+                .write('Dependencies were not resolved, skipping dartdoc.\n\n');
+          }
 
-      if (hasContent) {
-        try {
-          await DartdocCustomizer(
-                  job.packageName, job.packageVersion, job.isLatestStable)
-              .customizeDir(outputDir);
-          logFileOutput.write('Content customization completed.\n\n');
-        } catch (e, st) {
-          // Do not block on customization failure.
-          _logger.severe('Dartdoc customization failed ($job).', e, st);
-          logFileOutput.write('Content customization failed.\n\n');
-        }
+          if (hasContent) {
+            try {
+              await DartdocCustomizer(
+                      job.packageName, job.packageVersion, job.isLatestStable)
+                  .customizeDir(outputDir);
+              logFileOutput.write('Content customization completed.\n\n');
+            } catch (e, st) {
+              // Do not block on customization failure.
+              _logger.severe('Dartdoc customization failed ($job).', e, st);
+              logFileOutput.write('Content customization failed.\n\n');
+            }
 
-        await _tar(tempDirPath, tarDir, outputDir, logFileOutput);
-      } else {
-        logFileOutput.write('No content found!\n\n');
-      }
+            await _tar(tempDirPath, tarDir, outputDir, logFileOutput);
+          } else {
+            logFileOutput.write('No content found!\n\n');
+          }
 
-      entry = await _createEntry(
-          job, outputDir, usesFlutter, depsResolved, hasContent);
-      logFileOutput.write('entry created: ${entry.uuid}\n\n');
+          entry = await _createEntry(
+              job, outputDir, usesFlutter, depsResolved, hasContent);
+          logFileOutput.write('entry created: ${entry.uuid}\n\n');
 
-      logFileOutput.write('completed: ${entry.timestamp.toIso8601String()}\n');
-      await _writeLog(outputDir, logFileOutput);
+          logFileOutput
+              .write('completed: ${entry.timestamp.toIso8601String()}\n');
+          await _writeLog(outputDir, logFileOutput);
+        },
+      );
 
       final oldEntry =
           await dartdocBackend.getEntry(job.packageName, job.packageVersion);
@@ -270,7 +274,6 @@ class DartdocJobProcessor extends JobProcessor {
           'Running `dartdoc` failed with the following output: $e\n\n```\n$st\n```\n';
     } finally {
       await tempDir.delete(recursive: true);
-      await toolEnvRef.release();
     }
 
     final coverage = dartdocData?.coverage;

--- a/app/lib/shared/tool_env.dart
+++ b/app/lib/shared/tool_env.dart
@@ -6,32 +6,47 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:logging/logging.dart';
+import 'package:meta/meta.dart';
 import 'package:pana/pana.dart';
 
 import 'configuration.dart';
 
 final _logger = Logger('tool_env');
 
-/// Subsequent calls of the analyzer or dartdoc job can use the same [ToolEnvRef]
+/// Subsequent calls of the analyzer or dartdoc job can use the same [_ToolEnvRef]
 /// instance [_maxCount] times.
 ///
-/// Until the limit is reached, the [ToolEnvRef] will reuse the pub cache
+/// Until the limit is reached, the [_ToolEnvRef] will reuse the pub cache
 /// directory for its `pub upgrade` calls, but once it is reached, the cache
-/// will be deleted and a new [ToolEnvRef] with a new directory will be created.
+/// will be deleted and a new [_ToolEnvRef] with a new directory will be created.
 const _maxCount = 50;
 
-/// Subsequent calls of the analyzer or dartdoc job can use the same [ToolEnvRef]
+/// Subsequent calls of the analyzer or dartdoc job can use the same [_ToolEnvRef]
 /// instance up until its size reaches [_maxSize].
 ///
-/// Until the limit is reached, the [ToolEnvRef] will reuse the pub cache
+/// Until the limit is reached, the [_ToolEnvRef] will reuse the pub cache
 /// directory for its `pub upgrade` calls, but once it is reached, the cache
-/// will be deleted and a new [ToolEnvRef] with a new directory will be created.
+/// will be deleted and a new [_ToolEnvRef] with a new directory will be created.
 const _maxSize = 500 * 1024 * 1024; // 500 MB
 
-/// The id of the next [ToolEnvRef] to be created.
+/// Calls [fn] with the [ToolEnvironment], handling the lifecycle of the local
+/// pub cache.
+Future<R> withToolEnv<R>({
+  @required Future<R> Function(ToolEnvironment toolEnv) fn,
+}) async {
+  _ToolEnvRef ref;
+  try {
+    ref = await _getOrCreateToolEnvRef();
+    return await fn(ref.toolEnv);
+  } finally {
+    await ref?._release();
+  }
+}
+
+/// The id of the next [_ToolEnvRef] to be created.
 int _nextId = 0;
 
-ToolEnvRef _current;
+_ToolEnvRef _current;
 Completer _ongoing;
 
 /// Tracks the temporary directory of the downloaded package cache with the
@@ -41,7 +56,7 @@ Completer _ongoing;
 /// The pub cache will be reused between `pub upgrade` calls, until the
 /// [_maxCount] threshold is reached. The directory will be deleted once all of
 /// the associated jobs complete.
-class ToolEnvRef {
+class _ToolEnvRef {
   final Directory _pubCacheDir;
   final ToolEnvironment toolEnv;
   final _id = _nextId++;
@@ -49,7 +64,7 @@ class ToolEnvRef {
   int _active = 0;
   bool _isAboveSizeLimit = false;
 
-  ToolEnvRef(this._pubCacheDir, this.toolEnv);
+  _ToolEnvRef(this._pubCacheDir, this.toolEnv);
 
   bool get _isAvailable => _started < _maxCount && !_isAboveSizeLimit;
 
@@ -60,7 +75,7 @@ class ToolEnvRef {
         .info('($_id) Tool env acquired. started: $_started, active: $_active');
   }
 
-  Future<void> release() async {
+  Future<void> _release() async {
     _logger
         .info('($_id) Tool env released. started: $_started, active: $_active');
     await _checkSizeLimit();
@@ -88,11 +103,11 @@ class ToolEnvRef {
   }
 }
 
-/// Gets a currently available [ToolEnvRef] if it is used less than the
+/// Gets a currently available [_ToolEnvRef] if it is used less than the
 /// configured threshold ([_maxCount]). If it it has already
 /// reached the amount, a new cache dir and environment will be created.
-Future<ToolEnvRef> getOrCreateToolEnvRef() async {
-  ToolEnvRef result;
+Future<_ToolEnvRef> _getOrCreateToolEnvRef() async {
+  _ToolEnvRef result;
   while (result == null) {
     if (_current != null && _current._isAvailable) {
       result = _current;
@@ -114,7 +129,7 @@ Future<ToolEnvRef> getOrCreateToolEnvRef() async {
       flutterSdkDir: envConfig.flutterSdkDir,
       pubCacheDir: resolvedDirName,
     );
-    _current = ToolEnvRef(cacheDir, toolEnv);
+    _current = _ToolEnvRef(cacheDir, toolEnv);
     result = _current;
     result._acquire();
     _ongoing.complete();


### PR DESCRIPTION
- Closing down the `ToolEnvironment` cache related code to a single `withToolEnv` method, which later would also take a flag to decide whether current or future SDKs will be used (in preparation for #4464).
- `pana_runner.dart` and `dartdoc_runner.dart` has only changes that use this wrapper, and re-indent the related code. 