### PR TITLE
Upgrade dartdoc to 1.0.0 + tool for golden files update.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,13 @@ Important changes to data-models, configuration and migrations between each
 AppEngine version, listed here to ease deployment and troubleshooting.
 
 ## Next Release (replace with git tag when deployed)
- * Bumped runtimeVersion to `2021.07.01`.
+ * Bumped runtimeVersion to `2021.07.06`.
  * Migrated `pkg/api_builder` and most of `app/` to null-safety.
  * Upgraded stable Dart analysis SDK to `2.13.4`.
  * Upgraded stable Flutter analysis SDK to `2.2.3`.
  * Upgraded preview Dart analysis SDK to `2.14.0-188.5.beta`
  * Upgraded preview Flutter analysis SDK to `2.3.0-24.1.pre`.
+ * Upgraded dartdoc to `1.0.0`.
 
 ## `20210622t160400-all`
  * Bumped runtimeVersion to `2021.06.21`.

--- a/app/lib/shared/versions.dart
+++ b/app/lib/shared/versions.dart
@@ -21,7 +21,7 @@ final RegExp runtimeVersionPattern = RegExp(r'^\d{4}\.\d{2}\.\d{2}$');
 /// Make sure that at least two versions are kept here as the next candidates
 /// when the version switch happens.
 const acceptedRuntimeVersions = <String>[
-  '2021.07.01', // The current [runtimeVersion].
+  '2021.07.06', // The current [runtimeVersion].
   '2021.06.21',
   '2021.06.16',
 ];
@@ -63,7 +63,7 @@ final String panaVersion = pana.packageVersion;
 final Version semanticPanaVersion = Version.parse(panaVersion);
 
 // keep in-sync with pkg/pub_dartdoc/pubspec.yaml
-final String dartdocVersion = '0.45.0';
+final String dartdocVersion = '1.0.0';
 final Version semanticDartdocVersion = Version.parse(dartdocVersion);
 
 // Version that control the dartdoc serving.

--- a/app/test/dartdoc/golden/pana_0.12.2_index.html
+++ b/app/test/dartdoc/golden/pana_0.12.2_index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1, user-scalable=no">
-  <meta name="generator" content="made with love by dartdoc 0.45.0">
+  <meta name="generator" content="made with love by dartdoc 1.0.0">
   <meta name="description" content="pana API docs, for the Dart programming language.">
   <title>pana - Dart API docs</title>
   <link rel="canonical" href="https://pub.dev/documentation/pana/0.12.2/">

--- a/app/test/dartdoc/golden/pana_0.12.2_index.out.html
+++ b/app/test/dartdoc/golden/pana_0.12.2_index.out.html
@@ -6,7 +6,7 @@
     <meta charset="utf-8"/>
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1, user-scalable=no"/>
-    <meta name="generator" content="made with love by dartdoc 0.45.0"/>
+    <meta name="generator" content="made with love by dartdoc 1.0.0"/>
     <meta name="description" content="pana API docs, for the Dart programming language."/>
     <title>pana - Dart API docs</title>
     <link rel="alternate" href="/documentation/pana/latest/"/>

--- a/app/test/dartdoc/golden/pana_0.12.2_license_file_class.html
+++ b/app/test/dartdoc/golden/pana_0.12.2_license_file_class.html
@@ -61,7 +61,7 @@
 
         <dt>Annotations</dt>
         <dd><ul class="annotation-list clazz-relationships">
-          <li>@<a href="https://pub.dev/documentation/json_annotation/1.1.0/json_annotation/JsonSerializable-class.html">JsonSerializable</a>()</li>
+          <li>@<a href="https://pub.dev/documentation/json_annotation/1.2.0/json_annotation/JsonSerializable-class.html">JsonSerializable</a>()</li>
         </ul></dd>
       </dl>
     </section>
@@ -71,13 +71,13 @@
 
       <dl class="constructor-summary-list">
         <dt id="LicenseFile" class="callable">
-          <span class="name"><a href="../models/LicenseFile/LicenseFile.html">LicenseFile</a></span><span class="signature">(<span class="parameter" id="-param-path"><span class="type-annotation"><a href="https://api.dart.dev/stable/2.12.0/dart-core/String-class.html">String</a></span> <span class="parameter-name">path</span>, </span><span class="parameter" id="-param-name"><span class="type-annotation"><a href="https://api.dart.dev/stable/2.12.0/dart-core/String-class.html">String</a></span> <span class="parameter-name">name</span>, </span><span class="parameter" id="-param-version">{<span class="type-annotation"><a href="https://api.dart.dev/stable/2.12.0/dart-core/String-class.html">String</a></span> <span class="parameter-name">version</span>, </span><span class="parameter" id="-param-url"><span class="type-annotation"><a href="https://api.dart.dev/stable/2.12.0/dart-core/String-class.html">String</a></span> <span class="parameter-name">url</span>}</span>)</span>
+          <span class="name"><a href="../models/LicenseFile/LicenseFile.html">LicenseFile</a></span><span class="signature">(<span class="parameter" id="-param-path"><span class="type-annotation"><a href="https://api.dart.dev/stable/2.13.3/dart-core/String-class.html">String</a></span> <span class="parameter-name">path</span>, </span><span class="parameter" id="-param-name"><span class="type-annotation"><a href="https://api.dart.dev/stable/2.13.3/dart-core/String-class.html">String</a></span> <span class="parameter-name">name</span>, </span><span class="parameter" id="-param-version">{<span class="type-annotation"><a href="https://api.dart.dev/stable/2.13.3/dart-core/String-class.html">String</a></span> <span class="parameter-name">version</span>, </span><span class="parameter" id="-param-url"><span class="type-annotation"><a href="https://api.dart.dev/stable/2.13.3/dart-core/String-class.html">String</a></span> <span class="parameter-name">url</span>}</span>)</span>
         </dt>
         <dd>
            
         </dd>
         <dt id="LicenseFile.fromJson" class="callable">
