### PR TITLE
Prepare migration of detail page rendering.

### DIFF
--- a/app/lib/frontend/dom/dom.dart
+++ b/app/lib/frontend/dom/dom.dart
@@ -459,6 +459,27 @@ Node pre({
       children: _children(children, child, text),
     );
 
+/// Creates a `<script>` Element using the default [DomContext].
+Node script({
+  String? id,
+  Iterable<String>? classes,
+  Map<String, String>? attributes,
+  Iterable<Node>? children,
+  Node? child,
+  String? text,
+  String? type,
+}) =>
+    dom.element(
+      'script',
+      id: id,
+      classes: classes,
+      attributes: <String, String>{
+        if (type != null) 'type': type,
+        if (attributes != null) ...attributes,
+      },
+      children: _children(children, child, text),
+    );
+
 /// Creates an `<select>` Element using the default [DomContext].
 Node select({
   String? id,

--- a/app/lib/frontend/dom/dom.dart
+++ b/app/lib/frontend/dom/dom.dart
@@ -111,6 +111,15 @@ Node codeSnippet({
   );
 }
 
+/// Creates a DOM element with ld+json `<script>` content.
+Node ldJson(Map<String, dynamic> content) {
+  return script(
+    type: 'application/ld+json',
+    // TODO: check how this should be escaped
+    child: unsafeRawHtml(json.encode(content)),
+  );
+}
+
 /// Creates an `<a>` Element using the default [DomContext].
 Node a({
   String? id,

--- a/app/lib/frontend/dom/dom.dart
+++ b/app/lib/frontend/dom/dom.dart
@@ -4,6 +4,8 @@
 
 import 'dart:convert';
 
+import 'package:convert/convert.dart';
+
 import '../../shared/markdown.dart';
 
 final _attributeEscape = HtmlEscape(HtmlEscapeMode.attribute);
@@ -114,12 +116,12 @@ Node codeSnippet({
 /// Creates a DOM element with ld+json `<script>` content.
 Node ldJson(Map<String, dynamic> content) {
   final rawJson = json.encode(content);
-  final rawHtml = rawJson.replaceMapped(
+  final rawHtml = rawJson.replaceAllMapped(
     // As rawJson can only contain the following characters inside of
     // a JSON string, we can always encode them as \u00xx
     // This ensures that html tags cannot be embedded.
-    RegExp(r'</>'),
-    (m) => r'\u00' + hex.encode(m[0]!.codeUnitAt(0)),
+    RegExp(r'[</>]'),
+    (m) => r'\u00' + hex.encode([m[0]!.codeUnitAt(0)]),
   );
   return script(
     type: 'application/ld+json',

--- a/app/lib/frontend/dom/dom.dart
+++ b/app/lib/frontend/dom/dom.dart
@@ -113,10 +113,17 @@ Node codeSnippet({
 
 /// Creates a DOM element with ld+json `<script>` content.
 Node ldJson(Map<String, dynamic> content) {
+  final rawJson = json.encode(content);
+  final rawHtml = rawJson.replaceMapped(
+    // As rawJson can only contain the following characters inside of
+    // a JSON string, we can always encode them as \u00xx
+    // This ensures that html tags cannot be embedded.
+    RegExp(r'</>'),
+    (m) => r'\u00' + hex.encode(m[0]!.codeUnitAt(0)),
+  );
   return script(
     type: 'application/ld+json',
-    // TODO: check how this should be escaped
-    child: unsafeRawHtml(json.encode(content)),
+    child: unsafeRawHtml(rawHtml),
   );
 }
 

--- a/app/lib/frontend/templates/admin.dart
+++ b/app/lib/frontend/templates/admin.dart
@@ -60,7 +60,7 @@ String renderAccountPackagesPage({
     paginationHtml,
   ].join('\n');
   final content = renderDetailPage(
-    headerHtml: _accountDetailHeader(user, userSessionData),
+    headerNode: _accountDetailHeader(user, userSessionData),
     tabs: [
       Tab.withContent(
           id: 'my-packages', title: 'My packages', contentHtml: tabContent),
@@ -68,7 +68,7 @@ String renderAccountPackagesPage({
       _myPublishersLink(),
       _myActivityLogLink(),
     ],
-    infoBoxHtml: null,
+    infoBoxNode: null,
   );
 
   return renderLayoutPage(
@@ -98,7 +98,7 @@ String renderMyLikedPackagesPage({
     likedPackagesListHtml,
   ].join('\n');
   final content = renderDetailPage(
-    headerHtml: _accountDetailHeader(user, userSessionData),
+    headerNode: _accountDetailHeader(user, userSessionData),
     tabs: [
       _myPackagesLink(),
       Tab.withContent(
@@ -108,7 +108,7 @@ String renderMyLikedPackagesPage({
       _myPublishersLink(),
       _myActivityLogLink(),
     ],
-    infoBoxHtml: null,
+    infoBoxNode: null,
   );
 
   return renderLayoutPage(
@@ -128,7 +128,7 @@ String renderAccountPublishersPage({
 }) {
   final pln = publisherListNode(publishers: publishers, isGlobal: false);
   final content = renderDetailPage(
-    headerHtml: _accountDetailHeader(user, userSessionData),
+    headerNode: _accountDetailHeader(user, userSessionData),
     tabs: [
       _myPackagesLink(),
       _myLikedPackagesLink(),
@@ -139,7 +139,7 @@ String renderAccountPublishersPage({
       ),
       _myActivityLogLink(),
     ],
-    infoBoxHtml: null,
+    infoBoxNode: null,
   );
 
   return renderLayoutPage(
@@ -164,7 +164,7 @@ String renderAccountMyActivityPage({
   );
 
   final content = renderDetailPage(
-    headerHtml: _accountDetailHeader(user, userSessionData),
+    headerNode: _accountDetailHeader(user, userSessionData),
     tabs: [
       _myPackagesLink(),
       _myLikedPackagesLink(),
@@ -175,7 +175,7 @@ String renderAccountMyActivityPage({
         contentHtml: activityLog.toString(),
       ),
     ],
-    infoBoxHtml: null,
+    infoBoxNode: null,
   );
 
   return renderLayoutPage(
@@ -203,7 +203,7 @@ Tab _myActivityLogLink() => Tab.withLink(
     title: 'My activity log',
     href: urls.myActivityLogUrl());
 
-String _accountDetailHeader(User user, UserSessionData userSessionData) {
+d.Node _accountDetailHeader(User user, UserSessionData userSessionData) {
   final shortJoined = shortDateFormat.format(user.created!);
   return renderDetailHeader(
     title: userSessionData.name,

--- a/app/lib/frontend/templates/detail_page.dart
+++ b/app/lib/frontend/templates/detail_page.dart
@@ -12,7 +12,7 @@ final wideHeaderDetailPageClassName = '-wide-header-detail-page';
 /// Renders the detail page's header template.
 ///
 /// The like button in the header will not be displayed when [isLiked] is null.
-String renderDetailHeader({
+d.Node renderDetailHeader({
   String? title,
   d.Node? titleNode,
   String? imageUrl,
@@ -40,24 +40,24 @@ String renderDetailHeader({
     isLiked: isLiked == true,
     likeCount: packageLikes,
     isFlutterFavorite: isFlutterFavorite,
-  ).toString();
+  );
 }
 
 /// Renders the `shared/detail/page.mustache` template
 String renderDetailPage({
-  required String headerHtml,
+  required d.Node headerNode,
   required List<Tab> tabs,
-  required String? infoBoxHtml,
+  required String? infoBoxNode,
   String? infoBoxLead,
-  String? footerHtml,
+  d.Node? footerNode,
 }) {
   return templateCache.renderTemplate('shared/detail/page', {
-    'header_html': headerHtml,
+    'header_html': headerNode.toString(),
     'tabs_html': renderDetailTabs(tabs),
     'info_box_lead': infoBoxLead,
-    'has_info_box': infoBoxHtml != null,
-    'info_box_html': infoBoxHtml,
-    'footer_html': footerHtml,
+    'has_info_box': infoBoxNode != null,
+    'info_box_html': infoBoxNode?.toString(),
+    'footer_html': footerNode?.toString(),
   });
 }
 

--- a/app/lib/frontend/templates/package.dart
+++ b/app/lib/frontend/templates/package.dart
@@ -13,6 +13,7 @@ import '../../shared/handlers.dart';
 import '../../shared/tags.dart';
 import '../../shared/urls.dart' as urls;
 
+import '../dom/dom.dart' as d;
 import '../static_files.dart';
 
 import '_utils.dart';
@@ -90,9 +91,9 @@ String renderPkgInfoBox(PackagePageData data) {
   ).toString();
 }
 
-/// Renders the `views/pkg/header.mustache` template for header metadata and
+/// Renders the package header template for header metadata and
 /// wraps it with content-header.
-String renderPkgHeader(PackagePageData data) {
+d.Node renderPkgHeader(PackagePageData data) {
   final package = data.package!;
   final showPrereleaseVersion = data.latestReleases!.showPrerelease;
   final showPreviewVersion = data.latestReleases!.showPreview;
@@ -220,11 +221,11 @@ String _renderPkgPage({
   final card = data.scoreCard;
 
   final content = renderDetailPage(
-    headerHtml: renderPkgHeader(data),
+    headerNode: renderPkgHeader(data),
     tabs: tabs,
     infoBoxLead: data.version!.ellipsizedDescription,
-    infoBoxHtml: renderPkgInfoBox(data),
-    footerHtml: renderPackageSchemaOrgHtml(data),
+    infoBoxNode: renderPkgInfoBox(data),
+    footerNode: renderPackageSchemaOrgHtml(data),
   );
 
   final isFlutterPackage = data.version!.pubspec!.usesFlutter;
@@ -376,7 +377,7 @@ Tab _scoreTab(PackagePageData data) {
   );
 }
 
-String renderPackageSchemaOrgHtml(PackagePageData data) {
+d.Node renderPackageSchemaOrgHtml(PackagePageData data) {
   final p = data.package!;
   final pv = data.version!;
   final Map map = {
@@ -397,7 +398,11 @@ String renderPackageSchemaOrgHtml(PackagePageData data) {
     map['license'] = licenseFileUrl;
   }
   // TODO: add http://schema.org/codeRepository for github and gitlab links
-  return '<script type="application/ld+json">\n${json.encode(map)}\n</script>\n';
+  return d.script(
+    type: 'application/ld+json',
+    // TODO: check how this should be escaped
+    child: d.unsafeRawHtml(json.encode(map)),
+  );
 }
 
 /// Build package tabs.

--- a/app/lib/frontend/templates/package.dart
+++ b/app/lib/frontend/templates/package.dart
@@ -380,7 +380,7 @@ Tab _scoreTab(PackagePageData data) {
 d.Node renderPackageSchemaOrgHtml(PackagePageData data) {
   final p = data.package!;
   final pv = data.version!;
-  final Map map = {
+  final map = <String, dynamic>{
     '@context': 'http://schema.org',
     '@type': 'SoftwareSourceCode',
     'name': p.name,
@@ -398,11 +398,7 @@ d.Node renderPackageSchemaOrgHtml(PackagePageData data) {
     map['license'] = licenseFileUrl;
   }
   // TODO: add http://schema.org/codeRepository for github and gitlab links
-  return d.script(
-    type: 'application/ld+json',
-    // TODO: check how this should be escaped
-    child: d.unsafeRawHtml(json.encode(map)),
-  );
+  return d.ldJson(map);
 }
 
 /// Build package tabs.

--- a/app/lib/frontend/templates/package_admin.dart
+++ b/app/lib/frontend/templates/package_admin.dart
@@ -33,10 +33,10 @@ String renderPkgAdminPage(
   );
 
   final content = renderDetailPage(
-    headerHtml: renderPkgHeader(data),
+    headerNode: renderPkgHeader(data),
     tabs: tabs,
     infoBoxLead: data.version!.ellipsizedDescription,
-    infoBoxHtml: renderPkgInfoBox(data),
+    infoBoxNode: renderPkgInfoBox(data),
   );
 
   return renderLayoutPage(
@@ -67,10 +67,10 @@ String renderPkgActivityLogPage(
     ),
   );
   final content = renderDetailPage(
-    headerHtml: renderPkgHeader(data),
+    headerNode: renderPkgHeader(data),
     tabs: tabs,
     infoBoxLead: data.version!.ellipsizedDescription,
-    infoBoxHtml: renderPkgInfoBox(data),
+    infoBoxNode: renderPkgInfoBox(data),
   );
   return renderLayoutPage(
     PageType.package,

--- a/app/lib/frontend/templates/package_versions.dart
+++ b/app/lib/frontend/templates/package_versions.dart
@@ -92,11 +92,11 @@ String renderPkgVersionsPage(
   );
 
   final content = renderDetailPage(
-    headerHtml: renderPkgHeader(data),
+    headerNode: renderPkgHeader(data),
     tabs: tabs,
     infoBoxLead: data.version!.ellipsizedDescription,
-    infoBoxHtml: renderPkgInfoBox(data),
-    footerHtml: renderPackageSchemaOrgHtml(data),
+    infoBoxNode: renderPkgInfoBox(data),
+    footerNode: renderPackageSchemaOrgHtml(data),
   );
 
   final canonicalUrl = urls.pkgPageUrl(data.package!.name!,

--- a/app/lib/frontend/templates/publisher.dart
+++ b/app/lib/frontend/templates/publisher.dart
@@ -12,6 +12,7 @@ import '../../package/search_adapter.dart' show SearchResultPage;
 import '../../publisher/models.dart' show Publisher, PublisherSummary;
 import '../../search/search_form.dart' show SearchForm;
 import '../../shared/urls.dart' as urls;
+import '../dom/dom.dart' as d;
 import 'detail_page.dart';
 import 'layout.dart';
 import 'listing.dart';
@@ -83,9 +84,9 @@ String renderPublisherPackagesPage({
   ];
 
   final mainContent = renderDetailPage(
-    headerHtml: _renderDetailHeader(publisher),
+    headerNode: _renderDetailHeader(publisher),
     tabs: tabs,
-    infoBoxHtml: null,
+    infoBoxNode: null,
   );
 
   return renderLayoutPage(
@@ -126,9 +127,9 @@ String renderPublisherAdminPage({
   ];
 
   final content = renderDetailPage(
-    headerHtml: _renderDetailHeader(publisher),
+    headerNode: _renderDetailHeader(publisher),
     tabs: tabs,
-    infoBoxHtml: null,
+    infoBoxNode: null,
   );
   return renderLayoutPage(
     PageType.publisher,
@@ -167,9 +168,9 @@ String renderPublisherActivityLogPage({
   ];
 
   final content = renderDetailPage(
-    headerHtml: _renderDetailHeader(publisher),
+    headerNode: _renderDetailHeader(publisher),
     tabs: tabs,
-    infoBoxHtml: null,
+    infoBoxNode: null,
   );
   return renderLayoutPage(
     PageType.publisher,
@@ -186,7 +187,7 @@ String renderPublisherActivityLogPage({
   );
 }
 
-String _renderDetailHeader(Publisher publisher) {
+d.Node _renderDetailHeader(Publisher publisher) {
   return renderDetailHeader(
     title: publisher.publisherId,
     metadataNode: publisherHeaderMetadataNode(publisher),

--- a/app/test/frontend/golden/pkg_changelog_page.html
+++ b/app/test/frontend/golden/pkg_changelog_page.html
@@ -267,7 +267,7 @@
             </p>
           </aside>
         </div>
-        <script type="application/ld+json">{"@context":"http://schema.org","@type":"SoftwareSourceCode","name":"oxygen","version":"1.2.0","description":"oxygen - oxygen is awesome","url":"https://pub.dev/packages/oxygen","dateCreated":"%%published-timestamp%%","dateModified":"%%updated-timestamp%%","programmingLanguage":"Dart","image":"https://pub.dev/static/img/pub-dev-icon-cover-image.png"}</script>
+        <script type="application/ld+json">{"@context":"http:\u002f\u002fschema.org","@type":"SoftwareSourceCode","name":"oxygen","version":"1.2.0","description":"oxygen - oxygen is awesome","url":"https:\u002f\u002fpub.dev\u002fpackages\u002foxygen","dateCreated":"%%published-timestamp%%","dateModified":"%%updated-timestamp%%","programmingLanguage":"Dart","image":"https:\u002f\u002fpub.dev\u002fstatic\u002fimg\u002fpub-dev-icon-cover-image.png"}</script>
       </div>
       <div class="detail-metadata">
         <h3 class="detail-metadata-title">

--- a/app/test/frontend/golden/pkg_example_page.html
+++ b/app/test/frontend/golden/pkg_example_page.html
@@ -262,7 +262,7 @@
             </p>
           </aside>
         </div>
-        <script type="application/ld+json">{"@context":"http://schema.org","@type":"SoftwareSourceCode","name":"oxygen","version":"1.2.0","description":"oxygen - oxygen is awesome","url":"https://pub.dev/packages/oxygen","dateCreated":"%%published-timestamp%%","dateModified":"%%updated-timestamp%%","programmingLanguage":"Dart","image":"https://pub.dev/static/img/pub-dev-icon-cover-image.png"}</script>
+        <script type="application/ld+json">{"@context":"http:\u002f\u002fschema.org","@type":"SoftwareSourceCode","name":"oxygen","version":"1.2.0","description":"oxygen - oxygen is awesome","url":"https:\u002f\u002fpub.dev\u002fpackages\u002foxygen","dateCreated":"%%published-timestamp%%","dateModified":"%%updated-timestamp%%","programmingLanguage":"Dart","image":"https:\u002f\u002fpub.dev\u002fstatic\u002fimg\u002fpub-dev-icon-cover-image.png"}</script>
       </div>
       <div class="detail-metadata">
         <h3 class="detail-metadata-title">

--- a/app/test/frontend/golden/pkg_install_page.html
+++ b/app/test/frontend/golden/pkg_install_page.html
@@ -284,7 +284,7 @@
             </p>
           </aside>
         </div>
-        <script type="application/ld+json">{"@context":"http://schema.org","@type":"SoftwareSourceCode","name":"oxygen","version":"1.2.0","description":"oxygen - oxygen is awesome","url":"https://pub.dev/packages/oxygen","dateCreated":"%%published-timestamp%%","dateModified":"%%updated-timestamp%%","programmingLanguage":"Dart","image":"https://pub.dev/static/img/pub-dev-icon-cover-image.png"}</script>
+        <script type="application/ld+json">{"@context":"http:\u002f\u002fschema.org","@type":"SoftwareSourceCode","name":"oxygen","version":"1.2.0","description":"oxygen - oxygen is awesome","url":"https:\u002f\u002fpub.dev\u002fpackages\u002foxygen","dateCreated":"%%published-timestamp%%","dateModified":"%%updated-timestamp%%","programmingLanguage":"Dart","image":"https:\u002f\u002fpub.dev\u002fstatic\u002fimg\u002fpub-dev-icon-cover-image.png"}</script>
       </div>
       <div class="detail-metadata">
         <h3 class="detail-metadata-title">

--- a/app/test/frontend/golden/pkg_score_page.html
+++ b/app/test/frontend/golden/pkg_score_page.html
@@ -350,7 +350,7 @@
             </p>
           </aside>
         </div>
-        <script type="application/ld+json">{"@context":"http://schema.org","@type":"SoftwareSourceCode","name":"oxygen","version":"1.2.0","description":"oxygen - oxygen is awesome","url":"https://pub.dev/packages/oxygen","dateCreated":"%%published-timestamp%%","dateModified":"%%updated-timestamp%%","programmingLanguage":"Dart","image":"https://pub.dev/static/img/pub-dev-icon-cover-image.png"}</script>
+        <script type="application/ld+json">{"@context":"http:\u002f\u002fschema.org","@type":"SoftwareSourceCode","name":"oxygen","version":"1.2.0","description":"oxygen - oxygen is awesome","url":"https:\u002f\u002fpub.dev\u002fpackages\u002foxygen","dateCreated":"%%published-timestamp%%","dateModified":"%%updated-timestamp%%","programmingLanguage":"Dart","image":"https:\u002f\u002fpub.dev\u002fstatic\u002fimg\u002fpub-dev-icon-cover-image.png"}</script>
       </div>
       <div class="detail-metadata">
         <h3 class="detail-metadata-title">

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -261,7 +261,7 @@
             </p>
           </aside>
         </div>
-        <script type="application/ld+json">{"@context":"http://schema.org","@type":"SoftwareSourceCode","name":"oxygen","version":"1.2.0","description":"oxygen - oxygen is awesome","url":"https://pub.dev/packages/oxygen","dateCreated":"%%published-timestamp%%","dateModified":"%%updated-timestamp%%","programmingLanguage":"Dart","image":"https://pub.dev/static/img/pub-dev-icon-cover-image.png"}</script>
+        <script type="application/ld+json">{"@context":"http:\u002f\u002fschema.org","@type":"SoftwareSourceCode","name":"oxygen","version":"1.2.0","description":"oxygen - oxygen is awesome","url":"https:\u002f\u002fpub.dev\u002fpackages\u002foxygen","dateCreated":"%%published-timestamp%%","dateModified":"%%updated-timestamp%%","programmingLanguage":"Dart","image":"https:\u002f\u002fpub.dev\u002fstatic\u002fimg\u002fpub-dev-icon-cover-image.png"}</script>
       </div>
       <div class="detail-metadata">
         <h3 class="detail-metadata-title">

--- a/app/test/frontend/golden/pkg_show_page_discontinued.html
+++ b/app/test/frontend/golden/pkg_show_page_discontinued.html
@@ -248,7 +248,7 @@
             </p>
           </aside>
         </div>
-        <script type="application/ld+json">{"@context":"http://schema.org","@type":"SoftwareSourceCode","name":"pkg","version":"1.0.0","description":"pkg - pkg is awesome","url":"https://pub.dev/packages/pkg","dateCreated":"%%published-timestamp%%","dateModified":"%%updated-timestamp%%","programmingLanguage":"Dart","image":"https://pub.dev/static/img/pub-dev-icon-cover-image.png"}</script>
+        <script type="application/ld+json">{"@context":"http:\u002f\u002fschema.org","@type":"SoftwareSourceCode","name":"pkg","version":"1.0.0","description":"pkg - pkg is awesome","url":"https:\u002f\u002fpub.dev\u002fpackages\u002fpkg","dateCreated":"%%published-timestamp%%","dateModified":"%%updated-timestamp%%","programmingLanguage":"Dart","image":"https:\u002f\u002fpub.dev\u002fstatic\u002fimg\u002fpub-dev-icon-cover-image.png"}</script>
       </div>
       <div class="detail-metadata">
         <h3 class="detail-metadata-title">

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -261,7 +261,7 @@
             </p>
           </aside>
         </div>
-        <script type="application/ld+json">{"@context":"http://schema.org","@type":"SoftwareSourceCode","name":"flutter_titanium","version":"1.10.0","description":"flutter_titanium - flutter_titanium is awesome","url":"https://pub.dev/packages/flutter_titanium","dateCreated":"%%published-timestamp%%","dateModified":"%%updated-timestamp%%","programmingLanguage":"Dart","image":"https://pub.dev/static/img/pub-dev-icon-cover-image.png"}</script>
+        <script type="application/ld+json">{"@context":"http:\u002f\u002fschema.org","@type":"SoftwareSourceCode","name":"flutter_titanium","version":"1.10.0","description":"flutter_titanium - flutter_titanium is awesome","url":"https:\u002f\u002fpub.dev\u002fpackages\u002fflutter_titanium","dateCreated":"%%published-timestamp%%","dateModified":"%%updated-timestamp%%","programmingLanguage":"Dart","image":"https:\u002f\u002fpub.dev\u002fstatic\u002fimg\u002fpub-dev-icon-cover-image.png"}</script>
       </div>
       <div class="detail-metadata">
         <h3 class="detail-metadata-title">

--- a/app/test/frontend/golden/pkg_show_page_legacy.html
+++ b/app/test/frontend/golden/pkg_show_page_legacy.html
@@ -262,7 +262,7 @@
             </p>
           </aside>
         </div>
-        <script type="application/ld+json">{"@context":"http://schema.org","@type":"SoftwareSourceCode","name":"pkg","version":"1.0.0-legacy","description":"pkg - pkg is awesome","url":"https://pub.dev/packages/pkg","dateCreated":"%%published-timestamp%%","dateModified":"%%updated-timestamp%%","programmingLanguage":"Dart","image":"https://pub.dev/static/img/pub-dev-icon-cover-image.png"}</script>
+        <script type="application/ld+json">{"@context":"http:\u002f\u002fschema.org","@type":"SoftwareSourceCode","name":"pkg","version":"1.0.0-legacy","description":"pkg - pkg is awesome","url":"https:\u002f\u002fpub.dev\u002fpackages\u002fpkg","dateCreated":"%%published-timestamp%%","dateModified":"%%updated-timestamp%%","programmingLanguage":"Dart","image":"https:\u002f\u002fpub.dev\u002fstatic\u002fimg\u002fpub-dev-icon-cover-image.png"}</script>
       </div>
       <div class="detail-metadata">
         <h3 class="detail-metadata-title">

--- a/app/test/frontend/golden/pkg_show_page_publisher.html
+++ b/app/test/frontend/golden/pkg_show_page_publisher.html
@@ -255,7 +255,7 @@
             </p>
           </aside>
         </div>
-        <script type="application/ld+json">{"@context":"http://schema.org","@type":"SoftwareSourceCode","name":"neon","version":"1.0.0","description":"neon - neon is awesome","url":"https://pub.dev/packages/neon","dateCreated":"%%published-timestamp%%","dateModified":"%%updated-timestamp%%","programmingLanguage":"Dart","image":"https://pub.dev/static/img/pub-dev-icon-cover-image.png"}</script>
+        <script type="application/ld+json">{"@context":"http:\u002f\u002fschema.org","@type":"SoftwareSourceCode","name":"neon","version":"1.0.0","description":"neon - neon is awesome","url":"https:\u002f\u002fpub.dev\u002fpackages\u002fneon","dateCreated":"%%published-timestamp%%","dateModified":"%%updated-timestamp%%","programmingLanguage":"Dart","image":"https:\u002f\u002fpub.dev\u002fstatic\u002fimg\u002fpub-dev-icon-cover-image.png"}</script>
       </div>
       <div class="detail-metadata">
         <h3 class="detail-metadata-title">

--- a/app/test/frontend/golden/pkg_show_version_page.html
+++ b/app/test/frontend/golden/pkg_show_version_page.html
@@ -261,7 +261,7 @@
             </p>
           </aside>
         </div>
-        <script type="application/ld+json">{"@context":"http://schema.org","@type":"SoftwareSourceCode","name":"oxygen","version":"1.2.0","description":"oxygen - oxygen is awesome","url":"https://pub.dev/packages/oxygen","dateCreated":"%%published-timestamp%%","dateModified":"%%updated-timestamp%%","programmingLanguage":"Dart","image":"https://pub.dev/static/img/pub-dev-icon-cover-image.png"}</script>
+        <script type="application/ld+json">{"@context":"http:\u002f\u002fschema.org","@type":"SoftwareSourceCode","name":"oxygen","version":"1.2.0","description":"oxygen - oxygen is awesome","url":"https:\u002f\u002fpub.dev\u002fpackages\u002foxygen","dateCreated":"%%published-timestamp%%","dateModified":"%%updated-timestamp%%","programmingLanguage":"Dart","image":"https:\u002f\u002fpub.dev\u002fstatic\u002fimg\u002fpub-dev-icon-cover-image.png"}</script>
       </div>
       <div class="detail-metadata">
         <h3 class="detail-metadata-title">

--- a/app/test/frontend/golden/pkg_versions_page.html
+++ b/app/test/frontend/golden/pkg_versions_page.html
@@ -361,7 +361,7 @@
             </p>
           </aside>
         </div>
-        <script type="application/ld+json">{"@context":"http://schema.org","@type":"SoftwareSourceCode","name":"oxygen","version":"1.2.0","description":"oxygen - oxygen is awesome","url":"https://pub.dev/packages/oxygen","dateCreated":"%%package-created-timestamp%%","dateModified":"%%version-created-timestamp%%","programmingLanguage":"Dart","image":"https://pub.dev/static/img/pub-dev-icon-cover-image.png"}</script>
+        <script type="application/ld+json">{"@context":"http:\u002f\u002fschema.org","@type":"SoftwareSourceCode","name":"oxygen","version":"1.2.0","description":"oxygen - oxygen is awesome","url":"https:\u002f\u002fpub.dev\u002fpackages\u002foxygen","dateCreated":"%%package-created-timestamp%%","dateModified":"%%version-created-timestamp%%","programmingLanguage":"Dart","image":"https:\u002f\u002fpub.dev\u002fstatic\u002fimg\u002fpub-dev-icon-cover-image.png"}</script>
       </div>
       <div class="detail-metadata">
         <h3 class="detail-metadata-title">


### PR DESCRIPTION
- using `Node` as parameters (refactored callers without much change in code structure)
- `<script>` content is passed-in as unescaped HTML