### PR TITLE
'Core library' badge for SDK library hits.

### DIFF
--- a/app/lib/frontend/templates/package_misc.dart
+++ b/app/lib/frontend/templates/package_misc.dart
@@ -14,6 +14,9 @@ import 'views/pkg/badge.dart';
 import 'views/pkg/labeled_scores.dart';
 import 'views/pkg/tags.dart';
 
+/// Renders the core library badge node, used for SDK library hits.
+final coreLibraryBadgeNode = packageBadgeNode(label: 'Core library');
+
 /// Renders the Flutter Favorite badge, used by package listing.
 final flutterFavoriteBadgeNode = packageBadgeNode(
   label: 'Flutter Favorite',

--- a/app/lib/frontend/templates/views/pkg/package_list.dart
+++ b/app/lib/frontend/templates/views/pkg/package_list.dart
@@ -42,7 +42,10 @@ d.Node _sdkLibraryItem(SdkLibraryHit hit) {
     newTimestamp: null,
     labeledScoresNode: null,
     description: hit.description ?? '',
-    metadataNode: d.text(metadataText),
+    metadataNode: d.fragment([
+      d.span(classes: ['packages-metadata-block'], text: metadataText),
+      coreLibraryBadgeNode,
+    ]),
     tagsNode: null,
     apiPages: null,
   );


### PR DESCRIPTION
- part of #5214
- ![image](https://user-images.githubusercontent.com/4778111/139659647-212618f8-bea1-40cf-9917-e92ba51c4193.png)
