### PR TITLE
 Updated ToolEnvironment handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ AppEngine version, listed here to ease deployment and troubleshooting.
  * Upgraded pana to `0.15.0+1`.
  * NOTE: added daily periodic tasks: `delete-old-dartdoc-sdks`,
          `delete-old-search-snapshots`.
+ * NOTE: Running `git gc` regularly, disk full events (#4458) should decrease.
 
 ## `20210215t122000-all`
  * Bumped runtimeVersion to `2021.02.12`.

--- a/app/lib/shared/tool_env.dart
+++ b/app/lib/shared/tool_env.dart
@@ -126,7 +126,7 @@ Future<void> _gitGc(String path) async {
   if (path != null &&
       Directory(path).existsSync() &&
       Directory('$path/.git').existsSync()) {
-    await runProc('git', ['gc'], workingDirectory: path);
+    await runProc(['git', 'gc'], workingDirectory: path);
   }
 }
 

--- a/app/lib/shared/tool_env.dart
+++ b/app/lib/shared/tool_env.dart
@@ -117,6 +117,14 @@ Future<_ToolEnvRef> _createToolEnvRef() async {
       'FLUTTER_ROOT': envConfig.previewFlutterSdkDir,
     },
   );
+
+  // Flutter fetches the latest git objects when checking for new version.
+  // git stores these pack files not efficiently, and GC is not triggered by
+  // any other git operations. Forcing GC here helps to bound the required
+  // space.
+  //
+  // This should be removed once this PR reaches the stable branch:
+  // https://github.com/flutter/flutter/pull/76107
   await _gitGc(envConfig.stableFlutterSdkDir);
   await _gitGc(envConfig.previewFlutterSdkDir);
   return _ToolEnvRef(cacheDir, stableToolEnv, previewToolEnv);

--- a/app/lib/shared/tool_env.dart
+++ b/app/lib/shared/tool_env.dart
@@ -8,6 +8,7 @@ import 'dart:io';
 import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
 import 'package:pana/pana.dart';
+import 'package:pool/pool.dart';
 
 import 'configuration.dart';
 
@@ -19,7 +20,7 @@ final _logger = Logger('tool_env');
 /// Until the limit is reached, the [_ToolEnvRef] will reuse the pub cache
 /// directory for its `pub upgrade` calls, but once it is reached, the cache
 /// will be deleted and a new [_ToolEnvRef] with a new directory will be created.
-const _maxCount = 50;
+const _maxCount = 100;
 
 /// Subsequent calls of the analyzer or dartdoc job can use the same [_ToolEnvRef]
 /// instance up until its size reaches [_maxSize].
@@ -29,26 +30,51 @@ const _maxCount = 50;
 /// will be deleted and a new [_ToolEnvRef] with a new directory will be created.
 const _maxSize = 500 * 1024 * 1024; // 500 MB
 
+/// The id of the next [_ToolEnvRef] to be created.
+int _nextId = 0;
+
+/// The base temp directory for tool env.
+final _toolEnvTempDir = Directory.systemTemp.createTempSync('tool-env');
+
+/// Forcing callback processing into a single thread.
+final _pool = Pool(1);
+
+// The cached values of directory sizes (path -> size in bytes).
+Map<String, int> _sizes;
+
+_ToolEnvRef _current;
+
 /// Calls [fn] with the [ToolEnvironment], handling the lifecycle of the local
 /// pub cache.
 Future<R> withToolEnv<R>({
   @required bool usesPreviewSdk,
   @required Future<R> Function(ToolEnvironment toolEnv) fn,
 }) async {
-  _ToolEnvRef ref;
-  try {
-    ref = await _getOrCreateToolEnvRef();
-    return await fn(usesPreviewSdk ? ref.preview : ref.stable);
-  } finally {
-    await ref?._release();
-  }
+  return await _pool.withResource(() async {
+    if (_current != null && !_current._isAvailable) {
+      await _current?._cleanup();
+      _current = null;
+    }
+    if (_current == null) {
+      final sizes = await _calcSubdirSizes([
+        Directory.systemTemp,
+        Directory('/tmp'),
+        Directory('/var'),
+        Directory('/tool'),
+      ]);
+      _logSpecialDirSizes(sizes);
+      _logChanges(_sizes, sizes);
+      _sizes = sizes;
+    }
+    _current ??= await _createToolEnvRef();
+    _current._started++;
+    try {
+      return await fn(usesPreviewSdk ? _current.preview : _current.stable);
+    } finally {
+      await _current._checkSizeLimit();
+    }
+  });
 }
