### PR TITLE
Updated runtime/platform filters.

### DIFF
--- a/app/lib/frontend/templates/listing.dart
+++ b/app/lib/frontend/templates/listing.dart
@@ -139,19 +139,14 @@ String renderPkgIndexPage(
   final includeUnlisted = searchForm?.includeUnlisted ?? false;
   final nullSafe = searchForm?.nullSafe ?? false;
   final subSdkLayout = _calculateLayout(searchForm);
-  final hasActiveAdvanced = includeDiscontinued ||
-      includeUnlisted ||
-      subSdkLayout.hasActiveAdvanced ||
-      nullSafe;
+  final hasActiveAdvanced = includeDiscontinued || includeUnlisted || nullSafe;
   final values = {
     'has_active_advanced': hasActiveAdvanced,
     'sdk_tabs_html': renderSdkTabs(searchForm: searchForm),
+    'has_subsdk_options': subSdkLayout.hasOptions,
     'subsdk_label': _subSdkLabel(searchForm),
-    'subsdk_primary_buttons_html': _renderFilterButtons(
-        searchForm: searchForm, options: subSdkLayout.primaryOptions),
-    'has_subsdk_advanced_buttons_html': subSdkLayout.hasAdvanced,
-    'subsdk_advanced_buttons_html': _renderFilterButtons(
-        searchForm: searchForm, options: subSdkLayout.advancedOptions),
+    'subsdk_filter_buttons_html': _renderFilterButtons(
+        searchForm: searchForm, options: subSdkLayout.options),
     'is_search': isSearch,
     'listing_info_html': renderListingInfo(
       searchForm: searchForm,
@@ -346,8 +341,7 @@ String _renderFilterButtons({
 /// to display them only when the user has already opted-in to get them
 /// displayed.
 _SubSdkLayout _calculateLayout(SearchForm searchForm) {
-  List<_FilterOption> primaryOptions;
-  List<_FilterOption> advancedOptions;
+  List<_FilterOption> options;
 
   _FilterOption option({
     @required String label,
@@ -364,7 +358,7 @@ _SubSdkLayout _calculateLayout(SearchForm searchForm) {
 
   final sdk = searchForm?.sdk;
   if (sdk == SdkTagValue.dart) {
-    primaryOptions = [
+    options = [
       option(
         label: 'native',
         tag: DartSdkTag.runtimeNativeJit,
@@ -379,7 +373,7 @@ _SubSdkLayout _calculateLayout(SearchForm searchForm) {
     ];
   }
   if (sdk == SdkTagValue.flutter) {
-    primaryOptions = [
+    options = [
       option(
         label: 'Android',
         tag: FlutterSdkTag.platformAndroid,
@@ -395,9 +389,6 @@ _SubSdkLayout _calculateLayout(SearchForm searchForm) {
         tag: FlutterSdkTag.platformWeb,
         title: 'Packages compatible with Flutter on the Web platform',
       ),
-    ];
-
-    advancedOptions = [
       option(
         label: 'Linux',
         tag: FlutterSdkTag.platformLinux,
@@ -415,24 +406,17 @@ _SubSdkLayout _calculateLayout(SearchForm searchForm) {
       ),
     ];
   }
-  return _SubSdkLayout(
-    primaryOptions: primaryOptions,
-    advancedOptions: advancedOptions,
-  );
+  return _SubSdkLayout(options: options);
 }
 
 class _SubSdkLayout {
-  final List<_FilterOption> primaryOptions;
-  final List<_FilterOption> advancedOptions;
+  final List<_FilterOption> options;
 
   _SubSdkLayout({
-    @required this.primaryOptions,
-    @required this.advancedOptions,
+    @required this.options,
   });
 
-  bool get hasAdvanced => advancedOptions != null && advancedOptions.isNotEmpty;
-  bool get hasActiveAdvanced =>
-      hasAdvanced && advancedOptions.any((o) => o.isActive);
+  bool get hasOptions => options != null && options.isNotEmpty;
 }
 
 class _FilterOption {

--- a/app/lib/frontend/templates/views/pkg/index.mustache
+++ b/app/lib/frontend/templates/views/pkg/index.mustache
@@ -12,26 +12,25 @@
         <span class="search-controls-label">SDK</span>
         {{& sdk_tabs_html}}
       </div>
-      <div class="search-controls-subsdk search-controls-buttons">
-        <span class="search-controls-label">{{subsdk_label}}</span>
-        {{& subsdk_primary_buttons_html }}
-      </div>
       <div class="search-filters-btn search-filters-btn-wrapper search-controls-more" data-ga-click-event="toggle-advanced-search">
         Advanced
         <img src="{{& static_assets.img__carot-up_svg}}" class="search-controls-more-carot" />
       </div>
     </div>
   </div>
+  {{#has_subsdk_options}}
+  <div class="search-controls-subsdk">
+    <div class="container">
+      <span class="search-controls-label">{{subsdk_label}}</span>
+      <div class="search-controls-buttons">
+        {{& subsdk_filter_buttons_html }}
+      </div>
+    </div>
+  </div>
+  {{/has_subsdk_options}}
   <div class="search-controls-advanced">
     <div class="container">
       <div class="search-controls-advanced-block">
-        {{#has_subsdk_advanced_buttons_html}}
-        <div class="search-controls-subsdk-advanced search-controls-buttons"
-             title="Prerelease platforms">
-          <span class="search-controls-label">Prerelease platforms</span>
-          {{& subsdk_advanced_buttons_html }}
-        </div>
-        {{/has_subsdk_advanced_buttons_html}}
         <div class="search-controls-checkbox">
           <input id="-search-unlisted-checkbox" type="checkbox" name="unlisted" {{#include_unlisted}} checked="checked"{{/include_unlisted}} />
           <label for="-search-unlisted-checkbox">Include unlisted packages</label>

--- a/app/test/frontend/golden/pkg_index_page.html
+++ b/app/test/frontend/golden/pkg_index_page.html
@@ -149,9 +149,6 @@
                 </a>
               </div>
             </div>
-            <div class="search-controls-subsdk search-controls-buttons">
-              <span class="search-controls-label"></span>
-            </div>
             <div class="search-filters-btn search-filters-btn-wrapper search-controls-more" data-ga-click-event="toggle-advanced-search">
               Advanced
               <img src="/static/img/carot-up.svg?hash=mocked_hash_771440143" class="search-controls-more-carot"/>

--- a/app/test/frontend/golden/search_page.html
+++ b/app/test/frontend/golden/search_page.html
@@ -150,9 +150,6 @@
                 </a>
               </div>
             </div>
-            <div class="search-controls-subsdk search-controls-buttons">
-              <span class="search-controls-label"></span>
-            </div>
             <div class="search-filters-btn search-filters-btn-wrapper search-controls-more" data-ga-click-event="toggle-advanced-search">
               Advanced
               <img src="/static/img/carot-up.svg?hash=mocked_hash_771440143" class="search-controls-more-carot"/>

--- a/pkg/web_css/lib/src/_list.scss
+++ b/pkg/web_css/lib/src/_list.scss
@@ -19,6 +19,14 @@
   background: #f5f5f7;
   display: none;
 
+  .search-controls-subsdk {
+    @media (min-width: $device-desktop-min-width) {
+      background: white;
+      border-bottom: 1px solid #d5d5d5;
+      padding-top: 8px;
+    }
+  }
+
   .search-controls-advanced {
     display: none;
 
@@ -124,6 +132,7 @@
         color: #212121;
         display: inline-block;
         font-size: 14px;
+        margin-bottom: 8px;
         padding: 3px 24px;
 
         .filter-icon {
@@ -174,10 +183,6 @@
         transform: rotate(0deg);
       }
     }
-  }
-
-  .search-controls-subsdk-advanced {
-    padding: 12px 0 8px 0;
   }
 
   .search-controls-checkbox {


### PR DESCRIPTION
- Fixes #4511.
- Desktop view with open advanced tab:
  <img width="1079" alt="Screenshot 2021-03-02 at 17 38 56" src="https://user-images.githubusercontent.com/4778111/109682155-70976d80-7b7e-11eb-828b-55eee878aaea.png">

- Mobile view:
  <img width="331" alt="Screenshot 2021-03-02 at 17 39 17" src="https://user-images.githubusercontent.com/4778111/109682166-72f9c780-7b7e-11eb-80a1-c12ed965e35e.png">