### PR TITLE
Updated search API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Important changes to data-models, configuration and migrations between each
 AppEngine version, listed here to ease deployment and troubleshooting.
 
 ## Next Release (replace with git tag when deployed)
+ * NOTE: search API started to emit `PackageHit` and `SdkLibraryHit`.
 
 ## `20210506t120400-all`
  * Bumped runtimeVersion to `2021.05.03`.

--- a/app/lib/search/result_combiner.dart
+++ b/app/lib/search/result_combiner.dart
@@ -49,6 +49,9 @@ class SearchResultCombiner {
       timestamp: primaryResult.timestamp,
       totalCount: primaryResult.totalCount,
       packages: allPackages,
+      highlightedHit: primaryResult.highlightedHit,
+      packageHits: primaryResult.packageHits,
+      sdkLibraryHits: dartSdkResult.sdkLibraryHits,
     );
   }
 }

--- a/app/lib/search/search_service.dart
+++ b/app/lib/search/search_service.dart
@@ -618,6 +618,9 @@ class PackageSearchResult {
   final DateTime timestamp;
   final int totalCount;
   final List<PackageScore> packages;
+  final PackageHit highlightedHit;
+  final List<SdkLibraryHit> sdkLibraryHits;
+  final List<PackageHit> packageHits;
 
   /// An optional message from the search service / client library, in case
   /// the query was not processed entirely.
@@ -627,13 +630,21 @@ class PackageSearchResult {
     @required this.timestamp,
     this.totalCount,
     List<PackageScore> packages,
+    this.highlightedHit,
+    List<SdkLibraryHit> sdkLibraryHits,
+    List<PackageHit> packageHits,
     this.message,
-  }) : packages = packages ?? [];
+  })  : packages = packages ?? <PackageScore>[],
+        sdkLibraryHits = sdkLibraryHits ?? <SdkLibraryHit>[],
+        packageHits = packageHits ?? <PackageHit>[];
 
   PackageSearchResult.empty({this.message})
       : timestamp = DateTime.now().toUtc(),
         totalCount = 0,
-        packages = [];
+        packages = <PackageScore>[],
+        highlightedHit = null,
+        sdkLibraryHits = <SdkLibraryHit>[],
+        packageHits = <PackageHit>[];
 
   factory PackageSearchResult.fromJson(Map<String, dynamic> json) =>
       _$PackageSearchResultFromJson(json);
@@ -643,6 +654,7 @@ class PackageSearchResult {
   Map<String, dynamic> toJson() => _$PackageSearchResultToJson(this);
 }
 
+/// TODO: remove after all running instances are using only [PackageHit].
 @JsonSerializable()
 class PackageScore {
   final String package;
@@ -696,6 +708,50 @@ class PackageScore {
   bool get isExternal => url != null && version != null && description != null;
 
   Map<String, dynamic> toJson() => _$PackageScoreToJson(this);
+}
+
+@JsonSerializable(includeIfNull: false)
+class SdkLibraryHit {
+  final String sdk;
+  final String version;
+  final String library;
+  final String description;
+  final String url;
+  final double score;
+  final List<ApiPageRef> apiPages;
+
+  SdkLibraryHit({
+    @required this.sdk,
+    @required this.version,
+    @required this.library,
+    @required this.description,
+    @required this.url,
+    @required this.score,
+    @required this.apiPages,
+  });
+
+  factory SdkLibraryHit.fromJson(Map<String, dynamic> json) =>
+      _$SdkLibraryHitFromJson(json);
+
+  Map<String, dynamic> toJson() => _$SdkLibraryHitToJson(this);
+}
+
+@JsonSerializable(includeIfNull: false)
+class PackageHit {
+  final String package;
+  final double score;
+  final List<ApiPageRef> apiPages;
+
+  PackageHit({
+    @required this.package,
+    @required this.score,
+    @required this.apiPages,
+  });
+
+  factory PackageHit.fromJson(Map<String, dynamic> json) =>
+      _$PackageHitFromJson(json);
+
+  Map<String, dynamic> toJson() => _$PackageHitToJson(this);
 }
 
 @JsonSerializable()

--- a/app/lib/search/search_service.g.dart
+++ b/app/lib/search/search_service.g.dart
@@ -84,6 +84,18 @@ PackageSearchResult _$PackageSearchResultFromJson(Map<String, dynamic> json) {
         ?.map((e) =>
             e == null ? null : PackageScore.fromJson(e as Map<String, dynamic>))
         ?.toList(),
+    highlightedHit: json['highlightedHit'] == null
+        ? null
+        : PackageHit.fromJson(json['highlightedHit'] as Map<String, dynamic>),
+    sdkLibraryHits: (json['sdkLibraryHits'] as List)
+        ?.map((e) => e == null
+            ? null
+            : SdkLibraryHit.fromJson(e as Map<String, dynamic>))
+        ?.toList(),
+    packageHits: (json['packageHits'] as List)
+        ?.map((e) =>
+            e == null ? null : PackageHit.fromJson(e as Map<String, dynamic>))
+        ?.toList(),
     message: json['message'] as String,
   );
 }
