### PR TITLE
Don't leave dartdoc report permanently empty when unknown error happens.

### DIFF
--- a/app/lib/job/backend.dart
+++ b/app/lib/job/backend.dart
@@ -207,6 +207,7 @@ class JobBackend {
         final now = DateTime.now().toUtc();
         selected!
           ..state = JobState.processing
+          ..attemptCount = selected.attemptCount + 1
           ..processingKey = createUuid()
           ..lockedUntil = now.add(_defaultLockDuration);
         tx.insert(selected);

--- a/app/lib/job/model.dart
+++ b/app/lib/job/model.dart
@@ -101,6 +101,9 @@ class Job extends ExpandoModel<String> {
   int? lastRunDurationInSeconds;
 
   @IntProperty(indexed: false)
+  int attemptCount = 0;
+
+  @IntProperty(indexed: false)
   int errorCount = 0;
 
   bool get isLatest => isLatestStable || isLatestPrerelease || isLatestPreview;


### PR DESCRIPTION
- We retry non-successful Jobs after a day or so. If there was no report created on the previous attempt, creating an empty one will unblock the `awaiting` status for the package. 
- Fixes #4848.
