### PR TITLE
Limit dartdoc output to 2GiB and 10M files.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ AppEngine version, listed here to ease deployment and troubleshooting.
  * NOTE: added `PackageVersion.isRetracted`.
          TODO(deferred): make it required, add to integrity checks.
  * NOTE: added weekly (versioned) periodic task: `backfill-new-fields`.
+ * Limit `pkg/pub_dartdoc` output to 2 GiB and 10M files.
 
 ## `20210722t120000-all`
  * Bumped runtimeVersion to `2021.07.21`.

--- a/pkg/pub_dartdoc/bin/pub_dartdoc.dart
+++ b/pkg/pub_dartdoc/bin/pub_dartdoc.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:io';
+
 import 'package:dartdoc/dartdoc.dart';
 import 'package:dartdoc/options.dart';
 
@@ -31,4 +33,6 @@ Future<void> main(List<String> arguments) async {
   final pubDataGenerator =
       PubDataGenerator(config.inputDir, config.resourceProvider);
   pubDataGenerator.generate(results.packageGraph, config.output);
+
+  print('Max memory use: ${ProcessInfo.maxRss}');
 }

--- a/pkg/pub_dartdoc/bin/pub_dartdoc.dart
+++ b/pkg/pub_dartdoc/bin/pub_dartdoc.dart
@@ -6,16 +6,23 @@ import 'package:dartdoc/dartdoc.dart';
 import 'package:dartdoc/options.dart';
 
 import 'package:pub_dartdoc/pub_data_generator.dart';
