### PR TITLE
Better ScoreCard updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ AppEngine version, listed here to ease deployment and troubleshooting.
 ## Next Release (replace with git tag when deployed)
  * Bumped runtimeVersion to `2021.03.30`.
  * Upgraded dartdoc to `0.41.0`.
+ * NOTE: Expected reduction in Job-related API calls.
 
 ## `20210325t074600-all`
  * Tempoarily disabled youtube integration.

--- a/app/lib/analyzer/pana_runner.dart
+++ b/app/lib/analyzer/pana_runner.dart
@@ -123,12 +123,11 @@ class AnalyzerJobProcessor extends JobProcessor {
 
   Future<void> _storeScoreCard(Job job, Summary summary,
       {List<String> flags}) async {
-    await scoreCardBackend.updateReport(
+    await scoreCardBackend.updateReportAndCard(
       job.packageName,
       job.packageVersion,
       panaReportFromSummary(summary, flags: flags),
     );
-    await scoreCardBackend.updateScoreCard(job.packageName, job.packageVersion);
   }
 }
 

--- a/app/lib/dartdoc/dartdoc_runner.dart
+++ b/app/lib/dartdoc/dartdoc_runner.dart
@@ -412,7 +412,6 @@ class DartdocJobProcessor extends JobProcessor {
           dartdocEntry: entry,
           documentationSection: documentationSection,
         ));
-    await scoreCardBackend.updateScoreCard(job.packageName, job.packageVersion);
 
     if (abortLog != null) {
       return JobStatus.aborted;
@@ -422,9 +421,8 @@ class DartdocJobProcessor extends JobProcessor {
   }
 
   Future _storeScoreCard(Job job, DartdocReport report) async {
-    await scoreCardBackend.updateReport(
+    await scoreCardBackend.updateReportAndCard(
         job.packageName, job.packageVersion, report);
-    await scoreCardBackend.updateScoreCard(job.packageName, job.packageVersion);
   }
 
   Future<bool> _resolveDependencies(

--- a/app/lib/job/job.dart
+++ b/app/lib/job/job.dart
@@ -169,8 +169,8 @@ class JobMaintenance {
 
     Future<void> updateJob(PackageVersion pv, bool skipLatestStable) async {
       try {
-        if (!await packageBackend.isPackageVisible(pv.package)) return;
         final p = packages[pv.package];
+        if (p == null || p.isNotVisible) return;
         final releases = await packageBackend.latestReleases(p);
         final isLatestStable = releases.stable.version == pv.version;
         final isLatestPrerelease = releases.showPrerelease &&

--- a/app/lib/search/search_client.dart
+++ b/app/lib/search/search_client.dart
@@ -107,7 +107,7 @@ class SearchClient {
   /// This method will update the [ScoreCard] entry of the package, and it will
   /// be picked up by each search index individually, within a few minutes.
   Future<void> triggerReindex(String package, String version) async {
-    await scoreCardBackend.updateScoreCard(package, version);
+    await scoreCardBackend.markScoreCardUpdated(package, version);
   }
 
   Future<void> close() async {

--- a/app/test/shared/test_services.dart
+++ b/app/test/shared/test_services.dart
@@ -137,12 +137,10 @@ Future<void> _populateDefaultData() async {
     lithium.package.name: 0.7,
   });
 
-  await scoreCardBackend.updateReport(
+  await scoreCardBackend.updateReportAndCard(
       helium.package.name,
       helium.package.latestVersion,
       generatePanaReport(derivedTags: ['sdk:flutter']));
-  await scoreCardBackend.updateScoreCard(
-      helium.package.name, helium.package.latestVersion);
 }
 
 /// Creates local, non-HTTP-based API client with [authToken].


### PR DESCRIPTION
- As `ScoreCard` is always updated after `ScoreCardReport`, they should be in one call.
- This fixes a bug where we were calling it twice.
- Search index update trigger shouldn't do the full update, instead it should change only the `updated` timestamp.
- Also removed a package visibility check that was no longer needed there.