-          <span class="name"><a href="../models/LicenseFile/LicenseFile.fromJson.html">LicenseFile.fromJson</a></span><span class="signature">(<span class="parameter" id="fromJson-param-json"><span class="type-annotation"><a href="https://api.dart.dev/stable/2.12.0/dart-core/Map-class.html">Map</a><span class="signature">&lt;<wbr><span class="type-parameter"><a href="https://api.dart.dev/stable/2.12.0/dart-core/String-class.html">String</a></span>, <span class="type-parameter">dynamic</span>&gt;</span></span> <span class="parameter-name">json</span></span>)</span>
+          <span class="name"><a href="../models/LicenseFile/LicenseFile.fromJson.html">LicenseFile.fromJson</a></span><span class="signature">(<span class="parameter" id="fromJson-param-json"><span class="type-annotation"><a href="https://api.dart.dev/stable/2.13.3/dart-core/Map-class.html">Map</a><span class="signature">&lt;<wbr><span class="type-parameter"><a href="https://api.dart.dev/stable/2.13.3/dart-core/String-class.html">String</a></span>, <span class="type-parameter">dynamic</span>&gt;</span></span> <span class="parameter-name">json</span></span>)</span>
         </dt>
         <dd>
            
@@ -92,7 +92,7 @@
       <dl class="properties">
         <dt id="hashCode" class="property">
   <span class="name"><a href="../models/LicenseFile/hashCode.html">hashCode</a></span>
-  <span class="signature">&#8594; <a href="https://api.dart.dev/stable/2.12.0/dart-core/int-class.html">int</a></span> 
+  <span class="signature">&#8594; <a href="https://api.dart.dev/stable/2.13.3/dart-core/int-class.html">int</a></span> 
 
 </dt>
 <dd>
@@ -103,7 +103,7 @@
 
         <dt id="name" class="property">
   <span class="name"><a href="../models/LicenseFile/name.html">name</a></span>
-  <span class="signature">&#8594; <a href="https://api.dart.dev/stable/2.12.0/dart-core/String-class.html">String</a></span> 
+  <span class="signature">&#8594; <a href="https://api.dart.dev/stable/2.13.3/dart-core/String-class.html">String</a></span> 
 
 </dt>
 <dd>
@@ -114,7 +114,7 @@
 
         <dt id="path" class="property">
   <span class="name"><a href="../models/LicenseFile/path.html">path</a></span>
-  <span class="signature">&#8594; <a href="https://api.dart.dev/stable/2.12.0/dart-core/String-class.html">String</a></span> 
+  <span class="signature">&#8594; <a href="https://api.dart.dev/stable/2.13.3/dart-core/String-class.html">String</a></span> 
 
 </dt>
 <dd>
@@ -124,8 +124,8 @@
 </dd>
 
         <dt id="runtimeType" class="property inherited">
-  <span class="name"><a href="https://api.dart.dev/stable/2.12.0/dart-core/Object/runtimeType.html">runtimeType</a></span>
-  <span class="signature">&#8594; <a href="https://api.dart.dev/stable/2.12.0/dart-core/Type-class.html">Type</a></span> 
+  <span class="name"><a href="https://api.dart.dev/stable/2.13.3/dart-core/Object/runtimeType.html">runtimeType</a></span>
+  <span class="signature">&#8594; <a href="https://api.dart.dev/stable/2.13.3/dart-core/Type-class.html">Type</a></span> 
 
 </dt>
 <dd class="inherited">
@@ -136,7 +136,7 @@
 
         <dt id="shortFormatted" class="property">
   <span class="name"><a href="../models/LicenseFile/shortFormatted.html">shortFormatted</a></span>
-  <span class="signature">&#8594; <a href="https://api.dart.dev/stable/2.12.0/dart-core/String-class.html">String</a></span> 
+  <span class="signature">&#8594; <a href="https://api.dart.dev/stable/2.13.3/dart-core/String-class.html">String</a></span> 
 
 </dt>
 <dd>
@@ -147,23 +147,23 @@
 
         <dt id="url" class="property">
   <span class="name"><a href="../models/LicenseFile/url.html">url</a></span>
-  <span class="signature">&#8594; <a href="https://api.dart.dev/stable/2.12.0/dart-core/String-class.html">String</a></span> 
+  <span class="signature">&#8594; <a href="https://api.dart.dev/stable/2.13.3/dart-core/String-class.html">String</a></span> 
 
 </dt>
 <dd>
    
-  <div class="features">@<a href="https://pub.dev/documentation/json_annotation/1.1.0/json_annotation/JsonKey-class.html">JsonKey</a>(includeIfNull: false), final</div>
+  <div class="features">@<a href="https://pub.dev/documentation/json_annotation/1.2.0/json_annotation/JsonKey-class.html">JsonKey</a>(includeIfNull: false), final</div>
 
 </dd>
 
         <dt id="version" class="property">
   <span class="name"><a href="../models/LicenseFile/version.html">version</a></span>
-  <span class="signature">&#8594; <a href="https://api.dart.dev/stable/2.12.0/dart-core/String-class.html">String</a></span> 
+  <span class="signature">&#8594; <a href="https://api.dart.dev/stable/2.13.3/dart-core/String-class.html">String</a></span> 
 
 </dt>
 <dd>
    
-  <div class="features">@<a href="https://pub.dev/documentation/json_annotation/1.1.0/json_annotation/JsonKey-class.html">JsonKey</a>(includeIfNull: false), final</div>
+  <div class="features">@<a href="https://pub.dev/documentation/json_annotation/1.2.0/json_annotation/JsonKey-class.html">JsonKey</a>(includeIfNull: false), final</div>
 
 </dd>
 
@@ -174,7 +174,7 @@
       <h2>Methods</h2>
       <dl class="callables">
         <dt id="change" class="callable">