-
-/// The id of the next [_ToolEnvRef] to be created.
-int _nextId = 0;
-
-_ToolEnvRef _current;
-Completer _ongoing;
 
 /// Tracks the temporary directory of the downloaded package cache with the
 /// [ToolEnvironment] (that was initialized with that directory), along with its
@@ -63,91 +89,125 @@ class _ToolEnvRef {
   final ToolEnvironment preview;
   final _id = _nextId++;
   int _started = 0;
-  int _active = 0;
   bool _isAboveSizeLimit = false;
 
   _ToolEnvRef(this._pubCacheDir, this.stable, this.preview);
 
   bool get _isAvailable => _started < _maxCount && !_isAboveSizeLimit;
 
-  void _acquire() {
-    _started++;
-    _active++;
-    _logger
-        .info('($_id) Tool env acquired. started: $_started, active: $_active');
-  }
-
-  Future<void> _release() async {
-    _logger
-        .info('($_id) Tool env released. started: $_started, active: $_active');
-    await _checkSizeLimit();
-    _active--;
-    if (_active == 0) {
-      // Delete directory if the instance is no longer active or it reached the
-      // maximum threshold.
-      if (_started >= _maxCount || _current != this) {
-        _logger.info('($_id) Deleting pub cache dir: $_pubCacheDir');
-        await _pubCacheDir.delete(recursive: true);
-      }
-    }
+  Future<void> _cleanup() async {
+    _logger.info('($_id) Deleting pub cache dir: $_pubCacheDir');
+    await _pubCacheDir.delete(recursive: true);
   }
 
   Future<void> _checkSizeLimit() async {
     if (_isAboveSizeLimit) return;
-    int size = 0;
-    await for (var fse in _pubCacheDir.list(recursive: true)) {
-      if (fse is File) {
-        size += await fse.length();
-      }
-    }
+    final size = await _calcDirectorySize(_pubCacheDir);
     _logger.info('($_id) Current size of pub cache dir: $size');
     _isAboveSizeLimit = size > _maxSize;
   }
 }
 
-/// Gets a currently available [_ToolEnvRef] if it is used less than the
-/// configured threshold ([_maxCount]). If it it has already
-/// reached the amount, a new cache dir and environment will be created.
-Future<_ToolEnvRef> _getOrCreateToolEnvRef() async {
-  _ToolEnvRef result;
-  while (result == null) {
-    if (_current != null && _current._isAvailable) {
-      result = _current;
-      result._acquire();
-      break;
-    }
+/// Creates a new [_ToolEnvRef] with a new pub cache dir.
+Future<_ToolEnvRef> _createToolEnvRef() async {
+  _logger.info('Creating new tool env');
+  final cacheDir = await _toolEnvTempDir.createTemp('pub-cache-dir');
+  final resolvedDirName = await cacheDir.resolveSymbolicLinks();
+  final stableToolEnv = await ToolEnvironment.create(
+    dartSdkDir: envConfig.stableDartSdkDir,
+    flutterSdkDir: envConfig.stableFlutterSdkDir,
+    pubCacheDir: resolvedDirName,
+    environment: {
+      'CI': 'true',
+      'FLUTTER_ROOT': envConfig.stableFlutterSdkDir,
+    },
+  );
+  final previewToolEnv = await ToolEnvironment.create(
+    dartSdkDir: envConfig.previewDartSdkDir,
+    flutterSdkDir: envConfig.previewFlutterSdkDir,
+    pubCacheDir: resolvedDirName,
+    environment: {
+      'CI': 'true',
+      'FLUTTER_ROOT': envConfig.previewFlutterSdkDir,
+    },
+  );
+  await _gitGc(envConfig.stableFlutterSdkDir);
+  await _gitGc(envConfig.previewFlutterSdkDir);
+  return _ToolEnvRef(cacheDir, stableToolEnv, previewToolEnv);
+}
 
-    if (_ongoing != null) {
-      await _ongoing.future;
-      continue;
-    }
-
-    _ongoing = Completer();
-
-    final cacheDir = await Directory.systemTemp.createTemp('pub-cache-dir');
-    final resolvedDirName = await cacheDir.resolveSymbolicLinks();
-    final stableToolEnv = await ToolEnvironment.create(
-      dartSdkDir: envConfig.stableDartSdkDir,
-      flutterSdkDir: envConfig.stableFlutterSdkDir,
-      pubCacheDir: resolvedDirName,
-      environment: {
-        'FLUTTER_ROOT': envConfig.stableFlutterSdkDir,
-      },
-    );
-    final previewToolEnv = await ToolEnvironment.create(
-      dartSdkDir: envConfig.previewDartSdkDir,
-      flutterSdkDir: envConfig.previewFlutterSdkDir,
-      pubCacheDir: resolvedDirName,
-      environment: {
-        'FLUTTER_ROOT': envConfig.previewFlutterSdkDir,
-      },
-    );
-    _current = _ToolEnvRef(cacheDir, stableToolEnv, previewToolEnv);
-    result = _current;
-    result._acquire();
-    _ongoing.complete();
-    _ongoing = null;
-    break;
+Future<void> _gitGc(String path) async {
+  if (path != null &&
+      Directory(path).existsSync() &&
+      Directory('$path/.git').existsSync()) {
+    await runProc('git', ['gc'], workingDirectory: path);
   }
-  return result;
+}
+
+Future<int> _calcDirectorySize(Directory dir) async {
+  int size = 0;
+  if (dir.existsSync()) {
+    await for (var fse in dir.list(recursive: true)) {
+      if (fse is File) {
+        try {
+          size += await fse.length();
+        } catch (_) {
+          // unable to read file size, permission missing
+        }
+      }
+    }
+  }
+  return size;
+}
+
+Future<Map<String, int>> _calcSubdirSizes(Iterable<Directory> dirs) async {
+  final results = <String, int>{};
+  final sw = Stopwatch()..start();
+  for (final dir in dirs) {
+    if (dir.existsSync()) {
+      // filter duplicate directories
+      if (results.containsKey(dir.path)) continue;
+
+      // TODO: optimize this for a single directory scan
+      final subdirs = [
+        dir,
+        ...dir.listSync(recursive: true).whereType<Directory>(),
+      ];
+      for (final sd in subdirs) {
+        results[sd.path] = await _calcDirectorySize(sd);
+      }
+    } else {
+      _logger.info('No $dir directory');
+    }
+  }
+  _logger.info('Directory sizes scanned in ${sw.elapsed}');
+  return results;
+}
+
+void _logSpecialDirSizes(Map<String, int> sizes) {
+  final specials = <String>[
+    '/tool/stable/dart-sdk',
+    '/tool/stable/flutter',
+    '/tool/preview/dart-sdk',
+    '/tool/preview/flutter',
+  ];
+  for (final path in specials) {
+    if (sizes.containsKey(path)) {
+      _logger.info('Directory size of $path: ${sizes[path]}');
+    }
+  }
+}
+
+void _logChanges(Map<String, int> old, Map<String, int> current) {
+  if (old == null) return;
+  final paths = (<String>{...old.keys, ...current.keys}).toList()..sort();
+  for (final path in paths) {
+    final ov = old[path] ?? 0;
+    final nv = current[path] ?? 0;
+
+    final diff = nv - ov;
+    if (diff == 0) continue;
+
+    _logger.info('Directory size changed: $path $ov -> $nv ($diff)');
+  }
 }


### PR DESCRIPTION
- running `git gc` regularly to reduce the probability of "disk full" issue #4458
- forcing singleton use with `pool` (makes initialization and cleanup unambigious)
- increased the threshold for cache reset
- added `CI=true` to the environment variables