@@ -100,6 +112,9 @@ Map<String, dynamic> _$PackageSearchResultToJson(PackageSearchResult instance) {
   writeNotNull('timestamp', instance.timestamp?.toIso8601String());
   writeNotNull('totalCount', instance.totalCount);
   writeNotNull('packages', instance.packages);
+  writeNotNull('highlightedHit', instance.highlightedHit);
+  writeNotNull('sdkLibraryHits', instance.sdkLibraryHits);
+  writeNotNull('packageHits', instance.packageHits);
   writeNotNull('message', instance.message);
   return val;
 }
@@ -133,6 +148,66 @@ Map<String, dynamic> _$PackageScoreToJson(PackageScore instance) {
   writeNotNull('url', instance.url);
   writeNotNull('version', instance.version);
   writeNotNull('description', instance.description);
+  writeNotNull('apiPages', instance.apiPages);
+  return val;
+}
+
+SdkLibraryHit _$SdkLibraryHitFromJson(Map<String, dynamic> json) {
+  return SdkLibraryHit(
+    sdk: json['sdk'] as String,
+    version: json['version'] as String,
+    library: json['library'] as String,
+    description: json['description'] as String,
+    url: json['url'] as String,
+    score: (json['score'] as num)?.toDouble(),
+    apiPages: (json['apiPages'] as List)
+        ?.map((e) =>
+            e == null ? null : ApiPageRef.fromJson(e as Map<String, dynamic>))
+        ?.toList(),
+  );
+}
+
+Map<String, dynamic> _$SdkLibraryHitToJson(SdkLibraryHit instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('sdk', instance.sdk);
+  writeNotNull('version', instance.version);
+  writeNotNull('library', instance.library);
+  writeNotNull('description', instance.description);
+  writeNotNull('url', instance.url);
+  writeNotNull('score', instance.score);
+  writeNotNull('apiPages', instance.apiPages);
+  return val;
+}
+
+PackageHit _$PackageHitFromJson(Map<String, dynamic> json) {
+  return PackageHit(
+    package: json['package'] as String,
+    score: (json['score'] as num)?.toDouble(),
+    apiPages: (json['apiPages'] as List)
+        ?.map((e) =>
+            e == null ? null : ApiPageRef.fromJson(e as Map<String, dynamic>))
+        ?.toList(),
+  );
+}
+
+Map<String, dynamic> _$PackageHitToJson(PackageHit instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('package', instance.package);
+  writeNotNull('score', instance.score);
   writeNotNull('apiPages', instance.apiPages);
   return val;
 }

--- a/app/test/search/angular_test.dart
+++ b/app/test/search/angular_test.dart
@@ -45,6 +45,14 @@ void main() {
             'score': closeTo(0.88, 0.01),
           },
         ],
+        'highlightedHit': {'package': 'angular'},
+        'sdkLibraryHits': [],
+        'packageHits': [
+          {
+            'package': 'angular_ui',
+            'score': closeTo(0.88, 0.01),
+          },
+        ],
       });
     });
   });

--- a/app/test/search/api_doc_page_test.dart
+++ b/app/test/search/api_doc_page_test.dart
@@ -70,6 +70,18 @@ void main() {
           },
           // should not contain `other_without_api`
         ],
+        'highlightedHit': {'package': 'foo'}, // finds package name
+        'sdkLibraryHits': [],
+        'packageHits': [
+          {
+            'package': 'other_with_api',
+            'score': closeTo(0.695, 0.001), // finds foo method
+            'apiPages': [
+              {'title': null, 'path': 'main.html'},
+            ],
+          },
+          // should not contain `other_without_api`
+        ],
       });
     });
 
