### PR TITLE
Improved mobile view metadata handling

### DIFF
--- a/app/lib/frontend/templates/views/shared/detail/page.mustache
+++ b/app/lib/frontend/templates/views/shared/detail/page.mustache
@@ -13,6 +13,7 @@
         <h3 class="detail-lead-title">Metadata</h3>
       </div>
       <p class="detail-lead-text">{{info_box_lead}}</p>
+      <p class="detail-lead-more"><a class="detail-metadata-toggle">More...</a></p>
     </div>
   </div>
   {{/has_info_box}}
@@ -39,5 +40,7 @@
   <div class="detail-info-box">
   {{& info_box_html}}
   </div>
+
+  <p class="detail-lead-back"><a class="detail-metadata-toggle">Back</a></p>
 </div>
 {{/has_info_box}}

--- a/app/test/frontend/golden/pkg_admin_page_outdated.html
+++ b/app/test/frontend/golden/pkg_admin_page_outdated.html
@@ -167,6 +167,9 @@
               <h3 class="detail-lead-title">Metadata</h3>
             </div>
             <p class="detail-lead-text">my package description</p>
+            <p class="detail-lead-more">
+              <a class="detail-metadata-toggle">More...</a>
+            </p>
           </div>
         </div>
         <div class="detail-body">
@@ -401,6 +404,9 @@
             <a href="/packages?q=dependency%3Afoobar_pkg" rel="nofollow">Packages that depend on foobar_pkg</a>
           </p>
         </div>
+        <p class="detail-lead-back">
+          <a class="detail-metadata-toggle">Back</a>
+        </p>
       </div>
     </main>
     <footer class="site-footer">

--- a/app/test/frontend/golden/pkg_changelog_page.html
+++ b/app/test/frontend/golden/pkg_changelog_page.html
@@ -168,6 +168,9 @@
               <h3 class="detail-lead-title">Metadata</h3>
             </div>
             <p class="detail-lead-text">my package description</p>
+            <p class="detail-lead-more">
+              <a class="detail-metadata-toggle">More...</a>
+            </p>
           </div>
         </div>
         <div class="detail-body">
@@ -317,6 +320,9 @@
             <a href="/packages?q=dependency%3Afoobar_pkg" rel="nofollow">Packages that depend on foobar_pkg</a>
           </p>
         </div>
+        <p class="detail-lead-back">
+          <a class="detail-metadata-toggle">Back</a>
+        </p>
       </div>
     </main>
     <footer class="site-footer">

--- a/app/test/frontend/golden/pkg_example_page.html
+++ b/app/test/frontend/golden/pkg_example_page.html
@@ -168,6 +168,9 @@
               <h3 class="detail-lead-title">Metadata</h3>
             </div>
             <p class="detail-lead-text">my package description</p>
+            <p class="detail-lead-more">
+              <a class="detail-metadata-toggle">More...</a>
+            </p>
           </div>
         </div>
         <div class="detail-body">
@@ -318,6 +321,9 @@
             <a href="/packages?q=dependency%3Afoobar_pkg" rel="nofollow">Packages that depend on foobar_pkg</a>
           </p>
         </div>
+        <p class="detail-lead-back">
+          <a class="detail-metadata-toggle">Back</a>
+        </p>
       </div>
     </main>
     <footer class="site-footer">

--- a/app/test/frontend/golden/pkg_install_page.html
+++ b/app/test/frontend/golden/pkg_install_page.html
@@ -168,6 +168,9 @@
               <h3 class="detail-lead-title">Metadata</h3>
             </div>
             <p class="detail-lead-text">my package description</p>
+            <p class="detail-lead-more">
+              <a class="detail-metadata-toggle">More...</a>
+            </p>
           </div>
         </div>
         <div class="detail-body">
@@ -340,6 +343,9 @@
             <a href="/packages?q=dependency%3Afoobar_pkg" rel="nofollow">Packages that depend on foobar_pkg</a>
           </p>
         </div>
+        <p class="detail-lead-back">
+          <a class="detail-metadata-toggle">Back</a>
+        </p>
       </div>
     </main>
     <footer class="site-footer">

--- a/app/test/frontend/golden/pkg_score_page.html
+++ b/app/test/frontend/golden/pkg_score_page.html
@@ -168,6 +168,9 @@
               <h3 class="detail-lead-title">Metadata</h3>
             </div>
             <p class="detail-lead-text">my package description</p>
