### PR TITLE
Remove uploader emails.

### DIFF
--- a/app/lib/frontend/templates/package.dart
+++ b/app/lib/frontend/templates/package.dart
@@ -13,8 +13,6 @@ import '../../package/model_properties.dart';
 import '../../package/models.dart';
 import '../../package/overrides.dart'
     show devDependencyPackages, redirectPackageUrls;
-import '../../search/search_form.dart';
-import '../../shared/email.dart' show EmailAddress;
 import '../../shared/handlers.dart';
 import '../../shared/tags.dart';
 import '../../shared/urls.dart' as urls;
@@ -201,11 +199,6 @@ String renderPkgInfoBox(PackagePageData data) {
     'publisher_link': package.publisherId == null
         ? null
         : urls.publisherUrl(package.publisherId),
-    'uploaders_title':
-        data.uploaderEmails.length > 1 ? 'Uploaders' : 'Uploader',
-    'uploaders_html': data.uploaderEmails.isEmpty
-        ? null
-        : _getAuthorsHtml(data.uploaderEmails),
     'license_html': _renderLicense(data),
     'dependencies_html': _renderDependencyList(data.version.pubspec),
     'search_deps_link': urls.searchUrl(q: 'dependency:${package.name}'),
@@ -519,25 +512,6 @@ Tab _scoreTab(PackagePageData data) {
       likeCount: data.package.likes,
     ),
   );
