### PR TITLE
end2end tests for pana and dartdoc runners

### DIFF
--- a/app/lib/analyzer/pana_runner.dart
+++ b/app/lib/analyzer/pana_runner.dart
@@ -15,6 +15,7 @@ import '../package/overrides.dart';
 import '../scorecard/backend.dart';
 import '../scorecard/models.dart';
 import '../shared/configuration.dart';
+import '../shared/datastore.dart';
 import '../shared/tool_env.dart';
 
 final Logger _logger = Logger('pub.analyzer.pana');
@@ -39,6 +40,18 @@ abstract class PanaRunner {
     required String version,
     required PackageStatus packageStatus,
   });
+}
+
+@visibleForTesting
+Future<void> processJobsWithPanaRunner({
+  PanaRunner? runner,
+}) async {
+  final jobProcessor = AnalyzerJobProcessor(
+    aliveCallback: null,
+    runner: runner ?? _PanaRunner(),
+  );
+  // ignore: invalid_use_of_visible_for_testing_member
+  await JobMaintenance(dbService, jobProcessor).scanUpdateAndRunOnce();
 }
 
 class _PanaRunner implements PanaRunner {

--- a/app/lib/dartdoc/dartdoc_runner.dart
+++ b/app/lib/dartdoc/dartdoc_runner.dart
@@ -7,6 +7,7 @@ import 'dart:convert' as convert;
 import 'dart:io';
 
 import 'package:logging/logging.dart';
+import 'package:meta/meta.dart';
 import 'package:pana/pana.dart' hide Pubspec, ReportStatus;
 import 'package:pana/pana.dart' as pana show ReportStatus;
 import 'package:path/path.dart' as p;
@@ -21,6 +22,7 @@ import '../package/backend.dart';
 import '../scorecard/backend.dart';
 import '../scorecard/models.dart';
 import '../shared/configuration.dart';
+import '../shared/datastore.dart';
 import '../shared/env_config.dart';
 import '../shared/tool_env.dart';
 import '../shared/urls.dart';
@@ -155,6 +157,19 @@ class _DartdocRunner implements DartdocRunner {
     );
     return DartdocRunnerResult(args: args, processResult: pr);
   }
