### PR TITLE
Skeleton for new search form (desktop only).

### DIFF
--- a/app/lib/frontend/request_context.dart
+++ b/app/lib/frontend/request_context.dart
@@ -27,10 +27,14 @@ class RequestContext {
   /// pollution by visually changing the site).
   final bool uiCacheEnabled;
 
+  /// Whether to render the new search UI with un-nested platforms.
+  final bool showNewSearchUI;
+
   const RequestContext({
     this.indentJson = false,
     this.isExperimental = false,
     this.blockRobots = true,
     this.uiCacheEnabled = false,
+    this.showNewSearchUI = false,
   });
 }

--- a/app/lib/frontend/templates/views/pkg/index.dart
+++ b/app/lib/frontend/templates/views/pkg/index.dart
@@ -5,6 +5,7 @@
 import '../../../../search/search_form.dart';
 import '../../../../shared/tags.dart';
 import '../../../dom/dom.dart' as d;
+import '../../../request_context.dart';
 import '../../../static_files.dart';
 import '../../layout.dart';
 
@@ -16,20 +17,87 @@ d.Node packageListingNode({
   required d.Node packageList,
   required d.Node? pagination,
 }) {
-  return d.fragment([
-    _searchControls(searchForm, subSdkButtons),
-    d.div(
-      classes: ['container'],
-      children: [
-        listingInfo,
-        packageList,
-        if (pagination != null) pagination,
-        d.markdown('Check our help page for details on '
-            '[search expressions](/help/search#query-expressions) and '
-            '[result ranking](/help/search#ranking).'),
-      ],
-    ),
+  final innerContent = d.fragment([
+    listingInfo,
+    packageList,
+    if (pagination != null) pagination,
+    d.markdown('Check our help page for details on '
+        '[search expressions](/help/search#query-expressions) and '
+        '[result ranking](/help/search#ranking).'),
   ]);
+  if (requestContext.showNewSearchUI) {
+    return _searchFormContainer(
+      searchForm: searchForm,
+      innerContent: innerContent,
+    );
+  } else {
+    return d.fragment([
+      _searchControls(searchForm, subSdkButtons),
+      d.div(classes: ['container'], child: innerContent),
+    ]);
+  }
+}
+
+d.Node _searchFormContainer({
+  required SearchForm searchForm,
+  required d.Node innerContent,
+}) {
+  return d.div(
+    classes: ['container', 'search-form-container', 'experimental'],
+    children: [
+      d.div(
+        classes: ['search-form'],
+        children: [
+          _filterSection(
+            label: 'Platforms',
+            isActive: true,
+            children: [
+              // TODO: add platform checkboxes
+              d.span(text: '[placeholder]'),
+            ],
+          ),
+          _filterSection(
+            label: 'SDKs',
+            children: [
+              // TODO: add SDK checkboxes
+              d.span(text: '[placeholder]'),
+            ],
+          ),
+        ],
+      ),
+      d.div(
+        classes: ['search-results'],
+        child: innerContent,
+      ),
+    ],
+  );
+}
+
+d.Node _filterSection({
+  required String label,
+  required Iterable<d.Node> children,
+  bool isActive = false,
+}) {
+  return d.div(
+    classes: ['search-form-section', 'foldable', if (isActive) '-active'],
+    children: [
+      d.h3(
+        classes: ['search-form-section-header foldable-button'],
+        children: [
+          d.span(classes: ['search-form-section-header-label'], text: label),
+          d.img(
+            classes: ['foldable-icon'],
+            src: staticUrls
+                .getAssetUrl('/static/img/search-form-foldable-icon.svg'),
+          ),
+        ],
+      ),
+      d.div(
+        classes: ['foldable-content'],
+        children: children,
+      ),
+    ],
+  );
 }
 
 d.Node _searchControls(SearchForm searchForm, d.Node? subSdkButtons) {

--- a/app/lib/search/search_form.dart
+++ b/app/lib/search/search_form.dart
@@ -93,6 +93,9 @@ class SearchForm {
     List<String>? runtimes,
     List<String>? platforms,
     int? currentPage,
+    bool? includeDiscontinued,
+    bool? includeUnlisted,
+    bool? nullSafe,
   }) {
     runtimes ??= this.runtimes;
     platforms ??= this.platforms;
@@ -112,9 +115,9 @@ class SearchForm {
       order: order,
       currentPage: currentPage ?? this.currentPage,
       pageSize: pageSize,
-      includeDiscontinued: includeDiscontinued,
-      includeUnlisted: includeUnlisted,
-      nullSafe: nullSafe,
+      includeDiscontinued: includeDiscontinued ?? this.includeDiscontinued,
+      includeUnlisted: includeUnlisted ?? this.includeUnlisted,
+      nullSafe: nullSafe ?? this.nullSafe,
     );
   }
 

--- a/app/lib/shared/handler_helpers.dart
+++ b/app/lib/shared/handler_helpers.dart
@@ -142,6 +142,7 @@ shelf.Handler _requestContextWrapper(shelf.Handler handler) {
       isExperimental: isExperimental,
       blockRobots: !enableRobots,
       uiCacheEnabled: uiCacheEnabled,
+      showNewSearchUI: isExperimental,
     ));
     return await handler(request);
   };