@@ -80,6 +92,17 @@ void main() {
         'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
+          {
+            'package': 'other_with_api',
+            'score': closeTo(0.26, 0.01), // find serveWebPages
+            'apiPages': [
+              {'title': null, 'path': 'serve.html'},
+            ],
+          },
+          // should not contain `other_without_api`
+        ],
+        'sdkLibraryHits': [],
+        'packageHits': [
           {
             'package': 'other_with_api',
             'score': closeTo(0.26, 0.01), // find serveWebPages

--- a/app/test/search/api_doc_page_test.dart
+++ b/app/test/search/api_doc_page_test.dart
@@ -132,6 +132,17 @@ void main() {
           },
           // should not contain `other_without_api`
         ],
+        'sdkLibraryHits': [],
+        'packageHits': [
+          {
+            'package': 'foo',
+            'score': closeTo(0.072, 0.001), // find WebPageGenerator
+            'apiPages': [
+              {'title': null, 'path': 'generator.html'},
+            ],
+          },
+          // should not contain `other_without_api`
+        ],
       });
     });
 
@@ -142,6 +153,18 @@ void main() {
         'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
+          {
+            'package': 'foo',
+            'score': closeTo(0.025, 0.001), // find WebPageGenerator
+            'apiPages': [
+              {'title': null, 'path': 'generator.html'},
+            ],
+          },
+          // should contain 'other_with_api' finding `serveWebPages`
+          // should not contain `other_without_api`
+        ],
+        'sdkLibraryHits': [],
+        'packageHits': [
           {
             'package': 'foo',
             'score': closeTo(0.025, 0.001), // find WebPageGenerator
@@ -163,6 +186,16 @@ void main() {
         'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
+          {
+            'package': 'foo',
+            'score': closeTo(0.157, 0.001),
+            'apiPages': [
+              {'title': null, 'path': 'generator.html'},
+            ],
+          },
+        ],
+        'sdkLibraryHits': [],
+        'packageHits': [
           {
             'package': 'foo',
             'score': closeTo(0.157, 0.001),

--- a/app/test/search/bluetooth_test.dart
+++ b/app/test/search/bluetooth_test.dart
@@ -43,6 +43,13 @@ void main() {
             'score': closeTo(0.89, 0.01),
           },
         ],
+        'sdkLibraryHits': [],
+        'packageHits': [
+          {
+            'package': 'flutter_blue',
+            'score': closeTo(0.89, 0.01),
+          },
+        ],
       });
     });
   });

--- a/app/test/search/exact_name_test.dart
+++ b/app/test/search/exact_name_test.dart
@@ -50,6 +50,10 @@ void main() {
             'package': 'build_config',
             'score': 1.0,
           },
+        ],
+        'highlightedHit': {'package': 'build_config'},
+        'sdkLibraryHits': [],
+        'packageHits': [
           // would be nice if `package:build` would show up here
         ],
       });

--- a/app/test/search/flutter_95_test.dart
+++ b/app/test/search/flutter_95_test.dart
@@ -38,6 +38,13 @@ void main() {
             'score': 1.0,
           },
         ],
+        'sdkLibraryHits': [],
+        'packageHits': [
+          {
+            'package': 'flutter95',
+            'score': 1.0,
+          },
+        ],
       });
     });
   });

--- a/app/test/search/flutter_iap_test.dart
+++ b/app/test/search/flutter_iap_test.dart
@@ -61,6 +61,13 @@ void main() {
             'score': 1.0,
           },
         ],
+        'sdkLibraryHits': [],
+        'packageHits': [
+          {
+            'package': 'flutter_iap',
+            'score': 1.0,
+          },
+        ],
       });
     });
 
@@ -77,6 +84,9 @@ void main() {
             'score': 1.0,
           },
         ],
+        'highlightedHit': {'package': 'flutter_iap'},
+        'sdkLibraryHits': [],
+        'packageHits': [],
       });
     });
   });

--- a/app/test/search/handlers_test.dart
+++ b/app/test/search/handlers_test.dart
@@ -52,6 +52,9 @@ void main() {
               'score': closeTo(0.51, 0.01),
             }
           ],
+          'highlightedHit': {'package': 'pkg_foo'},
+          'sdkLibraryHits': [],
+          'packageHits': [],
         });
       });
 
@@ -65,6 +68,13 @@ void main() {
               'package': 'pkg_foo',
               'score': closeTo(0.45, 0.01),
             }
+          ],
+          'sdkLibraryHits': [],
+          'packageHits': [
+            {
+              'package': 'pkg_foo',
+              'score': closeTo(0.45, 0.01),
+            },
           ],
         });
       });
@@ -81,6 +91,13 @@ void main() {
                   'score': closeTo(0.45, 0.01),
                 }
               ],
+              'sdkLibraryHits': [],
+              'packageHits': [
+                {
+                  'package': 'pkg_foo',
+                  'score': closeTo(0.45, 0.01),
+                },
+              ],
             });
       });
 
@@ -95,6 +112,13 @@ void main() {
               'score': closeTo(0.51, 0.01),
             }
           ],
