### PR TITLE
Stable + preview ToolEnvironment (using the same SDKs).

### DIFF
--- a/app/lib/analyzer/pana_runner.dart
+++ b/app/lib/analyzer/pana_runner.dart
@@ -69,6 +69,7 @@ class AnalyzerJobProcessor extends JobProcessor {
 
     Future<Summary> analyze() async {
       return await withToolEnv(
+        usesPreviewSdk: packageStatus.usesPreviewSdk,
         fn: (toolEnv) async {
           try {
             final PackageAnalyzer analyzer =

--- a/app/lib/dartdoc/dartdoc_runner.dart
+++ b/app/lib/dartdoc/dartdoc_runner.dart
@@ -178,6 +178,7 @@ class DartdocJobProcessor extends JobProcessor {
         pubHostedUrl: activeConfiguration.primarySiteUri.toString(),
       );
       await withToolEnv(
+        usesPreviewSdk: packageStatus.usesPreviewSdk,
         fn: (toolEnv) async {
           final usesFlutter = await toolEnv.detectFlutterUse(pkgPath);
 

--- a/app/lib/scorecard/backend.dart
+++ b/app/lib/scorecard/backend.dart
@@ -7,16 +7,16 @@ import 'dart:async';
 import 'package:gcloud/service_scope.dart' as ss;
 import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
-
-import 'package:pub_dev/package/models.dart' show Package, PackageVersion;
-import 'package:pub_dev/tool/utils/dart_sdk_version.dart';
 import 'package:pub_semver/pub_semver.dart';
+
+import '../package/models.dart' show Package, PackageVersion;
 import '../package/overrides.dart';
 import '../shared/datastore.dart' as db;
 import '../shared/popularity_storage.dart';
 import '../shared/redis_cache.dart' show cache;
 import '../shared/utils.dart';
 import '../shared/versions.dart' as versions;
+import '../tool/utils/dart_sdk_version.dart';
 
 import 'helpers.dart';
 import 'models.dart';
@@ -390,8 +390,7 @@ class PackageStatus {
       isObsolete: isObsolete,
       isLegacy: pv.pubspec.supportsOnlyLegacySdk,
       usesFlutter: pv.pubspec.usesFlutter,
-      usesPreviewSdk:
-          pv.pubspec.isPreviewForCurrentSdk(currentSdkVersion),
+      usesPreviewSdk: pv.pubspec.isPreviewForCurrentSdk(currentSdkVersion),
     );
   }
 }


### PR DESCRIPTION
- follow-up on #4479, in preparation for #4464
- this only introduces the concept of deciding on stable/preview SDKs, but do not yet uses two different one (that is to be done in a subsequent PR)