### PR TITLE
Prioritize preview versions in job processing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ Important changes to data-models, configuration and migrations between each
 AppEngine version, listed here to ease deployment and troubleshooting.
 
 ## Next Release (replace with git tag when deployed)
- * Bumped runtimeVersion to `2021.02.09`.
+ * Bumped runtimeVersion to `2021.02.10`.
  * Split: stable Dart analysis SDK to `2.10.5`.
  * Split: preview Dart analysis SDK to `2.12.0-133.2.beta`.
  * Split: stable Flutter analysis SDK to `1.22.6`.

--- a/app/lib/job/backend.dart
+++ b/app/lib/job/backend.dart
@@ -79,7 +79,10 @@ class JobBackend {
     }
 
     final isLatestStable = p.latestVersion == version;
-    final isLatestPrerelease = p.latestPrereleaseVersion == version;
+    final isLatestPrerelease =
+        p.showPrereleaseVersion && p.latestPrereleaseVersion == version;
+    final isLatestPreview =
+        p.showPreviewVersion && p.latestPreviewVersion == version;
     shouldProcess ??= updated == null || updated.isAfter(pv.created);
     shouldProcess |= isHighPriority;
     await createOrUpdate(
@@ -88,6 +91,7 @@ class JobBackend {
       version: version,
       isLatestStable: isLatestStable,
       isLatestPrerelease: isLatestPrerelease,
+      isLatestPreview: isLatestPreview,
       packageVersionUpdated: pv.created,
       shouldProcess: shouldProcess,
       priority: isHighPriority ? 0 : null,
@@ -100,6 +104,7 @@ class JobBackend {
     @required String version,
     @required bool isLatestStable,
     @required bool isLatestPrerelease,
+    @required bool isLatestPreview,
     @required DateTime packageVersionUpdated,
     @required bool shouldProcess,
     int priority,
@@ -116,6 +121,7 @@ class JobBackend {
       if (current != null) {
         final hasNotChanged = current.isLatestStable == isLatestStable &&
             current.isLatestPrerelease == isLatestPrerelease &&
+            current.isLatestPreview == isLatestPreview &&
             !current.packageVersionUpdated.isBefore(packageVersionUpdated) &&
             (priority == null || current.priority <= priority);
         if (hasNotChanged) {
@@ -133,6 +139,7 @@ class JobBackend {
         current
           ..isLatestStable = isLatestStable
           ..isLatestPrerelease = isLatestPrerelease
+          ..isLatestPreview = isLatestPreview
           ..packageVersionUpdated = packageVersionUpdated
           ..state = state
           ..lockedUntil = lockedUntil
@@ -152,6 +159,7 @@ class JobBackend {
           ..packageVersion = version
           ..isLatestStable = isLatestStable
           ..isLatestPrerelease = isLatestPrerelease
+          ..isLatestPreview = isLatestPreview
           ..packageVersionUpdated = packageVersionUpdated
           ..state = state
           ..lockedUntil = lockedUntil

--- a/app/lib/job/model.dart
+++ b/app/lib/job/model.dart
@@ -61,32 +61,35 @@ class Job extends ExpandoModel<String> {
   @StringProperty()
   String packageName;
 
-  @StringProperty()
+  @StringProperty(indexed: false)
   String packageVersion;
 
-  @DateTimeProperty()
+  @DateTimeProperty(indexed: false)
   DateTime packageVersionUpdated;
 
-  @BoolProperty()
+  @BoolProperty(indexed: false)
   bool isLatestStable;
 
-  @BoolProperty()
+  @BoolProperty(indexed: false)
   bool isLatestPrerelease;
+
+  @BoolProperty(indexed: false)
+  bool isLatestPreview;
 
   @JobStateProperty()
   JobState state;
 
-  @DateTimeProperty()
+  @DateTimeProperty(indexed: false)
   DateTime lockedUntil;
 
   // fields for state = available
 
-  @IntProperty()
+  @IntProperty(indexed: false)
   int priority;
 
   // fields for state = processing
 
-  @StringProperty()
+  @StringProperty(indexed: false)
   String processingKey;
 
   // fields for state = idle
@@ -94,10 +97,10 @@ class Job extends ExpandoModel<String> {
   @JobStatusProperty()
   JobStatus lastStatus;
 
-  @IntProperty()
+  @IntProperty(indexed: false)
   int errorCount;
 
-  bool get isLatest => isLatestStable || isLatestPrerelease;
+  bool get isLatest => isLatestStable || isLatestPrerelease || isLatestPreview;
 
   @override
   String toString() => '$packageName $packageVersion';
@@ -140,7 +143,7 @@ class Job extends ExpandoModel<String> {
 
 class JobServiceProperty extends StringProperty {
   const JobServiceProperty({String propertyName, bool required = false})
-      : super(propertyName: propertyName, required: required, indexed: true);
+      : super(propertyName: propertyName, required: required, indexed: false);
 
   @override
   bool validate(ModelDB db, Object value) =>
@@ -166,7 +169,7 @@ class JobServiceProperty extends StringProperty {
 
 class JobStateProperty extends StringProperty {
   const JobStateProperty({String propertyName, bool required = false})
-      : super(propertyName: propertyName, required: required, indexed: true);
+      : super(propertyName: propertyName, required: required, indexed: false);
 
   @override
   bool validate(ModelDB db, Object value) =>
@@ -191,7 +194,7 @@ class JobStateProperty extends StringProperty {
 
 class JobStatusProperty extends StringProperty {
   const JobStatusProperty({String propertyName, bool required = false})
-      : super(propertyName: propertyName, required: required, indexed: true);
+      : super(propertyName: propertyName, required: required, indexed: false);
 
   @override
   bool validate(ModelDB db, Object value) =>

--- a/app/lib/shared/versions.dart
+++ b/app/lib/shared/versions.dart
@@ -21,7 +21,7 @@ final RegExp runtimeVersionPattern = RegExp(r'^\d{4}\.\d{2}\.\d{2}$');
 /// Make sure that at least two versions are kept here as the next candidates
 /// when the version switch happens.
 const acceptedRuntimeVersions = <String>[
-  '2021.02.09', // The current [runtimeVersion].
+  '2021.02.10', // The current [runtimeVersion].
   '2021.01.29',
   '2021.01.26',
 ];


### PR DESCRIPTION
- storing new field for priority recalculations
- removed fields indexes that we never use
- bumped `runtimeVersion` as the new field is being used in a boolean expression