### PR TITLE
X-ago hoverable title for formatted timestamps.

### DIFF
--- a/app/lib/frontend/dom/dom.dart
+++ b/app/lib/frontend/dom/dom.dart
@@ -5,6 +5,7 @@
 import 'dart:convert';
 
 import '../../shared/markdown.dart';
+import '../../shared/utils.dart' show formatXAgo, shortDateFormat;
 
 final _attributeEscape = HtmlEscape(HtmlEscapeMode.attribute);
 final _attributeRegExp = RegExp(r'^[a-z](?:[a-z0-9\-\_]*[a-z0-9]+)?$');
@@ -86,6 +87,16 @@ Node text(String value) => dom.text(value);
 
 /// Creates a DOM node with unsafe raw HTML content using the default [DomContext].
 Node unsafeRawHtml(String value) => dom.unsafeRawHtml(value);
+
+/// Creates a DOM node with the short, formatted [timestamp].
+Node shortTimestamp(DateTime timestamp) {
+  return span(
+    attributes: {
+      'title': formatXAgo(DateTime.now().difference(timestamp)),
+    },
+    text: shortDateFormat.format(timestamp),
+  );
+}
 
 /// Creates a DOM node with markdown content using the default [DomContext].
 Node markdown(

--- a/app/lib/frontend/templates/admin.dart
+++ b/app/lib/frontend/templates/admin.dart
@@ -9,7 +9,6 @@ import '../../package/search_adapter.dart' show SearchResultPage;
 import '../../publisher/models.dart' show PublisherSummary;
 import '../../search/search_form.dart' show SearchForm;
 import '../../shared/urls.dart' as urls;
-import '../../shared/utils.dart' show shortDateFormat;
 
 import '../dom/dom.dart' as d;
 import 'detail_page.dart';
@@ -200,13 +199,15 @@ Tab _myActivityLogLink() => Tab.withLink(
     href: urls.myActivityLogUrl());
 
 d.Node _accountDetailHeader(User user, UserSessionData userSessionData) {
-  final shortJoined = shortDateFormat.format(user.created!);
   return renderDetailHeader(
     title: userSessionData.name,
     imageUrl: userSessionData.imageUrlOfSize(200),
     metadataNode: d.fragment([
       d.p(text: user.email!),
-      d.p(text: 'Joined on $shortJoined'),
+      d.p(children: [
+        d.text('Joined on '),
+        d.shortTimestamp(user.created!),
+      ]),
     ]),
   );
 }

--- a/app/lib/frontend/templates/package_versions.dart
+++ b/app/lib/frontend/templates/package_versions.dart
@@ -9,7 +9,6 @@ import 'package:pub_semver/pub_semver.dart';
 import '../../package/model_properties.dart';
 import '../../package/models.dart';
 import '../../shared/urls.dart' as urls;
-import '../../shared/utils.dart' show shortDateFormat;
 import '../dom/dom.dart' as d;
 
 import 'detail_page.dart';
@@ -54,8 +53,9 @@ String renderPkgVersionsPage(
       children: [
         d.text('The latest prerelease was '),
         d.a(href: '#prerelease', text: latestPrereleaseVersion!.version),
-        d.text(
-            ' on ${shortDateFormat.format(latestPrereleaseVersion.published!)}.'),
+        d.text(' on '),
+        d.shortTimestamp(latestPrereleaseVersion.published!),
+        d.text('.'),
       ],
     ));
   }