-  <span class="name"><a href="../models/LicenseFile/change.html">change</a></span><span class="signature">(<wbr><span class="parameter" id="change-param-url">{<span class="type-annotation"><a href="https://api.dart.dev/stable/2.12.0/dart-core/String-class.html">String</a></span> <span class="parameter-name">url</span>}</span>)
+  <span class="name"><a href="../models/LicenseFile/change.html">change</a></span><span class="signature">(<wbr><span class="parameter" id="change-param-url">{<span class="type-annotation"><a href="https://api.dart.dev/stable/2.13.3/dart-core/String-class.html">String</a></span> <span class="parameter-name">url</span>}</span>)
     <span class="returntype parameter">&#8594; <a href="../models/LicenseFile-class.html">LicenseFile</a></span>
   </span>
   
@@ -187,21 +187,21 @@
 </dd>
 
         <dt id="noSuchMethod" class="callable inherited">
-  <span class="name"><a href="https://api.dart.dev/stable/2.12.0/dart-core/Object/noSuchMethod.html">noSuchMethod</a></span><span class="signature">(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation"><a href="https://api.dart.dev/stable/2.12.0/dart-core/Invocation-class.html">Invocation</a></span> <span class="parameter-name">invocation</span></span>)
+  <span class="name"><a href="https://api.dart.dev/stable/2.13.3/dart-core/Object/noSuchMethod.html">noSuchMethod</a></span><span class="signature">(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation"><a href="https://api.dart.dev/stable/2.13.3/dart-core/Invocation-class.html">Invocation</a></span> <span class="parameter-name">invocation</span></span>)
     <span class="returntype parameter">&#8594; dynamic</span>
   </span>
   
 
 </dt>
 <dd class="inherited">
-  Invoked when a non-existent method or property is accessed. <a href="https://api.dart.dev/stable/2.12.0/dart-core/Object/noSuchMethod.html">[...]</a>
+  Invoked when a non-existent method or property is accessed. <a href="https://api.dart.dev/stable/2.13.3/dart-core/Object/noSuchMethod.html">[...]</a>
   <div class="features">inherited</div>
 
 </dd>
 
         <dt id="toJson" class="callable inherited">
   <span class="name"><a href="../models/LicenseFile/toJson.html">toJson</a></span><span class="signature">(<wbr>)
-    <span class="returntype parameter">&#8594; <a href="https://api.dart.dev/stable/2.12.0/dart-core/Map-class.html">Map</a><span class="signature">&lt;<wbr><span class="type-parameter"><a href="https://api.dart.dev/stable/2.12.0/dart-core/String-class.html">String</a></span>, <span class="type-parameter">dynamic</span>&gt;</span></span>
+    <span class="returntype parameter">&#8594; <a href="https://api.dart.dev/stable/2.13.3/dart-core/Map-class.html">Map</a><span class="signature">&lt;<wbr><span class="type-parameter"><a href="https://api.dart.dev/stable/2.13.3/dart-core/String-class.html">String</a></span>, <span class="type-parameter">dynamic</span>&gt;</span></span>
   </span>
   
 
@@ -214,7 +214,7 @@
 
         <dt id="toString" class="callable">
   <span class="name"><a href="../models/LicenseFile/toString.html">toString</a></span><span class="signature">(<wbr>)
-    <span class="returntype parameter">&#8594; <a href="https://api.dart.dev/stable/2.12.0/dart-core/String-class.html">String</a></span>
+    <span class="returntype parameter">&#8594; <a href="https://api.dart.dev/stable/2.13.3/dart-core/String-class.html">String</a></span>
   </span>
   
 
@@ -232,8 +232,8 @@
       <h2>Operators</h2>
       <dl class="callables">
         <dt id="operator ==" class="callable">
-  <span class="name"><a href="../models/LicenseFile/operator_equals.html">operator ==</a></span><span class="signature">(<wbr><span class="parameter" id="==-param-other"><span class="type-annotation"><a href="https://api.dart.dev/stable/2.12.0/dart-core/Object-class.html">Object</a></span> <span class="parameter-name">other</span></span>)
-    <span class="returntype parameter">&#8594; <a href="https://api.dart.dev/stable/2.12.0/dart-core/bool-class.html">bool</a></span>
+  <span class="name"><a href="../models/LicenseFile/operator_equals.html">operator ==</a></span><span class="signature">(<wbr><span class="parameter" id="==-param-other"><span class="type-annotation"><a href="https://api.dart.dev/stable/2.13.3/dart-core/Object-class.html">Object</a></span> <span class="parameter-name">other</span></span>)
+    <span class="returntype parameter">&#8594; <a href="https://api.dart.dev/stable/2.13.3/dart-core/bool-class.html">bool</a></span>
   </span>
   
 
@@ -316,14 +316,14 @@
     <li><a href="../models/LicenseFile/hashCode.html">hashCode</a></li>
     <li><a href="../models/LicenseFile/name.html">name</a></li>
     <li><a href="../models/LicenseFile/path.html">path</a></li>
-    <li class="inherited"><a href="https://api.dart.dev/stable/2.12.0/dart-core/Object/runtimeType.html">runtimeType</a></li>
+    <li class="inherited"><a href="https://api.dart.dev/stable/2.13.3/dart-core/Object/runtimeType.html">runtimeType</a></li>
     <li><a href="../models/LicenseFile/shortFormatted.html">shortFormatted</a></li>
     <li><a href="../models/LicenseFile/url.html">url</a></li>
     <li><a href="../models/LicenseFile/version.html">version</a></li>
 
     <li class="section-title"><a href="../models/LicenseFile-class.html#instance-methods">Methods</a></li>
     <li><a href="../models/LicenseFile/change.html">change</a></li>
-    <li class="inherited"><a href="https://api.dart.dev/stable/2.12.0/dart-core/Object/noSuchMethod.html">noSuchMethod</a></li>
+    <li class="inherited"><a href="https://api.dart.dev/stable/2.13.3/dart-core/Object/noSuchMethod.html">noSuchMethod</a></li>
     <li class="inherited"><a href="../models/LicenseFile/toJson.html">toJson</a></li>
     <li><a href="../models/LicenseFile/toString.html">toString</a></li>
 

--- a/app/test/dartdoc/golden/pana_0.12.2_license_file_class.out.html
+++ b/app/test/dartdoc/golden/pana_0.12.2_license_file_class.out.html
@@ -57,7 +57,7 @@
               <ul class="annotation-list clazz-relationships">
                 <li>
                   @
-                  <a href="https://pub.dev/documentation/json_annotation/1.1.0/json_annotation/JsonSerializable-class.html">JsonSerializable</a>
+                  <a href="https://pub.dev/documentation/json_annotation/1.2.0/json_annotation/JsonSerializable-class.html">JsonSerializable</a>
                   ()
                 </li>
               </ul>
@@ -75,14 +75,14 @@
                 (
                 <span class="parameter" id="-param-path">
                   <span class="type-annotation">
-                    <a href="https://api.dart.dev/stable/2.12.0/dart-core/String-class.html">String</a>
+                    <a href="https://api.dart.dev/stable/2.13.3/dart-core/String-class.html">String</a>
                   </span>
                   <span class="parameter-name">path</span>
                   ,
                 </span>
                 <span class="parameter" id="-param-name">
                   <span class="type-annotation">
-                    <a href="https://api.dart.dev/stable/2.12.0/dart-core/String-class.html">String</a>
+                    <a href="https://api.dart.dev/stable/2.13.3/dart-core/String-class.html">String</a>
                   </span>
                   <span class="parameter-name">name</span>
                   ,
@@ -90,14 +90,14 @@
                 <span class="parameter" id="-param-version">
                   {
                   <span class="type-annotation">
-                    <a href="https://api.dart.dev/stable/2.12.0/dart-core/String-class.html">String</a>
+                    <a href="https://api.dart.dev/stable/2.13.3/dart-core/String-class.html">String</a>
                   </span>
                   <span class="parameter-name">version</span>
                   ,
                 </span>
                 <span class="parameter" id="-param-url">
                   <span class="type-annotation">
-                    <a href="https://api.dart.dev/stable/2.12.0/dart-core/String-class.html">String</a>
+                    <a href="https://api.dart.dev/stable/2.13.3/dart-core/String-class.html">String</a>
                   </span>
                   <span class="parameter-name">url</span>
                   }
@@ -114,12 +114,12 @@
                 (
                 <span class="parameter" id="fromJson-param-json">
                   <span class="type-annotation">
-                    <a href="https://api.dart.dev/stable/2.12.0/dart-core/Map-class.html">Map</a>
+                    <a href="https://api.dart.dev/stable/2.13.3/dart-core/Map-class.html">Map</a>
                     <span class="signature">
                       &lt;
                       <wbr/>
                       <span class="type-parameter">
-                        <a href="https://api.dart.dev/stable/2.12.0/dart-core/String-class.html">String</a>
+                        <a href="https://api.dart.dev/stable/2.13.3/dart-core/String-class.html">String</a>
                       </span>
                       ,
                       <span class="type-parameter">dynamic</span>
@@ -145,7 +145,7 @@
               </span>
               <span class="signature">
                 →
-                <a href="https://api.dart.dev/stable/2.12.0/dart-core/int-class.html">int</a>
+                <a href="https://api.dart.dev/stable/2.13.3/dart-core/int-class.html">int</a>
               </span>
             </dt>
             <dd>
@@ -159,7 +159,7 @@
               </span>
               <span class="signature">
                 →
-                <a href="https://api.dart.dev/stable/2.12.0/dart-core/String-class.html">String</a>
+                <a href="https://api.dart.dev/stable/2.13.3/dart-core/String-class.html">String</a>
               </span>
             </dt>
             <dd>
@@ -171,7 +171,7 @@
               </span>
               <span class="signature">
                 →
-                <a href="https://api.dart.dev/stable/2.12.0/dart-core/String-class.html">String</a>
+                <a href="https://api.dart.dev/stable/2.13.3/dart-core/String-class.html">String</a>
               </span>
             </dt>
             <dd>
@@ -179,11 +179,11 @@
             </dd>
             <dt id="runtimeType" class="property inherited">
               <span class="name">
-                <a href="https://api.dart.dev/stable/2.12.0/dart-core/Object/runtimeType.html">runtimeType</a>
+                <a href="https://api.dart.dev/stable/2.13.3/dart-core/Object/runtimeType.html">runtimeType</a>
               </span>
               <span class="signature">
                 →
-                <a href="https://api.dart.dev/stable/2.12.0/dart-core/Type-class.html">Type</a>
+                <a href="https://api.dart.dev/stable/2.13.3/dart-core/Type-class.html">Type</a>
               </span>
             </dt>
             <dd class="inherited">
@@ -196,7 +196,7 @@
               </span>
               <span class="signature">
                 →
-                <a href="https://api.dart.dev/stable/2.12.0/dart-core/String-class.html">String</a>
+                <a href="https://api.dart.dev/stable/2.13.3/dart-core/String-class.html">String</a>
               </span>
             </dt>
             <dd>
@@ -208,13 +208,13 @@
               </span>
               <span class="signature">
                 →
-                <a href="https://api.dart.dev/stable/2.12.0/dart-core/String-class.html">String</a>
+                <a href="https://api.dart.dev/stable/2.13.3/dart-core/String-class.html">String</a>
               </span>
             </dt>
             <dd>
               <div class="features">
                 @
-                <a href="https://pub.dev/documentation/json_annotation/1.1.0/json_annotation/JsonKey-class.html">JsonKey</a>
+                <a href="https://pub.dev/documentation/json_annotation/1.2.0/json_annotation/JsonKey-class.html">JsonKey</a>
                 (includeIfNull: false), final
               </div>
             </dd>
@@ -224,13 +224,13 @@
               </span>
               <span class="signature">
                 →
-                <a href="https://api.dart.dev/stable/2.12.0/dart-core/String-class.html">String</a>
+                <a href="https://api.dart.dev/stable/2.13.3/dart-core/String-class.html">String</a>
               </span>
             </dt>
             <dd>
               <div class="features">
                 @
-                <a href="https://pub.dev/documentation/json_annotation/1.1.0/json_annotation/JsonKey-class.html">JsonKey</a>
+                <a href="https://pub.dev/documentation/json_annotation/1.2.0/json_annotation/JsonKey-class.html">JsonKey</a>
                 (includeIfNull: false), final
               </div>
             </dd>
@@ -249,7 +249,7 @@
                 <span class="parameter" id="change-param-url">
                   {
                   <span class="type-annotation">
-                    <a href="https://api.dart.dev/stable/2.12.0/dart-core/String-class.html">String</a>
+                    <a href="https://api.dart.dev/stable/2.13.3/dart-core/String-class.html">String</a>
                   </span>
                   <span class="parameter-name">url</span>
                   }
@@ -264,14 +264,14 @@
             <dd></dd>
             <dt id="noSuchMethod" class="callable inherited">
               <span class="name">
-                <a href="https://api.dart.dev/stable/2.12.0/dart-core/Object/noSuchMethod.html">noSuchMethod</a>
+                <a href="https://api.dart.dev/stable/2.13.3/dart-core/Object/noSuchMethod.html">noSuchMethod</a>
               </span>
               <span class="signature">
                 (
                 <wbr/>
                 <span class="parameter" id="noSuchMethod-param-invocation">
                   <span class="type-annotation">
-                    <a href="https://api.dart.dev/stable/2.12.0/dart-core/Invocation-class.html">Invocation</a>
+                    <a href="https://api.dart.dev/stable/2.13.3/dart-core/Invocation-class.html">Invocation</a>
                   </span>
                   <span class="parameter-name">invocation</span>
                 </span>
@@ -281,7 +281,7 @@
             </dt>
             <dd class="inherited">
               Invoked when a non-existent method or property is accessed.
-              <a href="https://api.dart.dev/stable/2.12.0/dart-core/Object/noSuchMethod.html">[...]</a>
+              <a href="https://api.dart.dev/stable/2.13.3/dart-core/Object/noSuchMethod.html">[...]</a>
               <div class="features">inherited</div>
             </dd>
             <dt id="toJson" class="callable inherited">
@@ -294,12 +294,12 @@
                 )
                 <span class="returntype parameter">
                   →
-                  <a href="https://api.dart.dev/stable/2.12.0/dart-core/Map-class.html">Map</a>
+                  <a href="https://api.dart.dev/stable/2.13.3/dart-core/Map-class.html">Map</a>
                   <span class="signature">
                     &lt;
                     <wbr/>
                     <span class="type-parameter">
-                      <a href="https://api.dart.dev/stable/2.12.0/dart-core/String-class.html">String</a>
+                      <a href="https://api.dart.dev/stable/2.13.3/dart-core/String-class.html">String</a>
                     </span>
                     ,
                     <span class="type-parameter">dynamic</span>
@@ -321,7 +321,7 @@
                 )
                 <span class="returntype parameter">
                   →
-                  <a href="https://api.dart.dev/stable/2.12.0/dart-core/String-class.html">String</a>
+                  <a href="https://api.dart.dev/stable/2.13.3/dart-core/String-class.html">String</a>
                 </span>
               </span>
             </dt>
@@ -344,14 +344,14 @@
                 <wbr/>
                 <span class="parameter" id="==-param-other">
                   <span class="type-annotation">
-                    <a href="https://api.dart.dev/stable/2.12.0/dart-core/Object-class.html">Object</a>
+                    <a href="https://api.dart.dev/stable/2.13.3/dart-core/Object-class.html">Object</a>
                   </span>
                   <span class="parameter-name">other</span>
                 </span>
                 )
                 <span class="returntype parameter">
                   →
-                  <a href="https://api.dart.dev/stable/2.12.0/dart-core/bool-class.html">bool</a>
+                  <a href="https://api.dart.dev/stable/2.13.3/dart-core/bool-class.html">bool</a>
                 </span>
               </span>
             </dt>
@@ -476,7 +476,7 @@
             <a href="../models/LicenseFile/path.html">path</a>
           </li>
           <li class="inherited">
-            <a href="https://api.dart.dev/stable/2.12.0/dart-core/Object/runtimeType.html">runtimeType</a>
+            <a href="https://api.dart.dev/stable/2.13.3/dart-core/Object/runtimeType.html">runtimeType</a>
           </li>
           <li>
             <a href="../models/LicenseFile/shortFormatted.html">shortFormatted</a>
@@ -494,7 +494,7 @@
             <a href="../models/LicenseFile/change.html">change</a>
           </li>
           <li class="inherited">
-            <a href="https://api.dart.dev/stable/2.12.0/dart-core/Object/noSuchMethod.html">noSuchMethod</a>
+            <a href="https://api.dart.dev/stable/2.13.3/dart-core/Object/noSuchMethod.html">noSuchMethod</a>
           </li>
           <li class="inherited">
             <a href="../models/LicenseFile/toJson.html">toJson</a>

--- a/app/test/dartdoc/golden/pana_0.12.2_license_file_constructor.html
+++ b/app/test/dartdoc/golden/pana_0.12.2_license_file_constructor.html
@@ -50,10 +50,10 @@
 </h1></div>
 
     <section class="multi-line-signature">
-      <span class="name ">LicenseFile</span>(<wbr><ol class="parameter-list"><li><span class="parameter" id="-param-path"><span class="type-annotation"><a href="https://api.dart.dev/stable/2.12.0/dart-core/String-class.html">String</a></span> <span class="parameter-name">path</span>, </span></li>
-<li><span class="parameter" id="-param-name"><span class="type-annotation"><a href="https://api.dart.dev/stable/2.12.0/dart-core/String-class.html">String</a></span> <span class="parameter-name">name</span>, </span></li>
-<li><span class="parameter" id="-param-version">{<span class="type-annotation"><a href="https://api.dart.dev/stable/2.12.0/dart-core/String-class.html">String</a></span> <span class="parameter-name">version</span>, </span></li>
-<li><span class="parameter" id="-param-url"><span class="type-annotation"><a href="https://api.dart.dev/stable/2.12.0/dart-core/String-class.html">String</a></span> <span class="parameter-name">url</span>}</span></li>
+      <span class="name ">LicenseFile</span>(<wbr><ol class="parameter-list"><li><span class="parameter" id="-param-path"><span class="type-annotation"><a href="https://api.dart.dev/stable/2.13.3/dart-core/String-class.html">String</a></span> <span class="parameter-name">path</span>, </span></li>
+<li><span class="parameter" id="-param-name"><span class="type-annotation"><a href="https://api.dart.dev/stable/2.13.3/dart-core/String-class.html">String</a></span> <span class="parameter-name">name</span>, </span></li>
+<li><span class="parameter" id="-param-version">{<span class="type-annotation"><a href="https://api.dart.dev/stable/2.13.3/dart-core/String-class.html">String</a></span> <span class="parameter-name">version</span>, </span></li>
+<li><span class="parameter" id="-param-url"><span class="type-annotation"><a href="https://api.dart.dev/stable/2.13.3/dart-core/String-class.html">String</a></span> <span class="parameter-name">url</span>}</span></li>
 </ol>)
     </section>
 
@@ -98,14 +98,14 @@
     <li><a href="../../models/LicenseFile/hashCode.html">hashCode</a></li>
     <li><a href="../../models/LicenseFile/name.html">name</a></li>
     <li><a href="../../models/LicenseFile/path.html">path</a></li>
-    <li class="inherited"><a href="https://api.dart.dev/stable/2.12.0/dart-core/Object/runtimeType.html">runtimeType</a></li>
+    <li class="inherited"><a href="https://api.dart.dev/stable/2.13.3/dart-core/Object/runtimeType.html">runtimeType</a></li>
     <li><a href="../../models/LicenseFile/shortFormatted.html">shortFormatted</a></li>
     <li><a href="../../models/LicenseFile/url.html">url</a></li>
     <li><a href="../../models/LicenseFile/version.html">version</a></li>
 
     <li class="section-title"><a href="../../models/LicenseFile-class.html#instance-methods">Methods</a></li>
     <li><a href="../../models/LicenseFile/change.html">change</a></li>
-    <li class="inherited"><a href="https://api.dart.dev/stable/2.12.0/dart-core/Object/noSuchMethod.html">noSuchMethod</a></li>
+    <li class="inherited"><a href="https://api.dart.dev/stable/2.13.3/dart-core/Object/noSuchMethod.html">noSuchMethod</a></li>
     <li class="inherited"><a href="../../models/LicenseFile/toJson.html">toJson</a></li>
     <li><a href="../../models/LicenseFile/toString.html">toString</a></li>
 

--- a/app/test/dartdoc/golden/pana_0.12.2_license_file_constructor.out.html
+++ b/app/test/dartdoc/golden/pana_0.12.2_license_file_constructor.out.html
@@ -61,7 +61,7 @@
             <li>
               <span class="parameter" id="-param-path">
                 <span class="type-annotation">
-                  <a href="https://api.dart.dev/stable/2.12.0/dart-core/String-class.html">String</a>
+                  <a href="https://api.dart.dev/stable/2.13.3/dart-core/String-class.html">String</a>
                 </span>
                 <span class="parameter-name">path</span>
                 ,
@@ -70,7 +70,7 @@
             <li>
               <span class="parameter" id="-param-name">
                 <span class="type-annotation">
-                  <a href="https://api.dart.dev/stable/2.12.0/dart-core/String-class.html">String</a>
+                  <a href="https://api.dart.dev/stable/2.13.3/dart-core/String-class.html">String</a>
                 </span>
                 <span class="parameter-name">name</span>
                 ,
@@ -80,7 +80,7 @@
               <span class="parameter" id="-param-version">
                 {
                 <span class="type-annotation">
-                  <a href="https://api.dart.dev/stable/2.12.0/dart-core/String-class.html">String</a>
+                  <a href="https://api.dart.dev/stable/2.13.3/dart-core/String-class.html">String</a>
                 </span>
                 <span class="parameter-name">version</span>
                 ,
@@ -89,7 +89,7 @@
             <li>
               <span class="parameter" id="-param-url">
                 <span class="type-annotation">
-                  <a href="https://api.dart.dev/stable/2.12.0/dart-core/String-class.html">String</a>
+                  <a href="https://api.dart.dev/stable/2.13.3/dart-core/String-class.html">String</a>
                 </span>
                 <span class="parameter-name">url</span>
                 }
@@ -153,7 +153,7 @@
             <a href="../../models/LicenseFile/path.html">path</a>
           </li>
           <li class="inherited">
-            <a href="https://api.dart.dev/stable/2.12.0/dart-core/Object/runtimeType.html">runtimeType</a>
+            <a href="https://api.dart.dev/stable/2.13.3/dart-core/Object/runtimeType.html">runtimeType</a>
           </li>
           <li>
             <a href="../../models/LicenseFile/shortFormatted.html">shortFormatted</a>
@@ -171,7 +171,7 @@
             <a href="../../models/LicenseFile/change.html">change</a>
           </li>
           <li class="inherited">
-            <a href="https://api.dart.dev/stable/2.12.0/dart-core/Object/noSuchMethod.html">noSuchMethod</a>
+            <a href="https://api.dart.dev/stable/2.13.3/dart-core/Object/noSuchMethod.html">noSuchMethod</a>
           </li>
           <li class="inherited">
             <a href="../../models/LicenseFile/toJson.html">toJson</a>

--- a/app/test/dartdoc/golden/pana_0.12.2_license_file_name_field.html
+++ b/app/test/dartdoc/golden/pana_0.12.2_license_file_name_field.html
@@ -50,7 +50,7 @@
 </h1></div>
 
         <section class="multi-line-signature">
-          <a href="https://api.dart.dev/stable/2.12.0/dart-core/String-class.html">String</a>
+          <a href="https://api.dart.dev/stable/2.13.3/dart-core/String-class.html">String</a>
           <span class="name ">name</span>
           <div class="features">final</div>
 
@@ -97,14 +97,14 @@
     <li><a href="../../models/LicenseFile/hashCode.html">hashCode</a></li>
     <li><a href="../../models/LicenseFile/name.html">name</a></li>
     <li><a href="../../models/LicenseFile/path.html">path</a></li>
-    <li class="inherited"><a href="https://api.dart.dev/stable/2.12.0/dart-core/Object/runtimeType.html">runtimeType</a></li>
+    <li class="inherited"><a href="https://api.dart.dev/stable/2.13.3/dart-core/Object/runtimeType.html">runtimeType</a></li>
     <li><a href="../../models/LicenseFile/shortFormatted.html">shortFormatted</a></li>
     <li><a href="../../models/LicenseFile/url.html">url</a></li>
     <li><a href="../../models/LicenseFile/version.html">version</a></li>
 
     <li class="section-title"><a href="../../models/LicenseFile-class.html#instance-methods">Methods</a></li>
     <li><a href="../../models/LicenseFile/change.html">change</a></li>
-    <li class="inherited"><a href="https://api.dart.dev/stable/2.12.0/dart-core/Object/noSuchMethod.html">noSuchMethod</a></li>
+    <li class="inherited"><a href="https://api.dart.dev/stable/2.13.3/dart-core/Object/noSuchMethod.html">noSuchMethod</a></li>
     <li class="inherited"><a href="../../models/LicenseFile/toJson.html">toJson</a></li>
     <li><a href="../../models/LicenseFile/toString.html">toString</a></li>
 

--- a/app/test/dartdoc/golden/pana_0.12.2_license_file_name_field.out.html
+++ b/app/test/dartdoc/golden/pana_0.12.2_license_file_name_field.out.html
@@ -54,7 +54,7 @@
           </h1>
         </div>
         <section class="multi-line-signature">
-          <a href="https://api.dart.dev/stable/2.12.0/dart-core/String-class.html">String</a>
+          <a href="https://api.dart.dev/stable/2.13.3/dart-core/String-class.html">String</a>
           <span class="name ">name</span>
           <div class="features">final</div>
         </section>
@@ -113,7 +113,7 @@
             <a href="../../models/LicenseFile/path.html">path</a>
           </li>
           <li class="inherited">
-            <a href="https://api.dart.dev/stable/2.12.0/dart-core/Object/runtimeType.html">runtimeType</a>
+            <a href="https://api.dart.dev/stable/2.13.3/dart-core/Object/runtimeType.html">runtimeType</a>
           </li>
           <li>
             <a href="../../models/LicenseFile/shortFormatted.html">shortFormatted</a>
@@ -131,7 +131,7 @@
             <a href="../../models/LicenseFile/change.html">change</a>
           </li>
           <li class="inherited">
-            <a href="https://api.dart.dev/stable/2.12.0/dart-core/Object/noSuchMethod.html">noSuchMethod</a>
+            <a href="https://api.dart.dev/stable/2.13.3/dart-core/Object/noSuchMethod.html">noSuchMethod</a>
           </li>
           <li class="inherited">
             <a href="../../models/LicenseFile/toJson.html">toJson</a>

--- a/app/test/dartdoc/golden/pana_0.12.2_pretty_json.html
+++ b/app/test/dartdoc/golden/pana_0.12.2_pretty_json.html
@@ -52,7 +52,7 @@
     <section class="multi-line-signature">
         
 
-<span class="returntype"><a href="https://api.dart.dev/stable/2.12.0/dart-core/String-class.html">String</a></span>
+<span class="returntype"><a href="https://api.dart.dev/stable/2.13.3/dart-core/String-class.html">String</a></span>
 <span class="name ">prettyJson</span>(<wbr><ol class="parameter-list"><li><span class="parameter" id="prettyJson-param-obj"><span class="type-annotation">dynamic</span> <span class="parameter-name">obj</span></span></li>
 </ol>)
 

--- a/app/test/dartdoc/golden/pana_0.12.2_pretty_json.out.html
+++ b/app/test/dartdoc/golden/pana_0.12.2_pretty_json.out.html
@@ -52,7 +52,7 @@
         </div>
         <section class="multi-line-signature">
           <span class="returntype">
-            <a href="https://api.dart.dev/stable/2.12.0/dart-core/String-class.html">String</a>
+            <a href="https://api.dart.dev/stable/2.13.3/dart-core/String-class.html">String</a>
           </span>
           <span class="name ">prettyJson</span>
           (

--- a/pkg/pub_dartdoc/pubspec.lock
+++ b/pkg/pub_dartdoc/pubspec.lock
@@ -21,7 +21,7 @@ packages:
       name: args
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   async:
     dependency: transitive
     description:
@@ -42,14 +42,14 @@ packages:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   cli_util:
     dependency: transitive
     description:
       name: cli_util
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
+    version: "0.3.2"
   collection:
     dependency: transitive
     description:
@@ -63,14 +63,14 @@ packages:
       name: convert
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0"
+    version: "3.0.1"
   coverage:
     dependency: transitive
     description:
       name: coverage
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.3"
   crypto:
     dependency: transitive
     description:
@@ -91,14 +91,14 @@ packages:
       name: dartdoc
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.45.0"
+    version: "1.0.0"
   file:
     dependency: transitive
     description:
       name: file
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.1.1"
+    version: "6.1.2"
   frontend_server_client:
     dependency: transitive
     description:
@@ -120,6 +120,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.15.0"
+  http:
+    dependency: "direct dev"
+    description:
+      name: http
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.13.3"
   http_multi_server:
     dependency: transitive
     description:
@@ -140,7 +147,7 @@ packages:
       name: io
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.2"
   js:
     dependency: transitive
     description:
@@ -196,7 +203,7 @@ packages:
       name: node_preamble
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.0.1"
   package_config:
     dependency: transitive
     description:
@@ -217,7 +224,7 @@ packages:
       name: pedantic
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.11.0"
+    version: "1.11.1"
   pool:
     dependency: transitive
     description:
@@ -309,6 +316,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.0"
+  tar:
+    dependency: "direct dev"
+    description:
+      name: tar
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.4.0"
   term_glyph:
     dependency: transitive
     description:
@@ -322,21 +336,21 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.17.4"
+    version: "1.17.9"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.0"
+    version: "0.4.1"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.24"
+    version: "0.3.29"
   typed_data:
     dependency: transitive
     description:
@@ -350,7 +364,7 @@ packages:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.2.0"
+    version: "7.1.0"
   watcher:
     dependency: transitive
     description:

--- a/pkg/pub_dartdoc/pubspec.yaml
+++ b/pkg/pub_dartdoc/pubspec.yaml
@@ -10,7 +10,9 @@ dependencies:
   pub_dartdoc_data:
     path: ../pub_dartdoc_data
   # dartdoc version to be pinned, keep in-sync with app/lib/shared/versions.dart
-  dartdoc: 0.45.0
+  dartdoc: 1.0.0
 
 dev_dependencies:
+  http: ^0.13.0
   test: '^1.16.5'
+  tar: ^0.4.0

--- a/pkg/pub_dartdoc/tool/update_golden_files.dart
+++ b/pkg/pub_dartdoc/tool/update_golden_files.dart
@@ -1,0 +1,88 @@
+// Copyright (c) 2021, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:http/http.dart' as http;
+import 'package:path/path.dart' as p;
+import 'package:tar/tar.dart';
+
+Future<void> main() async {
+  final tempDir = await Directory.systemTemp.createTemp();
+  try {
+    final panaVersion = '0.12.2';
+
+    // download
+    final rs = await http.get(Uri.parse(
+        'https://storage.googleapis.com/pub-packages/packages/pana-$panaVersion.tar.gz'));
+    if (rs.statusCode != 200) {
+      throw AssertionError('Failed to fetch archive.');
+    }
+    await _extractTarGz(Stream.fromIterable([rs.bodyBytes]), tempDir.path);
+
+    // generate
+    final pr = await Process.run(
+      'dart',
+      [
+        'bin/pub_dartdoc.dart',
+        '--rel-canonical-prefix',
+        'https://pub.dev/documentation/pana/$panaVersion',
+        '--input',
+        tempDir.path,
+        '--output',
+        p.join(tempDir.path, 'doc', 'api'),
+      ],
+    );
+    if (pr.exitCode != 0) {
+      throw AssertionError('Non-zero exit code: ${pr.stdout}\n${pr.stderr}');
+    }
+
+    // copy
+    Future<void> copy(String docPath, String goldenPath) async {
+      final docFile = File(p.join(tempDir.path, 'doc', 'api', docPath));
+      final goldenFile = File(
+          p.join('..', '..', 'app', 'test', 'dartdoc', 'golden', goldenPath));
+      await goldenFile.parent.create(recursive: true);
+      await docFile.copy(goldenFile.path);
+    }
+
+    await copy('index.html', 'pana_${panaVersion}_index.html');
+    await copy('models/LicenseFile-class.html',
+        'pana_${panaVersion}_license_file_class.html');
+    await copy('models/LicenseFile/LicenseFile.html',
+        'pana_${panaVersion}_license_file_constructor.html');
+    await copy('models/LicenseFile/name.html',
+        'pana_${panaVersion}_license_file_name_field.html');
+    await copy('pana/prettyJson.html', 'pana_${panaVersion}_pretty_json.html');
+  } finally {
+    await tempDir.delete(recursive: true);
+  }
+}
+
+/// Extracts a `.tar.gz` file from [tarball] to [destination].
+Future _extractTarGz(Stream<List<int>> tarball, String destination) async {
+  final reader = TarReader(tarball.transform(gzip.decoder));
+  while (await reader.moveNext()) {
+    final entry = reader.current;
+    final path = p.join(destination, entry.name);
+    if (!p.isWithin(destination, path)) {
+      throw ArgumentError('"${entry.name}" is outside of the archive.');
+    }
+    final dir = File(path).parent;
+    await dir.create(recursive: true);
+    if (entry.header.linkName != null) {
+      final target = p.normalize(p.join(dir.path, entry.header.linkName));
+      if (p.isWithin(destination, target)) {
+        final link = Link(path);
+        if (!link.existsSync()) {
+          await link.create(target);
+        }
+      } else {
+        // Note to self: do not create links going outside the package, this is not safe!
+      }
+    } else {
+      await entry.contents.pipe(File(path).openWrite());
+    }
+  }
+}


### PR DESCRIPTION
- I was using a less-sophisticated shell script for a while, but eventually I'd like to have a pana-like golden files regeneration in our tests (e.g. if you delete the goldens, it will regenerate them).
- We may also want to move the HTML customization codes to `pkg/pub_dartdoc` for more efficient filesystem use, and at that point the current file in `tool` would become part of `test`. 