### PR TITLE
Restructured dartdoc runner + fixed inefficient Job handling.

### DIFF
--- a/app/lib/fake/backend/fake_dartdoc_runner.dart
+++ b/app/lib/fake/backend/fake_dartdoc_runner.dart
@@ -1,0 +1,88 @@
+// Copyright (c) 2021, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert';
+import 'dart:io';
+import 'dart:math';
+
+import 'package:meta/meta.dart';
+import 'package:pana/pana.dart' show ToolEnvironment;
+import 'package:path/path.dart' as p;
+import 'package:pub_dartdoc_data/pub_dartdoc_data.dart';
+
+import '../../dartdoc/dartdoc_runner.dart';
+
+/// Generates dartdoc content and results based on a deterministic random seed.
+class FakeDartdocRunner implements DartdocRunner {
+  @override
+  Future<DartdocRunnerResult> generateSdkDocs({
+    @required String outputDir,
+  }) async {
+    final file = File(p.join(outputDir, 'pub-data.json'));
+    final pubData = PubDartdocData(
+      coverage: Coverage(documented: 1000, total: 1000),
+      apiElements: [
+        // TODO: add fake Dart SDK library elements.
+      ],
+    );
+    await file.writeAsString(json.encode(pubData.toJson()));
+    return DartdocRunnerResult(
+      args: ['fake_dartdoc', '--sdk'],
+      processResult: ProcessResult(0, 0, 'OK', ''),
+    );
+  }
+
+  @override
+  Future<void> downloadAndExtract({
+    @required String package,
+    @required String version,
+    @required String destination,
+  }) async {
+    // no-op
+  }
+
+  @override
+  Future<ProcessResult> runPubUpgrade({
+    @required ToolEnvironment toolEnv,
+    @required String pkgPath,
+    @required bool usesFlutter,
+  }) async {
+    // no-op
+    return ProcessResult(0, 0, 'OK', '');
+  }
+
+  @override
+  Future<DartdocRunnerResult> generatePackageDocs({
+    @required String package,
+    @required String version,
+    @required String pkgPath,
+    @required String canonicalUrl,
+    @required bool usesPreviewSdk,
+    @required ToolEnvironment toolEnv,
+    @required bool useLongerTimeout,
+    @required String outputDir,
+  }) async {
+    final random = Random('$package/$version'.hashCode);
+
+    // basic content, existence checked by the job processor
+    await File(p.join(outputDir, 'index.html'))
+        .writeAsString('<html><head></head><body>index.html</body></html>');
+    // JS search index, existence checked by the job processor
+    await File(p.join(outputDir, 'index.json')).writeAsString(json.encode({}));
+    // pub search data
+    final pubData = PubDartdocData(
+      coverage: Coverage(documented: random.nextInt(21), total: 20),
+      apiElements: [
+        // TODO: add fake library elements
+      ],
+    );
+    await File(p.join(outputDir, 'pub-data.json'))
+        .writeAsString(json.encode(pubData));
+
+    return DartdocRunnerResult(
+      args: ['fake_dartdoc', '--input', pkgPath, '--output', outputDir],
+      processResult: ProcessResult(0, 0, 'OK', ''),
+    );
+  }
+}

