### PR TITLE
More page scope restriction for SDK and highlighted hits.

### DIFF
--- a/app/lib/search/result_combiner.dart
+++ b/app/lib/search/result_combiner.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import '../shared/tags.dart';
 import 'dart_sdk_mem_index.dart';
 import 'flutter_sdk_mem_index.dart';
 import 'search_service.dart';
@@ -27,12 +28,12 @@ class SearchResultCombiner {
     }
 
     final primaryResult = await primaryIndex.search(query);
-    final dartSdkResults = await dartSdkMemIndex.search(query.query!, limit: 2);
-    final flutterSdkResults =
-        await flutterSdkMemIndex.search(query.query!, limit: 2);
+    final queryFlutterSdk =
+        SdkTagValue.isAny(query.sdk) || query.sdk == SdkTagValue.flutter;
     final sdkLibraryHits = [
-      ...dartSdkResults,
-      ...flutterSdkResults,
+      ...await dartSdkMemIndex.search(query.query!, limit: 2),
+      if (queryFlutterSdk)
+        ...await flutterSdkMemIndex.search(query.query!, limit: 2),
     ];
     sdkLibraryHits.sort((a, b) => -a.score.compareTo(b.score));
 

--- a/app/lib/search/search_service.dart
+++ b/app/lib/search/search_service.dart
@@ -339,12 +339,15 @@ class ServiceSearchQuery {
       order == null || order == SearchOrder.top || order == SearchOrder.text;
   bool get _hasNoOwnershipScope =>
       publisherId == null && uploaderOrPublishers == null;
+  bool get _isFlutterFavorite =>
+      tagsPredicate.hasTag(PackageTags.isFlutterFavorite);
 
   bool get includeSdkResults =>
       offset == 0 &&
       _hasOnlyFreeText &&
       _isNaturalOrder &&
-      _hasNoOwnershipScope;
+      _hasNoOwnershipScope &&
+      !_isFlutterFavorite;
 
   bool get considerHighlightedHit => _hasOnlyFreeText && _hasNoOwnershipScope;
   bool get includeHighlightedHit => considerHighlightedHit && offset == 0;


### PR DESCRIPTION
- Fixes #4895
- Do not display Flutter SDK hits on Dart-only scope.
- Do not display highlighted hit or SDK hits on Flutter favorites.