### PR TITLE
Fetch/process SDK library descriptions for SDK search index.

### DIFF
--- a/app/lib/search/backend.dart
+++ b/app/lib/search/backend.dart
@@ -8,6 +8,7 @@ import 'dart:math';
 
 import 'package:gcloud/service_scope.dart' as ss;
 import 'package:gcloud/storage.dart';
+import 'package:html/parser.dart' as html_parser;
 import 'package:logging/logging.dart';
 
 import 'package:pub_dartdoc_data/pub_dartdoc_data.dart';
@@ -25,6 +26,7 @@ import '../shared/popularity_storage.dart';
 import '../shared/storage.dart';
 import '../shared/tags.dart';
 import '../shared/versions.dart';
+import '../tool/utils/http.dart';
 
 import 'models.dart';
 import 'search_service.dart';
@@ -58,6 +60,7 @@ void registerPackageIndex(PackageIndex index) =>
 /// Datastore-related access methods for the search service
 class SearchBackend {
   final DatastoreDB _db;
+  final _http = httpRetryClient();
 
   SearchBackend(this._db);
 
@@ -233,6 +236,64 @@ class SearchBackend {
         timestamp: DateTime.now().toUtc(),
       );
     }
+  }
+
+  /// Downloads the remote SDK content relative to the base URI.
+  Future<String> fetchSdkIndexContentAsString({
+    required Uri baseUri,
+    required String relativePath,
+  }) async {
+    final uri = baseUri.resolve(relativePath);
+    final rs = await _http.get(uri);
+    if (rs.statusCode != 200) {
+      throw Exception('Unexpected status code for $uri: ${rs.statusCode}');
+    }
+    return rs.body;
+  }
+
+  /// Downloads the remote SDK page and tries to extract the first paragraph of the content.
+  Future<String?> _fetchSdkLibraryDescription({
+    required Uri baseUri,
+    required String relativePath,
+  }) async {
+    try {
+      final content = await fetchSdkIndexContentAsString(
+          baseUri: baseUri, relativePath: relativePath);
+      final parsed = html_parser.parse(content);
+      final descr = parsed.body
+          ?.querySelector('section.desc.markdown')
+          ?.querySelector('p')
+          ?.text
+          .trim();
+      return descr == null ? null : compactDescription(descr);
+    } catch (e) {
+      _logger.info(
+          'Unable to fetch SDK library description $baseUri $relativePath', e);
+      return null;
+    }
+  }
+
+  /// Downloads the remote SDK page and tries to extract the first paragraph of the content
+  /// for each library in [libraryRelativeUrls].
+  Future<Map<String, String>> fetchSdkLibraryDescriptions({
+    required Uri baseUri,
+    required Map<String, String> libraryRelativeUrls,
+  }) async {
+    final values = <String, String>{};
+    for (final library in libraryRelativeUrls.keys) {
+      final descr = await _fetchSdkLibraryDescription(
+        baseUri: baseUri,
+        relativePath: libraryRelativeUrls[library]!,
+      );
+      if (descr != null) {
+        values[library] = descr;
+      }
+    }
+    return values;
+  }
+
+  Future<void> close() async {
+    _http.close();
   }
 }
 

--- a/app/lib/search/dart_sdk_mem_index.dart
+++ b/app/lib/search/dart_sdk_mem_index.dart
@@ -5,7 +5,6 @@
 import 'package:gcloud/service_scope.dart' as ss;
 import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
-import 'package:retry/retry.dart';
 
 import '../shared/cached_value.dart';
 import 'backend.dart';
