### PR TITLE
Force upgrade package:analyzer.

### DIFF
--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -14,7 +14,7 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "22.0.0"
+    version: "23.0.0"
   _popularity:
     dependency: "direct main"
     description:
@@ -23,12 +23,12 @@ packages:
     source: path
     version: "0.0.0"
   analyzer:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.2"
+    version: "2.0.0"
   api_builder:
     dependency: "direct main"
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -6,6 +6,7 @@ environment:
 dependencies:
   _popularity:
     path: ../pkg/_popularity
+  analyzer: ^2.0.0
   appengine: '^0.13.0'
   args: '^2.0.0'
   basics: ^0.6.0
@@ -68,3 +69,7 @@ dev_dependencies:
   source_gen: '^1.0.0'
   test: ^1.16.5
   xml: ^5.0.0
+
+dependency_overrides:
+  # TODO: remove after the codegen toolchain is upgraded to 2.0.0
+  analyzer: ^2.0.0


### PR DESCRIPTION
I've found two cases where the 1.7.2+22.0.0 versions produced cast exceptions we have in the logs, while the 2.0.0+23.0.0 already fixed it. As in pub-dev only pana is using it in live code (otherwise we use it only in codegen), and pana is already upgraded on CI to use it, I think there is little to no risk for us to upgrade it before the toolchain would allow it.