### PR TITLE
New tag display.

### DIFF
--- a/app/lib/frontend/templates/package_misc.dart
+++ b/app/lib/frontend/templates/package_misc.dart
@@ -8,6 +8,7 @@ import '../../shared/tags.dart';
 import '../../shared/urls.dart' as urls;
 
 import '../dom/dom.dart' as d;
+import '../request_context.dart';
 import '../static_files.dart';
 
 import 'views/pkg/badge.dart';
@@ -59,10 +60,81 @@ d.Node tagsNodeFromPackageView({
   if (package.isLegacy) {
     simpleTags.add(SimpleTag.legacy());
   }
+  if (requestContext.showNewSearchUI) {
+    final expandedTags = tags.expand(expandPanaTag).toSet();
+    String tagUrl(String requiredTag) =>
+        SearchForm().toggleRequiredTag(requiredTag).toSearchLink();
+
+    final sdkBadgeTag = BadgeTag(
+      text: 'SDK',
+      subTags: [
+        if (sdkTags.contains(SdkTag.sdkDart))
+          BadgeSubTag(
+            text: 'Dart',
+            title: 'Packages compatible with Dart SDK',
+            href: tagUrl(SdkTag.sdkDart),
+          ),
+        if (sdkTags.contains(SdkTag.sdkFlutter))
+          BadgeSubTag(
+            text: 'Flutter',
+            title: 'Packages compatible with Flutter SDK',
+            href: tagUrl(SdkTag.sdkFlutter),
+          ),
+      ],
+    );
+    if (sdkBadgeTag.subTags.isNotEmpty) {
+      badgeTags.add(sdkBadgeTag);
+    }
+
+    final platformBadgeTag = BadgeTag(
+      text: 'Platform',
+      subTags: [
+        if (expandedTags.contains(FlutterSdkTag.platformAndroid))
+          BadgeSubTag(
+            text: 'Android',
+            title: 'Packages compatible with Android platform',
+            href: tagUrl(FlutterSdkTag.platformAndroid),
+          ),
+        if (expandedTags.contains(FlutterSdkTag.platformIos))
+          BadgeSubTag(
+            text: 'iOS',
+            title: 'Packages compatible with iOS platform',
+            href: tagUrl(FlutterSdkTag.platformIos),
+          ),
+        if (expandedTags.contains(FlutterSdkTag.platformLinux))
+          BadgeSubTag(
+            text: 'Linux',
+            title: 'Packages compatible with Linux platform',
+            href: tagUrl(FlutterSdkTag.platformLinux),
+          ),
+        if (expandedTags.contains(FlutterSdkTag.platformMacos))
+          BadgeSubTag(
+            text: 'macOS',
+            title: 'Packages compatible with macOS platform',
+            href: tagUrl(FlutterSdkTag.platformMacos),
+          ),
+        if (expandedTags.contains(FlutterSdkTag.platformWeb))
+          BadgeSubTag(
+            text: 'web',
+            title: 'Packages compatible with Web platform',
+            href: tagUrl(FlutterSdkTag.platformWeb),
+          ),
+        if (expandedTags.contains(FlutterSdkTag.platformWindows))
+          BadgeSubTag(
+            text: 'Windows',
+            title: 'Packages compatible with Windows platform',
+            href: tagUrl(FlutterSdkTag.platformWindows),
+          ),
+      ],
+    );
+    if (platformBadgeTag.subTags.isNotEmpty) {
+      badgeTags.add(platformBadgeTag);
+    }
+  }
   // We only display first-class platform/runtimes
-  if (sdkTags.contains(SdkTag.sdkDart)) {
+  if (!requestContext.showNewSearchUI && sdkTags.contains(SdkTag.sdkDart)) {
     badgeTags.add(BadgeTag(
-      sdk: 'Dart',
+      text: 'Dart',
       title: 'Packages compatible with Dart SDK',
       href: urls.searchUrl(context: SearchContext.dart()),
       subTags: [
@@ -88,9 +160,9 @@ d.Node tagsNodeFromPackageView({
       ],
     ));
   }
-  if (sdkTags.contains(SdkTag.sdkFlutter)) {
+  if (!requestContext.showNewSearchUI && sdkTags.contains(SdkTag.sdkFlutter)) {
     badgeTags.add(BadgeTag(
-      sdk: 'Flutter',
+      text: 'Flutter',
       title: 'Packages compatible with Flutter SDK',
       href: urls.searchUrl(context: SearchContext.flutter()),
       subTags: [

--- a/app/lib/frontend/templates/views/pkg/tags.dart
+++ b/app/lib/frontend/templates/views/pkg/tags.dart
@@ -82,15 +82,15 @@ class SimpleTag {
 }
 
 class BadgeTag {
-  final String sdk;
-  final String title;
-  final String href;
+  final String text;
+  final String? title;
+  final String? href;
   final List<BadgeSubTag> subTags;
 
   BadgeTag({
-    required this.sdk,
-    required this.title,
-    required this.href,
+    required this.text,
+    this.title,
+    this.href,
     required this.subTags,
   });
 }
@@ -116,12 +116,15 @@ d.Node tagsNode({
       (t) => d.div(
         classes: ['-pub-tag-badge'],
         children: [
-          d.a(
-            classes: ['tag-badge-main'],
-            title: t.title,
-            href: t.href,
-            text: t.sdk,
-          ),
+          if (t.href == null)
+            d.span(classes: ['tag-badge-main'], text: t.text)
+          else
+            d.a(
+              classes: ['tag-badge-main'],
+              title: t.title,
+              href: t.href,
+              text: t.text,
+            ),
           ...t.subTags.map(
             (s) => d.a(
               classes: ['tag-badge-sub'],

--- a/app/lib/search/backend.dart
+++ b/app/lib/search/backend.dart
@@ -108,36 +108,6 @@ class SearchBackend {
         ? await loadTags(releases.preview!.version)
         : <String>[];
 
-    /// Expand `runtime:*` tags into `platform:*` tags to enable
-    /// unnested platform search queries to run on the current pana tagging.
-    Iterable<String> expandPanaTag(String tag) {
-      if (tag == DartSdkTag.runtimeNativeJit) {
-        return [
-          tag,
-          FlutterSdkTag.platformLinux,
-          FlutterSdkTag.platformMacos,
-          FlutterSdkTag.platformWindows,
-        ];
-      } else if (tag == DartSdkTag.runtimeNativeAot) {
-        return [
-          tag,
-          FlutterSdkTag.platformAndroid,
-          FlutterSdkTag.platformIos,
-          FlutterSdkTag.platformLinux,
-          FlutterSdkTag.platformMacos,
-          FlutterSdkTag.platformWeb,
-          FlutterSdkTag.platformWindows,
-        ];
-      } else if (tag == DartSdkTag.runtimeWeb) {
-        return [
-          tag,
-          FlutterSdkTag.platformWeb,
-        ];
-      } else {
-        return [tag];
-      }
-    }
-
     final tags = <String>{
       ...p.getTags(),
       ...pv.getTags(),

--- a/app/lib/shared/tags.dart
+++ b/app/lib/shared/tags.dart
@@ -134,3 +134,33 @@ abstract class FlutterSdkPlatform {
   static const String web = 'web';
   static const String windows = 'windows';
 }
+
+/// Expand `runtime:*` tags into `platform:*` tags to enable
+/// unnested platform search queries to run on the current pana tagging.
+Iterable<String> expandPanaTag(String tag) {
+  if (tag == DartSdkTag.runtimeNativeJit) {
+    return [
+      tag,
+      FlutterSdkTag.platformLinux,
+      FlutterSdkTag.platformMacos,
+      FlutterSdkTag.platformWindows,
+    ];
+  } else if (tag == DartSdkTag.runtimeNativeAot) {
+    return [
+      tag,
+      FlutterSdkTag.platformAndroid,
+      FlutterSdkTag.platformIos,
+      FlutterSdkTag.platformLinux,
+      FlutterSdkTag.platformMacos,
+      FlutterSdkTag.platformWeb,
+      FlutterSdkTag.platformWindows,
+    ];
+  } else if (tag == DartSdkTag.runtimeWeb) {
+    return [
+      tag,
+      FlutterSdkTag.platformWeb,
+    ];
+  } else {
+    return [tag];
+  }
+}

--- a/app/test/frontend/golden/pkg_index_page_experimental.html
+++ b/app/test/frontend/golden/pkg_index_page_experimental.html
@@ -421,9 +421,17 @@
               </p>
               <div>
                 <div class="-pub-tag-badge">
-                  <a class="tag-badge-main" href="/dart/packages" title="Packages compatible with Dart SDK">Dart</a>
-                  <a class="tag-badge-sub" href="/dart/packages?runtime=native" title="Packages compatible with Dart running on a native platform (JIT/AOT)">native</a>
-                  <a class="tag-badge-sub" href="/dart/packages?runtime=js" title="Packages compatible with Dart compiled for the web">js</a>
+                  <span class="tag-badge-main">SDK</span>
+                  <a class="tag-badge-sub" href="/packages?q=sdk%3Adart" title="Packages compatible with Dart SDK">Dart</a>
+                </div>
+                <div class="-pub-tag-badge">
+                  <span class="tag-badge-main">Platform</span>
+                  <a class="tag-badge-sub" href="/packages?q=platform%3Aandroid" title="Packages compatible with Android platform">Android</a>
+                  <a class="tag-badge-sub" href="/packages?q=platform%3Aios" title="Packages compatible with iOS platform">iOS</a>
+                  <a class="tag-badge-sub" href="/packages?q=platform%3Alinux" title="Packages compatible with Linux platform">Linux</a>
+                  <a class="tag-badge-sub" href="/packages?q=platform%3Amacos" title="Packages compatible with macOS platform">macOS</a>
+                  <a class="tag-badge-sub" href="/packages?q=platform%3Aweb" title="Packages compatible with Web platform">web</a>
+                  <a class="tag-badge-sub" href="/packages?q=platform%3Awindows" title="Packages compatible with Windows platform">Windows</a>
                 </div>
               </div>
             </div>
@@ -474,14 +482,18 @@
               </p>
               <div>
                 <div class="-pub-tag-badge">
-                  <a class="tag-badge-main" href="/dart/packages" title="Packages compatible with Dart SDK">Dart</a>
-                  <a class="tag-badge-sub" href="/dart/packages?runtime=native" title="Packages compatible with Dart running on a native platform (JIT/AOT)">native</a>
-                  <a class="tag-badge-sub" href="/dart/packages?runtime=js" title="Packages compatible with Dart compiled for the web">js</a>
+                  <span class="tag-badge-main">SDK</span>
+                  <a class="tag-badge-sub" href="/packages?q=sdk%3Adart" title="Packages compatible with Dart SDK">Dart</a>
+                  <a class="tag-badge-sub" href="/packages?q=sdk%3Aflutter" title="Packages compatible with Flutter SDK">Flutter</a>
                 </div>
                 <div class="-pub-tag-badge">
-                  <a class="tag-badge-main" href="/flutter/packages" title="Packages compatible with Flutter SDK">Flutter</a>
-                  <a class="tag-badge-sub" href="/flutter/packages?platform=android" title="Packages compatible with Flutter on the Android platform">Android</a>
-                  <a class="tag-badge-sub" href="/flutter/packages?platform=macos" title="Packages compatible with Flutter on the macOS platform">macOS</a>
+                  <span class="tag-badge-main">Platform</span>
+                  <a class="tag-badge-sub" href="/packages?q=platform%3Aandroid" title="Packages compatible with Android platform">Android</a>
+                  <a class="tag-badge-sub" href="/packages?q=platform%3Aios" title="Packages compatible with iOS platform">iOS</a>
+                  <a class="tag-badge-sub" href="/packages?q=platform%3Alinux" title="Packages compatible with Linux platform">Linux</a>
+                  <a class="tag-badge-sub" href="/packages?q=platform%3Amacos" title="Packages compatible with macOS platform">macOS</a>
+                  <a class="tag-badge-sub" href="/packages?q=platform%3Aweb" title="Packages compatible with Web platform">web</a>
+                  <a class="tag-badge-sub" href="/packages?q=platform%3Awindows" title="Packages compatible with Windows platform">Windows</a>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4778111/143240617-7c04dee8-901d-40ae-be9c-eee90f98b69c.png)

- behind experimental flag
- `sdk` and `platform` labels are not links
- tag links use the new search format
- applied both on the listing and the package page
