### PR TITLE
Updated integrity checks.

### DIFF
--- a/app/bin/tools/check_integrity.dart
+++ b/app/bin/tools/check_integrity.dart
@@ -33,7 +33,7 @@ Future main(List<String> args) async {
 
   await withToolRuntime(() async {
     final checker = IntegrityChecker(dbService, concurrency: concurrency);
-    final problems = await checker.check();
+    final problems = await checker.check().toList();
     print('\nProblems detected: ${problems.length}\n');
     for (String line in problems) {
       print(line);

--- a/app/lib/shared/integrity.dart
+++ b/app/lib/shared/integrity.dart
@@ -399,9 +399,10 @@ class IntegrityChecker {
       }
 
       final userId = like.userId!;
-      if (!_userToOauth.keys.contains(userId) ||
-          _deletedUsers.contains(userId)) {
-        yield 'Like entity with nonexisting or deleted user "$userId".';
+      if (!_userToOauth.keys.contains(userId)) {
+        yield 'Like entity with nonexisting user "$userId".';
+      } else if (_deletedUsers.contains(userId)) {
+         yield 'Like entity with deleted user "$userId".';
       }
 
       if (await _packageMissing(like.package!)) {

--- a/app/lib/shared/integrity.dart
+++ b/app/lib/shared/integrity.dart
@@ -20,7 +20,7 @@ class IntegrityChecker {
   final DatastoreDB _db;
   final int _concurrency;
 
-  final _userToOauth = <String, String>{};
+  final _userToOauth = <String, String?>{};
   final _oauthToUser = <String, String>{};
   final _deletedUsers = <String>{};
   final _invalidUsers = <String>{};
@@ -51,9 +51,7 @@ class IntegrityChecker {
     _logger.info('Scanning Users...');
     final gmailComEmails = <String>{};
     await for (User user in _db.query<User>().run()) {
-      if (user.oauthUserId != null) {
-        _userToOauth[user.userId!] = user.oauthUserId!;
-      }
+      _userToOauth[user.userId!] = user.oauthUserId;
       final email = user.email;
       if (email == null || email.isEmpty || !looksLikeEmail(email)) {
         yield 'User "${user.userId}" has invalid email: "${user.email}".';

--- a/app/lib/shared/integrity.dart
+++ b/app/lib/shared/integrity.dart
@@ -392,7 +392,7 @@ class IntegrityChecker {
     await for (final like in _db.query<Like>().run()) {
       if (like.packageName == null) {
         yield 'Like entity for user "${like.userId}" and package "${like.package}" has a '
-            '`packageName` property which is not at string.';
+            '`packageName` property which is not a string.';
       } else if (like.packageName != like.package) {
         yield 'Like entity for user "${like.userId}" and package "${like.package}"'
             ' has a `packageName` property which is not the same as `package`/`id`.';

--- a/app/lib/shared/integrity.dart
+++ b/app/lib/shared/integrity.dart
@@ -401,8 +401,9 @@ class IntegrityChecker {
       final userId = like.userId!;
       if (!_userToOauth.keys.contains(userId)) {
         yield 'Like entity with nonexisting user "$userId".';
-      } else if (_deletedUsers.contains(userId)) {
-         yield 'Like entity with deleted user "$userId".';
+      }
+      if (_deletedUsers.contains(userId)) {
+        yield 'Like entity with deleted user "$userId".';
       }
 
       if (await _packageMissing(like.package!)) {

--- a/app/lib/shared/integrity.dart
+++ b/app/lib/shared/integrity.dart
@@ -19,20 +19,16 @@ final _logger = Logger('integrity.check');
 class IntegrityChecker {
   final DatastoreDB _db;
   final int _concurrency;
-  final _problems = <String>[];
 
-  final _userToOauth = <String?, String?>{};
-  final _oauthToUser = <String?, String?>{};
-  final _emailToUser = <String?, List<String?>>{};
-  final _deletedUsers = <String?>{};
-  final _invalidUsers = <String?>{};
-  final _userToLikes = <String?, List<String?>>{};
-  final _packages = <String?>{};
-  final _packageReplacedBys = <String?, String?>{};
-  final _packagesWithVersion = <String?>{};
-  final _moderatedPackages = <String?>{};
-  final _publishers = <String?>{};
-  final _publishersAbandoned = <String?>{};
+  final _userToOauth = <String, String>{};
+  final _oauthToUser = <String, String>{};
+  final _deletedUsers = <String>{};
+  final _invalidUsers = <String>{};
+  final _packages = <String>{};
+  final _packageReplacedBys = <String, String>{};
+  final _packagesWithVersion = <String>{};
+  final _publishers = <String>{};
+  final _publishersAbandoned = <String>{};
   int _packageChecked = 0;
   int _versionChecked = 0;
 
@@ -40,76 +36,71 @@ class IntegrityChecker {
       : _concurrency = concurrency ?? 1;
 
   /// Runs integrity checks, and reports the list of problems.
-  Future<List<String>> check() async {
-    await _checkUsers();
-    await _checkOAuthUserIDs();
-    await _checkPublishers();
-    await _checkPublisherMembers();
-    await _checkPackages();
-    await _checkVersions();
-    await _checkLikes();
-    await _checkModeratedPackages();
-    return _problems;
+  Stream<String> check() async* {
+    yield* _checkUsers();
+    yield* _checkOAuthUserIDs();
+    yield* _checkPublishers();
+    yield* _checkPublisherMembers();
+    yield* _checkPackages();
+    yield* _checkVersions();
+    yield* _checkLikes();
+    yield* _checkModeratedPackages();
   }
 
-  Future<void> _checkUsers() async {
+  Stream<String> _checkUsers() async* {
     _logger.info('Scanning Users...');
+    final gmailComEmails = <String>{};
     await for (User user in _db.query<User>().run()) {
-      _userToOauth[user.userId] = user.oauthUserId;
-      if (user.email == null ||
-          user.email!.isEmpty ||
-          !looksLikeEmail(user.email)) {
-        _problems.add('User(${user.userId}) has invalid email: ${user.email}');
-        _invalidUsers.add(user.userId);
+      if (user.oauthUserId != null) {
+        _userToOauth[user.userId!] = user.oauthUserId!;
       }
-      if (user.email != null && user.email!.isNotEmpty) {
-        _emailToUser.putIfAbsent(user.email, () => []).add(user.userId);
+      final email = user.email;
+      if (email == null || email.isEmpty || !looksLikeEmail(email)) {
+        yield 'User "${user.userId}" has invalid email: "${user.email}".';
+        _invalidUsers.add(user.userId!);
       }
+
+      // We can have email addresses that have multiple account (also User and
+      // OAuthUserId entities), because at one point they have closed their account,
+      // and somebody (maybe the same person) later re-created one with the given email.
+      //
+      // This is considered normal for non-gmail.com accounts, but should be impossible
+      // for gmail.com accounts, as they cannot be recreated.
+      if (email != null &&
+          email.endsWith('@gmail.com') &&
+          !gmailComEmails.add(email)) {
+        yield 'Email address "$email" is present at "${user.userId}" and another Users.';
+      }
+
       if (user.isDeleted is! bool) {
-        _problems.add(
-            'User(${user.userId}) has a `isDeleted` property which is not a bool.');
+        yield 'User "${user.userId}" has an `isDeleted` property which is not a bool.';
       }
       if (user.isBlocked is! bool) {
-        _problems.add(
-            'User(${user.userId}) has a `isBlocked` property which is not a bool.');
+        yield 'User "${user.userId}" has an `isBlocked` property which is not a bool.';
       }
       if (user.isDeleted) {
-        _deletedUsers.add(user.userId);
+        _deletedUsers.add(user.userId!);
         if (user.oauthUserId != null) {
-          _problems.add(
-              'User(${user.userId}) is deleted, but oauthUserId is still set.');
+          yield 'User "${user.userId}" is deleted, but `oauthUserId` is still set.';
         }
         if (user.created != null) {
-          _problems.add(
-              'User(${user.userId}) is deleted, but created time is still set.');
+          yield 'User "${user.userId}" is deleted, but `created` time is still set.';
         }
       }
-    }
-    int badEmailToUserMappingCount = 0;
-    _emailToUser.forEach((email, userIds) {
-      if (userIds.length > 1) {
-        badEmailToUserMappingCount++;
-        _problems.add(
-            'Email address $email is present at ${userIds.length} User: ${userIds.join(', ')}');
-      }
-    });
-    if (badEmailToUserMappingCount > 0) {
-      _problems.add(
-          '$badEmailToUserMappingCount email addresses have more than one User entity.');
     }
   }
 
-  Future<void> _checkOAuthUserIDs() async {
+  Stream<String> _checkOAuthUserIDs() async* {
     _logger.info('Scanning OAuthUserIDs...');
     await for (OAuthUserID mapping in _db.query<OAuthUserID>().run()) {
       if (mapping.userIdKey == null) {
-        _problems
-            .add('OAuthUserID(${mapping.oauthUserId}) has invalid userId.');
+        yield 'OAuthUserID "${mapping.oauthUserId}" has invalid `userId`.';
+      } else {
+        _oauthToUser[mapping.oauthUserId!] = mapping.userId;
       }
-      _oauthToUser[mapping.oauthUserId] = mapping.userId;
     }
 
-    for (String? userId in _userToOauth.keys) {
+    for (final userId in _userToOauth.keys) {
       final oauthUserId = _userToOauth[userId];
       // Migrated users without login are OK.
       if (oauthUserId == null) {
@@ -117,198 +108,179 @@ class IntegrityChecker {
       }
       final pointer = _oauthToUser[oauthUserId];
       if (pointer == null) {
-        _problems.add(
-            'User($userId) points to OAuthUserID($oauthUserId) but has no mapping.');
+        yield 'User "$userId" points to OAuthUserID "$oauthUserId" but has no mapping.';
       } else if (pointer != userId) {
-        _problems.add(
-            'User($userId) points to OAuthUserID($oauthUserId) but it points to a different one ($pointer).');
+        yield 'User "$userId" points to OAuthUserID "$oauthUserId" but it points to a different one ("$pointer").';
       }
     }
 
-    for (String? oauthUserId in _oauthToUser.keys) {
+    for (final oauthUserId in _oauthToUser.keys) {
       final userId = _oauthToUser[oauthUserId];
       if (userId == null) {
-        _problems.add('OAuthUserID($oauthUserId) has no user.');
+        yield 'OAuthUserID "$oauthUserId" has no User.';
       }
       final pointer = _userToOauth[userId];
       if (pointer == null) {
-        _problems.add(
-            'User($userId) is mapped from OAuthUserID($oauthUserId), but does not have it set.');
+        yield 'User "$userId" is mapped from OAuthUserID "$oauthUserId", but does not have it set.';
       } else if (pointer != oauthUserId) {
-        _problems.add(
-            'User($userId) is mapped from OAuthUserID($oauthUserId), but points to a different one ($pointer).');
+        yield 'User "$userId" is mapped from OAuthUserID "$oauthUserId", but points to a different one ("$pointer").';
       }
     }
   }
 
-  Future<void> _checkPublishers() async {
+  Stream<String> _checkPublishers() async* {
     _logger.info('Scanning Publishers...');
     await for (final p in _db.query<Publisher>().run()) {
-      _publishers.add(p.publisherId);
+      _publishers.add(p.publisherId!);
       final members =
           await _db.query<PublisherMember>(ancestorKey: p.key).run().toList();
       if (p.isAbandoned!) {
-        _publishersAbandoned.add(p.publisherId);
+        _publishersAbandoned.add(p.publisherId!);
         if (members.isNotEmpty) {
-          _problems.add('Publisher(${p.publisherId}) is marked as abandoned, '
-              'but has members (first: ${members.first.userId}).');
+          yield 'Publisher "${p.publisherId}" is marked as abandoned, '
+              'but has members (first: "${members.first.userId}").';
         }
         if (members.isEmpty && p.contactEmail != null) {
-          _problems.add(
-              'Publisher(${p.publisherId}) is marked as abandoned, has no members, '
-              'but still has contact email (${p.contactEmail}).');
+          yield 'Publisher "${p.publisherId}" is marked as abandoned, has no members, '
+              'but still has contact email ("${p.contactEmail}").';
         }
       } else {
         if (members.isEmpty) {
-          _problems.add(
-              'Publisher(${p.publisherId}) is not marked as abandoned, but has no members.');
+          yield 'Publisher "${p.publisherId}" has no members, but it is not marked as abandoned.';
         }
       }
     }
   }
 
-  Future<void> _checkPublisherMembers() async {
+  Stream<String> _checkPublisherMembers() async* {
     _logger.info('Scanning PublisherMembers...');
     await for (final pm in _db.query<PublisherMember>().run()) {
       if (pm.id != pm.userId) {
-        _problems.add(
-            'PublisherMember(${pm.id}) has bad userId value: ${pm.userId}.');
+        yield 'PublisherMember "${pm.id}" has bad `userId` value: "${pm.userId}".';
       }
       if (!_publishers.contains(pm.publisherId)) {
-        _problems.add(
-            'PublisherMember(${pm.userId}) references a non-existing publisher: ${pm.publisherId}.');
+        yield 'PublisherMember "${pm.userId}" references a non-existing `publisherId`: "${pm.publisherId}".';
       }
       if (_deletedUsers.contains(pm.userId)) {
-        _problems.add(
-            'PublisherMember(${pm.publisherId} / ${pm.userId}) references a deleted User.');
+        yield 'PublisherMember "${pm.publisherId}" / "${pm.userId}" references a deleted User.';
       }
       if (!_userToOauth.containsKey(pm.userId)) {
-        _problems.add(
-            'PublisherMember(${pm.publisherId} / ${pm.userId}) references a non-existing User.');
+        yield 'PublisherMember "${pm.publisherId}" / "${pm.userId}" references a non-existing User.';
       }
     }
   }
 
-  Future<void> _checkPackages() async {
+  Stream<String> _checkPackages() async* {
     _logger.info('Scanning Packages...');
     final pool = Pool(_concurrency);
-    final futures = <Future>[];
+    final futures = <Future<List<String>>>[];
     await for (Package p in _db.query<Package>().run()) {
-      final f = pool.withResource(() => _checkPackage(p));
+      final f = pool.withResource(() => _checkPackage(p).toList());
       futures.add(f);
     }
-    await Future.wait(futures);
+    for (final f in futures) {
+      for (final item in await f) {
+        yield item;
+      }
+    }
     await pool.close();
 
     for (final r in _packageReplacedBys.entries) {
-      if (!_packages.contains(r.value)) {
-        _problems.add(
-            'Package(${r.key}) has a `replacedBy` property with missing package ("${r.value}").');
+      if (await _packageMissing(r.value)) {
+        yield 'Package "${r.key}" has a `replacedBy` property with missing package "${r.value}".';
       }
     }
   }
 
-  Future<void> _checkPackage(Package p) async {
-    _packages.add(p.name);
+  Stream<String> _checkPackage(Package p) async* {
+    if (p.name == null) {
+      yield 'Package "${p.id}" has a `name` property which is null.';
+    } else if (p.name != p.id) {
+      yield 'Package "${p.id}" has a `name` property which is not the same as the id.';
+    } else {
+      _packages.add(p.name!);
+    }
     if (p.replacedBy != null) {
-      _packageReplacedBys[p.name] = p.replacedBy;
+      _packageReplacedBys[p.name!] = p.replacedBy!;
 
       if (!p.isDiscontinued) {
-        _problems.add(
-            'Package(${p.name}) has a `replacedBy` property without being `isDiscontinued`.');
+        yield 'Package "${p.name}" has a `replacedBy` property without being `isDiscontinued`.';
       }
     }
     // empty uploaders
     if (p.uploaders == null || p.uploaders!.isEmpty) {
       // no publisher
       if (p.publisherId == null && !p.isDiscontinued) {
-        _problems.add(
-            'Package(${p.name}) has no uploaders, must be marked discontinued.');
+        yield 'Package "${p.name}" has no uploaders, must be marked discontinued.';
       }
 
       if (p.publisherId != null &&
           _publishersAbandoned.contains(p.publisherId) &&
           !p.isDiscontinued) {
-        _problems.add(
-            'Package(${p.name}) has an anandoned publisher, must be marked discontinued.');
+        yield 'Package "${p.name}" has an abandoned publisher, must be marked discontinued.';
       }
     }
     if (p.assignedTags == null || p.assignedTags is! List<String>) {
-      _problems.add(
-          'Package(${p.name}) has an `assignedTags` property which is not a list.');
+      yield 'Package "${p.name}" has an `assignedTags` property which is not a list.';
     }
     final assignedTags = p.assignedTags ?? <String>[];
     for (final tag in assignedTags) {
       if (!allowedTagPrefixes.any(tag.startsWith)) {
-        _problems.add(
-            'Package(${p.name}) have assigned tag `$tag` in `assignedTags` '
-            'property, which is not allowed.');
+        yield 'Package "${p.name}" has assigned tag "$tag" in `assignedTags` '
+            'property, which is not allowed.';
       }
     }
     if (assignedTags.length != assignedTags.toSet().length) {
-      _problems.add(
-          'Package(${p.name}) has an `assignedTags` property which contains duplicates.');
+      yield 'Package "${p.name}" has an `assignedTags` property which contains duplicates.';
     }
     if (p.likes is! int || p.likes < 0) {
-      _problems.add(
-          'Package(${p.name}) has a `likes` property which is not a non-negative integer.');
+      yield 'Package "${p.name}" has a `likes` property which is not a non-negative integer.';
     }
     if (p.isDiscontinued is! bool) {
-      _problems.add(
-          'Package(${p.name}) has a `isDiscontinued` property which is not a bool.');
+      yield 'Package "${p.name}" has an `isDiscontinued` property which is not a bool.';
     }
     if (p.isUnlisted is! bool) {
-      _problems.add(
-          'Package(${p.name}) has a `isUnlisted` property which is not a bool.');
+      yield 'Package "${p.name}" has an `isUnlisted` property which is not a bool.';
     }
     if (p.isWithheld is! bool) {
-      _problems.add(
-          'Package(${p.name}) has a `isWithheld` property which is not a bool.');
+      yield 'Package "${p.name}" has an `isWithheld` property which is not a bool.';
     }
     for (String? userId in p.uploaders!) {
       if (!_userToOauth.containsKey(userId)) {
-        _problems.add('Package(${p.name}) has uploader without User: $userId');
+        yield 'Package "${p.name}" has uploader without User: "$userId".';
       }
       if (_invalidUsers.contains(userId)) {
-        _problems.add('Package(${p.name}) has invalid uploader: User($userId)');
+        yield 'Package "${p.name}" has invalid uploader: "$userId".';
       }
     }
     final versionKeys = <Key>{};
     final qualifiedVersionKeys = <QualifiedVersionKey>{};
-    await for (PackageVersion pv
+    await for (final pv
         in _db.query<PackageVersion>(ancestorKey: p.key).run()) {
       versionKeys.add(pv.key);
       qualifiedVersionKeys.add(pv.qualifiedVersionKey);
       if (pv.uploader == null) {
-        _problems.add(
-            'PackageVersion(${pv.package} ${pv.version}) has no uploader.');
+        yield 'PackageVersion "${pv.qualifiedVersionKey}" has no uploader.';
       }
       if (!_userToOauth.containsKey(pv.uploader)) {
-        _problems.add(
-            'PackageVersion(${pv.package} ${pv.version}) has uploader without User: ${pv.uploader}');
+        yield 'PackageVersion "${pv.qualifiedVersionKey}" has uploader without User: "${pv.uploader}".';
       }
       if (_invalidUsers.contains(pv.uploader)) {
-        _problems.add(
-            'PackageVersion(${pv.package} ${pv.version}) has invalid uploader: User(${pv.uploader})');
+        yield 'PackageVersion "${pv.qualifiedVersionKey}" has invalid uploader: User "${pv.uploader}".';
       }
     }
     if (p.lastVersionPublished == null) {
-      _problems.add(
-          'Package(${p.name}) has a `lastVersionPublished` property which is null.');
+      yield 'Package "${p.name}" has an `lastVersionPublished` property which is null.';
     }
     if (p.latestVersionKey == null) {
-      _problems.add(
-          'Package(${p.name}) has a `latestVersionKey` property which is null.');
+      yield 'Package "${p.name}" has a `latestVersionKey` property which is null.';
     } else if (!versionKeys.contains(p.latestVersionKey)) {
-      _problems.add(
-          'Package(${p.name}) has missing latestVersionKey: ${p.latestVersionKey!.id}');
+      'Package "${p.name}" has missing `latestVersionKey`: "${p.latestVersionKey!.id}".';
     }
     if (p.latestPrereleaseVersionKey == null) {
-      _problems.add(
-          'Package(${p.name}) has a `latestPrereleaseVersionKey` property which is null.');
+      yield 'Package "${p.name}" has a `latestPrereleaseVersionKey` property which is null.';
     } else if (!versionKeys.contains(p.latestPrereleaseVersionKey)) {
-      _problems.add(
-          'Package(${p.name}) has missing latestPrereleaseVersionKey: ${p.latestPrereleaseVersionKey!.id}');
+      yield 'Package "${p.name}" has missing `latestPrereleaseVersionKey`: "${p.latestPrereleaseVersionKey!.id}".';
     }
 
     // Checking if PackageVersionInfo is referenced by a PackageVersion entity.
@@ -320,19 +292,16 @@ class IntegrityChecker {
       final key = pvi.qualifiedVersionKey;
       pviKeys.add(key);
       if (!qualifiedVersionKeys.contains(key)) {
-        _problems.add('PackageVersionInfo($key) has no PackageVersion.');
+        yield 'PackageVersionInfo "$key" has no PackageVersion.';
       }
       if (pvi.versionCreated == null) {
-        _problems.add(
-            'PackageVersionInfo($key) has a `versionCreated` property which is null.');
+        yield 'PackageVersionInfo "$key" has a `versionCreated` property which is null.';
       }
       if (pvi.updated == null) {
-        _problems.add(
-            'PackageVersionInfo($key) has a `updated` property which is null.');
+        yield 'PackageVersionInfo "$key" has an `updated` property which is null.';
       }
       if (pvi.libraryCount == null) {
-        _problems.add(
-            'PackageVersionInfo($key) has a `libraryCount` property which is null.');
+        yield 'PackageVersionInfo "$key" has a `libraryCount` property which is null.';
       }
       for (final kind in pvi.assets) {
         referencedAssetIds.add(key.assetId(kind));
@@ -340,7 +309,7 @@ class IntegrityChecker {
     }
     for (QualifiedVersionKey key in qualifiedVersionKeys) {
       if (!pviKeys.contains(key)) {
-        _problems.add('PackageVersion($key) has no PackageVersionInfo.');
+        yield 'PackageVersion "$key" has no PackageVersionInfo.';
       }
     }
 
@@ -352,25 +321,23 @@ class IntegrityChecker {
       final key = pva.qualifiedVersionKey;
       if (pva.id !=
           Uri(pathSegments: [pva.package!, pva.version!, pva.kind!]).path) {
-        _problems.add('PackageVersionAsset(${pva.id}) uses old id format.');
+        yield 'PackageVersionAsset "${pva.id}" uses old id format.';
         continue;
       }
       if (!qualifiedVersionKeys.contains(key)) {
-        _problems.add('PackageVersionAsset(${pva.id}) has no PackageVersion.');
+        yield 'PackageVersionAsset "${pva.id}" has no PackageVersion.';
       }
       foundAssetIds.add(pva.assetId);
       // check if PackageVersionAsset is referenced in PackageVersionInfo
       if (!referencedAssetIds.contains(pva.assetId)) {
-        _problems.add(
-            'PackageVersionAsset(${pva.id}) is not referenced from PackageVersionInfo.');
+        yield 'PackageVersionAsset "${pva.id}" is not referenced from PackageVersionInfo.';
       }
     }
 
     // check if all of PackageVersionInfo.assets exist
     for (final id in referencedAssetIds) {
       if (!foundAssetIds.contains(id)) {
-        _problems.add(
-            'PackageVersionAsset($id) is referenced from PackageVersionInfo but does not exist.');
+        yield 'PackageVersionAsset "$id" is referenced from PackageVersionInfo but does not exist.';
       }
     }
 
@@ -380,44 +347,39 @@ class IntegrityChecker {
     }
   }
 
-  Future<void> _checkVersions() async {
+  Stream<String> _checkVersions() async* {
     _logger.info('Scanning PackageVersions...');
     await for (PackageVersion pv in _db.query<PackageVersion>().run()) {
-      _checkPackageVersion(pv);
+      yield* _checkPackageVersion(pv);
     }
 
-    _packages
-        .where((package) => !_packagesWithVersion.contains(package))
-        .forEach((package) {
-      _problems.add('Package ($package) has no version.');
-    });
-    _packagesWithVersion
-        .where((package) => !_packages.contains(package))
-        .forEach((package) {
-      _problems.add('Package ($package) is missing.');
-    });
+    for (final package in _packages
+        .where((package) => !_packagesWithVersion.contains(package))) {
+      yield 'Package "$package" has no version.';
+    }
+    for (final package in _packagesWithVersion) {
+      if (await _packageMissing(package)) {
+        yield 'Package "$package" is missing.';
+      }
+    }
   }
 
-  void _checkPackageVersion(PackageVersion pv) {
+  Stream<String> _checkPackageVersion(PackageVersion pv) async* {
     _packagesWithVersion.add(pv.package);
 
     if (pv.uploader == null) {
-      _problems
-          .add('PackageVersion(${pv.qualifiedVersionKey}) has no uploader.');
+      yield 'PackageVersion "${pv.qualifiedVersionKey}" has no uploader.';
     }
 
     // Sanity checks for the `created` property
     if (pv.created == null) {
-      _problems.add(
-          'PackageVersion(${pv.qualifiedVersionKey}) has no `created` property.');
+      yield 'PackageVersion "${pv.qualifiedVersionKey}" has no `created` property.';
     } else if (pv.created!.isAfter(DateTime.now().add(Duration(minutes: 15)))) {
-      // Can't be published in the future (+15 min to allow for clock drift)
-      _problems.add(
-          'PackageVersion(${pv.qualifiedVersionKey}) has `created` > now().');
+      // Can't be published in the future (+15 min to allow for clock drift).
+      yield 'PackageVersion "${pv.qualifiedVersionKey}" has `created` > now().';
     } else if (pv.created!.isBefore(DateTime(2011))) {
-      // Can't be published before Dart was published in 2011
-      _problems.add(
-          'PackageVersion(${pv.qualifiedVersionKey}) has `created` < 2011.');
+      // Can't be published before Dart, which was first published in 2011.
+      yield 'PackageVersion "${pv.qualifiedVersionKey}" has `created` < 2011.';
     }
 
     _versionChecked++;
@@ -426,50 +388,45 @@ class IntegrityChecker {
     }
   }
 
-  Future<void> _checkLikes() async {
+  Stream<String> _checkLikes() async* {
     _logger.info('Scanning Likes...');
 
-    await for (Like like in _db.query<Like>().run()) {
+    await for (final like in _db.query<Like>().run()) {
       if (like.packageName == null) {
-        _problems.add(
-            'Like entity for user ${like.userId} and ${like.package} has a '
-            '`packageName` property which is not at string ');
+        yield 'Like entity for user "${like.userId}" and package "${like.package}" has a '
+            '`packageName` property which is not at string.';
       } else if (like.packageName != like.package) {
-        _problems.add('Like entity for user ${like.userId} and ${like.package}'
-            ' has a `packageName` property which is not the same as `package`/id');
+        yield 'Like entity for user "${like.userId}" and package "${like.package}"'
+            ' has a `packageName` property which is not the same as `package`/`id`.';
       }
 
-      _userToLikes.update(like.userId, (l) => l..add(like.package),
-          ifAbsent: () => <String?>[]);
+      final userId = like.userId!;
+      if (!_userToOauth.keys.contains(userId) ||
+          _deletedUsers.contains(userId)) {
+        yield 'Like entity with nonexisting or deleted user "$userId".';
+      }
+
+      if (await _packageMissing(like.package!)) {
+        yield 'User "$userId" likes missing package "${like.package}".';
+      }
     }
-
-    _userToLikes.keys
-        .where((user) =>
-            (!_userToOauth.keys.contains(user) || _deletedUsers.contains(user)))
-        .forEach((user) {
-      _problems.add('Like entity with nonexisting or deleted user $user');
-    });
-
-    _userToLikes.keys.forEach((user) {
-      _userToLikes[user]!
-          .where((String? package) => !_packages.contains(package))
-          .forEach((package) {
-        _problems.add('User $user likes missing package $package');
-      });
-    });
   }
 
-  Future<void> _checkModeratedPackages() async {
+  Stream<String> _checkModeratedPackages() async* {
     _logger.info('Scanning ModeratedPackages...');
 
-    await for (ModeratedPackage pkg in _db.query<ModeratedPackage>().run()) {
-      _moderatedPackages.add(pkg.name);
+    await for (final pkg in _db.query<ModeratedPackage>().run()) {
+      final packageName = pkg.name!;
+      if (await _packageExists(packageName)) {
+        yield 'Moderated package "$packageName" also present in active packages.';
+      }
     }
-
-    _moderatedPackages
-        .where((package) => _packages.contains(package))
-        .forEach((pkg) {
-      _problems.add('Moderated package:$pkg also present in active packages');
-    });
   }
+
+  Future<bool> _packageExists(String packageName) async {
+    return _packages.contains(packageName);
+  }
+
+  Future<bool> _packageMissing(String packageName) async =>
+      !(await _packageExists(packageName));
 }

--- a/app/test/shared/test_services.dart
+++ b/app/test/shared/test_services.dart
@@ -67,7 +67,7 @@ void testWithProfile(
         });
 
         // post-test integrity check
-        final problems = await IntegrityChecker(dbService).check();
+        final problems = await IntegrityChecker(dbService).check().toList();
         if (problems.isNotEmpty) {
           throw Exception(
               '${problems.length} integrity problems detected. First: ${problems.first}');


### PR DESCRIPTION
- Consistency: references between `"` quotes, and sentences end with `.`.
- Removed cached data holders whenever they were unnecessary (reduces memory usage which may be relevant if we are running on a server).
- Updated a few checks, including the one where we are checking the one-to-many relationship between emails and User entities. This is now allowed, except for `@gmail.com` addresses.