### PR TITLE
Upgrade runtime SDK to 2.12.0

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -44,15 +44,15 @@ jobs:
         uses: actions/cache@v2
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:2.10.0;packages:pkg/web_css-pkg/client_data-pkg/_popularity-pkg/api_builder-app-pkg/fake_gcloud-pkg/pub_dartdoc-pkg/pub_dartdoc_data-pkg/pub_package_reader-pkg/pub_validations-pkg/web_app;commands:dartfmt-dartanalyzer_0"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:2.12.0;packages:pkg/web_css-pkg/client_data-pkg/_popularity-pkg/api_builder-app-pkg/fake_gcloud-pkg/pub_dartdoc-pkg/pub_dartdoc_data-pkg/pub_package_reader-pkg/pub_validations-pkg/web_app;commands:dartfmt-dartanalyzer_0"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;dart:2.10.0;packages:pkg/web_css-pkg/client_data-pkg/_popularity-pkg/api_builder-app-pkg/fake_gcloud-pkg/pub_dartdoc-pkg/pub_dartdoc_data-pkg/pub_package_reader-pkg/pub_validations-pkg/web_app
-            os:ubuntu-latest;pub-cache-hosted;dart:2.10.0
+            os:ubuntu-latest;pub-cache-hosted;dart:2.12.0;packages:pkg/web_css-pkg/client_data-pkg/_popularity-pkg/api_builder-app-pkg/fake_gcloud-pkg/pub_dartdoc-pkg/pub_dartdoc_data-pkg/pub_package_reader-pkg/pub_validations-pkg/web_app
+            os:ubuntu-latest;pub-cache-hosted;dart:2.12.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - uses: dart-lang/setup-dart@v0.3
         with:
-          sdk: "2.10.0"
+          sdk: "2.12.0"
       - id: checkout
         uses: actions/checkout@v2
       - id: pkg_web_css_pub_get
@@ -206,15 +206,15 @@ jobs:
         uses: actions/cache@v2
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:2.10.0;packages:pkg/pub_integration;commands:dartfmt-dartanalyzer_1"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:2.12.0;packages:pkg/pub_integration;commands:dartfmt-dartanalyzer_1"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;dart:2.10.0;packages:pkg/pub_integration
-            os:ubuntu-latest;pub-cache-hosted;dart:2.10.0
+            os:ubuntu-latest;pub-cache-hosted;dart:2.12.0;packages:pkg/pub_integration
+            os:ubuntu-latest;pub-cache-hosted;dart:2.12.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - uses: dart-lang/setup-dart@v0.3
         with:
-          sdk: "2.10.0"
+          sdk: "2.12.0"
       - id: checkout
         uses: actions/checkout@v2
       - id: pkg_pub_integration_pub_get
@@ -238,15 +238,15 @@ jobs:
         uses: actions/cache@v2
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:2.10.0;packages:pkg/web_app;commands:command"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:2.12.0;packages:pkg/web_app;commands:command"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;dart:2.10.0;packages:pkg/web_app
-            os:ubuntu-latest;pub-cache-hosted;dart:2.10.0
+            os:ubuntu-latest;pub-cache-hosted;dart:2.12.0;packages:pkg/web_app
+            os:ubuntu-latest;pub-cache-hosted;dart:2.12.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - uses: dart-lang/setup-dart@v0.3
         with:
-          sdk: "2.10.0"
+          sdk: "2.12.0"
       - id: checkout
         uses: actions/checkout@v2
       - id: pkg_web_app_pub_get
@@ -270,15 +270,15 @@ jobs:
         uses: actions/cache@v2
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:2.10.0;packages:pkg/web_css;commands:command"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:2.12.0;packages:pkg/web_css;commands:command"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;dart:2.10.0;packages:pkg/web_css
-            os:ubuntu-latest;pub-cache-hosted;dart:2.10.0
+            os:ubuntu-latest;pub-cache-hosted;dart:2.12.0;packages:pkg/web_css
+            os:ubuntu-latest;pub-cache-hosted;dart:2.12.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - uses: dart-lang/setup-dart@v0.3
         with:
-          sdk: "2.10.0"
+          sdk: "2.12.0"
       - id: checkout
         uses: actions/checkout@v2
       - id: pkg_web_css_pub_get
@@ -302,15 +302,15 @@ jobs:
         uses: actions/cache@v2
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:2.10.0;packages:pkg/fake_gcloud;commands:test_07"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:2.12.0;packages:pkg/fake_gcloud;commands:test_07"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;dart:2.10.0;packages:pkg/fake_gcloud
-            os:ubuntu-latest;pub-cache-hosted;dart:2.10.0
+            os:ubuntu-latest;pub-cache-hosted;dart:2.12.0;packages:pkg/fake_gcloud
+            os:ubuntu-latest;pub-cache-hosted;dart:2.12.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - uses: dart-lang/setup-dart@v0.3
         with:
-          sdk: "2.10.0"
+          sdk: "2.12.0"
       - id: checkout
         uses: actions/checkout@v2
       - id: pkg_fake_gcloud_pub_get
@@ -336,15 +336,15 @@ jobs:
         uses: actions/cache@v2
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:2.10.0;packages:pkg/pub_dartdoc_data;commands:test_07"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:2.12.0;packages:pkg/pub_dartdoc_data;commands:test_07"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;dart:2.10.0;packages:pkg/pub_dartdoc_data
-            os:ubuntu-latest;pub-cache-hosted;dart:2.10.0
+            os:ubuntu-latest;pub-cache-hosted;dart:2.12.0;packages:pkg/pub_dartdoc_data
+            os:ubuntu-latest;pub-cache-hosted;dart:2.12.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - uses: dart-lang/setup-dart@v0.3
         with:
-          sdk: "2.10.0"
+          sdk: "2.12.0"
       - id: checkout
         uses: actions/checkout@v2
       - id: pkg_pub_dartdoc_data_pub_get
@@ -370,15 +370,15 @@ jobs:
         uses: actions/cache@v2
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:2.10.0;packages:pkg/_popularity;commands:test_07"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:2.12.0;packages:pkg/_popularity;commands:test_07"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;dart:2.10.0;packages:pkg/_popularity
-            os:ubuntu-latest;pub-cache-hosted;dart:2.10.0
+            os:ubuntu-latest;pub-cache-hosted;dart:2.12.0;packages:pkg/_popularity
+            os:ubuntu-latest;pub-cache-hosted;dart:2.12.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - uses: dart-lang/setup-dart@v0.3
         with:
-          sdk: "2.10.0"
+          sdk: "2.12.0"
       - id: checkout
         uses: actions/checkout@v2
       - id: pkg__popularity_pub_get
@@ -404,15 +404,15 @@ jobs:
         uses: actions/cache@v2
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:2.10.0;packages:pkg/pub_package_reader;commands:test_07"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:2.12.0;packages:pkg/pub_package_reader;commands:test_07"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;dart:2.10.0;packages:pkg/pub_package_reader
-            os:ubuntu-latest;pub-cache-hosted;dart:2.10.0
+            os:ubuntu-latest;pub-cache-hosted;dart:2.12.0;packages:pkg/pub_package_reader
+            os:ubuntu-latest;pub-cache-hosted;dart:2.12.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - uses: dart-lang/setup-dart@v0.3
         with:
-          sdk: "2.10.0"
+          sdk: "2.12.0"
       - id: checkout
         uses: actions/checkout@v2
       - id: pkg_pub_package_reader_pub_get
@@ -438,15 +438,15 @@ jobs:
         uses: actions/cache@v2
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:2.10.0;packages:pkg/pub_validations;commands:test_07"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:2.12.0;packages:pkg/pub_validations;commands:test_07"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;dart:2.10.0;packages:pkg/pub_validations
-            os:ubuntu-latest;pub-cache-hosted;dart:2.10.0
+            os:ubuntu-latest;pub-cache-hosted;dart:2.12.0;packages:pkg/pub_validations
+            os:ubuntu-latest;pub-cache-hosted;dart:2.12.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - uses: dart-lang/setup-dart@v0.3
         with:
-          sdk: "2.10.0"
+          sdk: "2.12.0"
       - id: checkout
         uses: actions/checkout@v2
       - id: pkg_pub_validations_pub_get
@@ -472,15 +472,15 @@ jobs:
         uses: actions/cache@v2
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:2.10.0;packages:pkg/client_data;commands:test_07"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:2.12.0;packages:pkg/client_data;commands:test_07"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;dart:2.10.0;packages:pkg/client_data
-            os:ubuntu-latest;pub-cache-hosted;dart:2.10.0
+            os:ubuntu-latest;pub-cache-hosted;dart:2.12.0;packages:pkg/client_data
+            os:ubuntu-latest;pub-cache-hosted;dart:2.12.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - uses: dart-lang/setup-dart@v0.3
         with:
-          sdk: "2.10.0"
+          sdk: "2.12.0"
       - id: checkout
         uses: actions/checkout@v2
       - id: pkg_client_data_pub_get
@@ -506,15 +506,15 @@ jobs:
         uses: actions/cache@v2
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:2.10.0;packages:pkg/web_app;commands:test_07"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:2.12.0;packages:pkg/web_app;commands:test_07"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;dart:2.10.0;packages:pkg/web_app
-            os:ubuntu-latest;pub-cache-hosted;dart:2.10.0
+            os:ubuntu-latest;pub-cache-hosted;dart:2.12.0;packages:pkg/web_app
+            os:ubuntu-latest;pub-cache-hosted;dart:2.12.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - uses: dart-lang/setup-dart@v0.3
         with:
-          sdk: "2.10.0"
+          sdk: "2.12.0"
       - id: checkout
         uses: actions/checkout@v2
       - id: pkg_web_app_pub_get
@@ -540,15 +540,15 @@ jobs:
         uses: actions/cache@v2
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:2.10.0;packages:pkg/web_css;commands:test_07"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:2.12.0;packages:pkg/web_css;commands:test_07"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;dart:2.10.0;packages:pkg/web_css
-            os:ubuntu-latest;pub-cache-hosted;dart:2.10.0
+            os:ubuntu-latest;pub-cache-hosted;dart:2.12.0;packages:pkg/web_css
+            os:ubuntu-latest;pub-cache-hosted;dart:2.12.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - uses: dart-lang/setup-dart@v0.3
         with:
-          sdk: "2.10.0"
+          sdk: "2.12.0"
       - id: checkout
         uses: actions/checkout@v2
       - id: pkg_web_css_pub_get
@@ -574,15 +574,15 @@ jobs:
         uses: actions/cache@v2
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:2.10.0;packages:pkg/pub_dartdoc;commands:test_07"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:2.12.0;packages:pkg/pub_dartdoc;commands:test_07"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;dart:2.10.0;packages:pkg/pub_dartdoc
-            os:ubuntu-latest;pub-cache-hosted;dart:2.10.0
+            os:ubuntu-latest;pub-cache-hosted;dart:2.12.0;packages:pkg/pub_dartdoc
+            os:ubuntu-latest;pub-cache-hosted;dart:2.12.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - uses: dart-lang/setup-dart@v0.3
         with:
-          sdk: "2.10.0"
+          sdk: "2.12.0"
       - id: checkout
         uses: actions/checkout@v2
       - id: pkg_pub_dartdoc_pub_get
@@ -608,15 +608,15 @@ jobs:
         uses: actions/cache@v2
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:2.10.0;packages:app;commands:test_05"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:2.12.0;packages:app;commands:test_05"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;dart:2.10.0;packages:app
-            os:ubuntu-latest;pub-cache-hosted;dart:2.10.0
+            os:ubuntu-latest;pub-cache-hosted;dart:2.12.0;packages:app
+            os:ubuntu-latest;pub-cache-hosted;dart:2.12.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - uses: dart-lang/setup-dart@v0.3
         with:
-          sdk: "2.10.0"
+          sdk: "2.12.0"
       - id: checkout
         uses: actions/checkout@v2
       - id: app_pub_get
