### PR TITLE
'<sdk> pub add' on install tab

### DIFF
--- a/app/lib/frontend/templates/package.dart
+++ b/app/lib/frontend/templates/package.dart
@@ -479,6 +479,7 @@ Tab _installTab(PackagePageData data) {
     id: 'installing',
     title: 'Installing',
     contentHtml: _renderInstallTab(data.version, data.analysis?.derivedTags),
+    isMarkdown: true,
   );
 }
 

--- a/app/lib/frontend/templates/views/pkg/install_tab.mustache
+++ b/app/lib/frontend/templates/views/pkg/install_tab.mustache
@@ -5,9 +5,9 @@
 <h2>Use this package as an executable</h2>
 <h3>1. Install it</h3>
 <p>You can install the package from the command line:</p>
-<pre><code class="language-shell">$ <strong>pub global activate {{package}}</strong>
+<pre><code class="language-shell">$ <strong>dart pub global activate {{ package }}</strong>
 </code></pre>
-<h3>2. Use it</h3>
+<h3>Use it</h3>
 <p>The package has the following executables:</p>
 <pre><code class="language-shell">{{#executables}}$ <strong>{{.}}</strong>
 {{/executables}}
@@ -15,29 +15,32 @@
 {{/use_as_an_executable}}
 {{#use_as_a_library}}
 <h2>Use this package as a library</h2>
-<h3>1. Depend on it</h3>
-<p>Add this to your package's pubspec.yaml file:</p>
-<pre><code class="language-yaml">{{dependencies_key}}:
-  <strong>{{package}}: {{example_version_constraint}}</strong>
-</code></pre>
-<h3>2. Install it</h3>
-<p>You can install packages from the command line:</p>
+<h3>Depend on it</h3>
+<p>Run this command:</p>
 {{#use_pub_get}}
-  <p>with pub:</p>
-  <pre><code class="language-shell">$ <strong>dart pub get</strong>
-</code></pre>
+<p>With Dart:</p>
+<pre><code class="language-shell"> $ dart pub add {{ package }}</code></pre>
 {{/use_pub_get}}
 {{#use_flutter_packages_get}}
-  <p>with Flutter:</p>
-  <pre><code class="language-shell">$ <strong>flutter pub get</strong>
-</code></pre>
+<p>With Flutter:</p>
+<pre><code class="language-shell"> $ flutter pub pub add {{ package }}</code></pre>
 {{/use_flutter_packages_get}}
+
+<p>
+  This will add a line like this to your package's pubspec.yaml (and run an implicit
+  <code class="language-shell">dart pub get</code>):
+</p>
+<pre><code class="language-yaml">
+{{ dependencies_key }}:
+  <strong>{{ package }}: {{ example_version_constraint }}</strong>
+</code></pre>
+
 {{#show_editor_support}}
 <p>Alternatively, your editor might support {{& editor_supported_tool_html}}.
   Check the docs for your editor to learn more.</p>
 {{/show_editor_support}}
 {{#has_libraries}}
-  <h3>3. Import it</h3>
+  <h3>Import it</h3>
   <p>Now in your Dart code, you can use:
   </p>
   <pre><code class="language-dart">{{#import_examples}}import 'package:{{package}}/{{library}}';

--- a/app/test/frontend/golden/pkg_install_page.html
+++ b/app/test/frontend/golden/pkg_install_page.html
@@ -199,23 +199,23 @@
             </div>
             <div class="detail-container detail-body-main">
               <div class="detail-tabs-content">
-                <section class="tab-content detail-tab-installing-content -active">
+                <section class="tab-content detail-tab-installing-content -active markdown-body">
                   <h2>Use this package as a library</h2>
-                  <h3>1. Depend on it</h3>
-                  <p>Add this to your package's pubspec.yaml file:</p>
+                  <h3>Depend on it</h3>
+                  <p>Run this command:</p>
+                  <p>With Dart:</p>
+                  <pre>
+                    <code class="language-shell">$ dart pub add foobar_pkg</code>
+                  </pre>
+                  <p>
+                    This will add a line like this to your package's pubspec.yaml (and run an implicit
+                    <code class="language-shell">dart pub get</code>
+                    ):
+                  </p>
                   <pre>
                     <code class="language-yaml">
                       dependencies:
                       <strong>foobar_pkg: ^0.1.1+5</strong>
-                    </code>
-                  </pre>
-                  <h3>2. Install it</h3>
-                  <p>You can install packages from the command line:</p>
-                  <p>with pub:</p>
-                  <pre>
-                    <code class="language-shell">
-                      $
-                      <strong>dart pub get</strong>
                     </code>
                   </pre>
                   <p>
@@ -223,7 +223,7 @@
                     <code>dart pub get</code>
                     . Check the docs for your editor to learn more.
                   </p>
-                  <h3>3. Import it</h3>
+                  <h3>Import it</h3>
                   <p>Now in your Dart code, you can use:</p>
                   <pre>
                     <code class="language-dart">import 'package:foobar_pkg/foolib.dart';</code>


### PR DESCRIPTION
- rebased / updated version of #4375
- also fixes rendering issue by adding markdown `class` name to the tab root
