### PR TITLE
Fix missing `pub` from command

### DIFF
--- a/doc/development.md
+++ b/doc/development.md
@@ -38,7 +38,7 @@ annotations. Input files are usually listed in `build.yaml`, and generated
 files usually suffixed `.g.dart`. To generate code use:
 
 ```bash
-dart run build_runner build
+dart pub run build_runner build
 ```
 
 ## Working with `mono_repo`


### PR DESCRIPTION
Minor change,
There was an error in the command in the  # Updating generated code of the development doc. 

It only included 
```
dart build_runner build
```

I also feel the last part of the doc is not clear enough, 
when I was setting up the project I was confused, what project to use the generating the IAM service account key? 
As far as I know, a project must be selected in Google cloud console to generate a key.
If I'm not wrong, I can include more clarity to that part.