### PR TITLE
Enable/customize dartdoc_options.yaml

### DIFF
--- a/app/lib/dartdoc/dartdoc_options.dart
+++ b/app/lib/dartdoc/dartdoc_options.dart
@@ -15,17 +15,15 @@
 /// https://github.com/dart-lang/pub-dev/issues/4521#issuecomment-779821098
 Map<String, dynamic> customizeDartdocOptions(Map<String, dynamic> original) {
   final passThroughOptions = <String, dynamic>{};
-  try {
-    if (original != null && original.containsKey('dartdoc')) {
-      final dartdoc = original['dartdoc'] as Map<String, dynamic>;
-      for (final key in _passThroughKeys) {
-        if (dartdoc.containsKey(key)) {
-          passThroughOptions[key] = dartdoc[key];
-        }
+  if (original != null &&
+      original.containsKey('dartdoc') &&
+      original['dartdoc'] is Map<String, dynamic>) {
+    final dartdoc = original['dartdoc'] as Map<String, dynamic>;
+    for (final key in _passThroughKeys) {
+      if (dartdoc.containsKey(key)) {
+        passThroughOptions[key] = dartdoc[key];
       }
     }
-  } catch (_) {
-    // ignore unexpected issues in the user-provided content
   }
   return <String, dynamic>{
     'dartdoc': <String, dynamic>{

--- a/app/lib/dartdoc/dartdoc_options.dart
+++ b/app/lib/dartdoc/dartdoc_options.dart
@@ -1,0 +1,46 @@
+// Copyright (c) 2021, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// Returns a new, pub-specific dartdoc options based on [original].
+///
+/// dartdoc_options.yaml allows to change how doc content is generated.
+/// To provide uniform experience across the pub site, and to reduce the
+/// potential attack surface (HTML-, and code-injections, code executions),
+/// we do not support every option.
+///
+/// https://github.com/dart-lang/dartdoc#dartdoc_optionsyaml
+///
+/// Discussion on the enabled options:
+/// https://github.com/dart-lang/pub-dev/issues/4521#issuecomment-779821098
+Map<String, dynamic> customizeDartdocOptions(Map<String, dynamic> original) {
+  final passThroughOptions = <String, dynamic>{};
+  try {
+    if (original != null && original.containsKey('dartdoc')) {
+      final dartdoc = original['dartdoc'] as Map<String, dynamic>;
+      for (final key in _passThroughKeys) {
+        if (dartdoc.containsKey(key)) {
+          passThroughOptions[key] = dartdoc[key];
+        }
+      }
+    }
+  } catch (_) {
+    // ignore unexpected issues in the user-provided content
+  }
+  return <String, dynamic>{
+    'dartdoc': <String, dynamic>{
+      ...passThroughOptions,
+      'showUndocumentedCategories': true,
+    },
+  };
+}
+
+final _passThroughKeys = <String>[
+  'categories',
+  'categoryOrder',
+  // TODO: enable after checking that the relative path doesn't escape the package folder
+  // 'examplePathPrefix',
+  'exclude',
+  'include',
+  'nodoc',
+];

--- a/app/test/dartdoc/dartdoc_options_test.dart
+++ b/app/test/dartdoc/dartdoc_options_test.dart
@@ -1,0 +1,77 @@
+// Copyright (c) 2021, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:pub_dev/dartdoc/dartdoc_options.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Dartdoc options', () {
+    final _defaultOptions = {
+      'dartdoc': {'showUndocumentedCategories': true}
+    };
+
+    test('no content', () {
+      expect(customizeDartdocOptions(null), _defaultOptions);
+    });
+
+    test('bad content', () {
+      expect(customizeDartdocOptions({'not': 'dartdoc'}), _defaultOptions);
+    });
+
+    test('empty content', () {
+      expect(customizeDartdocOptions({'dartdoc': {}}), _defaultOptions);
+    });
+
+    test('bad type', () {
+      expect(customizeDartdocOptions({'dartdoc': 'none'}), _defaultOptions);
+    });
+
+    test('pass-through', () {
+      expect(
+          customizeDartdocOptions({
+            'dartdoc': {
+              'categories': {
+                'a': {
+                  'markdown': 'doc/a.md',
+                },
+              },
+              'categoryOrder': ['a'],
+              'nodoc': ['lib/b.dart'],
+            },
+          }),
+          {
+            'dartdoc': {
+              'categories': {
+                'a': {
+                  'markdown': 'doc/a.md',
+                },
+              },
+              'categoryOrder': ['a'],
+              'nodoc': ['lib/b.dart'],
+              'showUndocumentedCategories': true,
+            },
+          });
+    });
+
+    test('remove', () {
+      expect(
+          customizeDartdocOptions({
+            'dartdoc': {
+              'ignore': ['a'],
+            },
+          }),
+          _defaultOptions);
+    });
+
+    test('override', () {
+      expect(
+          customizeDartdocOptions({
+            'dartdoc': {
+              'showUndocumentedCategories': false,
+            },
+          }),
+          _defaultOptions);
+    });
+  });
+}


### PR DESCRIPTION
- #4521
- some options are pass-through (with an allow-list)
- `showUndocumentedCategories` is always set to true
- Also needed to update `pkg/pub_dartdoc/bin/pub_dartdoc.dart`, as otherwise it didn't generate categories. The current main method is almost the same as `package:dartdoc's bin/dartdoc.dart`.