+}
+
+/// Generates package documentation for all packages with fake dartdoc runner.
+@visibleForTesting
+Future<void> processJobsWithDartdocRunner({
+  DartdocRunner? runner,
+}) async {
+  final jobProcessor = DartdocJobProcessor(
+    aliveCallback: null,
+    runner: runner ?? _DartdocRunner(),
+  );
+  // ignore: invalid_use_of_visible_for_testing_member
+  await JobMaintenance(dbService, jobProcessor).scanUpdateAndRunOnce();
 }
 
 class DartdocJobProcessor extends JobProcessor {

--- a/app/lib/fake/backend/fake_dartdoc_runner.dart
+++ b/app/lib/fake/backend/fake_dartdoc_runner.dart
@@ -11,17 +11,11 @@ import 'package:path/path.dart' as p;
 import 'package:pub_dartdoc_data/pub_dartdoc_data.dart';
 
 import '../../dartdoc/dartdoc_runner.dart';
-import '../../job/job.dart';
-import '../../shared/datastore.dart';
 
 /// Generates package documentation for all packages with fake dartdoc runner.
 Future<void> processJobsWithFakeDartdocRunner() async {
-  final jobProcessor = DartdocJobProcessor(
-    aliveCallback: null,
-    runner: FakeDartdocRunner(),
-  );
   // ignore: invalid_use_of_visible_for_testing_member
-  await JobMaintenance(dbService, jobProcessor).scanUpdateAndRunOnce();
+  await processJobsWithDartdocRunner(runner: FakeDartdocRunner());
 }
 
 /// Generates dartdoc content and results based on a deterministic random seed.

--- a/app/lib/fake/backend/fake_pana_runner.dart
+++ b/app/lib/fake/backend/fake_pana_runner.dart
@@ -8,19 +8,13 @@ import 'package:pana/pana.dart';
 import 'package:pub_semver/pub_semver.dart';
 
 import '../../analyzer/pana_runner.dart';
-import '../../job/job.dart';
 import '../../scorecard/backend.dart' show PackageStatus;
-import '../../shared/datastore.dart';
 import '../../shared/versions.dart';
 
 /// Runs package analysis for all packages with fake pana runner.
 Future<void> processJobsWithFakePanaRunner() async {
-  final jobProcessor = AnalyzerJobProcessor(
-    aliveCallback: null,
-    runner: FakePanaRunner(),
-  );
   // ignore: invalid_use_of_visible_for_testing_member
-  await JobMaintenance(dbService, jobProcessor).scanUpdateAndRunOnce();
+  await processJobsWithPanaRunner(runner: FakePanaRunner());
 }
 
 /// Generates pana analysis result based on a deterministic random seed.

--- a/app/lib/fake/tool/init_data_file.dart
+++ b/app/lib/fake/tool/init_data_file.dart
@@ -5,7 +5,6 @@
 import 'dart:io';
 
 import 'package:args/command_runner.dart';
-import 'package:gcloud/db.dart';
 import 'package:gcloud/service_scope.dart';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
@@ -15,7 +14,6 @@ import 'package:pub_dev/dartdoc/dartdoc_runner.dart';
 import 'package:pub_dev/fake/backend/fake_dartdoc_runner.dart';
 import 'package:pub_dev/fake/backend/fake_pana_runner.dart';
 import 'package:pub_dev/frontend/static_files.dart';
-import 'package:pub_dev/job/job.dart';
 import 'package:pub_dev/service/services.dart';
 import 'package:pub_dev/tool/test_profile/import_source.dart';
 import 'package:pub_dev/tool/test_profile/importer.dart';
@@ -92,19 +90,10 @@ class FakeInitDataFileCommand extends Command {
 }
 
 Future<void> _analyze() async {
-  // pana
   await fork(() async {
-    final jobProcessor = AnalyzerJobProcessor(aliveCallback: null);
-    final jobMaintenance = JobMaintenance(dbService, jobProcessor);
     // ignore: invalid_use_of_visible_for_testing_member
-    await jobMaintenance.scanUpdateAndRunOnce();
-  });
-
-  // dartdoc
-  await fork(() async {
-    final jobProcessor = DartdocJobProcessor(aliveCallback: null);
-    final jobMaintenance = JobMaintenance(dbService, jobProcessor);
+    await processJobsWithPanaRunner();
     // ignore: invalid_use_of_visible_for_testing_member
-    await jobMaintenance.scanUpdateAndRunOnce();
+    await processJobsWithDartdocRunner();
   });
 }

--- a/app/test/analyzer/pana_runner_test.dart
+++ b/app/test/analyzer/pana_runner_test.dart
@@ -3,12 +3,56 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:pub_dev/analyzer/pana_runner.dart';
+import 'package:pub_dev/fake/backend/fake_dartdoc_runner.dart';
+import 'package:pub_dev/scorecard/backend.dart';
+import 'package:pub_dev/tool/test_profile/import_source.dart';
+import 'package:pub_dev/tool/test_profile/models.dart';
 import 'package:test/test.dart';
+
+import '../shared/test_services.dart';
 
 void main() {
   test('static analysis options is available', () async {
     final content = await getDefaultAnalysisOptionsYaml();
     expect(content.trim(), isNotEmpty);
     expect(content, contains('void_checks'));
+  });
+
+  group('pana runner', () {
+    testWithProfile(
+      'end2end test',
+      testProfile: TestProfile(
+        packages: [
+          TestPackage(name: 'retry', versions: ['3.1.0']),
+        ],
+        defaultUser: 'admin@pub.dev',
+      ),
+      importSource: ImportSource.fromPubDev(),
+      fn: () async {
+        await processJobsWithPanaRunner();
+        await processJobsWithFakeDartdocRunner();
+        final card = await scoreCardBackend.getScoreCardData('retry', '3.1.0');
+
+        expect(card!.grantedPubPoints, greaterThan(125));
+        expect(card.maxPubPoints, card.grantedPubPoints);
+        expect(
+            card.derivedTags?.toSet(),
+            containsAll([
+              'sdk:dart',
+              'sdk:flutter',
+              'platform:android',
+              'platform:ios',
+              'platform:windows',
+              'platform:linux',
+              'platform:macos',
+              'platform:web',
+              'runtime:native-aot',
+              'runtime:native-jit',
+              'runtime:web',
+              'is:null-safe',
+            ]));
+      },
+      timeout: Timeout.factor(8),
+    );
   });
 }

--- a/app/test/dartdoc/dartdoc_runner_test.dart
+++ b/app/test/dartdoc/dartdoc_runner_test.dart
@@ -1,0 +1,68 @@
+// Copyright (c) 2021, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:pub_dev/dartdoc/backend.dart';
+import 'package:pub_dev/dartdoc/dartdoc_runner.dart';
+import 'package:pub_dev/fake/backend/fake_pana_runner.dart';
+import 'package:pub_dev/scorecard/backend.dart';
+import 'package:pub_dev/tool/test_profile/import_source.dart';
+import 'package:pub_dev/tool/test_profile/models.dart';
+import 'package:test/test.dart';
+
+import '../frontend/handlers/_utils.dart';
+import '../shared/test_services.dart';
+
+void main() {
+  group('dartdoc runner', () {
+    testWithProfile(
+      'end2end test',
+      testProfile: TestProfile(
+        packages: [
+          TestPackage(name: 'retry', versions: ['3.1.0']),
+        ],
+        defaultUser: 'admin@pub.dev',
+      ),
+      importSource: ImportSource.fromPubDev(),
+      fn: () async {
+        await processJobsWithFakePanaRunner();
+        await processJobsWithDartdocRunner();
+        final card = await scoreCardBackend.getScoreCardData('retry', '3.1.0');
+
+        expect(card!.grantedPubPoints, 22);
+        expect(card.maxPubPoints, 70);
+        expect(card.dartdocReport!.documentationSection!.grantedPoints, 10);
+        expect(card.dartdocReport!.documentationSection!.maxPoints, 10);
+
+        // size checks
+        final entry = card.dartdocReport!.dartdocEntry!;
+        expect(entry.archiveSize, greaterThan(40000));
+        expect(entry.archiveSize, lessThan(50000));
+        expect(entry.totalSize, greaterThan(180000));
+        expect(entry.totalSize, lessThan(220000));
+
+        // uploaded content check
+        final indexHtml = await dartdocBackend.getTextContent(
+          'retry',
+          '3.1.0',
+          'index.html',
+          timeout: Duration(seconds: 1),
+        );
+        expect(indexHtml, contains('retry/retry-library.html'));
+        final libraryHtml = await dartdocBackend.getTextContent(
+          'retry',
+          '3.1.0',
+          'retry/retry-library.html',
+          timeout: Duration(seconds: 1),
+        );
+        expect(libraryHtml, contains('retry/RetryOptions-class.html'));
+
+        final rs = await issueGet(
+            '/documentation/retry/latest/retry/retry-library.html');
+        expect(rs.statusCode, 200);
+        expect(await rs.readAsString(), libraryHtml);
+      },
+      timeout: Timeout.factor(8),
+    );
+  });
+}


### PR DESCRIPTION
- refactored/moved helper methods to accept the real runner and not just the fake ones
- `PanaRunner` is test with fake dartdoc runner, and `DartdocRunner` is tested with fake pana runner.
- dartdoc runner test has some checks against the generated files, which should be useful to detect regressions, but may break if there is huge change in the template
