### PR TITLE
Migrate Package property use to LatestReleases.

### DIFF
--- a/app/lib/frontend/handlers/package.dart
+++ b/app/lib/frontend/handlers/package.dart
@@ -334,7 +334,7 @@ Future<PackagePageData> loadPackagePageData(
 
   return PackagePageData(
     package: package,
-    latestReleases: package.latestReleases,
+    latestReleases: await packageBackend.latestReleases(package),
     version: selectedVersion,
     versionInfo: versionInfo,
     asset: asset,

--- a/app/lib/frontend/templates/package.dart
+++ b/app/lib/frontend/templates/package.dart
@@ -242,12 +242,14 @@ String renderPkgHeader(PackagePageData data) {
           ? urls.pkgPageUrl(package.name,
               version: data.latestReleases.prerelease.version)
           : null,
-      'prerelease_version': data.latestReleases.prerelease.version,
+      'prerelease_version':
+          showPrereleaseVersion ? data.latestReleases.prerelease.version : null,
       'preview_url': showPreviewVersion
           ? urls.pkgPageUrl(package.name,
               version: data.latestReleases.preview.version)
           : null,
-      'preview_version': data.latestReleases.preview.version,
+      'preview_version':
+          showPreviewVersion ? data.latestReleases.preview.version : null,
     },
     'short_created': data.version.shortCreated,
   });

--- a/app/lib/frontend/templates/package.dart
+++ b/app/lib/frontend/templates/package.dart
@@ -237,14 +237,17 @@ String renderPkgHeader(PackagePageData data) {
       'show_prerelease_version': showPrereleaseVersion,
       'show_preview_version': showPreviewVersion,
       'stable_url': urls.pkgPageUrl(package.name),
-      'stable_version': package.latestVersion,
-      'prerelease_url': urls.pkgPageUrl(package.name,
-          version: package.latestPrereleaseVersion),
-      'prerelease_version': package.latestPrereleaseVersion,
-      'preview_url': showPreviewVersion
-          ? urls.pkgPageUrl(package.name, version: package.latestPreviewVersion)
+      'stable_version': data.latestReleases.stable.version,
+      'prerelease_url': showPrereleaseVersion
+          ? urls.pkgPageUrl(package.name,
+              version: data.latestReleases.prerelease.version)
           : null,
-      'preview_version': package.latestPreviewVersion,
+      'prerelease_version': data.latestReleases.prerelease.version,
+      'preview_url': showPreviewVersion
+          ? urls.pkgPageUrl(package.name,
+              version: data.latestReleases.preview.version)
+          : null,
+      'preview_version': data.latestReleases.preview.version,
     },
     'short_created': data.version.shortCreated,
   });

