### PR TITLE
Migrate data classes in pkg/* to null-safety.

### DIFF
--- a/pkg/_popularity/lib/popularity.dart
+++ b/pkg/_popularity/lib/popularity.dart
@@ -14,13 +14,13 @@ class PackagePopularity {
 
   static final String popularityFileName = 'v$version/popularity.json.gz';
 
-  @JsonKey(name: 'date_first', nullable: false)
+  @JsonKey(name: 'date_first')
   final DateTime dateFirst;
 
-  @JsonKey(name: 'date_last', nullable: false)
+  @JsonKey(name: 'date_last')
   final DateTime dateLast;
 
-  @JsonKey(nullable: false)
+  @JsonKey()
   final Map<String, VoteTotals> items;
 
   PackagePopularity(this.dateFirst, this.dateLast, this.items);
@@ -33,9 +33,9 @@ class PackagePopularity {
 
 @JsonSerializable()
 class VoteTotals implements VoteData {
-  @JsonKey(nullable: false)
+  @JsonKey()
   final VoteData flutter;
-  @JsonKey(nullable: false)
+  @JsonKey()
   final VoteData notFlutter;
 
   @override
@@ -61,13 +61,13 @@ class VoteTotals implements VoteData {
 
 @JsonSerializable()
 class VoteData {
-  @JsonKey(name: 'votes_direct', nullable: false)
+  @JsonKey(name: 'votes_direct')
   final int direct;
 
-  @JsonKey(name: 'votes_dev', nullable: false)
+  @JsonKey(name: 'votes_dev')
   final int dev;
 
-  @JsonKey(name: 'votes_total', nullable: false)
+  @JsonKey(name: 'votes_total')
   final int total;
 
   int get score => _score(this);

--- a/pkg/_popularity/pubspec.lock
+++ b/pkg/_popularity/pubspec.lock
@@ -7,503 +7,475 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.0"
+    version: "21.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.39.14"
+    version: "1.5.0"
   args:
     dependency: transitive
     description:
       name: args
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.0"
+    version: "2.1.0"
   async:
     dependency: transitive
     description:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.2"
+    version: "2.6.1"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   build:
     dependency: transitive
     description:
       name: build
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "2.0.1"
   build_config:
     dependency: transitive
     description:
       name: build_config
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.2"
+    version: "1.0.0"
   build_daemon:
     dependency: transitive
     description:
       name: build_daemon
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.4"
+    version: "3.0.0"
   build_resolvers:
     dependency: transitive
     description:
       name: build_resolvers
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.11"
+    version: "2.0.1"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.1"
+    version: "2.0.2"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.1"
+    version: "7.0.0"
   build_verify:
     dependency: "direct dev"
     description:
       name: build_verify
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.1"
+    version: "2.0.0"
   built_collection:
     dependency: transitive
     description:
       name: built_collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.3.2"
+    version: "5.0.0"
   built_value:
     dependency: transitive
     description:
       name: built_value
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "7.1.0"
+    version: "8.0.5"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.3"
+    version: "1.2.0"
   checked_yaml:
     dependency: transitive
     description:
       name: checked_yaml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "2.0.1"
   cli_util:
     dependency: transitive
     description:
       name: cli_util
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.4"
+    version: "0.3.0"
   code_builder:
     dependency: transitive
     description:
       name: code_builder
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.4.1"
+    version: "4.0.0"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.13"
+    version: "1.15.0"
   convert:
     dependency: transitive
     description:
       name: convert
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "3.0.0"
   coverage:
     dependency: transitive
     description:
       name: coverage
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.14.1"
+    version: "1.0.2"
   crypto:
     dependency: transitive
     description:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.5"
-  csslib:
-    dependency: transitive
-    description:
-      name: csslib
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.16.2"
+    version: "3.0.1"
   dart_style:
     dependency: transitive
     description:
       name: dart_style
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.6"
+    version: "2.0.1"
+  file:
+    dependency: transitive
+    description:
+      name: file
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "6.1.0"
   fixnum:
     dependency: transitive
     description:
       name: fixnum
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.10.11"
+    version: "1.0.0"
+  frontend_server_client:
+    dependency: transitive
+    description:
+      name: frontend_server_client
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.0"
   glob:
     dependency: transitive
     description:
       name: glob
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "2.0.1"
   graphs:
     dependency: transitive
     description:
       name: graphs
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.0"
-  html:
-    dependency: transitive
-    description:
-      name: html
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.14.0+3"
-  http:
-    dependency: transitive
-    description:
-      name: http
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.12.2"
+    version: "2.0.0"
   http_multi_server:
     dependency: transitive
     description:
       name: http_multi_server
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.0"
+    version: "3.0.1"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.4"
+    version: "4.0.0"
   io:
     dependency: transitive
     description:
       name: io
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.4"
+    version: "1.0.0"
   js:
     dependency: transitive
     description:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.2"
+    version: "0.6.3"
   json_annotation:
     dependency: "direct main"
     description:
       name: json_annotation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.0"
+    version: "4.0.1"
   json_serializable:
     dependency: "direct dev"
     description:
       name: json_serializable
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.5.0"
+    version: "4.1.1"
   logging:
     dependency: transitive
     description:
       name: logging
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.11.4"
+    version: "1.0.1"
   matcher:
     dependency: transitive
     description:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.9"
+    version: "0.12.10"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.3"
+    version: "1.3.0"
   mime:
     dependency: transitive
     description:
       name: mime
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.7"
-  node_interop:
-    dependency: transitive
-    description:
-      name: node_interop
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.1.1"
-  node_io:
-    dependency: transitive
-    description:
-      name: node_io
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.1.1"
+    version: "1.0.0"
   node_preamble:
     dependency: transitive
     description:
       name: node_preamble
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.12"
+    version: "2.0.0"
   package_config:
     dependency: transitive
     description:
       name: package_config
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.3"
+    version: "2.0.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   pedantic:
     dependency: transitive
     description:
       name: pedantic
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.2"
+    version: "1.11.0"
   pool:
     dependency: transitive
     description:
       name: pool
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.0"
+    version: "1.5.0"
   pub_semver:
     dependency: transitive
     description:
       name: pub_semver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.4"
+    version: "2.0.0"
   pubspec_parse:
     dependency: transitive
     description:
       name: pubspec_parse
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.5"
-  quiver:
-    dependency: transitive
-    description:
-      name: quiver
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.1.3"
+    version: "1.0.0"
   shelf:
     dependency: transitive
     description:
       name: shelf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.7.9"
+    version: "1.1.1"
   shelf_packages_handler:
     dependency: transitive
     description:
       name: shelf_packages_handler
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "3.0.0"
   shelf_static:
     dependency: transitive
     description:
       name: shelf_static
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.8"
+    version: "1.0.0"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.3"
+    version: "1.0.1"
   source_gen:
     dependency: transitive
     description:
       name: source_gen
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.7+1"
+    version: "1.0.0"
   source_map_stack_trace:
     dependency: transitive
     description:
       name: source_map_stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   source_maps:
     dependency: transitive
     description:
       name: source_maps
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.10.9"
+    version: "0.10.10"
   source_span:
     dependency: transitive
     description:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.5"
+    version: "1.10.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   stream_transform:
     dependency: transitive
     description:
       name: stream_transform
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "2.0.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.5"
+    version: "1.1.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   test:
     dependency: "direct dev"
     description:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.4"
+    version: "1.17.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.18"
+    version: "0.4.0"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.11+1"
+    version: "0.3.23"
   timing:
     dependency: transitive
     description:
       name: timing
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.1+2"
+    version: "1.0.0"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.2.0"
+    version: "6.2.0"
   watcher:
     dependency: transitive
     description:
       name: watcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.7+15"
+    version: "1.0.0"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "2.1.0"
   webkit_inspection_protocol:
     dependency: transitive
     description:
       name: webkit_inspection_protocol
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.7.3"
+    version: "1.0.0"
   yaml:
     dependency: transitive
     description:
       name: yaml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.1"
+    version: "3.1.0"
 sdks:
-  dart: ">=2.7.0 <3.0.0"
+  dart: ">=2.12.0 <3.0.0"

--- a/pkg/_popularity/pubspec.yaml
+++ b/pkg/_popularity/pubspec.yaml
@@ -2,13 +2,13 @@ name: _popularity
 publish_to: none
 
 environment:
-  sdk: '>=2.6.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  json_annotation: ^3.0.0
+  json_annotation: '>=3.0.0 <5.0.0'
 
 dev_dependencies:
-  build_runner: ^1.0.0
-  build_verify: ^1.1.1
-  json_serializable: ^3.0.0
+  build_runner: ^2.0.0
+  build_verify: ^2.0.0
+  json_serializable: ^4.0.0
   test: ^1.3.0

--- a/pkg/client_data/lib/account_api.dart
+++ b/pkg/client_data/lib/account_api.dart
@@ -5,7 +5,6 @@
 import 'dart:convert';
 
 import 'package:json_annotation/json_annotation.dart';
-import 'package:meta/meta.dart';
 
 part 'account_api.g.dart';
 
@@ -18,10 +17,10 @@ class ClientSessionRequest {
   /// This must:
   ///  * be valid at the time of the request,
   ///  * obtained from the OAuth2 flow used on the pub.dev website.
-  final String accessToken;
+  final String? accessToken;
 
   ClientSessionRequest({
-    @required this.accessToken,
+    required this.accessToken,
   });
 
   factory ClientSessionRequest.fromJson(Map<String, dynamic> json) =>
@@ -35,12 +34,12 @@ class ClientSessionRequest {
 class ClientSessionStatus {
   /// True, if the user session has been updated and the current page should be
   /// reloaded.
-  final bool changed;
-  final DateTime expires;
+  final bool? changed;
+  final DateTime? expires;
 
   ClientSessionStatus({
-    @required this.changed,
-    @required this.expires,
+    required this.changed,
+    required this.expires,
   });
 
   factory ClientSessionStatus.fromJson(Map<String, dynamic> json) =>
@@ -52,14 +51,14 @@ class ClientSessionStatus {
 
   Map<String, dynamic> toJson() => _$ClientSessionStatusToJson(this);
 
-  bool get isValid => expires != null && DateTime.now().isBefore(expires);
+  bool get isValid => expires != null && DateTime.now().isBefore(expires!);
 }
 
 /// Response from listing of likes.
 @JsonSerializable()
 class LikedPackagesRepsonse {
-  List<PackageLikeResponse> likedPackages;
-  LikedPackagesRepsonse({@required this.likedPackages});
+  List<PackageLikeResponse>? likedPackages;
+  LikedPackagesRepsonse({required this.likedPackages});
 
   factory LikedPackagesRepsonse.fromJson(Map<String, dynamic> json) =>
       _$LikedPackagesRepsonseFromJson(json);
@@ -72,12 +71,12 @@ class LikedPackagesRepsonse {
 /// [created] might be null when [liked] is `false`.
 @JsonSerializable()
 class PackageLikeResponse {
-  String package;
-  bool liked;
-  DateTime created;
+  String? package;
+  bool? liked;
+  DateTime? created;
 
   PackageLikeResponse(
-      {@required this.package, @required this.liked, this.created});
+      {required this.package, required this.liked, this.created});
 
   factory PackageLikeResponse.fromJson(Map<String, dynamic> json) =>
       _$PackageLikeResponseFromJson(json);
@@ -89,12 +88,12 @@ class PackageLikeResponse {
 @JsonSerializable()
 class PackageLikesCount {
   /// Package that was liked.
-  String package;
+  String? package;
 
   /// Number of users who have liked [package].
-  int likes;
+  int? likes;
 
-  PackageLikesCount({@required this.package, @required this.likes});
+  PackageLikesCount({required this.package, required this.likes});
 
   factory PackageLikesCount.fromJson(Map<String, dynamic> json) =>
       _$PackageLikesCountFromJson(json);
@@ -105,10 +104,10 @@ class PackageLikesCount {
 /// Account-specific information about a package.
 @JsonSerializable()
 class AccountPkgOptions {
-  final bool isAdmin;
+  final bool? isAdmin;
 
   AccountPkgOptions({
-    @required this.isAdmin,
+    required this.isAdmin,
   });
 
   factory AccountPkgOptions.fromJson(Map<String, dynamic> json) =>
@@ -120,10 +119,10 @@ class AccountPkgOptions {
 /// Account-specific information about a publisher.
 @JsonSerializable()
 class AccountPublisherOptions {
-  final bool isAdmin;
+  final bool? isAdmin;
 
   AccountPublisherOptions({
-    @required this.isAdmin,
+    required this.isAdmin,
   });
 
   factory AccountPublisherOptions.fromJson(Map<String, dynamic> json) =>
@@ -132,7 +131,7 @@ class AccountPublisherOptions {
   Map<String, dynamic> toJson() => _$AccountPublisherOptionsToJson(this);
 }
 
-@JsonSerializable(nullable: false)
+@JsonSerializable()
 class Consent {
   /// Title for this consent request.
   final String titleText;
@@ -141,8 +140,8 @@ class Consent {
   final String descriptionHtml;
 
   Consent({
-    @required this.titleText,
-    @required this.descriptionHtml,
+    required this.titleText,
+    required this.descriptionHtml,
   });
 
   factory Consent.fromJson(Map<String, dynamic> json) =>
@@ -151,11 +150,11 @@ class Consent {
   Map<String, dynamic> toJson() => _$ConsentToJson(this);
 }
 
-@JsonSerializable(nullable: false)
+@JsonSerializable()
 class ConsentResult {
   final bool granted;
 
-  ConsentResult({@required this.granted});
+  ConsentResult({required this.granted});
 
   factory ConsentResult.fromJson(Map<String, dynamic> json) =>
       _$ConsentResultFromJson(json);
@@ -173,7 +172,10 @@ class InviteStatus {
   /// send a new message before this timestamp.
   final DateTime nextNotification;
 
-  InviteStatus({@required this.emailSent, @required this.nextNotification});
+  InviteStatus({
+    required this.emailSent,
+    required this.nextNotification,
+  });
   factory InviteStatus.fromJson(Map<String, dynamic> json) =>
       _$InviteStatusFromJson(json);
   Map<String, dynamic> toJson() => _$InviteStatusToJson(this);

--- a/pkg/client_data/lib/account_api.g.dart
+++ b/pkg/client_data/lib/account_api.g.dart
@@ -8,7 +8,7 @@ part of 'account_api.dart';
 
 ClientSessionRequest _$ClientSessionRequestFromJson(Map<String, dynamic> json) {
   return ClientSessionRequest(
-    accessToken: json['accessToken'] as String,
+    accessToken: json['accessToken'] as String?,
   );
 }
 
@@ -20,7 +20,7 @@ Map<String, dynamic> _$ClientSessionRequestToJson(
 
 ClientSessionStatus _$ClientSessionStatusFromJson(Map<String, dynamic> json) {
   return ClientSessionStatus(
-    changed: json['changed'] as bool,
+    changed: json['changed'] as bool?,
     expires: json['expires'] == null
         ? null
         : DateTime.parse(json['expires'] as String),
@@ -37,11 +37,9 @@ Map<String, dynamic> _$ClientSessionStatusToJson(
 LikedPackagesRepsonse _$LikedPackagesRepsonseFromJson(
     Map<String, dynamic> json) {
   return LikedPackagesRepsonse(
-    likedPackages: (json['likedPackages'] as List)
-        ?.map((e) => e == null
-            ? null
-            : PackageLikeResponse.fromJson(e as Map<String, dynamic>))
-        ?.toList(),
+    likedPackages: (json['likedPackages'] as List<dynamic>?)
+        ?.map((e) => PackageLikeResponse.fromJson(e as Map<String, dynamic>))
+        .toList(),
   );
 }
 
@@ -53,8 +51,8 @@ Map<String, dynamic> _$LikedPackagesRepsonseToJson(
 
 PackageLikeResponse _$PackageLikeResponseFromJson(Map<String, dynamic> json) {
   return PackageLikeResponse(
-    package: json['package'] as String,
-    liked: json['liked'] as bool,
+    package: json['package'] as String?,
+    liked: json['liked'] as bool?,
     created: json['created'] == null
         ? null
         : DateTime.parse(json['created'] as String),
@@ -71,8 +69,8 @@ Map<String, dynamic> _$PackageLikeResponseToJson(
 
 PackageLikesCount _$PackageLikesCountFromJson(Map<String, dynamic> json) {
   return PackageLikesCount(
-    package: json['package'] as String,
-    likes: json['likes'] as int,
+    package: json['package'] as String?,
+    likes: json['likes'] as int?,
   );
 }
 
@@ -84,7 +82,7 @@ Map<String, dynamic> _$PackageLikesCountToJson(PackageLikesCount instance) =>
 
 AccountPkgOptions _$AccountPkgOptionsFromJson(Map<String, dynamic> json) {
   return AccountPkgOptions(
-    isAdmin: json['isAdmin'] as bool,
+    isAdmin: json['isAdmin'] as bool?,
   );
 }
 
@@ -96,7 +94,7 @@ Map<String, dynamic> _$AccountPkgOptionsToJson(AccountPkgOptions instance) =>
 AccountPublisherOptions _$AccountPublisherOptionsFromJson(
     Map<String, dynamic> json) {
   return AccountPublisherOptions(
-    isAdmin: json['isAdmin'] as bool,
+    isAdmin: json['isAdmin'] as bool?,
   );
 }
 
@@ -132,14 +130,12 @@ Map<String, dynamic> _$ConsentResultToJson(ConsentResult instance) =>
 InviteStatus _$InviteStatusFromJson(Map<String, dynamic> json) {
   return InviteStatus(
     emailSent: json['emailSent'] as bool,
-    nextNotification: json['nextNotification'] == null
-        ? null
-        : DateTime.parse(json['nextNotification'] as String),
+    nextNotification: DateTime.parse(json['nextNotification'] as String),
   );
 }
 
 Map<String, dynamic> _$InviteStatusToJson(InviteStatus instance) =>
     <String, dynamic>{
       'emailSent': instance.emailSent,
-      'nextNotification': instance.nextNotification?.toIso8601String(),
+      'nextNotification': instance.nextNotification.toIso8601String(),
     };

--- a/pkg/client_data/lib/admin_api.dart
+++ b/pkg/client_data/lib/admin_api.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:json_annotation/json_annotation.dart';
-import 'package:meta/meta.dart';
 
 part 'admin_api.g.dart';
 
@@ -22,10 +21,10 @@ class AdminListUsersResponse {
   /// single request body can include, the [continuationToken] can be provided
   /// as query-string parameter `?ct=`, in another request.
   /// If [continuationToken] is `null` no further `users` can be returned.
-  final String continuationToken;
+  final String? continuationToken;
 
   // json_serializable boiler-plate
-  AdminListUsersResponse({@required this.users, this.continuationToken});
+  AdminListUsersResponse({required this.users, this.continuationToken});
   factory AdminListUsersResponse.fromJson(Map<String, dynamic> json) =>
       _$AdminListUsersResponseFromJson(json);
   Map<String, dynamic> toJson() => _$AdminListUsersResponseToJson(this);
@@ -37,21 +36,21 @@ class AdminUserEntry {
   /// The `pub.dev` specific user identifier.
   ///
   /// This is a random UUID generated when the user was created.
-  final String userId;
+  final String? userId;
 
   /// OAuth2 `user_id`, if one was ever set (otherwise this is `null`).
   ///
   /// Legacy users may not have an [oauthUserId], if they have not signed in
   /// since we started recording this attribute.
-  final String oauthUserId;
+  final String? oauthUserId;
 
   /// Email of the user.
-  final String email;
+  final String? email;
 
   // json_serializable boiler-plate
   AdminUserEntry({
-    @required this.userId,
-    @required this.email,
+    required this.userId,
+    required this.email,
     this.oauthUserId,
   });
   factory AdminUserEntry.fromJson(Map<String, dynamic> json) =>
@@ -65,7 +64,7 @@ class AssignedTags {
   final List<String> assignedTags;
 
   // json_serializable boiler-plate
-  AssignedTags({@required this.assignedTags});
+  AssignedTags({required this.assignedTags});
   factory AssignedTags.fromJson(Map<String, dynamic> json) =>
       _$AssignedTagsFromJson(json);
   Map<String, dynamic> toJson() => _$AssignedTagsToJson(this);
@@ -74,8 +73,8 @@ class AssignedTags {
 /// Admin API request to mutate list of assigned tags.
 @JsonSerializable()
 class PatchAssignedTags {
-  final List<String> assignedTagsAdded;
-  final List<String> assignedTagsRemoved;
+  final List<String>? assignedTagsAdded;
+  final List<String>? assignedTagsRemoved;
 
   // json_serializable boiler-plate
   PatchAssignedTags({

--- a/pkg/client_data/lib/admin_api.g.dart
+++ b/pkg/client_data/lib/admin_api.g.dart
@@ -9,12 +9,10 @@ part of 'admin_api.dart';
 AdminListUsersResponse _$AdminListUsersResponseFromJson(
     Map<String, dynamic> json) {
   return AdminListUsersResponse(
-    users: (json['users'] as List)
-        ?.map((e) => e == null
-            ? null
-            : AdminUserEntry.fromJson(e as Map<String, dynamic>))
-        ?.toList(),
-    continuationToken: json['continuationToken'] as String,
+    users: (json['users'] as List<dynamic>)
+        .map((e) => AdminUserEntry.fromJson(e as Map<String, dynamic>))
+        .toList(),
+    continuationToken: json['continuationToken'] as String?,
   );
 }
 
@@ -27,9 +25,9 @@ Map<String, dynamic> _$AdminListUsersResponseToJson(
 
 AdminUserEntry _$AdminUserEntryFromJson(Map<String, dynamic> json) {
   return AdminUserEntry(
-    userId: json['userId'] as String,
-    email: json['email'] as String,
-    oauthUserId: json['oauthUserId'] as String,
+    userId: json['userId'] as String?,
+    email: json['email'] as String?,
+    oauthUserId: json['oauthUserId'] as String?,
   );
 }
 
@@ -42,8 +40,9 @@ Map<String, dynamic> _$AdminUserEntryToJson(AdminUserEntry instance) =>
 
 AssignedTags _$AssignedTagsFromJson(Map<String, dynamic> json) {
   return AssignedTags(
-    assignedTags:
-        (json['assignedTags'] as List)?.map((e) => e as String)?.toList(),
+    assignedTags: (json['assignedTags'] as List<dynamic>)
+        .map((e) => e as String)
+        .toList(),
   );
 }
 
@@ -54,11 +53,12 @@ Map<String, dynamic> _$AssignedTagsToJson(AssignedTags instance) =>
 
 PatchAssignedTags _$PatchAssignedTagsFromJson(Map<String, dynamic> json) {
   return PatchAssignedTags(
-    assignedTagsAdded:
-        (json['assignedTagsAdded'] as List)?.map((e) => e as String)?.toList(),
-    assignedTagsRemoved: (json['assignedTagsRemoved'] as List)
+    assignedTagsAdded: (json['assignedTagsAdded'] as List<dynamic>?)
         ?.map((e) => e as String)
-        ?.toList(),
+        .toList(),
+    assignedTagsRemoved: (json['assignedTagsRemoved'] as List<dynamic>?)
+        ?.map((e) => e as String)
+        .toList(),
   );
 }
 

--- a/pkg/client_data/lib/package_api.dart
+++ b/pkg/client_data/lib/package_api.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:json_annotation/json_annotation.dart';
-import 'package:meta/meta.dart';
 
 part 'package_api.g.dart';
 
@@ -17,11 +16,11 @@ class UploadInfo {
   final String url;
 
   /// The fields the uploader should add to the multipart upload.
-  final Map<String, String> fields;
+  final Map<String, String>? fields;
 
   UploadInfo({
-    @required this.url,
-    @required this.fields,
+    required this.url,
+    required this.fields,
   });
 
   factory UploadInfo.fromJson(Map<String, dynamic> json) =>
@@ -33,9 +32,9 @@ class UploadInfo {
 /// Options and flags to get/set on a package.
 @JsonSerializable()
 class PkgOptions {
-  final bool isDiscontinued;
-  final String replacedBy;
-  final bool isUnlisted;
+  final bool? isDiscontinued;
+  final String? replacedBy;
+  final bool? isUnlisted;
 
   PkgOptions({
     this.isDiscontinued,
@@ -54,7 +53,7 @@ class PkgOptions {
 class PackagePublisherInfo {
   /// Domain name of the publisher that owns this package, `null` if package
   /// is not owned by a publisher.
-  final String publisherId;
+  final String? publisherId;
 
   PackagePublisherInfo({
     this.publisherId,
@@ -71,7 +70,7 @@ class PackagePublisherInfo {
 class SuccessMessage {
   final Message success;
 
-  SuccessMessage({@required this.success});
+  SuccessMessage({required this.success});
 
   factory SuccessMessage.fromJson(Map<String, dynamic> json) =>
       _$SuccessMessageFromJson(json);
@@ -84,7 +83,7 @@ class SuccessMessage {
 class Message {
   final String message;
 
-  Message({@required this.message});
+  Message({required this.message});
 
   factory Message.fromJson(Map<String, dynamic> json) =>
       _$MessageFromJson(json);
@@ -101,11 +100,11 @@ class PackageData {
 
   /// `true` if package is discontinued.
   /// If it is omitted, `null` or `false` the package is *not discontinued*.
-  final bool isDiscontinued;
+  final bool? isDiscontinued;
 
   /// If [isDiscontinued] is set, this _may_ point to a package that can be used
   /// instead (set by the package admin).
-  final String replacedBy;
+  final String? replacedBy;
 
   /// This is merely a convenience property, because the [VersionInfo] for the
   /// latest version also exists in the [versions] list.
@@ -118,11 +117,11 @@ class PackageData {
   final List<VersionInfo> versions;
 
   PackageData({
-    @required this.name,
+    required this.name,
     this.isDiscontinued,
     this.replacedBy,
-    @required this.latest,
-    @required this.versions,
+    required this.latest,
+    required this.versions,
   });
 
   factory PackageData.fromJson(Map<String, dynamic> json) =>
@@ -139,16 +138,16 @@ class VersionInfo {
 
   /// As of Dart 2.8 `pub` client uses [archiveUrl] to find the archive.
   @JsonKey(name: 'archive_url')
-  final String archiveUrl;
+  final String? archiveUrl;
 
   /// This is an optional field of the API response, it may be `null` or omitted.
-  final DateTime published;
+  final DateTime? published;
 
   VersionInfo({
-    @required this.version,
-    @required this.pubspec,
-    @required this.archiveUrl,
-    @required this.published,
+    required this.version,
+    required this.pubspec,
+    required this.archiveUrl,
+    required this.published,
   });
 
   factory VersionInfo.fromJson(Map<String, dynamic> json) =>
@@ -159,18 +158,18 @@ class VersionInfo {
 
 @JsonSerializable(includeIfNull: false)
 class VersionScore {
-  final int grantedPoints;
-  final int maxPoints;
-  final int likeCount;
-  final double popularityScore;
-  final DateTime lastUpdated;
+  final int? grantedPoints;
+  final int? maxPoints;
+  final int? likeCount;
+  final double? popularityScore;
+  final DateTime? lastUpdated;
 
   VersionScore({
-    @required this.grantedPoints,
-    @required this.maxPoints,
-    @required this.likeCount,
-    @required this.popularityScore,
-    @required this.lastUpdated,
+    required this.grantedPoints,
+    required this.maxPoints,
+    required this.likeCount,
+    required this.popularityScore,
+    required this.lastUpdated,
   });
 
   factory VersionScore.fromJson(Map<String, dynamic> json) =>
@@ -190,7 +189,7 @@ class InviteUploaderRequest {
   final String email;
 
   // json_serializable boiler-plate
-  InviteUploaderRequest({@required this.email});
+  InviteUploaderRequest({required this.email});
 
   factory InviteUploaderRequest.fromJson(Map<String, dynamic> json) =>
       _$InviteUploaderRequestFromJson(json);

--- a/pkg/client_data/lib/package_api.g.dart
+++ b/pkg/client_data/lib/package_api.g.dart
@@ -9,7 +9,7 @@ part of 'package_api.dart';
 UploadInfo _$UploadInfoFromJson(Map<String, dynamic> json) {
   return UploadInfo(
     url: json['url'] as String,
-    fields: (json['fields'] as Map<String, dynamic>)?.map(
+    fields: (json['fields'] as Map<String, dynamic>?)?.map(
       (k, e) => MapEntry(k, e as String),
     ),
   );
@@ -23,9 +23,9 @@ Map<String, dynamic> _$UploadInfoToJson(UploadInfo instance) =>
 
 PkgOptions _$PkgOptionsFromJson(Map<String, dynamic> json) {
   return PkgOptions(
-    isDiscontinued: json['isDiscontinued'] as bool,
-    replacedBy: json['replacedBy'] as String,
-    isUnlisted: json['isUnlisted'] as bool,
+    isDiscontinued: json['isDiscontinued'] as bool?,
+    replacedBy: json['replacedBy'] as String?,
+    isUnlisted: json['isUnlisted'] as bool?,
   );
 }
 
@@ -38,7 +38,7 @@ Map<String, dynamic> _$PkgOptionsToJson(PkgOptions instance) =>
 
 PackagePublisherInfo _$PackagePublisherInfoFromJson(Map<String, dynamic> json) {
   return PackagePublisherInfo(
-    publisherId: json['publisherId'] as String,
+    publisherId: json['publisherId'] as String?,
   );
 }
 
@@ -50,9 +50,7 @@ Map<String, dynamic> _$PackagePublisherInfoToJson(
 
 SuccessMessage _$SuccessMessageFromJson(Map<String, dynamic> json) {
   return SuccessMessage(
-    success: json['success'] == null
-        ? null
-        : Message.fromJson(json['success'] as Map<String, dynamic>),
+    success: Message.fromJson(json['success'] as Map<String, dynamic>),
   );
 }
 
@@ -74,20 +72,19 @@ Map<String, dynamic> _$MessageToJson(Message instance) => <String, dynamic>{
 PackageData _$PackageDataFromJson(Map<String, dynamic> json) {
   return PackageData(
     name: json['name'] as String,
-    isDiscontinued: json['isDiscontinued'] as bool,
-    replacedBy: json['replacedBy'] as String,
-    latest: json['latest'] == null
-        ? null
-        : VersionInfo.fromJson(json['latest'] as Map<String, dynamic>),
-    versions: (json['versions'] as List)
-        ?.map((e) =>
-            e == null ? null : VersionInfo.fromJson(e as Map<String, dynamic>))
-        ?.toList(),
+    isDiscontinued: json['isDiscontinued'] as bool?,
+    replacedBy: json['replacedBy'] as String?,
+    latest: VersionInfo.fromJson(json['latest'] as Map<String, dynamic>),
+    versions: (json['versions'] as List<dynamic>)
+        .map((e) => VersionInfo.fromJson(e as Map<String, dynamic>))
+        .toList(),
   );
 }
 
 Map<String, dynamic> _$PackageDataToJson(PackageData instance) {
-  final val = <String, dynamic>{};
+  final val = <String, dynamic>{
+    'name': instance.name,
+  };
 
   void writeNotNull(String key, dynamic value) {
     if (value != null) {
@@ -95,11 +92,10 @@ Map<String, dynamic> _$PackageDataToJson(PackageData instance) {
     }
   }
 
-  writeNotNull('name', instance.name);
   writeNotNull('isDiscontinued', instance.isDiscontinued);
   writeNotNull('replacedBy', instance.replacedBy);
-  writeNotNull('latest', instance.latest);
-  writeNotNull('versions', instance.versions);
+  val['latest'] = instance.latest;
+  val['versions'] = instance.versions;
   return val;
 }
 
@@ -107,7 +103,7 @@ VersionInfo _$VersionInfoFromJson(Map<String, dynamic> json) {
   return VersionInfo(
     version: json['version'] as String,
     pubspec: json['pubspec'] as Map<String, dynamic>,
-    archiveUrl: json['archive_url'] as String,
+    archiveUrl: json['archive_url'] as String?,
     published: json['published'] == null
         ? null
         : DateTime.parse(json['published'] as String),
@@ -124,10 +120,10 @@ Map<String, dynamic> _$VersionInfoToJson(VersionInfo instance) =>
 
 VersionScore _$VersionScoreFromJson(Map<String, dynamic> json) {
   return VersionScore(
-    grantedPoints: json['grantedPoints'] as int,
-    maxPoints: json['maxPoints'] as int,
-    likeCount: json['likeCount'] as int,
-    popularityScore: (json['popularityScore'] as num)?.toDouble(),
+    grantedPoints: json['grantedPoints'] as int?,
+    maxPoints: json['maxPoints'] as int?,
+    likeCount: json['likeCount'] as int?,
+    popularityScore: (json['popularityScore'] as num?)?.toDouble(),
     lastUpdated: json['lastUpdated'] == null
         ? null
         : DateTime.parse(json['lastUpdated'] as String),

--- a/pkg/client_data/lib/page_data.dart
+++ b/pkg/client_data/lib/page_data.dart
@@ -5,7 +5,6 @@
 import 'dart:convert';
 
 import 'package:json_annotation/json_annotation.dart';
-import 'package:meta/meta.dart';
 
 part 'page_data.g.dart';
 
@@ -18,9 +17,9 @@ final pageDataJsonCodec = json.fuse(utf8).fuse(base64);
 /// using [pageDataJsonCodec].
 @JsonSerializable(includeIfNull: false)
 class PageData {
-  final String consentId;
-  final PkgData pkgData;
-  final PublisherData publisher;
+  final String? consentId;
+  final PkgData? pkgData;
+  final PublisherData? publisher;
 
   PageData({
     this.consentId,
@@ -47,15 +46,15 @@ class PkgData {
 
   /// PublisherId of publisher that owns this package, `null` if the package
   /// isn't owned by a publisher.
-  final String publisherId;
+  final String? publisherId;
   final bool isDiscontinued;
 
   PkgData({
-    @required this.package,
-    @required this.version,
-    @required this.publisherId,
-    @required this.isDiscontinued,
-    @required this.likes,
+    required this.package,
+    required this.version,
+    required this.publisherId,
+    required this.isDiscontinued,
+    required this.likes,
   });
 
   factory PkgData.fromJson(Map<String, dynamic> json) =>
@@ -70,7 +69,7 @@ class PublisherData {
   final String publisherId;
 
   PublisherData({
-    @required this.publisherId,
+    required this.publisherId,
   });
 
   factory PublisherData.fromJson(Map<String, dynamic> json) =>

--- a/pkg/client_data/lib/page_data.g.dart
+++ b/pkg/client_data/lib/page_data.g.dart
@@ -8,7 +8,7 @@ part of 'page_data.dart';
 
 PageData _$PageDataFromJson(Map<String, dynamic> json) {
   return PageData(
-    consentId: json['consentId'] as String,
+    consentId: json['consentId'] as String?,
     pkgData: json['pkgData'] == null
         ? null
         : PkgData.fromJson(json['pkgData'] as Map<String, dynamic>),
@@ -37,14 +37,18 @@ PkgData _$PkgDataFromJson(Map<String, dynamic> json) {
   return PkgData(
     package: json['package'] as String,
     version: json['version'] as String,
-    publisherId: json['publisherId'] as String,
+    publisherId: json['publisherId'] as String?,
     isDiscontinued: json['isDiscontinued'] as bool,
     likes: json['likes'] as int,
   );
 }
 
 Map<String, dynamic> _$PkgDataToJson(PkgData instance) {
-  final val = <String, dynamic>{};
+  final val = <String, dynamic>{
+    'package': instance.package,
+    'version': instance.version,
+    'likes': instance.likes,
+  };
 
   void writeNotNull(String key, dynamic value) {
     if (value != null) {
@@ -52,11 +56,8 @@ Map<String, dynamic> _$PkgDataToJson(PkgData instance) {
     }
   }
 
-  writeNotNull('package', instance.package);
-  writeNotNull('version', instance.version);
-  writeNotNull('likes', instance.likes);
   writeNotNull('publisherId', instance.publisherId);
-  writeNotNull('isDiscontinued', instance.isDiscontinued);
+  val['isDiscontinued'] = instance.isDiscontinued;
   return val;
 }
 

--- a/pkg/client_data/lib/publisher_api.dart
+++ b/pkg/client_data/lib/publisher_api.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:json_annotation/json_annotation.dart';
-import 'package:meta/meta.dart';
 
 part 'publisher_api.g.dart';
 
@@ -20,7 +19,7 @@ class CreatePublisherRequest {
   final String accessToken;
 
   // json_serializable boiler-plate
-  CreatePublisherRequest({@required this.accessToken});
+  CreatePublisherRequest({required this.accessToken});
   factory CreatePublisherRequest.fromJson(Map<String, dynamic> json) =>
       _$CreatePublisherRequestFromJson(json);
   Map<String, dynamic> toJson() => _$CreatePublisherRequestToJson(this);
@@ -33,20 +32,20 @@ class UpdatePublisherRequest {
   ///
   /// If left as `null` this field will be ignored, and the description of the
   /// publisher will not be changed.
-  final String description;
+  final String? description;
 
   /// A valid URL that points to the publisher's website.
   ///
   /// If left as `null` this field will be ignored, and the website URL of the
   /// publisher will not be changed.
-  final String websiteUrl;
+  final String? websiteUrl;
 
   /// Email to be set as contact email for the publisher.
   ///
   /// If left as `null` this field will be ignored.
   /// If changed, the change will not take effect until the confirmation email
   /// have been confirmed by the user.
-  final String contactEmail;
+  final String? contactEmail;
 
   // json_serializable boiler-plate
   UpdatePublisherRequest({
@@ -64,19 +63,19 @@ class UpdatePublisherRequest {
 @JsonSerializable()
 class PublisherInfo {
   /// A human readable description in markdown.
-  final String description;
+  final String? description;
 
   /// The website URL of the publisher.
-  final String websiteUrl;
+  final String? websiteUrl;
 
   /// The currently verified contact email for the publisher.
-  final String contactEmail;
+  final String? contactEmail;
 
   // json_serializable boiler-plate
   PublisherInfo({
-    @required this.description,
-    @required this.websiteUrl,
-    @required this.contactEmail,
+    required this.description,
+    required this.websiteUrl,
+    required this.contactEmail,
   });
 
   factory PublisherInfo.fromJson(Map<String, dynamic> json) =>
@@ -91,7 +90,7 @@ class PublisherMembers {
   final List<PublisherMember> members;
 
   // json_serializable boiler-plate
-  PublisherMembers({@required this.members});
+  PublisherMembers({required this.members});
   factory PublisherMembers.fromJson(Map<String, dynamic> json) =>
       _$PublisherMembersFromJson(json);
   Map<String, dynamic> toJson() => _$PublisherMembersToJson(this);
@@ -116,9 +115,9 @@ class PublisherMember {
 
   // json_serializable boiler-plate
   PublisherMember({
-    @required this.userId,
-    @required this.role,
-    @required this.email,
+    required this.userId,
+    required this.role,
+    required this.email,
   });
 
   factory PublisherMember.fromJson(Map<String, dynamic> json) =>
@@ -135,7 +134,7 @@ class UpdatePublisherMemberRequest {
   ///  * `'admin'`, can perform any operation.
   ///
   /// If left `null` the server will ignore this field and leave it unchanged.
-  final String role;
+  final String? role;
 
   // json_serializable boiler-plate
   UpdatePublisherMemberRequest({this.role});
@@ -155,7 +154,7 @@ class InviteMemberRequest {
   final String email;
 
   // json_serializable boiler-plate
-  InviteMemberRequest({@required this.email});
+  InviteMemberRequest({required this.email});
   factory InviteMemberRequest.fromJson(Map<String, dynamic> json) =>
       _$InviteMemberRequestFromJson(json);
   Map<String, dynamic> toJson() => _$InviteMemberRequestToJson(this);

--- a/pkg/client_data/lib/publisher_api.g.dart
+++ b/pkg/client_data/lib/publisher_api.g.dart
@@ -22,9 +22,9 @@ Map<String, dynamic> _$CreatePublisherRequestToJson(
 UpdatePublisherRequest _$UpdatePublisherRequestFromJson(
     Map<String, dynamic> json) {
   return UpdatePublisherRequest(
-    description: json['description'] as String,
-    websiteUrl: json['websiteUrl'] as String,
-    contactEmail: json['contactEmail'] as String,
+    description: json['description'] as String?,
+    websiteUrl: json['websiteUrl'] as String?,
+    contactEmail: json['contactEmail'] as String?,
   );
 }
 
@@ -38,9 +38,9 @@ Map<String, dynamic> _$UpdatePublisherRequestToJson(
 
 PublisherInfo _$PublisherInfoFromJson(Map<String, dynamic> json) {
   return PublisherInfo(
-    description: json['description'] as String,
-    websiteUrl: json['websiteUrl'] as String,
-    contactEmail: json['contactEmail'] as String,
+    description: json['description'] as String?,
+    websiteUrl: json['websiteUrl'] as String?,
+    contactEmail: json['contactEmail'] as String?,
   );
 }
 
@@ -53,11 +53,9 @@ Map<String, dynamic> _$PublisherInfoToJson(PublisherInfo instance) =>
 
 PublisherMembers _$PublisherMembersFromJson(Map<String, dynamic> json) {
   return PublisherMembers(
-    members: (json['members'] as List)
-        ?.map((e) => e == null
-            ? null
-            : PublisherMember.fromJson(e as Map<String, dynamic>))
-        ?.toList(),
+    members: (json['members'] as List<dynamic>)
+        .map((e) => PublisherMember.fromJson(e as Map<String, dynamic>))
+        .toList(),
   );
 }
 
@@ -84,7 +82,7 @@ Map<String, dynamic> _$PublisherMemberToJson(PublisherMember instance) =>
 UpdatePublisherMemberRequest _$UpdatePublisherMemberRequestFromJson(
     Map<String, dynamic> json) {
   return UpdatePublisherMemberRequest(
-    role: json['role'] as String,
+    role: json['role'] as String?,
   );
 }
 

--- a/pkg/client_data/pubspec.lock
+++ b/pkg/client_data/pubspec.lock
@@ -7,21 +7,21 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.0"
+    version: "21.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.39.14"
+    version: "1.5.0"
   args:
     dependency: transitive
     description:
       name: args
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.0"
+    version: "2.1.0"
   async:
     dependency: transitive
     description:
@@ -42,63 +42,63 @@ packages:
       name: build
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "2.0.1"
   build_config:
     dependency: transitive
     description:
       name: build_config
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.2"
+    version: "1.0.0"
   build_daemon:
     dependency: transitive
     description:
       name: build_daemon
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.4"
+    version: "3.0.0"
   build_resolvers:
     dependency: transitive
     description:
       name: build_resolvers
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.11"
+    version: "2.0.1"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.1"
+    version: "2.0.2"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.1"
+    version: "7.0.0"
   build_verify:
     dependency: "direct dev"
     description:
       name: build_verify
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.1"
+    version: "2.0.0"
   built_collection:
     dependency: transitive
     description:
       name: built_collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.3.2"
+    version: "5.0.0"
   built_value:
     dependency: transitive
     description:
       name: built_value
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "7.1.0"
+    version: "8.0.5"
   charcode:
     dependency: transitive
     description:
@@ -112,21 +112,21 @@ packages:
       name: checked_yaml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "2.0.1"
   cli_util:
     dependency: transitive
     description:
       name: cli_util
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.4"
+    version: "0.3.0"
   code_builder:
     dependency: transitive
     description:
       name: code_builder
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.4.1"
+    version: "4.0.0"
   collection:
     dependency: transitive
     description:
@@ -140,84 +140,84 @@ packages:
       name: convert
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "3.0.0"
   coverage:
     dependency: transitive
     description:
       name: coverage
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.14.1"
+    version: "0.15.2"
   crypto:
     dependency: transitive
     description:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.5"
-  csslib:
-    dependency: transitive
-    description:
-      name: csslib
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.16.2"
+    version: "3.0.1"
   dart_style:
     dependency: transitive
     description:
       name: dart_style
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.6"
+    version: "2.0.1"
+  file:
+    dependency: transitive
+    description:
+      name: file
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "6.1.0"
   fixnum:
     dependency: transitive
     description:
       name: fixnum
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.10.11"
+    version: "1.0.0"
+  frontend_server_client:
+    dependency: transitive
+    description:
+      name: frontend_server_client
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.0"
   glob:
     dependency: transitive
     description:
       name: glob
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "2.0.1"
   graphs:
     dependency: transitive
     description:
       name: graphs
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.0"
-  html:
-    dependency: transitive
-    description:
-      name: html
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.14.0+3"
+    version: "2.0.0"
   http_multi_server:
     dependency: transitive
     description:
       name: http_multi_server
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.0"
+    version: "3.0.1"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.4"
+    version: "4.0.0"
   io:
     dependency: transitive
     description:
       name: io
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.4"
+    version: "1.0.0"
   js:
     dependency: transitive
     description:
@@ -231,21 +231,21 @@ packages:
       name: json_annotation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.0"
+    version: "4.0.1"
   json_serializable:
     dependency: "direct dev"
     description:
       name: json_serializable
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.5.0"
+    version: "4.1.1"
   logging:
     dependency: transitive
     description:
       name: logging
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.11.4"
+    version: "1.0.1"
   matcher:
     dependency: transitive
     description:
@@ -254,7 +254,7 @@ packages:
     source: hosted
     version: "0.12.10"
   meta:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
@@ -266,21 +266,7 @@ packages:
       name: mime
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.7"
-  node_interop:
-    dependency: transitive
-    description:
-      name: node_interop
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.1.1"
-  node_io:
-    dependency: transitive
-    description:
-      name: node_io
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.1.1"
+    version: "1.0.0"
   node_preamble:
     dependency: transitive
     description:
@@ -294,7 +280,7 @@ packages:
       name: package_config
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.3"
+    version: "2.0.0"
   path:
     dependency: transitive
     description:
@@ -322,56 +308,49 @@ packages:
       name: pub_semver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.4"
+    version: "2.0.0"
   pubspec_parse:
     dependency: transitive
     description:
       name: pubspec_parse
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.5"
-  quiver:
-    dependency: transitive
-    description:
-      name: quiver
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.1.3"
+    version: "1.0.0"
   shelf:
     dependency: transitive
     description:
       name: shelf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.7.9"
+    version: "1.1.1"
   shelf_packages_handler:
     dependency: transitive
     description:
       name: shelf_packages_handler
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "3.0.0"
   shelf_static:
     dependency: transitive
     description:
       name: shelf_static
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.8"
+    version: "1.0.0"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.3"
+    version: "1.0.1"
   source_gen:
     dependency: "direct dev"
     description:
       name: source_gen
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.7+1"
+    version: "1.0.0"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -413,7 +392,7 @@ packages:
       name: stream_transform
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "2.0.0"
   string_scanner:
     dependency: transitive
     description:
@@ -455,7 +434,7 @@ packages:
       name: timing
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.1+2"
+    version: "1.0.0"
   typed_data:
     dependency: transitive
     description:
@@ -476,27 +455,27 @@ packages:
       name: watcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.7+15"
+    version: "1.0.0"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "2.1.0"
   webkit_inspection_protocol:
     dependency: transitive
     description:
       name: webkit_inspection_protocol
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.7.3"
+    version: "1.0.0"
   yaml:
     dependency: transitive
     description:
       name: yaml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.1"
+    version: "3.1.0"
 sdks:
-  dart: ">=2.12.0-0.0 <3.0.0"
+  dart: ">=2.12.0 <3.0.0"

--- a/pkg/client_data/pubspec.yaml
+++ b/pkg/client_data/pubspec.yaml
@@ -2,15 +2,14 @@ name: client_data
 description: Shared data between server and JS client.
 publish_to: none
 environment:
-  sdk: '>=2.6.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  json_annotation: '^3.0.0'
-  meta: ^1.3.0
+  json_annotation: '>=3.0.0 <5.0.0'
 
 dev_dependencies:
-  build_runner: '^1.0.0'
-  build_verify: ^1.1.1
-  json_serializable: '^3.0.0'
-  source_gen: '^0.9.0'
+  build_runner: '^2.0.0'
+  build_verify: ^2.0.0
+  json_serializable: '^4.0.0'
+  source_gen: '^1.0.0'
   test: '^1.16.5'

--- a/pkg/pub_dartdoc_data/lib/pub_dartdoc_data.dart
+++ b/pkg/pub_dartdoc_data/lib/pub_dartdoc_data.dart
@@ -5,7 +5,6 @@
 import 'dart:math';
 
 import 'package:json_annotation/json_annotation.dart';
-import 'package:meta/meta.dart';
 
 part 'pub_dartdoc_data.g.dart';
 
@@ -14,12 +13,12 @@ class PubDartdocData {
   /// Coverage may be non-existent in `pub-data.json` created with runtime
   /// before version `2019.09.30`.
   /// TODO: remove this note after we've deprecated that runtime version.
-  final Coverage coverage;
-  final List<ApiElement> apiElements;
+  final Coverage? coverage;
+  final List<ApiElement>? apiElements;
 
   PubDartdocData({
-    @required this.coverage,
-    @required this.apiElements,
+    required this.coverage,
+    required this.apiElements,
   });
 
   factory PubDartdocData.fromJson(Map<String, dynamic> json) =>
@@ -33,18 +32,18 @@ class ApiElement {
   /// The last part of the [qualifiedName].
   final String name;
   final String kind;
-  final String parent;
-  final String source;
-  final String href;
-  String documentation;
+  final String? parent;
+  final String? source;
+  final String? href;
+  String? documentation;
 
   ApiElement({
-    @required this.name,
-    @required this.kind,
-    @required this.parent,
-    @required this.source,
-    @required this.href,
-    @required this.documentation,
+    required this.name,
+    required this.kind,
+    required this.parent,
+    required this.source,
+    required this.href,
+    required this.documentation,
   });
 
   factory ApiElement.fromJson(Map<String, dynamic> json) {
@@ -71,8 +70,8 @@ class Coverage {
   final int documented;
 
   Coverage({
-    @required this.total,
-    @required this.documented,
+    required this.total,
+    required this.documented,
   });
 
   factory Coverage.fromJson(Map<String, dynamic> json) =>

--- a/pkg/pub_dartdoc_data/lib/pub_dartdoc_data.g.dart
+++ b/pkg/pub_dartdoc_data/lib/pub_dartdoc_data.g.dart
@@ -11,10 +11,9 @@ PubDartdocData _$PubDartdocDataFromJson(Map<String, dynamic> json) {
     coverage: json['coverage'] == null
         ? null
         : Coverage.fromJson(json['coverage'] as Map<String, dynamic>),
-    apiElements: (json['apiElements'] as List)
-        ?.map((e) =>
-            e == null ? null : ApiElement.fromJson(e as Map<String, dynamic>))
-        ?.toList(),
+    apiElements: (json['apiElements'] as List<dynamic>?)
+        ?.map((e) => ApiElement.fromJson(e as Map<String, dynamic>))
+        .toList(),
   );
 }
 
@@ -28,15 +27,18 @@ ApiElement _$ApiElementFromJson(Map<String, dynamic> json) {
   return ApiElement(
     name: json['name'] as String,
     kind: json['kind'] as String,
-    parent: json['parent'] as String,
-    source: json['source'] as String,
-    href: json['href'] as String,
-    documentation: json['documentation'] as String,
+    parent: json['parent'] as String?,
+    source: json['source'] as String?,
+    href: json['href'] as String?,
+    documentation: json['documentation'] as String?,
   );
 }
 
 Map<String, dynamic> _$ApiElementToJson(ApiElement instance) {
-  final val = <String, dynamic>{};
+  final val = <String, dynamic>{
+    'name': instance.name,
+    'kind': instance.kind,
+  };
 
   void writeNotNull(String key, dynamic value) {
     if (value != null) {
@@ -44,8 +46,6 @@ Map<String, dynamic> _$ApiElementToJson(ApiElement instance) {
     }
   }
 
-  writeNotNull('name', instance.name);
-  writeNotNull('kind', instance.kind);
   writeNotNull('parent', instance.parent);
   writeNotNull('source', instance.source);
   writeNotNull('href', instance.href);

--- a/pkg/pub_dartdoc_data/pubspec.lock
+++ b/pkg/pub_dartdoc_data/pubspec.lock
@@ -7,21 +7,21 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.0"
+    version: "21.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.39.14"
+    version: "1.5.0"
   args:
     dependency: transitive
     description:
       name: args
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.0"
+    version: "2.1.0"
   async:
     dependency: transitive
     description:
@@ -42,63 +42,63 @@ packages:
       name: build
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "2.0.1"
   build_config:
     dependency: transitive
     description:
       name: build_config
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.2"
+    version: "1.0.0"
   build_daemon:
     dependency: transitive
     description:
       name: build_daemon
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.4"
+    version: "3.0.0"
   build_resolvers:
     dependency: transitive
     description:
       name: build_resolvers
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.11"
+    version: "2.0.1"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.1"
+    version: "2.0.2"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.1"
+    version: "7.0.0"
   build_verify:
     dependency: "direct dev"
     description:
       name: build_verify
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.1"
+    version: "2.0.0"
   built_collection:
     dependency: transitive
     description:
       name: built_collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.3.2"
+    version: "5.0.0"
   built_value:
     dependency: transitive
     description:
       name: built_value
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "7.1.0"
+    version: "8.0.5"
   charcode:
     dependency: transitive
     description:
@@ -112,21 +112,21 @@ packages:
       name: checked_yaml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "2.0.1"
   cli_util:
     dependency: transitive
     description:
       name: cli_util
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.4"
+    version: "0.3.0"
   code_builder:
     dependency: transitive
     description:
       name: code_builder
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.4.1"
+    version: "4.0.0"
   collection:
     dependency: transitive
     description:
@@ -140,84 +140,84 @@ packages:
       name: convert
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "3.0.0"
   coverage:
     dependency: transitive
     description:
       name: coverage
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.14.1"
+    version: "0.15.2"
   crypto:
     dependency: transitive
     description:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.5"
-  csslib:
-    dependency: transitive
-    description:
-      name: csslib
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.16.2"
+    version: "3.0.1"
   dart_style:
     dependency: transitive
     description:
       name: dart_style
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.6"
+    version: "2.0.1"
+  file:
+    dependency: transitive
+    description:
+      name: file
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "6.1.0"
   fixnum:
     dependency: transitive
     description:
       name: fixnum
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.10.11"
+    version: "1.0.0"
+  frontend_server_client:
+    dependency: transitive
+    description:
+      name: frontend_server_client
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.0"
   glob:
     dependency: transitive
     description:
       name: glob
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "2.0.1"
   graphs:
     dependency: transitive
     description:
       name: graphs
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.0"
-  html:
-    dependency: transitive
-    description:
-      name: html
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.14.0+3"
+    version: "2.0.0"
   http_multi_server:
     dependency: transitive
     description:
       name: http_multi_server
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.0"
+    version: "3.0.1"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.4"
+    version: "4.0.0"
   io:
     dependency: transitive
     description:
       name: io
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.4"
+    version: "1.0.0"
   js:
     dependency: transitive
     description:
@@ -231,21 +231,21 @@ packages:
       name: json_annotation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.0"
+    version: "4.0.1"
   json_serializable:
     dependency: "direct dev"
     description:
       name: json_serializable
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.5.0"
+    version: "4.1.1"
   logging:
     dependency: transitive
     description:
       name: logging
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.11.4"
+    version: "1.0.1"
   matcher:
     dependency: transitive
     description:
@@ -254,7 +254,7 @@ packages:
     source: hosted
     version: "0.12.10"
   meta:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
@@ -266,21 +266,7 @@ packages:
       name: mime
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.7"
-  node_interop:
-    dependency: transitive
-    description:
-      name: node_interop
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.1.1"
-  node_io:
-    dependency: transitive
-    description:
-      name: node_io
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.1.1"
+    version: "1.0.0"
   node_preamble:
     dependency: transitive
     description:
@@ -294,7 +280,7 @@ packages:
       name: package_config
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.3"
+    version: "2.0.0"
   path:
     dependency: transitive
     description:
@@ -322,56 +308,49 @@ packages:
       name: pub_semver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.4"
+    version: "2.0.0"
   pubspec_parse:
     dependency: transitive
     description:
       name: pubspec_parse
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.5"
-  quiver:
-    dependency: transitive
-    description:
-      name: quiver
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.1.3"
+    version: "1.0.0"
   shelf:
     dependency: transitive
     description:
       name: shelf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.7.9"
+    version: "1.1.1"
   shelf_packages_handler:
     dependency: transitive
     description:
       name: shelf_packages_handler
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "3.0.0"
   shelf_static:
     dependency: transitive
     description:
       name: shelf_static
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.8"
+    version: "1.0.0"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.3"
+    version: "1.0.1"
   source_gen:
     dependency: "direct dev"
     description:
       name: source_gen
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.7+1"
+    version: "1.0.0"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -413,7 +392,7 @@ packages:
       name: stream_transform
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "2.0.0"
   string_scanner:
     dependency: transitive
     description:
@@ -455,7 +434,7 @@ packages:
       name: timing
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.1+2"
+    version: "1.0.0"
   typed_data:
     dependency: transitive
     description:
@@ -476,27 +455,27 @@ packages:
       name: watcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.7+15"
+    version: "1.0.0"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "2.1.0"
   webkit_inspection_protocol:
     dependency: transitive
     description:
       name: webkit_inspection_protocol
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.7.3"
+    version: "1.0.0"
   yaml:
     dependency: transitive
     description:
       name: yaml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.1"
+    version: "3.1.0"
 sdks:
-  dart: ">=2.12.0-0.0 <3.0.0"
+  dart: ">=2.12.0 <3.0.0"

--- a/pkg/pub_dartdoc_data/pubspec.yaml
+++ b/pkg/pub_dartdoc_data/pubspec.yaml
@@ -2,15 +2,14 @@ name: pub_dartdoc_data
 description: Data structure for the pub-data.json
 publish_to: none
 environment:
-  sdk: '>=2.6.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  json_annotation: '^3.0.0'
-  meta: ^1.3.0
+  json_annotation: '>=3.0.0 <5.0.0'
 
 dev_dependencies:
-  build_runner: '^1.0.0'
-  build_verify: ^1.1.1
-  json_serializable: '^3.0.0'
-  source_gen: '^0.9.0'
+  build_runner: '^2.0.0'
+  build_verify: ^2.0.0
+  json_serializable: '^4.0.0'
+  source_gen: '^1.0.0'
   test: '^1.16.5'

--- a/pkg/pub_dartdoc_data/test/pub_dartdoc_data_test.dart
+++ b/pkg/pub_dartdoc_data/test/pub_dartdoc_data_test.dart
@@ -8,7 +8,11 @@ import 'package:pub_dartdoc_data/pub_dartdoc_data.dart';
 
 void main() {
   test('name conversion', () {
-    final value = ApiElement.fromJson({'name': 'a.B', 'parent': 'a'});
+    final value = ApiElement.fromJson({
+      'name': 'a.B',
+      'kind': 'x',
+      'parent': 'a',
+    });
     expect(value.name, 'B');
     expect(value.qualifiedName, 'a.B');
   });


### PR DESCRIPTION
- `pkg/_popularity`, `pkg/client_data` and `pkg/pub_dartdoc_data` is being migrated
- I've reviewed the fields and tried to be on the lenient side if there was a question about something nullable, but we should be able to finetune this later.