### PR TITLE
CSS cleanup + fixing reference test

### DIFF
--- a/pkg/web_css/lib/src/_base.scss
+++ b/pkg/web_css/lib/src/_base.scss
@@ -309,7 +309,7 @@ pre {
 
 .-pub-like-button {
   --mdc-theme-primary: #f8f8f8;
-  --mdc-theme-on-primary: $site-font-color;
+  --mdc-theme-on-primary: #4A4A4A;
 }
 
 .-pub-like-button-img {

--- a/pkg/web_css/lib/src/_home.scss
+++ b/pkg/web_css/lib/src/_home.scss
@@ -1,16 +1,6 @@
 /******************************************************
   home page
 ******************************************************/
-.landing-page-title {
-  color: gray;
-  font-weight: 500;
-  margin-bottom: 0px;
-}
-
-.landing-page-title-block {
-  text-align: center;
-  margin-bottom: 1em;
-}
 
 .home-banner {
   text-align: center;
@@ -240,7 +230,7 @@
 
     &.home-block-mp,
     &.home-block-tf,
-    &.home-block-td, {
+    &.home-block-td {
       display: flex;
       max-width: 596px;
       margin: 0 auto;

--- a/pkg/web_css/lib/src/_pkg.scss
+++ b/pkg/web_css/lib/src/_pkg.scss
@@ -185,8 +185,7 @@
     cursor: pointer;
   }
 
-  .pkg-report-header-icon,
-  .pkg-report-content-icon {
+  .pkg-report-header-icon {
     display: flex;
     align-items: center;
 

--- a/pkg/web_css/lib/src/_search.scss
+++ b/pkg/web_css/lib/src/_search.scss
@@ -104,19 +104,3 @@
     }
   }
 }
-
-.search-bar-details {
-  position: relative;
-  max-width: 650px;
-}
-
-.search-bar-options {
-  font-size: 14px;
-
-  @media (min-width: 600px) {
-    position: absolute;
-    top: 16px;
-    right: 0px;
-  }
-}
-


### PR DESCRIPTION
The root cause of the test not working was this line: `--mdc-theme-on-primary: $site-font-color;`
- `sass` didn't substitute the variable for some unknown reason
- `csslib` didn't parse the compiled+compressed source afterwards (it did parse the uncompressed one)

Adjusted the test to our generative patterns, and removing the unused rules.