### PR TITLE
Drop sub-SDK filters (platform and runtime) on SDK switch.

### DIFF
--- a/app/lib/search/search_form.dart
+++ b/app/lib/search/search_form.dart
@@ -120,12 +120,20 @@ class SearchForm {
   }) {
     if (sdk != null) {
       tagsPredicate ??= this.tagsPredicate ?? TagsPredicate();
-      tagsPredicate = tagsPredicate
-          .removePrefix('sdk:')
-          .withoutTag(PackageTags.isFlutterFavorite);
-      if (SdkTagValue.isNotAny(sdk)) {
+      if (!tagsPredicate.isRequiredTag('sdk:$sdk')) {
         tagsPredicate = tagsPredicate
-            .appendPredicate(TagsPredicate(requiredTags: ['sdk:$sdk']));
+            .removePrefix('sdk:')
+            .withoutTag(PackageTags.isFlutterFavorite);
+        if (SdkTagValue.isNotAny(sdk)) {
+          tagsPredicate = tagsPredicate
+              .appendPredicate(TagsPredicate(requiredTags: ['sdk:$sdk']));
+        }
+        if (sdk != SdkTagValue.dart) {
+          tagsPredicate = tagsPredicate.removePrefix('runtime:');
+        }
+        if (sdk != SdkTagValue.flutter) {
+          tagsPredicate = tagsPredicate.removePrefix('platform:');
+        }
       }
     }
     return SearchForm._(

--- a/app/test/search/search_form_test.dart
+++ b/app/test/search/search_form_test.dart
@@ -37,5 +37,24 @@ void main() {
       expect(form.toSearchLink(page: 2),
           '/flutter/packages?q=some+framework&page=2');
     });
+
+    test('removing Dart runtimes', () {
+      final form =
+          SearchForm.parse(query: 'text', sdk: 'dart', runtimes: ['js']);
+      expect(form.toSearchLink(), '/dart/packages?q=text&runtime=js');
+      expect(form.change(sdk: 'dart').toSearchLink(), form.toSearchLink());
+      expect(form.change(sdk: 'flutter').toSearchLink(),
+          '/flutter/packages?q=text');
+      expect(form.change(sdk: 'any').toSearchLink(), '/packages?q=text');
+    });
+
+    test('removing Flutter platforms', () {
+      final form =
+          SearchForm.parse(query: 'text', sdk: 'flutter', platforms: ['web']);
+      expect(form.toSearchLink(), '/flutter/packages?q=text&platform=web');
+      expect(form.change(sdk: 'dart').toSearchLink(), '/dart/packages?q=text');
+      expect(form.change(sdk: 'flutter').toSearchLink(), form.toSearchLink());
+      expect(form.change(sdk: 'any').toSearchLink(), '/packages?q=text');
+    });
   });
 }


### PR DESCRIPTION
- Example URL: https://pub.dev/flutter/packages?q=widget&platform=web
  Switching to Dart SDK should remove `platform=web` from the URL.
- When there is no change in the SDK it shouldn't change anything.
