### PR TITLE
Migrate some of the templates test to test-profile.

### DIFF
--- a/app/test/frontend/golden/landing_page.html
+++ b/app/test/frontend/golden/landing_page.html
@@ -137,11 +137,11 @@
           </p>
           <div class="mini-list">
             <div class="mini-list-item">
-              <a class="mini-list-item-title" href="/packages/foobar_pkg" data-ga-click-event="landing-flutter-favorites-card-title">
-                <h3>foobar_pkg</h3>
+              <a class="mini-list-item-title" href="/packages/flutter_titanium" data-ga-click-event="landing-flutter-favorites-card-title">
+                <h3>flutter_titanium</h3>
               </a>
               <div class="mini-list-item-body">
-                <p class="mini-list-item-description">my package description</p>
+                <p class="mini-list-item-description">flutter_titanium is awesome</p>
               </div>
               <div class="mini-list-item-footer"></div>
             </div>
@@ -160,20 +160,25 @@
           <p class="home-block-context-info">Some of the most downloaded packages over the past 60 days</p>
           <div class="mini-list">
             <div class="mini-list-item">
-              <a class="mini-list-item-title" href="/packages/foobar_pkg" data-ga-click-event="landing-most-popular-card-title">
-                <h3>foobar_pkg</h3>
+              <a class="mini-list-item-title" href="/packages/neon" data-ga-click-event="landing-most-popular-card-title">
+                <h3>neon</h3>
               </a>
               <div class="mini-list-item-body">
-                <p class="mini-list-item-description">my package description</p>
+                <p class="mini-list-item-description">neon is awesome</p>
               </div>
-              <div class="mini-list-item-footer"></div>
+              <div class="mini-list-item-footer">
+                <div class="mini-list-item-publisher">
+                  <img class="publisher-badge" src="/static/img/verified-publisher-gray.svg?hash=mocked_hash_248900311" title="Published by a pub.dev verified publisher"/>
+                  <a class="publisher-link" href="/publishers/example.com" data-ga-click-event="landing-most-popular-card-publisher">example.com</a>
+                </div>
+              </div>
             </div>
             <div class="mini-list-item">
-              <a class="mini-list-item-title" href="/packages/helium" data-ga-click-event="landing-most-popular-card-title">
-                <h3>helium</h3>
+              <a class="mini-list-item-title" href="/packages/oxygen" data-ga-click-event="landing-most-popular-card-title">
+                <h3>oxygen</h3>
               </a>
               <div class="mini-list-item-body">
-                <p class="mini-list-item-description">helium is a Dart package</p>
+                <p class="mini-list-item-description">oxygen is awesome</p>
               </div>
               <div class="mini-list-item-footer"></div>
             </div>

--- a/app/test/frontend/golden/my_liked_packages.html
+++ b/app/test/frontend/golden/my_liked_packages.html
@@ -125,13 +125,13 @@
           <div class="detail-container">
             <div class="detail-header-outer-block">
               <div class="detail-header-image-block">
-                <img src="https://juergen.com/hans.jpg=s400" class="detail-header-image"/>
+                <img src="pub.dev/user-img-url.png=s400" class="detail-header-image"/>
               </div>
               <div class="detail-header-content-block">
-                <h1 class="title">Hans Juergen</h1>
+                <h1 class="title">Pub User</h1>
                 <div class="metadata">
-                  <p>hans@juergen.com</p>
-                  <p>Joined on Jan 1, 2014</p>
+                  <p>user@pub.dev</p>
+                  <p>Joined on %%user-created-date%%</p>
                 </div>
                 <div class="detail-tags-and-like">
                   <div class="detail-tags"></div>

--- a/app/test/frontend/golden/my_packages.html
+++ b/app/test/frontend/golden/my_packages.html
@@ -125,13 +125,13 @@
           <div class="detail-container">
             <div class="detail-header-outer-block">
               <div class="detail-header-image-block">
-                <img src="https://juergen.com/hans.jpg=s400" class="detail-header-image"/>
+                <img src="pub.dev/user-img-url.png=s400" class="detail-header-image"/>
               </div>
               <div class="detail-header-content-block">
-                <h1 class="title">Hans Juergen</h1>
+                <h1 class="title">Pub User</h1>
                 <div class="metadata">
-                  <p>hans@juergen.com</p>
-                  <p>Joined on Jan 1, 2014</p>
+                  <p>user@pub.dev</p>
+                  <p>Joined on %%oxygen-created-date%%</p>
                 </div>
                 <div class="detail-tags-and-like">
                   <div class="detail-tags"></div>
@@ -186,44 +186,52 @@
                     <div class="packages-item">
                       <div class="packages-header">
                         <h3 class="packages-title">
-                          <a href="/packages/super_package">super_package</a>
+                          <a href="/packages/oxygen">oxygen</a>
                         </h3>
-                        <a class="packages-scores" href="/packages/super_package/score">
+                        <div class="packages-recent">
+                          <img class="packages-recent-icon" src="/static/img/schedule-icon.svg?hash=mocked_hash_164576935" title="new package"/>
+                          Added
+                          <b>in the last hour</b>
+                        </div>
+                        <a class="packages-scores" href="/packages/oxygen/score">
                           <div class="packages-score packages-score-like">
-                            <div class="packages-score-value">
-                              <span class="packages-score-value-number">--</span>
+                            <div class="packages-score-value -has-value">
+                              <span class="packages-score-value-number">0</span>
                               <span class="packages-score-value-sign"></span>
                             </div>
                             <div class="packages-score-label">likes</div>
                           </div>
                           <div class="packages-score packages-score-health">
-                            <div class="packages-score-value">
-                              <span class="packages-score-value-number">--</span>
+                            <div class="packages-score-value -has-value">
+                              <span class="packages-score-value-number">43</span>
                               <span class="packages-score-value-sign"></span>
                             </div>
                             <div class="packages-score-label">pub points</div>
                           </div>
                           <div class="packages-score packages-score-popularity">
-                            <div class="packages-score-value">
-                              <span class="packages-score-value-number">--</span>
+                            <div class="packages-score-value -has-value">
+                              <span class="packages-score-value-number">3</span>
                               <span class="packages-score-value-sign">%</span>
                             </div>
                             <div class="packages-score-label">popularity</div>
                           </div>
                         </a>
                       </div>
-                      <p class="packages-description">A great web UI library.</p>
+                      <p class="packages-description">oxygen is awesome</p>
                       <p class="packages-metadata">
                         <span class="packages-metadata-block">
                           v
-                          <a href="/packages/super_package">1.0.0</a>
+                          <a href="/packages/oxygen">1.2.0</a>
+                          /
+                          <a href="/packages/oxygen/versions/2.0.0-dev">2.0.0-dev</a>
                           • Updated:
