### PR TITLE
Style updates for license tab.

### DIFF
--- a/app/lib/frontend/templates/detail_page.dart
+++ b/app/lib/frontend/templates/detail_page.dart
@@ -122,6 +122,7 @@ class Tab {
     ];
     final contentClasses = <String>[
       'tab-content',
+      'detail-tab-$id-content',
       if (isActive) '-active',
       if (isMarkdown) 'markdown-body',
     ];

--- a/app/lib/frontend/templates/package.dart
+++ b/app/lib/frontend/templates/package.dart
@@ -464,13 +464,15 @@ Tab _installTab(PackagePageData data) {
 }
 
 Tab _licenseTab(PackagePageData data) {
-  final contentHtml = data.hasLicense
+  final licenseAsHtml = data.hasLicense
       ? renderFile(data.asset.toFileObject(), data.version.packageLinks.baseUrl)
       : 'No license file found.';
+  final contentHtml = '<h2>License</h2>\n$licenseAsHtml';
   return Tab.withContent(
     id: 'license',
     title: 'License',
     contentHtml: contentHtml,
+    isMarkdown: true,
   );
 }
 

--- a/app/test/frontend/golden/my_liked_packages.html
+++ b/app/test/frontend/golden/my_liked_packages.html
@@ -158,7 +158,7 @@
             </div>
             <div class="detail-container detail-body-main">
               <div class="detail-tabs-content">
-                <section class="tab-content -active">
+                <section class="tab-content detail-tab-liked-packages-content -active">
                   <p>You like 2 packages.</p>
                   <div class="packages -compact">
                     <div class="packages-item">

--- a/app/test/frontend/golden/my_packages.html
+++ b/app/test/frontend/golden/my_packages.html
@@ -158,7 +158,7 @@
             </div>
             <div class="detail-container detail-body-main">
               <div class="detail-tabs-content">
-                <section class="tab-content -active">
+                <section class="tab-content detail-tab-packages-content -active">
                   <div class="listing-info">
                     <div class="listing-info-count">
                       <span class="info-identifier">Results</span>

--- a/app/test/frontend/golden/my_publishers.html
+++ b/app/test/frontend/golden/my_publishers.html
@@ -158,7 +158,7 @@
             </div>
             <div class="detail-container detail-body-main">
               <div class="detail-tabs-content">
-                <section class="tab-content -active">
+                <section class="tab-content detail-tab-publishers-content -active">
                   <div class="publishers">
                     <div class="publishers-item">
                       <h3 class="publishers-item-title">

--- a/app/test/frontend/golden/pkg_admin_page_outdated.html
+++ b/app/test/frontend/golden/pkg_admin_page_outdated.html
@@ -198,7 +198,7 @@
             </div>
             <div class="detail-container detail-body-main">
               <div class="detail-tabs-content">
-                <section class="tab-content -active">
+                <section class="tab-content detail-tab-admin-content -active">
                   <h2>Package ownership</h2>
                   <div>
                     <p>You can transfer this package to a verified publisher if you are a member of the publisher. Transferring the package removes the current uploaders, so that only the members of the publisher can upload new versions.</p>

--- a/app/test/frontend/golden/pkg_changelog_page.html
+++ b/app/test/frontend/golden/pkg_changelog_page.html
@@ -199,7 +199,7 @@
             </div>
             <div class="detail-container detail-body-main">
               <div class="detail-tabs-content">
-                <section class="tab-content -active markdown-body">
+                <section class="tab-content detail-tab-changelog-content -active markdown-body">
                   <h1 class="hash-header" id="changelog">
                     Changelog
                     <a href="#changelog" class="hash-link">#</a>

--- a/app/test/frontend/golden/pkg_example_page.html
+++ b/app/test/frontend/golden/pkg_example_page.html
@@ -199,7 +199,7 @@
             </div>
             <div class="detail-container detail-body-main">
               <div class="detail-tabs-content">
-                <section class="tab-content -active markdown-body">
+                <section class="tab-content detail-tab-example-content -active markdown-body">
                   <p style="font-family: monospace">
                     <b>example/lib/main.dart</b>
                   </p>

--- a/app/test/frontend/golden/pkg_install_page.html
+++ b/app/test/frontend/golden/pkg_install_page.html
@@ -199,7 +199,7 @@
             </div>
             <div class="detail-container detail-body-main">
               <div class="detail-tabs-content">
-                <section class="tab-content -active">
+                <section class="tab-content detail-tab-installing-content -active">
                   <h2>Use this package as a library</h2>
                   <h3>1. Depend on it</h3>
                   <p>Add this to your package's pubspec.yaml file:</p>

--- a/app/test/frontend/golden/pkg_score_page.html
+++ b/app/test/frontend/golden/pkg_score_page.html
@@ -199,7 +199,7 @@
             </div>
             <div class="detail-container detail-body-main">
               <div class="detail-tabs-content">
-                <section class="tab-content -active">
+                <section class="tab-content detail-tab-analysis-content -active">
                   <div class="score-key-figures">
                     <div class="score-key-figure">
                       <div class="score-key-figure-title">

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -199,7 +199,7 @@
             </div>
             <div class="detail-container detail-body-main">
               <div class="detail-tabs-content">
-                <section class="tab-content -active markdown-body">
+                <section class="tab-content detail-tab-readme-content -active markdown-body">
                   <h1 class="hash-header" id="test-package">
                     Test Package
                     <a href="#test-package" class="hash-link">#</a>