--- a/app/lib/frontend/templates/package_versions.dart
+++ b/app/lib/frontend/templates/package_versions.dart
@@ -28,10 +28,12 @@ String renderPkgVersionsPage(
   final previewVersionRows = <String>[];
   final stableVersionRows = <String>[];
   final prereleaseVersionRows = <String>[];
-  final latestPrereleaseVersion = versions.firstWhere(
-    (v) => v.version == data.package.latestPrereleaseVersion,
-    orElse: () => null,
-  );
+  final latestPrereleaseVersion = data.latestReleases.showPrerelease
+      ? versions.firstWhere(
+          (v) => v.version == data.latestReleases.prerelease.version,
+          orElse: () => null,
+        )
+      : null;
   for (int i = 0; i < versions.length; i++) {
     final version = versions[i];
     final url = versionDownloadUrls[i].toString();
@@ -49,7 +51,7 @@ String renderPkgVersionsPage(
   final htmlBlocks = <String>[];
   if (stableVersionRows.isNotEmpty &&
       prereleaseVersionRows.isNotEmpty &&
-      data.package.showPrereleaseVersion) {
+      data.latestReleases.showPrerelease) {
     htmlBlocks.add(
         '<p>The latest prerelease was <a href="#prerelease">${latestPrereleaseVersion.version}</a> '
         'on ${latestPrereleaseVersion.shortCreated}.</p>');

--- a/app/lib/job/job.dart
+++ b/app/lib/job/job.dart
@@ -171,11 +171,12 @@ class JobMaintenance {
       try {
         if (!await packageBackend.isPackageVisible(pv.package)) return;
         final p = packages[pv.package];
-        final isLatestStable = p.latestVersion == pv.version;
-        final isLatestPrerelease =
-            p.showPrereleaseVersion && p.latestPrereleaseVersion == pv.version;
+        final releases = await packageBackend.latestReleases(p);
+        final isLatestStable = releases.stable.version == pv.version;
+        final isLatestPrerelease = releases.showPrerelease &&
+            releases.prerelease.version == pv.version;
         final isLatestPreview =
-            p.showPreviewVersion && p.latestPreviewVersion == pv.version;
+            releases.showPreview && releases.preview.version == pv.version;
         if (isLatestStable && skipLatestStable) return;
         final shouldProcess = await _processor.shouldProcess(pv, pv.created);
         await jobBackend.createOrUpdate(

--- a/app/lib/package/models.dart
+++ b/app/lib/package/models.dart
@@ -292,8 +292,8 @@ class LatestReleases {
 
   LatestReleases({
     @required this.stable,
-    @required this.prerelease,
-    @required this.preview,
+    this.prerelease,
+    this.preview,
   });
 
   factory LatestReleases.fromJson(Map<String, dynamic> json) =>
@@ -301,8 +301,9 @@ class LatestReleases {
 
   Map<String, dynamic> toJson() => _$LatestReleasesToJson(this);
 
-  bool get showPrerelease => prerelease != null;
-  bool get showPreview => preview != null;
+  bool get showPrerelease =>
+      prerelease != null && stable.version != prerelease.version;
+  bool get showPreview => preview != null && stable.version != preview.version;
 }
 
 @JsonSerializable()
@@ -338,7 +339,7 @@ class PackageVersion extends db.ExpandoModel<String> {
   db.Key packageKey;
 
   /// [DateTime] when [version] of [package] was published.
-  @db.DateTimeProperty(/* required: true */) // TODO: Enable after testing
+  @db.DateTimeProperty(required: true)
   DateTime created;
 
   // Extracted data from the uploaded package.

--- a/app/lib/package/search_adapter.dart
+++ b/app/lib/package/search_adapter.dart
@@ -147,7 +147,8 @@ class SearchAdapter {
         return null;
       }
 
-      final version = p.latestVersion;
+      final releases = await packageBackend.latestReleases(p);
+      final version = releases.stable.version;
       final pvFuture = packageBackend.lookupPackageVersion(package, version);
       final cardFuture = scoreCardBackend.getScoreCardData(package, version);
       await Future.wait([pvFuture, cardFuture]);

--- a/app/lib/search/backend.dart
+++ b/app/lib/search/backend.dart
@@ -76,14 +76,14 @@ class SearchBackend {
   /// When a package, or its latest version is missing, the method throws
   /// [RemovedPackageException].
   Future<PackageDocument> loadDocument(String packageName) async {
-    final packageKey = _db.emptyKey.append(Package, id: packageName);
-    final p = (await _db.lookup<Package>([packageKey])).single;
+    final p = await packageBackend.lookupPackage(packageName);
     if (p == null || p.isNotVisible) {
       throw RemovedPackageException();
     }
+    final releases = await packageBackend.latestReleases(p);
 
-    final pv = await _db.lookupValue<PackageVersion>(p.latestVersionKey,
-        orElse: () => null);
+    final pv = await packageBackend.lookupPackageVersion(
+        packageName, releases.stable.version);
     if (pv == null) {
       throw RemovedPackageException();
     }
@@ -93,36 +93,26 @@ class SearchBackend {
     final analysisView =
         await analyzerClient.getAnalysisView(packageName, pv.version);
 
-    // Find tags from latest prerelease (if there one)
+    // Find tags from latest prerelease and/or preview (if there one)
     // This allows searching for tags with `<tag>-in-prerelease`.
     // Example: `is:null-safe-in-prerelease`, or `platform:android-in-prerelease`
-    final prereleaseTags = <String>[];
-    if (p.showPrereleaseVersion) {
-      final prv = await _db.lookupValue<PackageVersion>(
-          p.latestPrereleaseVersionKey,
-          orElse: () => null);
-      prv?.getTags()?.forEach(prereleaseTags.add);
+    Future<List<String>> loadTags(String version) async {
+      final tags = <String>[];
+      final prv =
+          await packageBackend.lookupPackageVersion(packageName, version);
+      prv?.getTags()?.forEach(tags.add);
 
-      final pra = await analyzerClient.getAnalysisView(
-          packageName, p.latestPrereleaseVersion);
-      pra?.derivedTags?.forEach(prereleaseTags.add);
+      final pra = await analyzerClient.getAnalysisView(packageName, version);
+      pra?.derivedTags?.forEach(tags.add);
+      return tags;
     }
 
-    // Find tags from latest preview (if there one) following the same patter
-    // as for prerelease.
-    // This allows searching for tags with `<tag>-in-prerelease`.
-    // Example: `is:null-safe-in-prerelease`, or `platform:android-in-prerelease`
-    final previewTags = <String>[];
-    if (p.showPreviewVersion) {
-      final prv = await _db.lookupValue<PackageVersion>(
-          p.latestPreviewVersionKey,
-          orElse: () => null);
-      prv?.getTags()?.forEach(previewTags.add);
-
-      final pra = await analyzerClient.getAnalysisView(
-          packageName, p.latestPreviewVersion);
-      pra?.derivedTags?.forEach(previewTags.add);
-    }
+    final prereleaseTags = releases.showPrerelease
+        ? await loadTags(releases.prerelease.version)
+        : <String>[];
+    final previewTags = releases.showPreview
+        ? await loadTags(releases.preview.version)
+        : <String>[];
 
     final tags = <String>{
       ...p.getTags(),
@@ -159,7 +149,7 @@ class SearchBackend {
 
     return PackageDocument(
       package: pv.package,
-      version: p.latestVersion,
+      version: pv.version,
       tags: tags.toList(),
       description: compactDescription(pv.pubspec.description),
       created: p.created,
@@ -210,10 +200,11 @@ class SearchBackend {
   Stream<PackageDocument> loadMinimumPackageIndex() async* {
     final query = _db.query<Package>();
     await for (final p in query.run()) {
+      final releases = await packageBackend.latestReleases(p);
       final popularity = popularityStorage.lookup(p.name) ?? 0.0;
       yield PackageDocument(
         package: p.name,
-        version: p.latestVersion,
+        version: releases.stable.version,
         tags: p.getTags(),
         created: p.created,
         updated: p.lastVersionPublished,

--- a/app/lib/shared/handler_helpers.dart
+++ b/app/lib/shared/handler_helpers.dart
@@ -196,7 +196,6 @@ shelf.Handler _logRequestWrapper(Logger logger, shelf.Handler handler) {
     } catch (error, st) {
       logger.severe('Request handler failed', error, Trace.from(st));
 
-      print(st);
       final title = 'Pub is not feeling well';
       Map<String, String> debugHeaders;
       if (context.traceId != null) {

--- a/app/lib/shared/handler_helpers.dart
+++ b/app/lib/shared/handler_helpers.dart
@@ -196,6 +196,7 @@ shelf.Handler _logRequestWrapper(Logger logger, shelf.Handler handler) {
     } catch (error, st) {
       logger.severe('Request handler failed', error, Trace.from(st));
 
+      print(st);
       final title = 'Pub is not feeling well';
       Map<String, String> debugHeaders;
       if (context.traceId != null) {


### PR DESCRIPTION
- Migrated most non-backend uses of latest stable/prerelease/preview uses to the `LatestReleases` and with the backend function with the async API.
- Also added `required: true` to `PackageVersion.created`, which is already used as always present in many places.