+          'sdkLibraryHits': [],
+          'packageHits': [
+            {
+              'package': 'pkg_foo',
+              'score': closeTo(0.51, 0.01),
+            },
+          ],
         });
       });
 
@@ -105,6 +129,8 @@ void main() {
               'timestamp': isNotNull,
               'totalCount': 0,
               'packages': [],
+              'sdkLibraryHits': [],
+              'packageHits': [],
             });
       });
     });

--- a/app/test/search/haversine_test.dart
+++ b/app/test/search/haversine_test.dart
@@ -399,7 +399,19 @@ MIT'''),
             'package': 'latlong',
             'score': closeTo(0.71, 0.01),
           },
-        ]
+        ],
+        'highlightedHit': {'package': 'haversine'},
+        'sdkLibraryHits': [],
+        'packageHits': [
+          {
+            'package': 'great_circle_distance',
+            'score': closeTo(0.72, 0.01),
+          },
+          {
+            'package': 'latlong',
+            'score': closeTo(0.71, 0.01),
+          },
+        ],
       });
     });
 
@@ -415,7 +427,14 @@ MIT'''),
             'package': 'haversine',
             'score': closeTo(0.64, 0.01),
           },
-        ]
+        ],
+        'sdkLibraryHits': [],
+        'packageHits': [
+          {
+            'package': 'haversine',
+            'score': closeTo(0.64, 0.01),
+          },
+        ],
       });
     });
   });

--- a/app/test/search/in_app_payments_test.dart
+++ b/app/test/search/in_app_payments_test.dart
@@ -38,6 +38,13 @@ Add _In-App Payments_ to your Flutter app with this plugin.''')));
             'score': closeTo(0.73, 0.01),
           },
         ],
+        'sdkLibraryHits': [],
+        'packageHits': [
+          {
+            'package': 'flutter_iap',
+            'score': closeTo(0.73, 0.01),
+          },
+        ],
       });
     });
 
@@ -49,6 +56,13 @@ Add _In-App Payments_ to your Flutter app with this plugin.''')));
         'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
+          {
+            'package': 'flutter_iap',
+            'score': closeTo(0.41, 0.01),
+          },
+        ],
+        'sdkLibraryHits': [],
+        'packageHits': [
           {
             'package': 'flutter_iap',
             'score': closeTo(0.41, 0.01),

--- a/app/test/search/json_tool_test.dart
+++ b/app/test/search/json_tool_test.dart
@@ -31,6 +31,10 @@ void main() {
         'packages': [
           {'package': 'jsontool', 'score': 1.0},
         ],
+        'sdkLibraryHits': [],
+        'packageHits': [
+          {'package': 'jsontool', 'score': 1.0},
+        ],
       });
     });
   });
@@ -68,6 +72,12 @@ void main() {
         'timestamp': isNotNull,
         'totalCount': 3,
         'packages': [
+          {'package': 'jsontool', 'score': 1.0},
+          {'package': 'json2entity', 'score': closeTo(0.79, 0.01)},
+          {'package': 'json_to_model', 'score': closeTo(0.55, 0.01)},
+        ],
+        'sdkLibraryHits': [],
+        'packageHits': [
           {'package': 'jsontool', 'score': 1.0},
           {'package': 'json2entity', 'score': closeTo(0.79, 0.01)},
           {'package': 'json_to_model', 'score': closeTo(0.55, 0.01)},

--- a/app/test/search/lombok_test.dart
+++ b/app/test/search/lombok_test.dart
@@ -34,6 +34,13 @@ void main() {
             'score': closeTo(0.63, 0.01),
           },
         ],
+        'sdkLibraryHits': [],
+        'packageHits': [
+          {
+            'package': 'lombok',
+            'score': closeTo(0.63, 0.01),
+          },
+        ],
       });
     });
   });

--- a/app/test/search/maps_test.dart
+++ b/app/test/search/maps_test.dart
@@ -30,6 +30,11 @@ void main() {
           {'package': 'maps', 'score': 1.0},
           {'package': 'map', 'score': 1.0},
         ],
+        'highlightedHit': {'package': 'maps'},
+        'sdkLibraryHits': [],
+        'packageHits': [
+          {'package': 'map', 'score': 1.0},
+        ],
       });
     });
 
@@ -42,6 +47,11 @@ void main() {
         'packages': [
           {'package': 'maps', 'score': 1.0},
           {'package': 'map', 'score': 1.0},
+        ],
+        'highlightedHit': {'package': 'map'},
+        'sdkLibraryHits': [],
+        'packageHits': [
+          {'package': 'maps', 'score': 1.0},
         ],
       });
     });

