### PR TITLE
Updated search token weights and pre-filtering.

### DIFF
--- a/app/lib/search/text_utils.dart
+++ b/app/lib/search/text_utils.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:math' as math;
+
 import 'package:html/parser.dart';
 
 import '../shared/markdown.dart';
@@ -88,11 +90,12 @@ List<String> extractExactPhrases(String text) =>
 
 const int _maxWordLength = 80;
 
-Map<String, double>? tokenize(String? originalText) {
+Map<String, double>? tokenize(String? originalText, {bool isSplit = false}) {
   if (originalText == null || originalText.isEmpty) return null;
   final tokens = <String, double>{};
 
-  for (String word in splitForIndexing(originalText)) {
+  final words = isSplit ? [originalText] : splitForIndexing(originalText);
+  for (String word in words) {
     if (word.length > _maxWordLength) {
       continue;
     }
@@ -116,7 +119,7 @@ Map<String, double>? tokenize(String? originalText) {
     for (int i = 1; i < changeIndex.length; i++) {
       final token = normalizeBeforeIndexing(
           word.substring(changeIndex[i - 1], changeIndex[i]));
-      final double weight = token.length / word.length;
+      final weight = math.pow((token.length / word.length), 0.5).toDouble();
       if ((tokens[token] ?? 0.0) < weight) {
         tokens[token] = weight;
       }

--- a/app/test/search/api_doc_page_test.dart
+++ b/app/test/search/api_doc_page_test.dart
@@ -80,7 +80,7 @@ void main() {
         'packageHits': [
           {
             'package': 'other_with_api',
-            'score': closeTo(0.26, 0.01), // find serveWebPages
+            'score': closeTo(0.42, 0.01), // find serveWebPages
             'apiPages': [
               {'title': null, 'path': 'serve.html'},
             ],
@@ -101,7 +101,7 @@ void main() {
         'packageHits': [
           {
             'package': 'foo',
-            'score': closeTo(0.072, 0.001), // find WebPageGenerator
+            'score': closeTo(0.18, 0.01), // find WebPageGenerator
             'apiPages': [
               {'title': null, 'path': 'generator.html'},
             ],
@@ -121,7 +121,7 @@ void main() {
         'packageHits': [
           {
             'package': 'foo',
-            'score': closeTo(0.025, 0.001), // find WebPageGenerator
+            'score': closeTo(0.11, 0.01), // find WebPageGenerator
             'apiPages': [
               {'title': null, 'path': 'generator.html'},
             ],

--- a/app/test/search/dartdoc_index_parsing_test.dart
+++ b/app/test/search/dartdoc_index_parsing_test.dart
@@ -129,15 +129,15 @@ void main() {
           'apiPages': [
             {
               'title': null,
-              'path': 'widgets/StatelessWidget/StatelessWidget.html',
-              'url':
-                  'https://api.flutter.dev/flutter/widgets/StatelessWidget/StatelessWidget.html'
-            },
-            {
-              'title': null,
               'path': 'widgets/StatelessWidget-class.html',
               'url':
                   'https://api.flutter.dev/flutter/widgets/StatelessWidget-class.html'
+            },
+            {
+              'title': null,
+              'path': 'widgets/StatelessWidget/StatelessWidget.html',
+              'url':
+                  'https://api.flutter.dev/flutter/widgets/StatelessWidget/StatelessWidget.html'
             },
             {
               'title': null,

--- a/app/test/search/sdk_mem_index_test.dart
+++ b/app/test/search/sdk_mem_index_test.dart
@@ -102,7 +102,7 @@ void main() {
             'version': '',
             'library': 'dart:async',
             'url': 'https://api.dart.dev/x/dart-async/dart-async-library.html',
-            'score': closeTo(0.08, 0.01),
+            'score': closeTo(0.28, 0.01),
             'apiPages': [
               {
                 'title': null,

--- a/app/test/search/text_utils_test.dart
+++ b/app/test/search/text_utils_test.dart
@@ -105,21 +105,26 @@ Other useful methods will be added soon...
     });
 
     test('Cased words', () {
+      expect(tokenize('snake_case'), {
+        'snake': 1.0,
+        'case': 1.0,
+      });
+
       expect(tokenize('CamelCase snake_case firstLowerCase'), {
         'camelcase': 1.0,
-        'camel': 0.5555555555555556,
+        'camel': 0.7453559924999299,
         'case': 1.0, // firstLowerCase should not set a lower value
         'snake': 1.0,
         'firstlowercase': 1.0,
-        'first': 0.35714285714285715,
-        'lower': 0.35714285714285715,
+        'first': 0.5976143046671968,
+        'lower': 0.5976143046671968,
       });
 
       expect(tokenize('firstLowerCase'), {
         'firstlowercase': 1.0,
-        'first': 0.35714285714285715,
-        'lower': 0.35714285714285715,
-        'case': 0.2857142857142857,
+        'first': 0.5976143046671968,
+        'lower': 0.5976143046671968,
+        'case': 0.5345224838248488,
       });
     });
   });

--- a/app/test/search/token_index_test.dart
+++ b/app/test/search/token_index_test.dart
@@ -7,6 +7,16 @@ import 'package:test/test.dart';
 
 void main() {
   group('TokenIndex', () {
+    test('partial token lookup', () {
+      final index = TokenIndex()..add('x', 'SomeCamelCasedWord and others');
+      expect(index.lookupTokens('word').tokenWeights, {'word': 1.0});
+      expect(index.lookupTokens('OtherCased').tokenWeights,
+          {'cased': closeTo(0.70, 0.01)});
+      expect(index.lookupTokens('SomethingElse').tokenWeights, {});
+      // do not return `cased` here:
+      expect(index.lookupTokens('SomethingElse OtherCased').tokenWeights, {});
+    });
+
     test('No match', () {
       final TokenIndex index = TokenIndex()
         ..add('uri://http', 'http')
@@ -35,11 +45,11 @@ void main() {
         ..add('queue_lower', queueText.toLowerCase())
         ..add('unmodifiable', 'CustomUnmodifiableMapBase');
       expect(index.search('queue'), {
-        'queue': closeTo(0.29, 0.01),
+        'queue': closeTo(0.53, 0.01),
       });
       expect(index.search('unmodifiabl'), {}); // no partial matches
       expect(index.search('unmodifiable'), {
-        'unmodifiable': closeTo(0.47, 0.01),
+        'unmodifiable': closeTo(0.68, 0.01),
       });
     });
 
@@ -72,8 +82,8 @@ void main() {
     test('Do not overweight partial matches', () {
       final index = TokenIndex()..add('flutter_qr_reader', 'flutter_qr_reader');
       final data = index.search('ByteDataReader');
-      // The partial match should not return more than 0.5 as score.
-      expect(data, {'flutter_qr_reader': lessThan(0.5)});
+      // The partial match should not return more than 0.65 as score.
+      expect(data, {'flutter_qr_reader': lessThan(0.65)});
     });
 
     test('longer words', () {


### PR DESCRIPTION
- fixed the bogus SDK hits on certain queries, where some words are in the index, but others are not
- changes weights of partial words and increased threshold on SDK index
- fixes token match to filter out words correctly
- preemptively end `Score.multiply` if one of the iterated scores is empty (improves only lazily evaluated iterations)