+            <p class="detail-lead-more">
+              <a class="detail-metadata-toggle">More...</a>
+            </p>
           </div>
         </div>
         <div class="detail-body">
@@ -372,6 +375,9 @@
             <a href="/packages?q=dependency%3Afoobar_pkg" rel="nofollow">Packages that depend on foobar_pkg</a>
           </p>
         </div>
+        <p class="detail-lead-back">
+          <a class="detail-metadata-toggle">Back</a>
+        </p>
       </div>
     </main>
     <footer class="site-footer">

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -168,6 +168,9 @@
               <h3 class="detail-lead-title">Metadata</h3>
             </div>
             <p class="detail-lead-text">my package description</p>
+            <p class="detail-lead-more">
+              <a class="detail-metadata-toggle">More...</a>
+            </p>
           </div>
         </div>
         <div class="detail-body">
@@ -320,6 +323,9 @@
             <a href="/packages?q=dependency%3Afoobar_pkg" rel="nofollow">Packages that depend on foobar_pkg</a>
           </p>
         </div>
+        <p class="detail-lead-back">
+          <a class="detail-metadata-toggle">Back</a>
+        </p>
       </div>
     </main>
     <footer class="site-footer">

--- a/app/test/frontend/golden/pkg_show_page_discontinued.html
+++ b/app/test/frontend/golden/pkg_show_page_discontinued.html
@@ -168,6 +168,9 @@
               <h3 class="detail-lead-title">Metadata</h3>
             </div>
             <p class="detail-lead-text">my package description</p>
+            <p class="detail-lead-more">
+              <a class="detail-metadata-toggle">More...</a>
+            </p>
           </div>
         </div>
         <div class="detail-body">
@@ -315,6 +318,9 @@
             <a href="/packages?q=dependency%3Afoobar_pkg" rel="nofollow">Packages that depend on foobar_pkg</a>
           </p>
         </div>
+        <p class="detail-lead-back">
+          <a class="detail-metadata-toggle">Back</a>
+        </p>
       </div>
     </main>
     <footer class="site-footer">

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -171,6 +171,9 @@
               <h3 class="detail-lead-title">Metadata</h3>
             </div>
             <p class="detail-lead-text">my package description</p>
+            <p class="detail-lead-more">
+              <a class="detail-metadata-toggle">More...</a>
+            </p>
           </div>
         </div>
         <div class="detail-body">
@@ -313,6 +316,9 @@
             <a href="/packages?q=dependency%3Afoobar_pkg" rel="nofollow">Packages that depend on foobar_pkg</a>
           </p>
         </div>
+        <p class="detail-lead-back">
+          <a class="detail-metadata-toggle">Back</a>
+        </p>
       </div>
     </main>
     <footer class="site-footer">

--- a/app/test/frontend/golden/pkg_show_page_legacy.html
+++ b/app/test/frontend/golden/pkg_show_page_legacy.html
@@ -168,6 +168,9 @@
               <h3 class="detail-lead-title">Metadata</h3>
             </div>
             <p class="detail-lead-text">my package description</p>
+            <p class="detail-lead-more">
+              <a class="detail-metadata-toggle">More...</a>
+            </p>
           </div>
         </div>
         <div class="detail-body">
@@ -315,6 +318,9 @@
             <a href="/packages?q=dependency%3Afoobar_pkg" rel="nofollow">Packages that depend on foobar_pkg</a>
           </p>
         </div>
+        <p class="detail-lead-back">
+          <a class="detail-metadata-toggle">Back</a>
+        </p>
       </div>
     </main>
     <footer class="site-footer">

--- a/app/test/frontend/golden/pkg_show_page_outdated.html
+++ b/app/test/frontend/golden/pkg_show_page_outdated.html
@@ -168,6 +168,9 @@
               <h3 class="detail-lead-title">Metadata</h3>
             </div>
             <p class="detail-lead-text">my package description</p>
+            <p class="detail-lead-more">
+              <a class="detail-metadata-toggle">More...</a>
+            </p>
           </div>
         </div>
         <div class="detail-body">
@@ -307,6 +310,9 @@
             <a href="/packages?q=dependency%3Afoobar_pkg" rel="nofollow">Packages that depend on foobar_pkg</a>
           </p>
         </div>
+        <p class="detail-lead-back">
+          <a class="detail-metadata-toggle">Back</a>
+        </p>
       </div>
     </main>
     <footer class="site-footer">

