### PR TITLE
null-safety badge on the versions listing page

### DIFF
--- a/app/lib/frontend/templates/package_versions.dart
+++ b/app/lib/frontend/templates/package_versions.dart
@@ -116,6 +116,7 @@ String renderVersionTableRow(PackageVersion version, String downloadUrl) {
     'package': version.package,
     'version': version.version,
     'version_url': urls.pkgPageUrl(version.package, version: version.version),
+    'has_opted_into_null_safety': version.pubspec.hasOptedIntoNullSafety,
     'has_sdk': minSdkVersion != null,
     'sdk': minSdkVersion == null
         ? null

--- a/app/lib/frontend/templates/views/pkg/versions/index.mustache
+++ b/app/lib/frontend/templates/views/pkg/versions/index.mustache
@@ -7,6 +7,7 @@
   <thead>
   <tr>
     <th class="version">Version</th>
+    <th class="badge"></th>
     <th class="sdk"><span class="label">Min Dart SDK</span></th>
     <th class="uploaded"><span class="label">Uploaded</span></th>
     <th class="documentation"><span class="label">Documentation</span></th>

--- a/app/lib/frontend/templates/views/pkg/versions/version_row.mustache
+++ b/app/lib/frontend/templates/views/pkg/versions/version_row.mustache
@@ -6,7 +6,7 @@
   <td class="version"><a href="{{& version_url}}">{{version}}</a></td>
   <td class="badge">
     {{#has_opted_into_null_safety}}
-      <span class="package-badge maybe" title="Opted into null safety language feature.">Null safety</span>
+      <span class="package-badge" title="Package version is opted into null safety.">Null safety</span>
     {{/has_opted_into_null_safety}}
   </td>
   <td class="sdk">

--- a/app/lib/frontend/templates/views/pkg/versions/version_row.mustache
+++ b/app/lib/frontend/templates/views/pkg/versions/version_row.mustache
@@ -4,6 +4,11 @@
 
 <tr data-version="{{version}}">
   <td class="version"><a href="{{& version_url}}">{{version}}</a></td>
+  <td class="badge">
+    {{#has_opted_into_null_safety}}
+      <span class="package-badge maybe" title="Opted into null safety language feature.">Null safety</span>
+    {{/has_opted_into_null_safety}}
+  </td>
   <td class="sdk">
     {{#has_sdk}}
       {{ sdk.major }}.{{ sdk.minor }}

--- a/app/lib/package/model_properties.dart
+++ b/app/lib/package/model_properties.dart
@@ -104,12 +104,11 @@ class Pubspec {
     return _asString(environment['sdk']);
   }
 
+  SdkConstraintStatus get _sdkConstraintStatus =>
+      SdkConstraintStatus.fromSdkVersion(_inner.environment['sdk'], name);
+
   // TODO: migrate uses to SdkConstraintStatus.isDart2Compatible
-  bool get supportsOnlyLegacySdk {
-    final s =
-        SdkConstraintStatus.fromSdkVersion(_inner.environment['sdk'], name);
-    return !s.isDart2Compatible;
-  }
+  bool get supportsOnlyLegacySdk => !_sdkConstraintStatus.isDart2Compatible;
 
   /// Whether the pubspec file contains a flutter.plugin entry.
   bool get hasFlutterPlugin {
@@ -140,6 +139,9 @@ class Pubspec {
 
   /// Whether the package uses Flutter in any way.
   bool get usesFlutter => dependsOnFlutter || hasFlutterPlugin;
+
+  bool get hasOptedIntoNullSafety =>
+      _sdkConstraintStatus.hasOptedIntoNullSafety;
 
   void _load() {
     if (_json == null) {

--- a/app/test/frontend/golden/pkg_versions_page.html
+++ b/app/test/frontend/golden/pkg_versions_page.html
@@ -215,6 +215,7 @@
                     <thead>
                       <tr>
                         <th class="version">Version</th>
+                        <th class="badge"></th>
                         <th class="sdk">
                           <span class="label">Min Dart SDK</span>
                         </th>
@@ -234,6 +235,7 @@
                         <td class="version">
                           <a href="/packages/foobar_pkg/versions/0.1.1+5">0.1.1+5</a>
                         </td>
+                        <td class="badge"></td>
                         <td class="sdk"></td>
                         <td class="uploaded">Jan 1, 2014</td>
                         <td class="documentation">
@@ -254,6 +256,7 @@
                     <thead>
                       <tr>
                         <th class="version">Version</th>
+                        <th class="badge"></th>
                         <th class="sdk">
                           <span class="label">Min Dart SDK</span>
                         </th>
@@ -273,6 +276,7 @@
                         <td class="version">
                           <a href="/packages/foobar_pkg/versions/0.2.0-dev">0.2.0-dev</a>
                         </td>
+                        <td class="badge"></td>
                         <td class="sdk"></td>
                         <td class="uploaded">Jan 1, 2014</td>
                         <td class="documentation">

--- a/pkg/web_css/lib/src/_pkg.scss
+++ b/pkg/web_css/lib/src/_pkg.scss
@@ -28,11 +28,6 @@
     margin-left: 4px;
     margin-right: 4px;
   }
-
-  &.maybe {
-    color: #aaa;
-    border-color: #aaa;
-  }
 }
 
 .package-vp-icon {

--- a/pkg/web_css/lib/src/_pkg.scss
+++ b/pkg/web_css/lib/src/_pkg.scss
@@ -28,6 +28,11 @@
     margin-left: 4px;
     margin-right: 4px;
   }
+
+  &.maybe {
+    color: #aaa;
+    border-color: #aaa;
+  }
 }
 
 .package-vp-icon {
@@ -46,6 +51,14 @@
     border-bottom: 1px solid #c8c8ca;
     padding: 8px 4px;
     text-align: left;
+
+    &.badge {
+      width: 100px;
+
+      @media (max-width: $device-mobile-max-width) {
+        display: none;
+      }
+    }
 
     &.sdk {
       white-space: nowrap;


### PR DESCRIPTION
- Fixes #4825.
- Because the mobile view has not enough horizontal space, I've removed it from there.

<img width="561" alt="Screenshot 2021-06-04 124224" src="https://user-images.githubusercontent.com/4778111/120795407-b70fb600-c539-11eb-9600-e57e051e2cf2.png">
