### PR TITLE
Populate and use PackageDocument.uploaderUserIds for /my-packages.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Important changes to data-models, configuration and migrations between each
 AppEngine version, listed here to ease deployment and troubleshooting.
 
 ## Next Release (replace with git tag when deployed)
+ * Bumped runtimeVersion to `2021.08.16`.
  * NOTE: started to populate and use `PackageDocument.uploaderUserIds`
          TODO(deferred): remove `PackageDocument.uploaderEmails` in a future release
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@ Important changes to data-models, configuration and migrations between each
 AppEngine version, listed here to ease deployment and troubleshooting.
 
 ## Next Release (replace with git tag when deployed)
+ * NOTE: started to populate and use `PackageDocument.uploaderUserIds`
+         TODO(deferred): remove `PackageDocument.uploaderEmails` in a future release
 
 ## `20210812t143400-all`
-
  * Bumped runtimeVersion to `2021.08.12`.
  * Upgraded preview Dart analysis SDK to `2.14.0-377.4.beta`
  * Upgraded preview Flutter analysis SDK to `2.5.0-5.1.pre`.

--- a/app/lib/frontend/handlers/account.dart
+++ b/app/lib/frontend/handlers/account.dart
@@ -214,7 +214,9 @@ Future<shelf.Response> accountPackagesPageHandler(shelf.Request request) async {
   final searchForm = parseFrontendSearchForm(
     request.requestedUri.queryParameters,
     uploaderOrPublishers: [
+      // TODO: remove email after userId is populated in the search index
       userSessionData!.email!,
+      userSessionData!.userId!,
       ...page.publishers!.map((p) => p.publisherId),
     ],
     tagsPredicate: TagsPredicate.allPackages(),

--- a/app/lib/search/backend.dart
+++ b/app/lib/search/backend.dart
@@ -154,6 +154,7 @@ class SearchBackend {
       dependencies: _buildDependencies(pv.pubspec!, scoreCard),
       publisherId: p.publisherId,
       uploaderEmails: await _buildUploaderEmails(p),
+      uploaderUserIds: p.uploaders,
       apiDocPages: apiDocPages,
       timestamp: DateTime.now().toUtc(),
     );
@@ -206,6 +207,7 @@ class SearchBackend {
         maxPoints: 0,
         publisherId: p.publisherId,
         uploaderEmails: await _buildUploaderEmails(p),
+        uploaderUserIds: p.uploaders,
         timestamp: DateTime.now().toUtc(),
       );
     }

--- a/app/lib/search/mem_index.dart
+++ b/app/lib/search/mem_index.dart
@@ -171,6 +171,11 @@ class InMemoryPackageIndex implements PackageIndex {
         if (doc.publisherId != null) {
           return !query.uploaderOrPublishers!.contains(doc.publisherId);
         }
+        if (doc.uploaderUserIds != null &&
+            query.uploaderOrPublishers!.any(doc.uploaderUserIds!.contains)) {
+          return false;
+        }
+
         if (doc.uploaderEmails == null) {
           return true; // turn this into an error in the future.
         }

--- a/app/lib/search/search_service.dart
+++ b/app/lib/search/search_service.dart
@@ -100,7 +100,11 @@ class PackageDocument {
   final String? publisherId;
 
   /// The current uploader emails of the package.
+  /// TODO: remove after the /my-packages query uses userIds instead of emails.
   final List<String>? uploaderEmails;
+
+  /// The current uploader userIds of the package.
+  final List<String>? uploaderUserIds;
 
   final List<ApiDocPage>? apiDocPages;
 
@@ -122,6 +126,7 @@ class PackageDocument {
     this.dependencies = const {},
     this.publisherId,
     this.uploaderEmails = const [],
+    this.uploaderUserIds = const [],
     this.apiDocPages = const [],
     DateTime? timestamp,
   })  : tags = tags ?? const <String>[],

--- a/app/lib/search/search_service.g.dart
+++ b/app/lib/search/search_service.g.dart
@@ -32,6 +32,10 @@ PackageDocument _$PackageDocumentFromJson(Map<String, dynamic> json) =>
               ?.map((e) => e as String)
               .toList() ??
           const [],
+      uploaderUserIds: (json['uploaderUserIds'] as List<dynamic>?)
+              ?.map((e) => e as String)
+              .toList() ??
+          const [],
       apiDocPages: (json['apiDocPages'] as List<dynamic>?)
               ?.map((e) => ApiDocPage.fromJson(e as Map<String, dynamic>))
               .toList() ??
@@ -57,6 +61,7 @@ Map<String, dynamic> _$PackageDocumentToJson(PackageDocument instance) =>
       'dependencies': instance.dependencies,
       'publisherId': instance.publisherId,
       'uploaderEmails': instance.uploaderEmails,
+      'uploaderUserIds': instance.uploaderUserIds,
       'apiDocPages': instance.apiDocPages,
       'timestamp': instance.timestamp.toIso8601String(),
     };

--- a/app/lib/shared/versions.dart
+++ b/app/lib/shared/versions.dart
@@ -21,9 +21,9 @@ final RegExp runtimeVersionPattern = RegExp(r'^\d{4}\.\d{2}\.\d{2}$');
 /// Make sure that at least two versions are kept here as the next candidates
 /// when the version switch happens.
 const acceptedRuntimeVersions = <String>[
-  '2021.08.12', // The current [runtimeVersion].
+  '2021.08.16', // The current [runtimeVersion].
+  '2021.08.12',
   '2021.07.27',
-  '2021.07.21',
 ];
 
 /// Represents a combined version of the overall toolchain and processing,

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -536,7 +536,7 @@ void main() {
             imageUrl: 'pub.dev/user-img-url.png',
           );
           final searchForm =
-              SearchForm.parse(uploaderOrPublishers: [user.email!]);
+              SearchForm.parse(uploaderOrPublishers: [user.userId]);
           final String html = renderAccountPackagesPage(
             user: user,
             userSessionData: session,

--- a/app/test/search/mem_index_test.dart
+++ b/app/test/search/mem_index_test.dart
@@ -32,6 +32,7 @@ void main() {
         maxPoints: 110,
         dependencies: {'async': 'direct', 'test': 'dev', 'foo': 'transitive'},
         uploaderEmails: ['user1@example.com'],
+        uploaderUserIds: ['user1-at-example-dot-com'],
       ));
       await index.addPackage(PackageDocument(
         package: 'async',
@@ -54,6 +55,7 @@ The delegating wrapper classes allow users to easily add functionality on top of
         dependencies: {'test': 'dev'},
         publisherId: 'dart.dev',
         uploaderEmails: ['user1@example.com'],
+        uploaderUserIds: ['user1-at-example-dot-com'],
       ));
       await index.addPackage(PackageDocument(
         package: 'chrome_net',
@@ -449,7 +451,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
       final PackageSearchResult result =
           await index.search(ServiceSearchQuery.parse(uploaderOrPublishers: [
         'dart.dev',
-        'user1@example.com',
+        'user1-at-example-dot-com',
       ]));
       expect(json.decode(json.encode(result)), {
         'timestamp': isNotNull,

--- a/app/test/search/result_combiner_test.dart
+++ b/app/test/search/result_combiner_test.dart
@@ -34,6 +34,7 @@ void main() {
         grantedPoints: 110,
         maxPoints: 110,
         uploaderEmails: ['foo@example.com'],
+        uploaderUserIds: ['foo-at-example-dot-com'],
       ));
       dartSdkMemIndex.setDartdocIndex(
         DartdocIndex.fromJsonList([


### PR DESCRIPTION
- Follow-up on #4858.
- This is a backward-compatible change: old frontend requests are served correctly, also client reaching an old search service instance will keep working the same way.
- After two new release we will be able to remove `uploaderEmails` from the search service.