### PR TITLE
Adjust post-deployment check with new label.

### DIFF
--- a/pkg/pub_integration/lib/script/public_pages.dart
+++ b/pkg/pub_integration/lib/script/public_pages.dart
@@ -44,7 +44,7 @@ class PublicPagesScript {
     final html = await _pubClient.getContent('/');
     _contains(html, 'Find and use packages');
     if (expectLiveSite) {
-      _contains(html, 'Top packages');
+      _contains(html, 'top packages');
       _contains(html, 'View all');
     }
   }


### PR DESCRIPTION
Test was broken because of #4548.