### PR TITLE
Use 'x-ago' as the default timestamp format + hover/click to short date.

### DIFF
--- a/app/lib/frontend/dom/dom.dart
+++ b/app/lib/frontend/dom/dom.dart
@@ -88,13 +88,16 @@ Node text(String value) => dom.text(value);
 /// Creates a DOM node with unsafe raw HTML content using the default [DomContext].
 Node unsafeRawHtml(String value) => dom.unsafeRawHtml(value);
 
-/// Creates a DOM node with the short, formatted [timestamp].
-Node shortTimestamp(DateTime timestamp) {
+/// Creates a DOM node with the short, formatted x-ago [timestamp].
+Node xAgoTimestamp(DateTime timestamp, {String? datePrefix}) {
+  final title = [
+    if (datePrefix != null) datePrefix,
+    shortDateFormat.format(timestamp),
+  ].join(' ');
   return span(
-    attributes: {
-      'title': formatXAgo(DateTime.now().difference(timestamp)),
-    },
-    text: shortDateFormat.format(timestamp),
+    classes: ['-x-ago'],
+    attributes: {'title': title},
+    text: formatXAgo(DateTime.now().difference(timestamp)),
   );
 }
 

--- a/app/lib/frontend/templates/admin.dart
+++ b/app/lib/frontend/templates/admin.dart
@@ -205,8 +205,8 @@ d.Node _accountDetailHeader(User user, UserSessionData userSessionData) {
     metadataNode: d.fragment([
       d.p(text: user.email!),
       d.p(children: [
-        d.text('Joined on '),
-        d.shortTimestamp(user.created!),
+        d.text('Joined '),
+        d.xAgoTimestamp(user.created!, datePrefix: 'on'),
       ]),
     ]),
   );

--- a/app/lib/frontend/templates/package_versions.dart
+++ b/app/lib/frontend/templates/package_versions.dart
@@ -56,8 +56,8 @@ String renderPkgVersionsPage(
       children: [
         d.text('The latest prerelease was '),
         d.a(href: '#prerelease', text: latestPrereleaseVersion!.version),
-        d.text(' on '),
-        d.shortTimestamp(latestPrereleaseVersion.published!),
+        d.text(' '),
+        d.xAgoTimestamp(latestPrereleaseVersion.published!, datePrefix: 'on'),
         d.text('.'),
       ],
     ));