@@ -642,15 +642,15 @@ jobs:
         uses: actions/cache@v2
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:2.10.0;packages:app;commands:test_04"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:2.12.0;packages:app;commands:test_04"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;dart:2.10.0;packages:app
-            os:ubuntu-latest;pub-cache-hosted;dart:2.10.0
+            os:ubuntu-latest;pub-cache-hosted;dart:2.12.0;packages:app
+            os:ubuntu-latest;pub-cache-hosted;dart:2.12.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - uses: dart-lang/setup-dart@v0.3
         with:
-          sdk: "2.10.0"
+          sdk: "2.12.0"
       - id: checkout
         uses: actions/checkout@v2
       - id: app_pub_get
@@ -676,15 +676,15 @@ jobs:
         uses: actions/cache@v2
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:2.10.0;packages:app;commands:test_06"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:2.12.0;packages:app;commands:test_06"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;dart:2.10.0;packages:app
-            os:ubuntu-latest;pub-cache-hosted;dart:2.10.0
+            os:ubuntu-latest;pub-cache-hosted;dart:2.12.0;packages:app
+            os:ubuntu-latest;pub-cache-hosted;dart:2.12.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - uses: dart-lang/setup-dart@v0.3
         with:
-          sdk: "2.10.0"
+          sdk: "2.12.0"
       - id: checkout
         uses: actions/checkout@v2
       - id: app_pub_get
@@ -710,15 +710,15 @@ jobs:
         uses: actions/cache@v2
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:2.10.0;packages:app;commands:test_01"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:2.12.0;packages:app;commands:test_01"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;dart:2.10.0;packages:app
-            os:ubuntu-latest;pub-cache-hosted;dart:2.10.0
+            os:ubuntu-latest;pub-cache-hosted;dart:2.12.0;packages:app
+            os:ubuntu-latest;pub-cache-hosted;dart:2.12.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - uses: dart-lang/setup-dart@v0.3
         with:
-          sdk: "2.10.0"
+          sdk: "2.12.0"
       - id: checkout
         uses: actions/checkout@v2
       - id: app_pub_get
@@ -744,15 +744,15 @@ jobs:
         uses: actions/cache@v2
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:2.10.0;packages:pkg/pub_integration;commands:test_08"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:2.12.0;packages:pkg/pub_integration;commands:test_08"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;dart:2.10.0;packages:pkg/pub_integration
-            os:ubuntu-latest;pub-cache-hosted;dart:2.10.0
+            os:ubuntu-latest;pub-cache-hosted;dart:2.12.0;packages:pkg/pub_integration
+            os:ubuntu-latest;pub-cache-hosted;dart:2.12.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - uses: dart-lang/setup-dart@v0.3
         with:
-          sdk: "2.10.0"
+          sdk: "2.12.0"
       - id: checkout
         uses: actions/checkout@v2
       - id: pkg_pub_integration_pub_get
@@ -778,15 +778,15 @@ jobs:
         uses: actions/cache@v2
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:2.10.0;packages:pkg/pub_integration;commands:test_10"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:2.12.0;packages:pkg/pub_integration;commands:test_10"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;dart:2.10.0;packages:pkg/pub_integration
-            os:ubuntu-latest;pub-cache-hosted;dart:2.10.0
+            os:ubuntu-latest;pub-cache-hosted;dart:2.12.0;packages:pkg/pub_integration
+            os:ubuntu-latest;pub-cache-hosted;dart:2.12.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - uses: dart-lang/setup-dart@v0.3
         with:
-          sdk: "2.10.0"
+          sdk: "2.12.0"
       - id: checkout
         uses: actions/checkout@v2
       - id: pkg_pub_integration_pub_get
@@ -812,15 +812,15 @@ jobs:
         uses: actions/cache@v2
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:2.10.0;packages:app;commands:test_02"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:2.12.0;packages:app;commands:test_02"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;dart:2.10.0;packages:app
-            os:ubuntu-latest;pub-cache-hosted;dart:2.10.0
+            os:ubuntu-latest;pub-cache-hosted;dart:2.12.0;packages:app
+            os:ubuntu-latest;pub-cache-hosted;dart:2.12.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - uses: dart-lang/setup-dart@v0.3
         with:
-          sdk: "2.10.0"
+          sdk: "2.12.0"
       - id: checkout
         uses: actions/checkout@v2
       - id: app_pub_get
@@ -846,15 +846,15 @@ jobs:
         uses: actions/cache@v2
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:2.10.0;packages:app;commands:test_03"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:2.12.0;packages:app;commands:test_03"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;dart:2.10.0;packages:app
-            os:ubuntu-latest;pub-cache-hosted;dart:2.10.0
+            os:ubuntu-latest;pub-cache-hosted;dart:2.12.0;packages:app
+            os:ubuntu-latest;pub-cache-hosted;dart:2.12.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - uses: dart-lang/setup-dart@v0.3
         with:
-          sdk: "2.10.0"
+          sdk: "2.12.0"
       - id: checkout
         uses: actions/checkout@v2
       - id: app_pub_get
@@ -880,15 +880,15 @@ jobs:
         uses: actions/cache@v2
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:2.10.0;packages:pkg/pub_integration;commands:test_09"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:2.12.0;packages:pkg/pub_integration;commands:test_09"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;dart:2.10.0;packages:pkg/pub_integration
-            os:ubuntu-latest;pub-cache-hosted;dart:2.10.0
+            os:ubuntu-latest;pub-cache-hosted;dart:2.12.0;packages:pkg/pub_integration
+            os:ubuntu-latest;pub-cache-hosted;dart:2.12.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - uses: dart-lang/setup-dart@v0.3
         with:
-          sdk: "2.10.0"
+          sdk: "2.12.0"
       - id: checkout
         uses: actions/checkout@v2
       - id: pkg_pub_integration_pub_get
@@ -914,15 +914,15 @@ jobs:
         uses: actions/cache@v2
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:2.10.0;packages:app;commands:test_00"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:2.12.0;packages:app;commands:test_00"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;dart:2.10.0;packages:app
-            os:ubuntu-latest;pub-cache-hosted;dart:2.10.0
+            os:ubuntu-latest;pub-cache-hosted;dart:2.12.0;packages:app
+            os:ubuntu-latest;pub-cache-hosted;dart:2.12.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - uses: dart-lang/setup-dart@v0.3
         with:
-          sdk: "2.10.0"
+          sdk: "2.12.0"
       - id: checkout
         uses: actions/checkout@v2
       - id: app_pub_get

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Important changes to data-models, configuration and migrations between each
 AppEngine version, listed here to ease deployment and troubleshooting.
 
 ## Next Release (replace with git tag when deployed)
+ * Bumped runtimeVersion to `2021.03.04`.
+ * Upgraded runtime Dart SDK to `2.12.0`.
 
 ## `20210303t195300-all`
  * Bumped runtimeVersion to `2021.03.03`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Keep version in-sync with .mono_repo.yml and app/lib/shared/versions.dart
-FROM google/dart-runtime-base:2.10.0
+FROM google/dart-runtime-base:2.12.0
 
 # `apt-mark hold dart` ensures that Dart is not upgraded with the other packages
 #   We want to make sure SDK upgrades are explicit.

--- a/app/lib/shared/versions.dart
+++ b/app/lib/shared/versions.dart
@@ -21,7 +21,8 @@ final RegExp runtimeVersionPattern = RegExp(r'^\d{4}\.\d{2}\.\d{2}$');
 /// Make sure that at least two versions are kept here as the next candidates
 /// when the version switch happens.
 const acceptedRuntimeVersions = <String>[
-  '2021.03.03', // The current [runtimeVersion].
+  '2021.03.04', // The current [runtimeVersion].
+  '2021.03.03',
   '2021.03.02',
   '2021.02.24',
 ];
@@ -52,7 +53,7 @@ bool shouldGCVersion(String version) =>
     version.compareTo(gcBeforeRuntimeVersion) < 0;
 
 // keep in-sync with SDK version in .mono_repo.yml and Dockerfile
-final String runtimeSdkVersion = '2.10.0';
+final String runtimeSdkVersion = '2.12.0';
 final String toolStableDartSdkVersion = '2.12.0';
 final String toolStableFlutterSdkVersion = '2.0.0';
 final String toolPreviewDartSdkVersion = '2.12.0';

