### PR TITLE
Migrate admin API tests to test-profile.

### DIFF
--- a/app/lib/tool/test_profile/models.dart
+++ b/app/lib/tool/test_profile/models.dart
@@ -39,6 +39,15 @@ class TestProfile {
   }
 
   Map<String, dynamic> toJson() => _$TestProfileToJson(this);
+
+  TestProfile changeDefaultUser(String email) {
+    return TestProfile(
+      packages: packages,
+      publishers: publishers,
+      users: users,
+      defaultUser: email,
+    );
+  }
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)


### PR DESCRIPTION
- with the test profile the userIds are not deterministic, that forced me to change some test asserts
- also added a method to the `TestProfile`, maybe it could live only in the test if it is not useful enough