--- a/app/lib/frontend/templates/views/account/activity_log_table.dart
+++ b/app/lib/frontend/templates/views/account/activity_log_table.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import '../../../../audit/models.dart';
-import '../../../../shared/utils.dart';
 import '../../../dom/dom.dart' as d;
 
 d.Node activityLogNode({
@@ -37,7 +36,7 @@ d.Node _activityLogTableNode(AuditLogRecordPage activities) {
     body: activities.records.map(
       (a) => d.tr(
         children: [
-          d.td(classes: ['date'], text: shortDateFormat.format(a.created!)),
+          d.td(classes: ['date'], child: d.shortTimestamp(a.created!)),
           d.td(
             classes: ['summary'],
             children: [

--- a/app/lib/frontend/templates/views/pkg/header.dart
+++ b/app/lib/frontend/templates/views/pkg/header.dart
@@ -4,7 +4,6 @@
 
 import '../../../../package/models.dart';
 import '../../../../shared/urls.dart' as urls;
-import '../../../../shared/utils.dart' show shortDateFormat;
 import '../../../dom/dom.dart' as d;
 import '../../../static_files.dart';
 import '../../package_misc.dart';
@@ -18,7 +17,7 @@ d.Node packageHeaderNode({
 }) {
   return d.fragment([
     d.text('Published '),
-    d.span(text: shortDateFormat.format(published)),
+    d.span(child: d.shortTimestamp(published)),
     if (publisherId != null) ..._publisher(publisherId),
     if (isNullSafe) nullSafeBadgeNode(),
     if (releases != null) ..._releases(packageName, releases),

--- a/app/lib/frontend/templates/views/pkg/liked_package_list.dart
+++ b/app/lib/frontend/templates/views/pkg/liked_package_list.dart
@@ -4,7 +4,6 @@
 
 import '../../../../account/models.dart';
 import '../../../../shared/urls.dart' as urls;
-import '../../../../shared/utils.dart' show shortDateFormat;
 
 import '../../../dom/dom.dart' as d;
 import '../../../dom/material.dart' as material;
@@ -52,7 +51,7 @@ d.Node likedPackageListNode(List<LikeData> likes) {
             classes: ['packages-metadata'],
             children: [
               d.text(' Liked on: '),
-              d.span(text: shortDateFormat.format(like.created!)),
+              d.shortTimestamp(like.created!),
             ],
           ),
         ],

--- a/app/lib/frontend/templates/views/pkg/package_list.dart
+++ b/app/lib/frontend/templates/views/pkg/package_list.dart
@@ -6,7 +6,7 @@ import '../../../../package/models.dart';
 import '../../../../search/search_service.dart';
 import '../../../../shared/tags.dart';
 import '../../../../shared/urls.dart' as urls;
-import '../../../../shared/utils.dart' show shortDateFormat;
+import '../../../../shared/utils.dart' show formatXAgo;
 
 import '../../../dom/dom.dart' as d;
 import '../../../static_files.dart' show staticUrls;
@@ -74,9 +74,7 @@ d.Node _packageItem(PackageView view) {
         ],
         d.text(' • Updated: '),
         d.span(
-          text: view.updated == null
-              ? null
-              : shortDateFormat.format(view.updated!),
+          child: view.updated == null ? null : d.shortTimestamp(view.updated!),
         ),
       ],
     ),
@@ -128,7 +126,8 @@ d.Node _item({
   required d.Node? tagsNode,
   required List<_ApiPageUrl>? apiPages,
 }) {
-  final xAgoLabel = _renderXAgo(newTimestamp);
+  final age =
+      newTimestamp == null ? null : DateTime.now().difference(newTimestamp);
   return d.div(
     classes: ['packages-item'],
     children: [
@@ -139,7 +138,7 @@ d.Node _item({
             classes: ['packages-title'],
             child: d.a(href: url, text: name),
           ),
-          if (xAgoLabel != null)
+          if (age != null && age.inDays <= 30)
             d.div(
               classes: ['packages-recent'],
               children: [
@@ -149,7 +148,7 @@ d.Node _item({
                   title: 'new package',
                 ),
                 d.text(' Added '),
-                d.b(text: xAgoLabel),
+                d.b(text: formatXAgo(age)),
               ],
             ),
           if (labeledScoresNode != null) labeledScoresNode,
@@ -163,15 +162,6 @@ d.Node _item({
         d.div(classes: ['packages-api'], child: _apiPages(apiPages)),
     ],
   );
-}
-
-String? _renderXAgo(DateTime? value) {
-  if (value == null) return null;
-  final age = DateTime.now().difference(value);
-  if (age.inDays > 30) return null;
-  if (age.inDays > 1) return '${age.inDays} days ago';
-  if (age.inHours > 1) return '${age.inHours} hours ago';
-  return 'in the last hour';
 }
 
 class _ApiPageUrl {

--- a/app/lib/frontend/templates/views/pkg/score_tab.dart
+++ b/app/lib/frontend/templates/views/pkg/score_tab.dart
@@ -6,7 +6,6 @@ import 'package:pana/models.dart';
 
 import '../../../../scorecard/models.dart' hide ReportStatus;
 import '../../../../shared/urls.dart' as urls;
-import '../../../../shared/utils.dart' show shortDateFormat;
 import '../../../dom/dom.dart' as d;
 import '../../../static_files.dart';
 import '../../package_misc.dart' show formatScore;
@@ -23,9 +22,6 @@ d.Node scoreTabNode({
   final report = card.getJoinedReport();
   final showAwaiting = !card.isSkipped && report == null;
   final showReport = !card.isSkipped && report != null;
-  final dateCompleted = card.panaReport?.timestamp == null
-      ? ''
-      : shortDateFormat.format(card.panaReport!.timestamp!);
 
   final toolEnvInfo = _renderToolEnvInfoNode(
       card.panaReport?.panaRuntimeInfo, card.usesFlutter);
@@ -71,9 +67,14 @@ d.Node scoreTabNode({
     if (showReport)
       d.p(
         classes: ['analysis-info'],
-        text: 'We analyzed this package on $dateCompleted, '
-            'and awarded it ${report?.grantedPoints ?? 0} '
-            'pub points (of a possible ${report?.maxPoints ?? 0}):',
+        children: [
+          d.text('We analyzed this package on '),
+          if (card.panaReport?.timestamp != null)
+            d.shortTimestamp(card.panaReport!.timestamp!),
+          d.text(', '
+              'and awarded it ${report?.grantedPoints ?? 0} '
+              'pub points (of a possible ${report?.maxPoints ?? 0}):'),
+        ],
       ),
     if (report != null) _reportNode(report),
     if (toolEnvInfo != null) toolEnvInfo,

--- a/app/lib/frontend/templates/views/pkg/versions/version_row.dart
+++ b/app/lib/frontend/templates/views/pkg/versions/version_row.dart
@@ -6,7 +6,6 @@ import 'package:client_data/package_api.dart';
 
 import '../../../../../package/model_properties.dart';
 import '../../../../../shared/urls.dart' as urls;
-import '../../../../../shared/utils.dart' show shortDateFormat;
 import '../../../../dom/dom.dart' as d;
 import '../../../../static_files.dart';
 import '../../../package_misc.dart';
@@ -40,8 +39,9 @@ d.Node versionRowNode(String package, VersionInfo version, Pubspec pubspec) {
             : null,
       ),
       d.td(
-          classes: ['uploaded'],
-          text: shortDateFormat.format(version.published!)),
+        classes: ['uploaded'],
+        child: d.shortTimestamp(version.published!),
+      ),
       d.td(
         classes: ['documentation'],
         child: d.a(

--- a/app/lib/frontend/templates/views/publisher/header_metadata.dart
+++ b/app/lib/frontend/templates/views/publisher/header_metadata.dart
@@ -4,7 +4,6 @@
 
 import '../../../../publisher/models.dart' show Publisher;
 import '../../../../shared/urls.dart' as urls;
-import '../../../../shared/utils.dart' show shortDateFormat;
 import '../../../dom/dom.dart' as d;
 import '../../../static_files.dart' show staticUrls;
 
@@ -13,7 +12,6 @@ d.Node publisherHeaderMetadataNode(Publisher publisher) {
   final websiteUri = urls.parseValidUrl(publisher.websiteUrl);
   final websiteRel = (websiteUri?.shouldIndicateUgc ?? false) ? 'ugc' : null;
   final websiteDisplayable = urls.displayableUrl(publisher.websiteUrl);
-  final shortCreated = shortDateFormat.format(publisher.created!);
 
   return d.fragment([
     if (publisher.hasDescription)
@@ -32,7 +30,12 @@ d.Node publisherHeaderMetadataNode(Publisher publisher) {
           iconPath: '/static/img/email-icon.svg',
         ),
     ]),
-    d.p(text: 'Publisher registered on $shortCreated.'),
+    d.p(
+      children: [
+        d.text('Publisher registered on '),
+        d.shortTimestamp(publisher.created!),
+      ],
+    ),
   ]);
 }
 

--- a/app/lib/frontend/templates/views/publisher/publisher_list.dart
+++ b/app/lib/frontend/templates/views/publisher/publisher_list.dart
@@ -4,7 +4,6 @@
 
 import '../../../../publisher/models.dart';
 import '../../../../shared/urls.dart' as urls;
-import '../../../../shared/utils.dart';
 import '../../../dom/dom.dart' as d;
 
 d.Node publisherListNode({
@@ -27,7 +26,11 @@ d.Node publisherListNode({
                   text: p.publisherId,
                 ),
               ),
-              d.p(text: 'Registered on ${shortDateFormat.format(p.created)}.'),
+              d.p(children: [
+                d.text('Registered on '),
+                d.shortTimestamp(p.created),
+                d.text('.'),
+              ]),
             ],
           ),
         ),

--- a/app/lib/package/models.dart
+++ b/app/lib/package/models.dart
@@ -345,8 +345,6 @@ class Release {
       _$ReleaseFromJson(json);
 
   Map<String, dynamic> toJson() => _$ReleaseToJson(this);
-
-  String get shortPublished => shortDateFormat.format(published);
 }
 
 /// Pub package metadata for a specific uploaded version.
@@ -402,10 +400,6 @@ class PackageVersion extends db.ExpandoModel<String> {
     if (description == null) return null;
     if (description.length < 210) return description;
     return '${description.substring(0, 200)} [...]';
-  }
-
-  String get shortCreated {
-    return shortDateFormat.format(created!);
   }
 
   PackageLinks get packageLinks {

--- a/app/lib/shared/utils.dart
+++ b/app/lib/shared/utils.dart
@@ -43,6 +43,28 @@ final DateFormat shortDateFormat = DateFormat.yMMMd();
 final jsonUtf8Encoder = JsonUtf8Encoder();
 final utf8JsonDecoder = utf8.decoder.fuse(json.decoder);
 
+/// Formats an [age] duration with `<amount> <unit> ago` or `in the last hour`.
+String formatXAgo(Duration age) {
+  if (age.inDays > 365 * 2) {
+    final years = age.inDays ~/ 365;
+    return '$years years ago';
+  }
+  if (age.inDays > 30 * 2) {
+    final months = age.inDays ~/ 30;
+    return '$months months ago';
+  }
+  if (age.inDays > 1) {
+    return '${age.inDays} days ago';
+  }
+  if (age.inHours > 1) {
+    return '${age.inHours} hours ago';
+  }
+  if (age.inHours == 1) {
+    return '${age.inHours} hour ago';
+  }
+  return 'in the last hour';
+}
+
 Future<T> withTempDirectory<T>(Future<T> Function(Directory dir) func,
     {String prefix = 'dart-tempdir'}) {
   return Directory.systemTemp.createTemp(prefix).then((Directory dir) {

--- a/app/test/frontend/golden/analysis_tab_aborted.html
+++ b/app/test/frontend/golden/analysis_tab_aborted.html
@@ -22,7 +22,11 @@
       <div class="score-key-figure-label">popularity</div>
     </div>
   </div>
-  <p class="analysis-info">We analyzed this package on Dec 18, 2017, and awarded it 0 pub points (of a possible 0):</p>
+  <p class="analysis-info">
+    We analyzed this package on
+    <span title="3 years ago">Dec 18, 2017</span>
+    , and awarded it 0 pub points (of a possible 0):
+  </p>
   <div class="pkg-report"></div>
   <p class="tool-env-info">
     Analysed with Pana

--- a/app/test/frontend/golden/my_activity_log_page.html
+++ b/app/test/frontend/golden/my_activity_log_page.html
@@ -152,7 +152,10 @@
                 <h1 class="title">Pub User</h1>
                 <div class="metadata">
                   <p>admin@pub.dev</p>
-                  <p>Joined on %%user-created-date%%</p>
+                  <p>
+                    Joined on
+                    <span title="%%x-ago%%">%%user-created-date%%</span>
+                  </p>
                 </div>
               </div>
             </div>
@@ -189,7 +192,9 @@
                     </thead>
                     <tbody>
                       <tr>
-                        <td class="date">%%user-created-date%%</td>
+                        <td class="date">
+                          <span title="%%x-ago%%">%%user-created-date%%</span>
+                        </td>
                         <td class="summary">
                           <div class="markdown-body">
                             <p>
@@ -205,7 +210,9 @@
                         </td>
                       </tr>
                       <tr>
-                        <td class="date">%%user-created-date%%</td>
+                        <td class="date">
+                          <span title="%%x-ago%%">%%user-created-date%%</span>
+                        </td>
                         <td class="summary">
                           <div class="markdown-body">
                             <p>
@@ -221,7 +228,9 @@
                         </td>
                       </tr>
                       <tr>
-                        <td class="date">%%user-created-date%%</td>
+                        <td class="date">
+                          <span title="%%x-ago%%">%%user-created-date%%</span>
+                        </td>
                         <td class="summary">
                           <div class="markdown-body">
                             <p>
@@ -237,7 +246,9 @@
                         </td>
                       </tr>
                       <tr>
-                        <td class="date">%%user-created-date%%</td>
+                        <td class="date">
+                          <span title="%%x-ago%%">%%user-created-date%%</span>
+                        </td>
                         <td class="summary">
                           <div class="markdown-body">
                             <p>
@@ -253,7 +264,9 @@
                         </td>
                       </tr>
                       <tr>
-                        <td class="date">%%user-created-date%%</td>
+                        <td class="date">
+                          <span title="%%x-ago%%">%%user-created-date%%</span>
+                        </td>
                         <td class="summary">
                           <div class="markdown-body">
                             <p>
@@ -269,7 +282,9 @@
                         </td>
                       </tr>
                       <tr>
-                        <td class="date">%%user-created-date%%</td>
+                        <td class="date">
+                          <span title="%%x-ago%%">%%user-created-date%%</span>
+                        </td>
                         <td class="summary">
                           <div class="markdown-body">
                             <p>
@@ -285,7 +300,9 @@
                         </td>
                       </tr>
                       <tr>
-                        <td class="date">%%user-created-date%%</td>
+                        <td class="date">
+                          <span title="%%x-ago%%">%%user-created-date%%</span>
+                        </td>
                         <td class="summary">
                           <div class="markdown-body">
                             <p>
@@ -301,7 +318,9 @@
                         </td>
                       </tr>
                       <tr>
-                        <td class="date">%%user-created-date%%</td>
+                        <td class="date">
+                          <span title="%%x-ago%%">%%user-created-date%%</span>
+                        </td>
                         <td class="summary">
                           <div class="markdown-body">
                             <p>

--- a/app/test/frontend/golden/my_liked_packages.html
+++ b/app/test/frontend/golden/my_liked_packages.html
@@ -152,7 +152,10 @@
                 <h1 class="title">Pub User</h1>
                 <div class="metadata">
                   <p>user@pub.dev</p>
-                  <p>Joined on %%user-created-date%%</p>
+                  <p>
+                    Joined on
+                    <span title="%%x-ago%%">%%user-created-date%%</span>
+                  </p>
                 </div>
               </div>
             </div>
@@ -196,7 +199,7 @@
                       </div>
                       <p class="packages-metadata">
                         Liked on:
-                        <span>Nov 22, 2019</span>
+                        <span title="%%x-ago%%">%%liked1-date%%</span>
                       </p>
                     </div>
                     <div class="packages-item">
@@ -214,7 +217,7 @@
                       </div>
                       <p class="packages-metadata">
                         Liked on:
-                        <span>Nov 22, 2019</span>
+                        <span title="%%x-ago%%">%%liked1-date%%</span>
                       </p>
                     </div>
                   </div>

--- a/app/test/frontend/golden/my_packages.html
+++ b/app/test/frontend/golden/my_packages.html
@@ -152,7 +152,10 @@
                 <h1 class="title">Pub User</h1>
                 <div class="metadata">
                   <p>user@pub.dev</p>
-                  <p>Joined on %%oxygen-created-date%%</p>
+                  <p>
+                    Joined on
+                    <span title="%%x-ago%%">%%oxygen-created-date%%</span>
+                  </p>
                 </div>
               </div>
             </div>
@@ -211,7 +214,7 @@
                         <div class="packages-recent">
                           <img class="packages-recent-icon" src="/static/img/schedule-icon.svg?hash=mocked_hash_164576935" title="new package"/>
                           Added
-                          <b>in the last hour</b>
+                          <b>%%x-ago%%</b>
                         </div>
                         <a class="packages-scores" href="/packages/oxygen/score">
                           <div class="packages-score packages-score-like">
@@ -245,7 +248,9 @@
                           /
                           <a href="/packages/oxygen/versions/2.0.0-dev">2.0.0-dev</a>
                           • Updated:
-                          <span>%%oxygen-created-date%%</span>
+                          <span>
+                            <span title="%%x-ago%%">%%oxygen-created-date%%</span>
+                          </span>
                         </span>
                       </p>
                       <div>
@@ -264,7 +269,7 @@
                         <div class="packages-recent">
                           <img class="packages-recent-icon" src="/static/img/schedule-icon.svg?hash=mocked_hash_164576935" title="new package"/>
                           Added
-                          <b>in the last hour</b>
+                          <b>%%x-ago%%</b>
                         </div>
                         <a class="packages-scores" href="/packages/neon/score">
                           <div class="packages-score packages-score-like">
@@ -296,7 +301,9 @@
                           v
                           <a href="/packages/neon">1.0.0</a>
                           • Updated:
-                          <span>%%oxygen-created-date%%</span>
+                          <span>
+                            <span title="%%x-ago%%">%%oxygen-created-date%%</span>
+                          </span>
                         </span>
                         <span class="packages-metadata-block">
                           <img class="package-vp-icon" src="/static/img/verified-publisher-icon.svg?hash=mocked_hash_1044149352" title="Published by a pub.dev verified publisher"/>

--- a/app/test/frontend/golden/my_publishers.html
+++ b/app/test/frontend/golden/my_publishers.html
@@ -152,7 +152,10 @@
                 <h1 class="title">Pub User</h1>
                 <div class="metadata">
                   <p>user@pub.dev</p>
-                  <p>Joined on %%user-created-date%%</p>
+                  <p>
+                    Joined on
+                    <span title="%%x-ago%%">%%user-created-date%%</span>
+                  </p>
                 </div>
               </div>
             </div>
@@ -184,7 +187,11 @@
                       <h3 class="publishers-item-title">
                         <a href="/publishers/example.com">example.com</a>
                       </h3>
-                      <p>Registered on Jul 1, 2021.</p>
+                      <p>
+                        Registered on
+                        <span title="4 months ago">Jul 1, 2021</span>
+                        .
+                      </p>
                     </div>
                   </div>
                   <h3>Want to create a new publisher?</h3>

--- a/app/test/frontend/golden/pkg_activity_log_page.html
+++ b/app/test/frontend/golden/pkg_activity_log_page.html
@@ -128,7 +128,9 @@
                 </h1>
                 <div class="metadata">
                   Published
-                  <span>%%published-date%%</span>
+                  <span>
+                    <span title="%%x-ago%%">%%published-date%%</span>
+                  </span>
                   • Latest:
                   <span>
                     <a href="/packages/oxygen">1.2.0</a>

--- a/app/test/frontend/golden/pkg_admin_page.html
+++ b/app/test/frontend/golden/pkg_admin_page.html
@@ -128,7 +128,9 @@
                 </h1>
                 <div class="metadata">
                   Published
-                  <span>%%published-date%%</span>
+                  <span>
+                    <span title="%%x-ago%%">%%published-date%%</span>
+                  </span>
                   • Latest:
                   <span>
                     <a href="/packages/oxygen">1.2.0</a>

--- a/app/test/frontend/golden/pkg_changelog_page.html
+++ b/app/test/frontend/golden/pkg_changelog_page.html
@@ -129,7 +129,9 @@
                 </h1>
                 <div class="metadata">
                   Published
-                  <span>%%published-date%%</span>
+                  <span>
+                    <span title="%%x-ago%%">%%published-date%%</span>
+                  </span>
                   • Latest:
                   <span>
                     <a href="/packages/oxygen">1.2.0</a>

--- a/app/test/frontend/golden/pkg_example_page.html
+++ b/app/test/frontend/golden/pkg_example_page.html
@@ -129,7 +129,9 @@
                 </h1>
                 <div class="metadata">
                   Published
-                  <span>%%published-date%%</span>
+                  <span>
+                    <span title="%%x-ago%%">%%published-date%%</span>
+                  </span>
                   • Latest:
                   <span>
                     <a href="/packages/oxygen">1.2.0</a>

--- a/app/test/frontend/golden/pkg_index_page.html
+++ b/app/test/frontend/golden/pkg_index_page.html
@@ -202,7 +202,7 @@
               <div class="packages-recent">
                 <img class="packages-recent-icon" src="/static/img/schedule-icon.svg?hash=mocked_hash_164576935" title="new package"/>
                 Added
-                <b>in the last hour</b>
+                <b>%%x-ago%%</b>
               </div>
               <a class="packages-scores" href="/packages/oxygen/score">
                 <div class="packages-score packages-score-like">
@@ -236,7 +236,9 @@
                 /
                 <a href="/packages/oxygen/versions/2.0.0-dev">2.0.0-dev</a>
                 • Updated:
-                <span>%%oxygen-created-date%%</span>
+                <span>
+                  <span title="%%x-ago%%">%%oxygen-created-date%%</span>
+                </span>
               </span>
             </p>
             <div>
@@ -255,7 +257,7 @@
               <div class="packages-recent">
                 <img class="packages-recent-icon" src="/static/img/schedule-icon.svg?hash=mocked_hash_164576935" title="new package"/>
                 Added
-                <b>in the last hour</b>
+                <b>%%x-ago%%</b>
               </div>
               <a class="packages-scores" href="/packages/flutter_titanium/score">
                 <div class="packages-score packages-score-like">
@@ -287,7 +289,9 @@
                 v
                 <a href="/packages/flutter_titanium">1.10.0</a>
                 • Updated:
-                <span>%%oxygen-created-date%%</span>
+                <span>
+                  <span title="%%x-ago%%">%%oxygen-created-date%%</span>
+                </span>
               </span>
             </p>
             <div>

--- a/app/test/frontend/golden/pkg_index_page_experimental.html
+++ b/app/test/frontend/golden/pkg_index_page_experimental.html
@@ -367,7 +367,7 @@
                 <div class="packages-recent">
                   <img class="packages-recent-icon" src="/static/img/schedule-icon.svg?hash=mocked_hash_164576935" title="new package"/>
                   Added
-                  <b>in the last hour</b>
+                  <b>%%x-ago%%</b>
                 </div>
                 <a class="packages-scores" href="/packages/oxygen/score">
                   <div class="packages-score packages-score-like">
@@ -401,7 +401,9 @@
                   /
                   <a href="/packages/oxygen/versions/2.0.0-dev">2.0.0-dev</a>
                   • Updated:
-                  <span>%%oxygen-created-date%%</span>
+                  <span>
+                    <span title="%%x-ago%%">%%oxygen-created-date%%</span>
+                  </span>
                 </span>
               </p>
               <div>
@@ -420,7 +422,7 @@
                 <div class="packages-recent">
                   <img class="packages-recent-icon" src="/static/img/schedule-icon.svg?hash=mocked_hash_164576935" title="new package"/>
                   Added
-                  <b>in the last hour</b>
+                  <b>%%x-ago%%</b>
                 </div>
                 <a class="packages-scores" href="/packages/flutter_titanium/score">
                   <div class="packages-score packages-score-like">
@@ -452,7 +454,9 @@
                   v
                   <a href="/packages/flutter_titanium">1.10.0</a>
                   • Updated:
-                  <span>%%oxygen-created-date%%</span>
+                  <span>
+                    <span title="%%x-ago%%">%%oxygen-created-date%%</span>
+                  </span>
                 </span>
               </p>
               <div>

--- a/app/test/frontend/golden/pkg_install_page.html
+++ b/app/test/frontend/golden/pkg_install_page.html
@@ -129,7 +129,9 @@
                 </h1>
                 <div class="metadata">
                   Published
-                  <span>%%published-date%%</span>
+                  <span>
+                    <span title="%%x-ago%%">%%published-date%%</span>
+                  </span>
                   • Latest:
                   <span>
                     <a href="/packages/oxygen">1.2.0</a>

--- a/app/test/frontend/golden/pkg_score_page.html
+++ b/app/test/frontend/golden/pkg_score_page.html
@@ -129,7 +129,9 @@
                 </h1>
                 <div class="metadata">
                   Published
-                  <span>%%published-date%%</span>
+                  <span>
+                    <span title="%%x-ago%%">%%published-date%%</span>
+                  </span>
                   • Latest:
                   <span>
                     <a href="/packages/oxygen">1.2.0</a>
@@ -224,7 +226,11 @@
                       <div class="score-key-figure-label">popularity</div>
                     </div>
                   </div>
-                  <p class="analysis-info">We analyzed this package on %%published-date%%, and awarded it 43 pub points (of a possible 70):</p>
+                  <p class="analysis-info">
+                    We analyzed this package on
+                    <span title="%%x-ago%%">%%published-date%%</span>
+                    , and awarded it 43 pub points (of a possible 70):
+                  </p>
                   <div class="pkg-report">
                     <div class="pkg-report-section foldable">
                       <div class="pkg-report-header foldable-button" data-ga-click-event="toggle-report-section-convention">

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -129,7 +129,9 @@
                 </h1>
                 <div class="metadata">
                   Published
-                  <span>%%published-date%%</span>
+                  <span>
+                    <span title="%%x-ago%%">%%published-date%%</span>
+                  </span>
                   • Latest:
                   <span>
                     <a href="/packages/oxygen">1.2.0</a>

--- a/app/test/frontend/golden/pkg_show_page_discontinued.html
+++ b/app/test/frontend/golden/pkg_show_page_discontinued.html
@@ -129,7 +129,9 @@
                 </h1>
                 <div class="metadata">
                   Published
-                  <span>%%published-date%%</span>
+                  <span>
+                    <span title="%%x-ago%%">%%published-date%%</span>
+                  </span>
                 </div>
                 <div class="detail-tags-and-like">
                   <div class="detail-tags">

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -129,7 +129,9 @@
                 </h1>
                 <div class="metadata">
                   Published
-                  <span>%%published-date%%</span>
+                  <span>
+                    <span title="%%x-ago%%">%%published-date%%</span>
+                  </span>
                 </div>
                 <div class="detail-tags-and-like">
                   <div class="detail-tags">

--- a/app/test/frontend/golden/pkg_show_page_legacy.html
+++ b/app/test/frontend/golden/pkg_show_page_legacy.html
@@ -129,7 +129,9 @@
                 </h1>
                 <div class="metadata">
                   Published
-                  <span>%%published-date%%</span>
+                  <span>
+                    <span title="%%x-ago%%">%%published-date%%</span>
+                  </span>
                 </div>
                 <div class="detail-tags-and-like">
                   <div class="detail-tags">

--- a/app/test/frontend/golden/pkg_show_page_publisher.html
+++ b/app/test/frontend/golden/pkg_show_page_publisher.html
@@ -129,7 +129,9 @@
                 </h1>
                 <div class="metadata">
                   Published
-                  <span>%%published-date%%</span>
+                  <span>
+                    <span title="%%x-ago%%">%%published-date%%</span>
+                  </span>
                   •
                   <a class="-pub-publisher" href="/publishers/example.com">
                     <img class="-pub-publisher-shield" src="/static/img/verified-publisher-blue.svg?hash=mocked_hash_919645162" title="Published by a pub.dev verified publisher"/>

--- a/app/test/frontend/golden/pkg_show_version_page.html
+++ b/app/test/frontend/golden/pkg_show_version_page.html
@@ -129,7 +129,9 @@
                 </h1>
                 <div class="metadata">
                   Published
-                  <span>%%published-date%%</span>
+                  <span>
+                    <span title="%%x-ago%%">%%published-date%%</span>
+                  </span>
                   • Latest:
                   <span>
                     <a href="/packages/oxygen">1.2.0</a>

--- a/app/test/frontend/golden/pkg_versions_page.html
+++ b/app/test/frontend/golden/pkg_versions_page.html
@@ -129,7 +129,9 @@
                 </h1>
                 <div class="metadata">
                   Published
-                  <span>%%version-created-date%%</span>
+                  <span>
+                    <span title="%%x-ago%%">%%version-created-date%%</span>
+                  </span>
                   • Latest:
                   <span>
                     <a href="/packages/oxygen">1.2.0</a>
@@ -204,7 +206,9 @@
                   <p>
                     The latest prerelease was
                     <a href="#prerelease">2.0.0-dev</a>
-                    on %%version-created-date%%.
+                    on
+                    <span title="%%x-ago%%">%%version-created-date%%</span>
+                    .
                   </p>
                   <h2 id="stable">Stable versions of oxygen</h2>
                   <table class="version-table" data-package="oxygen">
@@ -233,7 +237,9 @@
                         </td>
                         <td class="badge"></td>
                         <td class="sdk">2.6</td>
-                        <td class="uploaded">%%version-created-date%%</td>
+                        <td class="uploaded">
+                          <span title="%%x-ago%%">%%version-created-date%%</span>
+                        </td>
                         <td class="documentation">
                           <a href="/documentation/oxygen/1.0.0/" rel="nofollow" title="Go to the documentation of oxygen 1.0.0">
                             <img class="version-table-icon" src="/static/img/description-24px.svg?hash=mocked_hash_130979311" alt="Go to the documentation of oxygen 1.0.0" data-failed-icon="/static/img/documentation-failed-icon.svg?hash=mocked_hash_57143192"/>
@@ -251,7 +257,9 @@
                         </td>
                         <td class="badge"></td>
                         <td class="sdk">2.6</td>
-                        <td class="uploaded">%%version-created-date%%</td>
+                        <td class="uploaded">
+                          <span title="%%x-ago%%">%%version-created-date%%</span>
+                        </td>
                         <td class="documentation">
                           <a href="/documentation/oxygen/1.2.0/" rel="nofollow" title="Go to the documentation of oxygen 1.2.0">
                             <img class="version-table-icon" src="/static/img/description-24px.svg?hash=mocked_hash_130979311" alt="Go to the documentation of oxygen 1.2.0" data-failed-icon="/static/img/documentation-failed-icon.svg?hash=mocked_hash_57143192"/>
@@ -292,7 +300,9 @@
                         </td>
                         <td class="badge"></td>
                         <td class="sdk">2.6</td>
-                        <td class="uploaded">%%version-created-date%%</td>
+                        <td class="uploaded">
+                          <span title="%%x-ago%%">%%version-created-date%%</span>
+                        </td>
                         <td class="documentation">
                           <a href="/documentation/oxygen/2.0.0-dev/" rel="nofollow" title="Go to the documentation of oxygen 2.0.0-dev">
                             <img class="version-table-icon" src="/static/img/description-24px.svg?hash=mocked_hash_130979311" alt="Go to the documentation of oxygen 2.0.0-dev" data-failed-icon="/static/img/documentation-failed-icon.svg?hash=mocked_hash_57143192"/>

--- a/app/test/frontend/golden/publisher_activity_log_page.html
+++ b/app/test/frontend/golden/publisher_activity_log_page.html
@@ -135,7 +135,10 @@
                       <a class="detail-header-metadata-ref-label" href="mailto:admin@pub.dev">admin@pub.dev</a>
                     </span>
                   </p>
-                  <p>Publisher registered on %%publisher-created-date%%.</p>
+                  <p>
+                    Publisher registered on
+                    <span title="%%x-ago%%">%%publisher-created-date%%</span>
+                  </p>
                 </div>
               </div>
             </div>
@@ -173,7 +176,9 @@
                     </thead>
                     <tbody>
                       <tr>
-                        <td class="date">%%publisher-created-date%%</td>
+                        <td class="date">
+                          <span title="%%x-ago%%">%%publisher-created-date%%</span>
+                        </td>
                         <td class="summary">
                           <div class="markdown-body">
                             <p>
@@ -189,7 +194,9 @@
                         </td>
                       </tr>
                       <tr>
-                        <td class="date">%%publisher-created-date%%</td>
+                        <td class="date">
+                          <span title="%%x-ago%%">%%publisher-created-date%%</span>
+                        </td>
                         <td class="summary">
                           <div class="markdown-body">
                             <p>

--- a/app/test/frontend/golden/publisher_admin_page.html
+++ b/app/test/frontend/golden/publisher_admin_page.html
@@ -135,7 +135,10 @@
                       <a class="detail-header-metadata-ref-label" href="mailto:admin@pub.dev">admin@pub.dev</a>
                     </span>
                   </p>
-                  <p>Publisher registered on %%publisher-created-date%%.</p>
+                  <p>
+                    Publisher registered on
+                    <span title="%%x-ago%%">%%publisher-created-date%%</span>
+                  </p>
                 </div>
               </div>
             </div>

--- a/app/test/frontend/golden/publisher_list_page.html
+++ b/app/test/frontend/golden/publisher_list_page.html
@@ -127,13 +127,21 @@
           <h3 class="publishers-item-title">
             <a href="/publishers/example.com">example.com</a>
           </h3>
-          <p>Registered on Sep 13, 2019.</p>
+          <p>
+            Registered on
+            <span title="2 years ago">Sep 13, 2019</span>
+            .
+          </p>
         </div>
         <div class="publishers-item">
           <h3 class="publishers-item-title">
             <a href="/publishers/other-domain.com">other-domain.com</a>
           </h3>
-          <p>Registered on Sep 19, 2019.</p>
+          <p>
+            Registered on
+            <span title="2 years ago">Sep 19, 2019</span>
+            .
+          </p>
         </div>
       </div>
       <h3>Want to create a new publisher?</h3>

--- a/app/test/frontend/golden/publisher_packages_page.html
+++ b/app/test/frontend/golden/publisher_packages_page.html
@@ -135,7 +135,10 @@
                       <a class="detail-header-metadata-ref-label" href="mailto:admin@pub.dev">admin@pub.dev</a>
                     </span>
                   </p>
-                  <p>Publisher registered on %%neon-created-date%%.</p>
+                  <p>
+                    Publisher registered on
+                    <span title="%%x-ago%%">%%neon-created-date%%</span>
+                  </p>
                 </div>
               </div>
             </div>
@@ -191,7 +194,7 @@
                         <div class="packages-recent">
                           <img class="packages-recent-icon" src="/static/img/schedule-icon.svg?hash=mocked_hash_164576935" title="new package"/>
                           Added
-                          <b>in the last hour</b>
+                          <b>%%x-ago%%</b>
                         </div>
                         <a class="packages-scores" href="/packages/neon/score">
                           <div class="packages-score packages-score-like">
@@ -223,7 +226,9 @@
                           v
                           <a href="/packages/neon">1.0.0</a>
                           • Updated:
-                          <span>%%neon-created-date%%</span>
+                          <span>
+                            <span title="%%x-ago%%">%%neon-created-date%%</span>
+                          </span>
                         </span>
                         <span class="packages-metadata-block">
                           <img class="package-vp-icon" src="/static/img/verified-publisher-icon.svg?hash=mocked_hash_1044149352" title="Published by a pub.dev verified publisher"/>
@@ -245,7 +250,7 @@
                         <div class="packages-recent">
                           <img class="packages-recent-icon" src="/static/img/schedule-icon.svg?hash=mocked_hash_164576935" title="new package"/>
                           Added
-                          <b>in the last hour</b>
+                          <b>%%x-ago%%</b>
                         </div>
                         <a class="packages-scores" href="/packages/flutter_titanium/score">
                           <div class="packages-score packages-score-like">
@@ -277,7 +282,9 @@
                           v
                           <a href="/packages/flutter_titanium">1.10.0</a>
                           • Updated:
-                          <span>%%neon-created-date%%</span>
+                          <span>
+                            <span title="%%x-ago%%">%%neon-created-date%%</span>
+                          </span>
                         </span>
                       </p>
                       <div>

--- a/app/test/frontend/golden/search_page.html
+++ b/app/test/frontend/golden/search_page.html
@@ -204,7 +204,7 @@
               <div class="packages-recent">
                 <img class="packages-recent-icon" src="/static/img/schedule-icon.svg?hash=mocked_hash_164576935" title="new package"/>
                 Added
-                <b>in the last hour</b>
+                <b>%%x-ago%%</b>
               </div>
               <a class="packages-scores" href="/packages/oxygen/score">
                 <div class="packages-score packages-score-like">
@@ -238,7 +238,9 @@
                 /
                 <a href="/packages/oxygen/versions/2.0.0-dev">2.0.0-dev</a>
                 • Updated:
-                <span>%%oxygen-created-date%%</span>
+                <span>
+                  <span title="%%x-ago%%">%%oxygen-created-date%%</span>
+                </span>
               </span>
             </p>
             <div>
@@ -268,7 +270,7 @@
               <div class="packages-recent">
                 <img class="packages-recent-icon" src="/static/img/schedule-icon.svg?hash=mocked_hash_164576935" title="new package"/>
                 Added
-                <b>in the last hour</b>
+                <b>%%x-ago%%</b>
               </div>
               <a class="packages-scores" href="/packages/flutter_titanium/score">
                 <div class="packages-score packages-score-like">
@@ -300,7 +302,9 @@
                 v
                 <a href="/packages/flutter_titanium">1.10.0</a>
                 • Updated:
-                <span>%%oxygen-created-date%%</span>
+                <span>
+                  <span title="%%x-ago%%">%%oxygen-created-date%%</span>
+                </span>
               </span>
             </p>
             <div>

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -35,7 +35,7 @@ import 'package:pub_dev/scorecard/models.dart';
 import 'package:pub_dev/search/search_form.dart';
 import 'package:pub_dev/search/search_service.dart';
 import 'package:pub_dev/service/youtube/backend.dart';
-import 'package:pub_dev/shared/utils.dart' show shortDateFormat;
+import 'package:pub_dev/shared/utils.dart' show formatXAgo, shortDateFormat;
 import 'package:pub_dev/shared/versions.dart';
 import 'package:pub_dev/tool/test_profile/models.dart';
 import 'package:pub_semver/pub_semver.dart';
@@ -94,9 +94,11 @@ void main() {
       var replacedContent = content;
       timestamps?.forEach((key, value) {
         if (value != null) {
+          final age = DateTime.now().difference(value);
           replacedContent = replacedContent
               .replaceAll(shortDateFormat.format(value), '%%$key-date%%')
-              .replaceAll(value.toIso8601String(), '%%$key-timestamp%%');
+              .replaceAll(value.toIso8601String(), '%%$key-timestamp%%')
+              .replaceAll(formatXAgo(age), '%%x-ago%%');
         }
       });
       replacements?.forEach((key, value) {
@@ -632,20 +634,24 @@ void main() {
           imageUrl: 'pub.dev/user-img-url.png',
         );
         registerUserSessionData(session);
+        final liked1 = DateTime.fromMillisecondsSinceEpoch(1574423824000);
+        final liked2 = DateTime.fromMillisecondsSinceEpoch(1574423824000);
         final html = renderMyLikedPackagesPage(
           user: user,
           userSessionData: session,
           likes: [
             LikeData(
                 package: 'super_package',
-                created: DateTime.fromMillisecondsSinceEpoch(1574423824000)),
+                created: liked1),
             LikeData(
                 package: 'another_package',
-                created: DateTime.fromMillisecondsSinceEpoch(1574423824000))
+                created: liked2)
           ],
         );
         expectGoldenFile(html, 'my_liked_packages.html', timestamps: {
           'user-created': user.created,
+          'liked1': liked1,
+          'liked2': liked2,
         });
       });
     });

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -640,12 +640,8 @@ void main() {
           user: user,
           userSessionData: session,
           likes: [
-            LikeData(
-                package: 'super_package',
-                created: liked1),
-            LikeData(
-                package: 'another_package',
-                created: liked2)
+            LikeData(package: 'super_package', created: liked1),
+            LikeData(package: 'another_package', created: liked2)
           ],
         );
         expectGoldenFile(html, 'my_liked_packages.html', timestamps: {

--- a/app/test/shared/utils_test.dart
+++ b/app/test/shared/utils_test.dart
@@ -9,6 +9,23 @@ import 'package:pub_dev/shared/utils.dart';
 import 'package:test/test.dart';
 
 void main() {
+  test('formatXAgo', () {
+    expect(formatXAgo(Duration()), 'in the last hour');
+    expect(formatXAgo(Duration(minutes: 59)), 'in the last hour');
+    expect(formatXAgo(Duration(minutes: 60)), '1 hour ago');
+    expect(formatXAgo(Duration(minutes: 119)), '1 hour ago');
+    expect(formatXAgo(Duration(minutes: 120)), '2 hours ago');
+    expect(formatXAgo(Duration(minutes: 179)), '2 hours ago');
+    expect(formatXAgo(Duration(minutes: 180)), '3 hours ago');
+    expect(formatXAgo(Duration(hours: 47)), '47 hours ago');
+    expect(formatXAgo(Duration(hours: 48)), '2 days ago');
+    expect(formatXAgo(Duration(hours: 72)), '3 days ago');
+    expect(formatXAgo(Duration(days: 60)), '60 days ago');
+    expect(formatXAgo(Duration(days: 61)), '2 months ago');
+    expect(formatXAgo(Duration(days: 365 * 2)), '24 months ago');
+    expect(formatXAgo(Duration(days: 365 * 2 + 1)), '2 years ago');
+  });
+
   group('Randomize Stream', () {
     test('Single batch', () async {
       final input = List.generate(10, (i) => i);


### PR DESCRIPTION
- partial solution to #4381
- does not change the current rendered output for short date formatted labels, but migrates every use of it to contain a title with `X ago`
- as not every use is suitable for `X ago` right out of the box, we can switch the labels with the title later on case-by-case
- updated tests and golden files to mask the `X ago` output too
