### PR TITLE
new search checkboxes + URLs for SDKs

### DIFF
--- a/app/lib/frontend/dom/material.dart
+++ b/app/lib/frontend/dom/material.dart
@@ -252,7 +252,9 @@ d.Node checkbox({
   required String id,
   required String label,
   required bool checked,
+  d.Node Function(String label)? labelNodeContent,
 }) {
+  labelNodeContent ??= d.text;
   return d.div(
     classes: ['mdc-form-field'],
     children: [
@@ -287,7 +289,10 @@ d.Node checkbox({
           d.div(classes: ['mdc-checkbox__ripple']),
         ],
       ),
-      d.label(attributes: {'for': id}, text: label),
+      d.label(
+        attributes: {'for': id},
+        child: labelNodeContent(label),
+      ),
     ],
   );
 }

--- a/app/lib/frontend/templates/views/pkg/index.dart
+++ b/app/lib/frontend/templates/views/pkg/index.dart
@@ -5,6 +5,7 @@
 import '../../../../search/search_form.dart';
 import '../../../../shared/tags.dart';
 import '../../../dom/dom.dart' as d;
+import '../../../dom/material.dart' as material;
 import '../../../request_context.dart';
 import '../../../static_files.dart';
 import '../../layout.dart';
@@ -58,9 +59,18 @@ d.Node _searchFormContainer({
           ),
           _filterSection(
             label: 'SDKs',
+            isActive: searchForm.sdks.isNotEmpty,
             children: [
-              // TODO: add SDK checkboxes
-              d.span(text: '[placeholder]'),
+              _sdkCheckbox(
+                sdk: SdkTagValue.dart,
+                label: 'Dart',
+                searchForm: searchForm,
+              ),
+              _sdkCheckbox(
+                sdk: SdkTagValue.flutter,
+                label: 'Flutter',
+                searchForm: searchForm,
+              ),
             ],
           ),
         ],
@@ -70,6 +80,26 @@ d.Node _searchFormContainer({
         child: innerContent,
       ),
     ],
+  );
+}
+
+d.Node _sdkCheckbox({
+  required String sdk,
+  required String label,
+  required SearchForm searchForm,
+}) {
+  return d.div(
+    classes: ['search-form-linked-checkbox'],
+    child: material.checkbox(
+      id: 'search-form-checkbox-sdk-$sdk',
+      label: label,
+      labelNodeContent: (label) => d.a(
+        classes: ['search-link'],
+        href: searchForm.toggleSdk(sdk).toSearchLink(),
+        text: label,
+      ),
+      checked: searchForm.sdks.contains(sdk),
+    ),
   );
 }
 

--- a/app/lib/shared/tags.dart
+++ b/app/lib/shared/tags.dart
@@ -64,6 +64,7 @@ abstract class SdkTagValue {
 
   static bool isAny(String? value) => value == null || value == any;
   static bool isNotAny(String? value) => !isAny(value);
+  static bool isValidSdk(String value) => value == dart || value == flutter;
 }
 
 /// Collection of Dart SDK runtime tags (with prefix and value).

--- a/app/test/frontend/golden/pkg_index_page_experimental.html
+++ b/app/test/frontend/golden/pkg_index_page_experimental.html
@@ -138,7 +138,40 @@
               <img class="foldable-icon" src="/static/img/search-form-foldable-icon.svg?hash=mocked_hash_663371761"/>
             </h3>
             <div class="foldable-content">
