### PR TITLE
Prepare dartdoc customizer to recieve external config.

### DIFF
--- a/app/lib/dartdoc/customizer_config_provider.dart
+++ b/app/lib/dartdoc/customizer_config_provider.dart
@@ -1,0 +1,32 @@
+// Copyright (c) 2021, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import '../frontend/static_files.dart';
+import '../shared/urls.dart';
+
+import 'customization.dart';
+
+/// Returns the customizer config, extended with the current runtime's data.
+DartdocCustomizerConfig customizerConfig({
+  required String packageName,
+  required String packageVersion,
+  required bool isLatestStable,
+}) {
+  return DartdocCustomizerConfig(
+    packageName: packageName,
+    packageVersion: packageVersion,
+    isLatestStable: isLatestStable,
+    docRootUrl: isLatestStable
+        ? pkgDocUrl(packageName, isLatest: true)
+        : pkgDocUrl(packageName, version: packageVersion),
+    latestStableDocumentationUrl: pkgDocUrl(packageName, isLatest: true),
+    pubPackagePageUrl: pkgPageUrl(packageName,
+        version: isLatestStable ? null : packageVersion),
+    dartLogoSvgUrl: staticUrls.dartLogoSvg,
+    githubMarkdownCssUrl: staticUrls.githubMarkdownCss,
+    gtmJsUrl: staticUrls.gtmJs,
+    trustedTargetHosts: trustedTargetHost,
+    trustedUrlSchemes: trustedUrlSchemes,
+  );
+}

--- a/app/lib/dartdoc/dartdoc_runner.dart
+++ b/app/lib/dartdoc/dartdoc_runner.dart
@@ -29,6 +29,7 @@ import '../shared/versions.dart' as versions;
 
 import 'backend.dart';
 import 'customization.dart';
+import 'customizer_config_provider.dart';
 import 'dartdoc_options.dart';
 import 'models.dart';
 
@@ -292,9 +293,11 @@ class DartdocJobProcessor extends JobProcessor {
 
           if (hasContent) {
             try {
-              await DartdocCustomizer(
-                      job.packageName!, job.packageVersion!, job.isLatestStable)
-                  .customizeDir(outputDir);
+              await DartdocCustomizer(customizerConfig(
+                packageName: job.packageName!,
+                packageVersion: job.packageVersion!,
+                isLatestStable: job.isLatestStable,
+              )).customizeDir(outputDir);
               logFileOutput.write('Content customization completed.\n\n');
             } catch (e, st) {
               // Do not block on customization failure.

--- a/app/lib/shared/urls.dart
+++ b/app/lib/shared/urls.dart
@@ -16,10 +16,10 @@ const httpsApiDartDev = 'https://api.dart.dev/';
 
 /// URI schemes that are trusted and can be rendered. Other URI schemes must be
 /// rejected and the URL mustn't be displayed.
-const _trustedSchemes = <String>['http', 'https', 'mailto'];
+const trustedUrlSchemes = <String>['http', 'https', 'mailto'];
 
 /// Hostnames that are trusted in user-generated content (and don't get rel="ugc").
-const _trustedTargetHost = [
+const trustedTargetHost = [
   'api.dart.dev',
   'api.flutter.dev',
   'dart.dev',
@@ -330,13 +330,13 @@ Uri? parseValidUrl(String? url) {
 
 extension UriExt on Uri {
   /// The [scheme] of the [Uri] is trusted, it may be displayed.
-  bool get isTrustedScheme => _trustedSchemes.contains(scheme);
+  bool get isTrustedScheme => trustedUrlSchemes.contains(scheme);
 
   /// Whether the [Uri] has an untrusted or incompatible structure.
   bool get isInvalid => hasScheme && !isTrustedScheme;
 
   /// The host of the link is trusted, it is unlikely to be a spam.
-  bool get isTrustedHost => _trustedTargetHost.contains(host);
+  bool get isTrustedHost => trustedTargetHost.contains(host);
 
   /// Whether on rendering we should emit rel="ugc".
   bool get shouldIndicateUgc => host.isNotEmpty && !isTrustedHost;

--- a/app/test/dartdoc/customization_test.dart
+++ b/app/test/dartdoc/customization_test.dart
@@ -10,6 +10,7 @@ import 'package:test/test.dart';
 import 'package:xml/xml.dart';
 
 import 'package:pub_dev/dartdoc/customization.dart';
+import 'package:pub_dev/dartdoc/customizer_config_provider.dart';
 import 'package:pub_dev/frontend/static_files.dart';
 import 'package:pub_validations/html/html_validation.dart';
 
@@ -48,8 +49,16 @@ void main() {
 
   void expectMatch(String package, String version, String name) {
     test('Match $package $version $name', () {
-      final prevCustomizer = DartdocCustomizer(package, version, false);
-      final latestCustomizer = DartdocCustomizer(package, version, true);
+      final prevCustomizer = DartdocCustomizer(customizerConfig(
+        packageName: package,
+        packageVersion: version,
+        isLatestStable: false,
+      ));
+      final latestCustomizer = DartdocCustomizer(customizerConfig(
+        packageName: package,
+        packageVersion: version,
+        isLatestStable: true,
+      ));
 
       final path = '${package}_${version}_$name';
       final inputName = '$path.html';


### PR DESCRIPTION
- #4807
- In the next step, we'll need to move the `DartdocCustomizer` to `pkg/pub_dartdoc`, and need to remove the tight dependencies on the `app/lib` codebase. I'm planning to pass the `DartdocCustomizerConfig` object as a file to the `pkg/pub_dartdoc` process.