--- a/app/test/search/mem_index_test.dart
+++ b/app/test/search/mem_index_test.dart
@@ -108,7 +108,10 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
             'package': 'async',
             'score': closeTo(0.71, 0.01),
           },
-        ]
+        ],
+        'highlightedHit': {'package': 'async'},
+        'sdkLibraryHits': [],
+        'packageHits': [],
       });
     });
 
@@ -123,7 +126,14 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
             'package': 'http',
             'score': closeTo(0.85, 0.01),
           },
-        ]
+        ],
+        'sdkLibraryHits': [],
+        'packageHits': [
+          {
+            'package': 'http',
+            'score': closeTo(0.85, 0.01),
+          },
+        ],
       });
     });
 
@@ -138,7 +148,14 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
             'package': 'chrome_net',
             'score': closeTo(0.29, 0.01),
           },
-        ]
+        ],
+        'sdkLibraryHits': [],
+        'packageHits': [
+          {
+            'package': 'chrome_net',
+            'score': closeTo(0.29, 0.01),
+          },
+        ],
       });
     });
 
@@ -152,6 +169,11 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
           {'package': 'http', 'score': closeTo(0.70, 0.01)},
           {'package': 'async', 'score': closeTo(0.62, 0.01)},
         ],
+        'sdkLibraryHits': [],
+        'packageHits': [
+          {'package': 'http', 'score': closeTo(0.70, 0.01)},
+          {'package': 'async', 'score': closeTo(0.62, 0.01)},
+        ],
       });
     });
 
@@ -162,6 +184,10 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
+          {'package': 'async', 'score': closeTo(0.29, 0.01)},
+        ],
+        'sdkLibraryHits': [],
+        'packageHits': [
           {'package': 'async', 'score': closeTo(0.29, 0.01)},
         ],
       });
@@ -178,7 +204,14 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
             'package': 'chrome_net',
             'score': closeTo(0.54, 0.1),
           },
-        ]
+        ],
+        'sdkLibraryHits': [],
+        'packageHits': [
+          {
+            'package': 'chrome_net',
+            'score': closeTo(0.54, 0.1),
+          },
+        ],
       });
     });
 
@@ -192,6 +225,11 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
           {'package': 'http', 'score': 0.5},
           {'package': 'chrome_net', 'score': closeTo(0.11, 0.01)},
         ],
+        'sdkLibraryHits': [],
+        'packageHits': [
+          {'package': 'http', 'score': 0.5},
+          {'package': 'chrome_net', 'score': closeTo(0.11, 0.01)},
+        ],
       });
     });
 
@@ -202,6 +240,12 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'timestamp': isNotNull,
         'totalCount': 3,
         'packages': [
+          {'package': 'async'},
+          {'package': 'http'},
+          {'package': 'chrome_net'},
+        ],
+        'sdkLibraryHits': [],
+        'packageHits': [
           {'package': 'async'},
           {'package': 'http'},
           {'package': 'chrome_net'},
@@ -220,6 +264,12 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
           {'package': 'async'},
           {'package': 'chrome_net'},
         ],
+        'sdkLibraryHits': [],
+        'packageHits': [
+          {'package': 'http'},
+          {'package': 'async'},
+          {'package': 'chrome_net'},
+        ],
       });
     });
 
@@ -231,6 +281,11 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'totalCount': 2,
         'packages': [
           {'package': 'http'},
+          {'package': 'chrome_net'},
+        ],
+        'highlightedHit': {'package': 'http'},
+        'sdkLibraryHits': [],
+        'packageHits': [
           {'package': 'chrome_net'},
         ],
       });
@@ -251,6 +306,11 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
           {'package': 'http'},
           {'package': 'async'},
         ],
+        'sdkLibraryHits': [],
+        'packageHits': [
+          {'package': 'http'},
+          {'package': 'async'},
+        ],
       });
     });
 
@@ -261,6 +321,12 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'timestamp': isNotNull,
         'totalCount': 3,
         'packages': [
+          {'package': 'async', 'score': 0.8},
+          {'package': 'http', 'score': 0.7},
+          {'package': 'chrome_net', 'score': 0.0},
+        ],
+        'sdkLibraryHits': [],
+        'packageHits': [
           {'package': 'async', 'score': 0.8},
           {'package': 'http', 'score': 0.7},
           {'package': 'chrome_net', 'score': 0.0},
@@ -279,6 +345,12 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
           {'package': 'async', 'score': 1.0},
           {'package': 'chrome_net', 'score': 0.0},
         ],
+        'sdkLibraryHits': [],
+        'packageHits': [
+          {'package': 'http', 'score': 10.0},
+          {'package': 'async', 'score': 1.0},
+          {'package': 'chrome_net', 'score': 0.0},
+        ],
       });
     });
 
