### PR TITLE
Store reports on ScoreCard too.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ AppEngine version, listed here to ease deployment and troubleshooting.
    * `package:tar` to `0.4.0`
  * NOTE: Removed `packages` and `PackageScore` from search results.
  * NOTE: `gc-dartdoc-storage-bucket` logs the total number of entries deleted.
+ * NOTE: Started to store report data on `ScoreCard` entities too.
 
 ## `20210526t104100-all`
  * Bumped runtimeVersion to `2021.05.25`.

--- a/app/lib/analyzer/analyzer_client.dart
+++ b/app/lib/analyzer/analyzer_client.dart
@@ -31,13 +31,21 @@ class AnalyzerClient {
     if (card == null) {
       return AnalysisView();
     }
-    final reports = await scoreCardBackend.loadReports(
-      package,
-      version,
-      runtimeVersion: card.runtimeVersion,
-    );
-    final panaReport = reports[ReportType.pana] as PanaReport;
-    final dartdocReport = reports[ReportType.dartdoc] as DartdocReport;
+    var dartdocReport = card.dartdocReport;
+    var panaReport = card.panaReport;
+    // TODO: remove this part once we store reports only on the card
+    if (dartdocReport == null &&
+        panaReport == null &&
+        card.reportTypes != null &&
+        card.reportTypes.isNotEmpty) {
+      final reports = await scoreCardBackend.loadReports(
+        package,
+        version,
+        runtimeVersion: card.runtimeVersion,
+      );
+      panaReport = reports[ReportType.pana] as PanaReport;
+      dartdocReport = reports[ReportType.dartdoc] as DartdocReport;
+    }
     return AnalysisView._(card, panaReport, dartdocReport);
   }
 

