### PR TITLE
Display private|admin lock sign on account-related tabs.

### DIFF
--- a/app/lib/frontend/templates/admin.dart
+++ b/app/lib/frontend/templates/admin.dart
@@ -64,7 +64,7 @@ String renderAccountPackagesPage({
     headerHtml: _accountDetailHeader(user, userSessionData),
     tabs: [
       Tab.withContent(
-          id: 'packages', title: 'My packages', contentHtml: tabContent),
+          id: 'my-packages', title: 'My packages', contentHtml: tabContent),
       _myLikedPackagesLink(),
       _myPublishersLink(),
       _myActivityLogLink(),
@@ -103,7 +103,7 @@ String renderMyLikedPackagesPage({
     tabs: [
       _myPackagesLink(),
       Tab.withContent(
-          id: 'liked-packages',
+          id: 'my-liked-packages',
           title: 'My liked packages',
           contentHtml: tabContent),
       _myPublishersLink(),
@@ -134,7 +134,7 @@ String renderAccountPublishersPage({
       _myPackagesLink(),
       _myLikedPackagesLink(),
       Tab.withContent(
-        id: 'publishers',
+        id: 'my-publishers',
         title: 'My publishers',
         contentHtml: pln.toString(),
       ),
@@ -171,7 +171,7 @@ String renderAccountMyActivityPage({
       _myLikedPackagesLink(),
       _myPublishersLink(),
       Tab.withContent(
-        id: 'activity-log',
+        id: 'my-activity-log',
         title: 'My activity log',
         contentHtml: activityLog.toString(),
       ),
@@ -189,18 +189,18 @@ String renderAccountMyActivityPage({
 }
 
 Tab _myPackagesLink() => Tab.withLink(
-    id: 'packages', title: 'My packages', href: urls.myPackagesUrl());
+    id: 'my-packages', title: 'My packages', href: urls.myPackagesUrl());
 
 Tab _myLikedPackagesLink() => Tab.withLink(
-    id: 'liked-packages',
+    id: 'my-liked-packages',
     title: 'My liked packages',
     href: urls.myLikedPackagesUrl());
 
 Tab _myPublishersLink() => Tab.withLink(
-    id: 'publishers', title: 'My publishers', href: urls.myPublishersUrl());
+    id: 'my-publishers', title: 'My publishers', href: urls.myPublishersUrl());
 
 Tab _myActivityLogLink() => Tab.withLink(
-    id: 'activity-log',
+    id: 'my-activity-log',
     title: 'My activity log',
     href: urls.myActivityLogUrl());
 

--- a/app/lib/frontend/templates/detail_page.dart
+++ b/app/lib/frontend/templates/detail_page.dart
@@ -6,6 +6,7 @@ import 'dart:convert';
 
 import 'package:intl/intl.dart';
 
+import '../dom/dom.dart' as d;
 import '_cache.dart';
 
 final wideHeaderDetailPageClassName = '-wide-header-detail-page';
@@ -86,38 +87,35 @@ String renderDetailTabs(List<Tab> tabs) {
 /// Defines the header and content part of a tab.
 class Tab {
   final String id;
-  final String titleHtml;
+  final String title;
+  final String? href;
   final String? contentHtml;
   final bool isMarkdown;
-  final bool hasHref;
   bool isActive = false;
 
   Tab.withContent({
     required this.id,
-    String? title,
-    String? titleHtml,
+    required this.title,
     required this.contentHtml,
     this.isMarkdown = false,
-    this.hasHref = false,
-  }) : titleHtml = titleHtml ?? htmlEscape.convert(title!);
+  }) : href = null;
 
   Tab.withLink({
     required this.id,
-    String? title,
-    String? titleHtml,
-    required String href,
-  })  : titleHtml =
-            '<a href="$href">${titleHtml ?? htmlEscape.convert(title!)}</a>',
-        contentHtml = null,
-        isMarkdown = false,
-        hasHref = true;
+    required this.title,
+    required this.href,
+  })  : contentHtml = null,
+        isMarkdown = false;
 
   Map _toMustacheData() {
+    final isPrivate =
+        id == 'admin' || id == 'activity-log' || id.startsWith('my-');
     final titleClasses = <String>[
       'detail-tab',
       contentHtml == null ? 'tab-link' : 'tab-button',
       'detail-tab-$id-title',
       if (isActive) '-active',
+      if (isPrivate) '-private',
     ];
     final contentClasses = <String>[
       'tab-content',
@@ -125,9 +123,11 @@ class Tab {
       if (isActive) '-active',
       if (isMarkdown) 'markdown-body',
     ];
+    final titleNode =
+        href == null ? d.text(title) : d.a(href: href, text: title);
     return <String, dynamic>{
       'title_classes': titleClasses.join(' '),
-      'title_html': titleHtml,
+      'title_html': titleNode.toString(),
       'content_classes': contentClasses.join(' '),
       'content_html': contentHtml,
       'has_content': contentHtml != null,

--- a/app/test/frontend/golden/my_activity_log_page.html
+++ b/app/test/frontend/golden/my_activity_log_page.html
@@ -146,22 +146,22 @@
             <div class="detail-tabs-wide-header">
               <div class="detail-container">
                 <ul class="detail-tabs-header">
-                  <li class="detail-tab tab-link detail-tab-packages-title" role="button">
+                  <li class="detail-tab tab-link detail-tab-my-packages-title -private" role="button">
                     <a href="/my-packages">My packages</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-liked-packages-title" role="button">
+                  <li class="detail-tab tab-link detail-tab-my-liked-packages-title -private" role="button">
                     <a href="/my-liked-packages">My liked packages</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-publishers-title" role="button">
+                  <li class="detail-tab tab-link detail-tab-my-publishers-title -private" role="button">
                     <a href="/my-publishers">My publishers</a>
                   </li>
-                  <li class="detail-tab tab-button detail-tab-activity-log-title -active" role="button">My activity log</li>
+                  <li class="detail-tab tab-button detail-tab-my-activity-log-title -active -private" role="button">My activity log</li>
                 </ul>
               </div>
             </div>
             <div class="detail-container detail-body-main">
               <div class="detail-tabs-content">
-                <section class="tab-content detail-tab-activity-log-content -active">
+                <section class="tab-content detail-tab-my-activity-log-content -active">
                   <p>List of activities relevant to you. Events other than package publication expire after 2 months.</p>
                   <table class="activity-log-table">
                     <thead>

--- a/app/test/frontend/golden/my_liked_packages.html
+++ b/app/test/frontend/golden/my_liked_packages.html
@@ -146,14 +146,14 @@
             <div class="detail-tabs-wide-header">
               <div class="detail-container">
                 <ul class="detail-tabs-header">
-                  <li class="detail-tab tab-link detail-tab-packages-title" role="button">
+                  <li class="detail-tab tab-link detail-tab-my-packages-title -private" role="button">
                     <a href="/my-packages">My packages</a>
                   </li>
-                  <li class="detail-tab tab-button detail-tab-liked-packages-title -active" role="button">My liked packages</li>
-                  <li class="detail-tab tab-link detail-tab-publishers-title" role="button">
+                  <li class="detail-tab tab-button detail-tab-my-liked-packages-title -active -private" role="button">My liked packages</li>
+                  <li class="detail-tab tab-link detail-tab-my-publishers-title -private" role="button">
                     <a href="/my-publishers">My publishers</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-activity-log-title" role="button">
+                  <li class="detail-tab tab-link detail-tab-my-activity-log-title -private" role="button">
                     <a href="/my-activity-log">My activity log</a>
                   </li>
                 </ul>
@@ -161,7 +161,7 @@
             </div>
             <div class="detail-container detail-body-main">
               <div class="detail-tabs-content">
-                <section class="tab-content detail-tab-liked-packages-content -active">
+                <section class="tab-content detail-tab-my-liked-packages-content -active">
                   <p>You like 2 packages.</p>
                   <div class="packages -compact">
                     <div class="packages-item">

--- a/app/test/frontend/golden/my_packages.html
+++ b/app/test/frontend/golden/my_packages.html
@@ -146,14 +146,14 @@
             <div class="detail-tabs-wide-header">
               <div class="detail-container">
                 <ul class="detail-tabs-header">
-                  <li class="detail-tab tab-button detail-tab-packages-title -active" role="button">My packages</li>
-                  <li class="detail-tab tab-link detail-tab-liked-packages-title" role="button">
+                  <li class="detail-tab tab-button detail-tab-my-packages-title -active -private" role="button">My packages</li>
+                  <li class="detail-tab tab-link detail-tab-my-liked-packages-title -private" role="button">
                     <a href="/my-liked-packages">My liked packages</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-publishers-title" role="button">
+                  <li class="detail-tab tab-link detail-tab-my-publishers-title -private" role="button">
                     <a href="/my-publishers">My publishers</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-activity-log-title" role="button">
+                  <li class="detail-tab tab-link detail-tab-my-activity-log-title -private" role="button">
                     <a href="/my-activity-log">My activity log</a>
                   </li>
                 </ul>
@@ -161,7 +161,7 @@
             </div>
             <div class="detail-container detail-body-main">
               <div class="detail-tabs-content">
-                <section class="tab-content detail-tab-packages-content -active">
+                <section class="tab-content detail-tab-my-packages-content -active">
                   <div class="listing-info">
                     <div class="listing-info-count">
                       <span class="info-identifier">Results</span>

--- a/app/test/frontend/golden/my_publishers.html
+++ b/app/test/frontend/golden/my_publishers.html
@@ -146,14 +146,14 @@
             <div class="detail-tabs-wide-header">
               <div class="detail-container">
                 <ul class="detail-tabs-header">
-                  <li class="detail-tab tab-link detail-tab-packages-title" role="button">
+                  <li class="detail-tab tab-link detail-tab-my-packages-title -private" role="button">
                     <a href="/my-packages">My packages</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-liked-packages-title" role="button">
+                  <li class="detail-tab tab-link detail-tab-my-liked-packages-title -private" role="button">
                     <a href="/my-liked-packages">My liked packages</a>
                   </li>
-                  <li class="detail-tab tab-button detail-tab-publishers-title -active" role="button">My publishers</li>
-                  <li class="detail-tab tab-link detail-tab-activity-log-title" role="button">
+                  <li class="detail-tab tab-button detail-tab-my-publishers-title -active -private" role="button">My publishers</li>
+                  <li class="detail-tab tab-link detail-tab-my-activity-log-title -private" role="button">
                     <a href="/my-activity-log">My activity log</a>
                   </li>
                 </ul>
@@ -161,7 +161,7 @@
             </div>
             <div class="detail-container detail-body-main">
               <div class="detail-tabs-content">
-                <section class="tab-content detail-tab-publishers-content -active">
+                <section class="tab-content detail-tab-my-publishers-content -active">
                   <div class="publishers">
                     <div class="publishers-item">
                       <h3 class="publishers-item-title">

--- a/app/test/frontend/golden/publisher_activity_log_page.html
+++ b/app/test/frontend/golden/publisher_activity_log_page.html
@@ -157,10 +157,10 @@
                   <li class="detail-tab tab-link detail-tab-packages-title" role="button">
                     <a href="/publishers/example.com/packages">Packages</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-admin-title" role="button">
+                  <li class="detail-tab tab-link detail-tab-admin-title -private" role="button">
                     <a href="/publishers/example.com/admin">Admin</a>
                   </li>
-                  <li class="detail-tab tab-button detail-tab-activity-log-title -active" role="button">Activity log</li>
+                  <li class="detail-tab tab-button detail-tab-activity-log-title -active -private" role="button">Activity log</li>
                 </ul>
               </div>
             </div>

--- a/app/test/frontend/golden/publisher_packages_page.html
+++ b/app/test/frontend/golden/publisher_packages_page.html
@@ -155,10 +155,10 @@
               <div class="detail-container">
                 <ul class="detail-tabs-header">
                   <li class="detail-tab tab-button detail-tab-packages-title -active" role="button">Packages</li>
-                  <li class="detail-tab tab-link detail-tab-admin-title" role="button">
+                  <li class="detail-tab tab-link detail-tab-admin-title -private" role="button">
                     <a href="/publishers/example.com/admin">Admin</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-activity-log-title" role="button">
+                  <li class="detail-tab tab-link detail-tab-activity-log-title -private" role="button">
                     <a href="/publishers/example.com/activity-log">Activity log</a>
                   </li>
                 </ul>

--- a/pkg/web_css/lib/src/_detail_page.scss
+++ b/pkg/web_css/lib/src/_detail_page.scss
@@ -321,10 +321,8 @@ $detail-tabs-tablet-width: calc(100% - 240px);
   }
 
   /* Render admin tabs with red. */
-  > .tab-button.detail-tab-admin-title,
-  > .tab-link.detail-tab-admin-title > a,
-  > .tab-button.detail-tab-activity-log-title,
-  > .tab-link.detail-tab-activity-log-title > a {
+  > .tab-button.-private,
+  > .tab-link.-private > a {
     color: $detail-tab-admin-color;
     position: relative;
     padding-right: 9px;
@@ -354,8 +352,8 @@ $detail-tabs-tablet-width: calc(100% - 240px);
       width: 12px;
     }
   }
-  > .tab-button.detail-tab-admin-title,
-  > .tab-button.detail-tab-activity-log-title {
+  > .tab-button.-private,
+  > .tab-button.-private {
     border-bottom-color: $detail-tab-admin-color;
   }
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4778111/129385208-bd67e18f-49e1-42e6-874e-b3165a76ba75.png)

(first underline was my mouse hover over the menu item, while the last is the active tab).