--- a/app/test/frontend/golden/pkg_index_page_experimental.html
+++ b/app/test/frontend/golden/pkg_index_page_experimental.html
@@ -1,0 +1,322 @@
+<!DOCTYPE html>
+<html lang="en-us">
+  <head>
+    <script src="https://www.googletagmanager.com/gtm.js?id=GTM-MX6DBN9" async="async"></script>
+    <script src="/static/js/gtm.js?hash=mocked_hash_451823545"></script>
+    <meta charset="utf-8"/>
+    <meta http-equiv="x-ua-compatible" content="ie=edge"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <meta name="robots" content="noindex"/>
+    <meta name="twitter:card" content="summary"/>
+    <meta name="twitter:site" content="@dart_lang"/>
+    <meta name="twitter:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
+    <meta name="twitter:image" content="https://pub.dev/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta property="og:type" content="website"/>
+    <meta property="og:site_name" content="Dart packages"/>
+    <meta property="og:title" content="Top packages"/>
+    <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
+    <meta property="og:image" content="https://pub.dev/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <title>Top packages</title>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Google+Sans:300,400,500|Google+Sans+Display:400|Roboto:300,400,500,700|Roboto+Mono:300,400,700"/>
+    <meta content="/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
+    <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/osd.xml?hash=mocked_hash_869379763"/>
+    <link rel="canonical" href="https://pub.dev/packages"/>
+    <meta name="description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
+    <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
+    <link rel="stylesheet" type="text/css" href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842"/>
+    <link rel="stylesheet" type="text/css" href="/static/highlight/github.css?hash=mocked_hash_145446167"/>
+    <link rel="stylesheet" type="text/css" href="/static/css/github-markdown.css?hash=mocked_hash_488759485"/>
+    <link rel="stylesheet" type="text/css" href="/static/css/style.css?hash=mocked_hash_537099079"/>
+    <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
+    <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
+    <meta name="google-signin-client_id" content=""/>
+    <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
+  </head>
+  <body>
+    <noscript>
+      <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MX6DBN9" height="0" width="0" style="display:none;visibility:hidden"></iframe>
+    </noscript>
+    <div class="site-header">
+      <button class="hamburger"></button>
+      <a class="logo" href="/">
+        <img class="site-logo" src="/static/img/pub-dev-logo-2x.png?hash=mocked_hash_685890546" alt="pub logo"/>
+      </a>
+      <div class="site-header-space"></div>
+      <div class="site-header-mask"></div>
+      <div class="site-header-nav scroll-container">
+        <div class="nav-login-container">
+          <button id="-account-login" class="nav-main-button link">Sign in</button>
+        </div>
+        <div class="nav-container nav-help-container hoverable">
+          <button class="nav-main-button">Help</button>
+          <div class="nav-hover-popup">
+            <div class="nav-table-columns">
+              <div class="nav-table-column">
+                <h3>Pub.dev</h3>
+                <a class="nav-link" href="/help/search" rel="noopener" target="_blank">Searching for packages</a>
+                <a class="nav-link" href="/help/scoring" rel="noopener" target="_blank">Package scoring and pub points</a>
+              </div>
+              <div class="nav-table-column">
+                <h3>Flutter</h3>
+                <a class="nav-link" href="https://flutter.io/using-packages/" rel="noopener" target="_blank">Using packages</a>
+                <a class="nav-link" href="https://flutter.io/developing-packages/" rel="noopener" target="_blank">Developing packages and plugins</a>
+                <a class="nav-link" href="https://dart.dev/tools/pub/publishing" rel="noopener" target="_blank">Publishing a package</a>
+              </div>
+              <div class="nav-table-column">
+                <h3>Dart</h3>
+                <a class="nav-link" href="https://dart.dev/tools/pub/get-started" rel="noopener" target="_blank">Using packages</a>
+                <a class="nav-link" href="https://dart.dev/tools/pub/publishing" rel="noopener" target="_blank">Publishing a package</a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="nav-container nav-help-container-mobile foldable">
+          <h3 class="foldable-button">
+            Pub.dev
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+          </h3>
+          <div class="foldable-content">
+            <a class="nav-link" href="/help/search" rel="noopener" target="_blank">Searching for packages</a>
+            <a class="nav-link" href="/help/scoring" rel="noopener" target="_blank">Package scoring and pub points</a>
+          </div>
+        </div>
+        <div class="nav-container nav-help-container-mobile foldable">
+          <h3 class="foldable-button">
+            Flutter
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+          </h3>
+          <div class="foldable-content">
+            <a class="nav-link" href="https://flutter.io/using-packages/" rel="noopener" target="_blank">Using packages</a>
+            <a class="nav-link" href="https://flutter.io/developing-packages/" rel="noopener" target="_blank">Developing packages and plugins</a>
+            <a class="nav-link" href="https://dart.dev/tools/pub/publishing" rel="noopener" target="_blank">Publishing a package</a>
+          </div>
+        </div>
+        <div class="nav-container nav-help-container-mobile foldable">
+          <h3 class="foldable-button">
+            Dart
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+          </h3>
+          <div class="foldable-content">
+            <a class="nav-link" href="https://dart.dev/tools/pub/get-started" rel="noopener" target="_blank">Using packages</a>
+            <a class="nav-link" href="https://dart.dev/tools/pub/publishing" rel="noopener" target="_blank">Publishing a package</a>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div id="banner-container"></div>
+    <div class="_banner-bg">
+      <div class="container">
+        <form class="search-bar banner-item" action="/packages">
+          <input class="input" name="q" placeholder="Search packages" autocomplete="on" autofocus="autofocus"/>
+          <button class="icon"></button>
+          <div class="search-filters-btn-wrapper">
+            <img class="search-filters-btn search-filters-btn-inactive" src="/static/img/search-filters-inactive.svg?hash=mocked_hash_963166179"/>
+            <img class="search-filters-btn search-filters-btn-active" src="/static/img/search-filters-active.svg?hash=mocked_hash_397783636"/>
+          </div>
+          <input id="-search-discontinued-field" type="hidden" name="discontinued" value="1" disabled="disabled"/>
+          <input id="-search-unlisted-field" type="hidden" name="unlisted" value="1" disabled="disabled"/>
+          <input id="-search-null-safe-field" type="hidden" name="null-safe" value="1" disabled="disabled"/>
+        </form>
+      </div>
+    </div>
+    <main>
+      <div class="container search-form-container experimental">
+        <div class="search-form">
+          <div class="search-form-section foldable -active">
+            <h3 class="search-form-section-header foldable-button">
+              <span class="search-form-section-header-label">Platforms</span>
+              <img class="foldable-icon" src="/static/img/search-form-foldable-icon.svg?hash=mocked_hash_663371761"/>
+            </h3>
+            <div class="foldable-content">
+              <span>[placeholder]</span>
+            </div>
+          </div>
+          <div class="search-form-section foldable">
+            <h3 class="search-form-section-header foldable-button">
+              <span class="search-form-section-header-label">SDKs</span>
+              <img class="foldable-icon" src="/static/img/search-form-foldable-icon.svg?hash=mocked_hash_663371761"/>
+            </h3>
+            <div class="foldable-content">
+              <span>[placeholder]</span>
+            </div>
+          </div>
+        </div>
+        <div class="search-results">
+          <div class="listing-info">
+            <div class="listing-info-count">
+              <span class="info-identifier">Results</span>
+              <span class="count">2</span>
+              packages
+            </div>
+            <div class="sort-control hoverable">
+              <div class="info-identifier" title="Packages are sorted by the combination of their overall score and their specificity to the selected platform.">
+                Sort by
+                <span class="sort-control-selected">listing relevance</span>
+              </div>
+              <div class="sort-control-popup">
+                <div class="sort-control-option selected" data-value="listing_relevance">listing relevance</div>
+                <div class="sort-control-option" data-value="top">overall score</div>
+                <div class="sort-control-option" data-value="updated">recently updated</div>
+                <div class="sort-control-option" data-value="created">newest package</div>
+                <div class="sort-control-option" data-value="like">most likes</div>
+                <div class="sort-control-option" data-value="points">most pub points</div>
+                <div class="sort-control-option" data-value="popularity">popularity</div>
+              </div>
+            </div>
+          </div>
+          <div class="packages">
+            <div class="packages-item">
+              <div class="packages-header">
+                <h3 class="packages-title">
+                  <a href="/packages/oxygen">oxygen</a>
+                </h3>
+                <div class="packages-recent">
+                  <img class="packages-recent-icon" src="/static/img/schedule-icon.svg?hash=mocked_hash_164576935" title="new package"/>
+                  Added
+                  <b>in the last hour</b>
+                </div>
+                <a class="packages-scores" href="/packages/oxygen/score">
+                  <div class="packages-score packages-score-like">
+                    <div class="packages-score-value -has-value">
+                      <span class="packages-score-value-number">0</span>
+                      <span class="packages-score-value-sign"></span>
+                    </div>
+                    <div class="packages-score-label">likes</div>
+                  </div>
+                  <div class="packages-score packages-score-health">
+                    <div class="packages-score-value -has-value">
+                      <span class="packages-score-value-number">43</span>
+                      <span class="packages-score-value-sign"></span>
+                    </div>
+                    <div class="packages-score-label">pub points</div>
+                  </div>
+                  <div class="packages-score packages-score-popularity">
+                    <div class="packages-score-value -has-value">
+                      <span class="packages-score-value-number">3</span>
+                      <span class="packages-score-value-sign">%</span>
+                    </div>
+                    <div class="packages-score-label">popularity</div>
+                  </div>
+                </a>
+              </div>
+              <p class="packages-description">oxygen is awesome</p>
+              <p class="packages-metadata">
+                <span class="packages-metadata-block">
+                  v
+                  <a href="/packages/oxygen">1.2.0</a>
+                  /
+                  <a href="/packages/oxygen/versions/2.0.0-dev">2.0.0-dev</a>
+                  • Updated:
+                  <span>%%oxygen-created-date%%</span>
+                </span>
+              </p>
+              <div>
+                <div class="-pub-tag-badge">
+                  <a class="tag-badge-main" href="/dart/packages" title="Packages compatible with Dart SDK">Dart</a>
+                  <a class="tag-badge-sub" href="/dart/packages?runtime=native" title="Packages compatible with Dart running on a native platform (JIT/AOT)">native</a>
+                  <a class="tag-badge-sub" href="/dart/packages?runtime=js" title="Packages compatible with Dart compiled for the web">js</a>
+                </div>
+              </div>
+            </div>
+            <div class="packages-item">
+              <div class="packages-header">
+                <h3 class="packages-title">
+                  <a href="/packages/flutter_titanium">flutter_titanium</a>
+                </h3>
+                <div class="packages-recent">
+                  <img class="packages-recent-icon" src="/static/img/schedule-icon.svg?hash=mocked_hash_164576935" title="new package"/>
+                  Added
+                  <b>in the last hour</b>
+                </div>
+                <a class="packages-scores" href="/packages/flutter_titanium/score">
+                  <div class="packages-score packages-score-like">
+                    <div class="packages-score-value -has-value">
+                      <span class="packages-score-value-number">0</span>
+                      <span class="packages-score-value-sign"></span>
+                    </div>
+                    <div class="packages-score-label">likes</div>
+                  </div>
+                  <div class="packages-score packages-score-health">
+                    <div class="packages-score-value -has-value">
+                      <span class="packages-score-value-number">24</span>
+                      <span class="packages-score-value-sign"></span>
+                    </div>
+                    <div class="packages-score-label">pub points</div>
+                  </div>
+                  <div class="packages-score packages-score-popularity">
+                    <div class="packages-score-value -has-value">
+                      <span class="packages-score-value-number">43</span>
+                      <span class="packages-score-value-sign">%</span>
+                    </div>
+                    <div class="packages-score-label">popularity</div>
+                  </div>
+                </a>
+              </div>
+              <p class="packages-description">flutter_titanium is awesome</p>
+              <p class="packages-metadata">
+                <span class="packages-metadata-block">
+                  v
+                  <a href="/packages/flutter_titanium">1.10.0</a>
+                  • Updated:
+                  <span>%%oxygen-created-date%%</span>
+                </span>
+              </p>
+              <div>
+                <div class="-pub-tag-badge">
+                  <a class="tag-badge-main" href="/dart/packages" title="Packages compatible with Dart SDK">Dart</a>
+                  <a class="tag-badge-sub" href="/dart/packages?runtime=native" title="Packages compatible with Dart running on a native platform (JIT/AOT)">native</a>
+                  <a class="tag-badge-sub" href="/dart/packages?runtime=js" title="Packages compatible with Dart compiled for the web">js</a>
+                </div>
+                <div class="-pub-tag-badge">
+                  <a class="tag-badge-main" href="/flutter/packages" title="Packages compatible with Flutter SDK">Flutter</a>
+                  <a class="tag-badge-sub" href="/flutter/packages?platform=android" title="Packages compatible with Flutter on the Android platform">Android</a>
+                  <a class="tag-badge-sub" href="/flutter/packages?platform=macos" title="Packages compatible with Flutter on the macOS platform">macOS</a>
+                </div>
+              </div>
+            </div>
+          </div>
+          <ul class="pagination">
+            <li class="-disabled">
+              <a rel="prev">
+                <span>«</span>
+              </a>
+            </li>
+            <li class="-active">
+              <a>
+                <span>1</span>
+              </a>
+            </li>
+            <li class="-disabled">
+              <a rel="next">
+                <span>»</span>
+              </a>
+            </li>
+          </ul>
+          <p>
+            Check our help page for details on
+            <a href="/help/search#query-expressions">search expressions</a>
+            and
+            <a href="/help/search#ranking">result ranking</a>
+            .
+          </p>
+        </div>
+      </div>
+    </main>
+    <footer class="site-footer">
+      <a class="link" href="https://dart.dev/">Dart language</a>
+      <a class="link sep" href="/policy">Policy</a>
+      <a class="link sep" href="https://www.google.com/intl/en/policies/terms/">Terms</a>
+      <a class="link sep" href="https://developers.google.com/terms/">API Terms</a>
+      <a class="link sep" href="/security">Security</a>
+      <a class="link sep" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
+      <a class="link sep" href="/help">Help</a>
+      <a class="link icon sep" href="/feed.atom">
+        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" title="RSS/atom feed" alt="RSS/atom feed"/>
+      </a>
+      <a class="link icon github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">
+        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" title="Report an issue with this site" alt="Report an issue with this site"/>
+      </a>
+    </footer>
+  </body>
+</html>

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -12,6 +12,7 @@ import 'package:pub_dev/audit/backend.dart';
 import 'package:pub_dev/audit/models.dart';
 import 'package:pub_dev/frontend/handlers/package.dart'
     show loadPackagePageData;
