### PR TITLE
Update the previous DartdocRun.wasLatestStable when there was a regression.

### DIFF
--- a/app/lib/dartdoc/dartdoc_runner.dart
+++ b/app/lib/dartdoc/dartdoc_runner.dart
@@ -250,13 +250,13 @@ class DartdocJobProcessor extends JobProcessor {
           await dartdocBackend.getEntry(job.packageName, job.packageVersion);
       if (entry.isRegression(oldEntry)) {
         logger.severe('Regression detected in $job, aborting upload.');
-        // If `isLatest` or `isObsolete` have changed, we still want to update
-        // the old entry, even if the job failed. `isLatest` is used to redirect
-        // latest versions from versioned url to url with `/latest/`, and this
+        // If `isLatest` has changed, we still want to update the old entry,
+        // even if the job failed. `isLatest` is used to redirect latest
+        // versions from versioned url to url with `/latest/`, and this
         // is cheaper than checking it on each request.
-        if (oldEntry.isLatest != entry.isLatest ||
-            oldEntry.isObsolete != entry.isObsolete) {
-          await dartdocBackend.updateOldEntry(oldEntry, entry);
+        if (oldEntry.isLatest != entry.isLatest) {
+          await dartdocBackend.updateOldIsLatest(oldEntry,
+              isLatest: entry.isLatest);
         }
       } else {
         await dartdocBackend.uploadDir(entry, outputDir);

--- a/app/lib/dartdoc/models.dart
+++ b/app/lib/dartdoc/models.dart
@@ -209,13 +209,13 @@ class DartdocEntry {
 
   /// Creates a new instance, copying fields that are not specified, overriding
   /// the ones that are.
-  DartdocEntry replace({bool isLatest, bool isObsolete}) {
+  DartdocEntry replace({bool isLatest}) {
     return DartdocEntry(
       uuid: uuid,
       packageName: packageName,
       packageVersion: packageVersion,
       isLatest: isLatest ?? this.isLatest,
-      isObsolete: isObsolete ?? this.isObsolete,
+      isObsolete: isObsolete,
       usesFlutter: usesFlutter,
       runtimeVersion: runtimeVersion,
       sdkVersion: sdkVersion,


### PR DESCRIPTION
- We don't use the `isObsolete` information in the content serving decision, no need to retroactively update it.
- We shall update the Datastore entity too.