### PR TITLE
Atom feed return all published versions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ AppEngine version, listed here to ease deployment and troubleshooting.
  * Upgraded dartdoc to `4.0.0`.
  * NOTE: Migrated SearchConsole API.
          When deploying publisher registration should be manually tested before migration.
+ * NOTE: Atom feed returns the latest 100 package versions published.
+         A package may be present more than once.
+         Instead of the `README.md`, the feed contains only the `description:` field from `pubspec.yaml`.
 
 ## `20211001t132700-all`
 

--- a/app/lib/frontend/handlers/atom_feed.dart
+++ b/app/lib/frontend/handlers/atom_feed.dart
@@ -21,7 +21,7 @@ import '../dom/dom.dart' as d;
 /// Handles requests for /feed.atom
 Future<shelf.Response> atomFeedHandler(shelf.Request request) async {
   final feedContent = await cache.atomFeedXml().get(() async {
-    final versions = await packageBackend.latestPackageVersions(limit: 25);
+    final versions = await packageBackend.latestPackageVersions(limit: 100);
     final feed = _feedFromPackageVersions(request.requestedUri, versions);
     return feed.toXmlDocument();
   });

--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -125,7 +125,7 @@ class PackageBackend {
 
   /// Retrieves package versions ordered by their published date descending.
   Future<List<PackageVersion>> latestPackageVersions(
-      {int offset = 0, int limit = 10}) async {
+      {int offset = 0, required int limit}) async {
     final query = db.query<PackageVersion>()
       ..order('-created')
       ..offset(offset)

--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -123,11 +123,21 @@ class PackageBackend {
         .map((p) => p.name!);
   }
 
-  /// Retrieves package versions ordered by their latest version date.
+  /// Retrieves package versions ordered by their published date descending.
   Future<List<PackageVersion>> latestPackageVersions(
-      {int? offset, int? limit}) async {
-    final pkgPage = await latestPackages(offset: offset, limit: limit);
-    return lookupLatestVersions(pkgPage.packages);
+      {int offset = 0, int limit = 10}) async {
+    final query = db.query<PackageVersion>()
+      ..order('-created')
+      ..offset(offset)
+      ..limit(limit);
+    final versions = await query.run().toList();
+    final results = <PackageVersion>[];
+    for (final v in versions) {
+      if (isSoftRemoved(v.package)) continue;
+      if (!(await isPackageVisible(v.package))) continue;
+      results.add(v);
+    }
+    return results;
   }
 
   /// Returns the latest stable version of a package.

--- a/app/test/frontend/handlers/atom_feed_test.dart
+++ b/app/test/frontend/handlers/atom_feed_test.dart
@@ -19,11 +19,14 @@ void main() {
       final feed = root.rootElement;
 
       final entries = feed.findElements('entry').toList();
-      expect(entries.length, 3);
+      expect(entries.length, 6);
       expect(entries.map((e) => e.findElements('title').first.text).toList(), [
+        'v2.0.0-dev of oxygen',
         'v1.2.0 of oxygen',
+        'v1.0.0 of oxygen',
         'v1.10.0 of flutter_titanium',
         'v1.0.0 of neon',
+        'v1.9.0 of flutter_titanium',
       ]);
 
       final oxygenExpr = RegExp('<entry>\n'
@@ -35,7 +38,7 @@ void main() {
           '</entry>');
       expect(
           oxygenExpr
-              .hasMatch(entries[0].toXmlString(pretty: true, indent: '  ')),
+              .hasMatch(entries[1].toXmlString(pretty: true, indent: '  ')),
           isTrue);
 
       final neonExpr = RegExp('<entry>\n'
@@ -46,7 +49,7 @@ void main() {
           '  <link href="https://pub.dev/packages/neon" rel="alternate" title="neon"/>\n'
           '</entry>');
       expect(
-          neonExpr.hasMatch(entries[2].toXmlString(pretty: true, indent: '  ')),
+          neonExpr.hasMatch(entries[4].toXmlString(pretty: true, indent: '  ')),
           isTrue);
 
       entries.forEach((e) => e.parent!.children.remove(e));

--- a/app/test/package/backend_test.dart
+++ b/app/test/package/backend_test.dart
@@ -72,11 +72,16 @@ void main() {
     });
 
     group('Backend.latestPackageVersions', () {
-      testWithProfile('one package', fn: () async {
-        final list =
-            await packageBackend.latestPackageVersions(offset: 2, limit: 1);
-        expect(list.map((pv) => pv.qualifiedVersionKey.toString()),
-            ['neon/1.0.0']);
+      testWithProfile('all packages', fn: () async {
+        final list = await packageBackend.latestPackageVersions(limit: 100);
+        expect(list.map((pv) => pv.qualifiedVersionKey.toString()), [
+          'oxygen/2.0.0-dev',
+          'oxygen/1.2.0',
+          'oxygen/1.0.0',
+          'flutter_titanium/1.10.0',
+          'neon/1.0.0',
+          'flutter_titanium/1.9.0',
+        ]);
       });
 
       testWithProfile('empty', fn: () async {


### PR DESCRIPTION
- feed returns the latest 100 package versions published
- a package may be present more than once (see changes in `atom_feed_test.dart`)
- fixes #5161