@@ -289,6 +361,12 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'timestamp': isNotNull,
         'totalCount': 3,
         'packages': [
+          {'package': 'http', 'score': 110.0},
+          {'package': 'async', 'score': 10.0},
+          {'package': 'chrome_net', 'score': 0.0},
+        ],
+        'sdkLibraryHits': [],
+        'packageHits': [
           {'package': 'http', 'score': 110.0},
           {'package': 'async', 'score': 10.0},
           {'package': 'chrome_net', 'score': 0.0},
@@ -306,6 +384,11 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
           {'package': 'http', 'score': closeTo(0.96, 0.01)},
           {'package': 'async', 'score': closeTo(0.70, 0.01)},
         ],
+        'sdkLibraryHits': [],
+        'packageHits': [
+          {'package': 'http', 'score': closeTo(0.96, 0.01)},
+          {'package': 'async', 'score': closeTo(0.70, 0.01)},
+        ],
       });
     });
 
@@ -316,6 +399,10 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
+          {'package': 'chrome_net', 'score': closeTo(0.54, 0.01)},
+        ],
+        'sdkLibraryHits': [],
+        'packageHits': [
           {'package': 'chrome_net', 'score': closeTo(0.54, 0.01)},
         ],
       });
@@ -331,6 +418,11 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
           {'package': 'http', 'score': closeTo(0.96, 0.01)},
           {'package': 'chrome_net', 'score': closeTo(0.54, 0.01)},
         ],
+        'sdkLibraryHits': [],
+        'packageHits': [
+          {'package': 'http', 'score': closeTo(0.96, 0.01)},
+          {'package': 'chrome_net', 'score': closeTo(0.54, 0.01)},
+        ],
       });
     });
 
@@ -341,6 +433,10 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
+          {'package': 'http', 'score': closeTo(0.85, 0.01)},
+        ],
+        'sdkLibraryHits': [],
+        'packageHits': [
           {'package': 'http', 'score': closeTo(0.85, 0.01)},
         ],
       });
@@ -355,6 +451,10 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'packages': [
           {'package': 'http', 'score': closeTo(0.96, 0.01)},
         ],
+        'sdkLibraryHits': [],
+        'packageHits': [
+          {'package': 'http', 'score': closeTo(0.96, 0.01)},
+        ],
       });
     });
 
@@ -365,6 +465,8 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'timestamp': isNotNull,
         'totalCount': 0,
         'packages': [],
+        'sdkLibraryHits': [],
+        'packageHits': [],
       });
     });
 
@@ -377,6 +479,10 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'packages': [
           {'package': 'async', 'score': closeTo(0.70, 0.01)},
         ],
+        'sdkLibraryHits': [],
+        'packageHits': [
+          {'package': 'async', 'score': closeTo(0.70, 0.01)},
+        ],
       });
     });
 
@@ -387,6 +493,8 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'timestamp': isNotNull,
         'totalCount': 0,
         'packages': [],
+        'sdkLibraryHits': [],
+        'packageHits': [],
       });
     });
 
@@ -397,6 +505,10 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
+          {'package': 'async', 'score': closeTo(0.70, 0.01)},
+        ],
+        'sdkLibraryHits': [],
+        'packageHits': [
           {'package': 'async', 'score': closeTo(0.70, 0.01)},
         ],
       });
@@ -415,6 +527,11 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
           {'package': 'http', 'score': closeTo(0.96, 0.01)},
           {'package': 'async', 'score': closeTo(0.70, 0.01)},
         ],
+        'sdkLibraryHits': [],
+        'packageHits': [
+          {'package': 'http', 'score': closeTo(0.96, 0.01)},
+          {'package': 'async', 'score': closeTo(0.70, 0.01)},
+        ],
       });
     });
 
@@ -425,6 +542,8 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'timestamp': isNotNull,
         'totalCount': 0,
         'packages': [],
+        'sdkLibraryHits': [],
+        'packageHits': [],
       });
     });
 
@@ -435,6 +554,11 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'timestamp': isNotNull,
         'totalCount': 2,
         'packages': [
+          {'package': 'http', 'score': closeTo(0.96, 0.01)},
+          {'package': 'async', 'score': closeTo(0.70, 0.01)},
+        ],
+        'sdkLibraryHits': [],
+        'packageHits': [
           {'package': 'http', 'score': closeTo(0.96, 0.01)},
           {'package': 'async', 'score': closeTo(0.70, 0.01)},
         ],
@@ -451,6 +575,10 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'packages': [
           {'package': 'http', 'score': closeTo(0.88, 0.01)},
         ],
