### PR TITLE
Update namesquatting policy when there is no uploader email

### DIFF
--- a/doc/policy.md
+++ b/doc/policy.md
@@ -38,17 +38,27 @@ manual process where name squatting is determined by a pub.dev moderator.
 If you believe a package is engaged in name squatting,
 you can use the following steps to request a pub.dev moderator review and that the package be transferred to you:
 
- 1. If the package has a publisher, locate the publisher in the details pane on 
-    the package page on pub.dev, the publisher page will have a contact email.
- 2. Email the publisher and copy/cc `support@pub.dev`, politely asking the
-    publisher to either explain their intended purpose or transfer the ownership
-    of the package to you.
+1. Send an email requesting package transfer:
 
-    If the package had no publisher email `support@pub.dev`, include the
-    package name, and we will forward the email to the package uploader.
+   * If the package has a publisher:
 
- 3. If the publisher does not respond within three (3) weeks, forward the thread
-    to `support@pub.dev`, and a pub.dev moderator will review your request.
+     * Locate the publisher-link in the details pane on the package page on
+       pub.dev. The publisher page will have a contact email.
+     * Email the publisher and copy/cc `support@pub.dev`, politely asking the
+       publisher to either explain their intended purpose or transfer the
+       ownership of the package to you.
+
+   * If the package has no publisher:
+
+     * Email `support@pub.dev`, politely asking the publisher to either
+       explain their intended purpose or transfer the ownership of the package
+       to you.
+       
+     * Be sure to mention the package name, and we will forward the email to the
+       package uploader.
+
+2. If the publisher does not respond within three (3) weeks, forward the thread
+  to `support@pub.dev`, and a pub.dev moderator will review your request.
 
 ### Trademark infringement
 Google and pub.dev respect the importance of trademarks and other proprietary rights,

--- a/doc/policy.md
+++ b/doc/policy.md
@@ -44,7 +44,7 @@ you can use the following steps to request a pub.dev moderator review and that t
     publisher to either explain their intended purpose or transfer the ownership
     of the package to you.
 
-    If the package had no publisher just email `support@pub.dev`, include the
+    If the package had no publisher email `support@pub.dev`, include the
     package name, and we will forward the email to the package uploader.
 
  3. If the publisher does not respond within three (3) weeks, forward the thread

--- a/doc/policy.md
+++ b/doc/policy.md
@@ -50,12 +50,12 @@ you can use the following steps to request a pub.dev moderator review and that t
 
    * If the package has no publisher:
 
-     * Email `support@pub.dev`, politely asking the publisher to either
+     * Email `support@pub.dev`, politely asking the uploader to either
        explain their intended purpose or transfer the ownership of the package
        to you.
        
-     * Be sure to mention the package name, and we will forward the email to the
-       package uploader.
+     * Be sure to mention the package name, and the pub.dev support team will
+       forward the email to the package uploader.
 
 2. If the publisher does not respond within three (3) weeks, forward the thread
   to `support@pub.dev`, and a pub.dev moderator will review your request.

--- a/doc/policy.md
+++ b/doc/policy.md
@@ -50,11 +50,12 @@ you can use the following steps to request a pub.dev moderator review and that t
 
    * If the package has no publisher:
 
-     * Email `support@pub.dev`, politely asking the uploader to either
+     * Draft an email, politely asking the uploader to either
        explain their intended purpose or transfer the ownership of the package
-       to you.
+       to you. Be sure to mention the package name, and your pub.dev user
+       account.
        
-     * Be sure to mention the package name, and the pub.dev support team will
+     * Send the email to `support@pub.dev`. The pub.dev support team will
        forward the email to the package uploader.
 
 2. If the publisher does not respond within three (3) weeks, forward the thread

--- a/doc/policy.md
+++ b/doc/policy.md
@@ -38,11 +38,17 @@ manual process where name squatting is determined by a pub.dev moderator.
 If you believe a package is engaged in name squatting,
 you can use the following steps to request a pub.dev moderator review and that the package be transferred to you:
 
- 1. Locate the email of the publisher, as shown in the details pane on the package page on pub.dev.
- 2. Email the publisher and copy/cc `support@pub.dev`, politely asking the publisher to either
-    explain their intended purpose or transfer the ownership of the package to you.
- 3. If the publisher does not respond within three (3) weeks, forward the thread to `support@pub.dev`,
-    and a pub.dev moderator will review your request.
+ 1. If the package has a publisher, locate the publisher in the details pane on 
+    the package page on pub.dev, the publisher page will have a contact email.
+ 2. Email the publisher and copy/cc `support@pub.dev`, politely asking the
+    publisher to either explain their intended purpose or transfer the ownership
+    of the package to you.
+
+    If the package had no publisher just email `support@pub.dev`, include the
+    package name, and we will forward the email to the package uploader.
+
+ 3. If the publisher does not respond within three (3) weeks, forward the thread
+    to `support@pub.dev`, and a pub.dev moderator will review your request.
 
 ### Trademark infringement
 Google and pub.dev respect the importance of trademarks and other proprietary rights,


### PR DESCRIPTION
Fixes: https://github.com/dart-lang/pub-dev/issues/5074

This is a short-term fix.
Long-term we will probably want a contact-form.