### PR TITLE
Upgrade pana + preview Flutter SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ AppEngine version, listed here to ease deployment and troubleshooting.
 
 ## Next Release (replace with git tag when deployed)
  * Bumped runtimeVersion to `2021.10.28`.
+ * Upgraded preview Flutter analysis SDK to `2.7.0-3.1.pre`.
  * Upgraded dependencies (e.g. `package:analyzer` to `2.7.0`).
 
 ## `20211027t134800-all`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@ Important changes to data-models, configuration and migrations between each
 AppEngine version, listed here to ease deployment and troubleshooting.
 
 ## Next Release (replace with git tag when deployed)
- * Bumped runtimeVersion to `2021.10.28`.
+ * Bumped runtimeVersion to `2021.11.01`.
  * Upgraded preview Flutter analysis SDK to `2.7.0-3.1.pre`.
+ * Upgraded pana to `0.21.4`.
  * Upgraded dependencies (e.g. `package:analyzer` to `2.7.0`).
 
 ## `20211027t134800-all`

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN /project/app/script/setup-dart.sh /tool/stable https://storage.googleapis.co
 RUN /project/app/script/setup-dart.sh /tool/preview https://storage.googleapis.com/dart-archive/channels/beta/release/2.15.0-178.1.beta/sdk/dartsdk-linux-x64-release.zip
 
 RUN /project/app/script/setup-flutter.sh /tool/stable 2.5.3
-RUN /project/app/script/setup-flutter.sh /tool/preview 2.7.0-3.0.pre
+RUN /project/app/script/setup-flutter.sh /tool/preview 2.7.0-3.1.pre
 
 # Clear out any arguments the base images might have set
 CMD []

--- a/app/lib/frontend/templates/package.dart
+++ b/app/lib/frontend/templates/package.dart
@@ -410,8 +410,11 @@ d.Node renderPackageSchemaOrgHtml(PackagePageData data) {
     'image': '${urls.siteRoot}/static/img/pub-dev-icon-cover-image.png'
   };
   if (data.hasLicense) {
-    map['license'] = urls.pkgLicenseUrl(data.package!.name!,
-        version: data.isLatestStable ? null : data.version!.version);
+    map['license'] = urls.pkgLicenseUrl(
+      data.package!.name!,
+      version: data.isLatestStable ? null : data.version!.version,
+      includeHost: true,
+    );
   }
   // TODO: add http://schema.org/codeRepository for github and gitlab links
   return d.ldJson(map);

--- a/app/lib/frontend/templates/package.dart
+++ b/app/lib/frontend/templates/package.dart
@@ -4,7 +4,6 @@
 
 import 'package:client_data/page_data.dart';
 import 'package:collection/collection.dart' show IterableExtension;
-import 'package:pana/pana.dart' show getRepositoryUrl;
 
 import '../../package/models.dart';
 import '../../package/overrides.dart' show devDependencyPackages;
