### PR TITLE
First attempt at LatestReleases

### DIFF
--- a/app/lib/frontend/handlers/package.dart
+++ b/app/lib/frontend/handlers/package.dart
@@ -286,7 +286,11 @@ Future<PackagePageData> loadPackagePageData(
   final package = await packageBackend.lookupPackage(packageName);
   if (package == null || package.isNotVisible) {
     final moderated = await packageBackend.lookupModeratedPackage(packageName);
-    return PackagePageData.missing(package: null, moderatedPackage: moderated);
+    return PackagePageData.missing(
+      package: null,
+      latestReleases: null,
+      moderatedPackage: moderated,
+    );
   }
 
   final bool isLiked = (userSessionData == null)
@@ -299,13 +303,19 @@ Future<PackagePageData> loadPackagePageData(
   final selectedVersion =
       await packageBackend.lookupPackageVersion(packageName, versionName);
   if (selectedVersion == null) {
-    return PackagePageData.missing(package: package);
+    return PackagePageData.missing(
+      package: package,
+      latestReleases: await packageBackend.latestReleases(package),
+    );
   }
 
   final versionInfo =
       await packageBackend.lookupPackageVersionInfo(packageName, versionName);
   if (versionInfo == null) {
-    return PackagePageData.missing(package: package);
+    return PackagePageData.missing(
+      package: package,
+      latestReleases: await packageBackend.latestReleases(package),
+    );
   }
 
   final asset = assetKind == null
@@ -324,6 +334,7 @@ Future<PackagePageData> loadPackagePageData(
 
   return PackagePageData(
     package: package,
+    latestReleases: package.latestReleases,
     version: selectedVersion,
     versionInfo: versionInfo,
     asset: asset,

--- a/app/lib/frontend/templates/package.dart
+++ b/app/lib/frontend/templates/package.dart
@@ -209,8 +209,8 @@ String renderPkgInfoBox(PackagePageData data) {
 /// wraps it with content-header.
 String renderPkgHeader(PackagePageData data) {
   final package = data.package;
-  final showPrereleaseVersion = package.showPrereleaseVersion;
-  final showPreviewVersion = package.showPreviewVersion;
+  final showPrereleaseVersion = data.latestReleases.showPrerelease;
+  final showPreviewVersion = data.latestReleases.showPreview;
   final bool showUpdated =
       !data.isLatestStable || showPrereleaseVersion || showPreviewVersion;
 

--- a/app/lib/job/backend.dart
+++ b/app/lib/job/backend.dart
@@ -69,8 +69,9 @@ class JobBackend {
       _logger.info("Couldn't trigger $service job: $package not found.");
       return;
     }
+    final latestReleases = await packageBackend.latestReleases(p);
 
-    version ??= p.latestVersion;
+    version ??= latestReleases.stable.version;
     final pvKey = pKey.append(PackageVersion, id: version);
     final list = await _db.lookup([pvKey]);
     final pv = list[0] as PackageVersion;
@@ -81,10 +82,10 @@ class JobBackend {
     }
 
     final isLatestStable = p.latestVersion == version;
-    final isLatestPrerelease =
-        p.showPrereleaseVersion && p.latestPrereleaseVersion == version;
+    final isLatestPrerelease = latestReleases.showPrerelease &&
+        latestReleases.prerelease.version == version;
     final isLatestPreview =
-        p.showPreviewVersion && p.latestPreviewVersion == version;
+        latestReleases.showPreview && latestReleases.preview.version == version;
     shouldProcess ??= updated == null || updated.isAfter(pv.created);
     shouldProcess |= isHighPriority;
     await createOrUpdate(

--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -175,6 +175,12 @@ class PackageBackend {
         .cast();
   }
 
+  /// Returns the latest releases info of a package.
+  Future<LatestReleases> latestReleases(Package package) async {
+    // TODO: implement runtimeVersion-specific release calculation
+    return package.latestReleases;
+  }
+
   /// Looks up a specific package version.
   ///
   /// Returns null if the version is not a semantic version or if the version

--- a/app/lib/package/models.g.dart
+++ b/app/lib/package/models.g.dart
@@ -6,6 +6,41 @@ part of pub_dartlang_org.appengine_repository.models;
 // JsonSerializableGenerator
 // **************************************************************************
 
+LatestReleases _$LatestReleasesFromJson(Map<String, dynamic> json) {
+  return LatestReleases(
+    stable: json['stable'] == null
+        ? null
+        : Release.fromJson(json['stable'] as Map<String, dynamic>),
+    prerelease: json['prerelease'] == null
+        ? null
+        : Release.fromJson(json['prerelease'] as Map<String, dynamic>),
+    preview: json['preview'] == null
+        ? null
+        : Release.fromJson(json['preview'] as Map<String, dynamic>),
+  );
+}
+
+Map<String, dynamic> _$LatestReleasesToJson(LatestReleases instance) =>
+    <String, dynamic>{
+      'stable': instance.stable,
+      'prerelease': instance.prerelease,
+      'preview': instance.preview,
+    };
+
+Release _$ReleaseFromJson(Map<String, dynamic> json) {
+  return Release(
+    version: json['version'] as String,
+    published: json['published'] == null
+        ? null
+        : DateTime.parse(json['published'] as String),
+  );
+}
+
+Map<String, dynamic> _$ReleaseToJson(Release instance) => <String, dynamic>{
+      'version': instance.version,
+      'published': instance.published?.toIso8601String(),
+    };
+
 PackageView _$PackageViewFromJson(Map<String, dynamic> json) {
   return PackageView(
     isExternal: json['isExternal'] as bool,


### PR DESCRIPTION
- This is the very first step towards runtime-versioned previewVersion calculation.
- It seems that many parts of the codebase depend on these values, and it seems to be better to first refactor them to use the same access pattern.
- `Release` may contain the SDK constraint info later - if needed.