-                          <span>Jan 3, 2019</span>
+                          <span>%%oxygen-created-date%%</span>
                         </span>
                       </p>
                       <div>
                         <div class="-pub-tag-badge">
                           <a class="tag-badge-main" title="Packages compatible with Dart SDK" href="/dart/packages">Dart</a>
+                          <a class="tag-badge-sub" title="Packages compatible with Dart running on a native platform (JIT/AOT)" href="/dart/packages?runtime=native">native</a>
                           <a class="tag-badge-sub" title="Packages compatible with Dart compiled for the web" href="/dart/packages?runtime=js">js</a>
                         </div>
                       </div>
@@ -231,47 +239,54 @@
                     <div class="packages-item">
                       <div class="packages-header">
                         <h3 class="packages-title">
-                          <a href="/packages/another_package">another_package</a>
+                          <a href="/packages/neon">neon</a>
                         </h3>
-                        <a class="packages-scores" href="/packages/another_package/score">
+                        <div class="packages-recent">
+                          <img class="packages-recent-icon" src="/static/img/schedule-icon.svg?hash=mocked_hash_164576935" title="new package"/>
+                          Added
+                          <b>in the last hour</b>
+                        </div>
+                        <a class="packages-scores" href="/packages/neon/score">
                           <div class="packages-score packages-score-like">
-                            <div class="packages-score-value">
-                              <span class="packages-score-value-number">--</span>
+                            <div class="packages-score-value -has-value">
+                              <span class="packages-score-value-number">0</span>
                               <span class="packages-score-value-sign"></span>
                             </div>
                             <div class="packages-score-label">likes</div>
                           </div>
                           <div class="packages-score packages-score-health">
-                            <div class="packages-score-value">
-                              <span class="packages-score-value-number">--</span>
+                            <div class="packages-score-value -has-value">
+                              <span class="packages-score-value-number">43</span>
                               <span class="packages-score-value-sign"></span>
                             </div>
                             <div class="packages-score-label">pub points</div>
                           </div>
                           <div class="packages-score packages-score-popularity">
-                            <div class="packages-score-value">
-                              <span class="packages-score-value-number">--</span>
+                            <div class="packages-score-value -has-value">
+                              <span class="packages-score-value-number">12</span>
                               <span class="packages-score-value-sign">%</span>
                             </div>
                             <div class="packages-score-label">popularity</div>
                           </div>
                         </a>
                       </div>
-                      <p class="packages-description">Camera plugin.</p>
+                      <p class="packages-description">neon is awesome</p>
                       <p class="packages-metadata">
                         <span class="packages-metadata-block">
                           v
-                          <a href="/packages/another_package">2.0.0</a>
-                          /
-                          <a href="/packages/another_package/versions/3.0.0-beta2">3.0.0-beta2</a>
+                          <a href="/packages/neon">1.0.0</a>
                           • Updated:
-                          <span>Mar 30, 2019</span>
+                          <span>%%oxygen-created-date%%</span>
+                        </span>
+                        <span class="packages-metadata-block">
+                          <img class="package-vp-icon" src="/static/img/verified-publisher-icon.svg?hash=mocked_hash_1044149352" title="Published by a pub.dev verified publisher"/>
+                          <a href="/publishers/example.com">example.com</a>
                         </span>
                       </p>
                       <div>
                         <div class="-pub-tag-badge">
-                          <a class="tag-badge-main" title="Packages compatible with Flutter SDK" href="/flutter/packages">Flutter</a>
-                          <a class="tag-badge-sub" title="Packages compatible with Flutter on the Android platform" href="/flutter/packages?platform=android">Android</a>
+                          <a class="tag-badge-main" title="Packages compatible with Dart SDK" href="/dart/packages">Dart</a>
+                          <a class="tag-badge-sub" title="Packages compatible with Dart running on a native platform (JIT/AOT)" href="/dart/packages?runtime=native">native</a>
                         </div>
                       </div>
                     </div>

--- a/app/test/frontend/golden/my_publishers.html
+++ b/app/test/frontend/golden/my_publishers.html
@@ -125,13 +125,13 @@
           <div class="detail-container">
             <div class="detail-header-outer-block">
               <div class="detail-header-image-block">
-                <img src="https://juergen.com/hans.jpg=s400" class="detail-header-image"/>
+                <img src="pub.dev/user-img-url.png=s400" class="detail-header-image"/>
               </div>
               <div class="detail-header-content-block">
-                <h1 class="title">Hans Juergen</h1>
+                <h1 class="title">Pub User</h1>
                 <div class="metadata">
-                  <p>hans@juergen.com</p>
-                  <p>Joined on Jan 1, 2014</p>
+                  <p>user@pub.dev</p>
+                  <p>Joined on %%user-created-date%%</p>
                 </div>
                 <div class="detail-tags-and-like">
                   <div class="detail-tags"></div>
@@ -164,7 +164,7 @@
                       <h3 class="publishers-item-title">
                         <a href="/publishers/example.com">example.com</a>
                       </h3>
-                      <p>Registered on Jul 15, 2019.</p>
+                      <p>Registered on Jul 1, 2021.</p>
                     </div>
                   </div>
                   <h3>Want to create a new publisher?</h3>

--- a/app/test/frontend/golden/pkg_index_page.html
+++ b/app/test/frontend/golden/pkg_index_page.html
@@ -201,9 +201,14 @@
           <div class="packages-item">
             <div class="packages-header">
               <h3 class="packages-title">
-                <a href="/packages/foobar_pkg">foobar_pkg</a>
+                <a href="/packages/oxygen">oxygen</a>
               </h3>
-              <a class="packages-scores" href="/packages/foobar_pkg/score">
+              <div class="packages-recent">
+                <img class="packages-recent-icon" src="/static/img/schedule-icon.svg?hash=mocked_hash_164576935" title="new package"/>
+                Added
+                <b>in the last hour</b>
+              </div>
+              <a class="packages-scores" href="/packages/oxygen/score">
                 <div class="packages-score packages-score-like">
                   <div class="packages-score-value -has-value">
                     <span class="packages-score-value-number">0</span>
@@ -212,42 +217,51 @@
                   <div class="packages-score-label">likes</div>
                 </div>
                 <div class="packages-score packages-score-health">
-                  <div class="packages-score-value">
-                    <span class="packages-score-value-number">--</span>
+                  <div class="packages-score-value -has-value">
+                    <span class="packages-score-value-number">43</span>
                     <span class="packages-score-value-sign"></span>
                   </div>
                   <div class="packages-score-label">pub points</div>
                 </div>
                 <div class="packages-score packages-score-popularity">
-                  <div class="packages-score-value">
-                    <span class="packages-score-value-number">--</span>
+                  <div class="packages-score-value -has-value">
+                    <span class="packages-score-value-number">3</span>
                     <span class="packages-score-value-sign">%</span>
                   </div>
                   <div class="packages-score-label">popularity</div>
                 </div>
               </a>
             </div>
-            <p class="packages-description">my package description</p>
+            <p class="packages-description">oxygen is awesome</p>
             <p class="packages-metadata">
               <span class="packages-metadata-block">
                 v
