### PR TITLE
webmasters/v3 -> searchconsole/v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ AppEngine version, listed here to ease deployment and troubleshooting.
  * Bumped runtimeVersion to `2021.10.01`.
  * Upgraded stable Dart analysis SDK to `2.14.3`.
  * Upgraded stable Flutter analysis SDK to `2.5.2`.
+ * Migrated searchconsole api. When deploying publisher registration should be
+   manually tested before migration.
 
 ## `20211001t132700-all`
 

--- a/app/lib/publisher/domain_verifier.dart
+++ b/app/lib/publisher/domain_verifier.dart
@@ -3,8 +3,9 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:gcloud/service_scope.dart' as ss;
-import 'package:googleapis/webmasters/v3.dart' as wmx;
+import 'package:googleapis/searchconsole/v1.dart' as wmx;
 import 'package:googleapis_auth/googleapis_auth.dart' as auth;
+
 import 'package:http/http.dart' as http;
 import 'package:retry/retry.dart' show retry;
 
@@ -38,13 +39,13 @@ class DomainVerifier {
           DateTime.now().toUtc().add(Duration(minutes: 20)), // avoid refresh
         ),
         null,
-        [wmx.WebmastersApi.webmastersReadonlyScope],
+        [wmx.SearchConsoleApi.webmastersReadonlyScope],
       ),
     );
     try {
       // Request list of sites/domains from the Search Console API.
       final sites = await retry(
-        () => wmx.WebmastersApi(client).sites.list(),
+        () => wmx.SearchConsoleApi(client).sites.list(),
         maxAttempts: 3,
         maxDelay: Duration(milliseconds: 500),
         retryIf: (e) => e is! auth.AccessDeniedException,


### PR DESCRIPTION
Deprecation notice here: https://developers.google.com/search/blog/2020/12/search-console-api-updates
Migrating according to https://developers.google.com/search/blog/2020/12/search-console-api-updates#discovery-doc-migration