### PR TITLE
Retry Datastore lookups.

### DIFF
--- a/app/lib/service/services.dart
+++ b/app/lib/service/services.dart
@@ -62,6 +62,10 @@ Future<void> withServices(FutureOr<void> Function() fn) async {
   }
   return withAppEngineServices(() async {
     return await fork(() async {
+      // retrying Datastore client
+      final origDbService = dbService;
+      registerDbService(RetryDatastoreDB(origDbService));
+
       // retrying auth client for storage service
       final authClient = await auth
           .clientViaApplicationDefaultCredentials(scopes: [...Storage.SCOPES]);
@@ -114,7 +118,7 @@ Future<void> withFakeServices({
   datastore ??= MemDatastore();
   storage ??= MemStorage();
   return await fork(() async {
-    registerDbService(DatastoreDB(datastore!));
+    registerDbService(RetryDatastoreDB(DatastoreDB(datastore!)));
     registerStorageService(storage!);
     if (configuration == null) {
       // start storage server

--- a/app/lib/shared/datastore.dart
+++ b/app/lib/shared/datastore.dart
@@ -171,15 +171,90 @@ Future<T> withRetryTransaction<T>(
 ) =>
     _transactionRetrier.retry<T>(
       () => _withTransaction<T>(db, fn),
-      // TODO(jonasfj): Over time we want reduce the number exceptions on which
-      //                we retry. The following is a list of exceptions we know
-      //                we want to retry:
-      //  - TransactionAbortedError, implies a transaction conflict.
-      // Never retry a ResponseException
-      retryIf: (e) => e is! ResponseException,
-      onRetry: (e) {
-        final message =
-            e is ds.DatastoreError ? 'DatastoreError' : 'non-DatastoreError';
-        _logger.info('retrying transaction - $message ${e.runtimeType}', e);
-      },
+      retryIf: _retryIf,
+      onRetry: (e) => _onRetry('transaction', e),
     );
+
+// TODO(jonasfj): Over time we want reduce the number exceptions on which
+//                we retry. The following is a list of exceptions we know
+//                we want to retry:
+//  - TransactionAbortedError, implies a transaction conflict.
+// Never retry a ResponseException
+bool _retryIf(Exception e) => e is! ResponseException;
+
+void _onRetry(String op, Exception e) {
+  final message =
+      e is ds.DatastoreError ? 'DatastoreError' : 'non-DatastoreError';
+  _logger.info('retrying $op - $message ${e.runtimeType}', e);
+}
+
+/// Wrapper for [DatastoreDB] that retries lookup opertations.
+///
+/// TODO: implement retry wrapper for queries
+/// TODO: implement retry wrapper for transaction and commit
+class RetryDatastoreDB implements DatastoreDB {
+  final DatastoreDB _db;
+
+  final _readRetrier = RetryOptions(
+    maxAttempts: 3,
+    delayFactor: Duration(milliseconds: 200),
+    maxDelay: Duration(seconds: 5),
+    randomizationFactor: 0.5,
+  );
+
+  RetryDatastoreDB(this._db);
+
+  @override
+  ds.Datastore get datastore => _db.datastore;
+
+  @override
+  Partition get defaultPartition => _db.defaultPartition;
+
+  @override
+  Key get emptyKey => _db.emptyKey;
+
+  @override
+  ModelDB get modelDB => _db.modelDB;
+
+  @override
+  Partition newPartition(String namespace) => _db.newPartition(namespace);
+
+  @override
+  Future<List<T?>> lookup<T extends Model>(List<Key> keys) async {
+    return await _retryRead(() => _db.lookup(keys));
+  }
+
+  @override
+  Future<T?> lookupOrNull<T extends Model>(Key key) async {
+    return await _retryRead(() => _db.lookupOrNull(key));
+  }
+
+  @override
+  Future<T> lookupValue<T extends Model>(Key key,
+      {T Function()? orElse}) async {
+    return await _retryRead(() => _db.lookupValue(key, orElse: orElse));
+  }
+
+  @override
+  Query<T> query<T extends Model>({Partition? partition, Key? ancestorKey}) {
+    return _db.query(partition: partition, ancestorKey: ancestorKey);
+  }
+
+  @override
+  Future<T> withTransaction<T>(TransactionHandler<T> transactionHandler) async {
+    return await _db.withTransaction(transactionHandler);
+  }
+
+  @override
+  Future commit({List<Model>? inserts, List<Key>? deletes}) async {
+    return await _db.commit(inserts: inserts, deletes: deletes);
+  }
+
+  Future<T> _retryRead<T>(Future<T> Function() fn) async {
+    return await _readRetrier.retry(
+      fn,
+      retryIf: _retryIf,
+      onRetry: (e) => _onRetry('read', e),
+    );
+  }
+}

--- a/app/lib/shared/datastore.dart
+++ b/app/lib/shared/datastore.dart
@@ -197,9 +197,9 @@ class RetryDatastoreDB implements DatastoreDB {
 
   final _readRetrier = RetryOptions(
     maxAttempts: 3,
-    delayFactor: Duration(milliseconds: 200),
-    maxDelay: Duration(seconds: 5),
-    randomizationFactor: 0.5,
+    delayFactor: Duration(milliseconds: 100),
+    maxDelay: Duration(seconds: 2),
+    randomizationFactor: 0.2,
   );
 
   RetryDatastoreDB(this._db);

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -541,7 +541,7 @@ packages:
     source: hosted
     version: "1.1.0"
   retry:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: retry
       url: "https://pub.dartlang.org"

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -37,6 +37,7 @@ dependencies:
     path: ../pkg/pub_package_reader
   pub_semver: '^2.0.0'
   pubspec_parse: ^1.0.0
+  retry: ^3.1.0
   shelf: '^1.0.0'
   shelf_router: ^1.1.0
   stack_trace: ^1.10.0


### PR DESCRIPTION
- replaces #5164 fixes #5101
- fixes bug where package:retry was not referenced in pubspec.yaml, but was used in the source code