-                <a href="/packages/foobar_pkg">0.1.1+5</a>
+                <a href="/packages/oxygen">1.2.0</a>
                 /
-                <a href="/packages/foobar_pkg/versions/0.2.0-dev">0.2.0-dev</a>
+                <a href="/packages/oxygen/versions/2.0.0-dev">2.0.0-dev</a>
                 • Updated:
-                <span>Jan 1, 2015</span>
+                <span>%%oxygen-created-date%%</span>
               </span>
             </p>
             <div>
-              <span class="package-tag missing" title="Analysis should be ready soon.">[awaiting]</span>
+              <div class="-pub-tag-badge">
+                <a class="tag-badge-main" title="Packages compatible with Dart SDK" href="/dart/packages">Dart</a>
+                <a class="tag-badge-sub" title="Packages compatible with Dart running on a native platform (JIT/AOT)" href="/dart/packages?runtime=native">native</a>
+                <a class="tag-badge-sub" title="Packages compatible with Dart compiled for the web" href="/dart/packages?runtime=js">js</a>
+              </div>
             </div>
           </div>
           <div class="packages-item">
             <div class="packages-header">
               <h3 class="packages-title">
-                <a href="/packages/foobar_pkg">foobar_pkg</a>
+                <a href="/packages/flutter_titanium">flutter_titanium</a>
               </h3>
-              <a class="packages-scores" href="/packages/foobar_pkg/score">
+              <div class="packages-recent">
+                <img class="packages-recent-icon" src="/static/img/schedule-icon.svg?hash=mocked_hash_164576935" title="new package"/>
+                Added
+                <b>in the last hour</b>
+              </div>
+              <a class="packages-scores" href="/packages/flutter_titanium/score">
                 <div class="packages-score packages-score-like">
                   <div class="packages-score-value -has-value">
                     <span class="packages-score-value-number">0</span>
@@ -256,36 +270,40 @@
                   <div class="packages-score-label">likes</div>
                 </div>
                 <div class="packages-score packages-score-health">
-                  <div class="packages-score-value">
-                    <span class="packages-score-value-number">--</span>
+                  <div class="packages-score-value -has-value">
+                    <span class="packages-score-value-number">24</span>
                     <span class="packages-score-value-sign"></span>
                   </div>
                   <div class="packages-score-label">pub points</div>
                 </div>
                 <div class="packages-score packages-score-popularity">
-                  <div class="packages-score-value">
-                    <span class="packages-score-value-number">--</span>
+                  <div class="packages-score-value -has-value">
+                    <span class="packages-score-value-number">43</span>
                     <span class="packages-score-value-sign">%</span>
                   </div>
                   <div class="packages-score-label">popularity</div>
                 </div>
               </a>
             </div>
-            <p class="packages-description">my package description</p>
+            <p class="packages-description">flutter_titanium is awesome</p>
             <p class="packages-metadata">
               <span class="packages-metadata-block">
                 v
-                <a href="/packages/foobar_pkg">0.1.1+5</a>
-                /
-                <a href="/packages/foobar_pkg/versions/0.2.0-dev">0.2.0-dev</a>
+                <a href="/packages/flutter_titanium">1.10.0</a>
                 • Updated:
-                <span>Jan 1, 2015</span>
+                <span>%%oxygen-created-date%%</span>
               </span>
             </p>
             <div>
               <div class="-pub-tag-badge">
+                <a class="tag-badge-main" title="Packages compatible with Dart SDK" href="/dart/packages">Dart</a>
+                <a class="tag-badge-sub" title="Packages compatible with Dart running on a native platform (JIT/AOT)" href="/dart/packages?runtime=native">native</a>
+                <a class="tag-badge-sub" title="Packages compatible with Dart compiled for the web" href="/dart/packages?runtime=js">js</a>
+              </div>
+              <div class="-pub-tag-badge">
                 <a class="tag-badge-main" title="Packages compatible with Flutter SDK" href="/flutter/packages">Flutter</a>
                 <a class="tag-badge-sub" title="Packages compatible with Flutter on the Android platform" href="/flutter/packages?platform=android">Android</a>
+                <a class="tag-badge-sub" title="Packages compatible with Flutter on the macOS platform" href="/flutter/packages?platform=macos">macOS</a>
               </div>
             </div>
           </div>

--- a/app/test/frontend/golden/pkg_show_page_publisher.html
+++ b/app/test/frontend/golden/pkg_show_page_publisher.html
@@ -142,10 +142,7 @@
                 </div>
                 <div class="detail-tags-and-like">
                   <div class="detail-tags">
-                    <div class="-pub-tag-badge">
-                      <a class="tag-badge-main" title="Packages compatible with Dart SDK" href="/dart/packages">Dart</a>
-                      <a class="tag-badge-sub" title="Packages compatible with Dart running on a native platform (JIT/AOT)" href="/dart/packages?runtime=native">native</a>
-                    </div>
+                    <span class="package-tag missing" title="Analysis should be ready soon.">[awaiting]</span>
                   </div>
                   <div class="detail-like">
                     <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-hidden="true" aria-pressed="true">
@@ -219,15 +216,15 @@
                 <div class="packages-score-label">likes</div>
               </div>
               <div class="packages-score packages-score-health">
-                <div class="packages-score-value -has-value">
-                  <span class="packages-score-value-number">43</span>
+                <div class="packages-score-value">
+                  <span class="packages-score-value-number">--</span>
                   <span class="packages-score-value-sign"></span>
                 </div>
                 <div class="packages-score-label">pub points</div>
               </div>
               <div class="packages-score packages-score-popularity">
-                <div class="packages-score-value -has-value">
-                  <span class="packages-score-value-number">12</span>
+                <div class="packages-score-value">
+                  <span class="packages-score-value-number">--</span>
                   <span class="packages-score-value-sign">%</span>
                 </div>
                 <div class="packages-score-label">popularity</div>
@@ -246,16 +243,9 @@
               <a class="link" href="https://neon.example.dev/" rel="ugc">Homepage</a>
               <br/>
             </p>
-            <h3 class="title">Documentation</h3>
-            <p>
-              <a class="link" href="/documentation/neon/latest/">API reference</a>
-              <br/>
-            </p>
             <h3 class="title">License</h3>
             <p>
-              BSD (
               <a href="/packages/neon/license">LICENSE</a>
-              )
             </p>
             <h3 class="title">More</h3>
             <p>
@@ -280,15 +270,15 @@
               <div class="packages-score-label">likes</div>
             </div>
             <div class="packages-score packages-score-health">
-              <div class="packages-score-value -has-value">
-                <span class="packages-score-value-number">43</span>
+              <div class="packages-score-value">
+                <span class="packages-score-value-number">--</span>
                 <span class="packages-score-value-sign"></span>
               </div>
               <div class="packages-score-label">pub points</div>
             </div>
             <div class="packages-score packages-score-popularity">
