### PR TITLE
Fix package listing badge's icon.

### DIFF
--- a/app/lib/frontend/templates/views/pkg/badge.dart
+++ b/app/lib/frontend/templates/views/pkg/badge.dart
@@ -13,7 +13,15 @@ d.Node packageBadgeNode({
     classes: ['package-badge'],
     attributes: title != null ? <String, String>{'title': title} : null,
     children: [
-      if (iconUrl != null) d.img(classes: ['package-badge-icon'], src: iconUrl),
+      if (iconUrl != null)
+        d.img(
+          classes: ['package-badge-icon'],
+          src: iconUrl,
+          attributes: {
+            'width': '13',
+            'height': '13',
+          },
+        ),
       d.text(label),
     ],
   );

--- a/app/lib/frontend/templates/views/pkg/badge.dart
+++ b/app/lib/frontend/templates/views/pkg/badge.dart
@@ -17,10 +17,8 @@ d.Node packageBadgeNode({
         d.img(
           classes: ['package-badge-icon'],
           src: iconUrl,
-          attributes: {
-            'width': '13',
-            'height': '13',
-          },
+          width: 13,
+          height: 13,
         ),
       d.text(label),
     ],

--- a/pkg/web_css/lib/src/_pkg.scss
+++ b/pkg/web_css/lib/src/_pkg.scss
@@ -18,6 +18,7 @@
     max-height: 13px;
     position: relative;
     top: 2px;
+    margin-right: 4px;
   }
 
   /*


### PR DESCRIPTION
- setting `width` and `height` attributes (#5262)
- there used to be an extra space between the label and the icon, but that got lost during the template migration, adding extra margin via CSS