### PR TITLE
Expire dartdoc runs that have newer content + periodic task for cleanup and GC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ AppEngine version, listed here to ease deployment and troubleshooting.
  * Bumped runtimeVersion to `2021.02.16`.
  * Upgraded pana to `0.15.0+1`.
  * NOTE: added daily periodic tasks: `delete-old-dartdoc-sdks`,
-         `delete-old-search-snapshots`, `delete-old-dartdoc-records`.
+         `delete-old-search-snapshots`, `delete-old-dartdoc-records`,
+         `delete-expired-dartdoc-records`, `gc-dartdoc-storage-bucket`.
  * NOTE: Running `git gc` regularly, disk full events (#4458) should decrease.
  * NOTE: started creating `DartdocRecord` entities in Datastore.
    TODO(deferred): we may use these entities instead of Bucket objects

--- a/app/lib/dartdoc/dartdoc_runner.dart
+++ b/app/lib/dartdoc/dartdoc_runner.dart
@@ -312,7 +312,6 @@ class DartdocJobProcessor extends JobProcessor {
     await scoreCardBackend.updateReport(
         job.packageName, job.packageVersion, report);
     await scoreCardBackend.updateScoreCard(job.packageName, job.packageVersion);
-    dartdocBackend.scheduleGC(job.packageName, job.packageVersion);
   }
 
   Future<bool> _resolveDependencies(

--- a/app/lib/dartdoc/models.dart
+++ b/app/lib/dartdoc/models.dart
@@ -48,6 +48,11 @@ class DartdocRecord extends db.ExpandoModel<String> {
   @db.StringProperty(required: true, indexed: true)
   String runtimeVersion;
 
+  /// The package, version and runtime encoded as
+  /// `<package>/<version>/<runtimeVersion>`.
+  @db.StringProperty(required: true, indexed: true)
+  String packageVersionRuntime;
+
   /// Indicates whether at the time of running dartdoc the version was
   /// considered the latest stable version of the package.
   @db.BoolProperty(required: true, indexed: false)
@@ -80,6 +85,11 @@ class DartdocRecord extends db.ExpandoModel<String> {
   @db.StringProperty(required: true, indexed: false)
   String entryJson;
 
+  /// Indicates whether the content has been expired and replaced by a newer
+  /// [DartdocRecord] in the current runtime.
+  @db.BoolProperty(required: true, indexed: true)
+  bool isExpired;
+
   DartdocRecord();
 
   DartdocRecord.fromEntry(
@@ -92,6 +102,7 @@ class DartdocRecord extends db.ExpandoModel<String> {
     version = entry.packageVersion;
     packageVersion = '$package/$version';
     runtimeVersion = entry.runtimeVersion;
+    packageVersionRuntime = '$package/$version/$runtimeVersion';
     wasLatestStable = entry.isLatest;
     hasValidContent = entry.hasContent;
     if (!hasValidContent && entry.isObsolete) {
@@ -103,6 +114,7 @@ class DartdocRecord extends db.ExpandoModel<String> {
     contentPath = entry.contentPrefix;
     contentSize = entry.totalSize ?? 0;
     entryJson = json.encode(entry.toJson());
+    isExpired = false;
   }
 
   DartdocEntry get entry => entryJson == null

--- a/app/lib/service/entrypoint/dartdoc.dart
+++ b/app/lib/service/entrypoint/dartdoc.dart
@@ -4,12 +4,10 @@
 
 import 'dart:async';
 import 'dart:isolate';
-import 'dart:math';
 
 import 'package:args/command_runner.dart';
 import 'package:logging/logging.dart';
 
-import '../../dartdoc/backend.dart';
 import '../../dartdoc/dartdoc_runner.dart';
 import '../../dartdoc/handlers.dart';
 import '../../job/backend.dart';
@@ -26,7 +24,6 @@ import '../services.dart';
 import '_isolate.dart';
 
 final Logger logger = Logger('pub.dartdoc');
-final _random = Random.secure();
 
 class DartdocCommand extends Command {
   @override
@@ -84,13 +81,6 @@ Future _workerMain(WorkerEntryMessage message) async {
         'backend': await jobBackend.stats(JobService.dartdoc),
         'processor': jobProcessor.stats(),
       });
-    });
-
-    // Start dartdoc file GC in the next 6-12 hours (randomized wait to reduce race).
-    // The delay is useful here so that a new deployment is not slowed down with GCs.
-    // TODO: setup a periodic task for this
-    Timer(Duration(minutes: 360 + _random.nextInt(360)), () {
-      dartdocBackend.processScheduledGCTasks();
     });
 
     await jobMaintenance.run();

--- a/app/lib/tool/neat_task/pub_dev_tasks.dart
+++ b/app/lib/tool/neat_task/pub_dev_tasks.dart
@@ -67,6 +67,19 @@ void setupDartdocPeriodicTasks() {
     name: 'delete-old-dartdoc-records',
     task: () async => await dartdocBackend.deleteOldRecords(),
   );
+
+  // Deletes DartdocRecord entities and their storage content that are expired,
+  // and have newer version with content.
+  _daily(
+    name: 'delete-expired-dartdoc-records',
+    task: () async => await dartdocBackend.deleteExpiredRecords(),
+  );
+
+  // Deletes content from dartdoc storage bucket based on the old entries.
+  _daily(
+    name: 'gc-dartdoc-storage-bucket',
+    task: () async => await dartdocBackend.gcStorageBucket(),
+  );
 }
 
 /// Setup the tasks that we are running in the search service.


### PR DESCRIPTION
- Last tasks migrated for #4482.
- Expired records have a separate daily cleanup job.
- Upload GC for now is best effort and it is the migration of the old method from in-memory task queue to Datastore query. Once we fully migrated to `DartdocRecord`, we could use better GC.
