### PR TITLE
Explicit SearchContext separate from SearchForm

### DIFF
--- a/app/bin/tools/check_drift.dart
+++ b/app/bin/tools/check_drift.dart
@@ -12,12 +12,12 @@ final _client = Client();
 final _random = math.Random.secure();
 
 final _forms = <SearchForm>[
-  SearchForm.parse(contextIsFlutterFavorites: true),
-  SearchForm.parse(query: 'json'),
-  SearchForm.parse(sdk: 'dart', currentPage: 2),
-  SearchForm.parse(sdk: 'flutter', currentPage: 5),
-  SearchForm.parse(order: SearchOrder.created),
-  SearchForm.parse(order: SearchOrder.updated, currentPage: 3),
+  SearchForm(context: SearchContext.flutterFavorites()),
+  SearchForm(query: 'json'),
+  SearchForm(context: SearchContext.dart(), currentPage: 2),
+  SearchForm(context: SearchContext.flutter(), currentPage: 5),
+  SearchForm(order: SearchOrder.created),
+  SearchForm(order: SearchOrder.updated, currentPage: 3),
 ];
 
 Future<void> main(List<String> args) async {
@@ -51,7 +51,7 @@ Future<_Sample> _sample({
   int maxAttempts = 20,
   int maxItems = 3,
 }) async {
-  form ??= SearchForm.parse();
+  form ??= SearchForm();
   var attempt = 0;
   final items = <_Item>[];
 

--- a/app/lib/frontend/handlers/account.dart
+++ b/app/lib/frontend/handlers/account.dart
@@ -210,15 +210,14 @@ Future<shelf.Response> accountPackagesPageHandler(shelf.Request request) async {
 
   final page =
       await publisherBackend.listPublishersForUser(userSessionData!.userId!);
-  final searchForm = parseFrontendSearchForm(
-    request.requestedUri.queryParameters,
-    uploaderOrPublishers: [
+  final searchForm = SearchForm.parse(
+    SearchContext.myPackages([
       // TODO: remove email after userId is populated in the search index
       userSessionData!.email!,
       userSessionData!.userId!,
       ...page.publishers!.map((p) => p.publisherId),
-    ],
-    includeAll: true,
+    ]),
+    request.requestedUri.queryParameters,
   );
 
   final searchResult = await searchAdapter.search(searchForm);

--- a/app/lib/frontend/handlers/custom_api.dart
+++ b/app/lib/frontend/handlers/custom_api.dart
@@ -261,8 +261,8 @@ Future<VersionScore> packageVersionScoreHandler(
 
 /// Handles requests for /api/search
 Future<shelf.Response> apiSearchHandler(shelf.Request request) async {
-  final searchForm =
-      parseFrontendSearchForm(request.requestedUri.queryParameters);
+  final searchForm = SearchForm.parse(
+      SearchContext.regular(), request.requestedUri.queryParameters);
   final sr = await searchClient.search(searchForm.toServiceQuery());
   final packages =
       sr.allPackageHits.map((ps) => {'package': ps.package}).toList();

--- a/app/lib/frontend/handlers/landing.dart
+++ b/app/lib/frontend/handlers/landing.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import 'package:pub_dev/search/search_form.dart';
 import 'package:shelf/shelf.dart' as shelf;
 
 import '../../package/search_adapter.dart';
@@ -19,18 +20,18 @@ import '../templates/landing.dart';
 
 /// Handles requests for /dart
 Future<shelf.Response> dartLandingHandler(shelf.Request request) async =>
-    redirectResponse(urls.searchUrl(sdk: SdkTagValue.dart));
+    redirectResponse(urls.searchUrl(context: SearchContext.dart()));
 
 /// Handles requests for /flutter
 Future<shelf.Response> flutterLandingHandler(shelf.Request request) async {
-  return redirectResponse(urls.searchUrl(sdk: SdkTagValue.flutter));
+  return redirectResponse(urls.searchUrl(context: SearchContext.flutter()));
 }
 
 /// Handles requests for /web
 Future<shelf.Response> webLandingHandler(shelf.Request request) async {
   return redirectResponse(
     urls.searchUrl(
-      sdk: SdkTagValue.dart,
+      context: SearchContext.dart(),
       runtimes: [DartSdkRuntime.web],
     ),
   );
@@ -49,18 +50,18 @@ Future<shelf.Response> indexLandingHandler(shelf.Request request) async {
 
   Future<String> _render() async {
     final ffPackages = await searchAdapter.topFeatured(
-      contextIsFlutterFavorites: true,
+      context: SearchContext.flutterFavorites(),
       count: 4,
     );
 
-    final mostPopularPackages =
-        await searchAdapter.topFeatured(order: SearchOrder.popularity);
+    final mostPopularPackages = await searchAdapter.topFeatured(
+        context: SearchContext.regular(), order: SearchOrder.popularity);
 
     final topFlutterPackages =
-        await searchAdapter.topFeatured(sdk: SdkTagValue.flutter);
+        await searchAdapter.topFeatured(context: SearchContext.flutter());
 
     final topDartPackages =
-        await searchAdapter.topFeatured(sdk: SdkTagValue.dart);
+        await searchAdapter.topFeatured(context: SearchContext.dart());
 
     final topPoWVideos = youtubeBackend.getTopPackageOfWeekVideos(count: 4);
 

--- a/app/lib/frontend/handlers/publisher.dart
+++ b/app/lib/frontend/handlers/publisher.dart
@@ -55,10 +55,9 @@ Future<shelf.Response> publisherPageHandler(
 /// Handles requests for GET /publishers/<publisherId>/packages [?q=...]
 Future<shelf.Response> publisherPackagesPageHandler(
     shelf.Request request, String publisherId) async {
-  final searchForm = parseFrontendSearchForm(
+  final searchForm = SearchForm.parse(
+    SearchContext.publisher(publisherId),
     request.requestedUri.queryParameters,
-    publisherId: publisherId,
-    includeAll: true,
   );
   // Redirect in case of empty search query.
   if (request.requestedUri.query == 'q=') {

--- a/app/lib/frontend/templates/layout.dart
+++ b/app/lib/frontend/templates/layout.dart
@@ -104,7 +104,7 @@ d.Node _renderSearchBanner({
   required SearchForm? searchForm,
   String? searchPlaceholder,
 }) {
-  final sdk = searchForm?.sdk ?? SdkTagValue.any;
+  final sdk = searchForm?.context.sdk ?? SdkTagValue.any;
   final queryText = searchForm?.query;
   bool includePreferencesAsHiddenFields = false;
   if (publisherId != null) {
@@ -117,19 +117,20 @@ d.Node _renderSearchBanner({
   }
   String searchFormUrl;
   if (publisherId != null) {
-    searchFormUrl = SearchForm.parse(publisherId: publisherId).toSearchLink();
+    searchFormUrl = SearchForm(context: SearchContext.publisher(publisherId))
+        .toSearchLink();
   } else if (type == PageType.account) {
     searchFormUrl = urls.myPackagesUrl();
   } else if (searchForm != null) {
-    searchFormUrl = searchForm.toSearchFormPath();
+    searchFormUrl = searchForm.context.toSearchFormPath();
   } else {
-    searchFormUrl = SearchForm.parse().toSearchFormPath();
+    searchFormUrl = SearchForm().context.toSearchFormPath();
   }
   final searchSort = searchForm?.order == null
       ? null
       : serializeSearchOrder(searchForm!.order);
   final hiddenInputs = includePreferencesAsHiddenFields
-      ? (searchForm ?? SearchForm.parse()).hiddenFields()
+      ? (searchForm ?? SearchForm()).hiddenFields()
       : null;
   return searchBannerNode(
     // When search is active (query text has a non-empty value) users may expect
@@ -151,19 +152,19 @@ d.Node _renderSearchBanner({
 d.Node sdkTabsNode({
   SearchForm? searchForm,
 }) {
-  final isff = searchForm?.contextIsFlutterFavorites ?? false;
-  final currentSdk = isff ? null : searchForm?.sdk ?? SdkTagValue.any;
-  SearchTab sdkTabData(String label, String tabSdk, String title) {
+  final isff = searchForm?.context.isFlutterFavorites ?? false;
+  final currentSdk = isff ? null : searchForm?.context.sdk ?? SdkTagValue.any;
+  SearchTab sdkTabData(SearchContext context, String label, String title) {
     String url;
     if (searchForm != null) {
-      url = searchForm.change(sdk: tabSdk, currentPage: 1).toSearchLink();
+      url = searchForm.change(context: context, currentPage: 1).toSearchLink();
     } else {
-      url = urls.searchUrl(sdk: tabSdk);
+      url = urls.searchUrl(context: context);
     }
     return SearchTab(
       text: label,
       href: url,
-      active: tabSdk == currentSdk,
+      active: (context.sdk ?? SdkTagValue.any) == currentSdk,
       title: title,
     );
   }
@@ -171,18 +172,18 @@ d.Node sdkTabsNode({
   return searchTabsNode(
     [
       sdkTabData(
+        SearchContext.dart(),
         'Dart',
-        SdkTagValue.dart,
         'Packages compatible with the Dart SDK',
       ),
       sdkTabData(
+        SearchContext.flutter(),
         'Flutter',
-        SdkTagValue.flutter,
         'Packages compatible with the Flutter SDK',
       ),
       sdkTabData(
+        SearchContext.regular(),
         'Any',
-        SdkTagValue.any,
         'Packages compatible with the any SDK',
       ),
     ],

--- a/app/lib/frontend/templates/listing.dart
+++ b/app/lib/frontend/templates/listing.dart
@@ -115,7 +115,7 @@ class PageLinks {
   PageLinks(this.searchForm, this.count);
 
   PageLinks.empty()
-      : searchForm = SearchForm.parse(),
+      : searchForm = SearchForm(),
         count = 1;
 
   int get leftmostPage => max(currentPage! - maxPageLinks ~/ 2, 1);
@@ -156,7 +156,7 @@ List<SearchTab> _calculateSearchTabs(SearchForm searchForm) {
     );
   }
 
-  final sdk = searchForm.sdk;
+  final sdk = searchForm.context.sdk;
   if (sdk == SdkTagValue.dart) {
     return <SearchTab>[
       runtimeTab(

--- a/app/lib/frontend/templates/package_misc.dart
+++ b/app/lib/frontend/templates/package_misc.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import '../../package/models.dart';
+import '../../search/search_form.dart';
 import '../../shared/tags.dart';
 import '../../shared/urls.dart' as urls;
 
@@ -55,7 +56,7 @@ d.Node tagsNodeFromPackageView({
     badgeTags.add(BadgeTag(
       sdk: 'Dart',
       title: 'Packages compatible with Dart SDK',
-      href: urls.searchUrl(sdk: SdkTagValue.dart),
+      href: urls.searchUrl(context: SearchContext.dart()),
       subTags: [
         if (tags.contains(DartSdkTag.runtimeNativeJit))
           BadgeSubTag(
@@ -63,7 +64,7 @@ d.Node tagsNodeFromPackageView({
             title:
                 'Packages compatible with Dart running on a native platform (JIT/AOT)',
             href: urls.searchUrl(
-                sdk: SdkTagValue.dart,
+                context: SearchContext.dart(),
                 runtimes: DartSdkRuntime.encodeRuntimeTags(
                     [DartSdkRuntime.nativeJit])),
           ),
@@ -72,7 +73,7 @@ d.Node tagsNodeFromPackageView({
             text: 'js',
             title: 'Packages compatible with Dart compiled for the web',
             href: urls.searchUrl(
-                sdk: SdkTagValue.dart,
+                context: SearchContext.dart(),
                 runtimes:
                     DartSdkRuntime.encodeRuntimeTags([DartSdkRuntime.web])),
           ),
@@ -83,14 +84,14 @@ d.Node tagsNodeFromPackageView({
     badgeTags.add(BadgeTag(
       sdk: 'Flutter',
       title: 'Packages compatible with Flutter SDK',
-      href: urls.searchUrl(sdk: SdkTagValue.flutter),
+      href: urls.searchUrl(context: SearchContext.flutter()),
       subTags: [
         if (tags.contains(FlutterSdkTag.platformAndroid))
           BadgeSubTag(
             text: 'Android',
             title: 'Packages compatible with Flutter on the Android platform',
             href: urls.searchUrl(
-                sdk: SdkTagValue.flutter,
+                context: SearchContext.flutter(),
                 platforms: [FlutterSdkPlatform.android]),
           ),
         if (tags.contains(FlutterSdkTag.platformIos))
@@ -98,14 +99,16 @@ d.Node tagsNodeFromPackageView({
             text: 'iOS',
             title: 'Packages compatible with Flutter on the iOS platform',
             href: urls.searchUrl(
-                sdk: SdkTagValue.flutter, platforms: [FlutterSdkPlatform.ios]),
+              context: SearchContext.flutter(),
+              platforms: [FlutterSdkPlatform.ios],
+            ),
           ),
         if (tags.contains(FlutterSdkTag.platformLinux))
           BadgeSubTag(
             text: 'Linux',
             title: 'Packages compatible with Flutter on the Linux platform',
             href: urls.searchUrl(
-                sdk: SdkTagValue.flutter,
+                context: SearchContext.flutter(),
                 platforms: [FlutterSdkPlatform.linux]),
           ),
         if (tags.contains(FlutterSdkTag.platformMacos))
@@ -113,7 +116,7 @@ d.Node tagsNodeFromPackageView({
             text: 'macOS',
             title: 'Packages compatible with Flutter on the macOS platform',
             href: urls.searchUrl(
-                sdk: SdkTagValue.flutter,
+                context: SearchContext.flutter(),
                 platforms: [FlutterSdkPlatform.macos]),
           ),
         if (tags.contains(FlutterSdkTag.platformWeb))
@@ -121,15 +124,18 @@ d.Node tagsNodeFromPackageView({
             text: 'web',
             title: 'Packages compatible with Flutter on the Web platform',
             href: urls.searchUrl(
-                sdk: SdkTagValue.flutter, platforms: [FlutterSdkPlatform.web]),
+              context: SearchContext.flutter(),
+              platforms: [FlutterSdkPlatform.web],
+            ),
           ),
         if (tags.contains(FlutterSdkTag.platformWindows))
           BadgeSubTag(
             text: 'Windows',
             title: 'Packages compatible with Flutter on the Windows platform',
             href: urls.searchUrl(
-                sdk: SdkTagValue.flutter,
-                platforms: [FlutterSdkPlatform.windows]),
+              context: SearchContext.flutter(),
+              platforms: [FlutterSdkPlatform.windows],
+            ),
           ),
       ],
     ));

--- a/app/lib/frontend/templates/views/pkg/index.dart
+++ b/app/lib/frontend/templates/views/pkg/index.dart
@@ -148,9 +148,9 @@ d.Node _checkbox({
 }
 
 String? _subSdkLabel(SearchForm sq) {
-  if (sq.sdk == SdkTagValue.dart) {
+  if (sq.context.sdk == SdkTagValue.dart) {
     return 'Runtime';
-  } else if (sq.sdk == SdkTagValue.flutter) {
+  } else if (sq.context.sdk == SdkTagValue.flutter) {
     return 'Platform';
   } else {
     return null;

--- a/app/lib/package/search_adapter.dart
+++ b/app/lib/package/search_adapter.dart
@@ -37,17 +37,11 @@ class SearchAdapter {
   /// Uses long-term caching and local randomized selection.
   /// Returns empty list when search is not available or doesn't yield results.
   Future<List<PackageView>> topFeatured({
-    String? sdk,
-    bool contextIsFlutterFavorites = false,
+    required SearchContext context,
     int count = 6,
     SearchOrder? order,
   }) async {
-    final form = SearchForm.parse(
-      contextIsFlutterFavorites: contextIsFlutterFavorites,
-      sdk: sdk,
-      pageSize: 100,
-      order: order,
-    );
+    final form = SearchForm(context: context, pageSize: 100, order: order);
     final searchResults = await _searchOrFallback(
       form,
       false,
@@ -122,7 +116,8 @@ class SearchAdapter {
   /// `search` service.
   Future<PackageSearchResult> _fallbackSearch(SearchForm form) async {
     // Some search queries must not be served with the fallback search.
-    if (form.uploaderOrPublishers != null || form.publisherId != null) {
+    if (form.context.uploaderOrPublishers != null ||
+        form.context.publisherId != null) {
       return PackageSearchResult.empty(
           message: 'Search is temporarily unavailable.');
     }

--- a/app/lib/shared/urls.dart
+++ b/app/lib/shared/urls.dart
@@ -5,7 +5,7 @@
 import 'package:path/path.dart' as p;
 
 import '../package/overrides.dart';
-import '../search/search_form.dart' show SearchForm, SearchOrder;
+import '../search/search_form.dart' show SearchContext, SearchForm, SearchOrder;
 
 const primaryHost = 'pub.dev';
 const legacyHost = 'pub.dartlang.org';
@@ -145,7 +145,7 @@ String pkgDocUrl(
 
 String publisherUrl(String publisherId) => '/publishers/$publisherId';
 String publisherPackagesUrl(String publisherId) =>
-    SearchForm.parse(publisherId: publisherId).toSearchLink();
+    SearchForm(context: SearchContext.publisher(publisherId)).toSearchLink();
 
 String publisherAdminUrl(String publisherId) =>
     publisherUrl(publisherId) + '/admin';
@@ -154,14 +154,14 @@ String publisherActivityLogUrl(String publisherId) =>
     publisherUrl(publisherId) + '/activity-log';
 
 String searchUrl({
-  String? sdk,
+  SearchContext? context,
   List<String> runtimes = const <String>[],
   List<String> platforms = const <String>[],
   String? q,
   int? page,
 }) {
-  final query = SearchForm.parse(
-    sdk: sdk,
+  final query = SearchForm(
+    context: context,
     runtimes: runtimes,
     platforms: platforms,
     query: q,
@@ -170,7 +170,7 @@ String searchUrl({
 }
 
 String listingByPopularity() =>
-    SearchForm.parse(order: SearchOrder.popularity).toSearchLink();
+    SearchForm(order: SearchOrder.popularity).toSearchLink();
 String listingFlutterPackages() => '/flutter/packages';
 String listingDartPackages() => '/dart/packages';
 

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -387,7 +387,7 @@ void main() {
       'package index page',
       processJobsWithFakeRunners: true,
       fn: () async {
-        final searchForm = SearchForm.parse();
+        final searchForm = SearchForm();
         final oxygen = (await scoreCardBackend.getPackageView('oxygen'))!;
         final titanium =
             (await scoreCardBackend.getPackageView('flutter_titanium'))!;
@@ -413,8 +413,7 @@ void main() {
       'package index page with search',
       processJobsWithFakeRunners: true,
       fn: () async {
-        final searchForm =
-            SearchForm.parse(query: 'foobar', order: SearchOrder.top);
+        final searchForm = SearchForm(query: 'foobar', order: SearchOrder.top);
         final oxygen = (await scoreCardBackend.getPackageView('oxygen'))!;
         final titanium =
             (await scoreCardBackend.getPackageView('flutter_titanium'))!;
@@ -482,7 +481,8 @@ void main() {
       'publisher packages page',
       processJobsWithFakeRunners: true,
       fn: () async {
-        final searchForm = SearchForm.parse(publisherId: 'example.com');
+        final searchForm =
+            SearchForm(context: SearchContext.publisher('example.com'));
         final publisher = (await publisherBackend.getPublisher('example.com'))!;
         final neon = (await scoreCardBackend.getPackageView('neon'))!;
         final titanium =
@@ -570,7 +570,7 @@ void main() {
             imageUrl: 'pub.dev/user-img-url.png',
           );
           final searchForm =
-              SearchForm.parse(uploaderOrPublishers: [user.userId]);
+              SearchForm(context: SearchContext.myPackages([user.userId]));
           final String html = renderAccountPackagesPage(
             user: user,
             userSessionData: session,
@@ -749,22 +749,19 @@ void main() {
     });
 
     test('pagination: in the middle', () {
-      final html =
-          paginationNode(PageLinks(SearchForm.parse(currentPage: 10), 299))
-              .toString();
+      final html = paginationNode(PageLinks(SearchForm(currentPage: 10), 299))
+          .toString();
       expectGoldenFile(html, 'pagination_middle.html', isFragment: true);
     });
 
     test('pagination: at first page', () {
-      final html =
-          paginationNode(PageLinks(SearchForm.parse(), 600)).toString();
+      final html = paginationNode(PageLinks(SearchForm(), 600)).toString();
       expectGoldenFile(html, 'pagination_first.html', isFragment: true);
     });
 
     test('pagination: at last page', () {
       final html =
-          paginationNode(PageLinks(SearchForm.parse(currentPage: 10), 91))
-              .toString();
+          paginationNode(PageLinks(SearchForm(currentPage: 10), 91)).toString();
       expectGoldenFile(html, 'pagination_last.html', isFragment: true);
     });
 
@@ -775,9 +772,9 @@ void main() {
 
     scopedTest('platform tabs: search', () {
       final html = sdkTabsNode(
-          searchForm: SearchForm.parse(
+          searchForm: SearchForm(
+        context: SearchContext.flutter(),
         query: 'foo',
-        sdk: 'flutter',
       )).toString();
       expectGoldenFile(html, 'platform_tabs_search.html', isFragment: true);
     });
@@ -792,28 +789,28 @@ void main() {
     });
 
     test('one', () {
-      final links = PageLinks(SearchForm.parse(), 1);
+      final links = PageLinks(SearchForm(), 1);
       expect(links.currentPage, 1);
       expect(links.leftmostPage, 1);
       expect(links.rightmostPage, 1);
     });
 
     test('PageLinks.RESULTS_PER_PAGE - 1', () {
-      final links = PageLinks(SearchForm.parse(), resultsPerPage - 1);
+      final links = PageLinks(SearchForm(), resultsPerPage - 1);
       expect(links.currentPage, 1);
       expect(links.leftmostPage, 1);
       expect(links.rightmostPage, 1);
     });
 
     test('PageLinks.RESULTS_PER_PAGE', () {
-      final links = PageLinks(SearchForm.parse(), resultsPerPage);
+      final links = PageLinks(SearchForm(), resultsPerPage);
       expect(links.currentPage, 1);
       expect(links.leftmostPage, 1);
       expect(links.rightmostPage, 1);
     });
 
     test('PageLinks.RESULTS_PER_PAGE + 1', () {
-      final links = PageLinks(SearchForm.parse(), resultsPerPage + 1);
+      final links = PageLinks(SearchForm(), resultsPerPage + 1);
       expect(links.currentPage, 1);
       expect(links.leftmostPage, 1);
       expect(links.rightmostPage, 2);
@@ -822,8 +819,7 @@ void main() {
     final int page2Offset = resultsPerPage;
 
     test('page=2 + one item', () {
-      final links =
-          PageLinks(SearchForm.parse(currentPage: 2), page2Offset + 1);
+      final links = PageLinks(SearchForm(currentPage: 2), page2Offset + 1);
       expect(links.currentPage, 2);
       expect(links.leftmostPage, 1);
       expect(links.rightmostPage, 2);
@@ -831,15 +827,15 @@ void main() {
 
     test('page=2 + PageLinks.RESULTS_PER_PAGE - 1', () {
       final links = PageLinks(
-          SearchForm.parse(currentPage: 2), page2Offset + resultsPerPage - 1);
+          SearchForm(currentPage: 2), page2Offset + resultsPerPage - 1);
       expect(links.currentPage, 2);
       expect(links.leftmostPage, 1);
       expect(links.rightmostPage, 2);
     });
 
     test('page=2 + PageLinks.RESULTS_PER_PAGE', () {
-      final links = PageLinks(
-          SearchForm.parse(currentPage: 2), page2Offset + resultsPerPage);
+      final links =
+          PageLinks(SearchForm(currentPage: 2), page2Offset + resultsPerPage);
       expect(links.currentPage, 2);
       expect(links.leftmostPage, 1);
       expect(links.rightmostPage, 2);
@@ -847,14 +843,14 @@ void main() {
 
     test('page=2 + PageLinks.RESULTS_PER_PAGE + 1', () {
       final links = PageLinks(
-          SearchForm.parse(currentPage: 2), page2Offset + resultsPerPage + 1);
+          SearchForm(currentPage: 2), page2Offset + resultsPerPage + 1);
       expect(links.currentPage, 2);
       expect(links.leftmostPage, 1);
       expect(links.rightmostPage, 3);
     });
 
     test('deep in the middle', () {
-      final links = PageLinks(SearchForm.parse(currentPage: 21), 600);
+      final links = PageLinks(SearchForm(currentPage: 21), 600);
       expect(links.currentPage, 21);
       expect(links.leftmostPage, 16);
       expect(links.rightmostPage, 26);

--- a/app/test/search/mem_index_test.dart
+++ b/app/test/search/mem_index_test.dart
@@ -260,8 +260,8 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
 
     test('order by updated: runtime filter', () async {
       final result = await index.search(
-        SearchForm.parse(
-          sdk: 'dart',
+        SearchForm(
+          context: SearchContext.dart(),
           order: SearchOrder.updated,
           runtimes: ['native'],
         ).toServiceQuery(),

--- a/app/test/search/scope_specificity_test.dart
+++ b/app/test/search/scope_specificity_test.dart
@@ -90,9 +90,9 @@ void main() {
 
     test('text search with platform', () async {
       final withPlatform = await index.search(
-        SearchForm.parse(
+        SearchForm(
+          context: SearchContext.flutter(),
           query: 'json',
-          sdk: 'flutter',
         ).toServiceQuery(),
       );
       expect(json.decode(json.encode(withPlatform)), {

--- a/app/test/search/search_form_test.dart
+++ b/app/test/search/search_form_test.dart
@@ -8,21 +8,21 @@ import 'package:test/test.dart';
 void main() {
   group('SearchForm', () {
     test('query with defaults', () {
-      final form = SearchForm.parse(query: 'web framework');
+      final form = SearchForm(query: 'web framework');
       expect(form.toSearchLink(), '/packages?q=web+framework');
       expect(form.toSearchLink(page: 1), '/packages?q=web+framework');
       expect(form.toSearchLink(page: 2), '/packages?q=web+framework&page=2');
     });
 
     test('query with defaults on page 1', () {
-      final form = SearchForm.parse(query: 'web framework', currentPage: 1);
+      final form = SearchForm(query: 'web framework', currentPage: 1);
       expect(form.toSearchLink(), '/packages?q=web+framework');
       expect(form.toSearchLink(page: 1), '/packages?q=web+framework');
       expect(form.toSearchLink(page: 2), '/packages?q=web+framework&page=2');
     });
 
     test('query with defaults on page 3', () {
-      final form = SearchForm.parse(query: 'web framework', currentPage: 3);
+      final form = SearchForm(query: 'web framework', currentPage: 3);
       expect(form.toSearchLink(), '/packages?q=web+framework&page=3');
       expect(form.toSearchLink(page: 1), '/packages?q=web+framework');
       expect(form.toSearchLink(page: 2), '/packages?q=web+framework&page=2');
@@ -30,7 +30,10 @@ void main() {
     });
 
     test('query with with sdk', () {
-      final form = SearchForm.parse(query: 'some framework', sdk: 'flutter');
+      final form = SearchForm(
+        context: SearchContext.flutter(),
+        query: 'some framework',
+      );
       expect(form.toSearchLink(), '/flutter/packages?q=some+framework');
       expect(form.toSearchLink(page: 1), '/flutter/packages?q=some+framework');
       expect(form.toSearchLink(page: 2),
@@ -38,22 +41,30 @@ void main() {
     });
 
     test('removing Dart runtimes', () {
-      final form =
-          SearchForm.parse(query: 'text', sdk: 'dart', runtimes: ['js']);
+      final form = SearchForm(
+        context: SearchContext.dart(),
+        query: 'text',
+        runtimes: ['js'],
+      );
       expect(form.toSearchLink(), '/dart/packages?q=text&runtime=js');
-      expect(form.change(sdk: 'dart').toSearchLink(), form.toSearchLink());
-      expect(form.change(sdk: 'flutter').toSearchLink(),
+      expect(form.change(context: SearchContext.dart()).toSearchLink(),
+          form.toSearchLink());
+      expect(form.change(context: SearchContext.flutter()).toSearchLink(),
           '/flutter/packages?q=text');
-      expect(form.change(sdk: 'any').toSearchLink(), '/packages?q=text');
+      expect(form.change(context: SearchContext.regular()).toSearchLink(),
+          '/packages?q=text');
     });
 
     test('removing Flutter platforms', () {
-      final form =
-          SearchForm.parse(query: 'text', sdk: 'flutter', platforms: ['web']);
+      final form = SearchForm(
+          query: 'text', context: SearchContext.flutter(), platforms: ['web']);
       expect(form.toSearchLink(), '/flutter/packages?q=text&platform=web');
-      expect(form.change(sdk: 'dart').toSearchLink(), '/dart/packages?q=text');
-      expect(form.change(sdk: 'flutter').toSearchLink(), form.toSearchLink());
-      expect(form.change(sdk: 'any').toSearchLink(), '/packages?q=text');
+      expect(form.change(context: SearchContext.dart()).toSearchLink(),
+          '/dart/packages?q=text');
+      expect(form.change(context: SearchContext.flutter()).toSearchLink(),
+          form.toSearchLink());
+      expect(form.change(context: SearchContext.regular()).toSearchLink(),
+          '/packages?q=text');
     });
   });
 }

--- a/app/test/search/search_service_test.dart
+++ b/app/test/search/search_service_test.dart
@@ -24,13 +24,13 @@ void main() {
 
   group('ParsedQuery', () {
     test('trim', () {
-      expect(SearchForm.parse(query: 'text').parsedQuery.text, 'text');
-      expect(SearchForm.parse(query: ' text ').query, 'text');
-      expect(SearchForm.parse(query: ' text ').parsedQuery.text, 'text');
+      expect(SearchForm(query: 'text').parsedQuery.text, 'text');
+      expect(SearchForm(query: ' text ').query, 'text');
+      expect(SearchForm(query: ' text ').parsedQuery.text, 'text');
     });
 
     test('no dependency', () {
-      final query = SearchForm.parse(query: 'text');
+      final query = SearchForm(query: 'text');
       expect(query.parsedQuery.text, 'text');
       expect(query.parsedQuery.refDependencies, []);
       expect(query.parsedQuery.allDependencies, []);
@@ -38,7 +38,7 @@ void main() {
     });
 
     test('only one dependency', () {
-      final query = SearchForm.parse(query: 'dependency:pkg');
+      final query = SearchForm(query: 'dependency:pkg');
       expect(query.parsedQuery.text, isNull);
       expect(query.parsedQuery.refDependencies, ['pkg']);
       expect(query.parsedQuery.allDependencies, []);
@@ -46,7 +46,7 @@ void main() {
     });
 
     test('only one dependency*', () {
-      final query = SearchForm.parse(query: 'dependency*:pkg');
+      final query = SearchForm(query: 'dependency*:pkg');
       expect(query.parsedQuery.text, isNull);
       expect(query.parsedQuery.refDependencies, []);
       expect(query.parsedQuery.allDependencies, ['pkg']);
@@ -54,8 +54,8 @@ void main() {
     });
 
     test('two dependencies with text blocks', () {
-      final query = SearchForm.parse(
-          query: 'text1 dependency:pkg1 text2 dependency:pkg2');
+      final query =
+          SearchForm(query: 'text1 dependency:pkg1 text2 dependency:pkg2');
       expect(query.parsedQuery.text, 'text1 text2');
       expect(query.parsedQuery.refDependencies, ['pkg1', 'pkg2']);
       expect(query.parsedQuery.allDependencies, []);
@@ -63,8 +63,8 @@ void main() {
     });
 
     test('two mixed dependencies with text blocks', () {
-      final query = SearchForm.parse(
-          query: 'text1 dependency:pkg1 text2 dependency*:pkg2');
+      final query =
+          SearchForm(query: 'text1 dependency:pkg1 text2 dependency*:pkg2');
       expect(query.parsedQuery.text, 'text1 text2');
       expect(query.parsedQuery.refDependencies, ['pkg1']);
       expect(query.parsedQuery.allDependencies, ['pkg2']);
@@ -72,27 +72,27 @@ void main() {
     });
 
     test('only publisher', () {
-      final query = SearchForm.parse(query: 'publisher:example.com');
+      final query = SearchForm(query: 'publisher:example.com');
       expect(query.parsedQuery.text, isNull);
       expect(query.parsedQuery.publisher, 'example.com');
     });
 
     test('known tag', () {
-      final query = SearchForm.parse(query: 'is:legacy');
+      final query = SearchForm(query: 'is:legacy');
       expect(query.parsedQuery.text, isNull);
       expect(
           query.parsedQuery.tagsPredicate.toQueryParameters(), ['is:legacy']);
     });
 
     test('forbidden known tag', () {
-      final query = SearchForm.parse(query: '-is:legacy');
+      final query = SearchForm(query: '-is:legacy');
       expect(query.parsedQuery.text, isNull);
       expect(
           query.parsedQuery.tagsPredicate.toQueryParameters(), ['-is:legacy']);
     });
 
     test('known tag + package prefix + search text', () {
-      final query = SearchForm.parse(query: 'json is:legacy package:foo_');
+      final query = SearchForm(query: 'json is:legacy package:foo_');
       expect(query.parsedQuery.text, 'json');
       expect(
           query.parsedQuery.tagsPredicate.toQueryParameters(), ['is:legacy']);
@@ -101,7 +101,7 @@ void main() {
 
     test('publisher + email + text + dependency', () {
       final query =
-          SearchForm.parse(query: 'publisher:example.com text dependency:pkg1');
+          SearchForm(query: 'publisher:example.com text dependency:pkg1');
       expect(query.parsedQuery.text, 'text');
       expect(query.parsedQuery.refDependencies, ['pkg1']);
       expect(query.parsedQuery.allDependencies, []);
@@ -111,48 +111,49 @@ void main() {
 
   group('Search URLs', () {
     test('empty', () {
-      final query = SearchForm.parse();
+      final query = SearchForm();
       expect(query.parsedQuery.text, isNull);
       expect(query.parsedQuery.packagePrefix, isNull);
       expect(query.toSearchLink(), '/packages');
     });
 
     test('platform: flutter', () {
-      final query = SearchForm.parse(sdk: 'flutter');
+      final query = SearchForm(context: SearchContext.flutter());
       expect(query.parsedQuery.text, isNull);
       expect(query.parsedQuery.packagePrefix, isNull);
       expect(query.toSearchLink(), '/flutter/packages');
     });
 
     test('Flutter favorites', () {
-      final query = SearchForm.parse(contextIsFlutterFavorites: true);
+      final query = SearchForm(context: SearchContext.flutterFavorites());
       expect(query.toSearchLink(page: 2), '/flutter/favorites?page=2');
     });
 
     test('publisher: example.com', () {
-      final query = SearchForm.parse(publisherId: 'example.com');
+      final query = SearchForm(context: SearchContext.publisher('example.com'));
       expect(query.toSearchLink(), '/publishers/example.com/packages');
       expect(query.toSearchLink(page: 2),
           '/publishers/example.com/packages?page=2');
     });
 
     test('publisher: example.com with query', () {
-      final query = SearchForm.parse(publisherId: 'example.com', query: 'json');
+      final query = SearchForm(
+          context: SearchContext.publisher('example.com'), query: 'json');
       expect(query.toSearchLink(), '/publishers/example.com/packages?q=json');
       expect(query.toSearchLink(page: 2),
           '/publishers/example.com/packages?q=json&page=2');
     });
 
     test('package prefix: angular', () {
-      final query = SearchForm.parse(query: 'package:angular');
+      final query = SearchForm(query: 'package:angular');
       expect(query.parsedQuery.text, isNull);
       expect(query.parsedQuery.packagePrefix, 'angular');
       expect(query.toSearchLink(), '/packages?q=package%3Aangular');
     });
 
     test('complex search', () {
-      final query = SearchForm.parse(
-          query: 'package:angular widget', order: SearchOrder.top);
+      final query =
+          SearchForm(query: 'package:angular widget', order: SearchOrder.top);
       expect(query.parsedQuery.text, 'widget');
       expect(query.parsedQuery.packagePrefix, 'angular');
       expect(query.toSearchLink(),
@@ -162,9 +163,9 @@ void main() {
 
   group('new sdk queries', () {
     test('sdk:flutter & platform:android', () {
-      final query = parseFrontendSearchForm(
+      final query = SearchForm.parse(
+        SearchContext.flutter(),
         {'platform': 'android'},
-        sdk: 'flutter',
       );
       expect(
         query.toServiceQuery().tagsPredicate.toQueryParameters().toSet(),
@@ -180,9 +181,9 @@ void main() {
     });
 
     test('sdk:flutter & platform:android & platform:ios', () {
-      final query = parseFrontendSearchForm(
+      final query = SearchForm.parse(
+        SearchContext.flutter(),
         Uri.parse('/flutter/packages?platform=android++ios').queryParameters,
-        sdk: 'flutter',
       );
       expect(
         query.toServiceQuery().tagsPredicate.toQueryParameters().toSet(),
@@ -199,9 +200,9 @@ void main() {
     });
 
     test('sdk:dart & runtime:web', () {
-      final query = parseFrontendSearchForm(
+      final query = SearchForm.parse(
+        SearchContext.dart(),
         Uri.parse('/dart/packages?runtime=web').queryParameters,
-        sdk: 'dart',
       );
       expect(
         query.toServiceQuery().tagsPredicate.toQueryParameters().toSet(),

--- a/app/test/shared/urls_test.dart
+++ b/app/test/shared/urls_test.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:pub_dev/search/search_form.dart' show SearchForm;
+import 'package:pub_dev/search/search_form.dart';
 import 'package:pub_dev/shared/urls.dart';
 import 'package:test/test.dart';
 
@@ -192,16 +192,18 @@ void main() {
     });
 
     test('sdk:dart', () {
-      expect(searchUrl(sdk: 'dart'), '/dart/packages');
-      expect(searchUrl(sdk: 'dart', q: 'abc'), '/dart/packages?q=abc');
+      expect(searchUrl(context: SearchContext.dart()), '/dart/packages');
+      expect(searchUrl(context: SearchContext.dart(), q: 'abc'),
+          '/dart/packages?q=abc');
     });
 
     test('sdk:dart runtime:native', () {
       expect(
-        searchUrl(sdk: 'dart', runtimes: ['native']),
+        searchUrl(context: SearchContext.dart(), runtimes: ['native']),
         '/dart/packages?runtime=native',
       );
-      final form = SearchForm.parse(runtimes: ['native'], includeAll: true);
+      final form =
+          SearchForm(runtimes: ['native'], context: SearchContext.all());
       expect(form.runtimes, ['native-jit']);
       expect(
         form.toServiceQuery().tagsPredicate.toQueryParameters(),
@@ -211,10 +213,11 @@ void main() {
 
     test('sdk:dart runtime:native-jit', () {
       expect(
-        searchUrl(sdk: 'dart', runtimes: ['native-jit']),
+        searchUrl(context: SearchContext.dart(), runtimes: ['native-jit']),
         '/dart/packages?runtime=native',
       );
-      final form = SearchForm.parse(runtimes: ['native-jit'], includeAll: true);
+      final form =
+          SearchForm(runtimes: ['native-jit'], context: SearchContext.all());
       expect(form.runtimes, ['native-jit']);
       expect(
         form.toServiceQuery().tagsPredicate.toQueryParameters(),
@@ -224,10 +227,10 @@ void main() {
 
     test('sdk:dart runtime:web', () {
       expect(
-        searchUrl(sdk: 'dart', runtimes: ['web']),
+        searchUrl(context: SearchContext.dart(), runtimes: ['web']),
         '/dart/packages?runtime=js',
       );
-      final form = SearchForm.parse(runtimes: ['web'], includeAll: true);
+      final form = SearchForm(runtimes: ['web'], context: SearchContext.all());
       expect(form.runtimes, ['web']);
       expect(
         form.toServiceQuery().tagsPredicate.toQueryParameters(),
@@ -237,10 +240,10 @@ void main() {
 
     test('sdk:dart runtime:js', () {
       expect(
-        searchUrl(sdk: 'dart', runtimes: ['js']),
+        searchUrl(context: SearchContext.dart(), runtimes: ['js']),
         '/dart/packages?runtime=js',
       );
-      final form = SearchForm.parse(runtimes: ['js'], includeAll: true);
+      final form = SearchForm(runtimes: ['js'], context: SearchContext.all());
       expect(form.runtimes, ['web']);
       expect(
         form.toServiceQuery().tagsPredicate.toQueryParameters(),
@@ -250,10 +253,10 @@ void main() {
 
     test('sdk:dart runtime:xxy', () {
       expect(
-        searchUrl(sdk: 'dart', runtimes: ['xxy']),
+        searchUrl(context: SearchContext.dart(), runtimes: ['xxy']),
         '/dart/packages?runtime=xxy',
       );
-      final form = SearchForm.parse(runtimes: ['xxy'], includeAll: true);
+      final form = SearchForm(runtimes: ['xxy'], context: SearchContext.all());
       expect(form.runtimes, ['xxy']);
       expect(
         form.toServiceQuery().tagsPredicate.toQueryParameters(),
@@ -262,12 +265,15 @@ void main() {
     });
 
     test('sdk:flutter', () {
-      expect(searchUrl(sdk: 'flutter'), '/flutter/packages');
-      expect(searchUrl(sdk: 'flutter', q: 'abc'), '/flutter/packages?q=abc');
+      expect(searchUrl(context: SearchContext.flutter()), '/flutter/packages');
+      expect(searchUrl(context: SearchContext.flutter(), q: 'abc'),
+          '/flutter/packages?q=abc');
     });
 
     test('sdk:flutter platform:android+ios', () {
-      expect(searchUrl(sdk: 'flutter', platforms: ['android', 'ios']),
+      expect(
+          searchUrl(
+              context: SearchContext.flutter(), platforms: ['android', 'ios']),
           '/flutter/packages?platform=android+ios');
     });
   });


### PR DESCRIPTION
With this change, `SearchForm` will have an endpoint-driven `SearchContext` and the rest is queryParameter-driven user-input.

I'm not entirely sure whether the `sdk` parameter should be part of the context or the form itself, but for now the context seemed the logical choice.

The change should not change behavior or URLs, only the internal representation and their uses are refactored.