+        'sdkLibraryHits': [],
+        'packageHits': [
+          {'package': 'http', 'score': closeTo(0.88, 0.01)},
+        ],
       });
 
       final PackageSearchResult library = await index.search(
@@ -459,6 +587,12 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'timestamp': isNotNull,
         'totalCount': 3,
         'packages': [
+          {'package': 'chrome_net', 'score': closeTo(0.88, 0.01)},
+          {'package': 'async', 'score': closeTo(0.88, 0.01)},
+          {'package': 'http', 'score': closeTo(0.72, 0.01)},
+        ],
+        'sdkLibraryHits': [],
+        'packageHits': [
           {'package': 'chrome_net', 'score': closeTo(0.88, 0.01)},
           {'package': 'async', 'score': closeTo(0.88, 0.01)},
           {'package': 'http', 'score': closeTo(0.72, 0.01)},
@@ -474,6 +608,10 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
+          {'package': 'http', 'score': closeTo(0.54, 0.01)},
+        ],
+        'sdkLibraryHits': [],
+        'packageHits': [
           {'package': 'http', 'score': closeTo(0.54, 0.01)},
         ],
       });

--- a/app/test/search/rest_api_test.dart
+++ b/app/test/search/rest_api_test.dart
@@ -60,6 +60,14 @@ Recent versions (0.3.x and 0.4.x) of this plugin require [extensible codec funct
           },
           // cloud_firestore should not show up
         ],
+        'sdkLibraryHits': [],
+        'packageHits': [
+          {
+            'package': 'currency_cloud',
+            'score': closeTo(0.79, 0.01),
+          },
+          // cloud_firestore should not show up
+        ],
       });
     });
   });

--- a/app/test/search/result_combiner_test.dart
+++ b/app/test/search/result_combiner_test.dart
@@ -53,6 +53,10 @@ void main() {
         'packages': [
           {'package': 'stringutils', 'score': 0.4},
         ],
+        'sdkLibraryHits': [],
+        'packageHits': [
+          {'package': 'stringutils', 'score': 0.4},
+        ],
       });
     });
 
@@ -63,6 +67,10 @@ void main() {
         'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
+          {'package': 'stringutils', 'score': closeTo(0.8, 0.01)},
+        ],
+        'sdkLibraryHits': [],
+        'packageHits': [
           {'package': 'stringutils', 'score': closeTo(0.8, 0.01)},
         ],
       });
@@ -92,6 +100,27 @@ void main() {
           },
           {'package': 'stringutils', 'score': closeTo(0.59, 0.01)},
         ],
+        'sdkLibraryHits': [
+          {
+            'sdk': 'dart',
+            'library': 'dart:core',
+            'description': 'Dart core utils',
+            'url':
+                'https://api.dartlang.org/stable/2.0.0/dart-core/String-class.html',
+            'score': closeTo(0.69, 0.01),
+            'apiPages': [
+              {
+                'title': null,
+                'path': 'dart-core/String-class.html',
+                'url':
+                    'https://api.dartlang.org/stable/2.0.0/dart-core/String-class.html'
+              }
+            ]
+          }
+        ],
+        'packageHits': [
+          {'package': 'stringutils', 'score': closeTo(0.59, 0.01)}
+        ],
       });
     });
 
@@ -119,6 +148,26 @@ void main() {
             ],
           },
         ],
+        'highlightedHit': {'package': 'stringutils'},
+        'sdkLibraryHits': [
+          {
+            'sdk': 'dart',
+            'library': 'dart:core',
+            'description': 'Dart core utils',
+            'url':
+                'https://api.dartlang.org/stable/2.0.0/dart-core/String-class.html',
+            'score': closeTo(0.69, 0.01),
+            'apiPages': [
+              {
+                'title': null,
+                'path': 'dart-core/String-class.html',
+                'url':
+                    'https://api.dartlang.org/stable/2.0.0/dart-core/String-class.html'
+              }
+            ]
+          }
+        ],
+        'packageHits': [],
       });
     });
   });

--- a/app/test/search/scope_specificity_test.dart
+++ b/app/test/search/scope_specificity_test.dart
@@ -85,6 +85,25 @@ void main() {
             'score': closeTo(0.4, 0.01),
           },
         ],
+        'sdkLibraryHits': [],
+        'packageHits': [
+          {
+            'package': 'json_0',
+            'score': closeTo(0.4, 0.01),
+          },
+          {
+            'package': 'json_1',
+            'score': closeTo(0.4, 0.01),
+          },
+          {
+            'package': 'json_2',
+            'score': closeTo(0.4, 0.01),
+          },
+          {
+            'package': 'json_3',
+            'score': closeTo(0.4, 0.01),
+          }
+        ],
       });
     });
 
