### PR TITLE
Better Job selection with local caching.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ AppEngine version, listed here to ease deployment and troubleshooting.
  * NOTE: started creating `DartdocRecord` entities in Datastore.
    TODO(deferred): we may use these entities instead of Bucket objects
                    to scan and load `DartdocEntry`.
+ * NOTE: Job processing uses a cached list of available entries.
 
 ## `20210215t122000-all`
  * Bumped runtimeVersion to `2021.02.12`.


### PR DESCRIPTION
- reduces the number of index-using queries on the Job table with the possible reduction in both cost and processing times
- a random sampling on staging shows about 2-8% increase in the processing throughput in analyzer, while dartdoc remains the same (analyzer jobs are quicker to complete and the job selection overhead is more important there)