--- a/app/mono_pkg.yaml
+++ b/app/mono_pkg.yaml
@@ -1,6 +1,6 @@
 # See https://github.com/dart-lang/mono_repo for details
 dart:
-  - 2.10.0
+  - 2.12.0
 
 stages:
   - smoke_test:

--- a/pkg/_popularity/mono_pkg.yaml
+++ b/pkg/_popularity/mono_pkg.yaml
@@ -1,6 +1,6 @@
 # See https://github.com/dart-lang/mono_repo for details
 dart:
-  - 2.10.0
+  - 2.12.0
 
 stages:
   - smoke_test:

--- a/pkg/api_builder/mono_pkg.yaml
+++ b/pkg/api_builder/mono_pkg.yaml
@@ -1,6 +1,6 @@
 # See https://github.com/dart-lang/mono_repo for details
 dart:
-  - 2.10.0
+  - 2.12.0
 
 stages:
   - smoke_test:

--- a/pkg/client_data/mono_pkg.yaml
+++ b/pkg/client_data/mono_pkg.yaml
@@ -1,6 +1,6 @@
 # See https://github.com/dart-lang/mono_repo for details
 dart:
-  - 2.10.0
+  - 2.12.0
 
 stages:
   - smoke_test:

--- a/pkg/fake_gcloud/mono_pkg.yaml
+++ b/pkg/fake_gcloud/mono_pkg.yaml
@@ -1,6 +1,6 @@
 # See https://pub.dev/packages/mono_repo for details on this file
 dart:
-  - 2.10.0
+  - 2.12.0
 
 stages:
   - smoke_test:

--- a/pkg/pub_dartdoc/mono_pkg.yaml
+++ b/pkg/pub_dartdoc/mono_pkg.yaml
@@ -1,6 +1,6 @@
 # See https://pub.dev/packages/mono_repo for details on this file
 dart:
-  - 2.10.0
+  - 2.12.0
 
 stages:
   - smoke_test:

--- a/pkg/pub_dartdoc_data/mono_pkg.yaml
+++ b/pkg/pub_dartdoc_data/mono_pkg.yaml
@@ -1,6 +1,6 @@
 # See https://pub.dev/packages/mono_repo for details on this file
 dart:
-  - 2.10.0
+  - 2.12.0
 
 stages:
   - smoke_test:

--- a/pkg/pub_integration/mono_pkg.yaml
+++ b/pkg/pub_integration/mono_pkg.yaml
@@ -1,6 +1,6 @@
 # See https://pub.dev/packages/mono_repo for details on this file
 dart:
-  - 2.10.0
+  - 2.12.0
 
 stages:
   - smoke_test:

--- a/pkg/pub_package_reader/mono_pkg.yaml
+++ b/pkg/pub_package_reader/mono_pkg.yaml
@@ -1,6 +1,6 @@
 # See https://pub.dev/packages/mono_repo for details on this file
 dart:
-  - 2.10.0
+  - 2.12.0
 
 stages:
   - smoke_test:

--- a/pkg/pub_validations/mono_pkg.yaml
+++ b/pkg/pub_validations/mono_pkg.yaml
@@ -1,6 +1,6 @@
 # See https://pub.dev/packages/mono_repo for details on this file
 dart:
-  - 2.10.0
+  - 2.12.0
 
 stages:
   - smoke_test:

--- a/pkg/web_app/mono_pkg.yaml
+++ b/pkg/web_app/mono_pkg.yaml
@@ -1,6 +1,6 @@
 # See https://pub.dev/packages/mono_repo for details on this file
 dart:
-  - 2.10.0
+  - 2.12.0
 
 stages:
   - smoke_test:

--- a/pkg/web_css/mono_pkg.yaml
+++ b/pkg/web_css/mono_pkg.yaml
@@ -1,6 +1,6 @@
 # See https://pub.dev/packages/mono_repo for details on this file
 dart:
-  - 2.10.0
+  - 2.12.0
 
 stages:
   - smoke_test:


### PR DESCRIPTION
- Only the SDK being used is updated, dependencies can be updated on a separate schedule.