### PR TITLE
Service account for sigining package uploads

### DIFF
--- a/app/lib/shared/configuration.dart
+++ b/app/lib/shared/configuration.dart
@@ -154,7 +154,7 @@ class Configuration {
           'pub-gsuite-gmail-delegatee@dartlang-pub.iam.gserviceaccount.com',
       gmailRelayImpersonatedGSuiteUser: 'noreply@pub.dev',
       uploadSignerServiceAccount:
-          null, // TODO: update before upgrading package:appengine
+          'package-uploader-signer@dartlang-pub.iam.gserviceaccount.com',
       blockRobots: false,
       productionHosts: const ['pub.dartlang.org', 'pub.dev', 'api.pub.dev'],
       primaryApiUri: Uri.parse('https://pub.dartlang.org/'),


### PR DESCRIPTION
I don't think we have a choice but to test this in production.

 * The service account has permission to upload, but only the specific bucket.
 * The default appengine service account has permission to create tokens using it.

The last bit we can't really tests until we ship it. But we can test it before switching traffic.

I tested the same permissions setup locally for the staging site, using my personal user in-place of the default appengine service account, so I think this can work.