### PR TITLE
Do not require admin access for publisher contact change.

### DIFF
--- a/app/lib/account/consent_backend.dart
+++ b/app/lib/account/consent_backend.dart
@@ -371,11 +371,8 @@ class _PublisherContactAction extends ConsentAction {
   Future<void> onAccept(Consent consent) async {
     final publisherId = consent.args[0];
     final contactEmail = consent.args[1];
-    await publisherBackend.updateContactEmail(
-      publisherId,
-      contactEmail,
-      fromConsentFlow: true,
-    );
+    await publisherBackend.updateContactWithVerifiedEmail(
+        publisherId, contactEmail);
   }
 
   @override

--- a/app/lib/account/consent_backend.dart
+++ b/app/lib/account/consent_backend.dart
@@ -371,7 +371,11 @@ class _PublisherContactAction extends ConsentAction {
   Future<void> onAccept(Consent consent) async {
     final publisherId = consent.args[0];
     final contactEmail = consent.args[1];
-    await publisherBackend.updateContactEmail(publisherId, contactEmail);
+    await publisherBackend.updateContactEmail(
+      publisherId,
+      contactEmail,
+      fromConsentFlow: true,
+    );
   }
 
   @override

--- a/app/lib/publisher/backend.dart
+++ b/app/lib/publisher/backend.dart
@@ -273,13 +273,6 @@ class PublisherBackend {
               break;
             }
           }
-
-          if (!contactEmailMatchedAdmin) {
-            InvalidInputException.check(
-              user.email == update.contactEmail,
-              'The contact email is a registered user, but not member of the publisher.',
-            );
-          }
         }
 
         if (!contactEmailMatchedAdmin) {

--- a/app/lib/publisher/backend.dart
+++ b/app/lib/publisher/backend.dart
@@ -307,10 +307,16 @@ class PublisherBackend {
   }
 
   /// Updates the contact email field of the publisher.
-  Future updateContactEmail(String publisherId, String contactEmail) async {
+  Future updateContactEmail(
+    String publisherId,
+    String contactEmail, {
+    bool fromConsentFlow = false,
+  }) async {
     checkPublisherIdParam(publisherId);
     final activeUser = await requireAuthenticatedUser();
-    await requirePublisherAdmin(publisherId, activeUser.userId);
+    if (!fromConsentFlow) {
+      await requirePublisherAdmin(publisherId, activeUser.userId);
+    }
     InvalidInputException.check(
         isValidEmail(contactEmail), 'Invalid email: `$contactEmail`');
 

--- a/app/lib/publisher/backend.dart
+++ b/app/lib/publisher/backend.dart
@@ -306,17 +306,11 @@ class PublisherBackend {
     return _asPublisherInfo(p);
   }
 
-  /// Updates the contact email field of the publisher.
-  Future updateContactEmail(
-    String publisherId,
-    String contactEmail, {
-    bool fromConsentFlow = false,
-  }) async {
+  /// Updates the contact email field of the publisher using a verified e-mail.
+  Future updateContactWithVerifiedEmail(
+      String publisherId, String contactEmail) async {
     checkPublisherIdParam(publisherId);
     final activeUser = await requireAuthenticatedUser();
-    if (!fromConsentFlow) {
-      await requirePublisherAdmin(publisherId, activeUser.userId);
-    }
     InvalidInputException.check(
         isValidEmail(contactEmail), 'Invalid email: `$contactEmail`');
 

--- a/app/test/account/consent_backend_test.dart
+++ b/app/test/account/consent_backend_test.dart
@@ -125,7 +125,7 @@ void main() {
       final consentId = await inviteContact();
 
       await withPubApiClient(
-          bearerToken: adminAtPubDevAuthToken,
+          bearerToken: userAtPubDevAuthToken,
           fn: (client) async {
             final rs = await client.resolveConsent(
                 consentId, account_api.ConsentResult(granted: true));
@@ -136,14 +136,14 @@ void main() {
       final r = records.firstWhere(
           (e) => e.kind == AuditLogRecordKind.publisherContactInviteAccepted);
       expect(r.summary,
-          '`admin@pub.dev` accepted `info@example.com` to be contact email for publisher `example.com`.');
+          '`user@pub.dev` accepted `info@example.com` to be contact email for publisher `example.com`.');
     });
 
     testWithProfile('Publisher contact rejected', fn: () async {
       final consentId = await inviteContact();
 
       await withPubApiClient(
-          bearerToken: adminAtPubDevAuthToken,
+          bearerToken: userAtPubDevAuthToken,
           fn: (client) async {
             final rs = await client.resolveConsent(
                 consentId, account_api.ConsentResult(granted: false));
@@ -154,7 +154,7 @@ void main() {
       final r = records.firstWhere(
           (e) => e.kind == AuditLogRecordKind.publisherContactInviteRejected);
       expect(r.summary,
-          '`admin@pub.dev` rejected contact invite of `info@example.com` for publisher `example.com`.');
+          '`user@pub.dev` rejected contact invite of `info@example.com` for publisher `example.com`.');
     });
 
     testWithProfile('Publisher contact expired', fn: () async {


### PR DESCRIPTION
- Fixes #4803.
- Publisher contact change already has a bypass and does not require that the current account matches the e-mail of the consent.
- However, it did have an extra check for admin access rights, now added a bypass if the call is coming from consent.
- Updated tests to use a non-admin / non-member user to accept the consent.
- Signed-in user is still required to accept consent.