### PR TITLE
Always use primary API endpoint as base uri for archive URLs.

### DIFF
--- a/app/lib/frontend/handlers/package.dart
+++ b/app/lib/frontend/handlers/package.dart
@@ -372,11 +372,11 @@ Future<PackagePageData> loadPackagePageData(
 
 /// Handles /api/packages/<package> requests.
 Future<shelf.Response> listVersionsHandler(
-    shelf.Request request, Uri baseUri, String package) async {
+    shelf.Request request, String package) async {
   checkPackageVersionParams(package);
 
   Future<List<int>> createRawBytes() async {
-    final data = await packageBackend.listVersions(baseUri, package);
+    final data = await packageBackend.listVersions(package);
     return jsonUtf8Encoder.convert(data.toJson());
   }
 

--- a/app/lib/frontend/handlers/pubapi.dart
+++ b/app/lib/frontend/handlers/pubapi.dart
@@ -14,7 +14,6 @@ import '../../account/consent_backend.dart';
 import '../../admin/backend.dart';
 import '../../package/backend.dart' hide InviteStatus;
 import '../../publisher/backend.dart';
-import '../../shared/configuration.dart';
 import '../../shared/exceptions.dart';
 import '../../shared/handlers.dart';
 import 'account.dart';
@@ -35,8 +34,7 @@ class PubApi {
   /// https://github.com/dart-lang/pub/blob/master/doc/repository-spec-v2.md#list-all-versions-of-a-package
   @EndPoint.get('/api/packages/<package>')
   Future<Response> listVersions(Request request, String package) async {
-    final baseUri = _replaceHost(request.requestedUri);
-    return await listVersionsHandler(request, baseUri, package);
+    return await listVersionsHandler(request, package);
   }
 
   /// Getting information about a specific (package, version) pair.
@@ -47,8 +45,7 @@ class PubApi {
     String package,
     String version,
   ) async =>
-      await packageBackend.lookupVersion(
-          _replaceHost(request.requestedUri), package, version);
+      await packageBackend.lookupVersion(package, version);
 
   /// Downloading package.
   /// https://github.com/dart-lang/pub/blob/master/doc/repository-spec-v2.md#download-a-specific-version-of-a-package
@@ -477,18 +474,4 @@ class PubApi {
   Future<PackageUploaders> adminRemovePackageUploader(
           Request request, String package, String email) =>
       adminBackend.handleRemovePackageUploader(package, email);
-}
-
-/// Replaces the requested uri with the primary API uri.
-///
-/// A few API endpoint use the requested uri as a base to generate further URLs
-/// that we return in the response. Such generated URLs may end up in our cache,
-/// and it is critical that we only cache the values with the proper URLs.
-Uri _replaceHost(Uri requestedUri) {
-  return activeConfiguration.primaryApiUri!.replace(
-    path: requestedUri.path,
-    queryParameters: requestedUri.queryParameters.isEmpty
-        ? null
-        : requestedUri.queryParametersAll,
-  );
 }

--- a/app/lib/frontend/templates/views/pkg/versions/version_row.dart
+++ b/app/lib/frontend/templates/views/pkg/versions/version_row.dart
@@ -61,7 +61,7 @@ d.Node versionRowNode(String package, VersionInfo version, Pubspec pubspec) {
       d.td(
         classes: ['archive'],
         child: d.a(
-          href: version.archiveUrl,
+          href: urls.pkgArchiveDownloadUrl(package, version.version),
           rel: 'nofollow',
           title: 'Download $package ${version.version} archive',
           child: d.img(

--- a/app/test/package/backend_test.dart
+++ b/app/test/package/backend_test.dart
@@ -408,37 +408,31 @@ void main() {
     });
 
     group('GCloudRepository.lookupVersion', () {
-      final baseUri = Uri.parse('https://pub.dev');
-
       testWithProfile('package not found', fn: () async {
-        final rs =
-            packageBackend.lookupVersion(baseUri, 'not_hydrogen', '1.0.0');
+        final rs = packageBackend.lookupVersion('not_hydrogen', '1.0.0');
         await expectLater(rs, throwsA(isA<NotFoundException>()));
       });
 
       testWithProfile('version not found', fn: () async {
-        final rs = packageBackend.lookupVersion(baseUri, 'oxygen', '0.3.0');
+        final rs = packageBackend.lookupVersion('oxygen', '0.3.0');
         await expectLater(rs, throwsA(isA<NotFoundException>()));
       });
 
       testWithProfile('successful', fn: () async {
-        final version =
-            await packageBackend.lookupVersion(baseUri, 'oxygen', '1.0.0');
+        final version = await packageBackend.lookupVersion('oxygen', '1.0.0');
         expect(version, isNotNull);
         expect(version.version, '1.0.0');
       });
     });
 
     group('listVersions', () {
-      final baseUri = Uri.parse('https://pub.dev');
-
       testWithProfile('not found', fn: () async {
-        final rs = packageBackend.listVersions(baseUri, 'non_hydrogen');
+        final rs = packageBackend.listVersions('non_hydrogen');
         await expectLater(rs, throwsA(isA<NotFoundException>()));
       });
 
       testWithProfile('found', fn: () async {
-        final pd = await packageBackend.listVersions(baseUri, 'oxygen');
+        final pd = await packageBackend.listVersions('oxygen');
         expect(pd.versions, isNotEmpty);
         expect(pd.versions, hasLength(3));
         expect(pd.versions.first.version, '1.0.0');
@@ -452,7 +446,7 @@ void main() {
             adminAtPubDevAuthToken,
             () => packageBackend.updateOptions(
                 'oxygen', PkgOptions(isDiscontinued: true)));
-        final pd = await packageBackend.listVersions(baseUri, 'oxygen');
+        final pd = await packageBackend.listVersions('oxygen');
         expect(pd.isDiscontinued, isTrue);
       });
     });


### PR DESCRIPTION
As we are always using the primary API, there is no need for the extra logic in the handlers and in the rendering.