+import 'package:pub_dartdoc/src/pub_hooks.dart';
 
 Future<void> main(List<String> arguments) async {
-  final config = await parseOptions(pubPackageMetaProvider, arguments);
+// pub hooks
+  final pubResourceProvider =
+      PubResourceProvider(pubPackageMetaProvider.resourceProvider);
+  final pubMetaProvider =
+      PubPackageMetaProvider(pubPackageMetaProvider, pubResourceProvider);
+
+  final config = await parseOptions(pubMetaProvider, arguments);
   if (config == null) {
     throw ArgumentError();
   }
 
   final packageConfigProvider = PhysicalPackageConfigProvider();
   final packageBuilder =
-      PubPackageBuilder(config, pubPackageMetaProvider, packageConfigProvider);
+      PubPackageBuilder(config, pubMetaProvider, packageConfigProvider);
   final dartdoc = config.generateDocs
       ? await Dartdoc.fromContext(config, packageBuilder)
       : await Dartdoc.withEmptyGenerator(config, packageBuilder);

--- a/pkg/pub_dartdoc/lib/src/pub_hooks.dart
+++ b/pkg/pub_dartdoc/lib/src/pub_hooks.dart
@@ -17,8 +17,8 @@ import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 import 'package:watcher/watcher.dart';
 
-const _maxFileCount = 10000;
-const _maxTotalLengthBytes = 10 * 1024 * 1024;
+const _defaultMaxFileCount = 10 * 1000 * 1000; // 10 million files
+const _defaultMaxTotalLengthBytes = 2 * 1024 * 1024 * 1024; // 2 GiB
 
 /// Creates an overlay file system with binary file support on top
 /// of the input sources.
@@ -28,12 +28,20 @@ const _maxTotalLengthBytes = 10 * 1024 * 1024;
 class PubResourceProvider implements ResourceProvider {
   final ResourceProvider _defaultProvider;
   final _memoryResourceProvider = MemoryResourceProvider();
+  final int _maxFileCount;
+  final int _maxTotalLengthBytes;
   bool _isSdkDocs = false;
   String _outputPath;
   int _fileCount = 0;
   int _totalLengthBytes = 0;
 
-  PubResourceProvider(this._defaultProvider);
+  PubResourceProvider(
+    this._defaultProvider, {
+    int maxFileCount,
+    int maxTotalLengthBytes,
+  })  : _maxFileCount = maxFileCount ?? _defaultMaxFileCount,
+        _maxTotalLengthBytes =
+            maxTotalLengthBytes ?? _defaultMaxTotalLengthBytes;
 
   /// Writes in-memory files to disk.
   void writeFilesToDiskSync() {

--- a/pkg/pub_dartdoc/lib/src/pub_hooks.dart
+++ b/pkg/pub_dartdoc/lib/src/pub_hooks.dart
@@ -20,6 +20,15 @@ import 'package:watcher/watcher.dart';
 const _defaultMaxFileCount = 10 * 1000 * 1000; // 10 million files
 const _defaultMaxTotalLengthBytes = 2 * 1024 * 1024 * 1024; // 2 GiB
 
+/// Thrown when current output exceeds limits.
+class DocumentationTooBigException implements Exception {
+  final String _message;
+  DocumentationTooBigException(this._message);
+
+  @override
+  String toString() => _message;
+}
+
 /// Creates an overlay file system with binary file support on top
 /// of the input sources.
 ///
@@ -69,11 +78,11 @@ class PubResourceProvider implements ResourceProvider {
       return;
     }
     if (_fileCount > _maxFileCount) {
-      throw AssertionError(
+      throw DocumentationTooBigException(
           'Reached $_maxFileCount files in the output directory.');
     }
     if (_totalLengthBytes > _maxTotalLengthBytes) {
-      throw AssertionError(
+      throw DocumentationTooBigException(
           'Reached $_maxTotalLengthBytes bytes in the output directory.');
     }
   }

--- a/pkg/pub_dartdoc/test/file_limit_test.dart
+++ b/pkg/pub_dartdoc/test/file_limit_test.dart
@@ -9,9 +9,10 @@ import 'package:pub_dartdoc/src/pub_hooks.dart';
 
 void main() {
   test('limit number of files', () {
-    final provider = PubResourceProvider(MemoryResourceProvider());
+    final provider =
+        PubResourceProvider(MemoryResourceProvider(), maxFileCount: 1000);
 
-    for (var i = 0; i < 10000; i++) {
+    for (var i = 0; i < 1000; i++) {
       provider.getFile('/tmp/$i.txt').writeAsStringSync('x');
     }
 
@@ -20,10 +21,9 @@ void main() {
   });
 
   test('limit total bytes', () {
-    final provider = PubResourceProvider(MemoryResourceProvider());
-    provider
-        .getFile('/tmp/1')
-        .writeAsBytesSync(List<int>.filled(10 * 1024 * 1024, 0));
+    final provider = PubResourceProvider(MemoryResourceProvider(),
+        maxTotalLengthBytes: 1024);
+    provider.getFile('/tmp/1').writeAsBytesSync(List<int>.filled(1024, 0));
     expect(() => provider.getFile('/tmp/2').writeAsBytesSync(<int>[0]),
         throwsA(isA<AssertionError>()));
   });

--- a/pkg/pub_dartdoc/test/file_limit_test.dart
+++ b/pkg/pub_dartdoc/test/file_limit_test.dart
@@ -17,7 +17,7 @@ void main() {
     }
 
     expect(() => provider.getFile('/tmp/next.txt').writeAsStringSync('next'),
-        throwsA(isA<AssertionError>()));
+        throwsA(isA<DocumentationTooBigException>()));
   });
 
   test('limit total bytes', () {
@@ -25,6 +25,6 @@ void main() {
         maxTotalLengthBytes: 1024);
     provider.getFile('/tmp/1').writeAsBytesSync(List<int>.filled(1024, 0));
     expect(() => provider.getFile('/tmp/2').writeAsBytesSync(<int>[0]),
-        throwsA(isA<AssertionError>()));
+        throwsA(isA<DocumentationTooBigException>()));
   });
 }


### PR DESCRIPTION
Follow-up to experimenting with #4807.