### PR TITLE
Display dependency constraint in package infobox on hover.

### DIFF
--- a/app/lib/frontend/templates/package.dart
+++ b/app/lib/frontend/templates/package.dart
@@ -7,7 +7,7 @@ import 'dart:convert';
 import 'package:client_data/page_data.dart';
 import 'package:meta/meta.dart';
 import 'package:pana/pana.dart' show getRepositoryUrl, LicenseNames;
-import 'package:pub_dev/shared/handlers.dart';
+import 'package:pubspec_parse/pubspec_parse.dart' show HostedDependency;
 
 import '../../package/model_properties.dart';
 import '../../package/models.dart';
@@ -15,6 +15,7 @@ import '../../package/overrides.dart'
     show devDependencyPackages, redirectPackageUrls;
 import '../../search/search_form.dart';
 import '../../shared/email.dart' show EmailAddress;
+import '../../shared/handlers.dart';
 import '../../shared/tags.dart';
 import '../../shared/urls.dart' as urls;
 
@@ -51,14 +52,21 @@ String _renderLicense(PackagePageData data) {
 
 String _renderDependencyList(Pubspec pubspec) {
   if (pubspec == null) return null;
-  final packages = pubspec.dependencies.toList()..sort();
+  final dependencies = pubspec.dependencies;
+  final packages = dependencies.keys.toList()..sort();
   if (packages.isEmpty) return null;
   return packages.map((p) {
+    final dep = dependencies[p];
     var href = redirectPackageUrls[p];
-    if (href == null && pubspec.isHostedDependency(p)) {
+    String constraint;
+    if (href == null && dep is HostedDependency) {
       href = urls.pkgPageUrl(p);
+      constraint = dep.version.toString();
     }
-    return href == null ? p : '<a href="$href">$p</a>';
+    final title = constraint == null
+        ? ''
+        : ' title="${htmlAttrEscape.convert(constraint)}"';
+    return href == null ? p : '<a href="$href"$title>$p</a>';
   }).join(', ');
 }
 

--- a/app/lib/package/deps_graph.dart
+++ b/app/lib/package/deps_graph.dart
@@ -162,7 +162,7 @@ class PackageDependencyBuilder {
   }
 
   void addPackageVersion(PackageVersion pv) {
-    final Set<String> depsSet = Set<String>.from(pv.pubspec.dependencies);
+    final Set<String> depsSet = Set<String>.from(pv.pubspec.dependencyNames);
     final Set<String> devDepsSet = Set<String>.from(pv.pubspec.devDependencies);
 
     // First we add the [package] together with the dependencies /

--- a/app/lib/package/model_properties.dart
+++ b/app/lib/package/model_properties.dart
@@ -9,7 +9,7 @@ import 'dart:convert';
 import 'package:pana/pana.dart' show SdkConstraintStatus;
 import 'package:pub_semver/pub_semver.dart';
 import 'package:pubspec_parse/pubspec_parse.dart' as pubspek
-    show HostedDependency, Pubspec;
+    show Dependency, Pubspec;
 import 'package:yaml/yaml.dart';
 
 import '../shared/datastore.dart';
@@ -61,12 +61,8 @@ class Pubspec {
     return _canonicalVersion;
   }
 
-  Iterable<String> get dependencies => _inner.dependencies.keys;
-
-  bool isHostedDependency(String package) {
-    final d = _inner.dependencies[package];
-    return d is pubspek.HostedDependency;
-  }
+  Iterable<String> get dependencyNames => _inner.dependencies.keys;
+  Map<String, pubspek.Dependency> get dependencies => _inner.dependencies;
 
   Iterable<String> get devDependencies => _inner.devDependencies.keys;
 

--- a/app/lib/search/backend.dart
+++ b/app/lib/search/backend.dart
@@ -185,7 +185,7 @@ class SearchBackend {
     pubspec.devDependencies.forEach((package) {
       dependencies[package] = DependencyTypes.dev;
     });
-    pubspec.dependencies.forEach((package) {
+    pubspec.dependencyNames.forEach((package) {
       dependencies[package] = DependencyTypes.direct;
     });
     return dependencies;

--- a/app/test/frontend/golden/pkg_admin_page_outdated.html
+++ b/app/test/frontend/golden/pkg_admin_page_outdated.html
@@ -342,7 +342,7 @@
             </p>
             <h3 class="title">Dependencies</h3>
             <p>
-              <a href="/packages/gcloud">gcloud</a>
+              <a href="/packages/gcloud" title="any">gcloud</a>
             </p>
             <h3 class="title">More</h3>
             <p>
@@ -394,7 +394,7 @@
           </p>
           <h3 class="title">Dependencies</h3>
           <p>
-            <a href="/packages/gcloud">gcloud</a>
+            <a href="/packages/gcloud" title="any">gcloud</a>
           </p>
           <h3 class="title">More</h3>
           <p>

--- a/app/test/frontend/golden/pkg_changelog_page.html
+++ b/app/test/frontend/golden/pkg_changelog_page.html
@@ -252,7 +252,7 @@
             </p>
             <h3 class="title">Dependencies</h3>
             <p>
-              <a href="/packages/gcloud">gcloud</a>
+              <a href="/packages/gcloud" title="any">gcloud</a>
             </p>
             <h3 class="title">More</h3>
             <p>
@@ -310,7 +310,7 @@
           </p>
           <h3 class="title">Dependencies</h3>
           <p>
-            <a href="/packages/gcloud">gcloud</a>
+            <a href="/packages/gcloud" title="any">gcloud</a>
           </p>
           <h3 class="title">More</h3>
           <p>

--- a/app/test/frontend/golden/pkg_example_page.html
+++ b/app/test/frontend/golden/pkg_example_page.html
@@ -253,7 +253,7 @@
             </p>
             <h3 class="title">Dependencies</h3>
             <p>
-              <a href="/packages/gcloud">gcloud</a>
+              <a href="/packages/gcloud" title="any">gcloud</a>
             </p>
             <h3 class="title">More</h3>
             <p>
@@ -311,7 +311,7 @@
           </p>
           <h3 class="title">Dependencies</h3>
           <p>
-            <a href="/packages/gcloud">gcloud</a>
+            <a href="/packages/gcloud" title="any">gcloud</a>
           </p>
           <h3 class="title">More</h3>
           <p>

--- a/app/test/frontend/golden/pkg_install_page.html
+++ b/app/test/frontend/golden/pkg_install_page.html
@@ -275,7 +275,7 @@
             </p>
             <h3 class="title">Dependencies</h3>
             <p>
-              <a href="/packages/gcloud">gcloud</a>
+              <a href="/packages/gcloud" title="any">gcloud</a>
             </p>
             <h3 class="title">More</h3>
             <p>
@@ -333,7 +333,7 @@
           </p>
           <h3 class="title">Dependencies</h3>
           <p>
-            <a href="/packages/gcloud">gcloud</a>
+            <a href="/packages/gcloud" title="any">gcloud</a>
           </p>
           <h3 class="title">More</h3>
           <p>

--- a/app/test/frontend/golden/pkg_score_page.html
+++ b/app/test/frontend/golden/pkg_score_page.html
@@ -307,7 +307,7 @@
             </p>
             <h3 class="title">Dependencies</h3>
             <p>
-              <a href="/packages/gcloud">gcloud</a>
+              <a href="/packages/gcloud" title="any">gcloud</a>
             </p>
             <h3 class="title">More</h3>
             <p>
@@ -365,7 +365,7 @@
           </p>
           <h3 class="title">Dependencies</h3>
           <p>
-            <a href="/packages/gcloud">gcloud</a>
+            <a href="/packages/gcloud" title="any">gcloud</a>
           </p>
           <h3 class="title">More</h3>
           <p>

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -255,7 +255,7 @@
             </p>
             <h3 class="title">Dependencies</h3>
             <p>
-              <a href="/packages/gcloud">gcloud</a>
+              <a href="/packages/gcloud" title="any">gcloud</a>
             </p>
             <h3 class="title">More</h3>
             <p>
@@ -313,7 +313,7 @@
           </p>
           <h3 class="title">Dependencies</h3>
           <p>
-            <a href="/packages/gcloud">gcloud</a>
+            <a href="/packages/gcloud" title="any">gcloud</a>
           </p>
           <h3 class="title">More</h3>
           <p>

--- a/app/test/frontend/golden/pkg_show_page_discontinued.html
+++ b/app/test/frontend/golden/pkg_show_page_discontinued.html
@@ -251,7 +251,7 @@
             </p>
             <h3 class="title">Dependencies</h3>
             <p>
-              <a href="/packages/gcloud">gcloud</a>
+              <a href="/packages/gcloud" title="any">gcloud</a>
             </p>
             <h3 class="title">More</h3>
             <p>
@@ -308,7 +308,7 @@
           </p>
           <h3 class="title">Dependencies</h3>
           <p>
-            <a href="/packages/gcloud">gcloud</a>
+            <a href="/packages/gcloud" title="any">gcloud</a>
           </p>
           <h3 class="title">More</h3>
           <p>

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -253,7 +253,7 @@
             </p>
             <h3 class="title">Dependencies</h3>
             <p>
-              <a href="/packages/gcloud">gcloud</a>
+              <a href="/packages/gcloud" title="any">gcloud</a>
             </p>
             <h3 class="title">More</h3>
             <p>
@@ -306,7 +306,7 @@
           </p>
           <h3 class="title">Dependencies</h3>
           <p>
-            <a href="/packages/gcloud">gcloud</a>
+            <a href="/packages/gcloud" title="any">gcloud</a>
           </p>
           <h3 class="title">More</h3>
           <p>

--- a/app/test/frontend/golden/pkg_show_page_legacy.html
+++ b/app/test/frontend/golden/pkg_show_page_legacy.html
@@ -251,7 +251,7 @@
             </p>
             <h3 class="title">Dependencies</h3>
             <p>
-              <a href="/packages/gcloud">gcloud</a>
+              <a href="/packages/gcloud" title="any">gcloud</a>
             </p>
             <h3 class="title">More</h3>
             <p>
@@ -308,7 +308,7 @@
           </p>
           <h3 class="title">Dependencies</h3>
           <p>
-            <a href="/packages/gcloud">gcloud</a>
+            <a href="/packages/gcloud" title="any">gcloud</a>
           </p>
           <h3 class="title">More</h3>
           <p>

--- a/app/test/frontend/golden/pkg_show_page_outdated.html
+++ b/app/test/frontend/golden/pkg_show_page_outdated.html
@@ -247,7 +247,7 @@
             </p>
             <h3 class="title">Dependencies</h3>
             <p>
-              <a href="/packages/gcloud">gcloud</a>
+              <a href="/packages/gcloud" title="any">gcloud</a>
             </p>
             <h3 class="title">More</h3>
             <p>
@@ -300,7 +300,7 @@
           </p>
           <h3 class="title">Dependencies</h3>
           <p>
-            <a href="/packages/gcloud">gcloud</a>
+            <a href="/packages/gcloud" title="any">gcloud</a>
           </p>
           <h3 class="title">More</h3>
           <p>

--- a/app/test/frontend/golden/pkg_show_version_page.html
+++ b/app/test/frontend/golden/pkg_show_version_page.html
@@ -235,7 +235,7 @@
             </p>
             <h3 class="title">Dependencies</h3>
             <p>
-              <a href="/packages/gcloud">gcloud</a>
+              <a href="/packages/gcloud" title="any">gcloud</a>
             </p>
             <h3 class="title">More</h3>
             <p>
@@ -288,7 +288,7 @@
           </p>
           <h3 class="title">Dependencies</h3>
           <p>
-            <a href="/packages/gcloud">gcloud</a>
+            <a href="/packages/gcloud" title="any">gcloud</a>
           </p>
           <h3 class="title">More</h3>
           <p>

--- a/app/test/frontend/golden/pkg_versions_page.html
+++ b/app/test/frontend/golden/pkg_versions_page.html
@@ -327,7 +327,7 @@
             </p>
             <h3 class="title">Dependencies</h3>
             <p>
-              <a href="/packages/gcloud">gcloud</a>
+              <a href="/packages/gcloud" title="any">gcloud</a>
             </p>
             <h3 class="title">More</h3>
             <p>
@@ -380,7 +380,7 @@
           </p>
           <h3 class="title">Dependencies</h3>
           <p>
-            <a href="/packages/gcloud">gcloud</a>
+            <a href="/packages/gcloud" title="any">gcloud</a>
           </p>
           <h3 class="title">More</h3>
           <p>


### PR DESCRIPTION
#4608 

This is using the `title` attribute, e.g.:
<img width="207" alt="Screenshot 2021-03-17 at 15 24 59" src="https://user-images.githubusercontent.com/4778111/111485289-c9e2cd80-8736-11eb-9ec1-e2d60b71b8dd.png">

Once we have a design for SDK constraints, we could apply the same here.