+import 'package:pub_dev/frontend/request_context.dart';
 import 'package:pub_dev/frontend/static_files.dart';
 import 'package:pub_dev/frontend/templates/admin.dart';
 import 'package:pub_dev/frontend/templates/consent.dart';
@@ -401,6 +402,34 @@ void main() {
           searchForm: searchForm,
         );
         expectGoldenFile(html, 'pkg_index_page.html', timestamps: {
+          'oxygen-created': oxygen.created,
+          'oxygen-updated': oxygen.updated,
+          'titanium-created': titanium.created,
+          'titanium-updated': titanium.updated,
+        });
+      },
+    );
+
+    testWithProfile(
+      'experimental package index page',
+      processJobsWithFakeRunners: true,
+      fn: () async {
+        registerRequestContext(
+            RequestContext(isExperimental: true, showNewSearchUI: true));
+        final searchForm = SearchForm();
+        final oxygen = (await scoreCardBackend.getPackageView('oxygen'))!;
+        final titanium =
+            (await scoreCardBackend.getPackageView('flutter_titanium'))!;
+        final String html = renderPkgIndexPage(
+          SearchResultPage(
+            searchForm,
+            2,
+            packageHits: [oxygen, titanium],
+          ),
+          PageLinks.empty(),
+          searchForm: searchForm,
+        );
+        expectGoldenFile(html, 'pkg_index_page_experimental.html', timestamps: {
           'oxygen-created': oxygen.created,
           'oxygen-updated': oxygen.updated,
           'titanium-created': titanium.created,

--- a/pkg/web_app/lib/src/foldable.dart
+++ b/pkg/web_app/lib/src/foldable.dart
@@ -21,10 +21,7 @@ void _setEventForFoldable() {
     final scrollContainer = _parentWithClass(h, 'scroll-container');
     if (content == null) continue;
 
-    h.onClick.listen((e) async {
-      // Toggle state.
-      final isActive = foldable.classes.toggle('-active');
-
+    Future<void> update(bool isActive) async {
       // Closing is simple: no measurements, no scrolling.
       if (!isActive) {
         content.style.maxHeight = '0px';
@@ -84,7 +81,17 @@ void _setEventForFoldable() {
       // Wait one animation frame before enabling the content to resize on its own.
       await window.animationFrame;
       content.style.maxHeight = 'none';
+    }
+
+    // listen on trigger events
+    h.onClick.listen((e) async {
+      // Toggle state.
+      final isActive = foldable.classes.toggle('-active');
+      await update(isActive);
     });
+
+    // also update the initial state
+    update(foldable.classes.contains('-active'));
   }
 }
 

--- a/pkg/web_css/lib/src/_list.scss
+++ b/pkg/web_css/lib/src/_list.scss
@@ -414,3 +414,42 @@
     }
   }
 }
+
+.search-form-container.experimental {
+  display: flex;
+
+  .search-form {
+    flex-grow: 0;
+    flex-shrink: 0;
+    flex-basis: 200px;
+    padding-right: 40px;
+  }
+
+  .search-results {
+    flex-grow: 1;
+  }
+
+  .search-form-section-header {
+    display: flex;
+
+    .search-form-section-header-label {
+      flex-grow: 1;
+    }
+  }
+
+  .search-form-section {
+    .foldable-icon {
+      margin-left: 18px;
+      width: 12px;
+
+      transform: rotate(180deg);
+      transition: transform .3s linear;
+    }
+
+    &.-active {
+      .foldable-icon {
+        transform: rotate(360deg);
+      }
+    }
+  }
+}

--- a/static/img/search-form-foldable-icon.svg
+++ b/static/img/search-form-foldable-icon.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="13px" height="6px" viewBox="0 0 13 6" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <g id="pub.dev" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="general-ui---icons-and-components" transform="translate(-762.000000, -314.000000)" fill="#6d7278" fill-rule="nonzero">
+            <polygon id="carot-op2---closed" transform="translate(768.686441, 317.072723) rotate(-180.000000) translate(-768.686441, -317.072723) " points="774.087752 314.589267 774.658011 315.410733 768.686441 319.556178 762.714871 315.410733 763.285129 314.589267 768.686 318.338"></polygon>
+        </g>
+    </g>
+</svg>


### PR DESCRIPTION
- added an extra flag that is driven by experimental cookie to decide what to render
- added the DOM skeleton for the search form on desktops (mobile view TBD)
- added template for sections with foldable content + rolling indicator (with `[placeholder]` content for now)
- added a template test golden file, specific to the experimental cookie so we can track the incremental changes, while also keeping the old template goldens