### PR TITLE
Partial migration of package infobox templates.

### DIFF
--- a/app/lib/frontend/templates/views/pkg/info_box.dart
+++ b/app/lib/frontend/templates/views/pkg/info_box.dart
@@ -26,19 +26,21 @@ d.Node? dependencyListNode(Map<String, pubspek.Dependency>? dependencies) {
   if (dependencies == null) return null;
   final packages = dependencies.keys.toList()..sort();
   if (packages.isEmpty) return null;
-  return d.fragment(
-    packages.expand((p) {
-      final dep = dependencies[p];
-      var href = redirectPackageUrls[p];
-      String? constraint;
-      if (href == null && dep is pubspek.HostedDependency) {
-        href = urls.pkgPageUrl(p);
-        constraint = dep.version.toString();
-      }
-      return <d.Node>[
-        d.text(', '),
-        href == null ? d.text(p) : d.a(href: href, title: constraint, text: p),
-      ];
-    }).skip(1), // skips the first comma (', ').
-  );
+  final nodes = <d.Node>[];
+  for (final p in packages) {
+    if (nodes.isNotEmpty) {
+      nodes.add(d.text(', '));
+    }
+    final dep = dependencies[p];
+    var href = redirectPackageUrls[p];
+    String? constraint;
+    if (href == null && dep is pubspek.HostedDependency) {
+      href = urls.pkgPageUrl(p);
+      constraint = dep.version.toString();
+    }
+    final node =
+        href == null ? d.text(p) : d.a(href: href, title: constraint, text: p);
+    nodes.add(node);
+  }
+  return d.fragment(nodes);
 }

--- a/app/lib/frontend/templates/views/pkg/info_box.dart
+++ b/app/lib/frontend/templates/views/pkg/info_box.dart
@@ -1,0 +1,44 @@
+// Copyright (c) 2021, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:pana/models.dart' show LicenseFile;
+import 'package:pubspec_parse/pubspec_parse.dart' as pubspek;
+
+import '../../../../package/overrides.dart' show redirectPackageUrls;
+import '../../../../shared/urls.dart' as urls;
+import '../../../dom/dom.dart' as d;
+
+d.Node? licenseNode({
+  required LicenseFile? licenseFile,
+  required String? licenseUrl,
+}) {
+  if (licenseUrl == null) return null;
+  licenseFile ??= LicenseFile('LICENSE', 'unknown');
+  return d.fragment([
+    d.text('${licenseFile.shortFormatted} ('),
+    d.a(href: licenseUrl, text: licenseFile.path),
+    d.text(')'),
+  ]);
+}
+
+d.Node? dependencyListNode(Map<String, pubspek.Dependency>? dependencies) {
+  if (dependencies == null) return null;
+  final packages = dependencies.keys.toList()..sort();
+  if (packages.isEmpty) return null;
+  return d.fragment(
+    packages.expand((p) {
+      final dep = dependencies[p];
+      var href = redirectPackageUrls[p];
+      String? constraint;
+      if (href == null && dep is pubspek.HostedDependency) {
+        href = urls.pkgPageUrl(p);
+        constraint = dep.version.toString();
+      }
+      return <d.Node>[
+        d.text(', '),
+        href == null ? d.text(p) : d.a(href: href, title: constraint, text: p),
+      ];
+    }).skip(1), // skips the first comma (', ').
+  );
+}

--- a/app/test/frontend/golden/pkg_show_page_discontinued.html
+++ b/app/test/frontend/golden/pkg_show_page_discontinued.html
@@ -238,7 +238,9 @@
             </p>
             <h3 class="title">License</h3>
             <p>
+              unknown (
               <a href="/packages/pkg/license">LICENSE</a>
+              )
             </p>
             <h3 class="title">More</h3>
             <p>
@@ -290,7 +292,9 @@
           </p>
           <h3 class="title">License</h3>
           <p>
+            unknown (
             <a href="/packages/pkg/license">LICENSE</a>
+            )
           </p>
           <h3 class="title">More</h3>
           <p>

--- a/app/test/frontend/golden/pkg_show_page_legacy.html
+++ b/app/test/frontend/golden/pkg_show_page_legacy.html
@@ -252,7 +252,9 @@
             </p>
             <h3 class="title">License</h3>
             <p>
+              unknown (
               <a href="/packages/pkg/license">LICENSE</a>
+              )
             </p>
             <h3 class="title">More</h3>
             <p>
@@ -299,7 +301,9 @@
           </p>
           <h3 class="title">License</h3>
           <p>
+            unknown (
             <a href="/packages/pkg/license">LICENSE</a>
+            )
           </p>
           <h3 class="title">More</h3>
           <p>

--- a/app/test/frontend/golden/pkg_show_page_publisher.html
+++ b/app/test/frontend/golden/pkg_show_page_publisher.html
@@ -245,7 +245,9 @@
             </p>
             <h3 class="title">License</h3>
             <p>
+              unknown (
               <a href="/packages/neon/license">LICENSE</a>
+              )
             </p>
             <h3 class="title">More</h3>
             <p>
@@ -299,7 +301,9 @@
           </p>
           <h3 class="title">License</h3>
           <p>
+            unknown (
             <a href="/packages/neon/license">LICENSE</a>
+            )
           </p>
           <h3 class="title">More</h3>
           <p>


### PR DESCRIPTION
- changes output to always include a formatted license name, or `unknown` if it is not recognized
- moves these parts to `views/pkg/info_box.dart`, which will be also the location of the migrated mustache template