--- a/app/lib/job/backend.dart
+++ b/app/lib/job/backend.dart
@@ -127,16 +127,14 @@ class JobBackend {
             current.isLatestPreview == isLatestPreview &&
             !current.packageVersionUpdated.isBefore(packageVersionUpdated) &&
             (priority == null || current.priority <= priority);
-        if (hasNotChanged) {
-          if (!shouldProcess) {
-            // no reason to re-schedule the job
-            return;
-          }
-          if (current.state == JobState.available &&
-              current.lockedUntil == null) {
-            // already scheduled for processing
-            return;
-          }
+        if (hasNotChanged && !shouldProcess) {
+          // no reason to re-schedule the job
+          return;
+        }
+        if (current.state == JobState.available &&
+            current.lockedUntil == null) {
+          // already scheduled for processing
+          return;
         }
         _logger.info('Updating job: $id ($state, $lockedUntil)');
         current
@@ -164,8 +162,8 @@ class JobBackend {
           ..isLatestPrerelease = isLatestPrerelease
           ..isLatestPreview = isLatestPreview
           ..packageVersionUpdated = packageVersionUpdated
-          ..state = state
-          ..lockedUntil = lockedUntil
+          ..state = JobState.available
+          ..lockedUntil = null
           ..lastStatus = JobStatus.none
           ..runtimeVersion = versions.runtimeVersion
           ..errorCount = 0

--- a/app/test/dartdoc/dartdoc_report_test.dart
+++ b/app/test/dartdoc/dartdoc_report_test.dart
@@ -2,66 +2,52 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:pana/pana.dart' hide ReportStatus;
 import 'package:pub_dev/dartdoc/backend.dart';
-import 'package:pub_dev/dartdoc/models.dart';
+import 'package:pub_dev/dartdoc/dartdoc_runner.dart';
+import 'package:pub_dev/fake/backend/fake_dartdoc_runner.dart';
+import 'package:pub_dev/job/job.dart';
 import 'package:pub_dev/scorecard/backend.dart';
-import 'package:pub_dev/shared/versions.dart';
+import 'package:pub_dev/shared/datastore.dart';
 import 'package:test/test.dart';
 
-import '../shared/test_models.dart';
 import '../shared/test_services.dart';
 
 void main() {
   group('ScoreCard dartdoc report', () {
-    testWithServices('write and read dartdoc reports', () async {
-      await scoreCardBackend.updateReport(
-          hydrogen.packageName,
-          hydrogen.latestVersion,
-          DartdocReport(
-            reportStatus: ReportStatus.success,
-            dartdocEntry: DartdocEntry(
-              uuid: 'report-uuid-1',
-              packageName: hydrogen.packageName,
-              packageVersion: hydrogen.latestVersion,
-              runtimeVersion: runtimeVersion,
-              flutterVersion: toolStableFlutterSdkVersion,
-              dartdocVersion: dartdocVersion,
-              sdkVersion: toolStableDartSdkVersion,
-              hasContent: true,
-              depsResolved: true,
-              isLatest: true,
-              isObsolete: false,
-              totalSize: 121212,
-              archiveSize: 101010,
-              usesFlutter: false,
-              timestamp: DateTime(2020, 07, 14, 11, 12, 13),
-              runDuration: Duration(seconds: 33),
-            ),
-            documentationSection:
-                documentationCoverageSection(documented: 10, total: 12),
-          ));
+    testWithProfile('write and read dartdoc reports', fn: () async {
+      // run with fake dartdoc runner
+      final jobProcessor = DartdocJobProcessor(
+        aliveCallback: null,
+        runner: FakeDartdocRunner(),
+      );
+      await JobMaintenance(dbService, jobProcessor).scanUpdateAndRunOnce();
 
       final reports = await scoreCardBackend.loadReportForAllVersions(
-        hydrogen.packageName,
-        [hydrogen.latestVersion, '0.1.2'],
+        'oxygen',
+        ['1.0.0', '1.2.0', '2.0.0-nonexisting'],
         reportType: ReportType.dartdoc,
       );
 
       expect(reports.first, isNotNull);
       expect(reports.last, isNull);
-      final report = reports.first as DartdocReport;
+      final report = reports[1] as DartdocReport;
       expect(report.dartdocEntry, isNotNull);
-      expect(report.dartdocEntry.totalSize, 121212);
+      expect(report.dartdocEntry.totalSize, 440);
+      expect(report.documentationSection.grantedPoints, 10);
+      expect(report.documentationSection.maxPoints, 10);
+      expect(
+          report.documentationSection.summary,
+          contains(
+              '17 out of 20 API elements (85.0 %) have documentation comments.'));
 
       final entries = await dartdocBackend.getEntriesForVersions(
-        hydrogen.packageName,
-        [hydrogen.latestVersion, '0.1.2'],
+        'oxygen',
+        ['1.0.0', '1.2.0', '2.0.0-nonexisting'],
       );
 
       expect(entries.first, isNotNull);
       expect(entries.last, isNull);
-      expect(entries.first.totalSize, 121212);
+      expect(entries[1].totalSize, 440);
     });
   });
 }


### PR DESCRIPTION
- Fixed `Job` backend inefficiencies:
  - Fixed `Job` creation status: a new `Job` should always be available for processing (and not wait for 12 hours, as it was the case for the non-latest versions)
  - Fixed `Job` update status: a new update may have demoted the the `Job` from available for processing to 12-hours idle.
  - This also reduces the number of updates/transactions in the beginning of the new deployment.

- Removed an extra and not needed `PackageStatus` query from `dartdoc_runner.dart`.
- New interface: `DartdocRunner` to actually download / upgrade the package and to run `dartdoc` on it.
- `FakeDartdocRunner` to provide a semi-random result.
- migrated a test to use test-profile + the fake results from the runner
