### PR TITLE
Change download URLs on versions page.

### DIFF
--- a/app/lib/frontend/handlers/package.dart
+++ b/app/lib/frontend/handlers/package.dart
@@ -76,13 +76,8 @@ Future<shelf.Response> packageVersionsListHandler(
       }
 
       sortPackageVersionsDesc(versions);
-      final versionDownloadUrls =
-          await Future.wait(versions.map((PackageVersion version) {
-        return packageBackend.downloadUrl(packageName, version.version!);
-      }).toList());
-
       final dartSdkVersion = await getDartSdkVersion();
-      return renderPkgVersionsPage(data, versions, versionDownloadUrls,
+      return renderPkgVersionsPage(data, versions,
           dartSdkVersion: dartSdkVersion.semanticVersion);
     },
     cacheEntry: cache.uiPackageVersions(packageName),

--- a/app/lib/frontend/templates/package_versions.dart
+++ b/app/lib/frontend/templates/package_versions.dart
@@ -18,12 +18,9 @@ import 'views/pkg/versions/version_row.dart';
 /// Renders the `views/pkg/versions/index` template.
 String renderPkgVersionsPage(
   PackagePageData data,
-  List<PackageVersion> versions,
-  List<Uri> versionDownloadUrls, {
+  List<PackageVersion> versions, {
   required Version dartSdkVersion,
 }) {
-  assert(versions.length == versionDownloadUrls.length);
-
   final previewVersionRows = <d.Node>[];
   final stableVersionRows = <d.Node>[];
   final prereleaseVersionRows = <d.Node>[];
@@ -34,8 +31,7 @@ String renderPkgVersionsPage(
       : null;
   for (int i = 0; i < versions.length; i++) {
     final version = versions[i];
-    final url = versionDownloadUrls[i].toString();
-    final rowNode = versionRowNode(version: version, downloadUrl: url);
+    final rowNode = versionRowNode(version);
     if (version.semanticVersion.isPreRelease) {
       prereleaseVersionRows.add(rowNode);
     } else if (version.pubspec!.isPreviewForCurrentSdk(dartSdkVersion)) {

--- a/app/lib/frontend/templates/views/pkg/versions/version_row.dart
+++ b/app/lib/frontend/templates/views/pkg/versions/version_row.dart
@@ -9,10 +9,7 @@ import '../../../../../shared/urls.dart' as urls;
 import '../../../../dom/dom.dart' as d;
 import '../../../../static_files.dart';
 
-d.Node versionRowNode({
-  required PackageVersion version,
-  required String downloadUrl,
-}) {
+d.Node versionRowNode(PackageVersion version) {
   final sdk = version.pubspec!.minSdkVersion;
   return d.tr(
     attributes: {
@@ -62,7 +59,7 @@ d.Node versionRowNode({
       d.td(
         classes: ['archive'],
         child: d.a(
-          href: downloadUrl,
+          href: urls.pkgArchiveDownloadUrl(version.package, version.version!),
           rel: 'nofollow',
           title: 'Download ${version.package} ${version.version} archive',
           child: d.img(

--- a/app/test/frontend/golden/pkg_versions_page.html
+++ b/app/test/frontend/golden/pkg_versions_page.html
@@ -240,7 +240,7 @@
                           </a>
                         </td>
                         <td class="archive">
-                          <a href="https://pub.dev/download-url/oxygen/1.0.0" rel="nofollow" title="Download oxygen 1.0.0 archive">
+                          <a href="/packages/oxygen/versions/1.0.0.tar.gz" rel="nofollow" title="Download oxygen 1.0.0 archive">
                             <img class="version-table-icon" src="/static/img/vertical_align_bottom-24px.svg?hash=mocked_hash_587025884" alt="Download oxygen 1.0.0 archive"/>
                           </a>
                         </td>
@@ -258,7 +258,7 @@
                           </a>
                         </td>
                         <td class="archive">
-                          <a href="https://pub.dev/download-url/oxygen/1.2.0" rel="nofollow" title="Download oxygen 1.2.0 archive">
+                          <a href="/packages/oxygen/versions/1.2.0.tar.gz" rel="nofollow" title="Download oxygen 1.2.0 archive">
                             <img class="version-table-icon" src="/static/img/vertical_align_bottom-24px.svg?hash=mocked_hash_587025884" alt="Download oxygen 1.2.0 archive"/>
                           </a>
                         </td>
@@ -299,7 +299,7 @@
                           </a>
                         </td>
                         <td class="archive">
-                          <a href="https://pub.dev/download-url/oxygen/2.0.0-dev" rel="nofollow" title="Download oxygen 2.0.0-dev archive">
+                          <a href="/packages/oxygen/versions/2.0.0-dev.tar.gz" rel="nofollow" title="Download oxygen 2.0.0-dev archive">
                             <img class="version-table-icon" src="/static/img/vertical_align_bottom-24px.svg?hash=mocked_hash_587025884" alt="Download oxygen 2.0.0-dev archive"/>
                           </a>
                         </td>

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -453,10 +453,6 @@ void main() {
         final html = renderPkgVersionsPage(
           data,
           versions,
-          versions
-              .map((v) => Uri.parse(
-                  'https://pub.dev/download-url/${v.package}/${v.version}'))
-              .toList(),
           dartSdkVersion: Version.parse(runtimeSdkVersion),
         );
         expectGoldenFile(html, 'pkg_versions_page.html', timestamps: {


### PR DESCRIPTION
- Part of #5171 
- Makes the displayed content the same as it is on `/api/packages/<pkg>` endpoint.
- We were using the current URL because later may have signed urls for that, but we don't need to pre-sign every download URL just because we list all versions. `/packages/<package>/versions/<version>.tar.gz` will get redirected to the storage bucket, and URL signing can happen at that time.