### PR TITLE
Remove aria-hidden=true from like button.

### DIFF
--- a/app/lib/frontend/templates/views/shared/detail/header.dart
+++ b/app/lib/frontend/templates/views/shared/detail/header.dart
@@ -93,7 +93,6 @@ d.Node detailHeaderNode({
                                     ? 'Unlike this package'
                                     : 'Like this package',
                                 'data-ga-click-event': 'toggle-like',
-                                'aria-hidden': 'true',
                                 'aria-pressed': isLiked ? 'true' : 'false',
                               },
                             ),

--- a/app/test/frontend/golden/pkg_activity_log_page.html
+++ b/app/test/frontend/golden/pkg_activity_log_page.html
@@ -150,7 +150,7 @@
                     </div>
                   </div>
                   <div class="detail-like">
-                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-hidden="true" aria-pressed="false">
+                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false">
                       <img class="mdc-icon-button__icon" src="/static/img/like-inactive.svg?hash=mocked_hash_1066096316" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/img/like-active.svg?hash=mocked_hash_986617859" width="18" height="18"/>
                     </button>

--- a/app/test/frontend/golden/pkg_admin_page.html
+++ b/app/test/frontend/golden/pkg_admin_page.html
@@ -150,7 +150,7 @@
                     </div>
                   </div>
                   <div class="detail-like">
-                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-hidden="true" aria-pressed="false">
+                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false">
                       <img class="mdc-icon-button__icon" src="/static/img/like-inactive.svg?hash=mocked_hash_1066096316" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/img/like-active.svg?hash=mocked_hash_986617859" width="18" height="18"/>
                     </button>

--- a/app/test/frontend/golden/pkg_changelog_page.html
+++ b/app/test/frontend/golden/pkg_changelog_page.html
@@ -151,7 +151,7 @@
                     </div>
                   </div>
                   <div class="detail-like">
-                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-hidden="true" aria-pressed="false">
+                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false">
                       <img class="mdc-icon-button__icon" src="/static/img/like-inactive.svg?hash=mocked_hash_1066096316" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/img/like-active.svg?hash=mocked_hash_986617859" width="18" height="18"/>
                     </button>

--- a/app/test/frontend/golden/pkg_example_page.html
+++ b/app/test/frontend/golden/pkg_example_page.html
@@ -151,7 +151,7 @@
                     </div>
                   </div>
                   <div class="detail-like">
-                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-hidden="true" aria-pressed="false">
+                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false">
                       <img class="mdc-icon-button__icon" src="/static/img/like-inactive.svg?hash=mocked_hash_1066096316" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/img/like-active.svg?hash=mocked_hash_986617859" width="18" height="18"/>
                     </button>

--- a/app/test/frontend/golden/pkg_install_page.html
+++ b/app/test/frontend/golden/pkg_install_page.html
@@ -151,7 +151,7 @@
                     </div>
                   </div>
                   <div class="detail-like">
-                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-hidden="true" aria-pressed="false">
+                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false">
                       <img class="mdc-icon-button__icon" src="/static/img/like-inactive.svg?hash=mocked_hash_1066096316" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/img/like-active.svg?hash=mocked_hash_986617859" width="18" height="18"/>
                     </button>

--- a/app/test/frontend/golden/pkg_score_page.html
+++ b/app/test/frontend/golden/pkg_score_page.html
@@ -151,7 +151,7 @@
                     </div>
                   </div>
                   <div class="detail-like">
-                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-hidden="true" aria-pressed="false">
+                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false">
                       <img class="mdc-icon-button__icon" src="/static/img/like-inactive.svg?hash=mocked_hash_1066096316" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/img/like-active.svg?hash=mocked_hash_986617859" width="18" height="18"/>
                     </button>

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -151,7 +151,7 @@
                     </div>
                   </div>
                   <div class="detail-like">
-                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-hidden="true" aria-pressed="false">
+                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false">
                       <img class="mdc-icon-button__icon" src="/static/img/like-inactive.svg?hash=mocked_hash_1066096316" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/img/like-active.svg?hash=mocked_hash_986617859" width="18" height="18"/>
                     </button>

--- a/app/test/frontend/golden/pkg_show_page_discontinued.html
+++ b/app/test/frontend/golden/pkg_show_page_discontinued.html
@@ -138,7 +138,7 @@
                     <span class="package-tag discontinued" title="Package was discontinued.">discontinued</span>
                   </div>
                   <div class="detail-like">
