### PR TITLE
Misc fixes (static files + template optimizations)

### DIFF
--- a/app/lib/frontend/templates/admin.dart
+++ b/app/lib/frontend/templates/admin.dart
@@ -23,7 +23,7 @@ import 'views/publisher/publisher_list.dart';
 String renderAuthorizedPage() {
   return renderLayoutPage(
     PageType.package,
-    authorizedNode(),
+    authorizedNode,
     title: 'Pub Authorized Successfully',
     noIndex: true,
   );

--- a/app/lib/frontend/templates/misc.dart
+++ b/app/lib/frontend/templates/misc.dart
@@ -33,7 +33,7 @@ final _helpPublishingMarkdown = _readDocContent('help-publishing.md');
 String renderUnauthenticatedPage() {
   return renderLayoutPage(
     PageType.standalone,
-    unauthenticatedNode(),
+    unauthenticatedNode,
     title: 'Authentication required',
     noIndex: true,
   );
@@ -43,7 +43,7 @@ String renderUnauthenticatedPage() {
 String renderUnauthorizedPage() {
   return renderLayoutPage(
     PageType.standalone,
-    unauthorizedNode(),
+    unauthorizedNode,
     title: 'Authorization required',
     noIndex: true,
   );

--- a/app/lib/frontend/templates/package.dart
+++ b/app/lib/frontend/templates/package.dart
@@ -398,8 +398,7 @@ d.Node renderPackageSchemaOrgHtml(PackagePageData data) {
     'dateCreated': p.created!.toIso8601String(),
     'dateModified': pv.created!.toIso8601String(),
     'programmingLanguage': 'Dart',
-    'image':
-        '${urls.siteRoot}${staticUrls.staticPath}/img/pub-dev-icon-cover-image.png'
+    'image': '${urls.siteRoot}/static/img/pub-dev-icon-cover-image.png'
   };
   final licenseFileUrl = data.scoreCard?.panaReport?.licenseFile?.url;
   if (licenseFileUrl != null) {

--- a/app/lib/frontend/templates/package_misc.dart
+++ b/app/lib/frontend/templates/package_misc.dart
@@ -14,12 +14,10 @@ import 'views/pkg/labeled_scores.dart';
 import 'views/pkg/tags.dart';
 
 /// Renders the Flutter Favorite badge, used by package listing.
-d.Node flutterFavoriteBadgeNode() {
-  return packageBadgeNode(
-    label: 'Flutter Favorite',
-    iconUrl: staticUrls.flutterLogo32x32,
-  );
-}
+final flutterFavoriteBadgeNode = packageBadgeNode(
+  label: 'Flutter Favorite',
+  iconUrl: staticUrls.flutterLogo32x32,
+);
 
 /// Renders the null-safe badge used by package listing and package page.
 d.Node nullSafeBadgeNode({String? title}) {

--- a/app/lib/frontend/templates/publisher.dart
+++ b/app/lib/frontend/templates/publisher.dart
@@ -22,10 +22,9 @@ import 'views/publisher/publisher_list.dart';
 
 /// Renders the create publisher page.
 String renderCreatePublisherPage() {
-  final content = createPublisherPageNode();
   return renderLayoutPage(
     PageType.standalone,
-    content,
+    createPublisherPageNode,
     title: 'Create publisher',
     noIndex: true, // no need to index, as the page is only for a logged-in user
   );

--- a/app/lib/frontend/templates/views/account/authorized.dart
+++ b/app/lib/frontend/templates/views/account/authorized.dart
@@ -4,16 +4,14 @@
 
 import '../../../dom/dom.dart' as d;
 
-d.Node authorizedNode() {
-  return d.fragment([
-    d.h1(text: 'Pub Authorized Successfully'),
-    d.p(
-      children: [
-        d.text('The '),
-        d.code(text: 'pub'),
-        d.text(' client has been successfully authorized. '
-            'You may now use it to upload packages and perform other tasks.'),
-      ],
-    ),
-  ]);
-}
+final authorizedNode = d.fragment([
+  d.h1(text: 'Pub Authorized Successfully'),
+  d.p(
+    children: [
+      d.text('The '),
+      d.code(text: 'pub'),
+      d.text(' client has been successfully authorized. '
+          'You may now use it to upload packages and perform other tasks.'),
+    ],
+  ),
+]);

--- a/app/lib/frontend/templates/views/account/unauthenticated.dart
+++ b/app/lib/frontend/templates/views/account/unauthenticated.dart
@@ -4,15 +4,13 @@
 
 import '../../../dom/dom.dart' as d;
 
-d.Node unauthenticatedNode() {
-  return d.fragment([
-    d.h1(text: 'Authentication required'),
-    d.p(text: 'You need to be logged in to view this page.'),
-    d.p(
-        text: 'You can sign in using your Google account '
-            'by clicking on the top-right "Sign in" menu.'),
-    d.p(
-        text: 'If you have not signed in on pub.dev before, '
-            'a pub.dev profile will be automatically created upon sign in.'),
-  ]);
-}
+final unauthenticatedNode = d.fragment([
+  d.h1(text: 'Authentication required'),
+  d.p(text: 'You need to be logged in to view this page.'),
+  d.p(
+      text: 'You can sign in using your Google account '
+          'by clicking on the top-right "Sign in" menu.'),
+  d.p(
+      text: 'If you have not signed in on pub.dev before, '
+          'a pub.dev profile will be automatically created upon sign in.'),
+]);

--- a/app/lib/frontend/templates/views/account/unauthorized.dart
+++ b/app/lib/frontend/templates/views/account/unauthorized.dart
@@ -4,9 +4,7 @@
 
 import '../../../dom/dom.dart' as d;
 
-d.Node unauthorizedNode() {
-  return d.fragment([
-    d.h1(text: 'Authorization required'),
-    d.p(text: 'You have insufficient permissions to view this page.'),
-  ]);
-}
+final unauthorizedNode = d.fragment([
+  d.h1(text: 'Authorization required'),
+  d.p(text: 'You have insufficient permissions to view this page.'),
+]);

--- a/app/lib/frontend/templates/views/landing/page.dart
+++ b/app/lib/frontend/templates/views/landing/page.dart
@@ -24,7 +24,7 @@ d.Node landingPageNode({
       _block(
         shortId: 'ff',
         title: 'Flutter Favorites',
-        info: _ffInfo(),
+        info: _ffInfo,
         content: miniListNode('flutter-favorites', ffPackages!),
         viewAllUrl: '/flutter/favorites',
         viewAllEvent: 'landing-flutter-favorites-view-all',
@@ -131,16 +131,13 @@ d.Node _block({
   );
 }
 
-d.Node _ffInfo() {
-  return d.fragment([
-    d.text('Some of the packages that demonstrate the '),
-    d.a(
-      href:
-          'https://flutter.dev/docs/development/packages-and-plugins/favorites',
-      target: '_blank',
-      rel: 'noopener',
-      text: 'highest levels of quality',
-    ),
-    d.text(', selected by the Flutter Ecosystem Committee'),
-  ]);
-}
+final _ffInfo = d.fragment([
+  d.text('Some of the packages that demonstrate the '),
+  d.a(
+    href: 'https://flutter.dev/docs/development/packages-and-plugins/favorites',
+    target: '_blank',
+    rel: 'noopener',
+    text: 'highest levels of quality',
+  ),
+  d.text(', selected by the Flutter Ecosystem Committee'),
+]);

--- a/app/lib/frontend/templates/views/pkg/package_list.dart
+++ b/app/lib/frontend/templates/views/pkg/package_list.dart
@@ -92,7 +92,7 @@ d.Node _packageItem(PackageView view) {
         ),
         d.a(href: urls.publisherUrl(view.publisherId!), text: view.publisherId),
       ]),
-    if (isFlutterFavorite) flutterFavoriteBadgeNode(),
+    if (isFlutterFavorite) flutterFavoriteBadgeNode,
     if (isNullSafe) nullSafeBadgeNode(),
   ]);
 

--- a/app/lib/frontend/templates/views/pkg/score_tab.dart
+++ b/app/lib/frontend/templates/views/pkg/score_tab.dart
@@ -178,13 +178,9 @@ String _updatedSummary(String summary) {
 
 d.Node? _renderToolEnvInfoNode(PanaRuntimeInfo? info, bool usesFlutter) {
   if (info == null) return null;
-  final flutterVersions = info.flutterVersions;
-  final flutterVersion = usesFlutter && flutterVersions != null
-      ? flutterVersions['frameworkVersion']
-      : null;
-  final flutterDartVersion = usesFlutter && flutterVersions != null
-      ? flutterVersions['dartSdkVersion']
-      : null;
+  final flutterVersion = usesFlutter ? info.flutterVersion : null;
+  final flutterDartVersion =
+      usesFlutter ? info.flutterInternalDartSdkVersion : null;
   return _toolEnvInfoNode([
     _ToolVersionInfo('Pana', info.panaVersion),
     if (flutterVersion != null)

--- a/app/lib/frontend/templates/views/pkg/versions/version_row.dart
+++ b/app/lib/frontend/templates/views/pkg/versions/version_row.dart
@@ -50,12 +50,11 @@ d.Node versionRowNode({
               'Go to the documentation of ${version.package} ${version.version}',
           child: d.img(
             classes: ['version-table-icon'],
-            src: staticUrls.versionsTableIcons['documentation'] as String,
+            src: staticUrls.documentationIcon,
             alt:
                 'Go to the documentation of ${version.package} ${version.version}',
             attributes: {
-              'data-failed-icon':
-                  staticUrls.versionsTableIcons['documentationFailed'] as String
+              'data-failed-icon': staticUrls.documentationFailedIcon,
             },
           ),
         ),
@@ -68,7 +67,7 @@ d.Node versionRowNode({
           title: 'Download ${version.package} ${version.version} archive',
           child: d.img(
             classes: ['version-table-icon'],
-            src: staticUrls.versionsTableIcons['download'] as String,
+            src: staticUrls.downloadIcon,
             alt: 'Download ${version.package} ${version.version} archive',
           ),
         ),

--- a/app/lib/frontend/templates/views/publisher/create_page.dart
+++ b/app/lib/frontend/templates/views/publisher/create_page.dart
@@ -7,112 +7,110 @@ import '../../../dom/dom.dart' as d;
 import '../../../dom/material.dart' as material;
 
 /// Creates the page for registering a new publisher.
-d.Node createPublisherPageNode() {
-  return d.fragment([
-    d.h2(text: 'Create a verified publisher'),
-    d.p(children: [
-      d.text('A '),
-      d.i(text: 'verified publisher'),
-      d.text(' is one or more users who own a set of packages. '),
-      d.text('Each publisher is identified by a verified domain name. '),
-      d.text(
-          'This domain lends credibility to packages owned by the publisher. '),
-      d.text('For example, the Dart team at Google uses the '),
-      d.a(
-        href: urls.publisherUrl('dart.dev'),
-        target: '_blank',
-        rel: 'noopener noreferrer',
-        text: 'dart.dev',
-      ),
-      d.text(
-          ' domain as the verified publisher of the packages that the team supported.'),
-    ]),
-    d.p(children: [
-      d.text('To create a verified publisher, you must be a '),
-      d.i(text: 'verified domain property'),
-      d.text(' owner in '),
-      d.a(
-        href: 'https://search.google.com/search-console/welcome',
-        target: '_blank',
-        rel: 'noopener noreferrer',
-        text: 'Google Search Console',
-      ),
-      d.text('. For help see '),
-      d.a(
-        href: 'https://support.google.com/webmasters/answer/34592?hl=en',
-        target: '_blank',
-        rel: 'noopener noreferrer',
-        text: 'Add a website property',
-      ),
-      d.text('.'),
-    ]),
-    d.p(children: [
-      d.text(
-          'The user account creating a publisher must be the verifier of the '),
-      d.i(text: 'domain property'),
-      d.text(' – not just a verifier of a '),
-      d.i(text: 'URL prefix property'),
-      d.text(
-          ' – or a collaborator on a property that someone else has verified.'),
-    ]),
-    d.p(children: [
-      d.text('After you create a verified publisher, you will be the '
-          'only member, and your email will be listed as the '),
-      d.i(text: 'public contact email'),
-      d.text(' of the publisher (you can change this later).'),
-    ]),
-    d.p(text: 'As a member of the publisher you can:'),
-    d.ul(children: [
-      d.li(children: [
-        d.text('Use the '),
-        d.i(text: 'publisher Admin page'),
-        d.text(' to: '),
-        d.ul(children: [
-          d.li(children: [
-            d.text('change the '),
-            d.i(text: 'public contact email'),
-            d.text(' of the publisher,'),
-          ]),
-          d.li(text: 'edit the description of the publisher,'),
-          d.li(
-              text:
-                  'invite other users to become members of the publisher, and,'),
-          d.li(text: 'remove users who are members of the publisher.'),
-        ]),
-      ]),
-      d.li(children: [
-        d.text('Use the '),
-        d.i(text: 'package Admin page'),
-        d.text(' to: '),
-        d.ul(children: [
-          d.li(text: 'update the options of the package, and'),
-          d.li(text: 'transfer a package to a publisher.'),
-        ]),
-      ]),
-    ]),
-    d.div(
-      classes: ['-pub-form-row'],
-      children: [
-        material.textField(
-          id: '-publisher-id',
-          label: 'Domain Name',
-        ),
-        material.raisedButton(
-          id: '-admin-create-publisher',
-          label: 'Create publisher',
-        ),
-      ],
+final createPublisherPageNode = d.fragment([
+  d.h2(text: 'Create a verified publisher'),
+  d.p(children: [
+    d.text('A '),
+    d.i(text: 'verified publisher'),
+    d.text(' is one or more users who own a set of packages. '),
+    d.text('Each publisher is identified by a verified domain name. '),
+    d.text(
+        'This domain lends credibility to packages owned by the publisher. '),
+    d.text('For example, the Dart team at Google uses the '),
+    d.a(
+      href: urls.publisherUrl('dart.dev'),
+      target: '_blank',
+      rel: 'noopener noreferrer',
+      text: 'dart.dev',
     ),
-    d.p(children: [
-      d.text(
-          'For more information on publishing and administering packages, see the '),
-      d.a(
-        href: 'https://dart.dev/tools/pub/publishing',
-        target: '_blank',
-        rel: 'noopener noreferrer',
-        text: 'documentation on publishing packages',
-      ),
-      d.text('.'),
+    d.text(
+        ' domain as the verified publisher of the packages that the team supported.'),
+  ]),
+  d.p(children: [
+    d.text('To create a verified publisher, you must be a '),
+    d.i(text: 'verified domain property'),
+    d.text(' owner in '),
+    d.a(
+      href: 'https://search.google.com/search-console/welcome',
+      target: '_blank',
+      rel: 'noopener noreferrer',
+      text: 'Google Search Console',
+    ),
+    d.text('. For help see '),
+    d.a(
+      href: 'https://support.google.com/webmasters/answer/34592?hl=en',
+      target: '_blank',
+      rel: 'noopener noreferrer',
+      text: 'Add a website property',
+    ),
+    d.text('.'),
+  ]),
+  d.p(children: [
+    d.text(
+        'The user account creating a publisher must be the verifier of the '),
+    d.i(text: 'domain property'),
+    d.text(' – not just a verifier of a '),
+    d.i(text: 'URL prefix property'),
+    d.text(
+        ' – or a collaborator on a property that someone else has verified.'),
+  ]),
+  d.p(children: [
+    d.text('After you create a verified publisher, you will be the '
+        'only member, and your email will be listed as the '),
+    d.i(text: 'public contact email'),
+    d.text(' of the publisher (you can change this later).'),
+  ]),
+  d.p(text: 'As a member of the publisher you can:'),
+  d.ul(children: [
+    d.li(children: [
+      d.text('Use the '),
+      d.i(text: 'publisher Admin page'),
+      d.text(' to: '),
+      d.ul(children: [
+        d.li(children: [
+          d.text('change the '),
+          d.i(text: 'public contact email'),
+          d.text(' of the publisher,'),
+        ]),
+        d.li(text: 'edit the description of the publisher,'),
+        d.li(
+            text:
+                'invite other users to become members of the publisher, and,'),
+        d.li(text: 'remove users who are members of the publisher.'),
+      ]),
     ]),
-  ]);
-}
+    d.li(children: [
+      d.text('Use the '),
+      d.i(text: 'package Admin page'),
+      d.text(' to: '),
+      d.ul(children: [
+        d.li(text: 'update the options of the package, and'),
+        d.li(text: 'transfer a package to a publisher.'),
+      ]),
+    ]),
+  ]),
+  d.div(
+    classes: ['-pub-form-row'],
+    children: [
+      material.textField(
+        id: '-publisher-id',
+        label: 'Domain Name',
+      ),
+      material.raisedButton(
+        id: '-admin-create-publisher',
+        label: 'Create publisher',
+      ),
+    ],
+  ),
+  d.p(children: [
+    d.text(
+        'For more information on publishing and administering packages, see the '),
+    d.a(
+      href: 'https://dart.dev/tools/pub/publishing',
+      target: '_blank',
+      rel: 'noopener noreferrer',
+      text: 'documentation on publishing packages',
+    ),
+    d.text('.'),
+  ]),
+]);

--- a/app/lib/frontend/templates/views/publisher/publisher_list.dart
+++ b/app/lib/frontend/templates/views/publisher/publisher_list.dart
@@ -32,8 +32,7 @@ d.Node publisherListNode({
           ),
         ),
       ),
-    if (publishers.isEmpty)
-      isGlobal ? _noPublisherGlobal() : _noPublisherLocal(),
+    if (publishers.isEmpty) isGlobal ? _noPublisherGlobal : _noPublisherLocal,
     d.h3(text: 'Want to create a new publisher?'),
     d.p(
       children: [
@@ -45,18 +44,16 @@ d.Node publisherListNode({
   ]);
 }
 
-d.Node _noPublisherGlobal() => d.p(text: 'No publisher has been registered.');
-d.Node _noPublisherLocal() {
-  return d.p(
-    children: [
-      d.text('You are not a member of any '),
-      d.a(
-        href: 'https://dart.dev/tools/pub/verified-publishers',
-        text: 'verified publishers',
-        rel: 'noreferrer',
-        target: '_blank',
-      ),
-      d.text('.'),
-    ],
-  );
-}
+final _noPublisherGlobal = d.p(text: 'No publisher has been registered.');
+final _noPublisherLocal = d.p(
+  children: [
+    d.text('You are not a member of any '),
+    d.a(
+      href: 'https://dart.dev/tools/pub/verified-publishers',
+      text: 'verified publishers',
+      rel: 'noreferrer',
+      target: '_blank',
+    ),
+    d.text('.'),
+  ],
+);

--- a/app/lib/frontend/templates/views/shared/site_header.dart
+++ b/app/lib/frontend/templates/views/shared/site_header.dart
@@ -90,17 +90,17 @@ d.Node siteHeaderNode({
                 child: d.div(
                   classes: ['nav-table-columns'],
                   children: [
-                    _desktopLinksColumn('Pub.dev', _pubDevLinks()),
-                    _desktopLinksColumn('Flutter', _flutterLinks()),
-                    _desktopLinksColumn('Dart', _dartLinks()),
+                    _desktopLinksColumn('Pub.dev', _pubDevLinks),
+                    _desktopLinksColumn('Flutter', _flutterLinks),
+                    _desktopLinksColumn('Dart', _dartLinks),
                   ],
                 ),
               ),
             ],
           ),
-          _foldableMobileLinks('Pub.dev', _pubDevLinks()),
-          _foldableMobileLinks('Flutter', _flutterLinks()),
-          _foldableMobileLinks('Dart', _dartLinks()),
+          _foldableMobileLinks('Pub.dev', _pubDevLinks),
+          _foldableMobileLinks('Flutter', _flutterLinks),
+          _foldableMobileLinks('Dart', _dartLinks),
           if (userSession != null) _userBlock(userSession),
         ],
       ),
@@ -159,30 +159,24 @@ d.Node _userBlock(UserSessionData userSession) {
   );
 }
 
-Iterable<d.Node> _pubDevLinks() {
-  return [
-    _navNewPage('/help/search', 'Searching for packages'),
-    _navNewPage('/help/scoring', 'Package scoring and pub points'),
-  ];
-}
+final _pubDevLinks = [
+  _navNewPage('/help/search', 'Searching for packages'),
+  _navNewPage('/help/scoring', 'Package scoring and pub points'),
+];
 
-Iterable<d.Node> _flutterLinks() {
-  return [
-    _navNewPage('https://flutter.io/using-packages/', 'Using packages'),
-    _navNewPage('https://flutter.io/developing-packages/',
-        'Developing packages and plugins'),
-    _navNewPage(
-        '${urls.dartSiteRoot}/tools/pub/publishing', 'Publishing a package'),
-  ];
-}
+final _flutterLinks = [
+  _navNewPage('https://flutter.io/using-packages/', 'Using packages'),
+  _navNewPage('https://flutter.io/developing-packages/',
+      'Developing packages and plugins'),
+  _navNewPage(
+      '${urls.dartSiteRoot}/tools/pub/publishing', 'Publishing a package'),
+];
 
-Iterable<d.Node> _dartLinks() {
-  return [
-    _navNewPage('${urls.dartSiteRoot}/tools/pub/get-started', 'Using packages'),
-    _navNewPage(
-        '${urls.dartSiteRoot}/tools/pub/publishing', 'Publishing a package'),
-  ];
-}
+final _dartLinks = [
+  _navNewPage('${urls.dartSiteRoot}/tools/pub/get-started', 'Using packages'),
+  _navNewPage(
+      '${urls.dartSiteRoot}/tools/pub/publishing', 'Publishing a package'),
+];
 
 d.Node _navLink(String href, String text) {
   return d.a(classes: ['nav-link'], href: href, text: text);

--- a/pkg/web_css/build.sh
+++ b/pkg/web_css/build.sh
@@ -14,7 +14,7 @@ mkdir -p "${OUTPUT_DIR}"
 # Change to web_css folder
 cd "${WEB_CSS_DIR}";
 
-dart pub run sass \
+dart run sass \
   --style=compressed \
   "${WEB_CSS_DIR}/lib/style.scss" \
   "${OUTPUT_DIR}/style.css"


### PR DESCRIPTION
- always use full request path for static resources (e.g. `/static/...`) - besides the consistency, this would allow another test where we cross-check the files and their references in the code
- cosmetic fix `StaticUrls` -> `late final` allows the initialize once pattern for static asset urls
- removed `StaticUrls.versionsTableIcons` as it is no longer necessary to have that configurable anymore
- moved trivial and immutable template blocks to final fields initialized once (instead of the method calls every time they are being rendered)
- using `dart run` instead of `dart pub run` to build the CSS file