-              <div class="packages-score-value -has-value">
-                <span class="packages-score-value-number">12</span>
+              <div class="packages-score-value">
+                <span class="packages-score-value-number">--</span>
                 <span class="packages-score-value-sign">%</span>
               </div>
               <div class="packages-score-label">popularity</div>
@@ -307,16 +297,9 @@
             <a class="link" href="https://neon.example.dev/" rel="ugc">Homepage</a>
             <br/>
           </p>
-          <h3 class="title">Documentation</h3>
-          <p>
-            <a class="link" href="/documentation/neon/latest/">API reference</a>
-            <br/>
-          </p>
           <h3 class="title">License</h3>
           <p>
-            BSD (
             <a href="/packages/neon/license">LICENSE</a>
-            )
           </p>
           <h3 class="title">More</h3>
           <p>

--- a/app/test/frontend/golden/pkg_versions_page.html
+++ b/app/test/frontend/golden/pkg_versions_page.html
@@ -14,16 +14,16 @@
     <!-- Facebook OG tags -->
     <meta property="og:type" content="website"/>
     <meta property="og:site_name" content="Dart packages"/>
-    <meta property="og:title" content="foobar_pkg package - All Versions"/>
+    <meta property="og:title" content="oxygen package - All Versions"/>
     <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <meta property="og:image" content="https://pub.dev/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
-    <meta property="og:url" content="https://pub.dev/packages/foobar_pkg/versions"/>
-    <title>foobar_pkg package - All Versions</title>
+    <meta property="og:url" content="https://pub.dev/packages/oxygen/versions"/>
+    <title>oxygen package - All Versions</title>
     <link href="https://fonts.googleapis.com/css?family=Google+Sans:300,400,500|Google+Sans+Display:400|Roboto:300,400,500,700|Roboto+Mono:300,400,700" rel="stylesheet"/>
     <meta content="/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
     <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
     <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/osd.xml?hash=mocked_hash_869379763"/>
-    <link rel="canonical" href="https://pub.dev/packages/foobar_pkg/versions"/>
+    <link rel="canonical" href="https://pub.dev/packages/oxygen/versions"/>
     <meta name="description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
     <link href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842" rel="stylesheet" type="text/css"/>
@@ -34,7 +34,7 @@
     <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
     <meta name="google-signin-client_id" content=""/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
-    <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJmb29iYXJfcGtnIiwidmVyc2lvbiI6IjAuMS4xKzUiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlfX0="/>
+    <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJveHlnZW4iLCJ2ZXJzaW9uIjoiMS4yLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlfX0="/>
   </head>
   <body class="">
     <!-- Google Tag Manager (noscript) -->
@@ -122,34 +122,33 @@
             <div class="detail-header-outer-block">
               <div class="detail-header-content-block">
                 <h1 class="title">
-                  foobar_pkg 0.1.1+5
+                  oxygen 1.2.0
                   <span class="pkg-page-title-copy">
-                    <img class="pkg-page-title-copy-icon" data-copy-content="foobar_pkg: ^0.1.1+5" data-ga-click-event="copy-package-version" src="/static/img/content-copy-icon.svg?hash=mocked_hash_1005735992" title="Copy &quot;foobar_pkg: ^0.1.1+5&quot; to clipboard"/>
+                    <img class="pkg-page-title-copy-icon" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version" src="/static/img/content-copy-icon.svg?hash=mocked_hash_1005735992" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard"/>
                     <div class="pkg-page-title-copy-feedback">
-                      <span class="code">foobar_pkg: ^0.1.1+5</span>
+                      <span class="code">oxygen: ^1.2.0</span>
                       copied to clipboard
                     </div>
                   </span>
                 </h1>
                 <div class="metadata">
                   Published
-                  <span>Jan 1, 2014</span>
+                  <span>%%version-created-date%%</span>
                   • Latest:
                   <span>
-                    <a href="/packages/foobar_pkg">0.1.1+5</a>
+                    <a href="/packages/oxygen">1.2.0</a>
                   </span>
                   / Prerelease:
                   <span>
-                    <a href="/packages/foobar_pkg/versions/0.2.0-dev">0.2.0-dev</a>
+                    <a href="/packages/oxygen/versions/2.0.0-dev">2.0.0-dev</a>
                   </span>
                 </div>
                 <div class="detail-tags-and-like">
                   <div class="detail-tags">
                     <div class="-pub-tag-badge">
                       <a class="tag-badge-main" title="Packages compatible with Dart SDK" href="/dart/packages">Dart</a>
-                    </div>
-                    <div class="-pub-tag-badge">
-                      <a class="tag-badge-main" title="Packages compatible with Flutter SDK" href="/flutter/packages">Flutter</a>
+                      <a class="tag-badge-sub" title="Packages compatible with Dart running on a native platform (JIT/AOT)" href="/dart/packages?runtime=native">native</a>
+                      <a class="tag-badge-sub" title="Packages compatible with Dart compiled for the web" href="/dart/packages?runtime=js">js</a>
                     </div>
                   </div>
                   <div class="detail-like">
@@ -172,7 +171,7 @@
               <div class="detail-metadata-toggle-icon">→</div>
               <h3 class="detail-lead-title">Metadata</h3>
             </div>
-            <p class="detail-lead-text">my package description</p>
+            <p class="detail-lead-text">oxygen is awesome</p>
             <p class="detail-lead-more">
               <a class="detail-metadata-toggle">More...</a>
             </p>
@@ -184,20 +183,20 @@
               <div class="detail-container">
                 <ul class="detail-tabs-header">
                   <li class="detail-tab tab-link detail-tab-readme-title" role="button">
-                    <a href="/packages/foobar_pkg">Readme</a>
+                    <a href="/packages/oxygen">Readme</a>
                   </li>
                   <li class="detail-tab tab-link detail-tab-changelog-title" role="button">
-                    <a href="/packages/foobar_pkg/changelog">Changelog</a>
+                    <a href="/packages/oxygen/changelog">Changelog</a>
                   </li>
                   <li class="detail-tab tab-link detail-tab-example-title" role="button">
-                    <a href="/packages/foobar_pkg/example">Example</a>
+                    <a href="/packages/oxygen/example">Example</a>
                   </li>
                   <li class="detail-tab tab-link detail-tab-installing-title" role="button">
-                    <a href="/packages/foobar_pkg/install">Installing</a>
+                    <a href="/packages/oxygen/install">Installing</a>
                   </li>
                   <li class="detail-tab tab-button detail-tab-versions-title -active" role="button">Versions</li>
                   <li class="detail-tab tab-link detail-tab-analysis-title" role="button">
-                    <a href="/packages/foobar_pkg/score">Scores</a>
+                    <a href="/packages/oxygen/score">Scores</a>
                   </li>
                 </ul>
               </div>
