### PR TITLE
Use dedicated CSS selector for search link overrides.

### DIFF
--- a/app/lib/frontend/templates/views/shared/search_tabs.dart
+++ b/app/lib/frontend/templates/views/shared/search_tabs.dart
@@ -25,6 +25,7 @@ d.Node searchTabsNode(Iterable<SearchTab> tabs) {
     children: tabs.map(
       (tab) => d.a(
         classes: [
+          'search-link',
           'filter',
           if (tab.active) '-active',
         ],

--- a/app/test/frontend/golden/pkg_index_page.html
+++ b/app/test/frontend/golden/pkg_index_page.html
@@ -126,9 +126,9 @@
           <div class="search-controls-primary">
             <div class="search-controls-sdk search-controls-tabs">
               <div class="list-filters">
-                <a class="filter" href="/dart/packages" title="Packages compatible with the Dart SDK">Dart</a>
-                <a class="filter" href="/flutter/packages" title="Packages compatible with the Flutter SDK">Flutter</a>
-                <a class="filter -active" href="/packages" title="Packages compatible with the any SDK">
+                <a class="search-link filter" href="/dart/packages" title="Packages compatible with the Dart SDK">Dart</a>
+                <a class="search-link filter" href="/flutter/packages" title="Packages compatible with the Flutter SDK">Flutter</a>
+                <a class="search-link filter -active" href="/packages" title="Packages compatible with the any SDK">
                   <img class="filter-icon" src="/static/img/checkmark-icon.svg?hash=mocked_hash_296261337"/>
                   Any
                 </a>
@@ -137,9 +137,9 @@
             <div class="search-controls-sdk search-controls-buttons">
               <span class="search-controls-label">SDK</span>
               <div class="list-filters">
-                <a class="filter" href="/dart/packages" title="Packages compatible with the Dart SDK">Dart</a>
-                <a class="filter" href="/flutter/packages" title="Packages compatible with the Flutter SDK">Flutter</a>
-                <a class="filter -active" href="/packages" title="Packages compatible with the any SDK">
+                <a class="search-link filter" href="/dart/packages" title="Packages compatible with the Dart SDK">Dart</a>
+                <a class="search-link filter" href="/flutter/packages" title="Packages compatible with the Flutter SDK">Flutter</a>
+                <a class="search-link filter -active" href="/packages" title="Packages compatible with the any SDK">
                   <img class="filter-icon" src="/static/img/checkmark-icon.svg?hash=mocked_hash_296261337"/>
                   Any
                 </a>

--- a/app/test/frontend/golden/platform_tabs_list.html
+++ b/app/test/frontend/golden/platform_tabs_list.html
@@ -1,8 +1,8 @@
 <fragment>
   <div class="list-filters">
-    <a class="filter" href="/dart/packages" title="Packages compatible with the Dart SDK">Dart</a>
-    <a class="filter" href="/flutter/packages" title="Packages compatible with the Flutter SDK">Flutter</a>
-    <a class="filter -active" href="/packages" title="Packages compatible with the any SDK">
+    <a class="search-link filter" href="/dart/packages" title="Packages compatible with the Dart SDK">Dart</a>
+    <a class="search-link filter" href="/flutter/packages" title="Packages compatible with the Flutter SDK">Flutter</a>
+    <a class="search-link filter -active" href="/packages" title="Packages compatible with the any SDK">
       <img class="filter-icon" src="/static/img/checkmark-icon.svg?hash=mocked_hash_296261337"/>
       Any
     </a>

--- a/app/test/frontend/golden/platform_tabs_search.html
+++ b/app/test/frontend/golden/platform_tabs_search.html
@@ -1,10 +1,10 @@
 <fragment>
   <div class="list-filters">
-    <a class="filter" href="/dart/packages?q=foo" title="Packages compatible with the Dart SDK">Dart</a>
-    <a class="filter -active" href="/flutter/packages?q=foo" title="Packages compatible with the Flutter SDK">
+    <a class="search-link filter" href="/dart/packages?q=foo" title="Packages compatible with the Dart SDK">Dart</a>
+    <a class="search-link filter -active" href="/flutter/packages?q=foo" title="Packages compatible with the Flutter SDK">
       <img class="filter-icon" src="/static/img/checkmark-icon.svg?hash=mocked_hash_296261337"/>
       Flutter
     </a>
-    <a class="filter" href="/packages?q=foo" title="Packages compatible with the any SDK">Any</a>
+    <a class="search-link filter" href="/packages?q=foo" title="Packages compatible with the any SDK">Any</a>
   </div>
 </fragment>

--- a/app/test/frontend/golden/search_page.html
+++ b/app/test/frontend/golden/search_page.html
@@ -127,9 +127,9 @@
           <div class="search-controls-primary">
             <div class="search-controls-sdk search-controls-tabs">
               <div class="list-filters">
-                <a class="filter" href="/dart/packages?q=foobar&amp;sort=top" title="Packages compatible with the Dart SDK">Dart</a>
-                <a class="filter" href="/flutter/packages?q=foobar&amp;sort=top" title="Packages compatible with the Flutter SDK">Flutter</a>
-                <a class="filter -active" href="/packages?q=foobar&amp;sort=top" title="Packages compatible with the any SDK">
+                <a class="search-link filter" href="/dart/packages?q=foobar&amp;sort=top" title="Packages compatible with the Dart SDK">Dart</a>
+                <a class="search-link filter" href="/flutter/packages?q=foobar&amp;sort=top" title="Packages compatible with the Flutter SDK">Flutter</a>
+                <a class="search-link filter -active" href="/packages?q=foobar&amp;sort=top" title="Packages compatible with the any SDK">
                   <img class="filter-icon" src="/static/img/checkmark-icon.svg?hash=mocked_hash_296261337"/>
                   Any
                 </a>
@@ -138,9 +138,9 @@
             <div class="search-controls-sdk search-controls-buttons">
               <span class="search-controls-label">SDK</span>
               <div class="list-filters">
-                <a class="filter" href="/dart/packages?q=foobar&amp;sort=top" title="Packages compatible with the Dart SDK">Dart</a>
-                <a class="filter" href="/flutter/packages?q=foobar&amp;sort=top" title="Packages compatible with the Flutter SDK">Flutter</a>
-                <a class="filter -active" href="/packages?q=foobar&amp;sort=top" title="Packages compatible with the any SDK">
+                <a class="search-link filter" href="/dart/packages?q=foobar&amp;sort=top" title="Packages compatible with the Dart SDK">Dart</a>
+                <a class="search-link filter" href="/flutter/packages?q=foobar&amp;sort=top" title="Packages compatible with the Flutter SDK">Flutter</a>
+                <a class="search-link filter -active" href="/packages?q=foobar&amp;sort=top" title="Packages compatible with the any SDK">
                   <img class="filter-icon" src="/static/img/checkmark-icon.svg?hash=mocked_hash_296261337"/>
                   Any
                 </a>

--- a/pkg/web_app/lib/src/search.dart
+++ b/pkg/web_app/lib/src/search.dart
@@ -45,7 +45,7 @@ void _setEventForKeyboardShortcut() {
 void _setEventForSearchInput() {
   final q = document.querySelector('input[name="q"]') as InputElement?;
   if (q == null) return null;
-  final anchors = document.querySelectorAll('.list-filters > a');
+  final anchors = document.querySelectorAll('.search-link');
   q.onChange.listen((_) {
     final newSearchQuery = q.value!.trim();
     for (final a in anchors) {


### PR DESCRIPTION
When we have both an input for search query, and server-prepared search links, we override the links when the query is updated. This change will introduce a new CSS class to identify these links, in order to use not only the current link structures, but also new ones.