### PR TITLE
Refactor/cleanup upload-related backend code.

### DIFF
--- a/app/lib/package/model_properties.dart
+++ b/app/lib/package/model_properties.dart
@@ -76,11 +76,6 @@ class Pubspec {
 
   String get description => _inner.description;
 
-  bool get hasBothAuthorAndAuthors {
-    _load();
-    return _json['author'] != null && _json['authors'] != null;
-  }
-
   Map<String, dynamic> get executables {
     _load();
     final map = _json['executables'];

--- a/app/lib/package/models.dart
+++ b/app/lib/package/models.dart
@@ -142,7 +142,7 @@ class Package extends db.ExpandoModel<String> {
   factory Package.fromVersion(PackageVersion version) {
     final now = DateTime.now().toUtc();
     return Package()
-      ..parentKey = version.packageKey
+      ..parentKey = version.packageKey.parent
       ..id = version.pubspec.name
       ..name = version.pubspec.name
       ..created = now

--- a/app/lib/package/models.dart
+++ b/app/lib/package/models.dart
@@ -136,6 +136,29 @@ class Package extends db.ExpandoModel<String> {
   @db.StringListProperty()
   List<String> assignedTags;
 
+  Package();
+
+  /// Creates a new [Package] and populates all of it's fields from [version].
+  factory Package.fromVersion(PackageVersion version) {
+    final now = DateTime.now().toUtc();
+    return Package()
+      ..parentKey = version.packageKey
+      ..id = version.pubspec.name
+      ..name = version.pubspec.name
+      ..created = now
+      ..updated = now
+      ..latestVersionKey = version.key
+      ..latestPublished = now
+      ..latestPrereleaseVersionKey = version.key
+      ..latestPrereleasePublished = now
+      ..uploaders = [version.uploader]
+      ..likes = 0
+      ..isDiscontinued = false
+      ..isUnlisted = false
+      ..isWithheld = false
+      ..assignedTags = [];
+  }
+
   // Convenience Fields:
 
   bool get isVisible => !isWithheld;

--- a/pkg/pub_package_reader/lib/pub_package_reader.dart
+++ b/pkg/pub_package_reader/lib/pub_package_reader.dart
@@ -109,8 +109,8 @@ Future<PackageSummary> summarizePackageArchive(
     issues.add(ArchiveIssue('Error parsing pubspec.yaml: $e'));
     return PackageSummary(issues: issues);
   }
-  // Check wether the pubspecContent can be converted to JSON
   issues.addAll(checkValidJson(pubspecContent));
+  issues.addAll(checkAuthors(pubspecContent));
   // Check whether the files can be extracted on case-preserving file systems
   // (e.g. on Windows). We can't allow two files with the same case-insensitive
   // name.
@@ -253,6 +253,15 @@ Iterable<ArchiveIssue> validatePackageVersion(Version version) sync* {
   }
 }
 
+/// Checks if the pubspec has both `author` and `authors` specified.
+Iterable<ArchiveIssue> checkAuthors(String pubspecContent) sync* {
+  final map = loadYaml(pubspecContent);
+  if (map is Map && map.containsKey('author') && map.containsKey('authors')) {
+    yield ArchiveIssue(
+        'Do not specify both `author` and `authors` in `pubspec.yaml`.');
+  }
+}
+
 /// Removes extra characters from the package name
 String reducePackageName(String name) =>
     // we allow only `_` as part of the name.
@@ -336,6 +345,7 @@ Iterable<ArchiveIssue> forbidGitDependencies(Pubspec pubspec) sync* {
   }
 }
 
+/// Check wether the pubspecContent can be converted to JSON
 Iterable<ArchiveIssue> checkValidJson(String pubspecContent) sync* {
   try {
     final map = loadYaml(pubspecContent) as Map;

--- a/pkg/pub_package_reader/lib/src/yaml_utils.dart
+++ b/pkg/pub_package_reader/lib/src/yaml_utils.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2021, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'package:yaml/yaml.dart';
 
 /// Check if given YAML string has aliases.

--- a/pkg/pub_package_reader/test/package_archive_test.dart
+++ b/pkg/pub_package_reader/test/package_archive_test.dart
@@ -91,6 +91,20 @@ void main() {
     });
   });
 
+  group('author vs. authors', () {
+    test('author is allowed', () {
+      expect(checkAuthors('author: x'), isEmpty);
+    });
+
+    test('authors is allowed', () {
+      expect(checkAuthors('authors: x'), isEmpty);
+    });
+
+    test('both author and authors is not allowed', () {
+      expect(checkAuthors('author: x\nauthors: x'), isNotEmpty);
+    });
+  });
+
   group('too many dependencies', () {
     test('allow the limit', () {
       final dependencies =


### PR DESCRIPTION
- moved `summarizePackageArchive` to upper level, to make it clear where it happens
- moved some generic checks to `pkg/pub_package_reader`
- moved some pub-specific checks to upper level (right after `pub_package_reader` checks)
- renamed `_parseAndValidateUpload`, as it neither parses, nor uploads the content -> `_createUploadEntities`
- also renamed `_ValidatedUpload` -> `_UploadEntities`
- moved `Package.fromVersion` to `models.dart`
