### PR TITLE
Refresh tokens in post deployment tests

### DIFF
--- a/.gitallowed
+++ b/.gitallowed
@@ -1,1 +1,3 @@
 app/lib/shared/configuration.dart:.*\.apps\.googleusercontent.com
+app/lib/shared/configuration.dart:.*\.apps\.googleusercontent.com
+pkg/pub_integration/lib/src/pub_tool_client.dart:.*\.apps\.googleusercontent.com

--- a/pkg/pub_integration/lib/src/pub_tool_client.dart
+++ b/pkg/pub_integration/lib/src/pub_tool_client.dart
@@ -39,15 +39,17 @@ class DartToolClient {
     await Directory(tool._pubCacheDir).create(recursive: true);
 
     var creds = oauth2.Credentials.fromJson(credentialsFileContent);
-    final c = http.Client();
-    try {
-      creds = await creds.refresh(
-        identifier: _pubClientId,
-        secret: _pubClientSecret,
-        httpClient: c,
-      );
-    } finally {
-      c.close();
+    if ((creds.expiration ?? DateTime(0)).isBefore(DateTime.now())) {
+      final c = http.Client();
+      try {
+        creds = await creds.refresh(
+          identifier: _pubClientId,
+          secret: _pubClientSecret,
+          httpClient: c,
+        );
+      } finally {
+        c.close();
+      }
     }
 
     // If we set $XDG_CONFIG_HOME, $APPDATA and $HOME to _configHome, we only

--- a/pkg/pub_integration/lib/src/pub_tool_client.dart
+++ b/pkg/pub_integration/lib/src/pub_tool_client.dart
@@ -3,9 +3,17 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
+import 'package:http/http.dart' as http;
+import 'package:oauth2/oauth2.dart' as oauth2;
 
 import 'package:path/path.dart' as p;
+
+// OAuth clientId and clientSecret also hardcoded into the `pub` client.
+final _pubClientId =
+    '818368855108-8grd2eg9tj9f38os6f1urbcvsq399u8n.apps.googleusercontent.com';
+final _pubClientSecret = 'SWeqj8seoJW0w7_CpEPFLX0K';
 
 /// Wrapper for the `dart` command-line tool, with a focus on `dart pub`.
 class DartToolClient {
@@ -30,6 +38,18 @@ class DartToolClient {
     final tool = DartToolClient._(pubHostedUrl, tempDir.path);
     await Directory(tool._pubCacheDir).create(recursive: true);
 
+    var creds = oauth2.Credentials.fromJson(credentialsFileContent);
+    final c = http.Client();
+    try {
+      creds = await creds.refresh(
+        identifier: _pubClientId,
+        secret: _pubClientSecret,
+        httpClient: c,
+      );
+    } finally {
+      c.close();
+    }
+
     // If we set $XDG_CONFIG_HOME, $APPDATA and $HOME to _configHome, we only
     // need to write the config file to two locations to supported:
     //  - $XDG_CONFIG_HOME/dart/pub-credentials.json
@@ -39,10 +59,24 @@ class DartToolClient {
       p.join(tool._configHome, 'dart'),
       p.join(tool._configHome, 'Library', 'Application Support', 'dart'),
     ].map((folder) async {
-      final configFile = File(p.join(folder, 'pub-credentials.json'));
+      final credentialsFile = File(p.join(folder, 'pub-credentials.json'));
+      await credentialsFile.parent.create(recursive: true);
+      await credentialsFile.writeAsString(credentialsFileContent);
 
-      await configFile.parent.create(recursive: true);
-      await configFile.writeAsString(credentialsFileContent);
+      // if pubHostedUrl is NOT pub.dev or pub.dartlang.org, then the 'dart pub'
+      // client will refuse to use the oauth credentials from
+      // pub-credentials.json, so instead we use accessToken directly.
+      final tokensFile = File(p.join(folder, 'pub-tokens.json'));
+      await tokensFile.parent.create(recursive: true);
+      await tokensFile.writeAsString(json.encode({
+        'version': 1,
+        'hosted': [
+          {
+            'url': pubHostedUrl,
+            'token': creds.accessToken,
+          },
+        ],
+      }));
     }));
     // Also write to legacy location in $PUB_CACHE/credentials.json
     await File(p.join(tool._pubCacheDir, 'credentials.json')).writeAsString(

--- a/pkg/pub_integration/pubspec.lock
+++ b/pkg/pub_integration/pubspec.lock
@@ -190,6 +190,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.1"
+  oauth2:
+    dependency: "direct main"
+    description:
+      name: oauth2
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
   package_config:
     dependency: transitive
     description:

--- a/pkg/pub_integration/pubspec.yaml
+++ b/pkg/pub_integration/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   pub_validations:
     path: ../pub_validations
   puppeteer: 2.0.0
+  oauth2: ^2.0.0
 
 dev_dependencies:
   coverage: any # test already depends on it


### PR DESCRIPTION
Newer versions of `dart pub` client will refuse to use `credentials.json` when `PUB_HOSTED_URL` is specified... so we have to refresh the access_token manually and use `dart pub token add $PUB_HOSTED_URL`.