### PR TITLE
Copy to clipboard: strip the dollar-sign prefix from single-line shell commands.

### DIFF
--- a/app/lib/frontend/templates/views/pkg/install_tab.mustache
+++ b/app/lib/frontend/templates/views/pkg/install_tab.mustache
@@ -23,7 +23,7 @@
 {{/use_pub_get}}
 {{#use_flutter_packages_get}}
 <p>With Flutter:</p>
-<pre data-text-to-copy="flutter pub pub add {{ package }}"><code class="language-shell"> $ flutter pub pub add {{ package }}</code></pre>
+<pre data-text-to-copy="flutter pub add {{ package }}"><code class="language-shell"> $ flutter pub add {{ package }}</code></pre>
 {{/use_flutter_packages_get}}
 
 <p>

--- a/app/lib/frontend/templates/views/pkg/install_tab.mustache
+++ b/app/lib/frontend/templates/views/pkg/install_tab.mustache
@@ -5,7 +5,7 @@
 <h2>Use this package as an executable</h2>
 <h3>1. Install it</h3>
 <p>You can install the package from the command line:</p>
-<pre><code class="language-shell">$ <strong>dart pub global activate {{ package }}</strong>
+<pre data-text-to-copy="dart pub global activate {{ package }}"><code class="language-shell">$ <strong>dart pub global activate {{ package }}</strong>
 </code></pre>
 <h3>Use it</h3>
 <p>The package has the following executables:</p>
@@ -19,11 +19,11 @@
 <p>Run this command:</p>
 {{#use_pub_get}}
 <p>With Dart:</p>
-<pre><code class="language-shell"> $ dart pub add {{ package }}</code></pre>
+<pre data-text-to-copy="dart pub add {{ package }}"><code class="language-shell"> $ dart pub add {{ package }}</code></pre>
 {{/use_pub_get}}
 {{#use_flutter_packages_get}}
 <p>With Flutter:</p>
-<pre><code class="language-shell"> $ flutter pub pub add {{ package }}</code></pre>
+<pre data-text-to-copy="flutter pub pub add {{ package }}"><code class="language-shell"> $ flutter pub pub add {{ package }}</code></pre>
 {{/use_flutter_packages_get}}
 
 <p>

--- a/app/test/frontend/golden/pkg_install_page.html
+++ b/app/test/frontend/golden/pkg_install_page.html
@@ -204,7 +204,7 @@
                   <h3>Depend on it</h3>
                   <p>Run this command:</p>
                   <p>With Dart:</p>
-                  <pre>
+                  <pre data-text-to-copy="dart pub add foobar_pkg">
                     <code class="language-shell">$ dart pub add foobar_pkg</code>
                   </pre>
                   <p>

--- a/pkg/web_app/lib/src/hoverable.dart
+++ b/pkg/web_app/lib/src/hoverable.dart
@@ -108,11 +108,7 @@ void _setEventForPreCodeCopyToClipboard() {
     container.append(feedback);
 
     button.onClick.listen((_) async {
-      var text = pre.text.trim();
-      // Strip the dollar-sign prefix from single-line shell commands.
-      if (text.startsWith(r'$ ') && !text.contains('\n')) {
-        text = text.substring(1).trim();
-      }
+      final text = pre.dataset['textToCopy']?.trim() ?? pre.text.trim();
       _copyToClipboard(text);
       await _animateCopyFeedback(feedback);
     });

--- a/pkg/web_app/lib/src/hoverable.dart
+++ b/pkg/web_app/lib/src/hoverable.dart
@@ -108,7 +108,12 @@ void _setEventForPreCodeCopyToClipboard() {
     container.append(feedback);
 
     button.onClick.listen((_) async {
-      _copyToClipboard(pre.text);
+      var text = pre.text.trim();
+      // Strip the dollar-sign prefix from single-line shell commands.
+      if (text.startsWith(r'$ ') && !text.contains('\n')) {
+        text = text.substring(1).trim();
+      }
+      _copyToClipboard(text);
       await _animateCopyFeedback(feedback);
     });
   });


### PR DESCRIPTION
Fixes #4716.