### PR TITLE
Null safety badge for SDK hits

### DIFF
--- a/app/lib/frontend/templates/views/pkg/package_list.dart
+++ b/app/lib/frontend/templates/views/pkg/package_list.dart
@@ -45,6 +45,7 @@ d.Node _sdkLibraryItem(SdkLibraryHit hit) {
     metadataNode: d.fragment([
       d.span(classes: ['packages-metadata-block'], text: metadataText),
       coreLibraryBadgeNode,
+      nullSafeBadgeNode(),
     ]),
     tagsNode: null,
     apiPages: null,

--- a/app/test/frontend/golden/pkg_index_page_experimental.html
+++ b/app/test/frontend/golden/pkg_index_page_experimental.html
@@ -363,6 +363,18 @@
             <div class="packages-item">
               <div class="packages-header">
                 <h3 class="packages-title">
+                  <a href="https://api.dart.dev/library-page.html">dart:core</a>
+                </h3>
+              </div>
+              <p class="packages-description">core description</p>
+              <p class="packages-metadata">
+                <span class="packages-metadata-block">v 2.14.0 • Dart SDK library</span>
+                <span class="package-badge">Core library</span>
+              </p>
+            </div>
+            <div class="packages-item">
+              <div class="packages-header">
+                <h3 class="packages-title">
                   <a href="/packages/oxygen">oxygen</a>
                 </h3>
                 <div class="packages-recent">

--- a/app/test/frontend/golden/pkg_index_page_experimental.html
+++ b/app/test/frontend/golden/pkg_index_page_experimental.html
@@ -370,6 +370,7 @@
               <p class="packages-metadata">
                 <span class="packages-metadata-block">v 2.14.0 • Dart SDK library</span>
                 <span class="package-badge">Core library</span>
+                <span class="package-badge" title="Supports the null safety language feature.">Null safety</span>
               </p>
             </div>
             <div class="packages-item">

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -429,6 +429,17 @@ void main() {
           SearchResultPage(
             searchForm,
             2,
+            sdkLibraryHits: [
+              SdkLibraryHit(
+                sdk: 'dart',
+                version: '2.14.0',
+                library: 'dart:core',
+                description: 'core description',
+                url: 'https://api.dart.dev/library-page.html',
+                score: 1.0,
+                apiPages: null,
+              ),
+            ],
             packageHits: [oxygen, titanium],
           ),
           PageLinks.empty(),


### PR DESCRIPTION
- prepared golden in a separate commit
- closes #5214