### PR TITLE
Remove in-memory buffering in pkg/pub_dartdoc.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ AppEngine version, listed here to ease deployment and troubleshooting.
  * Upgraded preview Flutter analysis SDK to `2.8.0-3.1.pre`.
  * NOTE: First release that includes `/help/api`.
    TODO(deferred): request community members on announce@ to self-report API use.
+ * NOTE: removed in-memory buffering in `pkg/pub_dartdoc`.
 
 ## `20211108t124400-all`
  * NOTE: Verify backfill logs (`[backfill-version-count-*]` entries) after a few days of this release.

--- a/pkg/pub_dartdoc/bin/pub_dartdoc.dart
+++ b/pkg/pub_dartdoc/bin/pub_dartdoc.dart
@@ -22,7 +22,6 @@ Future<void> main(List<String> arguments) async {
   if (config == null) {
     throw ArgumentError();
   }
-  pubResourceProvider.setConfig(output: config.output);
 
   final packageConfigProvider = PhysicalPackageConfigProvider();
   final packageBuilder =
@@ -35,9 +34,6 @@ Future<void> main(List<String> arguments) async {
   final pubDataGenerator =
       PubDataGenerator(config.inputDir, config.resourceProvider);
   pubDataGenerator.generate(results.packageGraph, config.output);
-
-  print('[${DateTime.now().toIso8601String()}] Writing files...');
-  pubResourceProvider.writeFilesToDiskSync();
 
   print(
       '[${DateTime.now().toIso8601String()}] Max memory use: ${ProcessInfo.maxRss}');

--- a/pkg/pub_dartdoc/pubspec.lock
+++ b/pkg/pub_dartdoc/pubspec.lock
@@ -184,7 +184,7 @@ packages:
     source: hosted
     version: "0.12.11"
   meta:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"

--- a/pkg/pub_dartdoc/pubspec.yaml
+++ b/pkg/pub_dartdoc/pubspec.yaml
@@ -4,7 +4,6 @@ environment:
   sdk: ">=2.6.0 <3.0.0"
 dependencies:
   analyzer: any # whatever dartdoc supports
-  meta: ^1.0.0
   path: ^1.8.0
   pub_dartdoc_data:
     path: ../pub_dartdoc_data


### PR DESCRIPTION
In the recent versions of dartdoc + analyzer, we no longer see the performance penalty of writing the files directly. The file count and total size limit is still in place and applied.