### PR TITLE
Migrate versions page template to use VersionInfo

### DIFF
--- a/app/lib/frontend/handlers/package.dart
+++ b/app/lib/frontend/handlers/package.dart
@@ -77,8 +77,11 @@ Future<shelf.Response> packageVersionsListHandler(
 
       sortPackageVersionsDesc(versions);
       final dartSdkVersion = await getDartSdkVersion();
-      return renderPkgVersionsPage(data, versions,
-          dartSdkVersion: dartSdkVersion.semanticVersion);
+      return renderPkgVersionsPage(
+        data,
+        versions.map((v) => v.toApiVersionInfo()).toList(),
+        dartSdkVersion: dartSdkVersion.semanticVersion,
+      );
     },
     cacheEntry: cache.uiPackageVersions(packageName),
   );

--- a/app/lib/frontend/templates/views/pkg/versions/version_row.dart
+++ b/app/lib/frontend/templates/views/pkg/versions/version_row.dart
@@ -2,30 +2,32 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:pub_dev/frontend/templates/package_misc.dart';
+import 'package:client_data/package_api.dart';
 
-import '../../../../../package/models.dart';
+import '../../../../../package/model_properties.dart';
 import '../../../../../shared/urls.dart' as urls;
+import '../../../../../shared/utils.dart' show shortDateFormat;
 import '../../../../dom/dom.dart' as d;
 import '../../../../static_files.dart';
+import '../../../package_misc.dart';
 
-d.Node versionRowNode(PackageVersion version) {
-  final sdk = version.pubspec!.minSdkVersion;
+d.Node versionRowNode(String package, VersionInfo version, Pubspec pubspec) {
+  final sdk = pubspec.minSdkVersion;
   return d.tr(
     attributes: {
-      'data-version': version.version!,
+      'data-version': version.version,
     },
     children: [
       d.td(
         classes: ['version'],
         child: d.a(
-          href: urls.pkgPageUrl(version.package, version: version.version),
-          text: version.version!,
+          href: urls.pkgPageUrl(package, version: version.version),
+          text: version.version,
         ),
       ),
       d.td(
         classes: ['badge'],
-        child: version.pubspec!.hasOptedIntoNullSafety
+        child: pubspec.hasOptedIntoNullSafety
             ? nullSafeBadgeNode(
                 title: 'Package version is opted into null safety.')
             : null,
@@ -37,19 +39,19 @@ d.Node versionRowNode(PackageVersion version) {
                 '${sdk.major}.${sdk.minor}${sdk.channel != null ? '(${sdk.channel})' : ''}')
             : null,
       ),
-      d.td(classes: ['uploaded'], text: version.shortCreated),
+      d.td(
+          classes: ['uploaded'],
+          text: shortDateFormat.format(version.published!)),
       d.td(
         classes: ['documentation'],
         child: d.a(
-          href: urls.pkgDocUrl(version.package, version: version.version),
+          href: urls.pkgDocUrl(package, version: version.version),
           rel: 'nofollow',
-          title:
-              'Go to the documentation of ${version.package} ${version.version}',
+          title: 'Go to the documentation of $package ${version.version}',
           child: d.img(
             classes: ['version-table-icon'],
             src: staticUrls.documentationIcon,
-            alt:
-                'Go to the documentation of ${version.package} ${version.version}',
+            alt: 'Go to the documentation of $package ${version.version}',
             attributes: {
               'data-failed-icon': staticUrls.documentationFailedIcon,
             },
@@ -59,13 +61,13 @@ d.Node versionRowNode(PackageVersion version) {
       d.td(
         classes: ['archive'],
         child: d.a(
-          href: urls.pkgArchiveDownloadUrl(version.package, version.version!),
+          href: version.archiveUrl,
           rel: 'nofollow',
-          title: 'Download ${version.package} ${version.version} archive',
+          title: 'Download $package ${version.version} archive',
           child: d.img(
             classes: ['version-table-icon'],
             src: staticUrls.downloadIcon,
-            alt: 'Download ${version.package} ${version.version} archive',
+            alt: 'Download $package ${version.version} archive',
           ),
         ),
       ),

--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -631,9 +631,10 @@ class PackageBackend {
       name: package,
       isDiscontinued: pkg.isDiscontinued ? true : null,
       replacedBy: pkg.replacedBy,
-      latest: _toApiVersionInfo(baseUri, latest),
-      versions:
-          packageVersions.map((pv) => _toApiVersionInfo(baseUri, pv)).toList(),
+      latest: latest.toApiVersionInfo(baseUri: baseUri),
+      versions: packageVersions
+          .map((pv) => pv.toApiVersionInfo(baseUri: baseUri))
+          .toList(),
     );
   }
 
@@ -658,18 +659,8 @@ class PackageBackend {
       throw NotFoundException.resource('version "$version"');
     }
 
-    return _toApiVersionInfo(baseUri, pv);
+    return pv.toApiVersionInfo(baseUri: baseUri);
   }
-
-  api.VersionInfo _toApiVersionInfo(Uri baseUri, PackageVersion pv) =>
-      api.VersionInfo(
-        version: pv.version!,
-        isRetracted: pv.isRetracted == true ? true : null,
-        pubspec: pv.pubspec!.asJson,
-        archiveUrl: urls.pkgArchiveDownloadUrl(pv.package, pv.version!,
-            baseUri: baseUri),
-        published: pv.created,
-      );
 
   @visibleForTesting
   Stream<List<int>> download(String package, String version) {
@@ -1096,6 +1087,19 @@ class PackageBackend {
     // safe fallback on enabling uploads
     _logger.warning('Unknown upload restriction status: $value');
     return UploadRestrictionStatus.noRestriction;
+  }
+}
+
+extension PackageVersionExt on PackageVersion {
+  api.VersionInfo toApiVersionInfo({Uri? baseUri}) {
+    return api.VersionInfo(
+      version: version!,
+      isRetracted: isRetracted == true ? true : null,
+      pubspec: pubspec!.asJson,
+      archiveUrl:
+          urls.pkgArchiveDownloadUrl(package, version!, baseUri: baseUri),
+      published: created,
+    );
   }
 }
 

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -452,7 +452,7 @@ void main() {
         final versions = await packageBackend.versionsOfPackage('oxygen');
         final html = renderPkgVersionsPage(
           data,
-          versions,
+          versions.map((v) => v.toApiVersionInfo()).toList(),
           dartSdkVersion: Version.parse(runtimeSdkVersion),
         );
         expectGoldenFile(html, 'pkg_versions_page.html', timestamps: {


### PR DESCRIPTION
- `VersionInfo` is being used in the `/api/packages/<pkg>` endpoint and is already cached, we should fully reuse the cached value.
-  Before doing that, I think we should simplify the `baseUri` parts of the output, but want to do it in a separate PR. (+ same for the common cache).
- #5171