### PR TITLE
Increase the number of search service instances to 4 (autoscale up to 6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ AppEngine version, listed here to ease deployment and troubleshooting.
 ## Next Release (replace with git tag when deployed)
  * Bumped runtimeVersion to `2021.08.24`.
  * Upgraded dartdoc to `2.0.0`.
+ * NOTE: increased the number of search service instances to 4 (autoscale up to 6).
 
 ## `20210819t120700-all`
  * Bumped runtimeVersion to `2021.08.17`.

--- a/app/lib/shared/handlers.dart
+++ b/app/lib/shared/handlers.dart
@@ -93,6 +93,7 @@ shelf.Response debugResponse([Map<String, dynamic>? data]) {
       'GAE_MEMORY_MB': Platform.environment['GAE_MEMORY_MB'],
     },
     'vm': {
+      'numberOfProcessors': Platform.numberOfProcessors,
       'currentRss': ProcessInfo.currentRss,
       'maxRss': ProcessInfo.maxRss,
       'eventLoopLatencyMillis': {

--- a/search.yaml
+++ b/search.yaml
@@ -14,8 +14,8 @@ resources:
 #  instances: 1
 
 automatic_scaling:
-  min_num_instances: 3
-  max_num_instances: 4
+  min_num_instances: 4
+  max_num_instances: 6
 
 skip_files:
 - ^\.git/.*$


### PR DESCRIPTION
Also added a debug info about the reported CPU count to cross-check the number with the requested ones.