-}
-
-String _getAuthorsHtml(List<String> authors) {
-  return (authors ?? const []).map((String value) {
-    final EmailAddress author = EmailAddress.parse(value);
-    final escapedName = htmlEscape.convert(author.name ?? author.email);
-    if (author.email != null) {
-      final escapedEmail = htmlAttrEscape.convert(author.email);
-      final emailSearchUrl = htmlAttrEscape.convert(
-          SearchForm.parse(query: 'email:${author.email}').toSearchLink());
-      final text =
-          '<a href="$emailSearchUrl" title="Search packages from $escapedName" rel="nofollow">'
-          '$escapedEmail'
-          '</a>';
-      return '<span class="author">$text</span>';
-    } else {
-      return '<span class="author">$escapedName</span>';
-    }
-  }).join('<br/>');
 }
 
 String renderPackageSchemaOrgHtml(PackagePageData data) {

--- a/app/lib/frontend/templates/views/pkg/info_box.mustache
+++ b/app/lib/frontend/templates/views/pkg/info_box.mustache
@@ -11,15 +11,18 @@
 </p>
 {{/replaced_by}}
 
-{{#publisher_id}}
 <h3 class="title">Publisher</h3>
 <p>
+  {{#publisher_id}}
   <a href="{{& publisher_link}}"><img
           class="-pub-publisher-shield"
           title="Published by a pub.dev verified publisher"
           src="{{{static_assets.img__verified-publisher-blue_svg}}}" />{{publisher_id}}</a>
+  {{/publisher_id}}
+  {{^publisher_id}}
+  Unknown
+  {{/publisher_id}}
 </p>
-{{/publisher_id}}
 
 <h3 class="title pkg-infobox-metadata">Metadata</h3>
 {{#description}}
@@ -39,11 +42,6 @@
   {{/doc_links}}
 </p>
 {{/has_doc_links}}
-
-{{#uploaders_html}}
-<h3 class="title">{{uploaders_title}}</h3>
-<p>{{& uploaders_html}}</p>
-{{/uploaders_html}}
 
 {{#license_html}}
 <h3 class="title">License</h3>

--- a/app/lib/shared/email.dart
+++ b/app/lib/shared/email.dart
@@ -10,7 +10,6 @@ import 'urls.dart';
 
 const pubDartlangOrgEmail = 'noreply@pub.dev';
 final _lenientEmailRegExp = RegExp(r'^\S+@\S+\.\S+$');
-final _nameEmailRegExp = RegExp(r'^(.*)<(.+@.+)>$');
 
 /// Strict regular expression used in <input type="email" />
 /// https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address
@@ -28,35 +27,6 @@ class EmailAddress {
   final String email;
 
   EmailAddress(this.name, this.email);
-
-  factory EmailAddress.parse(String value) {
-    value = value.trim();
-    String name = value;
-    String email;
-
-    final match = _nameEmailRegExp.matchAsPrefix(value);
-    if (match != null) {
-      name = match.group(1).trim();
-      email = match.group(2).trim();
-    } else if (value.contains('@')) {
-      final List<String> parts = value.split(' ');
-      for (int i = 0; i < parts.length; i++) {
-        if (looksLikeEmail(parts[i])) {
-          email = parts[i];
-          parts.removeAt(i);
-          name = parts.join(' ').trim();
-          break;
-        }
-      }
-    }
-    if (name != null && name.isEmpty) {
-      name = null;
-    }
-    if (!looksLikeEmail(email)) {
-      email = null;
-    }
-    return EmailAddress(name, email);
-  }
 
   bool get isEmpty => name == null && email == null;
 

--- a/app/test/frontend/golden/pkg_admin_page_outdated.html
+++ b/app/test/frontend/golden/pkg_admin_page_outdated.html
@@ -331,17 +331,13 @@
                 <div class="packages-score-label">popularity</div>
               </div>
             </a>
+            <h3 class="title">Publisher</h3>
+            <p>Unknown</p>
             <h3 class="title pkg-infobox-metadata">Metadata</h3>
             <p>my package description</p>
             <p>
               <a class="link" href="http://hans.juergen.com" rel="ugc">Homepage</a>
               <br/>
-            </p>
-            <h3 class="title">Uploader</h3>
-            <p>
-              <span class="author">
-                <a href="/packages?q=email%3Ahans%40juergen.com" title="Search packages from hans@juergen.com" rel="nofollow">hans@juergen.com</a>
-              </span>
             </p>
             <h3 class="title">Dependencies</h3>
             <p>
@@ -383,17 +379,13 @@
               <div class="packages-score-label">popularity</div>
             </div>
           </a>
+          <h3 class="title">Publisher</h3>
+          <p>Unknown</p>
           <h3 class="title pkg-infobox-metadata">Metadata</h3>
           <p>my package description</p>
           <p>
             <a class="link" href="http://hans.juergen.com" rel="ugc">Homepage</a>
             <br/>
-          </p>
-          <h3 class="title">Uploader</h3>
-          <p>
-            <span class="author">
-              <a href="/packages?q=email%3Ahans%40juergen.com" title="Search packages from hans@juergen.com" rel="nofollow">hans@juergen.com</a>
-            </span>
           </p>
           <h3 class="title">Dependencies</h3>
           <p>

--- a/app/test/frontend/golden/pkg_changelog_page.html
+++ b/app/test/frontend/golden/pkg_changelog_page.html
@@ -236,6 +236,8 @@
                 <div class="packages-score-label">popularity</div>
               </div>
             </a>
+            <h3 class="title">Publisher</h3>
+            <p>Unknown</p>
             <h3 class="title pkg-infobox-metadata">Metadata</h3>
             <p>my package description</p>
             <p>
@@ -246,12 +248,6 @@
             <p>
               <a class="link" href="/documentation/foobar_pkg/latest/">API reference</a>
               <br/>
-            </p>
-            <h3 class="title">Uploader</h3>
-            <p>
-              <span class="author">
-                <a href="/packages?q=email%3Ahans%40juergen.com" title="Search packages from hans@juergen.com" rel="nofollow">hans@juergen.com</a>
-              </span>
             </p>
             <h3 class="title">Dependencies</h3>
             <p>
@@ -294,6 +290,8 @@
               <div class="packages-score-label">popularity</div>
             </div>
           </a>
+          <h3 class="title">Publisher</h3>
+          <p>Unknown</p>
           <h3 class="title pkg-infobox-metadata">Metadata</h3>
           <p>my package description</p>
           <p>
@@ -304,12 +302,6 @@
           <p>
             <a class="link" href="/documentation/foobar_pkg/latest/">API reference</a>
             <br/>
-          </p>
-          <h3 class="title">Uploader</h3>
-          <p>
-            <span class="author">
-              <a href="/packages?q=email%3Ahans%40juergen.com" title="Search packages from hans@juergen.com" rel="nofollow">hans@juergen.com</a>
-            </span>
           </p>
           <h3 class="title">Dependencies</h3>
           <p>

--- a/app/test/frontend/golden/pkg_example_page.html
+++ b/app/test/frontend/golden/pkg_example_page.html
@@ -237,6 +237,8 @@
                 <div class="packages-score-label">popularity</div>
               </div>
             </a>
+            <h3 class="title">Publisher</h3>
+            <p>Unknown</p>
             <h3 class="title pkg-infobox-metadata">Metadata</h3>
             <p>my package description</p>
             <p>
@@ -247,12 +249,6 @@
             <p>
               <a class="link" href="/documentation/foobar_pkg/latest/">API reference</a>
               <br/>
-            </p>
-            <h3 class="title">Uploader</h3>
-            <p>
-              <span class="author">
-                <a href="/packages?q=email%3Ahans%40juergen.com" title="Search packages from hans@juergen.com" rel="nofollow">hans@juergen.com</a>
-              </span>
             </p>
             <h3 class="title">Dependencies</h3>
             <p>
@@ -295,6 +291,8 @@
               <div class="packages-score-label">popularity</div>
             </div>
           </a>
+          <h3 class="title">Publisher</h3>
+          <p>Unknown</p>
           <h3 class="title pkg-infobox-metadata">Metadata</h3>
           <p>my package description</p>
           <p>
@@ -305,12 +303,6 @@
           <p>
             <a class="link" href="/documentation/foobar_pkg/latest/">API reference</a>
             <br/>
-          </p>
-          <h3 class="title">Uploader</h3>
-          <p>
-            <span class="author">
-              <a href="/packages?q=email%3Ahans%40juergen.com" title="Search packages from hans@juergen.com" rel="nofollow">hans@juergen.com</a>
-            </span>
           </p>
           <h3 class="title">Dependencies</h3>
           <p>

--- a/app/test/frontend/golden/pkg_install_page.html
+++ b/app/test/frontend/golden/pkg_install_page.html
@@ -259,6 +259,8 @@
                 <div class="packages-score-label">popularity</div>
               </div>
             </a>
+            <h3 class="title">Publisher</h3>
+            <p>Unknown</p>
             <h3 class="title pkg-infobox-metadata">Metadata</h3>
             <p>my package description</p>
             <p>
@@ -269,12 +271,6 @@
             <p>
               <a class="link" href="/documentation/foobar_pkg/latest/">API reference</a>
               <br/>
-            </p>
-            <h3 class="title">Uploader</h3>
-            <p>
-              <span class="author">
-                <a href="/packages?q=email%3Ahans%40juergen.com" title="Search packages from hans@juergen.com" rel="nofollow">hans@juergen.com</a>
-              </span>
             </p>
             <h3 class="title">Dependencies</h3>
             <p>
@@ -317,6 +313,8 @@
               <div class="packages-score-label">popularity</div>
             </div>
           </a>
+          <h3 class="title">Publisher</h3>
+          <p>Unknown</p>
           <h3 class="title pkg-infobox-metadata">Metadata</h3>
           <p>my package description</p>
           <p>
@@ -327,12 +325,6 @@
           <p>
             <a class="link" href="/documentation/foobar_pkg/latest/">API reference</a>
             <br/>
-          </p>
-          <h3 class="title">Uploader</h3>
-          <p>
-            <span class="author">
-              <a href="/packages?q=email%3Ahans%40juergen.com" title="Search packages from hans@juergen.com" rel="nofollow">hans@juergen.com</a>
-            </span>
           </p>
           <h3 class="title">Dependencies</h3>
           <p>

--- a/app/test/frontend/golden/pkg_score_page.html
+++ b/app/test/frontend/golden/pkg_score_page.html
@@ -291,6 +291,8 @@
                 <div class="packages-score-label">popularity</div>
               </div>
             </a>
+            <h3 class="title">Publisher</h3>
+            <p>Unknown</p>
             <h3 class="title pkg-infobox-metadata">Metadata</h3>
             <p>my package description</p>
             <p>
@@ -301,12 +303,6 @@
             <p>
               <a class="link" href="/documentation/foobar_pkg/latest/">API reference</a>
               <br/>
-            </p>
-            <h3 class="title">Uploader</h3>
-            <p>
-              <span class="author">
-                <a href="/packages?q=email%3Ahans%40juergen.com" title="Search packages from hans@juergen.com" rel="nofollow">hans@juergen.com</a>
-              </span>
             </p>
             <h3 class="title">Dependencies</h3>
             <p>
@@ -349,6 +345,8 @@
               <div class="packages-score-label">popularity</div>
             </div>
           </a>
+          <h3 class="title">Publisher</h3>
+          <p>Unknown</p>
           <h3 class="title pkg-infobox-metadata">Metadata</h3>
           <p>my package description</p>
           <p>
@@ -359,12 +357,6 @@
           <p>
             <a class="link" href="/documentation/foobar_pkg/latest/">API reference</a>
             <br/>
-          </p>
-          <h3 class="title">Uploader</h3>
-          <p>
-            <span class="author">
-              <a href="/packages?q=email%3Ahans%40juergen.com" title="Search packages from hans@juergen.com" rel="nofollow">hans@juergen.com</a>
-            </span>
           </p>
           <h3 class="title">Dependencies</h3>
           <p>

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -239,6 +239,8 @@
                 <div class="packages-score-label">popularity</div>
               </div>
             </a>
+            <h3 class="title">Publisher</h3>
+            <p>Unknown</p>
             <h3 class="title pkg-infobox-metadata">Metadata</h3>
             <p>my package description</p>
             <p>
@@ -249,12 +251,6 @@
             <p>
               <a class="link" href="/documentation/foobar_pkg/latest/">API reference</a>
               <br/>
-            </p>
-            <h3 class="title">Uploader</h3>
-            <p>
-              <span class="author">
-                <a href="/packages?q=email%3Ahans%40juergen.com" title="Search packages from hans@juergen.com" rel="nofollow">hans@juergen.com</a>
-              </span>
             </p>
             <h3 class="title">Dependencies</h3>
             <p>
@@ -297,6 +293,8 @@
               <div class="packages-score-label">popularity</div>
             </div>
           </a>
+          <h3 class="title">Publisher</h3>
+          <p>Unknown</p>
           <h3 class="title pkg-infobox-metadata">Metadata</h3>
           <p>my package description</p>
           <p>
@@ -307,12 +305,6 @@
           <p>
             <a class="link" href="/documentation/foobar_pkg/latest/">API reference</a>
             <br/>
-          </p>
-          <h3 class="title">Uploader</h3>
-          <p>
-            <span class="author">
-              <a href="/packages?q=email%3Ahans%40juergen.com" title="Search packages from hans@juergen.com" rel="nofollow">hans@juergen.com</a>
-            </span>
           </p>
           <h3 class="title">Dependencies</h3>
           <p>

--- a/app/test/frontend/golden/pkg_show_page_discontinued.html
+++ b/app/test/frontend/golden/pkg_show_page_discontinued.html
@@ -240,17 +240,13 @@
             <p>
               <a href="/packages/helium" title="This package is discontinued, but author has suggested package:helium as a replacement">helium</a>
             </p>
+            <h3 class="title">Publisher</h3>
+            <p>Unknown</p>
             <h3 class="title pkg-infobox-metadata">Metadata</h3>
             <p>my package description</p>
             <p>
               <a class="link" href="http://hans.juergen.com" rel="ugc">Homepage</a>
               <br/>
-            </p>
-            <h3 class="title">Uploader</h3>
-            <p>
-              <span class="author">
-                <a href="/packages?q=email%3Ahans%40juergen.com" title="Search packages from hans@juergen.com" rel="nofollow">hans@juergen.com</a>
-              </span>
             </p>
             <h3 class="title">Dependencies</h3>
             <p>
@@ -297,17 +293,13 @@
           <p>
             <a href="/packages/helium" title="This package is discontinued, but author has suggested package:helium as a replacement">helium</a>
           </p>
+          <h3 class="title">Publisher</h3>
+          <p>Unknown</p>
           <h3 class="title pkg-infobox-metadata">Metadata</h3>
           <p>my package description</p>
           <p>
             <a class="link" href="http://hans.juergen.com" rel="ugc">Homepage</a>
             <br/>
-          </p>
-          <h3 class="title">Uploader</h3>
-          <p>
-            <span class="author">
-              <a href="/packages?q=email%3Ahans%40juergen.com" title="Search packages from hans@juergen.com" rel="nofollow">hans@juergen.com</a>
-            </span>
           </p>
           <h3 class="title">Dependencies</h3>
           <p>

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -242,17 +242,13 @@
                 <div class="packages-score-label">popularity</div>
               </div>
             </a>
+            <h3 class="title">Publisher</h3>
+            <p>Unknown</p>
             <h3 class="title pkg-infobox-metadata">Metadata</h3>
             <p>my package description</p>
             <p>
               <a class="link" href="http://hans.juergen.com" rel="ugc">Homepage</a>
               <br/>
-            </p>
-            <h3 class="title">Uploader</h3>
-            <p>
-              <span class="author">
-                <a href="/packages?q=email%3Ahans%40juergen.com" title="Search packages from hans@juergen.com" rel="nofollow">hans@juergen.com</a>
-              </span>
             </p>
             <h3 class="title">Dependencies</h3>
             <p>
@@ -295,17 +291,13 @@
               <div class="packages-score-label">popularity</div>
             </div>
           </a>
+          <h3 class="title">Publisher</h3>
+          <p>Unknown</p>
           <h3 class="title pkg-infobox-metadata">Metadata</h3>
           <p>my package description</p>
           <p>
             <a class="link" href="http://hans.juergen.com" rel="ugc">Homepage</a>
             <br/>
-          </p>
-          <h3 class="title">Uploader</h3>
-          <p>
-            <span class="author">
-              <a href="/packages?q=email%3Ahans%40juergen.com" title="Search packages from hans@juergen.com" rel="nofollow">hans@juergen.com</a>
-            </span>
           </p>
           <h3 class="title">Dependencies</h3>
           <p>

--- a/app/test/frontend/golden/pkg_show_page_legacy.html
+++ b/app/test/frontend/golden/pkg_show_page_legacy.html
@@ -236,21 +236,13 @@
                 <div class="packages-score-label">popularity</div>
               </div>
             </a>
+            <h3 class="title">Publisher</h3>
+            <p>Unknown</p>
             <h3 class="title pkg-infobox-metadata">Metadata</h3>
             <p>my package description</p>
             <p>
               <a class="link" href="http://hans.juergen.com" rel="ugc">Homepage</a>
               <br/>
-            </p>
-            <h3 class="title">Uploaders</h3>
-            <p>
-              <span class="author">
-                <a href="/packages?q=email%3Ahans%40juergen.com" title="Search packages from hans@juergen.com" rel="nofollow">hans@juergen.com</a>
-              </span>
-              <br/>
-              <span class="author">
-                <a href="/packages?q=email%3Ajoe%40example.com" title="Search packages from joe@example.com" rel="nofollow">joe@example.com</a>
-              </span>
             </p>
             <h3 class="title">Dependencies</h3>
             <p>
@@ -293,21 +285,13 @@
               <div class="packages-score-label">popularity</div>
             </div>
           </a>
+          <h3 class="title">Publisher</h3>
+          <p>Unknown</p>
           <h3 class="title pkg-infobox-metadata">Metadata</h3>
           <p>my package description</p>
           <p>
             <a class="link" href="http://hans.juergen.com" rel="ugc">Homepage</a>
             <br/>
-          </p>
-          <h3 class="title">Uploaders</h3>
-          <p>
-            <span class="author">
-              <a href="/packages?q=email%3Ahans%40juergen.com" title="Search packages from hans@juergen.com" rel="nofollow">hans@juergen.com</a>
-            </span>
-            <br/>
-            <span class="author">
-              <a href="/packages?q=email%3Ajoe%40example.com" title="Search packages from joe@example.com" rel="nofollow">joe@example.com</a>
-            </span>
           </p>
           <h3 class="title">Dependencies</h3>
           <p>

--- a/app/test/frontend/golden/pkg_show_page_outdated.html
+++ b/app/test/frontend/golden/pkg_show_page_outdated.html
@@ -236,17 +236,13 @@
                 <div class="packages-score-label">popularity</div>
               </div>
             </a>
+            <h3 class="title">Publisher</h3>
+            <p>Unknown</p>
             <h3 class="title pkg-infobox-metadata">Metadata</h3>
             <p>my package description</p>
             <p>
               <a class="link" href="http://hans.juergen.com" rel="ugc">Homepage</a>
               <br/>
-            </p>
-            <h3 class="title">Uploader</h3>
-            <p>
-              <span class="author">
-                <a href="/packages?q=email%3Ahans%40juergen.com" title="Search packages from hans@juergen.com" rel="nofollow">hans@juergen.com</a>
-              </span>
             </p>
             <h3 class="title">Dependencies</h3>
             <p>
@@ -289,17 +285,13 @@
               <div class="packages-score-label">popularity</div>
             </div>
           </a>
+          <h3 class="title">Publisher</h3>
+          <p>Unknown</p>
           <h3 class="title pkg-infobox-metadata">Metadata</h3>
           <p>my package description</p>
           <p>
             <a class="link" href="http://hans.juergen.com" rel="ugc">Homepage</a>
             <br/>
-          </p>
-          <h3 class="title">Uploader</h3>
-          <p>
-            <span class="author">
-              <a href="/packages?q=email%3Ahans%40juergen.com" title="Search packages from hans@juergen.com" rel="nofollow">hans@juergen.com</a>
-            </span>
           </p>
           <h3 class="title">Dependencies</h3>
           <p>

--- a/app/test/frontend/golden/pkg_show_version_page.html
+++ b/app/test/frontend/golden/pkg_show_version_page.html
@@ -224,17 +224,13 @@
                 <div class="packages-score-label">popularity</div>
               </div>
             </a>
+            <h3 class="title">Publisher</h3>
+            <p>Unknown</p>
             <h3 class="title pkg-infobox-metadata">Metadata</h3>
             <p>my package description</p>
             <p>
               <a class="link" href="http://hans.juergen.com" rel="ugc">Homepage</a>
               <br/>
-            </p>
-            <h3 class="title">Uploader</h3>
-            <p>
-              <span class="author">
-                <a href="/packages?q=email%3Ahans%40juergen.com" title="Search packages from hans@juergen.com" rel="nofollow">hans@juergen.com</a>
-              </span>
             </p>
             <h3 class="title">Dependencies</h3>
             <p>
@@ -277,17 +273,13 @@
               <div class="packages-score-label">popularity</div>
             </div>
           </a>
+          <h3 class="title">Publisher</h3>
+          <p>Unknown</p>
           <h3 class="title pkg-infobox-metadata">Metadata</h3>
           <p>my package description</p>
           <p>
             <a class="link" href="http://hans.juergen.com" rel="ugc">Homepage</a>
             <br/>
-          </p>
-          <h3 class="title">Uploader</h3>
-          <p>
-            <span class="author">
-              <a href="/packages?q=email%3Ahans%40juergen.com" title="Search packages from hans@juergen.com" rel="nofollow">hans@juergen.com</a>
-            </span>
           </p>
           <h3 class="title">Dependencies</h3>
           <p>

--- a/app/test/frontend/golden/pkg_versions_page.html
+++ b/app/test/frontend/golden/pkg_versions_page.html
@@ -316,17 +316,13 @@
                 <div class="packages-score-label">popularity</div>
               </div>
             </a>
+            <h3 class="title">Publisher</h3>
+            <p>Unknown</p>
             <h3 class="title pkg-infobox-metadata">Metadata</h3>
             <p>my package description</p>
             <p>
               <a class="link" href="http://hans.juergen.com" rel="ugc">Homepage</a>
               <br/>
-            </p>
-            <h3 class="title">Uploader</h3>
-            <p>
-              <span class="author">
-                <a href="/packages?q=email%3Ahans%40juergen.com" title="Search packages from hans@juergen.com" rel="nofollow">hans@juergen.com</a>
-              </span>
             </p>
             <h3 class="title">Dependencies</h3>
             <p>
@@ -369,17 +365,13 @@
               <div class="packages-score-label">popularity</div>
             </div>
           </a>
+          <h3 class="title">Publisher</h3>
+          <p>Unknown</p>
           <h3 class="title pkg-infobox-metadata">Metadata</h3>
           <p>my package description</p>
           <p>
             <a class="link" href="http://hans.juergen.com" rel="ugc">Homepage</a>
             <br/>
-          </p>
-          <h3 class="title">Uploader</h3>
-          <p>
-            <span class="author">
-              <a href="/packages?q=email%3Ahans%40juergen.com" title="Search packages from hans@juergen.com" rel="nofollow">hans@juergen.com</a>
-            </span>
           </p>
           <h3 class="title">Dependencies</h3>
           <p>

--- a/app/test/shared/email_test.dart
+++ b/app/test/shared/email_test.dart
@@ -100,42 +100,6 @@ void main() {
     });
   });
 
-  group('EmailAddress.parse', () {
-    void validateParse(String input, String name, String email) {
-      final parsed = EmailAddress.parse(input);
-      expect(parsed.name, name);
-      expect(parsed.email, email);
-    }
-
-    test('empty', () {
-      validateParse('', null, null);
-    });
-
-    test('John Doe', () {
-      validateParse('John Doe', 'John Doe', null);
-      validateParse('<John Doe>', '<John Doe>', null);
-      validateParse('John <Doe>', 'John <Doe>', null);
-      validateParse('<John> <Doe>', '<John> <Doe>', null);
-    });
-
-    test('John Doe <email>', () {
-      validateParse('John Doe <john.doe@example.com>', 'John Doe',
-          'john.doe@example.com');
-    });
-
-    test('John Doe inline email', () {
-      validateParse(
-          'John Doe john.doe@example.com', 'John Doe', 'john.doe@example.com');
-      validateParse(
-          'John john.doe@example.com Doe', 'John Doe', 'john.doe@example.com');
-    });
-
-    test('email only', () {
-      validateParse('john.doe@example.com', null, 'john.doe@example.com');
-      validateParse('<john.doe@example.com>', null, 'john.doe@example.com');
-    });
-  });
-
   group('EmailAddress format', () {
     test('empty', () {
       expect(EmailAddress(null, null).toString(), null);

--- a/pkg/pub_integration/lib/script/publisher.dart
+++ b/pkg/pub_integration/lib/script/publisher.dart
@@ -122,19 +122,13 @@ class PublisherScript {
       throw Exception('New version is not to be found on package page.');
     }
 
+    // author must not be present
+    if (pageHtml.contains('developer@example.com')) {
+      throw Exception(
+          'pubspec author field most not be found on package page.');
+    }
     if (uploaderEmail != null) {
       if (publisherId != null) throw ArgumentError();
-
-      // author must not be present
-      if (pageHtml.contains('developer@example.com')) {
-        throw Exception(
-            'pubspec author field most not be found on package page.');
-      }
-      // uploader must be present
-      if (!pageHtml.contains('Uploader') ||
-          !pageHtml.contains('user@example.com')) {
-        throw Exception('Uploader not found on the package page.');
-      }
       // publisher most not be present
       if (pageHtml.contains('href="/publishers/')) {
         throw Exception('Publisher link found on the package page.');
@@ -144,10 +138,6 @@ class PublisherScript {
     if (publisherId != null) {
       if (uploaderEmail != null) throw ArgumentError();
 
-      // author must not be present
-      if (pageHtml.contains('developer@example.com')) {
-        throw Exception('pubspec author field found on package page.');
-      }
       // uploader must not be present
       if (pageHtml.contains('Uploader') ||
           pageHtml.contains('user@example.com')) {

--- a/pkg/pub_integration/lib/script/publishing.dart
+++ b/pkg/pub_integration/lib/script/publishing.dart
@@ -87,9 +87,9 @@ class PublishingScript {
       // add/remove uploader
       await _pubToolClient!.addUploader(_dummyDir.path, invitedEmail);
       await inviteCompleterFn();
-      await _verifyDummyPkg(matchInvited: true);
+      await _verifyDummyPkg();
       await _pubToolClient!.removeUploader(_dummyDir.path, invitedEmail);
-      await _verifyDummyPkg(matchInvited: false);
+      await _verifyDummyPkg();
 
       if (expectLiveSite) {
         await _verifyDummyDocumentation();
@@ -131,7 +131,7 @@ class PublishingScript {
     await _pubToolClient!.runProc('dart', [file], workingDirectory: dir.path);
   }
 
-  Future<void> _verifyDummyPkg({bool? matchInvited}) async {
+  Future<void> _verifyDummyPkg() async {
     final dv = await _pubHttpClient.getLatestVersionName('_dummy_pkg');
     if (dv != _newDummyVersion) {
       throw Exception(
@@ -147,16 +147,6 @@ class PublishingScript {
       if (pageHtml.contains('developer@example.com')) {
         throw Exception(
             'pubspec author field must not be found on package page.');
-      }
-      if (matchInvited != null) {
-        final found = pageHtml.contains(invitedEmail);
-        if (matchInvited && !found) {
-          throw Exception('Invited email is not to be found on package page.');
-        }
-        if (!matchInvited && found) {
-          throw Exception(
-              'Invited email is still to be found on package page.');
-        }
       }
     }
   }


### PR DESCRIPTION
- Fixes #4858.
- Also removes email parsing code that was there from the time when we've displayed authors from `pubspec.yaml`.
