### PR TITLE
Client-side update of new search UI.

### DIFF
--- a/app/lib/frontend/handlers/listing.dart
+++ b/app/lib/frontend/handlers/listing.dart
@@ -75,6 +75,8 @@ Future<shelf.Response> _packagesHandlerHtmlCore(
   String? title,
   String? searchPlaceholder,
 }) async {
+  final openSections =
+      request.requestedUri.queryParameters['open-sections']?.split(' ').toSet();
   final searchForm =
       SearchForm.parse(context, request.requestedUri.queryParameters);
   final sw = Stopwatch()..start();
@@ -91,6 +93,7 @@ Future<shelf.Response> _packagesHandlerHtmlCore(
       title: title,
       searchPlaceholder: searchPlaceholder,
       messageFromBackend: searchResult.message,
+      openSections: openSections,
     ),
   );
   _searchOverallLatencyTracker.add(sw.elapsed);

--- a/app/lib/frontend/templates/listing.dart
+++ b/app/lib/frontend/templates/listing.dart
@@ -41,6 +41,7 @@ String renderPkgIndexPage(
   required SearchForm searchForm,
   String? searchPlaceholder,
   String? messageFromBackend,
+  Set<String>? openSections,
 }) {
   final topPackages = getSdkDict(sdk).topSdkPackages;
   final isSearch = searchForm.hasQuery;
@@ -57,6 +58,7 @@ String renderPkgIndexPage(
     ),
     packageList: packageList(searchResultPage),
     pagination: searchResultPage.hasHit ? paginationNode(links) : null,
+    openSections: openSections,
   );
 
   String pageTitle = title ?? topPackages;