@@ -313,7 +312,7 @@ Tab? _exampleTab(PackagePageData data) {
 
   final exampleFilename = data.asset!.path;
   final renderedExample = renderFile(data.asset!, baseUrl: baseUrl);
-  final url = getRepositoryUrl(baseUrl, exampleFilename!);
+  final url = urls.getRepositoryUrl(baseUrl, exampleFilename!);
 
   return Tab.withContent(
     id: 'example',
@@ -410,9 +409,9 @@ d.Node renderPackageSchemaOrgHtml(PackagePageData data) {
     'programmingLanguage': 'Dart',
     'image': '${urls.siteRoot}/static/img/pub-dev-icon-cover-image.png'
   };
-  final licenseFileUrl = data.scoreCard?.panaReport?.licenseFile?.url;
-  if (licenseFileUrl != null) {
-    map['license'] = licenseFileUrl;
+  if (data.hasLicense) {
+    map['license'] = urls.pkgLicenseUrl(data.package!.name!,
+        version: data.isLatestStable ? null : data.version!.version);
   }
   // TODO: add http://schema.org/codeRepository for github and gitlab links
   return d.ldJson(map);

--- a/app/lib/shared/markdown.dart
+++ b/app/lib/shared/markdown.dart
@@ -4,12 +4,11 @@
 
 import 'package:logging/logging.dart';
 import 'package:markdown/markdown.dart' as m;
-import 'package:pana/pana.dart' show getRepositoryUrl;
 import 'package:path/path.dart' as p;
 import 'package:pub_semver/pub_semver.dart';
 import 'package:sanitize_html/sanitize_html.dart';
 
-import 'urls.dart' show UriExt;
+import 'urls.dart' show getRepositoryUrl, UriExt;
 
 final Logger _logger = Logger('pub.markdown');
 

--- a/app/lib/shared/urls.dart
+++ b/app/lib/shared/urls.dart
@@ -19,7 +19,16 @@ const httpsApiDartDev = 'https://api.dart.dev/';
 const trustedUrlSchemes = <String>['http', 'https', 'mailto'];
 
 /// Extensions that are considered to be images.
-final _imageExtensions = <String>{'.gif', '.jpg', '.jpeg', '.png'};
+final _imageExtensions = <String>{
+  '.apng',
+  '.avif',
+  '.gif',
+  '.jpg',
+  '.jpeg',
+  '.png',
+  '.svg',
+  '.webp',
+};
 
 /// Common repository URL replacement patterns.
 const _repositoryReplacePrefixes = {

--- a/app/lib/shared/urls.dart
+++ b/app/lib/shared/urls.dart
@@ -93,8 +93,17 @@ String pkgChangelogUrl(String package, {String? version}) =>
 String pkgExampleUrl(String package, {String? version}) =>
     pkgPageUrl(package, version: version, pkgPageTab: PkgPageTab.example);
 
-String pkgLicenseUrl(String package, {String? version}) =>
-    pkgPageUrl(package, version: version, pkgPageTab: PkgPageTab.license);
+String pkgLicenseUrl(
+  String package, {
+  String? version,
+  bool? includeHost,
+}) =>
+    pkgPageUrl(
+      package,
+      version: version,
+      pkgPageTab: PkgPageTab.license,
+      includeHost: includeHost ?? false,
+    );
 
 String pkgInstallUrl(String package, {String? version}) =>
     pkgPageUrl(package, version: version, pkgPageTab: PkgPageTab.install);

--- a/app/lib/shared/versions.dart
+++ b/app/lib/shared/versions.dart
@@ -21,7 +21,7 @@ final RegExp runtimeVersionPattern = RegExp(r'^\d{4}\.\d{2}\.\d{2}$');
 /// Make sure that at least two versions are kept here as the next candidates
 /// when the version switch happens.
 const acceptedRuntimeVersions = <String>[
-  '2021.10.28', // The current [runtimeVersion].
+  '2021.11.01', // The current [runtimeVersion].
   '2021.10.26',
   '2021.10.12',
 ];

--- a/app/lib/shared/versions.dart
+++ b/app/lib/shared/versions.dart
@@ -56,7 +56,7 @@ final String runtimeSdkVersion = '2.14.1';
 final String toolStableDartSdkVersion = '2.14.4';
 final String toolStableFlutterSdkVersion = '2.5.3';
 final String toolPreviewDartSdkVersion = '2.15.0-178.1.beta';
-final String toolPreviewFlutterSdkVersion = '2.7.0-3.0.pre';
+final String toolPreviewFlutterSdkVersion = '2.7.0-3.1.pre';
 
 // Value comes from package:pana.
 final String panaVersion = pana.packageVersion;

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -469,7 +469,7 @@ packages:
       name: pana
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.21.3"
+    version: "0.21.4"
   path:
     dependency: "direct main"
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -45,7 +45,7 @@ dependencies:
   watcher: ^1.0.0
   yaml: '^3.0.0'
   # pana version to be pinned
-  pana: '0.21.3'
+  pana: '0.21.4'
   # 3rd-party packages with pinned versions
   buffer: '1.1.1'
   mailer: '5.0.1'

--- a/app/test/frontend/golden/pkg_changelog_page.html
+++ b/app/test/frontend/golden/pkg_changelog_page.html
@@ -263,7 +263,7 @@
             </p>
           </aside>
         </div>
-        <script type="application/ld+json">{"@context":"http:\u002f\u002fschema.org","@type":"SoftwareSourceCode","name":"oxygen","version":"1.2.0","description":"oxygen - oxygen is awesome","url":"https:\u002f\u002fpub.dev\u002fpackages\u002foxygen","dateCreated":"%%published-timestamp%%","dateModified":"%%updated-timestamp%%","programmingLanguage":"Dart","image":"https:\u002f\u002fpub.dev\u002fstatic\u002fimg\u002fpub-dev-icon-cover-image.png"}</script>
+        <script type="application/ld+json">{"@context":"http:\u002f\u002fschema.org","@type":"SoftwareSourceCode","name":"oxygen","version":"1.2.0","description":"oxygen - oxygen is awesome","url":"https:\u002f\u002fpub.dev\u002fpackages\u002foxygen","dateCreated":"%%published-timestamp%%","dateModified":"%%updated-timestamp%%","programmingLanguage":"Dart","image":"https:\u002f\u002fpub.dev\u002fstatic\u002fimg\u002fpub-dev-icon-cover-image.png","license":"https:\u002f\u002fpub.dev\u002fpackages\u002foxygen\u002flicense"}</script>
       </div>
       <div class="detail-metadata">
         <h3 class="detail-metadata-title">

--- a/app/test/frontend/golden/pkg_example_page.html
+++ b/app/test/frontend/golden/pkg_example_page.html
@@ -258,7 +258,7 @@
             </p>
           </aside>
         </div>
-        <script type="application/ld+json">{"@context":"http:\u002f\u002fschema.org","@type":"SoftwareSourceCode","name":"oxygen","version":"1.2.0","description":"oxygen - oxygen is awesome","url":"https:\u002f\u002fpub.dev\u002fpackages\u002foxygen","dateCreated":"%%published-timestamp%%","dateModified":"%%updated-timestamp%%","programmingLanguage":"Dart","image":"https:\u002f\u002fpub.dev\u002fstatic\u002fimg\u002fpub-dev-icon-cover-image.png"}</script>
+        <script type="application/ld+json">{"@context":"http:\u002f\u002fschema.org","@type":"SoftwareSourceCode","name":"oxygen","version":"1.2.0","description":"oxygen - oxygen is awesome","url":"https:\u002f\u002fpub.dev\u002fpackages\u002foxygen","dateCreated":"%%published-timestamp%%","dateModified":"%%updated-timestamp%%","programmingLanguage":"Dart","image":"https:\u002f\u002fpub.dev\u002fstatic\u002fimg\u002fpub-dev-icon-cover-image.png","license":"https:\u002f\u002fpub.dev\u002fpackages\u002foxygen\u002flicense"}</script>
       </div>
       <div class="detail-metadata">
         <h3 class="detail-metadata-title">

--- a/app/test/frontend/golden/pkg_install_page.html
+++ b/app/test/frontend/golden/pkg_install_page.html
@@ -280,7 +280,7 @@
             </p>
           </aside>
         </div>
-        <script type="application/ld+json">{"@context":"http:\u002f\u002fschema.org","@type":"SoftwareSourceCode","name":"oxygen","version":"1.2.0","description":"oxygen - oxygen is awesome","url":"https:\u002f\u002fpub.dev\u002fpackages\u002foxygen","dateCreated":"%%published-timestamp%%","dateModified":"%%updated-timestamp%%","programmingLanguage":"Dart","image":"https:\u002f\u002fpub.dev\u002fstatic\u002fimg\u002fpub-dev-icon-cover-image.png"}</script>
+        <script type="application/ld+json">{"@context":"http:\u002f\u002fschema.org","@type":"SoftwareSourceCode","name":"oxygen","version":"1.2.0","description":"oxygen - oxygen is awesome","url":"https:\u002f\u002fpub.dev\u002fpackages\u002foxygen","dateCreated":"%%published-timestamp%%","dateModified":"%%updated-timestamp%%","programmingLanguage":"Dart","image":"https:\u002f\u002fpub.dev\u002fstatic\u002fimg\u002fpub-dev-icon-cover-image.png","license":"https:\u002f\u002fpub.dev\u002fpackages\u002foxygen\u002flicense"}</script>
       </div>
       <div class="detail-metadata">
         <h3 class="detail-metadata-title">

--- a/app/test/frontend/golden/pkg_score_page.html
+++ b/app/test/frontend/golden/pkg_score_page.html
@@ -346,7 +346,7 @@
             </p>
           </aside>
         </div>
-        <script type="application/ld+json">{"@context":"http:\u002f\u002fschema.org","@type":"SoftwareSourceCode","name":"oxygen","version":"1.2.0","description":"oxygen - oxygen is awesome","url":"https:\u002f\u002fpub.dev\u002fpackages\u002foxygen","dateCreated":"%%published-timestamp%%","dateModified":"%%updated-timestamp%%","programmingLanguage":"Dart","image":"https:\u002f\u002fpub.dev\u002fstatic\u002fimg\u002fpub-dev-icon-cover-image.png"}</script>
+        <script type="application/ld+json">{"@context":"http:\u002f\u002fschema.org","@type":"SoftwareSourceCode","name":"oxygen","version":"1.2.0","description":"oxygen - oxygen is awesome","url":"https:\u002f\u002fpub.dev\u002fpackages\u002foxygen","dateCreated":"%%published-timestamp%%","dateModified":"%%updated-timestamp%%","programmingLanguage":"Dart","image":"https:\u002f\u002fpub.dev\u002fstatic\u002fimg\u002fpub-dev-icon-cover-image.png","license":"https:\u002f\u002fpub.dev\u002fpackages\u002foxygen\u002flicense"}</script>
       </div>
       <div class="detail-metadata">
         <h3 class="detail-metadata-title">

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -257,7 +257,7 @@
             </p>
           </aside>
         </div>
-        <script type="application/ld+json">{"@context":"http:\u002f\u002fschema.org","@type":"SoftwareSourceCode","name":"oxygen","version":"1.2.0","description":"oxygen - oxygen is awesome","url":"https:\u002f\u002fpub.dev\u002fpackages\u002foxygen","dateCreated":"%%published-timestamp%%","dateModified":"%%updated-timestamp%%","programmingLanguage":"Dart","image":"https:\u002f\u002fpub.dev\u002fstatic\u002fimg\u002fpub-dev-icon-cover-image.png"}</script>
+        <script type="application/ld+json">{"@context":"http:\u002f\u002fschema.org","@type":"SoftwareSourceCode","name":"oxygen","version":"1.2.0","description":"oxygen - oxygen is awesome","url":"https:\u002f\u002fpub.dev\u002fpackages\u002foxygen","dateCreated":"%%published-timestamp%%","dateModified":"%%updated-timestamp%%","programmingLanguage":"Dart","image":"https:\u002f\u002fpub.dev\u002fstatic\u002fimg\u002fpub-dev-icon-cover-image.png","license":"https:\u002f\u002fpub.dev\u002fpackages\u002foxygen\u002flicense"}</script>
       </div>
       <div class="detail-metadata">
         <h3 class="detail-metadata-title">

--- a/app/test/frontend/golden/pkg_show_page_discontinued.html
+++ b/app/test/frontend/golden/pkg_show_page_discontinued.html
@@ -244,7 +244,7 @@
             </p>
           </aside>
         </div>
-        <script type="application/ld+json">{"@context":"http:\u002f\u002fschema.org","@type":"SoftwareSourceCode","name":"pkg","version":"1.0.0","description":"pkg - pkg is awesome","url":"https:\u002f\u002fpub.dev\u002fpackages\u002fpkg","dateCreated":"%%published-timestamp%%","dateModified":"%%updated-timestamp%%","programmingLanguage":"Dart","image":"https:\u002f\u002fpub.dev\u002fstatic\u002fimg\u002fpub-dev-icon-cover-image.png"}</script>
+        <script type="application/ld+json">{"@context":"http:\u002f\u002fschema.org","@type":"SoftwareSourceCode","name":"pkg","version":"1.0.0","description":"pkg - pkg is awesome","url":"https:\u002f\u002fpub.dev\u002fpackages\u002fpkg","dateCreated":"%%published-timestamp%%","dateModified":"%%updated-timestamp%%","programmingLanguage":"Dart","image":"https:\u002f\u002fpub.dev\u002fstatic\u002fimg\u002fpub-dev-icon-cover-image.png","license":"https:\u002f\u002fpub.dev\u002fpackages\u002fpkg\u002flicense"}</script>
       </div>
       <div class="detail-metadata">
         <h3 class="detail-metadata-title">

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -257,7 +257,7 @@
             </p>
           </aside>
         </div>
-        <script type="application/ld+json">{"@context":"http:\u002f\u002fschema.org","@type":"SoftwareSourceCode","name":"flutter\u005ftitanium","version":"1.10.0","description":"flutter\u005ftitanium - flutter\u005ftitanium is awesome","url":"https:\u002f\u002fpub.dev\u002fpackages\u002fflutter\u005ftitanium","dateCreated":"%%published-timestamp%%","dateModified":"%%updated-timestamp%%","programmingLanguage":"Dart","image":"https:\u002f\u002fpub.dev\u002fstatic\u002fimg\u002fpub-dev-icon-cover-image.png"}</script>
+        <script type="application/ld+json">{"@context":"http:\u002f\u002fschema.org","@type":"SoftwareSourceCode","name":"flutter\u005ftitanium","version":"1.10.0","description":"flutter\u005ftitanium - flutter\u005ftitanium is awesome","url":"https:\u002f\u002fpub.dev\u002fpackages\u002fflutter\u005ftitanium","dateCreated":"%%published-timestamp%%","dateModified":"%%updated-timestamp%%","programmingLanguage":"Dart","image":"https:\u002f\u002fpub.dev\u002fstatic\u002fimg\u002fpub-dev-icon-cover-image.png","license":"https:\u002f\u002fpub.dev\u002fpackages\u002fflutter\u005ftitanium\u002flicense"}</script>
       </div>
       <div class="detail-metadata">
         <h3 class="detail-metadata-title">

--- a/app/test/frontend/golden/pkg_show_page_legacy.html
+++ b/app/test/frontend/golden/pkg_show_page_legacy.html
@@ -258,7 +258,7 @@
             </p>
           </aside>
         </div>
-        <script type="application/ld+json">{"@context":"http:\u002f\u002fschema.org","@type":"SoftwareSourceCode","name":"pkg","version":"1.0.0-legacy","description":"pkg - pkg is awesome","url":"https:\u002f\u002fpub.dev\u002fpackages\u002fpkg","dateCreated":"%%published-timestamp%%","dateModified":"%%updated-timestamp%%","programmingLanguage":"Dart","image":"https:\u002f\u002fpub.dev\u002fstatic\u002fimg\u002fpub-dev-icon-cover-image.png"}</script>
+        <script type="application/ld+json">{"@context":"http:\u002f\u002fschema.org","@type":"SoftwareSourceCode","name":"pkg","version":"1.0.0-legacy","description":"pkg - pkg is awesome","url":"https:\u002f\u002fpub.dev\u002fpackages\u002fpkg","dateCreated":"%%published-timestamp%%","dateModified":"%%updated-timestamp%%","programmingLanguage":"Dart","image":"https:\u002f\u002fpub.dev\u002fstatic\u002fimg\u002fpub-dev-icon-cover-image.png","license":"https:\u002f\u002fpub.dev\u002fpackages\u002fpkg\u002flicense"}</script>
       </div>
       <div class="detail-metadata">
         <h3 class="detail-metadata-title">

--- a/app/test/frontend/golden/pkg_show_page_publisher.html
+++ b/app/test/frontend/golden/pkg_show_page_publisher.html
@@ -251,7 +251,7 @@
             </p>
           </aside>
         </div>
-        <script type="application/ld+json">{"@context":"http:\u002f\u002fschema.org","@type":"SoftwareSourceCode","name":"neon","version":"1.0.0","description":"neon - neon is awesome","url":"https:\u002f\u002fpub.dev\u002fpackages\u002fneon","dateCreated":"%%published-timestamp%%","dateModified":"%%updated-timestamp%%","programmingLanguage":"Dart","image":"https:\u002f\u002fpub.dev\u002fstatic\u002fimg\u002fpub-dev-icon-cover-image.png"}</script>
+        <script type="application/ld+json">{"@context":"http:\u002f\u002fschema.org","@type":"SoftwareSourceCode","name":"neon","version":"1.0.0","description":"neon - neon is awesome","url":"https:\u002f\u002fpub.dev\u002fpackages\u002fneon","dateCreated":"%%published-timestamp%%","dateModified":"%%updated-timestamp%%","programmingLanguage":"Dart","image":"https:\u002f\u002fpub.dev\u002fstatic\u002fimg\u002fpub-dev-icon-cover-image.png","license":"https:\u002f\u002fpub.dev\u002fpackages\u002fneon\u002flicense"}</script>
       </div>
       <div class="detail-metadata">
         <h3 class="detail-metadata-title">

--- a/app/test/frontend/golden/pkg_show_version_page.html
+++ b/app/test/frontend/golden/pkg_show_version_page.html
@@ -257,7 +257,7 @@
             </p>
           </aside>
         </div>
-        <script type="application/ld+json">{"@context":"http:\u002f\u002fschema.org","@type":"SoftwareSourceCode","name":"oxygen","version":"1.2.0","description":"oxygen - oxygen is awesome","url":"https:\u002f\u002fpub.dev\u002fpackages\u002foxygen","dateCreated":"%%published-timestamp%%","dateModified":"%%updated-timestamp%%","programmingLanguage":"Dart","image":"https:\u002f\u002fpub.dev\u002fstatic\u002fimg\u002fpub-dev-icon-cover-image.png"}</script>
+        <script type="application/ld+json">{"@context":"http:\u002f\u002fschema.org","@type":"SoftwareSourceCode","name":"oxygen","version":"1.2.0","description":"oxygen - oxygen is awesome","url":"https:\u002f\u002fpub.dev\u002fpackages\u002foxygen","dateCreated":"%%published-timestamp%%","dateModified":"%%updated-timestamp%%","programmingLanguage":"Dart","image":"https:\u002f\u002fpub.dev\u002fstatic\u002fimg\u002fpub-dev-icon-cover-image.png","license":"https:\u002f\u002fpub.dev\u002fpackages\u002foxygen\u002flicense"}</script>
       </div>
       <div class="detail-metadata">
         <h3 class="detail-metadata-title">

--- a/app/test/frontend/golden/pkg_versions_page.html
+++ b/app/test/frontend/golden/pkg_versions_page.html
@@ -357,7 +357,7 @@
             </p>
           </aside>
         </div>
-        <script type="application/ld+json">{"@context":"http:\u002f\u002fschema.org","@type":"SoftwareSourceCode","name":"oxygen","version":"1.2.0","description":"oxygen - oxygen is awesome","url":"https:\u002f\u002fpub.dev\u002fpackages\u002foxygen","dateCreated":"%%package-created-timestamp%%","dateModified":"%%version-created-timestamp%%","programmingLanguage":"Dart","image":"https:\u002f\u002fpub.dev\u002fstatic\u002fimg\u002fpub-dev-icon-cover-image.png"}</script>
+        <script type="application/ld+json">{"@context":"http:\u002f\u002fschema.org","@type":"SoftwareSourceCode","name":"oxygen","version":"1.2.0","description":"oxygen - oxygen is awesome","url":"https:\u002f\u002fpub.dev\u002fpackages\u002foxygen","dateCreated":"%%package-created-timestamp%%","dateModified":"%%version-created-timestamp%%","programmingLanguage":"Dart","image":"https:\u002f\u002fpub.dev\u002fstatic\u002fimg\u002fpub-dev-icon-cover-image.png","license":"https:\u002f\u002fpub.dev\u002fpackages\u002foxygen\u002flicense"}</script>
       </div>
       <div class="detail-metadata">
         <h3 class="detail-metadata-title">


### PR DESCRIPTION
- copied `getRepositoryUrl` from `pana` as-is, we should extend it with fetching the default branch name dynamically
- removed the repository-linked license url from the schema.org metadata, using the license page instead