### PR TITLE
Stop using and creating ScoreCardReport entities.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Important changes to data-models, configuration and migrations between each
 AppEngine version, listed here to ease deployment and troubleshooting.
 
 ## Next Release (replace with git tag when deployed)
+ * Bumped runtimeVersion to `2021.06.03`.
+ * NOTE: Stopped creating `ScoreCardReport` entities.
 
 ## `20210603t155700-all`
  * Bumped runtimeVersion to `2021.06.01`.

--- a/app/lib/analyzer/analyzer_client.dart
+++ b/app/lib/analyzer/analyzer_client.dart
@@ -31,22 +31,7 @@ class AnalyzerClient {
     if (card == null) {
       return AnalysisView();
     }
-    var dartdocReport = card.dartdocReport;
-    var panaReport = card.panaReport;
-    // TODO: remove this part once we store reports only on the card
-    if (dartdocReport == null &&
-        panaReport == null &&
-        card.reportTypes != null &&
-        card.reportTypes.isNotEmpty) {
-      final reports = await scoreCardBackend.loadReports(
-        package,
-        version,
-        runtimeVersion: card.runtimeVersion,
-      );
-      panaReport = reports[ReportType.pana] as PanaReport;
-      dartdocReport = reports[ReportType.dartdoc] as DartdocReport;
-    }
-    return AnalysisView._(card, panaReport, dartdocReport);
+    return AnalysisView(card);
   }
 
   Future<void> triggerAnalysis(
@@ -70,18 +55,12 @@ class AnalyzerClient {
 
 class AnalysisView {
   final ScoreCardData _card;
-  final PanaReport _pana;
-  final DartdocReport _dartdoc;
   Report _report;
 
-  AnalysisView._(this._card, this._pana, this._dartdoc);
+  AnalysisView([this._card]);
 
-  factory AnalysisView({
-    ScoreCardData card,
-    PanaReport panaReport,
-    DartdocReport dartdocReport,
-  }) =>
-      AnalysisView._(card, panaReport, dartdocReport);
+  PanaReport get _pana => _card?.panaReport;
+  DartdocReport get _dartdoc => card?.dartdocReport;
 
   PanaRuntimeInfo get panaRuntimeInfo => _pana?.panaRuntimeInfo;
 

--- a/app/lib/analyzer/pana_runner.dart
+++ b/app/lib/analyzer/pana_runner.dart
@@ -156,10 +156,10 @@ class AnalyzerJobProcessor extends JobProcessor {
 
   Future<void> _storeScoreCard(Job job, Summary summary,
       {List<String> flags}) async {
-    await scoreCardBackend.updateReportAndCard(
+    await scoreCardBackend.updateReportOnCard(
       job.packageName,
       job.packageVersion,
-      panaReportFromSummary(summary, flags: flags),
+      panaReport: panaReportFromSummary(summary, flags: flags),
     );
   }
 }

--- a/app/lib/dartdoc/backend.dart
+++ b/app/lib/dartdoc/backend.dart
@@ -215,17 +215,16 @@ class DartdocBackend {
           versions.where((v) => !entries.containsKey(v)).toList();
       if (queryVersions.isEmpty) break;
 
-      final reports = await scoreCardBackend.loadReportForAllVersions(
+      final cards = await scoreCardBackend.getScoreCardDataForAllVersions(
         package,
         queryVersions,
-        reportType: ReportType.dartdoc,
         runtimeVersion: rv,
       );
       for (var i = 0; i < queryVersions.length; i++) {
-        final r = reports[i];
+        final r = cards[i];
         if (r != null) {
           final version = queryVersions[i];
-          final entry = (r as DartdocReport).dartdocEntry;
+          final entry = r.dartdocReport?.dartdocEntry;
           if (entry != null) {
             entries[version] = entry;
             cacheUpdateFutures.add(pool.withResource(

--- a/app/lib/dartdoc/dartdoc_runner.dart
+++ b/app/lib/dartdoc/dartdoc_runner.dart
@@ -415,6 +415,7 @@ class DartdocJobProcessor extends JobProcessor {
     await _storeScoreCard(
         job,
         DartdocReport(
+          timestamp: DateTime.now().toUtc(),
           reportStatus: reportStatus,
           dartdocEntry: entry,
           documentationSection: documentationSection,
@@ -697,6 +698,7 @@ String _mergeOutput(ProcessResult pr, {bool compress = false}) {
 }
 
 DartdocReport _emptyReport() => DartdocReport(
+      timestamp: DateTime.now().toUtc(),
       reportStatus: ReportStatus.aborted,
       dartdocEntry: null,
       // TODO: add meaningful message for missing documentation on dartdoc

--- a/app/lib/dartdoc/dartdoc_runner.dart
+++ b/app/lib/dartdoc/dartdoc_runner.dart
@@ -428,8 +428,9 @@ class DartdocJobProcessor extends JobProcessor {
   }
 
   Future _storeScoreCard(Job job, DartdocReport report) async {
-    await scoreCardBackend.updateReportAndCard(
-        job.packageName, job.packageVersion, report);
+    await scoreCardBackend.updateReportOnCard(
+        job.packageName, job.packageVersion,
+        dartdocReport: report);
   }
 
   Future<String> _resolveDependencies(

--- a/app/lib/frontend/handlers/custom_api.dart
+++ b/app/lib/frontend/handlers/custom_api.dart
@@ -219,15 +219,6 @@ Future<shelf.Response> apiPackageMetricsHandler(
     'score': score?.toJson(),
     'scorecard': data.toJson(),
   };
-  if (request.requestedUri.queryParameters.containsKey('reports')) {
-    final reports = await scoreCardBackend.loadReports(
-      packageName,
-      data.packageVersion,
-      runtimeVersion: data.runtimeVersion,
-    );
-    result['reports'] =
-        reports.map((k, report) => MapEntry(k, report.toJson()));
-  }
   return jsonResponse(result);
 }
 

--- a/app/lib/scorecard/backend.dart
+++ b/app/lib/scorecard/backend.dart
@@ -191,18 +191,6 @@ class ScoreCardBackend {
     return result;
   }
 
-  /// Load and deserialize the reports for the given package and version.
-  Future<Map<String, ReportData>> loadReports(
-    String packageName,
-    String packageVersion, {
-    List<String> reportTypes,
-    String runtimeVersion,
-  }) async {
-    final list = await _loadReports(packageName, packageVersion,
-        reportTypes: reportTypes, runtimeVersion: runtimeVersion);
-    return _extractReportData(list);
-  }
-
   /// Load and deserialize a specific report type for the given package's versions.
   Future<List<ReportData>> loadReportForAllVersions(
     String packageName,

--- a/app/lib/scorecard/models.dart
+++ b/app/lib/scorecard/models.dart
@@ -177,62 +177,11 @@ class ScoreCard extends db.ExpandoModel<String> {
 }
 
 /// Detail of a specific report for a given PackageVersion.
+///
+/// TODO: Remove this class after `2021.06.01` is no longer an accepted runtimeVersion.
 @db.Kind(name: 'ScoreCardReport', idType: db.IdType.String)
 class ScoreCardReport extends db.ExpandoModel<String> {
-  @db.StringProperty(required: true)
-  String packageName;
-
-  @db.StringProperty(required: true)
-  String packageVersion;
-
-  @db.StringProperty(required: true)
-  String runtimeVersion;
-
-  @db.StringProperty(required: true)
-  String reportType;
-
-  @db.DateTimeProperty()
-  DateTime updated;
-
-  @db.StringProperty(required: true)
-  String reportStatus;
-
-  @db.BlobProperty()
-  List<int> reportJsonGz;
-
   ScoreCardReport();
-
-  ScoreCardReport.init({
-    @required this.packageName,
-    @required this.packageVersion,
-    @required ReportData reportData,
-  }) {
-    runtimeVersion = versions.runtimeVersion;
-    parentKey = scoreCardKey(packageName, packageVersion);
-    reportType = reportData.reportType;
-    reportStatus = reportData.reportStatus;
-    id = reportType;
-    updated = DateTime.now().toUtc();
-    reportJson = reportData.toJson();
-  }
-
-  set reportJson(Map<String, dynamic> map) {
-    if (map == null) {
-      reportJsonGz = null;
-    } else {
-      reportJsonGz = _gzipCodec.encode(jsonUtf8Encoder.convert(map));
-    }
-  }
-
-  ReportData get reportData {
-    switch (reportType) {
-      case ReportType.pana:
-        return PanaReport.fromBytes(reportJsonGz);
-      case ReportType.dartdoc:
-        return DartdocReport.fromBytes(reportJsonGz);
-    }
-    throw Exception('Unknown report type: $reportType');
-  }
 }
 
 abstract class FlagMixin {

--- a/app/lib/scorecard/models.dart
+++ b/app/lib/scorecard/models.dart
@@ -58,7 +58,7 @@ class ScoreCard extends db.ExpandoModel<String> {
   @db.StringProperty(required: true)
   String runtimeVersion;
 
-  @db.DateTimeProperty()
+  @db.DateTimeProperty(required: true)
   DateTime updated;
 
   @db.DateTimeProperty(required: true)
@@ -386,6 +386,8 @@ class DartdocReport implements ReportData {
   @override
   String get reportType => ReportType.dartdoc;
 
+  final DateTime timestamp;
+
   @override
   final String reportStatus;
 
@@ -396,6 +398,7 @@ class DartdocReport implements ReportData {
   final ReportSection documentationSection;
 
   DartdocReport({
+    @required this.timestamp,
     @required this.reportStatus,
     @required this.dartdocEntry,
     @required this.documentationSection,

--- a/app/lib/scorecard/models.g.dart
+++ b/app/lib/scorecard/models.g.dart
@@ -103,6 +103,9 @@ Map<String, dynamic> _$PanaReportToJson(PanaReport instance) {
 
 DartdocReport _$DartdocReportFromJson(Map<String, dynamic> json) {
   return DartdocReport(
+    timestamp: json['timestamp'] == null
+        ? null
+        : DateTime.parse(json['timestamp'] as String),
     reportStatus: json['reportStatus'] as String,
     dartdocEntry: json['dartdocEntry'] == null
         ? null
@@ -116,6 +119,7 @@ DartdocReport _$DartdocReportFromJson(Map<String, dynamic> json) {
 
 Map<String, dynamic> _$DartdocReportToJson(DartdocReport instance) =>
     <String, dynamic>{
+      'timestamp': instance.timestamp?.toIso8601String(),
       'reportStatus': instance.reportStatus,
       'dartdocEntry': instance.dartdocEntry,
       'documentationSection': instance.documentationSection,

--- a/app/lib/shared/versions.dart
+++ b/app/lib/shared/versions.dart
@@ -21,9 +21,9 @@ final RegExp runtimeVersionPattern = RegExp(r'^\d{4}\.\d{2}\.\d{2}$');
 /// Make sure that at least two versions are kept here as the next candidates
 /// when the version switch happens.
 const acceptedRuntimeVersions = <String>[
-  '2021.06.01', // The current [runtimeVersion].
+  '2021.06.03', // The current [runtimeVersion].
+  '2021.06.01',
   '2021.05.25',
-  '2021.05.19',
 ];
 
 /// Represents a combined version of the overall toolchain and processing,

--- a/app/test/analyzer/pana_report_test.dart
+++ b/app/test/analyzer/pana_report_test.dart
@@ -13,15 +13,15 @@ void main() {
     testWithProfile('write and read pana reports', fn: () async {
       await processJobsWithFakePanaRunner();
 
-      final reports = await scoreCardBackend.loadReportForAllVersions(
+      final cards = await scoreCardBackend.getScoreCardDataForAllVersions(
         'oxygen',
         ['1.0.0', '1.2.0', '2.0.0-nonexisting'],
-        reportType: ReportType.pana,
       );
+      final reports = cards.map((c) => c?.panaReport).toList();
 
       expect(reports.first, isNotNull);
       expect(reports.last, isNull);
-      final report = reports[1] as PanaReport;
+      final report = reports[1];
       expect(report.derivedTags, [
         'sdk:dart',
         'runtime:native-aot',

--- a/app/test/dartdoc/dartdoc_report_test.dart
+++ b/app/test/dartdoc/dartdoc_report_test.dart
@@ -22,15 +22,15 @@ void main() {
       );
       await JobMaintenance(dbService, jobProcessor).scanUpdateAndRunOnce();
 
-      final reports = await scoreCardBackend.loadReportForAllVersions(
+      final cards = await scoreCardBackend.getScoreCardDataForAllVersions(
         'oxygen',
         ['1.0.0', '1.2.0', '2.0.0-nonexisting'],
-        reportType: ReportType.dartdoc,
       );
+      final reports = cards.map((c) => c?.dartdocReport).toList();
 
       expect(reports.first, isNotNull);
       expect(reports.last, isNull);
-      final report = reports[1] as DartdocReport;
+      final report = reports[1];
       expect(report.dartdocEntry, isNotNull);
       expect(report.dartdocEntry.totalSize, 440);
       expect(report.documentationSection.grantedPoints, 10);

--- a/app/test/frontend/golden/analysis_tab_http.json
+++ b/app/test/frontend/golden/analysis_tab_http.json
@@ -20,10 +20,8 @@
     "reportTypes": [
       "pana"
     ],
-    "overallScore": 0.9395473064735175
-  },
-  "reports": {
-    "pana": {
+    "overallScore": 0.9395473064735175,
+    "panaReport": {
       "timestamp": "2018-11-16T13:46:22.548220Z",
       "panaRuntimeInfo": {
         "panaVersion": "0.12.6",

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -172,40 +172,40 @@ void main() {
           versionInfo: foobarStablePvInfo,
           asset: assetKind == null ? null : foobarAssets[assetKind],
           analysis: AnalysisView(
-            card: ScoreCardData(
+            ScoreCardData(
               reportTypes: ['pana', 'dartdoc'],
-            ),
-            panaReport: PanaReport(
-                timestamp: DateTime(2018, 02, 05),
-                panaRuntimeInfo: _panaRuntimeInfo,
+              panaReport: PanaReport(
+                  timestamp: DateTime(2018, 02, 05),
+                  panaRuntimeInfo: _panaRuntimeInfo,
+                  reportStatus: ReportStatus.success,
+                  derivedTags: null,
+                  allDependencies: ['quiver', 'http'],
+                  licenseFile: LicenseFile('LICENSE.txt', 'BSD'),
+                  report: Report(sections: <ReportSection>[]),
+                  flags: null),
+              dartdocReport: DartdocReport(
                 reportStatus: ReportStatus.success,
-                derivedTags: null,
-                allDependencies: ['quiver', 'http'],
-                licenseFile: LicenseFile('LICENSE.txt', 'BSD'),
-                report: Report(sections: <ReportSection>[]),
-                flags: null),
-            dartdocReport: DartdocReport(
-              reportStatus: ReportStatus.success,
-              dartdocEntry: DartdocEntry(
-                uuid: '1234-5678-dartdocentry-90ab',
-                packageName: foobarPkgName,
-                packageVersion: foobarStableVersion,
-                isLatest: true,
-                isObsolete: false,
-                usesFlutter: false,
-                runtimeVersion: runtimeVersion,
-                sdkVersion: _panaRuntimeInfo.sdkVersion,
-                dartdocVersion: dartdocVersion,
-                flutterVersion: null,
-                timestamp: DateTime(2018, 02, 05),
-                runDuration: Duration(seconds: 33),
-                depsResolved: true,
-                hasContent: true,
-                archiveSize: 101023,
-                totalSize: 203045,
+                dartdocEntry: DartdocEntry(
+                  uuid: '1234-5678-dartdocentry-90ab',
+                  packageName: foobarPkgName,
+                  packageVersion: foobarStableVersion,
+                  isLatest: true,
+                  isObsolete: false,
+                  usesFlutter: false,
+                  runtimeVersion: runtimeVersion,
+                  sdkVersion: _panaRuntimeInfo.sdkVersion,
+                  dartdocVersion: dartdocVersion,
+                  flutterVersion: null,
+                  timestamp: DateTime(2018, 02, 05),
+                  runDuration: Duration(seconds: 33),
+                  depsResolved: true,
+                  hasContent: true,
+                  archiveSize: 101023,
+                  totalSize: 203045,
+                ),
+                documentationSection:
+                    documentationCoverageSection(documented: 17, total: 17),
               ),
-              documentationSection:
-                  documentationCoverageSection(documented: 17, total: 17),
             ),
           ),
           isAdmin: true,
@@ -248,17 +248,19 @@ void main() {
         versionInfo: foobarDevPvInfo,
         asset: null,
         analysis: AnalysisView(
-          card: ScoreCardData(reportTypes: ['pana']),
-          panaReport: PanaReport(
-              timestamp: DateTime(2018, 02, 05),
-              panaRuntimeInfo: _panaRuntimeInfo,
-              reportStatus: ReportStatus.success,
-              derivedTags: null,
-              allDependencies: ['quiver', 'http'],
-              licenseFile: LicenseFile('LICENSE.txt', 'BSD'),
-              report: Report(sections: <ReportSection>[]),
-              flags: null),
-          dartdocReport: null,
+          ScoreCardData(
+            reportTypes: ['pana'],
+            panaReport: PanaReport(
+                timestamp: DateTime(2018, 02, 05),
+                panaRuntimeInfo: _panaRuntimeInfo,
+                reportStatus: ReportStatus.success,
+                derivedTags: null,
+                allDependencies: ['quiver', 'http'],
+                licenseFile: LicenseFile('LICENSE.txt', 'BSD'),
+                report: Report(sections: <ReportSection>[]),
+                flags: null),
+            dartdocReport: null,
+          ),
         ),
         isAdmin: true,
       ));
@@ -274,21 +276,21 @@ void main() {
         versionInfo: foobarStablePvInfo,
         asset: foobarAssets[AssetKind.readme],
         analysis: AnalysisView(
-          card: ScoreCardData(
+          ScoreCardData(
             popularityScore: 0.3,
             derivedTags: ['sdk:flutter', 'platform:android'],
             flags: [PackageFlags.usesFlutter],
             reportTypes: ['pana'],
+            panaReport: PanaReport(
+                timestamp: DateTime(2018, 02, 05),
+                panaRuntimeInfo: _panaRuntimeInfo,
+                reportStatus: ReportStatus.success,
+                derivedTags: ['sdk:flutter', 'platform:android'],
+                allDependencies: null,
+                licenseFile: null,
+                report: Report(sections: <ReportSection>[]),
+                flags: null),
           ),
-          panaReport: PanaReport(
-              timestamp: DateTime(2018, 02, 05),
-              panaRuntimeInfo: _panaRuntimeInfo,
-              reportStatus: ReportStatus.success,
-              derivedTags: ['sdk:flutter', 'platform:android'],
-              allDependencies: null,
-              licenseFile: null,
-              report: Report(sections: <ReportSection>[]),
-              flags: null),
         ),
         isAdmin: true,
       ));
@@ -304,7 +306,7 @@ void main() {
         versionInfo: foobarStablePvInfo,
         asset: foobarAssets[AssetKind.readme],
         analysis: AnalysisView(
-          card: ScoreCardData(
+          ScoreCardData(
             flags: [PackageFlags.isObsolete],
             updated: DateTime(2018, 02, 05),
           ),
@@ -324,7 +326,7 @@ void main() {
         versionInfo: foobarStablePvInfo,
         asset: foobarAssets[AssetKind.readme],
         analysis: AnalysisView(
-          card: ScoreCardData(
+          ScoreCardData(
             flags: [PackageFlags.isDiscontinued],
             updated: DateTime(2018, 02, 05),
           ),
@@ -347,7 +349,7 @@ void main() {
         versionInfo: foobarStablePvInfo,
         asset: foobarAssets[AssetKind.readme],
         analysis: AnalysisView(
-          card: ScoreCardData(
+          ScoreCardData(
             popularityScore: 0.5,
             flags: [PackageFlags.isLegacy],
           ),
@@ -385,10 +387,7 @@ void main() {
       final map = json.decode(content) as Map<String, dynamic>;
       final card =
           ScoreCardData.fromJson(map['scorecard'] as Map<String, dynamic>);
-      final reports = map['reports'] as Map<String, dynamic>;
-      final panaReport =
-          PanaReport.fromJson(reports['pana'] as Map<String, dynamic>);
-      final view = AnalysisView(card: card, panaReport: panaReport);
+      final view = AnalysisView(card);
       final String html = renderAnalysisTab(
         'http',
         '>=1.23.0-dev.0.0 <2.0.0',
@@ -404,19 +403,17 @@ void main() {
         popularityScore: 0.2323232,
         derivedTags: ['sdk:dart', 'runtime:web'],
         reportTypes: ['pana'],
-      );
-      final analysisView = AnalysisView(
-        card: card,
         panaReport: PanaReport(
             timestamp: DateTime.utc(2017, 10, 26, 14, 03, 06),
             panaRuntimeInfo: _panaRuntimeInfo,
             reportStatus: ReportStatus.failed,
-            derivedTags: card.derivedTags,
+            derivedTags: ['sdk:dart', 'runtime:web'],
             allDependencies: ['http', 'async'],
             licenseFile: null,
             report: Report(sections: <ReportSection>[]),
             flags: null),
       );
+      final analysisView = AnalysisView(card);
       final String html = renderAnalysisTab(
         'pkg_foo',
         '>=1.25.0-dev.9.0 <2.0.0',
@@ -433,18 +430,18 @@ void main() {
         null,
         ScoreCardData(),
         AnalysisView(
-          card: ScoreCardData(
+          ScoreCardData(
             reportTypes: ['pana'],
-          ),
-          panaReport: PanaReport(
-            timestamp: DateTime(2017, 12, 18, 14, 26, 00),
-            panaRuntimeInfo: _panaRuntimeInfo,
-            reportStatus: ReportStatus.aborted,
-            derivedTags: null,
-            allDependencies: null,
-            licenseFile: null,
-            report: Report(sections: <ReportSection>[]),
-            flags: null,
+            panaReport: PanaReport(
+              timestamp: DateTime(2017, 12, 18, 14, 26, 00),
+              panaRuntimeInfo: _panaRuntimeInfo,
+              reportStatus: ReportStatus.aborted,
+              derivedTags: null,
+              allDependencies: null,
+              licenseFile: null,
+              report: Report(sections: <ReportSection>[]),
+              flags: null,
+            ),
           ),
         ),
         likeCount: 1000000,
@@ -459,7 +456,7 @@ void main() {
         null,
         ScoreCardData(flags: [PackageFlags.isObsolete]),
         AnalysisView(
-          card: ScoreCardData(
+          ScoreCardData(
             flags: [PackageFlags.isObsolete],
             updated: DateTime(2017, 12, 18, 14, 26, 00),
           ),
@@ -478,7 +475,7 @@ void main() {
           versionInfo: foobarStablePvInfo,
           asset: null,
           analysis: AnalysisView(
-            card: ScoreCardData(
+            ScoreCardData(
               flags: [PackageFlags.isObsolete],
               updated: DateTime(2018, 02, 05),
             ),
@@ -565,7 +562,7 @@ void main() {
           versionInfo: foobarStablePvInfo,
           asset: null,
           analysis: AnalysisView(
-            card: ScoreCardData(
+            ScoreCardData(
               derivedTags: ['sdk:dart', 'sdk:flutter'],
               popularityScore: 0.2,
             ),

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -184,6 +184,7 @@ void main() {
                   report: Report(sections: <ReportSection>[]),
                   flags: null),
               dartdocReport: DartdocReport(
+                timestamp: DateTime(2018, 02, 05),
                 reportStatus: ReportStatus.success,
                 dartdocEntry: DartdocEntry(
                   uuid: '1234-5678-dartdocentry-90ab',

--- a/app/test/shared/test_services.dart
+++ b/app/test/shared/test_services.dart
@@ -144,10 +144,11 @@ Future<void> _populateDefaultData() async {
     lithium.package.name: 0.7,
   });
 
-  await scoreCardBackend.updateReportAndCard(
-      helium.package.name,
-      helium.package.latestVersion,
-      generatePanaReport(derivedTags: ['sdk:flutter']));
+  await scoreCardBackend.updateReportOnCard(
+    helium.package.name,
+    helium.package.latestVersion,
+    panaReport: generatePanaReport(derivedTags: ['sdk:flutter']),
+  );
 }
 
 /// Creates local, non-HTTP-based API client with [authToken].


### PR DESCRIPTION
- Simpler update of the entity, fewer entities being inserted and used in Datastore.
- Keeping the entity around, as cleanups should happen on older runtime versions.
