### PR TITLE
Code cleanup: FileObject

### DIFF
--- a/app/lib/frontend/templates/_utils.dart
+++ b/app/lib/frontend/templates/_utils.dart
@@ -2,24 +2,20 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:convert';
-
 import 'package:path/path.dart' as p;
 
-import '../../package/model_properties.dart' show FileObject;
+import '../../package/models.dart' show PackageVersionAsset;
 import '../../shared/markdown.dart';
 import '../dom/dom.dart' as d;
 
-const HtmlEscape htmlAttrEscape = HtmlEscape(HtmlEscapeMode.attribute);
-
 /// Renders a file content (e.g. markdown, dart source file) into HTML.
 d.Node renderFile(
-  FileObject file, {
+  PackageVersionAsset asset, {
   String? baseUrl,
   bool isChangelog = false,
 }) {
-  final filename = file.filename;
-  final content = file.text;
+  final filename = asset.path!;
+  final content = asset.textContent!;
   if (_isMarkdownFile(filename)) {
     return d.unsafeRawHtml(
       markdownToHtml(

--- a/app/lib/frontend/templates/misc.dart
+++ b/app/lib/frontend/templates/misc.dart
@@ -5,7 +5,6 @@
 import 'dart:io' as io;
 
 import 'package:path/path.dart' as p;
-import 'package:pub_dev/frontend/templates/views/page/error.dart';
 
 import '../dom/dom.dart' as d;
 import '../static_files.dart' as static_files;
@@ -13,6 +12,7 @@ import '../static_files.dart' as static_files;
 import 'layout.dart';
 import 'views/account/unauthenticated.dart';
 import 'views/account/unauthorized.dart';
+import 'views/page/error.dart';
 import 'views/page/standalone.dart';
 
 /// The content of `/doc/policy.md`

--- a/app/lib/frontend/templates/package.dart
+++ b/app/lib/frontend/templates/package.dart
@@ -269,7 +269,7 @@ Tab _readmeTab(PackagePageData data) {
   final content = data.hasReadme &&
           data.asset != null &&
           data.asset!.kind == AssetKind.readme
-      ? renderFile(data.asset!.toFileObject(), baseUrl: baseUrl)
+      ? renderFile(data.asset!, baseUrl: baseUrl)
       : d.text('');
   return Tab.withContent(
     id: 'readme',
@@ -283,7 +283,7 @@ Tab? _changelogTab(PackagePageData data) {
   if (!data.hasChangelog) return null;
   if (data.asset?.kind != AssetKind.changelog) return null;
   final content = renderFile(
-    data.asset!.toFileObject(),
+    data.asset!,
     baseUrl: data.version!.packageLinks.baseUrl,
     isChangelog: true,
   );
@@ -301,8 +301,7 @@ Tab? _exampleTab(PackagePageData data) {
   final baseUrl = data.version!.packageLinks.baseUrl;
 
   final exampleFilename = data.asset!.path;
-  final renderedExample =
-      renderFile(data.asset!.toFileObject(), baseUrl: baseUrl);
+  final renderedExample = renderFile(data.asset!, baseUrl: baseUrl);
   final url = getRepositoryUrl(baseUrl, exampleFilename!);
 
   return Tab.withContent(
@@ -345,7 +344,7 @@ Tab _installTab(PackagePageData data) {
 Tab _licenseTab(PackagePageData data) {
   final license = data.hasLicense
       ? renderFile(
-          data.asset!.toFileObject(),
+          data.asset!,
           baseUrl: data.version!.packageLinks.baseUrl,
         )
       : d.text('No license file found.');
@@ -363,7 +362,7 @@ Tab _licenseTab(PackagePageData data) {
 Tab _pubspecTab(PackagePageData data) {
   final content = data.hasPubspec
       ? renderFile(
-          data.asset!.toFileObject(),
+          data.asset!,
           baseUrl: data.version!.packageLinks.baseUrl,
         )
       : d.text('No pubspec file found.');

--- a/app/lib/frontend/templates/publisher.dart
+++ b/app/lib/frontend/templates/publisher.dart
@@ -4,7 +4,6 @@
 
 import 'package:client_data/page_data.dart';
 import 'package:client_data/publisher_api.dart' as api;
-import 'package:pub_dev/frontend/templates/views/publisher/admin_page.dart';
 
 import '../../audit/models.dart';
 import '../../frontend/templates/views/account/activity_log_table.dart';
@@ -16,6 +15,7 @@ import '../dom/dom.dart' as d;
 import 'detail_page.dart';
 import 'layout.dart';
 import 'listing.dart';
+import 'views/publisher/admin_page.dart';
 import 'views/publisher/create_page.dart';
 import 'views/publisher/header_metadata.dart';
 import 'views/publisher/publisher_list.dart';

--- a/app/lib/package/model_properties.dart
+++ b/app/lib/package/model_properties.dart
@@ -211,10 +211,3 @@ class PubspecProperty extends StringProperty {
     return null;
   }
 }
-
-class FileObject {
-  final String filename;
-  final String text;
-
-  FileObject(this.filename, this.text);
-}

--- a/app/lib/package/models.dart
+++ b/app/lib/package/models.dart
@@ -20,8 +20,6 @@ import '../shared/tags.dart';
 import '../shared/urls.dart' as urls;
 import '../shared/utils.dart';
 
-export '../package/model_properties.dart' show FileObject;
-
 part 'models.g.dart';
 
 /// The age of package (the last version published) after it is hidden in
@@ -592,8 +590,6 @@ class PackageVersionAsset extends db.ExpandoModel {
       version: version,
     );
   }
-
-  FileObject toFileObject() => FileObject(path!, textContent!);
 }
 
 /// Entity representing a package that has been removed.


### PR DESCRIPTION
- No need for `FileObject`, as `PackageVersionAsset` is used as the source of it anyway.
- Also fixed a few import and removed unused escaping.