### PR TITLE
Fix Job model's indexes and sleeping after nothing to do.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ Important changes to data-models, configuration and migrations between each
 AppEngine version, listed here to ease deployment and troubleshooting.
 
 ## Next Release (replace with git tag when deployed)
- * Bumped runtimeVersion to `2021.02.10`.
+ * Bumped runtimeVersion to `2021.02.11`.
  * Split: stable Dart analysis SDK to `2.10.5`.
  * Split: preview Dart analysis SDK to `2.12.0-133.2.beta`.
  * Split: stable Flutter analysis SDK to `1.22.6`.

--- a/app/lib/job/job.dart
+++ b/app/lib/job/job.dart
@@ -52,9 +52,9 @@ abstract class JobProcessor {
     for (;;) {
       final status = await _runOneJob();
       if (_aliveCallback != null) await _aliveCallback();
-      sleepSeconds = (status == JobStatus.failed || status == JobStatus.aborted)
-          ? math.min(sleepSeconds + 1, 60)
-          : 0;
+      final wasProcessing =
+          status == JobStatus.success || status == JobStatus.skipped;
+      sleepSeconds = wasProcessing ? 0 : math.min(sleepSeconds + 1, 60);
       await Future.delayed(Duration(seconds: sleepSeconds));
     }
   }

--- a/app/lib/job/model.dart
+++ b/app/lib/job/model.dart
@@ -79,12 +79,12 @@ class Job extends ExpandoModel<String> {
   @JobStateProperty()
   JobState state;
 
-  @DateTimeProperty(indexed: false)
+  @DateTimeProperty()
   DateTime lockedUntil;
 
   // fields for state = available
 
-  @IntProperty(indexed: false)
+  @IntProperty()
   int priority;
 
   // fields for state = processing
@@ -143,7 +143,7 @@ class Job extends ExpandoModel<String> {
 
 class JobServiceProperty extends StringProperty {
   const JobServiceProperty({String propertyName, bool required = false})
-      : super(propertyName: propertyName, required: required, indexed: false);
+      : super(propertyName: propertyName, required: required, indexed: true);
 
   @override
   bool validate(ModelDB db, Object value) =>
@@ -169,7 +169,7 @@ class JobServiceProperty extends StringProperty {
 
 class JobStateProperty extends StringProperty {
   const JobStateProperty({String propertyName, bool required = false})
-      : super(propertyName: propertyName, required: required, indexed: false);
+      : super(propertyName: propertyName, required: required, indexed: true);
 
   @override
   bool validate(ModelDB db, Object value) =>
@@ -194,7 +194,7 @@ class JobStateProperty extends StringProperty {
 
 class JobStatusProperty extends StringProperty {
   const JobStatusProperty({String propertyName, bool required = false})
-      : super(propertyName: propertyName, required: required, indexed: false);
+      : super(propertyName: propertyName, required: required, indexed: true);
 
   @override
   bool validate(ModelDB db, Object value) =>

--- a/app/lib/shared/versions.dart
+++ b/app/lib/shared/versions.dart
@@ -21,7 +21,7 @@ final RegExp runtimeVersionPattern = RegExp(r'^\d{4}\.\d{2}\.\d{2}$');
 /// Make sure that at least two versions are kept here as the next candidates
 /// when the version switch happens.
 const acceptedRuntimeVersions = <String>[
-  '2021.02.10', // The current [runtimeVersion].
+  '2021.02.11', // The current [runtimeVersion].
   '2021.01.29',
   '2021.01.26',
 ];


### PR DESCRIPTION
- Some of the removed indexes in #4509 caused the `Job` to be not queryable for the multi-parameter queries. I'm adding some of the back that may be used for such queries.
- In such cases where no Job were selected and processed, we are doing a new query immediately. Instead, we shall increase the sleep unless there was a successful job selection and processing (or skipping it for valid reasons).
