### PR TITLE
Check for extra bytes at the end of the tar archive

### DIFF
--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -693,7 +693,7 @@ packages:
       name: tar
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
+    version: "0.3.2"
   term_glyph:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -51,7 +51,7 @@ dependencies:
   mailer: '3.2.1'
   sanitize_html: ^2.0.0
   ulid: '2.0.0'
-  tar: '0.3.0'
+  tar: '0.3.2'
   http_retry: '0.1.1+3'
   api_builder:
     path: ../pkg/api_builder

--- a/pkg/pub_package_reader/lib/src/tar_utils.dart
+++ b/pkg/pub_package_reader/lib/src/tar_utils.dart
@@ -112,7 +112,10 @@ class _PkgTarArchive extends TarArchive {
   /// Creates a new instance by scanning the archive at [path].
   static Future<_PkgTarArchive> _scan(String path) async {
     final names = <String>[];
-    final reader = TarReader(File(path).openRead().transform(gzip.decoder));
+    final reader = TarReader(
+      File(path).openRead().transform(gzip.decoder),
+      disallowTrailingData: true,
+    );
     while (await reader.moveNext()) {
       final entry = reader.current;
       names.add(entry.name);
@@ -124,7 +127,10 @@ class _PkgTarArchive extends TarArchive {
   @override
   Future<String> readContentAsString(String name, {int maxLength = 0}) async {
     final mappedName = _normalizedNames[name] ?? name;
-    final reader = TarReader(File(_path).openRead().transform(gzip.decoder));
+    final reader = TarReader(
+      File(_path).openRead().transform(gzip.decoder),
+      disallowTrailingData: true,
+    );
     try {
       while (await reader.moveNext()) {
         if (reader.current.name != mappedName) continue;

--- a/pkg/pub_package_reader/pubspec.lock
+++ b/pkg/pub_package_reader/pubspec.lock
@@ -308,7 +308,7 @@ packages:
       name: tar
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
+    version: "0.3.2"
   term_glyph:
     dependency: transitive
     description:
@@ -380,4 +380,4 @@ packages:
     source: hosted
     version: "2.2.1"
 sdks:
-  dart: ">=2.12.0-259.9.beta <3.0.0"
+  dart: ">=2.12.0 <3.0.0"

--- a/pkg/pub_package_reader/pubspec.yaml
+++ b/pkg/pub_package_reader/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   pub_semver: ^1.4.4
   pubspec_parse: ^0.1.4
   yaml: ^2.0.0
-  tar: 0.3.0
+  tar: 0.3.2
 
 dev_dependencies:
   http: ^0.13.0

--- a/pkg/pub_package_reader/test/end2end_test.dart
+++ b/pkg/pub_package_reader/test/end2end_test.dart
@@ -30,6 +30,12 @@ void main() {
       return file.path;
     }
 
+    Future<void> expandWithBytes(String path, List<int> bytes) async {
+      final compressed = await File(path).readAsBytes();
+      final uncompressed = gzip.decode(compressed);
+      await File(path).writeAsBytes([...uncompressed, ...bytes]);
+    }
+
     test('pana 0.12.19', () async {
       void verify(PackageSummary summary) {
         expect(summary.issues, isEmpty);
@@ -49,6 +55,15 @@ void main() {
       verify(await summarizePackageArchive(path, maxContentLength: 128 * 1024));
       verify(await summarizePackageArchive(path,
           maxContentLength: 128 * 1024, useNative: true));
+
+      await expandWithBytes(path, <int>[1]);
+      await expectLater(
+          () => summarizePackageArchive(path, maxContentLength: 128 * 1024),
+          throwsA(isA<Exception>()));
+      await expectLater(
+          () => summarizePackageArchive(path,
+              maxContentLength: 128 * 1024, useNative: true),
+          throwsA(isA<Exception>()));
     });
 
     test('maxContentLength', () async {
@@ -61,6 +76,15 @@ void main() {
       verify(await summarizePackageArchive(path, maxContentLength: 16));
       verify(await summarizePackageArchive(path,
           maxContentLength: 16, useNative: true));
+
+      await expandWithBytes(path, <int>[1]);
+      await expectLater(
+          () => summarizePackageArchive(path, maxContentLength: 16),
+          throwsA(isA<Exception>()));
+      await expectLater(
+          () => summarizePackageArchive(path,
+              maxContentLength: 16, useNative: true),
+          throwsA(isA<Exception>()));
     });
   });
 }


### PR DESCRIPTION
- `package:tar` is used only in tests
- the next step should be to check the existing archives with the extra bytes, and after that using it on new package uploads.