### PR TITLE
Remove SearchForm.tagsPredicate

### DIFF
--- a/app/lib/frontend/handlers/account.dart
+++ b/app/lib/frontend/handlers/account.dart
@@ -16,7 +16,6 @@ import '../../package/search_adapter.dart';
 import '../../publisher/backend.dart';
 import '../../publisher/models.dart';
 import '../../search/search_form.dart';
-import '../../search/search_service.dart';
 import '../../shared/configuration.dart' show activeConfiguration;
 import '../../shared/exceptions.dart';
 import '../../shared/handlers.dart';
@@ -219,7 +218,7 @@ Future<shelf.Response> accountPackagesPageHandler(shelf.Request request) async {
       userSessionData!.userId!,
       ...page.publishers!.map((p) => p.publisherId),
     ],
-    tagsPredicate: TagsPredicate.allPackages(),
+    includeAll: true,
   );
 
   final searchResult = await searchAdapter.search(searchForm);

--- a/app/lib/frontend/handlers/custom_api.dart
+++ b/app/lib/frontend/handlers/custom_api.dart
@@ -261,10 +261,8 @@ Future<VersionScore> packageVersionScoreHandler(
 
 /// Handles requests for /api/search
 Future<shelf.Response> apiSearchHandler(shelf.Request request) async {
-  final searchForm = parseFrontendSearchForm(
-    request.requestedUri.queryParameters,
-    tagsPredicate: TagsPredicate.regularSearch(),
-  );
+  final searchForm =
+      parseFrontendSearchForm(request.requestedUri.queryParameters);
   final sr = await searchClient.search(searchForm.toServiceQuery());
   final packages =
       sr.allPackageHits.map((ps) => {'package': ps.package}).toList();

--- a/app/lib/frontend/handlers/landing.dart
+++ b/app/lib/frontend/handlers/landing.dart
@@ -49,7 +49,7 @@ Future<shelf.Response> indexLandingHandler(shelf.Request request) async {
 
   Future<String> _render() async {
     final ffPackages = await searchAdapter.topFeatured(
-      requiredTags: [PackageTags.isFlutterFavorite],
+      contextIsFlutterFavorites: true,
       count: 4,
     );
 
@@ -57,10 +57,10 @@ Future<shelf.Response> indexLandingHandler(shelf.Request request) async {
         await searchAdapter.topFeatured(order: SearchOrder.popularity);
 
     final topFlutterPackages =
-        await searchAdapter.topFeatured(requiredTags: [SdkTag.sdkFlutter]);
+        await searchAdapter.topFeatured(sdk: SdkTagValue.flutter);
 
     final topDartPackages =
-        await searchAdapter.topFeatured(requiredTags: [SdkTag.sdkDart]);
+        await searchAdapter.topFeatured(sdk: SdkTagValue.dart);
 
     final topPoWVideos = youtubeBackend.getTopPackageOfWeekVideos(count: 4);
 

--- a/app/lib/frontend/handlers/listing.dart
+++ b/app/lib/frontend/handlers/listing.dart
@@ -81,7 +81,6 @@ Future<shelf.Response> _packagesHandlerHtmlCore(
     request.requestedUri.queryParameters,
     sdk: sdk,
     contextIsFlutterFavorites: contextIsFlutterFavorites,
-    tagsPredicate: TagsPredicate.regularSearch(),
   );
   final sw = Stopwatch()..start();
   final searchResult = await searchAdapter.search(searchForm);

--- a/app/lib/frontend/handlers/publisher.dart
+++ b/app/lib/frontend/handlers/publisher.dart
@@ -58,7 +58,7 @@ Future<shelf.Response> publisherPackagesPageHandler(
   final searchForm = parseFrontendSearchForm(
     request.requestedUri.queryParameters,
     publisherId: publisherId,
-    tagsPredicate: TagsPredicate.allPackages(),
+    includeAll: true,
   );
   // Redirect in case of empty search query.
   if (request.requestedUri.query == 'q=') {

--- a/app/lib/frontend/templates/views/pkg/index.dart
+++ b/app/lib/frontend/templates/views/pkg/index.dart
@@ -33,9 +33,9 @@ d.Node packageListingNode({
 }
 
 d.Node _searchControls(SearchForm searchForm, d.Node? subSdkButtons) {
-  final includeDiscontinued = searchForm.includeDiscontinued ?? false;
-  final includeUnlisted = searchForm.includeUnlisted ?? false;
-  final nullSafe = searchForm.nullSafe ?? false;
+  final includeDiscontinued = searchForm.includeDiscontinued;
+  final includeUnlisted = searchForm.includeUnlisted;
+  final nullSafe = searchForm.nullSafe;
   final hasActiveAdvanced = includeDiscontinued || includeUnlisted || nullSafe;
   return d.div(
     classes: [

--- a/app/lib/package/search_adapter.dart
+++ b/app/lib/package/search_adapter.dart
@@ -37,13 +37,15 @@ class SearchAdapter {
   /// Uses long-term caching and local randomized selection.
   /// Returns empty list when search is not available or doesn't yield results.
   Future<List<PackageView>> topFeatured({
-    List<String>? requiredTags,
+    String? sdk,
+    bool contextIsFlutterFavorites = false,
     int count = 6,
     SearchOrder? order,
   }) async {
     final form = SearchForm.parse(
+      contextIsFlutterFavorites: contextIsFlutterFavorites,
+      sdk: sdk,
       pageSize: 100,
-      tagsPredicate: TagsPredicate.advertisement(requiredTags: requiredTags),
       order: order,
     );
     final searchResults = await _searchOrFallback(

--- a/app/lib/search/search_service.dart
+++ b/app/lib/search/search_service.dart
@@ -409,16 +409,6 @@ class TagsPredicate {
         ],
       );
 
-  factory TagsPredicate.advertisement({List<String>? requiredTags}) =>
-      TagsPredicate(
-        prohibitedTags: [
-          PackageTags.isDiscontinued,
-          PackageTags.isUnlisted,
-          PackageVersionTags.isLegacy,
-        ],
-        requiredTags: requiredTags,
-      );
-
   /// Pre-populates the predicate with the default tags for all package listings
   /// (e.g. "My packages").
   factory TagsPredicate.allPackages() => TagsPredicate();

--- a/app/test/search/search_service_test.dart
+++ b/app/test/search/search_service_test.dart
@@ -165,17 +165,16 @@ void main() {
       final query = parseFrontendSearchForm(
         {'platform': 'android'},
         sdk: 'flutter',
-        tagsPredicate: TagsPredicate.regularSearch(),
       );
       expect(
-        query.toServiceQuery().tagsPredicate.toQueryParameters(),
-        [
+        query.toServiceQuery().tagsPredicate.toQueryParameters().toSet(),
+        {
           '-is:discontinued',
           '-is:unlisted',
           '-is:legacy',
           'sdk:flutter',
           'platform:android',
-        ],
+        },
       );
       expect(query.toSearchLink(), '/flutter/packages?platform=android');
     });
@@ -184,18 +183,17 @@ void main() {
       final query = parseFrontendSearchForm(
         Uri.parse('/flutter/packages?platform=android++ios').queryParameters,
         sdk: 'flutter',
-        tagsPredicate: TagsPredicate.regularSearch(),
       );
       expect(
-        query.toServiceQuery().tagsPredicate.toQueryParameters(),
-        [
+        query.toServiceQuery().tagsPredicate.toQueryParameters().toSet(),
+        {
           '-is:discontinued',
           '-is:unlisted',
           '-is:legacy',
           'sdk:flutter',
           'platform:android',
           'platform:ios',
-        ],
+        },
       );
       expect(query.toSearchLink(), '/flutter/packages?platform=android+ios');
     });
@@ -204,17 +202,16 @@ void main() {
       final query = parseFrontendSearchForm(
         Uri.parse('/dart/packages?runtime=web').queryParameters,
         sdk: 'dart',
-        tagsPredicate: TagsPredicate.regularSearch(),
       );
       expect(
-        query.toServiceQuery().tagsPredicate.toQueryParameters(),
-        [
+        query.toServiceQuery().tagsPredicate.toQueryParameters().toSet(),
+        {
           '-is:discontinued',
           '-is:unlisted',
           '-is:legacy',
           'sdk:dart',
           'runtime:web',
-        ],
+        },
       );
       expect(query.toSearchLink(), '/dart/packages?runtime=js');
     });

--- a/app/test/shared/urls_test.dart
+++ b/app/test/shared/urls_test.dart
@@ -201,7 +201,7 @@ void main() {
         searchUrl(sdk: 'dart', runtimes: ['native']),
         '/dart/packages?runtime=native',
       );
-      final form = SearchForm.parse(runtimes: ['native']);
+      final form = SearchForm.parse(runtimes: ['native'], includeAll: true);
       expect(form.runtimes, ['native-jit']);
       expect(
         form.toServiceQuery().tagsPredicate.toQueryParameters(),
@@ -214,7 +214,7 @@ void main() {
         searchUrl(sdk: 'dart', runtimes: ['native-jit']),
         '/dart/packages?runtime=native',
       );
-      final form = SearchForm.parse(runtimes: ['native-jit']);
+      final form = SearchForm.parse(runtimes: ['native-jit'], includeAll: true);
       expect(form.runtimes, ['native-jit']);
       expect(
         form.toServiceQuery().tagsPredicate.toQueryParameters(),
@@ -227,7 +227,7 @@ void main() {
         searchUrl(sdk: 'dart', runtimes: ['web']),
         '/dart/packages?runtime=js',
       );
-      final form = SearchForm.parse(runtimes: ['web']);
+      final form = SearchForm.parse(runtimes: ['web'], includeAll: true);
       expect(form.runtimes, ['web']);
       expect(
         form.toServiceQuery().tagsPredicate.toQueryParameters(),
@@ -240,7 +240,7 @@ void main() {
         searchUrl(sdk: 'dart', runtimes: ['js']),
         '/dart/packages?runtime=js',
       );
-      final form = SearchForm.parse(runtimes: ['js']);
+      final form = SearchForm.parse(runtimes: ['js'], includeAll: true);
       expect(form.runtimes, ['web']);
       expect(
         form.toServiceQuery().tagsPredicate.toQueryParameters(),
@@ -253,7 +253,7 @@ void main() {
         searchUrl(sdk: 'dart', runtimes: ['xxy']),
         '/dart/packages?runtime=xxy',
       );
-      final form = SearchForm.parse(runtimes: ['xxy']);
+      final form = SearchForm.parse(runtimes: ['xxy'], includeAll: true);
       expect(form.runtimes, ['xxy']);
       expect(
         form.toServiceQuery().tagsPredicate.toQueryParameters(),


### PR DESCRIPTION
Follow-up on #5155 and #5162 to finally clean up the `TagsPredicate` use inside `SearchForm`.