### PR TITLE
Dart SDK search with SdkMemIndex.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ AppEngine version, listed here to ease deployment and troubleshooting.
  * Upgraded preview Dart analysis SDK to `2.13.3`.
  * Upgraded stable Flutter analysis SDK to `2.2.2`.
  * Upgraded preview Flutter analysis SDK to `2.2.2`.
+ * NOTE: Stopped creating and using dartdoc data for Dart SDK.
 
 ## `20210610t211000-all`
 

--- a/app/lib/fake/backend/fake_dartdoc_runner.dart
+++ b/app/lib/fake/backend/fake_dartdoc_runner.dart
@@ -28,24 +28,6 @@ Future<void> processJobsWithFakeDartdocRunner() async {
 /// Generates dartdoc content and results based on a deterministic random seed.
 class FakeDartdocRunner implements DartdocRunner {
   @override
-  Future<DartdocRunnerResult> generateSdkDocs({
-    @required String outputDir,
-  }) async {
-    final file = File(p.join(outputDir, 'pub-data.json'));
-    final pubData = PubDartdocData(
-      coverage: Coverage(documented: 1000, total: 1000),
-      apiElements: [
-        // TODO: add fake Dart SDK library elements.
-      ],
-    );
-    await file.writeAsString(json.encode(pubData.toJson()));
-    return DartdocRunnerResult(
-      args: ['fake_dartdoc', '--sdk'],
-      processResult: ProcessResult(0, 0, 'OK', ''),
-    );
-  }
-
-  @override
   Future<void> downloadAndExtract({
     @required String package,
     @required String version,

--- a/app/lib/search/backend.dart
+++ b/app/lib/search/backend.dart
@@ -24,7 +24,6 @@ import '../shared/exceptions.dart';
 import '../shared/popularity_storage.dart';
 import '../shared/storage.dart';
 import '../shared/tags.dart';
-import '../shared/versions.dart' as versions;
 
 import 'models.dart';
 import 'search_service.dart';
@@ -46,13 +45,6 @@ void registerSnapshotStorage(SnapshotStorage storage) =>
 /// The active snapshot storage
 SnapshotStorage get snapshotStorage =>
     ss.lookup(#_snapshotStorage) as SnapshotStorage;
-
-/// The [PackageIndex] for Dart SDK API.
-PackageIndex get dartSdkIndex => ss.lookup(#_dartSdkIndex) as PackageIndex;
-
-/// Register a new [PackageIndex] for Dart SDK API.
-void registerDartSdkIndex(PackageIndex index) =>
-    ss.register(#_dartSdkIndex, index);
 
 /// The [PackageIndex] registered in the current service scope.
 PackageIndex get packageIndex =>
@@ -267,45 +259,6 @@ List<ApiDocPage> apiDocPagesFromPubData(PubDartdocData pubData) {
   }).toList();
   results.sort((a, b) => a.relativePath.compareTo(b.relativePath));
   return results;
-}
-
-/// Splits the flat SDK data into per-library data (in the same data format).
-List<PubDartdocData> splitLibraries(PubDartdocData data) {
-  final librariesMap = <String, List<ApiElement>>{};
-  final rootMap = <String, String>{};
-  data.apiElements?.forEach((elem) {
-    String library;
-    if (elem.parent == null && elem.kind != 'library') {
-      // keep only top-level libraries
-      return;
-    } else if (elem.parent == null) {
-      library = elem.name;
-    } else {
-      library = rootMap[elem.parent] ?? elem.parent;
-      rootMap[elem.qualifiedName] = library;
-    }
-    librariesMap.putIfAbsent(library, () => <ApiElement>[]).add(elem);
-  });
-  return librariesMap.values
-      .map((list) => PubDartdocData(
-            coverage: Coverage(total: list.length, documented: list.length),
-            apiElements: list,
-          ))
-      .toList();
-}
-
-/// Creates the index-related data structure for an SDK library.
-PackageDocument createSdkDocument(PubDartdocData lib) {
-  final apiDocPages = apiDocPagesFromPubData(lib);
-  final package = lib.apiElements.first.name;
-  final documentation = lib.apiElements.first.documentation ?? '';
-  final description = documentation.split('\n\n').first.trim();
-  return PackageDocument(
-    package: package,
-    version: versions.toolStableDartSdkVersion,
-    description: description,
-    apiDocPages: apiDocPages,
-  );
 }
 
 class SnapshotStorage {

--- a/app/lib/search/dart_sdk_mem_index.dart
+++ b/app/lib/search/dart_sdk_mem_index.dart
@@ -5,6 +5,7 @@
 import 'package:gcloud/service_scope.dart' as ss;
 import 'package:http/http.dart' as http;
 import 'package:logging/logging.dart';
+import 'package:meta/meta.dart';
 import 'package:retry/retry.dart';
 
 import '../shared/cached_value.dart';
@@ -12,49 +13,25 @@ import 'models.dart';
 import 'sdk_mem_index.dart';
 import 'search_service.dart';
 
-/// The index.json file contains overlap with the Dart SDK and also repeats
-/// regular packages. The selected libraries are unique to the index.json.
-///
-/// TODO: try to find a way to derive this list automatically.
-const _allowedLibraries = <String>{
-  'dart:ui',
-  'animation',
-  'cupertino',
-  'foundation',
-  'gestures',
-  'material',
-  'painting',
-  'physics',
-  'rendering',
-  'scheduler',
-  'semantics',
-  'services',
-  'widgets',
-  'flutter_test',
-  'flutter_driver',
-  'flutter_driver_extension',
-  'flutter_web_plugins',
-};
+final _logger = Logger('search.dart_sdk_mem_index');
 
-final _logger = Logger('search.flutter_sdk_mem_index');
+/// Sets the Dart SDK in-memory index.
+void registerDartSdkMemIndex(DartSdkMemIndex updater) =>
+    ss.register(#_dartSdkMemIndex, updater);
 
-/// Sets the Flutter SDK in-memory index.
-void registerFlutterSdkMemIndex(FlutterSdkMemIndex updater) =>
-    ss.register(#_flutterSdkMemIndex, updater);
+/// The active Dart SDK in-memory index.
+DartSdkMemIndex get dartSdkMemIndex =>
+    ss.lookup(#_dartSdkMemIndex) as DartSdkMemIndex;
 
-/// The active Flutter SDK in-memory index.
-FlutterSdkMemIndex get flutterSdkMemIndex =>
-    ss.lookup(#_flutterSdkMemIndex) as FlutterSdkMemIndex;
-
-/// Flutter SDK in-memory index that fetches `index.json` from
-/// api.flutter.dev and returns search results based on [SdkMemIndex].
-class FlutterSdkMemIndex {
+/// Dart SDK in-memory index that fetches `index.json` from
+/// api.dart.dev and returns search results based on [SdkMemIndex].
+class DartSdkMemIndex {
   final _index = CachedValue<SdkMemIndex>(
-    name: 'flutter-sdk-index',
+    name: 'dart-sdk-index',
     interval: Duration(days: 1),
     maxAge: Duration(days: 30),
     timeout: Duration(hours: 1),
-    updateFn: _createFlutterSdkMemIndex,
+    updateFn: _createDartSdkMemIndex,
   );
 
   Future<void> start() async {
@@ -69,27 +46,34 @@ class FlutterSdkMemIndex {
     if (!_index.isAvailable) return <SdkLibraryHit>[];
     return await _index.value.search(query, limit: limit);
   }
+
+  @visibleForTesting
+  void setDartdocIndex(DartdocIndex index, {String version}) {
+    final smi = SdkMemIndex.dart(version: version);
+    smi.addDartdocIndex(index);
+    // ignore: invalid_use_of_visible_for_testing_member
+    _index.setValue(smi);
+  }
 }
 
-Future<SdkMemIndex> _createFlutterSdkMemIndex() async {
+Future<SdkMemIndex> _createDartSdkMemIndex() async {
   try {
     return await retry(
       () async {
-        final index = SdkMemIndex.flutter();
+        final index = SdkMemIndex.dart();
         final uri = index.baseUri.resolve('index.json');
         final rs = await http.get(uri);
         if (rs.statusCode != 200) {
           throw Exception('Unexpected status code for $uri: ${rs.statusCode}');
         }
         final content = DartdocIndex.parseJsonText(rs.body);
-        await index.addDartdocIndex(content,
-            allowedLibraries: _allowedLibraries);
+        await index.addDartdocIndex(content);
         return index;
       },
       maxAttempts: 3,
     );
   } catch (e, st) {
-    _logger.warning('Unable to load Flutter SDK index.', e, st);
+    _logger.warning('Unable to load Dart SDK index.', e, st);
     return null;
   }
 }

--- a/app/lib/search/handlers.dart
+++ b/app/lib/search/handlers.dart
@@ -7,6 +7,7 @@ import 'dart:convert';
 
 import 'package:crypto/crypto.dart';
 import 'package:logging/logging.dart';
+import 'package:pub_dev/search/dart_sdk_mem_index.dart';
 import 'package:shelf/shelf.dart' as shelf;
 
 import '../shared/configuration.dart';
@@ -70,7 +71,7 @@ Future<shelf.Response> _searchHandler(shelf.Request request) async {
   final query = ServiceSearchQuery.fromServiceUrl(request.requestedUri);
   final combiner = SearchResultCombiner(
     primaryIndex: packageIndex,
-    dartSdkIndex: dartSdkIndex,
+    dartSdkMemIndex: dartSdkMemIndex,
     flutterSdkMemIndex: flutterSdkMemIndex,
   );
   final result = await combiner.search(query);

--- a/app/lib/search/result_combiner.dart
+++ b/app/lib/search/result_combiner.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 
 import 'package:meta/meta.dart';
 
+import 'dart_sdk_mem_index.dart';
 import 'flutter_sdk_mem_index.dart';
 import 'search_service.dart';
 
@@ -13,12 +14,12 @@ import 'search_service.dart';
 /// SDK index.
 class SearchResultCombiner {
   final PackageIndex primaryIndex;
-  final PackageIndex dartSdkIndex;
+  final DartSdkMemIndex dartSdkMemIndex;
   final FlutterSdkMemIndex flutterSdkMemIndex;
 
   SearchResultCombiner({
     @required this.primaryIndex,
-    @required this.dartSdkIndex,
+    @required this.dartSdkMemIndex,
     @required this.flutterSdkMemIndex,
   });
 
@@ -28,12 +29,11 @@ class SearchResultCombiner {
     }
 
     final primaryResult = await primaryIndex.search(query);
-    final dartSdkResult = await dartSdkIndex
-        .search(query.change(order: SearchOrder.text, offset: 0, limit: 2));
+    final dartSdkResults = await dartSdkMemIndex.search(query.query, limit: 2);
     final flutterSdkResults =
         await flutterSdkMemIndex.search(query.query, limit: 2);
     final sdkLibraryHits = [
-      if (dartSdkResult.sdkLibraryHits != null) ...dartSdkResult.sdkLibraryHits,
+      ...dartSdkResults,
       ...flutterSdkResults,
     ];
     sdkLibraryHits.sort((a, b) => -a.score.compareTo(b.score));

--- a/app/lib/search/sdk_mem_index.dart
+++ b/app/lib/search/sdk_mem_index.dart
@@ -4,6 +4,7 @@
 
 import 'package:meta/meta.dart';
 
+import '../shared/versions.dart' show toolStableDartSdkVersion;
 import 'models.dart';
 import 'search_service.dart';
 import 'token_index.dart';
@@ -24,10 +25,23 @@ class SdkMemIndex {
         _version = version,
         _baseUri = baseUri;
 
-  SdkMemIndex.flutter()
-      : _sdk = 'flutter',
-        _version = null,
-        _baseUri = Uri.parse('https://api.flutter.dev/flutter/');
+  factory SdkMemIndex.dart({String version}) {
+    version ??= toolStableDartSdkVersion;
+    return SdkMemIndex(
+        sdk: 'dart',
+        version: version,
+        baseUri: Uri.parse('https://api.dart.dev/stable/$version/'));
+  }
+
+  factory SdkMemIndex.flutter() {
+    return SdkMemIndex(
+      sdk: 'flutter',
+      version: null,
+      baseUri: Uri.parse('https://api.flutter.dev/flutter/'),
+    );
+  }
+
+  Uri get baseUri => _baseUri;
 
   Future<void> addDartdocIndex(
     DartdocIndex index, {

--- a/app/lib/search/updater.dart
+++ b/app/lib/search/updater.dart
@@ -5,14 +5,11 @@
 import 'dart:async';
 import 'dart:math';
 
-import 'package:_discoveryapis_commons/_discoveryapis_commons.dart'
-    show DetailedApiRequestError;
 import 'package:gcloud/service_scope.dart' as ss;
 import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
 import 'package:pub_dev/search/search_service.dart';
 
-import '../dartdoc/backend.dart';
 import '../package/models.dart' show Package;
 import '../shared/datastore.dart';
 import '../shared/exceptions.dart';
@@ -149,43 +146,6 @@ class IndexUpdater implements TaskRunner {
       _logger.info('Removing: ${task.package}');
       snapshotStorage.remove(task.package);
       await _packageIndex.removePackage(task.package);
-    }
-  }
-
-  /// Triggers the load of the SDK index from the dartdoc storage bucket.
-  void initDartSdkIndex() {
-    // Don't block on SDK index updates, as it may take several minutes before
-    // the dartdoc service produces the required output.
-    _updateDartSdkIndex().whenComplete(() {});
-  }
-
-  Future<void> _updateDartSdkIndex() async {
-    for (int i = 0;; i++) {
-      try {
-        _logger.info('Trying to load SDK index.');
-        final data = await dartdocBackend.getDartSdkDartdocData();
-        if (data != null) {
-          final docs = splitLibraries(data)
-              .map((lib) => createSdkDocument(lib))
-              .toList();
-          await dartSdkIndex.addPackages(docs);
-          await dartSdkIndex.markReady();
-          _logger.info('Dart SDK index loaded successfully.');
-          return;
-        }
-      } on DetailedApiRequestError catch (e, st) {
-        if (e.status == 404) {
-          _logger.info('Error loading Dart SDK index.', e, st);
-        } else {
-          _logger.warning('Error loading Dart SDK index.', e, st);
-        }
-      } catch (e, st) {
-        _logger.warning('Error loading Dart SDK index.', e, st);
-      }
-      if (i % 10 == 0) {
-        _logger.warning('Unable to load Dart SDK index. Attempt: $i');
-      }
-      await Future.delayed(const Duration(minutes: 1));
     }
   }
 }

--- a/app/lib/service/entrypoint/dartdoc.dart
+++ b/app/lib/service/entrypoint/dartdoc.dart
@@ -72,8 +72,6 @@ Future _workerMain(WorkerEntryMessage message) async {
     final jobProcessor = DartdocJobProcessor(
       aliveCallback: () => message.aliveSendPort.send(null),
     );
-    await jobProcessor.generateDocsForSdk();
-
     final jobMaintenance = JobMaintenance(dbService, jobProcessor);
 
     Timer.periodic(const Duration(minutes: 15), (_) async {

--- a/app/lib/service/entrypoint/search.dart
+++ b/app/lib/service/entrypoint/search.dart
@@ -8,6 +8,7 @@ import 'dart:isolate';
 import 'package:args/command_runner.dart';
 import 'package:logging/logging.dart';
 
+import '../../search/dart_sdk_mem_index.dart';
 import '../../search/flutter_sdk_mem_index.dart';
 import '../../search/handlers.dart';
 import '../../search/updater.dart';
@@ -59,10 +60,9 @@ Future _main(FrontendEntryMessage message) async {
     final ReceivePort taskReceivePort = ReceivePort();
     registerTaskSendPort(taskReceivePort.sendPort);
 
-    indexUpdater.initDartSdkIndex();
-
     // Don't block on init, we need to serve liveliness and readiness checks.
     scheduleMicrotask(() async {
+      await dartSdkMemIndex.start();
       await flutterSdkMemIndex.start();
       try {
         await indexUpdater.init();

--- a/app/lib/service/services.dart
+++ b/app/lib/service/services.dart
@@ -36,6 +36,7 @@ import '../publisher/backend.dart';
 import '../publisher/domain_verifier.dart';
 import '../scorecard/backend.dart';
 import '../search/backend.dart';
+import '../search/dart_sdk_mem_index.dart';
 import '../search/flutter_sdk_mem_index.dart';
 import '../search/mem_index.dart';
 import '../search/search_client.dart';
@@ -45,8 +46,6 @@ import '../shared/datastore.dart';
 import '../shared/popularity_storage.dart';
 import '../shared/redis_cache.dart' show setupCache;
 import '../shared/storage.dart';
-import '../shared/urls.dart';
-import '../shared/versions.dart';
 import '../tool/utils/http.dart';
 
 import 'announcement/backend.dart';
@@ -161,8 +160,7 @@ Future<void> _withPubServices(FutureOr<void> Function() fn) async {
       ),
     );
     registerDartdocClient(DartdocClient());
-    registerDartSdkIndex(InMemoryPackageIndex.sdk(
-        urlPrefix: dartSdkMainUrl(toolStableDartSdkVersion)));
+    registerDartSdkMemIndex(DartSdkMemIndex());
     registerFlutterSdkMemIndex(FlutterSdkMemIndex());
     registerJobBackend(JobBackend(dbService));
     registerNameTracker(NameTracker(dbService));
@@ -199,6 +197,7 @@ Future<void> _withPubServices(FutureOr<void> Function() fn) async {
     registerScopeExitCallback(indexUpdater.close);
     registerScopeExitCallback(authProvider.close);
     registerScopeExitCallback(dartdocClient.close);
+    registerScopeExitCallback(dartSdkMemIndex.close);
     registerScopeExitCallback(flutterSdkMemIndex.close);
     registerScopeExitCallback(popularityStorage.close);
     registerScopeExitCallback(searchClient.close);

--- a/app/test/search/handlers_test.dart
+++ b/app/test/search/handlers_test.dart
@@ -4,10 +4,11 @@
 
 import 'dart:async';
 
-import 'package:pub_dev/search/flutter_sdk_mem_index.dart';
 import 'package:test/test.dart';
 
 import 'package:pub_dev/search/backend.dart';
+import 'package:pub_dev/search/dart_sdk_mem_index.dart';
+import 'package:pub_dev/search/flutter_sdk_mem_index.dart';
 import 'package:pub_dev/search/mem_index.dart';
 import 'package:pub_dev/search/search_service.dart';
 
@@ -36,7 +37,7 @@ void main() {
       Future<void> setUpInServiceScope() async {
         registerSearchBackend(MockSearchBackend());
         registerPackageIndex(InMemoryPackageIndex());
-        registerDartSdkIndex(InMemoryPackageIndex());
+        registerDartSdkMemIndex(DartSdkMemIndex());
         registerFlutterSdkMemIndex(FlutterSdkMemIndex());
         await packageIndex
             .addPackage(await searchBackend.loadDocument('pkg_foo'));

--- a/app/test/shared/test_services.dart
+++ b/app/test/shared/test_services.dart
@@ -17,7 +17,6 @@ import 'package:pub_dev/fake/backend/fake_popularity.dart';
 import 'package:pub_dev/frontend/handlers/pubapi.client.dart';
 import 'package:pub_dev/package/name_tracker.dart';
 import 'package:pub_dev/scorecard/backend.dart';
-import 'package:pub_dev/search/backend.dart';
 import 'package:pub_dev/search/handlers.dart';
 import 'package:pub_dev/search/updater.dart';
 import 'package:pub_dev/shared/integrity.dart';
@@ -87,7 +86,6 @@ void testWithServices(
         if (!omitData) {
           await _populateDefaultData();
         }
-        await dartSdkIndex.markReady();
         await indexUpdater.updateAllPackages();
 
         registerSearchClient(SearchClient(


### PR DESCRIPTION
- Closes #4549.
- Consistent scoring between Dart and Flutter SDK results.
- No need to run `dartdoc` for the Dart SDK for each release.
- Removal of the dartdoc data cleanup code in a subsequent PR after a few releases.