@@ -207,11 +206,11 @@
                 <section class="tab-content detail-tab-versions-content -active">
                   <p>
                     The latest prerelease was
-                    <a href="#prerelease">0.2.0-dev</a>
-                    on Jan 1, 2014.
+                    <a href="#prerelease">2.0.0-dev</a>
+                    on %%version-created-date%%.
                   </p>
-                  <h2 id="stable">Stable versions of foobar_pkg</h2>
-                  <table class="version-table" data-package="foobar_pkg">
+                  <h2 id="stable">Stable versions of oxygen</h2>
+                  <table class="version-table" data-package="oxygen">
                     <thead>
                       <tr>
                         <th class="version">Version</th>
@@ -231,28 +230,46 @@
                       </tr>
                     </thead>
                     <tbody>
-                      <tr data-version="0.1.1+5">
+                      <tr data-version="1.0.0">
                         <td class="version">
-                          <a href="/packages/foobar_pkg/versions/0.1.1+5">0.1.1+5</a>
+                          <a href="/packages/oxygen/versions/1.0.0">1.0.0</a>
                         </td>
                         <td class="badge"></td>
-                        <td class="sdk">2.10</td>
-                        <td class="uploaded">Jan 1, 2014</td>
+                        <td class="sdk">2.6</td>
+                        <td class="uploaded">%%version-created-date%%</td>
                         <td class="documentation">
-                          <a href="/documentation/foobar_pkg/0.1.1+5/" rel="nofollow" title="Go to the documentation of foobar_pkg 0.1.1+5">
-                            <img class="version-table-icon" src="/static/img/description-24px.svg?hash=mocked_hash_130979311" data-failed-icon="/static/img/documentation-failed-icon.svg?hash=mocked_hash_57143192" alt="Go to the documentation of foobar_pkg 0.1.1+5"/>
+                          <a href="/documentation/oxygen/1.0.0/" rel="nofollow" title="Go to the documentation of oxygen 1.0.0">
+                            <img class="version-table-icon" src="/static/img/description-24px.svg?hash=mocked_hash_130979311" data-failed-icon="/static/img/documentation-failed-icon.svg?hash=mocked_hash_57143192" alt="Go to the documentation of oxygen 1.0.0"/>
                           </a>
                         </td>
                         <td class="archive">
-                          <a href="https://pub.dartlang.org/mock-download-uri.tar.gz" rel="nofollow" title="Download foobar_pkg 0.1.1+5 archive">
-                            <img class="version-table-icon" src="/static/img/vertical_align_bottom-24px.svg?hash=mocked_hash_587025884" alt="Download foobar_pkg 0.1.1+5 archive"/>
+                          <a href="https://pub.dev/download-url/oxygen/1.0.0" rel="nofollow" title="Download oxygen 1.0.0 archive">
+                            <img class="version-table-icon" src="/static/img/vertical_align_bottom-24px.svg?hash=mocked_hash_587025884" alt="Download oxygen 1.0.0 archive"/>
+                          </a>
+                        </td>
+                      </tr>
+                      <tr data-version="1.2.0">
+                        <td class="version">
+                          <a href="/packages/oxygen/versions/1.2.0">1.2.0</a>
+                        </td>
+                        <td class="badge"></td>
+                        <td class="sdk">2.6</td>
+                        <td class="uploaded">%%version-created-date%%</td>
+                        <td class="documentation">
+                          <a href="/documentation/oxygen/1.2.0/" rel="nofollow" title="Go to the documentation of oxygen 1.2.0">
+                            <img class="version-table-icon" src="/static/img/description-24px.svg?hash=mocked_hash_130979311" data-failed-icon="/static/img/documentation-failed-icon.svg?hash=mocked_hash_57143192" alt="Go to the documentation of oxygen 1.2.0"/>
+                          </a>
+                        </td>
+                        <td class="archive">
+                          <a href="https://pub.dev/download-url/oxygen/1.2.0" rel="nofollow" title="Download oxygen 1.2.0 archive">
+                            <img class="version-table-icon" src="/static/img/vertical_align_bottom-24px.svg?hash=mocked_hash_587025884" alt="Download oxygen 1.2.0 archive"/>
                           </a>
                         </td>
                       </tr>
                     </tbody>
                   </table>
-                  <h2 id="prerelease">Prerelease versions of foobar_pkg</h2>
-                  <table class="version-table" data-package="foobar_pkg">
+                  <h2 id="prerelease">Prerelease versions of oxygen</h2>
+                  <table class="version-table" data-package="oxygen">
                     <thead>
                       <tr>
                         <th class="version">Version</th>
@@ -272,21 +289,21 @@
                       </tr>
                     </thead>
                     <tbody>
-                      <tr data-version="0.2.0-dev">
+                      <tr data-version="2.0.0-dev">
                         <td class="version">
-                          <a href="/packages/foobar_pkg/versions/0.2.0-dev">0.2.0-dev</a>
+                          <a href="/packages/oxygen/versions/2.0.0-dev">2.0.0-dev</a>
                         </td>
                         <td class="badge"></td>
-                        <td class="sdk">2.10</td>
-                        <td class="uploaded">Jan 1, 2014</td>
+                        <td class="sdk">2.6</td>
+                        <td class="uploaded">%%version-created-date%%</td>
                         <td class="documentation">
-                          <a href="/documentation/foobar_pkg/0.2.0-dev/" rel="nofollow" title="Go to the documentation of foobar_pkg 0.2.0-dev">
-                            <img class="version-table-icon" src="/static/img/description-24px.svg?hash=mocked_hash_130979311" data-failed-icon="/static/img/documentation-failed-icon.svg?hash=mocked_hash_57143192" alt="Go to the documentation of foobar_pkg 0.2.0-dev"/>
+                          <a href="/documentation/oxygen/2.0.0-dev/" rel="nofollow" title="Go to the documentation of oxygen 2.0.0-dev">
+                            <img class="version-table-icon" src="/static/img/description-24px.svg?hash=mocked_hash_130979311" data-failed-icon="/static/img/documentation-failed-icon.svg?hash=mocked_hash_57143192" alt="Go to the documentation of oxygen 2.0.0-dev"/>
                           </a>
                         </td>
                         <td class="archive">
-                          <a href="https://pub.dartlang.org/mock-download-uri.tar.gz" rel="nofollow" title="Download foobar_pkg 0.2.0-dev archive">
-                            <img class="version-table-icon" src="/static/img/vertical_align_bottom-24px.svg?hash=mocked_hash_587025884" alt="Download foobar_pkg 0.2.0-dev archive"/>
+                          <a href="https://pub.dev/download-url/oxygen/2.0.0-dev" rel="nofollow" title="Download oxygen 2.0.0-dev archive">
+                            <img class="version-table-icon" src="/static/img/vertical_align_bottom-24px.svg?hash=mocked_hash_587025884" alt="Download oxygen 2.0.0-dev archive"/>
                           </a>
                         </td>
                       </tr>