--- a/app/lib/frontend/templates/views/pkg/index.dart
+++ b/app/lib/frontend/templates/views/pkg/index.dart
@@ -17,6 +17,7 @@ d.Node packageListingNode({
   required d.Node listingInfo,
   required d.Node packageList,
   required d.Node? pagination,
+  required Set<String>? openSections,
 }) {
   final innerContent = d.fragment([
     listingInfo,
@@ -30,6 +31,7 @@ d.Node packageListingNode({
     return _searchFormContainer(
       searchForm: searchForm,
       innerContent: innerContent,
+      openSections: openSections ?? const <String>{},
     );
   } else {
     return d.fragment([
@@ -42,6 +44,7 @@ d.Node packageListingNode({
 d.Node _searchFormContainer({
   required SearchForm searchForm,
   required d.Node innerContent,
+  required Set<String> openSections,
 }) {
   return d.div(
     classes: [
@@ -91,9 +94,11 @@ d.Node _searchFormContainer({
             ],
           ),
           _filterSection(
+            sectionTag: 'sdks',
             label: 'SDKs',
-            isActive: searchForm.parsedQuery.tagsPredicate
-                .anyTag((t) => t.startsWith('sdk:')),
+            isActive: openSections.contains('sdks') ||
+                searchForm.parsedQuery.tagsPredicate
+                    .anyTag((t) => t.startsWith('sdk:')),
             children: [
               _sdkCheckbox(
                 sdk: SdkTagValue.dart,
@@ -108,8 +113,10 @@ d.Node _searchFormContainer({
             ],
           ),
           _filterSection(
+            sectionTag: 'advanced',
             label: 'Advanced',
-            isActive: searchForm.hasActiveAdvanced,
+            isActive: openSections.contains('advanced') ||
+                searchForm.hasActiveAdvanced,
             children: [
               _formLinkedCheckbox(
                 id: 'search-form-checkbox-discontinued',
@@ -181,6 +188,7 @@ d.Node _tagBasedCheckbox({
     toggledSearchForm: toggledSearchForm,
     isChecked: searchForm.parsedQuery.tagsPredicate.isRequiredTag(tag),
     isIndeterminate: searchForm.parsedQuery.tagsPredicate.isProhibitedTag(tag),
+    tag: tag,
   );
 }
 
@@ -190,6 +198,7 @@ d.Node _formLinkedCheckbox({
   required SearchForm toggledSearchForm,
   required bool isChecked,
   bool isIndeterminate = false,
+  String? tag,
 }) {
   return d.div(
     classes: ['search-form-linked-checkbox'],
@@ -197,9 +206,11 @@ d.Node _formLinkedCheckbox({
       id: id,
       label: label,
       labelNodeContent: (label) => d.a(
-        classes: ['search-link'],
         href: toggledSearchForm.toSearchLink(),
         text: label,
+        attributes: {
+          if (tag != null) 'data-tag': isIndeterminate ? '-$tag' : tag,
+        },
       ),
       checked: isChecked,
       indeterminate: isIndeterminate,
@@ -208,12 +219,14 @@ d.Node _formLinkedCheckbox({
 }
 
 d.Node _filterSection({
+  String? sectionTag,
   required String label,
   required Iterable<d.Node> children,
   bool isActive = false,
 }) {
   return d.div(
     classes: ['search-form-section', 'foldable', if (isActive) '-active'],
+    attributes: {if (sectionTag != null) 'data-section-tag': sectionTag},
     children: [
       d.h3(
         classes: ['search-form-section-header foldable-button'],

--- a/app/test/frontend/golden/pkg_index_page_experimental.html
+++ b/app/test/frontend/golden/pkg_index_page_experimental.html
@@ -142,7 +142,7 @@
                     <div class="mdc-checkbox__ripple"></div>
                   </div>
                   <label for="search-form-checkbox-platform-android">
-                    <a class="search-link" href="/packages?q=sdk%3Adart+platform%3Aandroid&amp;unlisted=1">Android</a>
+                    <a href="/packages?q=sdk%3Adart+platform%3Aandroid&amp;unlisted=1" data-tag="platform:android">Android</a>
                   </label>
                 </div>
               </div>
@@ -159,7 +159,7 @@
                     <div class="mdc-checkbox__ripple"></div>
                   </div>
                   <label for="search-form-checkbox-platform-ios">
-                    <a class="search-link" href="/packages?q=sdk%3Adart+platform%3Aios&amp;unlisted=1">iOS</a>
+                    <a href="/packages?q=sdk%3Adart+platform%3Aios&amp;unlisted=1" data-tag="platform:ios">iOS</a>
                   </label>
                 </div>
               </div>
@@ -176,7 +176,7 @@
                     <div class="mdc-checkbox__ripple"></div>
                   </div>
                   <label for="search-form-checkbox-platform-linux">
-                    <a class="search-link" href="/packages?q=sdk%3Adart+platform%3Alinux&amp;unlisted=1">Linux</a>
+                    <a href="/packages?q=sdk%3Adart+platform%3Alinux&amp;unlisted=1" data-tag="platform:linux">Linux</a>
                   </label>
                 </div>
               </div>
@@ -193,7 +193,7 @@
                     <div class="mdc-checkbox__ripple"></div>
                   </div>
                   <label for="search-form-checkbox-platform-macos">
-                    <a class="search-link" href="/packages?q=sdk%3Adart+platform%3Amacos&amp;unlisted=1">macOS</a>
+                    <a href="/packages?q=sdk%3Adart+platform%3Amacos&amp;unlisted=1" data-tag="platform:macos">macOS</a>
                   </label>
                 </div>
               </div>
@@ -210,7 +210,7 @@
                     <div class="mdc-checkbox__ripple"></div>
                   </div>
                   <label for="search-form-checkbox-platform-web">
-                    <a class="search-link" href="/packages?q=sdk%3Adart+platform%3Aweb&amp;unlisted=1">Web</a>
+                    <a href="/packages?q=sdk%3Adart+platform%3Aweb&amp;unlisted=1" data-tag="platform:web">Web</a>
                   </label>
                 </div>
               </div>
@@ -227,13 +227,13 @@
                     <div class="mdc-checkbox__ripple"></div>
                   </div>
                   <label for="search-form-checkbox-platform-windows">
-                    <a class="search-link" href="/packages?q=sdk%3Adart+platform%3Awindows&amp;unlisted=1">Windows</a>
+                    <a href="/packages?q=sdk%3Adart+platform%3Awindows&amp;unlisted=1" data-tag="platform:windows">Windows</a>
                   </label>
                 </div>
               </div>
             </div>
           </div>
-          <div class="search-form-section foldable -active">
+          <div class="search-form-section foldable -active" data-section-tag="sdks">
             <h3 class="search-form-section-header foldable-button">
               <span class="search-form-section-header-label">SDKs</span>
               <img class="foldable-icon" src="/static/img/search-form-foldable-icon.svg?hash=mocked_hash_663371761"/>
@@ -252,7 +252,7 @@
                     <div class="mdc-checkbox__ripple"></div>
                   </div>
                   <label for="search-form-checkbox-sdk-dart">
-                    <a class="search-link" href="/packages?unlisted=1">Dart</a>
+                    <a href="/packages?unlisted=1" data-tag="sdk:dart">Dart</a>
                   </label>
                 </div>
               </div>
@@ -269,13 +269,13 @@
                     <div class="mdc-checkbox__ripple"></div>
                   </div>
                   <label for="search-form-checkbox-sdk-flutter">
-                    <a class="search-link" href="/packages?q=sdk%3Adart+sdk%3Aflutter&amp;unlisted=1">Flutter</a>
+                    <a href="/packages?q=sdk%3Adart+sdk%3Aflutter&amp;unlisted=1" data-tag="sdk:flutter">Flutter</a>
                   </label>
                 </div>
               </div>
             </div>
           </div>
-          <div class="search-form-section foldable -active">
+          <div class="search-form-section foldable -active" data-section-tag="advanced">
             <h3 class="search-form-section-header foldable-button">
               <span class="search-form-section-header-label">Advanced</span>
               <img class="foldable-icon" src="/static/img/search-form-foldable-icon.svg?hash=mocked_hash_663371761"/>
@@ -294,7 +294,7 @@
                     <div class="mdc-checkbox__ripple"></div>
                   </div>
                   <label for="search-form-checkbox-discontinued">
-                    <a class="search-link" href="/packages?q=sdk%3Adart&amp;discontinued=1&amp;unlisted=1">Include discontinued</a>
+                    <a href="/packages?q=sdk%3Adart&amp;discontinued=1&amp;unlisted=1">Include discontinued</a>
                   </label>
                 </div>
               </div>
@@ -311,7 +311,7 @@
                     <div class="mdc-checkbox__ripple"></div>
                   </div>
                   <label for="search-form-checkbox-unlisted">
-                    <a class="search-link" href="/packages?q=sdk%3Adart">Include unlisted</a>
+                    <a href="/packages?q=sdk%3Adart">Include unlisted</a>
                   </label>
                 </div>
               </div>
@@ -328,7 +328,7 @@
                     <div class="mdc-checkbox__ripple"></div>
                   </div>
                   <label for="search-form-checkbox-null-safe">
-                    <a class="search-link" href="/packages?q=sdk%3Adart&amp;unlisted=1&amp;null-safe=1">Supports null safety</a>
+                    <a href="/packages?q=sdk%3Adart&amp;unlisted=1&amp;null-safe=1">Supports null safety</a>
                   </label>
                 </div>
               </div>

--- a/pkg/web_app/lib/script.dart
+++ b/pkg/web_app/lib/script.dart
@@ -11,11 +11,18 @@ import 'src/hoverable.dart';
 import 'src/issues.dart';
 import 'src/likes.dart';
 import 'src/mobile_nav.dart';
+import 'src/page_updater.dart';
 import 'src/scroll.dart';
 import 'src/search.dart';
 
 void main() {
   window.onLoad.listen((_) => mdc.autoInit());
+  setupAccount();
+  _setupAllEvents();
+  setupPageUpdater(_setupAllEvents);
+}
+
+void _setupAllEvents() {
   setupSearch();
   setupScroll();
   setupFoldable();
@@ -23,7 +30,6 @@ void main() {
   setupMobileNav();
   setupIssues();
   updateDartdocStatus();
-  setupAccount();
   setupLikes();
   setupLikesList();
 }

--- a/pkg/web_app/lib/src/page_updater.dart
+++ b/pkg/web_app/lib/src/page_updater.dart
@@ -1,0 +1,78 @@
+// Copyright (c) 2021, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:html';
+
+import 'package:http/http.dart' as http;
+
+typedef PopStateFn = Function();
+
+PopStateFn? _popStateFn;
+
+/// Initialize the search history at the beginning of the app lifecycle
+/// with a callback function that should be run on state changes.
+void setupPageUpdater(PopStateFn popStateFn) {
+  if (_popStateFn != null) {
+    throw StateError('popState callback already initialized.');
+  }
+  _popStateFn = popStateFn;
+
+  // initialize history with the current state
+  window.history.replaceState(
+    {'html': document.documentElement?.outerHtml},
+    document.title,
+    window.location.href,
+  );
+
+  // handle back button updates
+  window.onPopState.listen((event) {
+    final state = event.state;
+    if (state is Map && state['html'] is String) {
+      _update(
+        state['html'] as String,
+        pushState: false,
+        url: null,
+      );
+    }
+  });
+}
+
+/// Parse input [html] and replace the current `<body>` element with its `<body>`.
+Document _update(
+  String html, {
+  required bool pushState,
+  required String? url,
+}) {
+  final doc = DomParser().parseFromString(html, 'text/html');
+  document.querySelector('body')!.replaceWith(doc.querySelector('body')!);
+  _popStateFn!();
+  if (pushState) {
+    final title = doc.querySelector('title')?.text;
+    window.history.pushState({'html': html}, title ?? '', url);
+  }
+  return doc;
+}
+
+/// Request new HTML content and update current page.
+Future<void> updateBodyWithHttpGet({
+  required Uri requestUri,
+  String? navigationUrl,
+  Duration timeout = const Duration(seconds: 4),
+}) async {
+  try {
+    final page = await http.get(requestUri).timeout(timeout);
+    if (page.statusCode == 200) {
+      _update(
+        page.body,
+        pushState: true,
+        url: navigationUrl ?? requestUri.toString(),
+      );
+      return;
+    }
+  } catch (e, st) {
+    window.console.error(['Page replace failed.', e, st]);
+  }
+  // fallback: reload the new URL
+  window.location.href = navigationUrl ?? requestUri.toString();
+}


### PR DESCRIPTION
- `open-sections` parameter to keep the opened sections open
- `data-tag` attribute to drive the update of the input text
- using history pop-state to handle back-button (works in most cases)
- split of `main` to have one-time initialization and also repeated initialization on updates