--- a/app/lib/scorecard/backend.dart
+++ b/app/lib/scorecard/backend.dart
@@ -314,7 +314,7 @@ class ScoreCardBackend {
         final size = scr.reportJsonGz.length;
         if (size > _reportSizeDropThreshold) {
           // TODO: replace it with meaningful content
-          _logger.shout(
+          _logger.reportError(
               '${scr.reportType} report exceeded size threshold ($size > $_reportSizeWarnThreshold)');
           continue;
         }

--- a/app/lib/scorecard/backend.dart
+++ b/app/lib/scorecard/backend.dart
@@ -27,6 +27,8 @@ export 'models.dart';
 final _logger = Logger('pub.scorecard.backend');
 
 final Duration _deleteThreshold = const Duration(days: 182);
+final _reportSizeWarnThreshold = 16 * 1024;
+final _reportSizeDropThreshold = 32 * 1024;
 
 /// The minimum age of the [PackageVersion] which will trigger a fallback to
 /// older scorecards. Below this age we only display the current [ScoreCard].
@@ -82,7 +84,8 @@ class ScoreCardBackend {
     }
 
     final key = scoreCardKey(packageName, packageVersion);
-    final current = (await _db.lookup<ScoreCard>([key])).single?.toData();
+    final current =
+        (await _db.lookupValue<ScoreCard>(key, orElse: () => null))?.toData();
     if (current != null) {
       // only full cards will be stored in cache
       if (current.isCurrent && current.hasReports(ReportType.values)) {
@@ -164,8 +167,7 @@ class ScoreCardBackend {
     await _updateScoreCard(packageName, packageVersion);
   }
 
-  /// Load and deserialize the reports for the given package and version.
-  Future<Map<String, ReportData>> loadReports(
+  Future<List<ScoreCardReport>> _loadReports(
     String packageName,
     String packageVersion, {
     List<String> reportTypes,
@@ -174,18 +176,31 @@ class ScoreCardBackend {
     reportTypes ??= [ReportType.pana, ReportType.dartdoc];
     final key = scoreCardKey(packageName, packageVersion,
         runtimeVersion: runtimeVersion);
-
-    final list = await _db.lookup(reportTypes
+    return await _db.lookup<ScoreCardReport>(reportTypes
         .map((type) => key.append(ScoreCardReport, id: type))
         .toList());
+  }
 
+  Map<String, ReportData> _extractReportData(List<ScoreCardReport> items) {
     final result = <String, ReportData>{};
-    for (db.Model model in list) {
+    for (db.Model model in items) {
       if (model == null) continue;
       final report = model as ScoreCardReport;
       result[report.reportType] = report.reportData;
     }
     return result;
+  }
+
+  /// Load and deserialize the reports for the given package and version.
+  Future<Map<String, ReportData>> loadReports(
+    String packageName,
+    String packageVersion, {
+    List<String> reportTypes,
+    String runtimeVersion,
+  }) async {
+    final list = await _loadReports(packageName, packageVersion,
+        reportTypes: reportTypes, runtimeVersion: runtimeVersion);
+    return _extractReportData(list);
   }
 
   /// Load and deserialize a specific report type for the given package's versions.
@@ -250,7 +265,8 @@ class ScoreCardBackend {
     final currentSdkVersion = await getDartSdkVersion();
     final status = PackageStatus.fromModels(
         package, version, currentSdkVersion.semanticVersion);
-    final reports = await loadReports(packageName, packageVersion);
+    final reportEntities = await _loadReports(packageName, packageVersion);
+    final reports = _extractReportData(reportEntities);
 
     await db.withRetryTransaction(_db, (tx) async {
       var scoreCard = await tx.lookupValue<ScoreCard>(key, orElse: () => null);
@@ -291,6 +307,31 @@ class ScoreCardBackend {
         panaReport: reports[ReportType.pana] as PanaReport,
         dartdocReport: reports[ReportType.dartdoc] as DartdocReport,
       );
+
+      // store compressed report on the ScoreCard entity too
+      for (final scr in reportEntities) {
+        if (scr == null || scr.reportJsonGz == null) continue;
+        final size = scr.reportJsonGz.length;
+        if (size > _reportSizeDropThreshold) {
+          // TODO: replace it with meaningful content
+          _logger.shout(
+              '${scr.reportType} report exceeded size threshold ($size > $_reportSizeWarnThreshold)');
+          continue;
+        }
+
+        if (size > _reportSizeWarnThreshold) {
+          _logger.warning(
+              '${scr.reportType} report exceeded size threshold ($size > $_reportSizeWarnThreshold)');
+        }
+        switch (scr.reportType) {
+          case ReportType.dartdoc:
+            scoreCard.dartdocReportJsonGz = scr.reportJsonGz;
+            break;
+          case ReportType.pana:
+            scoreCard.panaReportJsonGz = scr.reportJsonGz;
+            break;
+        }
+      }
 
       tx.insert(scoreCard);
     });

--- a/app/lib/scorecard/models.dart
+++ b/app/lib/scorecard/models.dart
@@ -8,7 +8,6 @@ import 'package:json_annotation/json_annotation.dart';
 import 'package:meta/meta.dart';
 import 'package:pana/models.dart'
     show LicenseFile, PanaRuntimeInfo, Report, ReportSection;
-import 'package:pub_dev/scorecard/backend.dart';
 import 'package:pub_semver/pub_semver.dart';
 
 import '../dartdoc/models.dart';

--- a/app/lib/scorecard/models.g.dart
+++ b/app/lib/scorecard/models.g.dart
@@ -28,6 +28,12 @@ ScoreCardData _$ScoreCardDataFromJson(Map<String, dynamic> json) {
     flags: (json['flags'] as List)?.map((e) => e as String)?.toList(),
     reportTypes:
         (json['reportTypes'] as List)?.map((e) => e as String)?.toList(),
+    dartdocReport: json['dartdocReport'] == null
+        ? null
+        : DartdocReport.fromJson(json['dartdocReport'] as Map<String, dynamic>),
+    panaReport: json['panaReport'] == null
+        ? null
+        : PanaReport.fromJson(json['panaReport'] as Map<String, dynamic>),
   );
 }
 
@@ -46,6 +52,8 @@ Map<String, dynamic> _$ScoreCardDataToJson(ScoreCardData instance) =>
       'derivedTags': instance.derivedTags,
       'flags': instance.flags,
       'reportTypes': instance.reportTypes,
+      'dartdocReport': instance.dartdocReport,
+      'panaReport': instance.panaReport,
     };
 
 PanaReport _$PanaReportFromJson(Map<String, dynamic> json) {

--- a/app/lib/shared/utils.dart
+++ b/app/lib/shared/utils.dart
@@ -339,3 +339,9 @@ Map<String, String> cloudTraceHeaders() {
   if (context?.traceId == null) return null;
   return {_cloudTraceContextHeader: context.traceId};
 }
+
+extension CustomException on Logger {
+  /// Reports an error [message] with the current stacktrace.
+  void reportError(String message) =>
+      shout(message, Exception(message), StackTrace.current);
+}


### PR DESCRIPTION
- Starts to store reports if they are <32 KiB. Reports larger than 16 KiB are logged with warning or shout.
- Starts to use the reports stored on the ScoreCard, if they are available on the entity, otherwise falls back to use the ScoreCardReport ones.
- Once we have confirmed that this is not causing issues, we'll have a release that doesn't store the reports separately, and eventually we can remove them.