### PR TITLE
Add lint package to devDependency overrides

### DIFF
--- a/app/lib/package/overrides.dart
+++ b/app/lib/package/overrides.dart
@@ -66,6 +66,7 @@ const devDependencyPackages = <String>{
   'build_verify',
   'build_web_compilers',
   'flutter_lints',
+  'lint',
   'lints',
   'test',
   'test_descriptor',


### PR DESCRIPTION
[`lint`](https://github.com/passsy/dart-lint/) - like `lints` - is only used as dev dependency and should displayed like that on pub.dev