### PR TITLE
Use new search API when displaying the results.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ AppEngine version, listed here to ease deployment and troubleshooting.
  * Bumped runtimeVersion to `2021.05.19`.
  * Upgraded stable Flutter analysis SDK to `2.2.0`.
  * Upgraded preview Flutter analysis SDK to `2.2.0`.
+ * NOTE: Started to display `PackageHit` and `SdkLibraryHit` results.
 
 ## `20210517t183200-all`
  * Bumped runtimeVersion to `2021.05.17`.

--- a/app/lib/frontend/handlers/account.dart
+++ b/app/lib/frontend/handlers/account.dart
@@ -225,7 +225,7 @@ Future<shelf.Response> accountPackagesPageHandler(shelf.Request request) async {
   final html = renderAccountPackagesPage(
     user: await accountBackend.lookupUserById(userSessionData.userId),
     userSessionData: userSessionData,
-    packages: searchResult.packages,
+    searchResultPage: searchResult,
     pageLinks: links,
     searchForm: searchForm,
     totalCount: totalCount,

--- a/app/lib/frontend/handlers/listing.dart
+++ b/app/lib/frontend/handlers/listing.dart
@@ -91,7 +91,7 @@ Future<shelf.Response> _packagesHandlerHtmlCore(
   final links = PageLinks(searchForm, totalCount);
   final result = htmlResponse(
     renderPkgIndexPage(
-      searchResult.packages,
+      searchResult,
       links,
       sdk: sdk,
       searchForm: searchForm,

--- a/app/lib/frontend/handlers/publisher.dart
+++ b/app/lib/frontend/handlers/publisher.dart
@@ -85,7 +85,7 @@ Future<shelf.Response> publisherPackagesPageHandler(
 
   final html = renderPublisherPackagesPage(
     publisher: publisher,
-    packages: searchResult.packages,
+    searchResultPage: searchResult,
     pageLinks: links,
     searchForm: searchForm,
     totalCount: totalCount,

--- a/app/lib/frontend/templates/_consts.dart
+++ b/app/lib/frontend/templates/_consts.dart
@@ -9,23 +9,28 @@ import '../../shared/tags.dart' show SdkTagValue;
 class SdkDict {
   final String topSdkPackages;
   final String searchPackagesLabel;
+  final String libraryTypeLabel;
 
   const SdkDict({
     @required this.topSdkPackages,
     @required this.searchPackagesLabel,
+    @required this.libraryTypeLabel,
   });
 
   const SdkDict.any()
       : topSdkPackages = 'Top packages',
-        searchPackagesLabel = 'Search packages';
+        searchPackagesLabel = 'Search packages',
+        libraryTypeLabel = 'SDK library';
 
   const SdkDict.dart()
       : topSdkPackages = 'Top Dart packages',
-        searchPackagesLabel = 'Search Dart packages';
+        searchPackagesLabel = 'Search Dart packages',
+        libraryTypeLabel = 'Dart SDK library';
 
   const SdkDict.flutter()
       : topSdkPackages = 'Top Flutter packages',
-        searchPackagesLabel = 'Search Flutter packages';
+        searchPackagesLabel = 'Search Flutter packages',
+        libraryTypeLabel = 'Flutter SDK library';
 }
 
 /// Returns the dictionary spec for [sdk].

--- a/app/lib/frontend/templates/admin.dart
+++ b/app/lib/frontend/templates/admin.dart
@@ -7,7 +7,7 @@ import 'dart:convert';
 import 'package:meta/meta.dart';
 
 import '../../account/models.dart' show LikeData, User, UserSessionData;
-import '../../package/models.dart' show PackageView;
+import '../../package/search_adapter.dart' show SearchResultPage;
 import '../../publisher/models.dart' show PublisherSummary;
 import '../../search/search_form.dart' show SearchForm;
 import '../../shared/urls.dart' as urls;
@@ -34,7 +34,7 @@ String renderAuthorizedPage() {
 String renderAccountPackagesPage({
   @required User user,
   @required UserSessionData userSessionData,
-  @required List<PackageView> packages,
+  @required SearchResultPage searchResultPage,
   @required String messageFromBackend,
   @required PageLinks pageLinks,
   @required SearchForm searchForm,
@@ -46,12 +46,8 @@ String renderAccountPackagesPage({
     title += ' | Page ${pageLinks.currentPage}';
   }
 
-  final packageListHtml = packages.isEmpty
-      ? ''
-      : renderPackageList(
-          packages,
-          searchForm: searchForm,
-        );
+  final packageListHtml =
+      searchResultPage.hasNoHit ? '' : renderPackageList(searchResultPage);
   final paginationHtml = renderPagination(pageLinks);
 
   final tabContent = [

--- a/app/lib/frontend/templates/package_misc.dart
+++ b/app/lib/frontend/templates/package_misc.dart
@@ -180,7 +180,7 @@ String renderTags({
       'title': 'Analysis should be ready soon.',
     });
   }
-  if (!package.isExternal && tagValues.isEmpty && tagBadges.isEmpty) {
+  if (tagValues.isEmpty && tagBadges.isEmpty) {
     tagValues.add({
       'status': 'unidentified',
       'text': '[unidentified]',

--- a/app/lib/frontend/templates/publisher.dart
+++ b/app/lib/frontend/templates/publisher.dart
@@ -7,7 +7,7 @@ import 'package:client_data/page_data.dart';
 import 'package:meta/meta.dart';
 import 'package:pub_dev/shared/markdown.dart';
 
-import '../../package/models.dart' show PackageView;
+import '../../package/search_adapter.dart' show SearchResultPage;
 import '../../publisher/models.dart' show Publisher, PublisherSummary;
 import '../../search/search_form.dart' show SearchForm;
 import '../../shared/urls.dart' as urls;
@@ -78,7 +78,7 @@ String _shortDescriptionHtml(Publisher publisher) {
 /// Renders the search results on the publisher's packages page.
 String renderPublisherPackagesPage({
   @required Publisher publisher,
-  @required List<PackageView> packages,
+  @required SearchResultPage searchResultPage,
   @required String messageFromBackend,
   @required PageLinks pageLinks,
   @required SearchForm searchForm,
@@ -91,9 +91,8 @@ String renderPublisherPackagesPage({
     title += ' | Page ${pageLinks.currentPage}';
   }
 
-  final packageListHtml = packages.isEmpty
-      ? ''
-      : renderPackageList(packages, searchForm: searchForm);
+  final packageListHtml =
+      searchResultPage.hasNoHit ? '' : renderPackageList(searchResultPage);
   final paginationHtml = renderPagination(pageLinks);
 
   final tabContent = [
@@ -134,7 +133,7 @@ String renderPublisherPackagesPage({
     searchForm: searchForm,
     canonicalUrl: searchForm.toSearchLink(),
     // index only the first page, if it has packages displayed without search query
-    noIndex: packages.isEmpty || isSearch || pageLinks.currentPage > 1,
+    noIndex: searchResultPage.hasNoHit || isSearch || pageLinks.currentPage > 1,
     mainClasses: [wideHeaderDetailPageClassName],
   );
 }

--- a/app/lib/package/models.dart
+++ b/app/lib/package/models.dart
@@ -650,8 +650,6 @@ class QualifiedVersionKey {
 /// display-only uses.
 @JsonSerializable(includeIfNull: false)
 class PackageView extends Object with FlagMixin {
-  final bool isExternal;
-  final String url;
   final String name;
   final String version;
 
@@ -687,8 +685,6 @@ class PackageView extends Object with FlagMixin {
   final List<ApiPageRef> apiPages;
 
   PackageView({
-    this.isExternal = false,
-    this.url,
     this.name,
     this.version,
     this.prereleaseVersion,
@@ -760,8 +756,6 @@ class PackageView extends Object with FlagMixin {
 
   PackageView change({List<ApiPageRef> apiPages}) {
     return PackageView(
-      isExternal: isExternal,
-      url: url,
       name: name,
       version: version,
       prereleaseVersion: prereleaseVersion,

--- a/app/lib/package/models.g.dart
+++ b/app/lib/package/models.g.dart
@@ -43,8 +43,6 @@ Map<String, dynamic> _$ReleaseToJson(Release instance) => <String, dynamic>{
 
 PackageView _$PackageViewFromJson(Map<String, dynamic> json) {
   return PackageView(
-    isExternal: json['isExternal'] as bool,
-    url: json['url'] as String,
     name: json['name'] as String,
     version: json['version'] as String,
     prereleaseVersion: json['prereleaseVersion'] as String,
@@ -80,8 +78,6 @@ Map<String, dynamic> _$PackageViewToJson(PackageView instance) {
     }
   }
 
-  writeNotNull('isExternal', instance.isExternal);
-  writeNotNull('url', instance.url);
   writeNotNull('name', instance.name);
   writeNotNull('version', instance.version);
   writeNotNull('prereleaseVersion', instance.prereleaseVersion);

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -7,6 +7,7 @@ import 'dart:io';
 
 import 'package:html/parser.dart';
 import 'package:pana/pana.dart' hide ReportStatus;
+import 'package:pub_dev/package/search_adapter.dart';
 import 'package:pub_semver/pub_semver.dart';
 import 'package:test/test.dart';
 import 'package:xml/xml.dart' as xml;
@@ -493,24 +494,29 @@ void main() {
     });
 
     scopedTest('package index page', () {
+      final searchForm = SearchForm.parse();
       final String html = renderPkgIndexPage(
-        [
-          PackageView.fromModel(
-            package: foobarPackage,
-            version: foobarStablePV,
-            scoreCard: ScoreCardData(),
-          ),
-          PackageView.fromModel(
-            package: foobarPackage,
-            version: flutterPackageVersion,
-            scoreCard: ScoreCardData(
-              derivedTags: ['sdk:flutter', 'platform:android'],
-              reportTypes: ['pana'],
+        SearchResultPage(
+          searchForm,
+          2,
+          packageHits: [
+            PackageView.fromModel(
+              package: foobarPackage,
+              version: foobarStablePV,
+              scoreCard: ScoreCardData(),
             ),
-          ),
-        ],
+            PackageView.fromModel(
+              package: foobarPackage,
+              version: flutterPackageVersion,
+              scoreCard: ScoreCardData(
+                derivedTags: ['sdk:flutter', 'platform:android'],
+                reportTypes: ['pana'],
+              ),
+            ),
+          ],
+        ),
         PageLinks.empty(),
-        searchForm: SearchForm.parse(),
+        searchForm: searchForm,
       );
       expectGoldenFile(html, 'pkg_index_page.html');
     });
@@ -519,25 +525,29 @@ void main() {
       final searchForm =
           SearchForm.parse(query: 'foobar', order: SearchOrder.top);
       final String html = renderPkgIndexPage(
-        [
-          PackageView.fromModel(
-            package: foobarPackage,
-            version: foobarStablePV,
-            scoreCard: ScoreCardData(),
-            apiPages: [
-              ApiPageRef(path: 'some/some-library.html'),
-              ApiPageRef(title: 'Class X', path: 'some/x-class.html'),
-            ],
-          ),
-          PackageView.fromModel(
-            package: foobarPackage,
-            version: flutterPackageVersion,
-            scoreCard: ScoreCardData(
-              derivedTags: ['sdk:flutter', 'platform:android'],
-              reportTypes: ['pana'],
+        SearchResultPage(
+          searchForm,
+          2,
+          packageHits: [
+            PackageView.fromModel(
+              package: foobarPackage,
+              version: foobarStablePV,
+              scoreCard: ScoreCardData(),
+              apiPages: [
+                ApiPageRef(path: 'some/some-library.html'),
+                ApiPageRef(title: 'Class X', path: 'some/x-class.html'),
+              ],
             ),
-          ),
-        ],
+            PackageView.fromModel(
+              package: foobarPackage,
+              version: flutterPackageVersion,
+              scoreCard: ScoreCardData(
+                derivedTags: ['sdk:flutter', 'platform:android'],
+                reportTypes: ['pana'],
+              ),
+            ),
+          ],
+        ),
         PageLinks(searchForm, 50),
         searchForm: searchForm,
         totalCount: 2,
@@ -601,27 +611,31 @@ void main() {
               'We develop full-stack in Dart, and happy about it.'
           ..websiteUrl = 'https://example.com/'
           ..created = DateTime(2019, 09, 13),
-        packages: [
-          PackageView(
-            name: 'super_package',
-            version: '1.0.0',
-            previewVersion: '1.4.0',
-            prereleaseVersion: '1.5.0-dev',
-            ellipsizedDescription: 'A great web UI library.',
-            created: DateTime.utc(2019, 01, 03),
-            updated: DateTime.utc(2019, 01, 03),
-            tags: ['sdk:dart', 'runtime:web'],
-          ),
-          PackageView(
-            name: 'another_package',
-            version: '2.0.0',
-            prereleaseVersion: '3.0.0-beta2',
-            ellipsizedDescription: 'Camera plugin.',
-            created: DateTime.utc(2019, 03, 30),
-            updated: DateTime.utc(2019, 03, 30),
-            tags: ['sdk:flutter', 'platform:android'],
-          ),
-        ],
+        searchResultPage: SearchResultPage(
+          searchForm,
+          2,
+          packageHits: [
+            PackageView(
+              name: 'super_package',
+              version: '1.0.0',
+              previewVersion: '1.4.0',
+              prereleaseVersion: '1.5.0-dev',
+              ellipsizedDescription: 'A great web UI library.',
+              created: DateTime.utc(2019, 01, 03),
+              updated: DateTime.utc(2019, 01, 03),
+              tags: ['sdk:dart', 'runtime:web'],
+            ),
+            PackageView(
+              name: 'another_package',
+              version: '2.0.0',
+              prereleaseVersion: '3.0.0-beta2',
+              ellipsizedDescription: 'Camera plugin.',
+              created: DateTime.utc(2019, 03, 30),
+              updated: DateTime.utc(2019, 03, 30),
+              tags: ['sdk:flutter', 'platform:android'],
+            ),
+          ],
+        ),
         totalCount: 2,
         searchForm: searchForm,
         pageLinks: PageLinks(searchForm, 10),
@@ -637,25 +651,29 @@ void main() {
       final String html = renderAccountPackagesPage(
         user: hansUser,
         userSessionData: hansUserSessionData,
-        packages: [
-          PackageView(
-            name: 'super_package',
-            version: '1.0.0',
-            ellipsizedDescription: 'A great web UI library.',
-            created: DateTime.utc(2019, 01, 03),
-            updated: DateTime.utc(2019, 01, 03),
-            tags: ['sdk:dart', 'runtime:web'],
-          ),
-          PackageView(
-            name: 'another_package',
-            version: '2.0.0',
-            prereleaseVersion: '3.0.0-beta2',
-            ellipsizedDescription: 'Camera plugin.',
-            created: DateTime.utc(2019, 03, 30),
-            updated: DateTime.utc(2019, 03, 30),
-            tags: ['sdk:flutter', 'platform:android'],
-          ),
-        ],
+        searchResultPage: SearchResultPage(
+          searchForm,
+          2,
+          packageHits: [
+            PackageView(
+              name: 'super_package',
+              version: '1.0.0',
+              ellipsizedDescription: 'A great web UI library.',
+              created: DateTime.utc(2019, 01, 03),
+              updated: DateTime.utc(2019, 01, 03),
+              tags: ['sdk:dart', 'runtime:web'],
+            ),
+            PackageView(
+              name: 'another_package',
+              version: '2.0.0',
+              prereleaseVersion: '3.0.0-beta2',
+              ellipsizedDescription: 'Camera plugin.',
+              created: DateTime.utc(2019, 03, 30),
+              updated: DateTime.utc(2019, 03, 30),
+              tags: ['sdk:flutter', 'platform:android'],
+            ),
+          ],
+        ),
         pageLinks: PageLinks(searchForm, 10),
         searchForm: searchForm,
         totalCount: 2,

--- a/pkg/web_app/pubspec.lock
+++ b/pkg/web_app/pubspec.lock
@@ -492,4 +492,4 @@ packages:
     source: hosted
     version: "2.2.1"
 sdks:
-  dart: ">=2.12.0-0.0 <3.0.0"
+  dart: ">=2.12.0 <3.0.0"


### PR DESCRIPTION
- #4549
- Removed now-obsolete fields from `PackageView`, and as it affects caching, bumped runtimeVersion.
- A follow-up PR will separate the template for SDK vs package hits.