--- a/app/test/frontend/golden/pkg_show_page_publisher.html
+++ b/app/test/frontend/golden/pkg_show_page_publisher.html
@@ -168,6 +168,9 @@
               <h3 class="detail-lead-title">Metadata</h3>
             </div>
             <p class="detail-lead-text">neon is awesome</p>
+            <p class="detail-lead-more">
+              <a class="detail-metadata-toggle">More...</a>
+            </p>
           </div>
         </div>
         <div class="detail-body">
@@ -320,6 +323,9 @@
             <a href="/packages?q=dependency%3Aneon" rel="nofollow">Packages that depend on neon</a>
           </p>
         </div>
+        <p class="detail-lead-back">
+          <a class="detail-metadata-toggle">Back</a>
+        </p>
       </div>
     </main>
     <footer class="site-footer">

--- a/app/test/frontend/golden/pkg_show_version_page.html
+++ b/app/test/frontend/golden/pkg_show_version_page.html
@@ -168,6 +168,9 @@
               <h3 class="detail-lead-title">Metadata</h3>
             </div>
             <p class="detail-lead-text">my package description</p>
+            <p class="detail-lead-more">
+              <a class="detail-metadata-toggle">More...</a>
+            </p>
           </div>
         </div>
         <div class="detail-body">
@@ -295,6 +298,9 @@
             <a href="/packages?q=dependency%3Afoobar_pkg" rel="nofollow">Packages that depend on foobar_pkg</a>
           </p>
         </div>
+        <p class="detail-lead-back">
+          <a class="detail-metadata-toggle">Back</a>
+        </p>
       </div>
     </main>
     <footer class="site-footer">

--- a/app/test/frontend/golden/pkg_versions_page.html
+++ b/app/test/frontend/golden/pkg_versions_page.html
@@ -173,6 +173,9 @@
               <h3 class="detail-lead-title">Metadata</h3>
             </div>
             <p class="detail-lead-text">my package description</p>
+            <p class="detail-lead-more">
+              <a class="detail-metadata-toggle">More...</a>
+            </p>
           </div>
         </div>
         <div class="detail-body">
@@ -387,6 +390,9 @@
             <a href="/packages?q=dependency%3Afoobar_pkg" rel="nofollow">Packages that depend on foobar_pkg</a>
           </p>
         </div>
+        <p class="detail-lead-back">
+          <a class="detail-metadata-toggle">Back</a>
+        </p>
       </div>
     </main>
     <footer class="site-footer">

--- a/pkg/web_app/lib/src/mobile_nav.dart
+++ b/pkg/web_app/lib/src/mobile_nav.dart
@@ -30,10 +30,24 @@ void _setEventForMobileNav() {
 }
 
 void _setEventForDetailMetadataToggle() {
+  // Stored x,y coordinate of the scroll position at the time of the opening of metadata.
+  int origX, origY;
+
   document.querySelectorAll('.detail-metadata-toggle').forEach((e) {
-    e.onClick.listen((_) {
+    e.onClick.listen((_) async {
       document.querySelector('.detail-wrapper')?.classes?.toggle('-active');
       document.querySelector('.detail-metadata')?.classes?.toggle('-active');
+      await window.animationFrame;
+      if (origX == null) {
+        // store scroll position and scroll to the top
+        origX = window.scrollX;
+        origY = window.scrollY;
+        window.scrollTo(0, 0);
+      } else {
+        // restore scroll position
+        window.scrollTo(origX, origY);
+        origX = null;
+      }
     });
   });
 }

--- a/pkg/web_css/lib/src/_detail_page.scss
+++ b/pkg/web_css/lib/src/_detail_page.scss
@@ -120,6 +120,12 @@ $detail-tabs-tablet-width: calc(100% - 240px);
   }
 }
 
+.detail-lead-more,
+.detail-lead-back {
+  padding-right: 16px;
+  text-align: right;
+}
+
 .detail-header {
   .detail-header-outer-block {
     display: flex;


### PR DESCRIPTION
- Scroll position is saved and restored on returning to main view. 
- Hopefully improves #4688, by adding extra right-side links to view the details (`More...`) and going back (`Back`):

<img width="416" alt="Screenshot 2021-04-15 102106" src="https://user-images.githubusercontent.com/4778111/114838249-cd6c8180-9dd4-11eb-81ea-d960c05e4173.png">

<img width="419" alt="Screenshot 2021-04-15 102145" src="https://user-images.githubusercontent.com/4778111/114838245-cc3b5480-9dd4-11eb-97b5-e3c15f81725b.png">

