### PR TITLE
Fix URL rewrite in bad markdown.

### DIFF
--- a/app/lib/shared/markdown.dart
+++ b/app/lib/shared/markdown.dart
@@ -222,9 +222,9 @@ class _RelativeUrlRewriter implements m.NodeVisitor {
   void visitElementAfter(m.Element element) {
     // check current element
     if (element.tag == 'a') {
-      _updateAttributes(element, 'href');
+      _updateUrlAttributes(element, 'href');
     } else if (element.tag == 'img') {
-      _updateAttributes(element, 'src', raw: true);
+      _updateUrlAttributes(element, 'src', raw: true);
     }
     // remove children that are marked to be removed
     if (element.children != null &&
@@ -243,7 +243,7 @@ class _RelativeUrlRewriter implements m.NodeVisitor {
     }
   }
 
-  void _updateAttributes(m.Element element, String attrName,
+  void _updateUrlAttributes(m.Element element, String attrName,
       {bool raw = false}) {
     final newUrl = _rewriteUrl(element.attributes[attrName], raw: raw);
     if (newUrl != null) {

--- a/app/test/shared/markdown_test.dart
+++ b/app/test/shared/markdown_test.dart
@@ -217,6 +217,11 @@ void main() {
       expect(markdownToHtml('[a][b]', baseUrl: 'http://www.example.com/'),
           '<p>[a][b]</p>\n');
     });
+
+    test('bad image link with attribute', () {
+      expect(markdownToHtml('![demo](src="https://github.com/a/b/c.gif")'),
+          '<p></p>\n');
+    });
   });
 
   group('non-whitelisted inline HTML', () {

--- a/app/test/shared/markdown_test.dart
+++ b/app/test/shared/markdown_test.dart
@@ -218,6 +218,18 @@ void main() {
           '<p>[a][b]</p>\n');
     });
 
+    test('bad link, keeping link content', () {
+      expect(markdownToHtml('[awesome](href="https://github.com/a/b/c.gif")'),
+          '<p>awesome</p>\n');
+    });
+
+    test('complex link inside a quote, keeping link content', () {
+      expect(
+          markdownToHtml(
+              '> [**awesome**](href="https://github.com/a/b/c.gif")'),
+          '<blockquote>\n<p><strong>awesome</strong></p>\n</blockquote>\n');
+    });
+
     test('bad image link with attribute', () {
       expect(markdownToHtml('![demo](src="https://github.com/a/b/c.gif")'),
           '<p></p>\n');

--- a/app/test/shared/markdown_test.dart
+++ b/app/test/shared/markdown_test.dart
@@ -218,9 +218,9 @@ void main() {
           '<p>[a][b]</p>\n');
     });
 
-    test('bad link, keeping link content', () {
-      expect(markdownToHtml('[awesome](href="https://github.com/a/b/c.gif")'),
-          '<p>awesome</p>\n');
+    test('bad link, keeping link text', () {
+      expect(markdownToHtml('[my illegal url](http://illegal@@thing)'),
+          '<p>my illegal url</p>\n');
     });
 
     test('complex link inside a quote, keeping link content', () {


### PR DESCRIPTION
- Fixes #4627.
- Urls that do not parse will be removed alongside with the enclosing element.