-              <span>[placeholder]</span>
+              <div class="search-form-linked-checkbox">
+                <div class="mdc-form-field">
+                  <div class="mdc-checkbox">
+                    <input id="search-form-checkbox-sdk-dart" class="mdc-checkbox__native-control" type="checkbox"/>
+                    <div class="mdc-checkbox__background">
+                      <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
+                        <path class="mdc-checkbox__checkmark-path" fill="none" d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
+                      </svg>
+                      <div class="mdc-checkbox__mixedmark"></div>
+                    </div>
+                    <div class="mdc-checkbox__ripple"></div>
+                  </div>
+                  <label for="search-form-checkbox-sdk-dart">
+                    <a class="search-link" href="/packages?sdk=dart">Dart</a>
+                  </label>
+                </div>
+              </div>
+              <div class="search-form-linked-checkbox">
+                <div class="mdc-form-field">
+                  <div class="mdc-checkbox">
+                    <input id="search-form-checkbox-sdk-flutter" class="mdc-checkbox__native-control" type="checkbox"/>
+                    <div class="mdc-checkbox__background">
+                      <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
+                        <path class="mdc-checkbox__checkmark-path" fill="none" d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
+                      </svg>
+                      <div class="mdc-checkbox__mixedmark"></div>
+                    </div>
+                    <div class="mdc-checkbox__ripple"></div>
+                  </div>
+                  <label for="search-form-checkbox-sdk-flutter">
+                    <a class="search-link" href="/packages?sdk=flutter">Flutter</a>
+                  </label>
+                </div>
+              </div>
             </div>
           </div>
         </div>

--- a/app/test/search/search_service_test.dart
+++ b/app/test/search/search_service_test.dart
@@ -161,8 +161,8 @@ void main() {
     });
   });
 
-  group('new sdk queries', () {
-    test('sdk:flutter & platform:android', () {
+  group('old SDK queries', () {
+    test('sdk:flutter context & platform:android', () {
       final query = SearchForm.parse(
         SearchContext.flutter(),
         {'platform': 'android'},
@@ -180,7 +180,7 @@ void main() {
       expect(query.toSearchLink(), '/flutter/packages?platform=android');
     });
 
-    test('sdk:flutter & platform:android & platform:ios', () {
+    test('sdk:flutter context & platform:android & platform:ios', () {
       final query = SearchForm.parse(
         SearchContext.flutter(),
         Uri.parse('/flutter/packages?platform=android++ios').queryParameters,
@@ -199,7 +199,7 @@ void main() {
       expect(query.toSearchLink(), '/flutter/packages?platform=android+ios');
     });
 
-    test('sdk:dart & runtime:web', () {
+    test('sdk:dart context & runtime:web', () {
       final query = SearchForm.parse(
         SearchContext.dart(),
         Uri.parse('/dart/packages?runtime=web').queryParameters,

--- a/pkg/web_app/lib/src/search.dart
+++ b/pkg/web_app/lib/src/search.dart
@@ -9,6 +9,7 @@ import 'package:web_app/src/gtag_js.dart';
 void setupSearch() {
   _setEventForKeyboardShortcut();
   _setEventForSearchInput();
+  _setEventsForSearchForm();
   _setEventForFiltersToggle();
   _setEventForSortControl();
   _setEventForCheckboxChanges();
@@ -55,6 +56,18 @@ void _setEventForSearchInput() {
       params['q'] = newSearchQuery;
       final String newHref = oldUri.replace(queryParameters: params).toString();
       a.setAttribute('href', newHref);
+    }
+  });
+}
+
+void _setEventsForSearchForm() {
+  // When a search form checkbox has a linked search label,
+  //checking the checkbox will trigger a click on the link.
+  document.querySelectorAll('.search-form-linked-checkbox').forEach((e) {
+    final checkbox = e.querySelector('input');
+    final link = e.querySelector('a.search-link');
+    if (checkbox != null && link != null) {
+      checkbox.onChange.first.then((_) => link.click());
     }
   });
 }


### PR DESCRIPTION
- parses and emits `sdk=<space separated sdks>` URL parameter on the frontend
- emits `sdk:<sdk>` tag predicate towards the search backend 
- contains text link that can be clicked to toggle the checkbox
- the checkbox input change will trigger the text link, so that the URL and the results are updated 
- the search form section is opened if any of the SDK checkboxes is set