@@ -297,7 +314,7 @@
             </div>
           </div>
           <aside class="detail-info-box">
-            <a class="packages-scores" href="/packages/foobar_pkg/score">
+            <a class="packages-scores" href="/packages/oxygen/score">
               <div class="packages-score packages-score-like">
                 <div class="packages-score-value -has-value">
                   <span class="packages-score-value-number">0</span>
@@ -306,37 +323,44 @@
                 <div class="packages-score-label">likes</div>
               </div>
               <div class="packages-score packages-score-health">
-                <div class="packages-score-value">
-                  <span class="packages-score-value-number">--</span>
+                <div class="packages-score-value -has-value">
+                  <span class="packages-score-value-number">43</span>
                   <span class="packages-score-value-sign"></span>
                 </div>
                 <div class="packages-score-label">pub points</div>
               </div>
               <div class="packages-score packages-score-popularity">
                 <div class="packages-score-value -has-value">
-                  <span class="packages-score-value-number">20</span>
+                  <span class="packages-score-value-number">3</span>
                   <span class="packages-score-value-sign">%</span>
                 </div>
                 <div class="packages-score-label">popularity</div>
               </div>
             </a>
             <h3 class="title pkg-infobox-metadata">Metadata</h3>
-            <p>my package description</p>
+            <p>oxygen is awesome</p>
             <p>
-              <a class="link" href="http://hans.juergen.com" rel="ugc">Homepage</a>
+              <a class="link" href="https://oxygen.example.dev/" rel="ugc">Homepage</a>
               <br/>
             </p>
-            <h3 class="title">Dependencies</h3>
+            <h3 class="title">Documentation</h3>
             <p>
-              <a href="/packages/gcloud" title="any">gcloud</a>
+              <a class="link" href="/documentation/oxygen/latest/">API reference</a>
+              <br/>
+            </p>
+            <h3 class="title">License</h3>
+            <p>
+              BSD (
+              <a href="/packages/oxygen/license">LICENSE</a>
+              )
             </p>
             <h3 class="title">More</h3>
             <p>
-              <a href="/packages?q=dependency%3Afoobar_pkg" rel="nofollow">Packages that depend on foobar_pkg</a>
+              <a href="/packages?q=dependency%3Aoxygen" rel="nofollow">Packages that depend on oxygen</a>
             </p>
           </aside>
         </div>
-        <script type="application/ld+json">{"@context":"http://schema.org","@type":"SoftwareSourceCode","name":"foobar_pkg","version":"0.1.1+5","description":"foobar_pkg - my package description","url":"https://pub.dev/packages/foobar_pkg","dateCreated":"2014-01-01T00:00:00.000Z","dateModified":"2014-01-01T00:00:00.000Z","programmingLanguage":"Dart","image":"https://pub.dev/static/img/pub-dev-icon-cover-image.png"}</script>
+        <script type="application/ld+json">{"@context":"http://schema.org","@type":"SoftwareSourceCode","name":"oxygen","version":"1.2.0","description":"oxygen - oxygen is awesome","url":"https://pub.dev/packages/oxygen","dateCreated":"%%package-created-timestamp%%","dateModified":"%%version-created-timestamp%%","programmingLanguage":"Dart","image":"https://pub.dev/static/img/pub-dev-icon-cover-image.png"}</script>
       </div>
       <div class="detail-metadata">
         <h3 class="detail-metadata-title">
@@ -344,7 +368,7 @@
           Metadata
         </h3>
         <div class="detail-info-box">
-          <a class="packages-scores" href="/packages/foobar_pkg/score">
+          <a class="packages-scores" href="/packages/oxygen/score">
             <div class="packages-score packages-score-like">
               <div class="packages-score-value -has-value">
                 <span class="packages-score-value-number">0</span>
@@ -353,33 +377,40 @@
               <div class="packages-score-label">likes</div>
             </div>
             <div class="packages-score packages-score-health">
-              <div class="packages-score-value">
-                <span class="packages-score-value-number">--</span>
+              <div class="packages-score-value -has-value">
+                <span class="packages-score-value-number">43</span>
                 <span class="packages-score-value-sign"></span>
               </div>
               <div class="packages-score-label">pub points</div>
             </div>
             <div class="packages-score packages-score-popularity">
               <div class="packages-score-value -has-value">
-                <span class="packages-score-value-number">20</span>
+                <span class="packages-score-value-number">3</span>
                 <span class="packages-score-value-sign">%</span>
               </div>
               <div class="packages-score-label">popularity</div>
             </div>
           </a>
           <h3 class="title pkg-infobox-metadata">Metadata</h3>
-          <p>my package description</p>
+          <p>oxygen is awesome</p>
           <p>
-            <a class="link" href="http://hans.juergen.com" rel="ugc">Homepage</a>
+            <a class="link" href="https://oxygen.example.dev/" rel="ugc">Homepage</a>
             <br/>
           </p>
-          <h3 class="title">Dependencies</h3>
+          <h3 class="title">Documentation</h3>
           <p>
-            <a href="/packages/gcloud" title="any">gcloud</a>
+            <a class="link" href="/documentation/oxygen/latest/">API reference</a>
+            <br/>
+          </p>
+          <h3 class="title">License</h3>
+          <p>
+            BSD (
+            <a href="/packages/oxygen/license">LICENSE</a>
+            )
           </p>
           <h3 class="title">More</h3>
           <p>
-            <a href="/packages?q=dependency%3Afoobar_pkg" rel="nofollow">Packages that depend on foobar_pkg</a>
+            <a href="/packages?q=dependency%3Aoxygen" rel="nofollow">Packages that depend on oxygen</a>
           </p>
         </div>
         <p class="detail-lead-back">

--- a/app/test/frontend/golden/publisher_packages_page.html
+++ b/app/test/frontend/golden/publisher_packages_page.html
@@ -130,21 +130,16 @@
                 <h1 class="title">example.com</h1>
                 <div class="metadata">
                   <p>
-                    This is our little software developer shop.
-                    <br/>
-                    We develop full-stack in Dart, and happy about it.
-                  </p>
-                  <p>
                     <span class="detail-header-metadata-ref">
                       <img class="detail-header-metadata-ref-icon" src="/static/img/link-icon.svg?hash=mocked_hash_709199651"/>
                       <a class="detail-header-metadata-ref-label" href="https://example.com/" rel="ugc">example.com/</a>
                     </span>
                     <span class="detail-header-metadata-ref">
                       <img class="detail-header-metadata-ref-icon" src="/static/img/email-icon.svg?hash=mocked_hash_308057918"/>
-                      <a class="detail-header-metadata-ref-label" href="mailto:hello@example.com">hello@example.com</a>
+                      <a class="detail-header-metadata-ref-label" href="mailto:admin@pub.dev">admin@pub.dev</a>
                     </span>
                   </p>