--- a/app/test/frontend/golden/pkg_show_page_discontinued.html
+++ b/app/test/frontend/golden/pkg_show_page_discontinued.html
@@ -196,7 +196,7 @@
             </div>
             <div class="detail-container detail-body-main">
               <div class="detail-tabs-content">
-                <section class="tab-content -active markdown-body">
+                <section class="tab-content detail-tab-readme-content -active markdown-body">
                   <h1 class="hash-header" id="test-package">
                     Test Package
                     <a href="#test-package" class="hash-link">#</a>

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -202,7 +202,7 @@
             </div>
             <div class="detail-container detail-body-main">
               <div class="detail-tabs-content">
-                <section class="tab-content -active markdown-body">
+                <section class="tab-content detail-tab-readme-content -active markdown-body">
                   <h1 class="hash-header" id="test-package">
                     Test Package
                     <a href="#test-package" class="hash-link">#</a>

--- a/app/test/frontend/golden/pkg_show_page_legacy.html
+++ b/app/test/frontend/golden/pkg_show_page_legacy.html
@@ -196,7 +196,7 @@
             </div>
             <div class="detail-container detail-body-main">
               <div class="detail-tabs-content">
-                <section class="tab-content -active markdown-body">
+                <section class="tab-content detail-tab-readme-content -active markdown-body">
                   <h1 class="hash-header" id="test-package">
                     Test Package
                     <a href="#test-package" class="hash-link">#</a>

--- a/app/test/frontend/golden/pkg_show_page_outdated.html
+++ b/app/test/frontend/golden/pkg_show_page_outdated.html
@@ -196,7 +196,7 @@
             </div>
             <div class="detail-container detail-body-main">
               <div class="detail-tabs-content">
-                <section class="tab-content -active markdown-body">
+                <section class="tab-content detail-tab-readme-content -active markdown-body">
                   <h1 class="hash-header" id="test-package">
                     Test Package
                     <a href="#test-package" class="hash-link">#</a>

--- a/app/test/frontend/golden/pkg_show_page_publisher.html
+++ b/app/test/frontend/golden/pkg_show_page_publisher.html
@@ -193,7 +193,7 @@
             </div>
             <div class="detail-container detail-body-main">
               <div class="detail-tabs-content">
-                <section class="tab-content -active markdown-body">
+                <section class="tab-content detail-tab-readme-content -active markdown-body">
                   <h1 class="hash-header" id="neon">
                     neon
                     <a href="#neon" class="hash-link">#</a>

--- a/app/test/frontend/golden/pkg_show_version_page.html
+++ b/app/test/frontend/golden/pkg_show_version_page.html
@@ -193,7 +193,7 @@
             </div>
             <div class="detail-container detail-body-main">
               <div class="detail-tabs-content">
-                <section class="tab-content -active markdown-body"></section>
+                <section class="tab-content detail-tab-readme-content -active markdown-body"></section>
               </div>
             </div>
           </div>

--- a/app/test/frontend/golden/pkg_versions_page.html
+++ b/app/test/frontend/golden/pkg_versions_page.html
@@ -201,7 +201,7 @@
             </div>
             <div class="detail-container detail-body-main">
               <div class="detail-tabs-content">
-                <section class="tab-content -active">
+                <section class="tab-content detail-tab-versions-content -active">
                   <p>
                     The latest prerelease was
                     <a href="#prerelease">0.2.0-dev</a>

--- a/app/test/frontend/golden/publisher_packages_page.html
+++ b/app/test/frontend/golden/publisher_packages_page.html
@@ -168,7 +168,7 @@
             </div>
             <div class="detail-container detail-body-main">
               <div class="detail-tabs-content">
-                <section class="tab-content -active">
+                <section class="tab-content detail-tab-packages-content -active">
                   <div class="listing-info">
                     <div class="listing-info-count">
                       <span class="info-identifier">Results</span>

--- a/pkg/pub_integration/test/browser_test.dart
+++ b/pkg/pub_integration/test/browser_test.dart
@@ -129,6 +129,11 @@ void main() {
               'http://localhost:${fakePubServerProcess.port}/packages/retry/versions/2.0.01',
               wait: Until.networkIdle);
           await checkHeaderTitle();
+
+          await page.goto(
+              'http://localhost:${fakePubServerProcess.port}/packages/retry/license',
+              wait: Until.networkIdle);
+          await checkHeaderTitle();
         },
       );
     });

--- a/pkg/web_css/lib/src/_pkg.scss
+++ b/pkg/web_css/lib/src/_pkg.scss
@@ -317,3 +317,23 @@
   margin-top: 40px;
   font-size: 14px;
 }
+
+.detail-tab-license-content.markdown-body {
+  .highlight {
+    pre {
+      // Most lines have 80 characters, better to scale down the font size
+      // to keep everything visible at the same time.
+      font-size: 60%;
+
+      @media (min-width: $device-desktop-min-width) {
+        // On larger screens the above setting seems to be too small. The
+        // vertical width scaling will roughly make the 80-character lines
+        // fit the available width of the container.
+        //
+        // The scaling breaks down on smaller screens, keeping it for
+        // desktop only.
+        font-size: 1.2vw;
+      }
+    }
+  }
+}


### PR DESCRIPTION
- each tab content gets a custom `class` attribute similar to the titles
- license tab gets a header
- license text is smaller, and in some screens dynamically resized to match about 80 characters per line