### PR TITLE
Reduce the number of PackageVersion lookups in Job processing.

### DIFF
--- a/app/lib/analyzer/pana_runner.dart
+++ b/app/lib/analyzer/pana_runner.dart
@@ -9,6 +9,7 @@ import 'package:meta/meta.dart';
 import 'package:pana/pana.dart' hide ReportStatus;
 
 import '../job/job.dart';
+import '../package/models.dart';
 import '../package/overrides.dart';
 import '../scorecard/backend.dart';
 import '../scorecard/models.dart';
@@ -28,10 +29,9 @@ class AnalyzerJobProcessor extends JobProcessor {
         );
 
   @override
-  Future<bool> shouldProcess(String package, String version, DateTime updated) {
+  Future<bool> shouldProcess(PackageVersion pv, DateTime updated) {
     return scoreCardBackend.shouldUpdateReport(
-      package,
-      version,
+      pv,
       ReportType.pana,
       updatedAfter: updated,
     );

--- a/app/lib/dartdoc/dartdoc_runner.dart
+++ b/app/lib/dartdoc/dartdoc_runner.dart
@@ -17,6 +17,7 @@ import '../frontend/static_files.dart';
 import '../job/backend.dart';
 import '../job/job.dart';
 import '../package/backend.dart';
+import '../package/models.dart';
 import '../scorecard/backend.dart';
 import '../scorecard/models.dart';
 import '../shared/configuration.dart';
@@ -110,10 +111,9 @@ class DartdocJobProcessor extends JobProcessor {
   }
 
   @override
-  Future<bool> shouldProcess(String package, String version, DateTime updated) {
+  Future<bool> shouldProcess(PackageVersion pv, DateTime updated) {
     return scoreCardBackend.shouldUpdateReport(
-      package,
-      version,
+      pv,
       ReportType.dartdoc,
       updatedAfter: updated,
     );

--- a/app/lib/job/job.dart
+++ b/app/lib/job/job.dart
@@ -43,7 +43,7 @@ abstract class JobProcessor {
 
   Future<JobStatus> process(Job job);
 
-  Future<bool> shouldProcess(String package, String version, DateTime updated);
+  Future<bool> shouldProcess(PackageVersion pv, DateTime updated);
 
   /// Never completes.
   Future<void> run() async {
@@ -177,8 +177,7 @@ class JobMaintenance {
         final isLatestPrerelease =
             latestPrereleaseVersions[pv.package] == pv.version;
         if (isLatestStable && skipLatestStable) return;
-        final shouldProcess =
-            await _processor.shouldProcess(pv.package, pv.version, pv.created);
+        final shouldProcess = await _processor.shouldProcess(pv, pv.created);
         await jobBackend.createOrUpdate(
           service: _processor.service,
           package: pv.package,

--- a/app/lib/scorecard/backend.dart
+++ b/app/lib/scorecard/backend.dart
@@ -300,34 +300,26 @@ class ScoreCardBackend {
   }
 
   /// Returns whether we should update the [reportType] report for the given
-  /// [packageName] and [packageVersion].
+  /// package version.
   ///
-  /// The method will return false, if the package or version does not exists.
   /// The method will return true, if either of the following is true:
   /// - it does not have a report yet,
   /// - the report was updated before [updatedAfter],
   /// - the report is older than [successThreshold] if it was a success,
   /// - the report is older than [failureThreshold] if it was a failure.
   Future<bool> shouldUpdateReport(
-    String packageName,
-    String packageVersion,
+    PackageVersion pv,
     String reportType, {
     Duration successThreshold = const Duration(days: 30),
     Duration failureThreshold = const Duration(days: 1),
     DateTime updatedAfter,
   }) async {
-    if (packageName == null ||
-        packageVersion == null ||
-        isSoftRemoved(packageName)) {
-      return false;
-    }
-    final pkgStatus = await getPackageStatus(packageName, packageVersion);
-    if (!pkgStatus.exists) {
+    if (pv == null || isSoftRemoved(pv.package)) {
       return false;
     }
 
     // checking existing report
-    final key = scoreCardKey(packageName, packageVersion)
+    final key = scoreCardKey(pv.package, pv.version)
         .append(ScoreCardReport, id: reportType);
     final list = await _db.lookup([key]);
     final report = list.single as ScoreCardReport;


### PR DESCRIPTION
This should help especially at the beginning of a new deployment, at the time of the first database scan.