--- a/app/lib/frontend/templates/views/account/activity_log_table.dart
+++ b/app/lib/frontend/templates/views/account/activity_log_table.dart
@@ -36,7 +36,7 @@ d.Node _activityLogTableNode(AuditLogRecordPage activities) {
     body: activities.records.map(
       (a) => d.tr(
         children: [
-          d.td(classes: ['date'], child: d.shortTimestamp(a.created!)),
+          d.td(classes: ['date'], child: d.xAgoTimestamp(a.created!)),
           d.td(
             classes: ['summary'],
             children: [

--- a/app/lib/frontend/templates/views/pkg/header.dart
+++ b/app/lib/frontend/templates/views/pkg/header.dart
@@ -17,7 +17,7 @@ d.Node packageHeaderNode({
 }) {
   return d.fragment([
     d.text('Published '),
-    d.span(child: d.shortTimestamp(published)),
+    d.span(child: d.xAgoTimestamp(published)),
     if (publisherId != null) ..._publisher(publisherId),
     if (isNullSafe) nullSafeBadgeNode(),
     if (releases != null) ..._releases(packageName, releases),

--- a/app/lib/frontend/templates/views/pkg/liked_package_list.dart
+++ b/app/lib/frontend/templates/views/pkg/liked_package_list.dart
@@ -50,8 +50,8 @@ d.Node likedPackageListNode(List<LikeData> likes) {
           d.p(
             classes: ['packages-metadata'],
             children: [
-              d.text(' Liked on: '),
-              d.shortTimestamp(like.created!),
+              d.text(' Liked '),
+              d.xAgoTimestamp(like.created!, datePrefix: 'on'),
             ],
           ),
         ],

--- a/app/lib/frontend/templates/views/pkg/package_list.dart
+++ b/app/lib/frontend/templates/views/pkg/package_list.dart
@@ -78,7 +78,7 @@ d.Node _packageItem(PackageView view) {
         ],
         d.text(' • Updated: '),
         d.span(
-          child: view.updated == null ? null : d.shortTimestamp(view.updated!),
+          child: view.updated == null ? null : d.xAgoTimestamp(view.updated!),
         ),
       ],
     ),

--- a/app/lib/frontend/templates/views/pkg/score_tab.dart
+++ b/app/lib/frontend/templates/views/pkg/score_tab.dart
@@ -68,9 +68,9 @@ d.Node scoreTabNode({
       d.p(
         classes: ['analysis-info'],
         children: [
-          d.text('We analyzed this package on '),
+          d.text('We analyzed this package '),
           if (card.panaReport?.timestamp != null)
-            d.shortTimestamp(card.panaReport!.timestamp!),
+            d.xAgoTimestamp(card.panaReport!.timestamp!, datePrefix: 'on'),
           d.text(', '
               'and awarded it ${report?.grantedPoints ?? 0} '
               'pub points (of a possible ${report?.maxPoints ?? 0}):'),

--- a/app/lib/frontend/templates/views/pkg/versions/version_row.dart
+++ b/app/lib/frontend/templates/views/pkg/versions/version_row.dart
@@ -40,7 +40,7 @@ d.Node versionRowNode(String package, VersionInfo version, Pubspec pubspec) {
       ),
       d.td(
         classes: ['uploaded'],
-        child: d.shortTimestamp(version.published!),
+        child: d.xAgoTimestamp(version.published!),
       ),
       d.td(
         classes: ['documentation'],

--- a/app/lib/frontend/templates/views/publisher/header_metadata.dart
+++ b/app/lib/frontend/templates/views/publisher/header_metadata.dart
@@ -32,8 +32,8 @@ d.Node publisherHeaderMetadataNode(Publisher publisher) {
     ]),
     d.p(
       children: [
-        d.text('Publisher registered on '),
-        d.shortTimestamp(publisher.created!),
+        d.text('Publisher registered '),
+        d.xAgoTimestamp(publisher.created!, datePrefix: 'on'),
       ],
     ),
   ]);

--- a/app/lib/frontend/templates/views/publisher/publisher_list.dart
+++ b/app/lib/frontend/templates/views/publisher/publisher_list.dart
@@ -27,8 +27,8 @@ d.Node publisherListNode({
                 ),
               ),
               d.p(children: [
-                d.text('Registered on '),
-                d.shortTimestamp(p.created),
+                d.text('Registered '),
+                d.xAgoTimestamp(p.created, datePrefix: 'on'),
                 d.text('.'),
               ]),
             ],

--- a/app/test/frontend/golden/analysis_tab_aborted.html
+++ b/app/test/frontend/golden/analysis_tab_aborted.html
@@ -23,8 +23,8 @@
     </div>
   </div>
   <p class="analysis-info">
-    We analyzed this package on
-    <span title="3 years ago">Dec 18, 2017</span>
+    We analyzed this package
+    <span class="-x-ago" title="on Dec 18, 2017">3 years ago</span>
     , and awarded it 0 pub points (of a possible 0):
   </p>
   <div class="pkg-report"></div>

--- a/app/test/frontend/golden/my_activity_log_page.html
+++ b/app/test/frontend/golden/my_activity_log_page.html
@@ -153,8 +153,8 @@
                 <div class="metadata">
                   <p>admin@pub.dev</p>
                   <p>
-                    Joined on
-                    <span title="%%x-ago%%">%%user-created-date%%</span>
+                    Joined
+                    <span class="-x-ago" title="on %%user-created-date%%">%%x-ago%%</span>
                   </p>
                 </div>
               </div>
@@ -193,7 +193,7 @@
                     <tbody>
                       <tr>
                         <td class="date">
-                          <span title="%%x-ago%%">%%user-created-date%%</span>
+                          <span class="-x-ago" title="%%user-created-date%%">%%x-ago%%</span>
                         </td>
                         <td class="summary">
                           <div class="markdown-body">
@@ -211,7 +211,7 @@
                       </tr>
                       <tr>
                         <td class="date">
-                          <span title="%%x-ago%%">%%user-created-date%%</span>
+                          <span class="-x-ago" title="%%user-created-date%%">%%x-ago%%</span>
                         </td>
                         <td class="summary">
                           <div class="markdown-body">
@@ -229,7 +229,7 @@
                       </tr>
                       <tr>
                         <td class="date">
-                          <span title="%%x-ago%%">%%user-created-date%%</span>
+                          <span class="-x-ago" title="%%user-created-date%%">%%x-ago%%</span>
                         </td>
                         <td class="summary">
                           <div class="markdown-body">
@@ -247,7 +247,7 @@
                       </tr>
                       <tr>
                         <td class="date">
-                          <span title="%%x-ago%%">%%user-created-date%%</span>
+                          <span class="-x-ago" title="%%user-created-date%%">%%x-ago%%</span>
                         </td>
                         <td class="summary">
                           <div class="markdown-body">
@@ -265,7 +265,7 @@
                       </tr>
                       <tr>
                         <td class="date">
-                          <span title="%%x-ago%%">%%user-created-date%%</span>
+                          <span class="-x-ago" title="%%user-created-date%%">%%x-ago%%</span>
                         </td>
                         <td class="summary">
                           <div class="markdown-body">
@@ -283,7 +283,7 @@
                       </tr>
                       <tr>
                         <td class="date">
-                          <span title="%%x-ago%%">%%user-created-date%%</span>
+                          <span class="-x-ago" title="%%user-created-date%%">%%x-ago%%</span>
                         </td>
                         <td class="summary">
                           <div class="markdown-body">
@@ -301,7 +301,7 @@
                       </tr>
                       <tr>
                         <td class="date">
-                          <span title="%%x-ago%%">%%user-created-date%%</span>
+                          <span class="-x-ago" title="%%user-created-date%%">%%x-ago%%</span>
                         </td>
                         <td class="summary">
                           <div class="markdown-body">
@@ -319,7 +319,7 @@
                       </tr>
                       <tr>
                         <td class="date">
-                          <span title="%%x-ago%%">%%user-created-date%%</span>
+                          <span class="-x-ago" title="%%user-created-date%%">%%x-ago%%</span>
                         </td>
                         <td class="summary">
                           <div class="markdown-body">

--- a/app/test/frontend/golden/my_liked_packages.html
+++ b/app/test/frontend/golden/my_liked_packages.html
@@ -153,8 +153,8 @@
                 <div class="metadata">
                   <p>user@pub.dev</p>
                   <p>
-                    Joined on
-                    <span title="%%x-ago%%">%%user-created-date%%</span>
+                    Joined
+                    <span class="-x-ago" title="on %%user-created-date%%">%%x-ago%%</span>
                   </p>
                 </div>
               </div>
@@ -198,8 +198,8 @@
                         </div>
                       </div>
                       <p class="packages-metadata">
-                        Liked on:
-                        <span title="%%x-ago%%">%%liked1-date%%</span>
+                        Liked
+                        <span class="-x-ago" title="on %%liked1-date%%">%%x-ago%%</span>
                       </p>
                     </div>
                     <div class="packages-item">
@@ -216,8 +216,8 @@
                         </div>
                       </div>
                       <p class="packages-metadata">
-                        Liked on:
-                        <span title="%%x-ago%%">%%liked1-date%%</span>
+                        Liked
+                        <span class="-x-ago" title="on %%liked1-date%%">%%x-ago%%</span>
                       </p>
                     </div>
                   </div>

--- a/app/test/frontend/golden/my_packages.html
+++ b/app/test/frontend/golden/my_packages.html
@@ -153,8 +153,8 @@
                 <div class="metadata">
                   <p>user@pub.dev</p>
                   <p>
-                    Joined on
-                    <span title="%%x-ago%%">%%oxygen-created-date%%</span>
+                    Joined
+                    <span class="-x-ago" title="on %%oxygen-created-date%%">%%x-ago%%</span>
                   </p>
                 </div>
               </div>
@@ -249,7 +249,7 @@
                           <a href="/packages/oxygen/versions/2.0.0-dev">2.0.0-dev</a>
                           • Updated:
                           <span>
-                            <span title="%%x-ago%%">%%oxygen-created-date%%</span>
+                            <span class="-x-ago" title="%%oxygen-created-date%%">%%x-ago%%</span>
                           </span>
                         </span>
                       </p>
@@ -302,7 +302,7 @@
                           <a href="/packages/neon">1.0.0</a>
                           • Updated:
                           <span>
-                            <span title="%%x-ago%%">%%oxygen-created-date%%</span>
+                            <span class="-x-ago" title="%%oxygen-created-date%%">%%x-ago%%</span>
                           </span>
                         </span>
                         <span class="packages-metadata-block">

--- a/app/test/frontend/golden/my_publishers.html
+++ b/app/test/frontend/golden/my_publishers.html
@@ -153,8 +153,8 @@
                 <div class="metadata">
                   <p>user@pub.dev</p>
                   <p>
-                    Joined on
-                    <span title="%%x-ago%%">%%user-created-date%%</span>
+                    Joined
+                    <span class="-x-ago" title="on %%user-created-date%%">%%x-ago%%</span>
                   </p>
                 </div>
               </div>
@@ -188,8 +188,8 @@
                         <a href="/publishers/example.com">example.com</a>
                       </h3>
                       <p>
-                        Registered on
-                        <span title="%%x-ago%%">%%publisher-created-date%%</span>
+                        Registered
+                        <span class="-x-ago" title="on %%publisher-created-date%%">%%x-ago%%</span>
                         .
                       </p>
                     </div>

--- a/app/test/frontend/golden/pkg_activity_log_page.html
+++ b/app/test/frontend/golden/pkg_activity_log_page.html
@@ -129,7 +129,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <span title="%%x-ago%%">%%published-date%%</span>
+                    <span class="-x-ago" title="%%published-date%%">%%x-ago%%</span>
                   </span>
                   • Latest:
                   <span>

--- a/app/test/frontend/golden/pkg_admin_page.html
+++ b/app/test/frontend/golden/pkg_admin_page.html
@@ -129,7 +129,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <span title="%%x-ago%%">%%published-date%%</span>
+                    <span class="-x-ago" title="%%published-date%%">%%x-ago%%</span>
                   </span>
                   • Latest:
                   <span>

--- a/app/test/frontend/golden/pkg_changelog_page.html
+++ b/app/test/frontend/golden/pkg_changelog_page.html
@@ -130,7 +130,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <span title="%%x-ago%%">%%published-date%%</span>
+                    <span class="-x-ago" title="%%published-date%%">%%x-ago%%</span>
                   </span>
                   • Latest:
                   <span>

--- a/app/test/frontend/golden/pkg_example_page.html
+++ b/app/test/frontend/golden/pkg_example_page.html
@@ -130,7 +130,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <span title="%%x-ago%%">%%published-date%%</span>
+                    <span class="-x-ago" title="%%published-date%%">%%x-ago%%</span>
                   </span>
                   • Latest:
                   <span>

--- a/app/test/frontend/golden/pkg_index_page.html
+++ b/app/test/frontend/golden/pkg_index_page.html
@@ -252,7 +252,7 @@
                 <a href="/packages/oxygen/versions/2.0.0-dev">2.0.0-dev</a>
                 • Updated:
                 <span>
-                  <span title="%%x-ago%%">%%oxygen-created-date%%</span>
+                  <span class="-x-ago" title="%%oxygen-created-date%%">%%x-ago%%</span>
                 </span>
               </span>
             </p>
@@ -305,7 +305,7 @@
                 <a href="/packages/flutter_titanium">1.10.0</a>
                 • Updated:
                 <span>
-                  <span title="%%x-ago%%">%%oxygen-created-date%%</span>
+                  <span class="-x-ago" title="%%oxygen-created-date%%">%%x-ago%%</span>
                 </span>
               </span>
             </p>

--- a/app/test/frontend/golden/pkg_index_page_experimental.html
+++ b/app/test/frontend/golden/pkg_index_page_experimental.html
@@ -415,7 +415,7 @@
                   <a href="/packages/oxygen/versions/2.0.0-dev">2.0.0-dev</a>
                   • Updated:
                   <span>
-                    <span title="%%x-ago%%">%%oxygen-created-date%%</span>
+                    <span class="-x-ago" title="%%oxygen-created-date%%">%%x-ago%%</span>
                   </span>
                 </span>
               </p>
@@ -476,7 +476,7 @@
                   <a href="/packages/flutter_titanium">1.10.0</a>
                   • Updated:
                   <span>
-                    <span title="%%x-ago%%">%%oxygen-created-date%%</span>
+                    <span class="-x-ago" title="%%oxygen-created-date%%">%%x-ago%%</span>
                   </span>
                 </span>
               </p>

--- a/app/test/frontend/golden/pkg_install_page.html
+++ b/app/test/frontend/golden/pkg_install_page.html
@@ -130,7 +130,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <span title="%%x-ago%%">%%published-date%%</span>
+                    <span class="-x-ago" title="%%published-date%%">%%x-ago%%</span>
                   </span>
                   • Latest:
                   <span>

--- a/app/test/frontend/golden/pkg_score_page.html
+++ b/app/test/frontend/golden/pkg_score_page.html
@@ -130,7 +130,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <span title="%%x-ago%%">%%published-date%%</span>
+                    <span class="-x-ago" title="%%published-date%%">%%x-ago%%</span>
                   </span>
                   • Latest:
                   <span>
@@ -227,8 +227,8 @@
                     </div>
                   </div>
                   <p class="analysis-info">
-                    We analyzed this package on
-                    <span title="%%x-ago%%">%%published-date%%</span>
+                    We analyzed this package
+                    <span class="-x-ago" title="on %%published-date%%">%%x-ago%%</span>
                     , and awarded it 43 pub points (of a possible 70):
                   </p>
                   <div class="pkg-report">

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -130,7 +130,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <span title="%%x-ago%%">%%published-date%%</span>
+                    <span class="-x-ago" title="%%published-date%%">%%x-ago%%</span>
                   </span>
                   • Latest:
                   <span>

--- a/app/test/frontend/golden/pkg_show_page_discontinued.html
+++ b/app/test/frontend/golden/pkg_show_page_discontinued.html
@@ -130,7 +130,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <span title="%%x-ago%%">%%published-date%%</span>
+                    <span class="-x-ago" title="%%published-date%%">%%x-ago%%</span>
                   </span>
                 </div>
                 <div class="detail-tags-and-like">

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -130,7 +130,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <span title="%%x-ago%%">%%published-date%%</span>
+                    <span class="-x-ago" title="%%published-date%%">%%x-ago%%</span>
                   </span>
                 </div>
                 <div class="detail-tags-and-like">

--- a/app/test/frontend/golden/pkg_show_page_legacy.html
+++ b/app/test/frontend/golden/pkg_show_page_legacy.html
@@ -130,7 +130,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <span title="%%x-ago%%">%%published-date%%</span>
+                    <span class="-x-ago" title="%%published-date%%">%%x-ago%%</span>
                   </span>
                 </div>
                 <div class="detail-tags-and-like">

--- a/app/test/frontend/golden/pkg_show_page_publisher.html
+++ b/app/test/frontend/golden/pkg_show_page_publisher.html
@@ -130,7 +130,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <span title="%%x-ago%%">%%published-date%%</span>
+                    <span class="-x-ago" title="%%published-date%%">%%x-ago%%</span>
                   </span>
                   •
                   <a class="-pub-publisher" href="/publishers/example.com">

--- a/app/test/frontend/golden/pkg_show_page_retracted.html
+++ b/app/test/frontend/golden/pkg_show_page_retracted.html
@@ -130,7 +130,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <span title="%%x-ago%%">%%published-date%%</span>
+                    <span class="-x-ago" title="%%published-date%%">%%x-ago%%</span>
                   </span>
                   • Latest:
                   <span>

--- a/app/test/frontend/golden/pkg_show_page_retracted_non_retracted_version.html
+++ b/app/test/frontend/golden/pkg_show_page_retracted_non_retracted_version.html
@@ -130,7 +130,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <span title="%%x-ago%%">%%published-date%%</span>
+                    <span class="-x-ago" title="%%published-date%%">%%x-ago%%</span>
                   </span>
                 </div>
                 <div class="detail-tags-and-like">

--- a/app/test/frontend/golden/pkg_show_version_page.html
+++ b/app/test/frontend/golden/pkg_show_version_page.html
@@ -130,7 +130,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <span title="%%x-ago%%">%%published-date%%</span>
+                    <span class="-x-ago" title="%%published-date%%">%%x-ago%%</span>
                   </span>
                   • Latest:
                   <span>

--- a/app/test/frontend/golden/pkg_versions_page.html
+++ b/app/test/frontend/golden/pkg_versions_page.html
@@ -130,7 +130,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <span title="%%x-ago%%">%%version-created-date%%</span>
+                    <span class="-x-ago" title="%%version-created-date%%">%%x-ago%%</span>
                   </span>
                   • Latest:
                   <span>
@@ -206,8 +206,7 @@
                   <p>
                     The latest prerelease was
                     <a href="#prerelease">2.0.0-dev</a>
-                    on
-                    <span title="%%x-ago%%">%%version-created-date%%</span>
+                    <span class="-x-ago" title="on %%version-created-date%%">%%x-ago%%</span>
                     .
                   </p>
                   <h2 id="stable">Stable versions of oxygen</h2>
@@ -238,7 +237,7 @@
                         <td class="badge"></td>
                         <td class="sdk">2.6</td>
                         <td class="uploaded">
-                          <span title="%%x-ago%%">%%version-created-date%%</span>
+                          <span class="-x-ago" title="%%version-created-date%%">%%x-ago%%</span>
                         </td>
                         <td class="documentation">
                           <a href="/documentation/oxygen/1.2.0/" rel="nofollow" title="Go to the documentation of oxygen 1.2.0">
@@ -258,7 +257,7 @@
                         <td class="badge"></td>
                         <td class="sdk">2.6</td>
                         <td class="uploaded">
-                          <span title="%%x-ago%%">%%version-created-date%%</span>
+                          <span class="-x-ago" title="%%version-created-date%%">%%x-ago%%</span>
                         </td>
                         <td class="documentation">
                           <a href="/documentation/oxygen/1.0.0/" rel="nofollow" title="Go to the documentation of oxygen 1.0.0">
@@ -301,7 +300,7 @@
                         <td class="badge"></td>
                         <td class="sdk">2.6</td>
                         <td class="uploaded">
-                          <span title="%%x-ago%%">%%version-created-date%%</span>
+                          <span class="-x-ago" title="%%version-created-date%%">%%x-ago%%</span>
                         </td>
                         <td class="documentation">
                           <a href="/documentation/oxygen/2.0.0-dev/" rel="nofollow" title="Go to the documentation of oxygen 2.0.0-dev">

--- a/app/test/frontend/golden/publisher_activity_log_page.html
+++ b/app/test/frontend/golden/publisher_activity_log_page.html
@@ -136,8 +136,8 @@
                     </span>
                   </p>
                   <p>
-                    Publisher registered on
-                    <span title="%%x-ago%%">%%publisher-created-date%%</span>
+                    Publisher registered
+                    <span class="-x-ago" title="on %%publisher-created-date%%">%%x-ago%%</span>
                   </p>
                 </div>
               </div>
@@ -177,7 +177,7 @@
                     <tbody>
                       <tr>
                         <td class="date">
-                          <span title="%%x-ago%%">%%publisher-created-date%%</span>
+                          <span class="-x-ago" title="%%publisher-created-date%%">%%x-ago%%</span>
                         </td>
                         <td class="summary">
                           <div class="markdown-body">
@@ -195,7 +195,7 @@
                       </tr>
                       <tr>
                         <td class="date">
-                          <span title="%%x-ago%%">%%publisher-created-date%%</span>
+                          <span class="-x-ago" title="%%publisher-created-date%%">%%x-ago%%</span>
                         </td>
                         <td class="summary">
                           <div class="markdown-body">

--- a/app/test/frontend/golden/publisher_admin_page.html
+++ b/app/test/frontend/golden/publisher_admin_page.html
@@ -136,8 +136,8 @@
                     </span>
                   </p>
                   <p>
-                    Publisher registered on
-                    <span title="%%x-ago%%">%%publisher-created-date%%</span>
+                    Publisher registered
+                    <span class="-x-ago" title="on %%publisher-created-date%%">%%x-ago%%</span>
                   </p>
                 </div>
               </div>

--- a/app/test/frontend/golden/publisher_list_page.html
+++ b/app/test/frontend/golden/publisher_list_page.html
@@ -128,8 +128,8 @@
             <a href="/publishers/example.com">example.com</a>
           </h3>
           <p>
-            Registered on
-            <span title="2 years ago">Sep 13, 2019</span>
+            Registered
+            <span class="-x-ago" title="on Sep 13, 2019">2 years ago</span>
             .
           </p>
         </div>
@@ -138,8 +138,8 @@
             <a href="/publishers/other-domain.com">other-domain.com</a>
           </h3>
           <p>
-            Registered on
-            <span title="2 years ago">Sep 19, 2019</span>
+            Registered
+            <span class="-x-ago" title="on Sep 19, 2019">2 years ago</span>
             .
           </p>
         </div>

--- a/app/test/frontend/golden/publisher_packages_page.html
+++ b/app/test/frontend/golden/publisher_packages_page.html
@@ -136,8 +136,8 @@
                     </span>
                   </p>
                   <p>
-                    Publisher registered on
-                    <span title="%%x-ago%%">%%neon-created-date%%</span>
+                    Publisher registered
+                    <span class="-x-ago" title="on %%neon-created-date%%">%%x-ago%%</span>
                   </p>
                 </div>
               </div>
@@ -227,7 +227,7 @@
                           <a href="/packages/neon">1.0.0</a>
                           • Updated:
                           <span>
-                            <span title="%%x-ago%%">%%neon-created-date%%</span>
+                            <span class="-x-ago" title="%%neon-created-date%%">%%x-ago%%</span>
                           </span>
                         </span>
                         <span class="packages-metadata-block">
@@ -283,7 +283,7 @@
                           <a href="/packages/flutter_titanium">1.10.0</a>
                           • Updated:
                           <span>
-                            <span title="%%x-ago%%">%%neon-created-date%%</span>
+                            <span class="-x-ago" title="%%neon-created-date%%">%%x-ago%%</span>
                           </span>
                         </span>
                       </p>

--- a/app/test/frontend/golden/search_page.html
+++ b/app/test/frontend/golden/search_page.html
@@ -239,7 +239,7 @@
                 <a href="/packages/oxygen/versions/2.0.0-dev">2.0.0-dev</a>
                 • Updated:
                 <span>
-                  <span title="%%x-ago%%">%%oxygen-created-date%%</span>
+                  <span class="-x-ago" title="%%oxygen-created-date%%">%%x-ago%%</span>
                 </span>
               </span>
             </p>
@@ -303,7 +303,7 @@
                 <a href="/packages/flutter_titanium">1.10.0</a>
                 • Updated:
                 <span>
-                  <span title="%%x-ago%%">%%oxygen-created-date%%</span>
+                  <span class="-x-ago" title="%%oxygen-created-date%%">%%x-ago%%</span>
                 </span>
               </span>
             </p>

--- a/pkg/web_app/lib/src/hoverable.dart
+++ b/pkg/web_app/lib/src/hoverable.dart
@@ -8,6 +8,7 @@ void setupHoverable() {
   _setEventForHoverable();
   _setEventForPackageTitleCopyToClipboard();
   _setEventForPreCodeCopyToClipboard();
+  _setEventForXAgo();
 }
 
 Element? _activeHover;
@@ -111,6 +112,16 @@ void _setEventForPreCodeCopyToClipboard() {
       final text = pre.dataset['textToCopy']?.trim() ?? pre.text!.trim();
       _copyToClipboard(text);
       await _animateCopyFeedback(feedback);
+    });
+  });
+}
+
+void _setEventForXAgo() {
+  document.querySelectorAll('span.-x-ago').forEach((e) {
+    e.onClick.listen((_) {
+      final text = e.text;
+      e.text = e.getAttribute('title');
+      e.setAttribute('title', text!);
     });
   });
 }

--- a/pkg/web_css/lib/src/_base.scss
+++ b/pkg/web_css/lib/src/_base.scss
@@ -387,3 +387,11 @@ pre {
 
   text-align: center;
 }
+
+span.-x-ago {
+  cursor: pointer;
+
+  &:hover {
+    text-decoration: underline dotted #ccc;
+  }
+}


### PR DESCRIPTION
- Fixes #4381.
- optional `[prefix] <short-format>` for the short date timestamp when the text flow requires it
- display a dotted underline and a pointer mouse icon on hovering, clicking will switch the title with the text