@@ -58,26 +57,21 @@ class DartSdkMemIndex {
 
 Future<SdkMemIndex?> _createDartSdkMemIndex() async {
   try {
-    return await retry(
-      () async {
-        final index = SdkMemIndex.dart();
-        final content = DartdocIndex.parseJsonText(
-          await searchBackend.fetchSdkIndexContentAsString(
-            baseUri: index.baseUri,
-            relativePath: 'index.json',
-          ),
-        );
-        await index.addDartdocIndex(content);
-        index.addLibraryDescriptions(
-          await searchBackend.fetchSdkLibraryDescriptions(
-            baseUri: index.baseUri,
-            libraryRelativeUrls: content.libraryRelativeUrls,
-          ),
-        );
-        return index;
-      },
-      maxAttempts: 3,
+    final index = SdkMemIndex.dart();
+    final content = DartdocIndex.parseJsonText(
+      await searchBackend.fetchSdkIndexContentAsString(
+        baseUri: index.baseUri,
+        relativePath: 'index.json',
+      ),
     );
+    await index.addDartdocIndex(content);
+    index.addLibraryDescriptions(
+      await searchBackend.fetchSdkLibraryDescriptions(
+        baseUri: index.baseUri,
+        libraryRelativeUrls: content.libraryRelativeUrls,
+      ),
+    );
+    return index;
   } catch (e, st) {
     _logger.warning('Unable to load Dart SDK index.', e, st);
     return null;

--- a/app/lib/search/dart_sdk_mem_index.dart
+++ b/app/lib/search/dart_sdk_mem_index.dart
@@ -3,12 +3,12 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:gcloud/service_scope.dart' as ss;
-import 'package:http/http.dart' as http;
 import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
 import 'package:retry/retry.dart';
 
 import '../shared/cached_value.dart';
+import 'backend.dart';
 import 'models.dart';
 import 'sdk_mem_index.dart';
 import 'search_service.dart';
@@ -61,13 +61,19 @@ Future<SdkMemIndex?> _createDartSdkMemIndex() async {
     return await retry(
       () async {
         final index = SdkMemIndex.dart();
-        final uri = index.baseUri.resolve('index.json');
-        final rs = await http.get(uri);
-        if (rs.statusCode != 200) {
-          throw Exception('Unexpected status code for $uri: ${rs.statusCode}');
-        }
-        final content = DartdocIndex.parseJsonText(rs.body);
+        final content = DartdocIndex.parseJsonText(
+          await searchBackend.fetchSdkIndexContentAsString(
+            baseUri: index.baseUri,
+            relativePath: 'index.json',
+          ),
+        );
         await index.addDartdocIndex(content);
+        index.addLibraryDescriptions(
+          await searchBackend.fetchSdkLibraryDescriptions(
+            baseUri: index.baseUri,
+            libraryRelativeUrls: content.libraryRelativeUrls,
+          ),
+        );
         return index;
       },
       maxAttempts: 3,

--- a/app/lib/search/models.dart
+++ b/app/lib/search/models.dart
@@ -52,6 +52,15 @@ class DartdocIndex {
     return DartdocIndex(list);
   }
 
+  late final libraryRelativeUrls = Map<String, String>.fromEntries(
+    entries.where((e) => e.type == 'library').map(
+          (e) => MapEntry<String, String>(
+            e.qualifiedName.split('.').first,
+            e.href,
+          ),
+        ),
+  );
+
   String toJsonText() => json.encode(entries);
 }
 

--- a/app/lib/search/sdk_mem_index.dart
+++ b/app/lib/search/sdk_mem_index.dart
@@ -14,6 +14,7 @@ class SdkMemIndex {
   final Uri _baseUri;
   final _tokensPerLibrary = <String, TokenIndex>{};
   final _baseUriPerLibrary = <String, String>{};
+  final _descriptionPerLibrary = <String, String>{};
 
   SdkMemIndex({
     required String sdk,
@@ -62,6 +63,11 @@ class SdkMemIndex {
     }
   }
 
+  /// Adds the descriptions for each library.
+  void addLibraryDescriptions(Map<String, String> descriptions) {
+    _descriptionPerLibrary.addAll(descriptions);
+  }
+
   Future<List<SdkLibraryHit>> search(
     String query, {
     int? limit,
@@ -90,7 +96,7 @@ class SdkMemIndex {
               sdk: _sdk,
               version: _version,
               library: hit.library,
-              description: null,
+              description: _descriptionPerLibrary[hit.library],
               url: _baseUriPerLibrary[hit.library] ?? _baseUri.toString(),
               score: hit.score,
               apiPages: hit.top

--- a/app/lib/service/services.dart
+++ b/app/lib/service/services.dart
@@ -193,6 +193,7 @@ Future<void> _withPubServices(FutureOr<void> Function() fn) async {
     await setupCache();
 
     registerScopeExitCallback(announcementBackend.close);
+    registerScopeExitCallback(searchBackend.close);
     registerScopeExitCallback(() async => nameTracker.stopTracking());
     registerScopeExitCallback(snapshotStorage.close);
     registerScopeExitCallback(indexUpdater.close);

--- a/app/test/search/backend_test.dart
+++ b/app/test/search/backend_test.dart
@@ -1,0 +1,27 @@
+// Copyright (c) 2021, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:pub_dev/search/backend.dart';
+import 'package:pub_dev/search/sdk_mem_index.dart';
+import 'package:test/test.dart';
+
+import '../shared/test_services.dart';
+
+void main() {
+  group('search backend', () {
+    testWithProfile('fetch SDK library description', fn: () async {
+      final index = SdkMemIndex.dart();
+      final descr = await searchBackend.fetchSdkLibraryDescriptions(
+        baseUri: index.baseUri,
+        libraryRelativeUrls: {
+          'dart:async': 'dart-async/dart-async-library.html',
+        },
+      );
+      expect(descr, {
+        'dart:async':
+            'Support for asynchronous programming, with classes such as Future and Stream.',
+      });
+    });
+  });
+}

--- a/app/test/search/handlers_test.dart
+++ b/app/test/search/handlers_test.dart
@@ -137,4 +137,25 @@ class MockSearchBackend implements SearchBackend {
   Stream<PackageDocument> loadMinimumPackageIndex() async* {
     throw UnimplementedError();
   }
+
+  @override
+  Future<String> fetchSdkIndexContentAsString({
+    required Uri baseUri,
+    required String relativePath,
+  }) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<Map<String, String>> fetchSdkLibraryDescriptions({
+    required Uri baseUri,
+    required Map<String, String> libraryRelativeUrls,
+  }) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<void> close() {
+    throw UnimplementedError();
+  }
 }

--- a/app/test/search/sdk_mem_index_test.dart
+++ b/app/test/search/sdk_mem_index_test.dart
@@ -55,6 +55,7 @@ void main() {
           'enclosedBy': {'name': 'AsyncError', 'type': 'class'},
         },
       ]));
+      index.addLibraryDescriptions({'dart:async': 'async description'});
     });
 
     test('AsyncError', () async {
@@ -66,6 +67,7 @@ void main() {
             'sdk': 'dart',
             'version': '',
             'library': 'dart:async',
+            'description': 'async description',
             'url': 'https://api.dart.dev/x/dart-async/dart-async-library.html',
             'score': closeTo(0.98, 0.01),
             'apiPages': [
@@ -101,6 +103,7 @@ void main() {
             'sdk': 'dart',
             'version': '',
             'library': 'dart:async',
+            'description': 'async description',
             'url': 'https://api.dart.dev/x/dart-async/dart-async-library.html',
             'score': closeTo(0.08, 0.01),
             'apiPages': [
@@ -125,6 +128,7 @@ void main() {
             'sdk': 'dart',
             'version': '',
             'library': 'dart:async',
+            'description': 'async description',
             'url': 'https://api.dart.dev/x/dart-async/dart-async-library.html',
             'score': closeTo(0.98, 0.01),
             'apiPages': [


### PR DESCRIPTION
- #5214
- the `api.<sdk>.dev` dartdoc page is fetched, and the first paragraph is used for description