### PR TITLE
Fix search mixing with SDK results.

### DIFF
--- a/app/lib/frontend/templates/listing.dart
+++ b/app/lib/frontend/templates/listing.dart
@@ -86,7 +86,7 @@ String renderPackageList(
       'publisher_url':
           view.publisherId == null ? null : urls.publisherUrl(view.publisherId),
       'tags_html': renderTags(package: view),
-      'labeled_scores_html': renderLabeledScores(view),
+      'labeled_scores_html': view.isExternal ? null : renderLabeledScores(view),
       'has_api_pages': hasApiPages,
       'has_more_api_pages': hasMoreThanOneApiPages,
       'first_api_page': hasApiPages ? apiPages.first : null,

--- a/app/lib/search/mem_index.dart
+++ b/app/lib/search/mem_index.dart
@@ -270,6 +270,8 @@ class InMemoryPackageIndex implements PackageIndex {
         break;
     }
 
+    //
+
     // bound by offset and limit (or randomize items)
     final totalCount = results.length;
     results = boundedList(results, offset: query.offset, limit: query.limit);
@@ -457,12 +459,8 @@ class InMemoryPackageIndex implements PackageIndex {
   }
 
   List<PackageScore> _rankWithValues(Map<String, double> values) {
-    final List<PackageScore> list = values.keys
-        .map((package) {
-          final score = values[package];
-          return PackageScore(package: package, score: score);
-        })
-        .where((ps) => ps != null)
+    final list = values.entries
+        .map((e) => PackageScore(package: e.key, score: e.value))
         .toList();
     list.sort((a, b) {
       final int scoreCompare = -a.score.compareTo(b.score);

--- a/app/lib/search/result_combiner.dart
+++ b/app/lib/search/result_combiner.dart
@@ -6,8 +6,6 @@ import 'dart:async';
 
 import 'package:meta/meta.dart';
 
-import '../shared/utils.dart' show boundedList;
-
 import 'search_service.dart';
 
 /// Combines the results from the primary package index and the optional Dart
@@ -22,64 +20,35 @@ class SearchResultCombiner {
   });
 
   Future<PackageSearchResult> search(ServiceSearchQuery query) async {
-    final includeSdkResults = shouldIncludeSdkResults(query);
+    final includeSdkResults =
+        query.offset == 0 && query.hasFreeTextComponent && query.isNaturalOrder;
     if (!includeSdkResults) {
       return primaryIndex.search(query);
     }
 
-    // Setting the query to request an unbounded result set. The original offset
-    // and limit will be applied after the result sets are merged.
-    final primaryQuery = query.change(offset: 0, limit: 0);
-    final primaryResult = await primaryIndex.search(primaryQuery);
+    final primaryResult = await primaryIndex.search(query);
     final threshold = primaryResult.packages.isEmpty
         ? 0.0
         : (primaryResult.packages.first.score ?? 0.0) / 2;
 
     final dartSdkResult = await dartSdkIndex
-        .search(query.change(order: SearchOrder.text, offset: 0, limit: 3));
+        .search(query.change(order: SearchOrder.text, offset: 0, limit: 2));
 
-    final allPackages = [
-      primaryResult.packages,
-      dartSdkResult.packages.where((ps) => ps.score >= threshold).toList(),
-    ].expand((list) => list).toList();
-
-    final matchedPackage = query.parsedQuery.text;
-    final matchedPackageIsFirst = primaryResult.packages.isNotEmpty &&
-        primaryResult.packages.first.package == matchedPackage;
-    allPackages.sort((a, b) {
-      // matching package name should be the first
-      if (matchedPackageIsFirst && a.package == matchedPackage) return -1;
-      if (matchedPackageIsFirst && b.package == matchedPackage) return 1;
-
-      // otherwise sort on score
-      return -a.score.compareTo(b.score);
-    });
-
-    final packages =
-        boundedList(allPackages, offset: query.offset, limit: query.limit);
+    final hits = List<PackageScore>.from(primaryResult.packages);
+    PackageScore exactNameHit;
+    if (hits.isNotEmpty && query.parsedQuery.text == hits.first.package) {
+      exactNameHit = hits.removeAt(0);
+    }
+    final allPackages = <PackageScore>[
+      if (exactNameHit != null) exactNameHit,
+      ...dartSdkResult.packages.where((ps) => ps.score >= threshold),
+      ...hits,
+    ];
 
     return PackageSearchResult(
       timestamp: primaryResult.timestamp,
-      totalCount: allPackages.length,
-      packages: packages,
+      totalCount: primaryResult.totalCount,
+      packages: allPackages,
     );
   }
-}
-
-/// Whether the results for the query should include SDK results.
-bool shouldIncludeSdkResults(ServiceSearchQuery query) {
-  // No reason to display SDK packages if:
-  // - there is no text query
-  // - the query is about a filter (e.g. dependency or package-prefix)
-  final hasFreeTextComponent = query.offset == 0 &&
-      query.hasQuery &&
-      query.parsedQuery.text != null &&
-      query.parsedQuery.text.isNotEmpty;
-  // No reason to display SDK packages if:
-  // - the order is based on analysis score (e.g. health)
-  // - the order is based on timestamp (e.g. created time)
-  final isNaturalOrder = query.order == null ||
-      query.order == SearchOrder.top ||
-      query.order == SearchOrder.text;
-  return hasFreeTextComponent && isNaturalOrder;
 }

--- a/app/lib/search/search_service.dart
+++ b/app/lib/search/search_service.dart
@@ -331,6 +331,10 @@ class ServiceSearchQuery {
   }
 
   bool get hasQuery => query != null && query.isNotEmpty;
+  bool get hasFreeTextComponent =>
+      hasQuery && parsedQuery.text != null && parsedQuery.text.isNotEmpty;
+  bool get isNaturalOrder =>
+      order == null || order == SearchOrder.top || order == SearchOrder.text;
 
   String get sdk {
     final values = tagsPredicate._values.entries

--- a/app/test/search/result_combiner_test.dart
+++ b/app/test/search/result_combiner_test.dart
@@ -73,7 +73,7 @@ void main() {
           await combiner.search(ServiceSearchQuery.parse(query: 'substring'));
       expect(json.decode(json.encode(results.toJson())), {
         'timestamp': isNotNull,
-        'totalCount': 2,
+        'totalCount': 1,
         'packages': [
           {
             'package': 'dart:core',
@@ -100,7 +100,7 @@ void main() {
           await combiner.search(ServiceSearchQuery.parse(query: 'stringutils'));
       expect(json.decode(json.encode(results.toJson())), {
         'timestamp': isNotNull,
-        'totalCount': 2,
+        'totalCount': 1,
         'packages': [
           {'package': 'stringutils', 'score': closeTo(0.80, 0.01)},
           {


### PR DESCRIPTION
Mixing SDK results and normal package hits is broken: the first page may contain the SDK results, the rest of the pages will not (due to a condition to include the search). As a side effect, any search query that contains SDK results will report the total package count inconsistently: the first page reports more results (by 1, 2, or 3) while the pages on and after the second will report only the actual package count. There is also a few lost package that is not shown, as the SDK package takes their place on the first result page. (Demo query: https://pub.dev/packages?q=json)

To fix that, this PR simplifies the merging of the SDK results:
- On the first page:
  - Exact name match is still the first result (at least with non-specific search order).
  - We may display 0-2 SDK library hits.
  - We follow by the rest of the packages on the first page (displaying up to 12 including the SDK hits).
- On the second page onward: we only display the regular hits.

The PR also hides the `--` score labels for SDK libraries on the listing page.

A demo can be seen on staging. (Related issues: #4549, #4474).