@@ -108,6 +127,17 @@ void main() {
             'score': closeTo(0.36, 0.01),
           },
         ],
+        'sdkLibraryHits': [],
+        'packageHits': [
+          {
+            'package': 'json_1',
+            'score': closeTo(0.40, 0.01),
+          },
+          {
+            'package': 'json_3',
+            'score': closeTo(0.36, 0.01),
+          },
+        ]
       });
     });
   });

--- a/app/test/search/stack_trace_test.dart
+++ b/app/test/search/stack_trace_test.dart
@@ -40,7 +40,14 @@ void main() {
             'package': 'stack_trace',
             'score': 1.0,
           },
-        ]
+        ],
+        'sdkLibraryHits': [],
+        'packageHits': [
+          {
+            'package': 'stack_trace',
+            'score': 1.0,
+          },
+        ],
       });
     });
   });

--- a/app/test/search/tags_test.dart
+++ b/app/test/search/tags_test.dart
@@ -23,6 +23,8 @@ void main() {
         'timestamp': isNotNull,
         'totalCount': 0,
         'packages': [],
+        'sdkLibraryHits': [],
+        'packageHits': [],
       });
     });
 
@@ -38,6 +40,10 @@ void main() {
         'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
+          {'package': 'pkg1', 'score': isNotNull},
+        ],
+        'sdkLibraryHits': [],
+        'packageHits': [
           {'package': 'pkg1', 'score': isNotNull},
         ],
       });
@@ -58,6 +64,10 @@ void main() {
         'packages': [
           {'package': 'pkg2', 'score': isNotNull},
         ],
+        'sdkLibraryHits': [],
+        'packageHits': [
+          {'package': 'pkg2', 'score': isNotNull},
+        ],
       });
     });
 
@@ -74,6 +84,10 @@ void main() {
         'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
+          {'package': 'pkg1', 'score': isNotNull},
+        ],
+        'sdkLibraryHits': [],
+        'packageHits': [
           {'package': 'pkg1', 'score': isNotNull},
         ],
       });
@@ -97,6 +111,11 @@ void main() {
           {'package': 'pkg1', 'score': isNotNull},
           {'package': 'pkg2', 'score': isNotNull},
         ],
+        'sdkLibraryHits': [],
+        'packageHits': [
+          {'package': 'pkg1', 'score': isNotNull},
+          {'package': 'pkg2', 'score': isNotNull},
+        ],
       });
     });
 
@@ -115,6 +134,10 @@ void main() {
         'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
+          {'package': 'pkg2', 'score': isNotNull},
+        ],
+        'sdkLibraryHits': [],
+        'packageHits': [
           {'package': 'pkg2', 'score': isNotNull},
         ],
       });
@@ -137,6 +160,10 @@ void main() {
         'packages': [
           {'package': 'pkg1', 'score': isNotNull},
         ],
+        'sdkLibraryHits': [],
+        'packageHits': [
+          {'package': 'pkg1', 'score': isNotNull},
+        ],
       });
     });
 
@@ -153,6 +180,10 @@ void main() {
         'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
+          {'package': 'pkg2', 'score': isNotNull},
+        ],
+        'sdkLibraryHits': [],
+        'packageHits': [
           {'package': 'pkg2', 'score': isNotNull},
         ],
       });
@@ -172,6 +203,10 @@ void main() {
         'timestamp': isNotNull,
         'totalCount': 1,
         'packages': [
+          {'package': 'pkg1', 'score': isNotNull},
+        ],
+        'sdkLibraryHits': [],
+        'packageHits': [
           {'package': 'pkg1', 'score': isNotNull},
         ],
       });

--- a/app/test/search/travis_test.dart
+++ b/app/test/search/travis_test.dart
@@ -63,6 +63,9 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor i
             'score': 1.0,
           },
         ],
+        'highlightedHit': {'package': 'travis'},
+        'sdkLibraryHits': [],
+        'packageHits': [],
       });
     });
   });


### PR DESCRIPTION
- #4549
- A few suggestions on evolving the search API without breaking traffic migrations:
  - `highlightedHit` will be the package where the name matches the query string.
    - It will be featured as top position (and with a different background), regardless of its other status wrt. query filters.
    - It won't be included in the package hits if it would be present on the first page. (second page hits would include it)
  - `sdkLibraryHits` will have the proper data structure required for SDK library results
  - `packageHits` will have only the reduced data required for hosted packages 
- Tests are not migrated yet, but updated a few that provides insight on what it will look like.