-                  <p>Publisher registered on Sep 13, 2019.</p>
+                  <p>Publisher registered on %%neon-created-date%%.</p>
                 </div>
                 <div class="detail-tags-and-like">
                   <div class="detail-tags"></div>
@@ -196,96 +191,110 @@
                     <div class="packages-item">
                       <div class="packages-header">
                         <h3 class="packages-title">
-                          <a href="/packages/super_package">super_package</a>
+                          <a href="/packages/neon">neon</a>
                         </h3>
-                        <a class="packages-scores" href="/packages/super_package/score">
+                        <div class="packages-recent">
+                          <img class="packages-recent-icon" src="/static/img/schedule-icon.svg?hash=mocked_hash_164576935" title="new package"/>
+                          Added
+                          <b>in the last hour</b>
+                        </div>
+                        <a class="packages-scores" href="/packages/neon/score">
                           <div class="packages-score packages-score-like">
-                            <div class="packages-score-value">
-                              <span class="packages-score-value-number">--</span>
+                            <div class="packages-score-value -has-value">
+                              <span class="packages-score-value-number">0</span>
                               <span class="packages-score-value-sign"></span>
                             </div>
                             <div class="packages-score-label">likes</div>
                           </div>
                           <div class="packages-score packages-score-health">
-                            <div class="packages-score-value">
-                              <span class="packages-score-value-number">--</span>
+                            <div class="packages-score-value -has-value">
+                              <span class="packages-score-value-number">43</span>
                               <span class="packages-score-value-sign"></span>
                             </div>
                             <div class="packages-score-label">pub points</div>
                           </div>
                           <div class="packages-score packages-score-popularity">
-                            <div class="packages-score-value">
-                              <span class="packages-score-value-number">--</span>
+                            <div class="packages-score-value -has-value">
+                              <span class="packages-score-value-number">12</span>
                               <span class="packages-score-value-sign">%</span>
                             </div>
                             <div class="packages-score-label">popularity</div>
                           </div>
                         </a>
                       </div>
-                      <p class="packages-description">A great web UI library.</p>
+                      <p class="packages-description">neon is awesome</p>
                       <p class="packages-metadata">
                         <span class="packages-metadata-block">
                           v
-                          <a href="/packages/super_package">1.0.0</a>
-                          /
-                          <a href="/packages/super_package/versions/1.4.0">1.4.0</a>
-                          /
-                          <a href="/packages/super_package/versions/1.5.0-dev">1.5.0-dev</a>
+                          <a href="/packages/neon">1.0.0</a>
                           • Updated:
-                          <span>Jan 3, 2019</span>
+                          <span>%%neon-created-date%%</span>
+                        </span>
+                        <span class="packages-metadata-block">
+                          <img class="package-vp-icon" src="/static/img/verified-publisher-icon.svg?hash=mocked_hash_1044149352" title="Published by a pub.dev verified publisher"/>
+                          <a href="/publishers/example.com">example.com</a>
                         </span>
                       </p>
                       <div>
                         <div class="-pub-tag-badge">
                           <a class="tag-badge-main" title="Packages compatible with Dart SDK" href="/dart/packages">Dart</a>
-                          <a class="tag-badge-sub" title="Packages compatible with Dart compiled for the web" href="/dart/packages?runtime=js">js</a>
+                          <a class="tag-badge-sub" title="Packages compatible with Dart running on a native platform (JIT/AOT)" href="/dart/packages?runtime=native">native</a>
                         </div>
                       </div>
                     </div>
                     <div class="packages-item">
                       <div class="packages-header">
                         <h3 class="packages-title">
-                          <a href="/packages/another_package">another_package</a>
+                          <a href="/packages/flutter_titanium">flutter_titanium</a>
                         </h3>
-                        <a class="packages-scores" href="/packages/another_package/score">
+                        <div class="packages-recent">
+                          <img class="packages-recent-icon" src="/static/img/schedule-icon.svg?hash=mocked_hash_164576935" title="new package"/>
+                          Added
+                          <b>in the last hour</b>
+                        </div>
+                        <a class="packages-scores" href="/packages/flutter_titanium/score">
                           <div class="packages-score packages-score-like">
-                            <div class="packages-score-value">
-                              <span class="packages-score-value-number">--</span>
+                            <div class="packages-score-value -has-value">
+                              <span class="packages-score-value-number">0</span>
                               <span class="packages-score-value-sign"></span>
                             </div>
                             <div class="packages-score-label">likes</div>
                           </div>
                           <div class="packages-score packages-score-health">
-                            <div class="packages-score-value">
-                              <span class="packages-score-value-number">--</span>
+                            <div class="packages-score-value -has-value">
+                              <span class="packages-score-value-number">24</span>
                               <span class="packages-score-value-sign"></span>
                             </div>
                             <div class="packages-score-label">pub points</div>
                           </div>
                           <div class="packages-score packages-score-popularity">
-                            <div class="packages-score-value">
-                              <span class="packages-score-value-number">--</span>
+                            <div class="packages-score-value -has-value">
+                              <span class="packages-score-value-number">43</span>
                               <span class="packages-score-value-sign">%</span>
                             </div>
                             <div class="packages-score-label">popularity</div>
                           </div>
                         </a>
                       </div>
-                      <p class="packages-description">Camera plugin.</p>
+                      <p class="packages-description">flutter_titanium is awesome</p>
                       <p class="packages-metadata">
                         <span class="packages-metadata-block">
                           v
-                          <a href="/packages/another_package">2.0.0</a>
-                          /
-                          <a href="/packages/another_package/versions/3.0.0-beta2">3.0.0-beta2</a>
+                          <a href="/packages/flutter_titanium">1.10.0</a>
                           • Updated:
-                          <span>Mar 30, 2019</span>
+                          <span>%%neon-created-date%%</span>
                         </span>
                       </p>
                       <div>
                         <div class="-pub-tag-badge">
+                          <a class="tag-badge-main" title="Packages compatible with Dart SDK" href="/dart/packages">Dart</a>
+                          <a class="tag-badge-sub" title="Packages compatible with Dart running on a native platform (JIT/AOT)" href="/dart/packages?runtime=native">native</a>
+                          <a class="tag-badge-sub" title="Packages compatible with Dart compiled for the web" href="/dart/packages?runtime=js">js</a>
+                        </div>
+                        <div class="-pub-tag-badge">
                           <a class="tag-badge-main" title="Packages compatible with Flutter SDK" href="/flutter/packages">Flutter</a>
                           <a class="tag-badge-sub" title="Packages compatible with Flutter on the Android platform" href="/flutter/packages?platform=android">Android</a>
+                          <a class="tag-badge-sub" title="Packages compatible with Flutter on the macOS platform" href="/flutter/packages?platform=macos">macOS</a>
                         </div>
                       </div>
                     </div>

--- a/app/test/frontend/golden/search_page.html
+++ b/app/test/frontend/golden/search_page.html
@@ -203,9 +203,14 @@
           <div class="packages-item">
             <div class="packages-header">
               <h3 class="packages-title">
