### PR TITLE
DartdocRecord to store dartdoc content information in Datastore.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,11 @@ AppEngine version, listed here to ease deployment and troubleshooting.
  * Bumped runtimeVersion to `2021.02.16`.
  * Upgraded pana to `0.15.0+1`.
  * NOTE: added daily periodic tasks: `delete-old-dartdoc-sdks`,
-         `delete-old-search-snapshots`.
+         `delete-old-search-snapshots`, `delete-old-dartdoc-records`.
  * NOTE: Running `git gc` regularly, disk full events (#4458) should decrease.
+ * NOTE: started creating `DartdocRecord` entities in Datastore.
+   TODO(deferred): we may use these entities instead of Bucket objects
+                   to scan and load `DartdocEntry`.
 
 ## `20210215t122000-all`
  * Bumped runtimeVersion to `2021.02.12`.

--- a/app/lib/dartdoc/backend.dart
+++ b/app/lib/dartdoc/backend.dart
@@ -110,7 +110,9 @@ class DartdocBackend {
     final record =
         DartdocRecord.fromEntry(entry, status: DartdocRecordStatus.uploading);
     // store record's upload status
-    await withRetryTransaction(_db, (tx) async => tx.insert(record));
+    await withRetryTransaction(_db, (tx) async {
+      tx.insert(record);
+    });
 
     // upload is in progress
     await uploadBytesWithRetry(

--- a/app/lib/dartdoc/backend.dart
+++ b/app/lib/dartdoc/backend.dart
@@ -107,6 +107,11 @@ class DartdocBackend {
 
   /// Uploads a directory to the storage bucket.
   Future<void> uploadDir(DartdocEntry entry, String dirPath) async {
+    final record =
+        DartdocRecord.fromEntry(entry, status: DartdocRecordStatus.uploading);
+    // store record's upload status
+    await withRetryTransaction(_db, (tx) async => tx.insert(record));
+
     // upload is in progress
     await uploadBytesWithRetry(
         _storage, entry.inProgressObjectName, entry.asBytes());
@@ -149,6 +154,14 @@ class DartdocBackend {
         '$count files uploaded in ${sw.elapsed}.');
 
     // upload was completed
+    await withRetryTransaction(_db, (tx) async {
+      final r = await tx.lookupValue<DartdocRecord>(record.key);
+      if (r.status == DartdocRecordStatus.uploading) {
+        r.status = DartdocRecordStatus.ready;
+        tx.insert(r);
+      }
+    });
+
     await uploadBytesWithRetry(
         _storage, entry.entryObjectName, entry.asBytes());
 
@@ -289,6 +302,17 @@ class DartdocBackend {
     await _deleteAllWithPrefix(prefix, concurrency: concurrency);
   }
 
+  /// Scan the Datastore for [DartdocRecord]s and remove the ones that
+  /// predate [shared_versions.gcBeforeRuntimeVersion]. This will delete
+  /// both the Datastore entity and the Storage Bucket's content.
+  Future<void> deleteOldRecords() async {
+    final query = _db.query<DartdocRecord>()
+      ..filter('runtimeVersion < ', shared_versions.gcBeforeRuntimeVersion);
+    await for (final r in query.run()) {
+      await _deleteAll(r.entry);
+    }
+  }
+
   /// Schedules the garbage collection of the [package] and [version].
   ///
   /// The wait queue is in-memory, it is not persisted, and only only works as a
@@ -376,9 +400,29 @@ class DartdocBackend {
   }
 
   Future<void> _deleteAll(DartdocEntry entry, {int concurrency}) async {
+    await withRetryTransaction(_db, (tx) async {
+      final r = await tx.lookupValue<DartdocRecord>(
+        _db.emptyKey.append(DartdocRecord, id: entry.uuid),
+        orElse: () => null,
+      );
+      if (r != null) {
+        r.status = DartdocRecordStatus.deleting;
+        tx.insert(r);
+      }
+    });
+
     await _deleteAllWithPrefix(entry.contentPrefix, concurrency: concurrency);
     await deleteFromBucket(_storage, entry.entryObjectName);
     await deleteFromBucket(_storage, entry.inProgressObjectName);
+    await withRetryTransaction(_db, (tx) async {
+      final r = await tx.lookupValue<DartdocRecord>(
+        _db.emptyKey.append(DartdocRecord, id: entry.uuid),
+        orElse: () => null,
+      );
+      if (r != null) {
+        tx.delete(r.key);
+      }
+    });
   }
 
   Future<void> _deleteAllWithPrefix(String prefix, {int concurrency}) async {

--- a/app/lib/dartdoc/models.dart
+++ b/app/lib/dartdoc/models.dart
@@ -64,7 +64,7 @@ class DartdocRecord extends db.ExpandoModel<String> {
   String errorMessage;
 
   /// The size of the archive file.
-  @db.StringProperty(required: true, indexed: false)
+  @db.IntProperty(required: true, indexed: false)
   int archiveSize;
 
   /// The directory path inside the storage bucket where the content lives.
@@ -72,7 +72,7 @@ class DartdocRecord extends db.ExpandoModel<String> {
   String contentPath;
 
   /// The total size of the generated content.
-  @db.StringProperty(required: true, indexed: false)
+  @db.IntProperty(required: true, indexed: false)
   int contentSize;
 
   /// [DartdocEntry] encoded as JSON string.
@@ -98,9 +98,9 @@ class DartdocRecord extends db.ExpandoModel<String> {
     } else if (!hasValidContent && !entry.depsResolved) {
       errorMessage = "Couldn't resolve dependencies.";
     }
-    archiveSize = entry.archiveSize;
+    archiveSize = entry.archiveSize ?? 0;
     contentPath = entry.contentPrefix;
-    contentSize = entry.totalSize;
+    contentSize = entry.totalSize ?? 0;
     entryJson = json.encode(entry.toJson());
   }
 

--- a/app/lib/dartdoc/models.dart
+++ b/app/lib/dartdoc/models.dart
@@ -24,7 +24,8 @@ abstract class DartdocRecordStatus {
 
 @db.Kind(name: 'DartdocRecord', idType: db.IdType.String)
 class DartdocRecord extends db.ExpandoModel<String> {
-  String get uuid => id;
+  /// Unique identifier that identifies a specific execution of dartdoc.
+  String get runId => id;
 
   @db.DateTimeProperty(required: true)
   DateTime created;

--- a/app/lib/tool/neat_task/pub_dev_tasks.dart
+++ b/app/lib/tool/neat_task/pub_dev_tasks.dart
@@ -60,6 +60,13 @@ void setupDartdocPeriodicTasks() {
     name: 'delete-old-dartdoc-sdks',
     task: () => dartdocBackend.deleteOldData(),
   );
+
+  // Deletes DartdocRecord entities and their storage content that are older
+  // than the accepted runtime versions.
+  _daily(
+    name: 'delete-old-dartdoc-records',
+    task: () async => await dartdocBackend.deleteOldRecords(),
+  );
 }
 
 /// Setup the tasks that we are running in the search service.


### PR DESCRIPTION
- `uploading` / `ready` / `deleting` status is in-sync with the entry file stored in the storage bucket
- periodic task to remove entities with old runtime versions

- Planned status: `obsolete` - when a runtime version has a new entry file that is ready to serve content. Periodic task can be running to delete entities with obsolete status.
- Reducing the use of the entry files in the bucket will come only later.