### PR TITLE
Display detected URL problems.

### DIFF
--- a/app/lib/frontend/templates/package.dart
+++ b/app/lib/frontend/templates/package.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:client_data/page_data.dart';
+import 'package:collection/collection.dart' show IterableExtension;
 import 'package:pana/pana.dart' show getRepositoryUrl;
 
 import '../../package/models.dart';
@@ -41,6 +42,7 @@ d.Node renderPkgInfoBox(PackagePageData data) {
     isLatest: data.isLatestStable,
   );
 
+  final urlProblems = data.scoreCard?.panaReport?.urlProblems;
   final metaLinks = <InfoBoxLink>[];
   final docLinks = <InfoBoxLink>[];
   void addLink(
@@ -52,14 +54,23 @@ d.Node renderPkgInfoBox(PackagePageData data) {
     final uri = urls.parseValidUrl(href);
     if (uri == null) return;
 
-    if (detectServiceProvider) {
+    final problemCode = urlProblems == null
+        ? null
+        : urlProblems.firstWhereOrNull((p) => p.url == uri.toString())?.problem;
+    if (detectServiceProvider && problemCode == null) {
       final providerName = urls.inferServiceProviderName(href);
       if (providerName != null) {
         label += ' ($providerName)';
       }
     }
-    final linkData = InfoBoxLink(uri.toString(), label,
-        rel: uri.shouldIndicateUgc ? 'ugc' : null);
+    final linkData = InfoBoxLink(
+      uri.toString(),
+      label,
+      rel: problemCode != null
+          ? 'nofollow noopener ugc'
+          : (uri.shouldIndicateUgc ? 'ugc' : null),
+      problemCode: problemCode,
+    );
     if (documentation) {
       docLinks.add(linkData);
     } else {

--- a/app/lib/frontend/templates/views/pkg/info_box.dart
+++ b/app/lib/frontend/templates/views/pkg/info_box.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:pana/models.dart' show LicenseFile;
+import 'package:pana/pana.dart';
 import 'package:pubspec_parse/pubspec_parse.dart' as pubspek;
 
 import '../../../../package/models.dart';
@@ -17,7 +18,10 @@ class InfoBoxLink {
   final String label;
   final String? rel;
 
-  InfoBoxLink(this.href, this.label, {this.rel});
+  /// One of [UrlProblemCodes].
+  final String? problemCode;
+
+  InfoBoxLink(this.href, this.label, {this.rel, this.problemCode});
 }
 
 /// Renders the package info box.
@@ -118,6 +122,7 @@ d.Node _block(String title, d.Node? content) {
 d.Node _linkAndBr(InfoBoxLink link) {
   return d.fragment([
     d.a(classes: ['link'], href: link.href, text: link.label, rel: link.rel),
+    if (link.problemCode != null) d.text(' (${link.problemCode})'),
     d.br(),
   ]);
 }


### PR DESCRIPTION
- Fixes #4902.
- When a problem is present:
   - we don't add the provider to the label (e.g. `(GitHub)`,
   - we add `rel="nofollow noopener ugc"` to the `<a>` element to de-emphasize the link
   - we add ` (<code>)` after the link label
 