-                <a href="/packages/foobar_pkg">foobar_pkg</a>
+                <a href="/packages/oxygen">oxygen</a>
               </h3>
-              <a class="packages-scores" href="/packages/foobar_pkg/score">
+              <div class="packages-recent">
+                <img class="packages-recent-icon" src="/static/img/schedule-icon.svg?hash=mocked_hash_164576935" title="new package"/>
+                Added
+                <b>in the last hour</b>
+              </div>
+              <a class="packages-scores" href="/packages/oxygen/score">
                 <div class="packages-score packages-score-like">
                   <div class="packages-score-value -has-value">
                     <span class="packages-score-value-number">0</span>
@@ -214,43 +219,47 @@
                   <div class="packages-score-label">likes</div>
                 </div>
                 <div class="packages-score packages-score-health">
-                  <div class="packages-score-value">
-                    <span class="packages-score-value-number">--</span>
+                  <div class="packages-score-value -has-value">
+                    <span class="packages-score-value-number">43</span>
                     <span class="packages-score-value-sign"></span>
                   </div>
                   <div class="packages-score-label">pub points</div>
                 </div>
                 <div class="packages-score packages-score-popularity">
-                  <div class="packages-score-value">
-                    <span class="packages-score-value-number">--</span>
+                  <div class="packages-score-value -has-value">
+                    <span class="packages-score-value-number">3</span>
                     <span class="packages-score-value-sign">%</span>
                   </div>
                   <div class="packages-score-label">popularity</div>
                 </div>
               </a>
             </div>
-            <p class="packages-description">my package description</p>
+            <p class="packages-description">oxygen is awesome</p>
             <p class="packages-metadata">
               <span class="packages-metadata-block">
                 v
-                <a href="/packages/foobar_pkg">0.1.1+5</a>
+                <a href="/packages/oxygen">1.2.0</a>
                 /
-                <a href="/packages/foobar_pkg/versions/0.2.0-dev">0.2.0-dev</a>
+                <a href="/packages/oxygen/versions/2.0.0-dev">2.0.0-dev</a>
                 • Updated:
-                <span>Jan 1, 2015</span>
+                <span>%%oxygen-created-date%%</span>
               </span>
             </p>
             <div>
-              <span class="package-tag missing" title="Analysis should be ready soon.">[awaiting]</span>
+              <div class="-pub-tag-badge">
+                <a class="tag-badge-main" title="Packages compatible with Dart SDK" href="/dart/packages">Dart</a>
+                <a class="tag-badge-sub" title="Packages compatible with Dart running on a native platform (JIT/AOT)" href="/dart/packages?runtime=native">native</a>
+                <a class="tag-badge-sub" title="Packages compatible with Dart compiled for the web" href="/dart/packages?runtime=js">js</a>
+              </div>
             </div>
             <div class="packages-api">
               <div class="packages-api-label">API results:</div>
               <details class="packages-api-details packages-api-links">
                 <summary>
-                  <a href="/documentation/foobar_pkg/latest/some/some-library.html">some/some-library.html</a>
+                  <a href="/documentation/oxygen/latest/some/some-library.html">some/some-library.html</a>
                 </summary>
                 <div class="-rest">
-                  <a href="/documentation/foobar_pkg/latest/some/x-class.html">Class X</a>
+                  <a href="/documentation/oxygen/latest/some/x-class.html">Class X</a>
                 </div>
               </details>
             </div>
@@ -258,9 +267,14 @@
           <div class="packages-item">
             <div class="packages-header">
               <h3 class="packages-title">
-                <a href="/packages/foobar_pkg">foobar_pkg</a>
+                <a href="/packages/flutter_titanium">flutter_titanium</a>
               </h3>
-              <a class="packages-scores" href="/packages/foobar_pkg/score">
+              <div class="packages-recent">
+                <img class="packages-recent-icon" src="/static/img/schedule-icon.svg?hash=mocked_hash_164576935" title="new package"/>
+                Added
+                <b>in the last hour</b>
+              </div>
+              <a class="packages-scores" href="/packages/flutter_titanium/score">
                 <div class="packages-score packages-score-like">
                   <div class="packages-score-value -has-value">
                     <span class="packages-score-value-number">0</span>
@@ -269,36 +283,40 @@
                   <div class="packages-score-label">likes</div>
                 </div>
                 <div class="packages-score packages-score-health">
-                  <div class="packages-score-value">
-                    <span class="packages-score-value-number">--</span>
+                  <div class="packages-score-value -has-value">
+                    <span class="packages-score-value-number">24</span>
                     <span class="packages-score-value-sign"></span>
                   </div>
                   <div class="packages-score-label">pub points</div>
                 </div>
                 <div class="packages-score packages-score-popularity">
-                  <div class="packages-score-value">
-                    <span class="packages-score-value-number">--</span>
+                  <div class="packages-score-value -has-value">
+                    <span class="packages-score-value-number">43</span>
                     <span class="packages-score-value-sign">%</span>
                   </div>
                   <div class="packages-score-label">popularity</div>
                 </div>
               </a>
             </div>
-            <p class="packages-description">my package description</p>
+            <p class="packages-description">flutter_titanium is awesome</p>
             <p class="packages-metadata">
               <span class="packages-metadata-block">
                 v
-                <a href="/packages/foobar_pkg">0.1.1+5</a>
-                /
-                <a href="/packages/foobar_pkg/versions/0.2.0-dev">0.2.0-dev</a>
+                <a href="/packages/flutter_titanium">1.10.0</a>
                 • Updated:
-                <span>Jan 1, 2015</span>
+                <span>%%oxygen-created-date%%</span>
               </span>
             </p>
             <div>
               <div class="-pub-tag-badge">
+                <a class="tag-badge-main" title="Packages compatible with Dart SDK" href="/dart/packages">Dart</a>
+                <a class="tag-badge-sub" title="Packages compatible with Dart running on a native platform (JIT/AOT)" href="/dart/packages?runtime=native">native</a>
+                <a class="tag-badge-sub" title="Packages compatible with Dart compiled for the web" href="/dart/packages?runtime=js">js</a>
+              </div>
+              <div class="-pub-tag-badge">
                 <a class="tag-badge-main" title="Packages compatible with Flutter SDK" href="/flutter/packages">Flutter</a>
                 <a class="tag-badge-sub" title="Packages compatible with Flutter on the Android platform" href="/flutter/packages?platform=android">Android</a>
+                <a class="tag-badge-sub" title="Packages compatible with Flutter on the macOS platform" href="/flutter/packages?platform=macos">macOS</a>
               </div>
             </div>
           </div>


### PR DESCRIPTION
- Instead of using the hand-made objects, the tests are now using object that are created by our backends (including user sessions).
- Tried to keep the diversity of the tests (e.g. in one case no fake analysis is done), which may be more prominent in the remaining tests that need migration.