-                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-hidden="true" aria-pressed="false">
+                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false">
                       <img class="mdc-icon-button__icon" src="/static/img/like-inactive.svg?hash=mocked_hash_1066096316" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/img/like-active.svg?hash=mocked_hash_986617859" width="18" height="18"/>
                     </button>

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -147,7 +147,7 @@
                     </div>
                   </div>
                   <div class="detail-like">
-                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-hidden="true" aria-pressed="false">
+                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false">
                       <img class="mdc-icon-button__icon" src="/static/img/like-inactive.svg?hash=mocked_hash_1066096316" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/img/like-active.svg?hash=mocked_hash_986617859" width="18" height="18"/>
                     </button>

--- a/app/test/frontend/golden/pkg_show_page_legacy.html
+++ b/app/test/frontend/golden/pkg_show_page_legacy.html
@@ -138,7 +138,7 @@
                     <span class="package-tag legacy" title="Package does not support Dart 2.">Dart 2 incompatible</span>
                   </div>
                   <div class="detail-like">
-                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-hidden="true" aria-pressed="false">
+                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false">
                       <img class="mdc-icon-button__icon" src="/static/img/like-inactive.svg?hash=mocked_hash_1066096316" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/img/like-active.svg?hash=mocked_hash_986617859" width="18" height="18"/>
                     </button>

--- a/app/test/frontend/golden/pkg_show_page_publisher.html
+++ b/app/test/frontend/golden/pkg_show_page_publisher.html
@@ -143,7 +143,7 @@
                     <span class="package-tag missing" title="Analysis should be ready soon.">[awaiting]</span>
                   </div>
                   <div class="detail-like">
-                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-hidden="true" aria-pressed="false">
+                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false">
                       <img class="mdc-icon-button__icon" src="/static/img/like-inactive.svg?hash=mocked_hash_1066096316" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/img/like-active.svg?hash=mocked_hash_986617859" width="18" height="18"/>
                     </button>

--- a/app/test/frontend/golden/pkg_show_page_retracted.html
+++ b/app/test/frontend/golden/pkg_show_page_retracted.html
@@ -147,7 +147,7 @@
                     <span class="package-tag retracted" title="This version was retracted.">retracted</span>
                   </div>
                   <div class="detail-like">
-                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-hidden="true" aria-pressed="false">
+                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false">
                       <img class="mdc-icon-button__icon" src="/static/img/like-inactive.svg?hash=mocked_hash_1066096316" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/img/like-active.svg?hash=mocked_hash_986617859" width="18" height="18"/>
                     </button>

--- a/app/test/frontend/golden/pkg_show_page_retracted_non_retracted_version.html
+++ b/app/test/frontend/golden/pkg_show_page_retracted_non_retracted_version.html
@@ -142,7 +142,7 @@
                     </div>
                   </div>
                   <div class="detail-like">
-                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-hidden="true" aria-pressed="false">
+                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false">
                       <img class="mdc-icon-button__icon" src="/static/img/like-inactive.svg?hash=mocked_hash_1066096316" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/img/like-active.svg?hash=mocked_hash_986617859" width="18" height="18"/>
                     </button>

--- a/app/test/frontend/golden/pkg_show_version_page.html
+++ b/app/test/frontend/golden/pkg_show_version_page.html
@@ -151,7 +151,7 @@
                     </div>
                   </div>
                   <div class="detail-like">
-                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-hidden="true" aria-pressed="false">
+                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false">
                       <img class="mdc-icon-button__icon" src="/static/img/like-inactive.svg?hash=mocked_hash_1066096316" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/img/like-active.svg?hash=mocked_hash_986617859" width="18" height="18"/>
                     </button>

--- a/app/test/frontend/golden/pkg_versions_page.html
+++ b/app/test/frontend/golden/pkg_versions_page.html
@@ -151,7 +151,7 @@
                     </div>
                   </div>
                   <div class="detail-like">
-                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-hidden="true" aria-pressed="false">
+                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false">
                       <img class="mdc-icon-button__icon" src="/static/img/like-inactive.svg?hash=mocked_hash_1066096316" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/img/like-active.svg?hash=mocked_hash_986617859" width="18" height="18"/>
                     </button>


### PR DESCRIPTION
- #5263.
- We should only hide the icon if it is part of a proper button. This is not the case for the like button, so we should not hide it from the accessibility perspective.