### PR TITLE
Update version + timestamps on listing pages.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Important changes to data-models, configuration and migrations between each
 AppEngine version, listed here to ease deployment and troubleshooting.
 
 ## Next Release (replace with git tag when deployed)
+ * Bumped runtimeVersion to `2021.12.08`.
 
 ## `20211206t162600-all`
  * Renamed `retracted` field in API response object `VersionInfo`.

--- a/app/lib/frontend/templates/views/pkg/package_list.dart
+++ b/app/lib/frontend/templates/views/pkg/package_list.dart
@@ -56,30 +56,39 @@ d.Node _packageItem(PackageView view) {
   final isFlutterFavorite = view.tags.contains(PackageTags.isFlutterFavorite);
   final isNullSafe = view.tags.contains(PackageVersionTags.isNullSafe);
 
+  Iterable<d.Node> versionAndTimestamp(
+    Release release, {
+    bool isLatest = false,
+  }) {
+    return [
+      d.a(
+        href: urls.pkgPageUrl(
+          view.name!,
+          version: isLatest ? null : release.version,
+        ),
+        text: release.version,
+      ),
+      d.text(' ('),
+      d.xAgoTimestamp(release.published),
+      d.text(')'),
+    ];
+  }
+
+  final releases = view.releases!;
   final metadataNode = d.fragment([
     d.span(
       classes: ['packages-metadata-block'],
       children: [
         d.text('v '),
-        d.a(href: urls.pkgPageUrl(view.name!), text: view.version),
-        if (view.previewVersion != null) ...[
+        ...versionAndTimestamp(releases.stable, isLatest: true),
+        if (releases.showPreview) ...[
           d.text(' / '),
-          d.a(
-            href: urls.pkgPageUrl(view.name!, version: view.previewVersion),
-            text: view.previewVersion,
-          ),
+          ...versionAndTimestamp(releases.preview!),
         ],
-        if (view.prereleaseVersion != null) ...[
-          d.text('/ '),
-          d.a(
-            href: urls.pkgPageUrl(view.name!, version: view.prereleaseVersion),
-            text: view.prereleaseVersion,
-          ),
+        if (releases.showPrerelease) ...[
+          d.text(' / '),
+          ...versionAndTimestamp(releases.prerelease!),
         ],
-        d.text(' • Updated: '),
-        d.span(
-          child: view.updated == null ? null : d.xAgoTimestamp(view.updated!),
-        ),
       ],
     ),
     if (view.publisherId != null)

--- a/app/lib/package/models.dart
+++ b/app/lib/package/models.dart
@@ -699,17 +699,11 @@ class QualifiedVersionKey {
 @JsonSerializable(includeIfNull: false)
 class PackageView extends Object with FlagMixin {
   final String? name;
-  final String? version;
-
-  // Not null only if there is a difference compared to the [version] or [previewVersion].
-  final String? prereleaseVersion;
-  // Not null only if there is a difference compared to the [version].
-  final String? previewVersion;
+  final LatestReleases? releases;
   final String? ellipsizedDescription;
 
   /// The date when the package was first published.
   final DateTime? created;
-  final DateTime? updated;
   @override
   final List<String>? flags;
   final String? publisherId;
@@ -734,12 +728,9 @@ class PackageView extends Object with FlagMixin {
 
   PackageView({
     this.name,
-    this.version,
-    this.prereleaseVersion,
-    this.previewVersion,
+    this.releases,
     this.ellipsizedDescription,
     this.created,
-    this.updated,
     this.flags,
     this.publisherId,
     this.isAwaiting = false,
@@ -756,14 +747,11 @@ class PackageView extends Object with FlagMixin {
 
   factory PackageView.fromModel({
     required Package package,
+    required LatestReleases releases,
     PackageVersion? version,
     ScoreCardData? scoreCard,
     List<ApiPageRef>? apiPages,
   }) {
-    final prereleaseVersion =
-        package.showPrereleaseVersion ? package.latestPrereleaseVersion : null;
-    final previewVersion =
-        package.showPreviewVersion ? package.latestPreviewVersion : null;
     final hasPanaReport = scoreCard?.reportTypes != null &&
         scoreCard!.reportTypes!.contains(ReportType.pana);
     final isAwaiting =
@@ -776,12 +764,9 @@ class PackageView extends Object with FlagMixin {
             (!scoreCard.isSkipped && !hasPanaReport);
     return PackageView(
       name: version?.package ?? package.name,
-      version: version?.version ?? package.latestVersion,
-      prereleaseVersion: prereleaseVersion,
-      previewVersion: previewVersion,
+      releases: releases,
       ellipsizedDescription: version?.ellipsizedDescription,
       created: package.created,
-      updated: package.lastVersionPublished,
       flags: scoreCard?.flags,
       publisherId: package.publisherId,
       isAwaiting: isAwaiting,
@@ -803,12 +788,9 @@ class PackageView extends Object with FlagMixin {
   PackageView change({List<ApiPageRef>? apiPages}) {
     return PackageView(
       name: name,
-      version: version,
-      prereleaseVersion: prereleaseVersion,
-      previewVersion: previewVersion,
+      releases: releases,
       ellipsizedDescription: ellipsizedDescription,
       created: created,
-      updated: updated,
       flags: flags,
       publisherId: publisherId,
       isAwaiting: isAwaiting,
@@ -933,6 +915,7 @@ class PackagePageData {
   PackageView toPackageView() {
     return _view ??= PackageView.fromModel(
       package: package!,
+      releases: latestReleases!,
       version: version,
       scoreCard: scoreCard,
     );

--- a/app/lib/package/models.g.dart
+++ b/app/lib/package/models.g.dart
@@ -36,16 +36,13 @@ Map<String, dynamic> _$ReleaseToJson(Release instance) => <String, dynamic>{
 
 PackageView _$PackageViewFromJson(Map<String, dynamic> json) => PackageView(
       name: json['name'] as String?,
-      version: json['version'] as String?,
-      prereleaseVersion: json['prereleaseVersion'] as String?,
-      previewVersion: json['previewVersion'] as String?,
+      releases: json['releases'] == null
+          ? null
+          : LatestReleases.fromJson(json['releases'] as Map<String, dynamic>),
       ellipsizedDescription: json['ellipsizedDescription'] as String?,
       created: json['created'] == null
           ? null
           : DateTime.parse(json['created'] as String),
-      updated: json['updated'] == null
-          ? null
-          : DateTime.parse(json['updated'] as String),
       flags:
           (json['flags'] as List<dynamic>?)?.map((e) => e as String).toList(),
       publisherId: json['publisherId'] as String?,
@@ -70,12 +67,9 @@ Map<String, dynamic> _$PackageViewToJson(PackageView instance) {
   }
 
   writeNotNull('name', instance.name);
-  writeNotNull('version', instance.version);
-  writeNotNull('prereleaseVersion', instance.prereleaseVersion);
-  writeNotNull('previewVersion', instance.previewVersion);
+  writeNotNull('releases', instance.releases);
   writeNotNull('ellipsizedDescription', instance.ellipsizedDescription);
   writeNotNull('created', instance.created?.toIso8601String());
-  writeNotNull('updated', instance.updated?.toIso8601String());
   writeNotNull('flags', instance.flags);
   writeNotNull('publisherId', instance.publisherId);
   writeNotNull('isAwaiting', instance.isAwaiting);

--- a/app/lib/scorecard/backend.dart
+++ b/app/lib/scorecard/backend.dart
@@ -79,7 +79,12 @@ class ScoreCardBackend {
 
       final pv = await pvFuture;
       final card = await cardFuture;
-      return PackageView.fromModel(package: p, version: pv, scoreCard: card);
+      return PackageView.fromModel(
+        package: p,
+        releases: releases,
+        version: pv,
+        scoreCard: card,
+      );
     });
   }
 

--- a/app/lib/shared/versions.dart
+++ b/app/lib/shared/versions.dart
@@ -21,9 +21,9 @@ final RegExp runtimeVersionPattern = RegExp(r'^\d{4}\.\d{2}\.\d{2}$');
 /// Make sure that at least two versions are kept here as the next candidates
 /// when the version switch happens.
 const acceptedRuntimeVersions = <String>[
-  '2021.12.06', // The current [runtimeVersion].
+  '2021.12.08', // The current [runtimeVersion].
+  '2021.12.06',
   '2021.11.28',
-  '2021.11.22',
 ];
 
 /// Represents a combined version of the overall toolchain and processing,

--- a/app/test/frontend/golden/my_packages.html
+++ b/app/test/frontend/golden/my_packages.html
@@ -245,12 +245,13 @@
                         <span class="packages-metadata-block">
                           v
                           <a href="/packages/oxygen">1.2.0</a>
-                          /
+                          (
+                          <span class="-x-ago" title="%%oxygen-created-date%%">%%x-ago%%</span>
+                          ) /
                           <a href="/packages/oxygen/versions/2.0.0-dev">2.0.0-dev</a>
-                          • Updated:
-                          <span>
-                            <span class="-x-ago" title="%%oxygen-created-date%%">%%x-ago%%</span>
-                          </span>
+                          (
+                          <span class="-x-ago" title="%%oxygen-created-date%%">%%x-ago%%</span>
+                          )
                         </span>
                       </p>
                       <div>
@@ -300,10 +301,9 @@
                         <span class="packages-metadata-block">
                           v
                           <a href="/packages/neon">1.0.0</a>
-                          • Updated:
-                          <span>
-                            <span class="-x-ago" title="%%oxygen-created-date%%">%%x-ago%%</span>
-                          </span>
+                          (
+                          <span class="-x-ago" title="%%oxygen-created-date%%">%%x-ago%%</span>
+                          )
                         </span>
                         <span class="packages-metadata-block">
                           <img class="package-vp-icon" src="/static/img/verified-publisher-icon.svg?hash=mocked_hash_1044149352" title="Published by a pub.dev verified publisher"/>

--- a/app/test/frontend/golden/pkg_index_page.html
+++ b/app/test/frontend/golden/pkg_index_page.html
@@ -248,12 +248,13 @@
               <span class="packages-metadata-block">
                 v
                 <a href="/packages/oxygen">1.2.0</a>
-                /
+                (
+                <span class="-x-ago" title="%%oxygen-created-date%%">%%x-ago%%</span>
+                ) /
                 <a href="/packages/oxygen/versions/2.0.0-dev">2.0.0-dev</a>
-                • Updated:
-                <span>
-                  <span class="-x-ago" title="%%oxygen-created-date%%">%%x-ago%%</span>
-                </span>
+                (
+                <span class="-x-ago" title="%%oxygen-created-date%%">%%x-ago%%</span>
+                )
               </span>
             </p>
             <div>
@@ -303,10 +304,9 @@
               <span class="packages-metadata-block">
                 v
                 <a href="/packages/flutter_titanium">1.10.0</a>
-                • Updated:
-                <span>
-                  <span class="-x-ago" title="%%oxygen-created-date%%">%%x-ago%%</span>
-                </span>
+                (
+                <span class="-x-ago" title="%%oxygen-created-date%%">%%x-ago%%</span>
+                )
               </span>
             </p>
             <div>

--- a/app/test/frontend/golden/pkg_index_page_experimental.html
+++ b/app/test/frontend/golden/pkg_index_page_experimental.html
@@ -411,12 +411,13 @@
                 <span class="packages-metadata-block">
                   v
                   <a href="/packages/oxygen">1.2.0</a>
-                  /
+                  (
+                  <span class="-x-ago" title="%%oxygen-created-date%%">%%x-ago%%</span>
+                  ) /
                   <a href="/packages/oxygen/versions/2.0.0-dev">2.0.0-dev</a>
-                  • Updated:
-                  <span>
-                    <span class="-x-ago" title="%%oxygen-created-date%%">%%x-ago%%</span>
-                  </span>
+                  (
+                  <span class="-x-ago" title="%%oxygen-created-date%%">%%x-ago%%</span>
+                  )
                 </span>
               </p>
               <div>
@@ -474,10 +475,9 @@
                 <span class="packages-metadata-block">
                   v
                   <a href="/packages/flutter_titanium">1.10.0</a>
-                  • Updated:
-                  <span>
-                    <span class="-x-ago" title="%%oxygen-created-date%%">%%x-ago%%</span>
-                  </span>
+                  (
+                  <span class="-x-ago" title="%%oxygen-created-date%%">%%x-ago%%</span>
+                  )
                 </span>
               </p>
               <div>

--- a/app/test/frontend/golden/publisher_packages_page.html
+++ b/app/test/frontend/golden/publisher_packages_page.html
@@ -225,10 +225,9 @@
                         <span class="packages-metadata-block">
                           v
                           <a href="/packages/neon">1.0.0</a>
-                          • Updated:
-                          <span>
-                            <span class="-x-ago" title="%%neon-created-date%%">%%x-ago%%</span>
-                          </span>
+                          (
+                          <span class="-x-ago" title="%%neon-created-date%%">%%x-ago%%</span>
+                          )
                         </span>
                         <span class="packages-metadata-block">
                           <img class="package-vp-icon" src="/static/img/verified-publisher-icon.svg?hash=mocked_hash_1044149352" title="Published by a pub.dev verified publisher"/>
@@ -281,10 +280,9 @@
                         <span class="packages-metadata-block">
                           v
                           <a href="/packages/flutter_titanium">1.10.0</a>
-                          • Updated:
-                          <span>
-                            <span class="-x-ago" title="%%neon-created-date%%">%%x-ago%%</span>
-                          </span>
+                          (
+                          <span class="-x-ago" title="%%neon-created-date%%">%%x-ago%%</span>
+                          )
                         </span>
                       </p>
                       <div>

--- a/app/test/frontend/golden/search_page.html
+++ b/app/test/frontend/golden/search_page.html
@@ -235,12 +235,13 @@
               <span class="packages-metadata-block">
                 v
                 <a href="/packages/oxygen">1.2.0</a>
-                /
+                (
+                <span class="-x-ago" title="%%oxygen-created-date%%">%%x-ago%%</span>
+                ) /
                 <a href="/packages/oxygen/versions/2.0.0-dev">2.0.0-dev</a>
-                • Updated:
-                <span>
-                  <span class="-x-ago" title="%%oxygen-created-date%%">%%x-ago%%</span>
-                </span>
+                (
+                <span class="-x-ago" title="%%oxygen-created-date%%">%%x-ago%%</span>
+                )
               </span>
             </p>
             <div>
@@ -301,10 +302,9 @@
               <span class="packages-metadata-block">
                 v
                 <a href="/packages/flutter_titanium">1.10.0</a>
-                • Updated:
-                <span>
-                  <span class="-x-ago" title="%%oxygen-created-date%%">%%x-ago%%</span>
-                </span>
+                (
+                <span class="-x-ago" title="%%oxygen-created-date%%">%%x-ago%%</span>
+                )
               </span>
             </p>
             <div>

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -456,9 +456,7 @@ void main() {
         );
         expectGoldenFile(html, 'pkg_index_page.html', timestamps: {
           'oxygen-created': oxygen.created,
-          'oxygen-updated': oxygen.updated,
           'titanium-created': titanium.created,
-          'titanium-updated': titanium.updated,
         });
       },
     );
@@ -498,9 +496,7 @@ void main() {
         );
         expectGoldenFile(html, 'pkg_index_page_experimental.html', timestamps: {
           'oxygen-created': oxygen.created,
-          'oxygen-updated': oxygen.updated,
           'titanium-created': titanium.created,
-          'titanium-updated': titanium.updated,
         });
       },
     );
@@ -532,9 +528,7 @@ void main() {
         );
         expectGoldenFile(html, 'search_page.html', timestamps: {
           'oxygen-created': oxygen.created,
-          'oxygen-updated': oxygen.updated,
           'titanium-created': titanium.created,
-          'titanium-updated': titanium.updated,
         });
       },
     );
@@ -594,9 +588,7 @@ void main() {
         );
         expectGoldenFile(html, 'publisher_packages_page.html', timestamps: {
           'neon-created': neon.created,
-          'neon-updated': neon.updated,
           'titanium-created': titanium.created,
-          'titanium-updated': titanium.updated,
           'publisher-created': publisher.created,
           'publisher-updated': publisher.updated,
         });
@@ -679,9 +671,7 @@ void main() {
           );
           expectGoldenFile(html, 'my_packages.html', timestamps: {
             'oxygen-created': oxygen.created,
-            'oxygen-updated': oxygen.updated,
             'neon-created': neon.created,
-            'neon-updated': neon.updated,
           });
         });
       },

--- a/app/test/package/models_test.dart
+++ b/app/test/package/models_test.dart
@@ -2,11 +2,16 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:convert';
+
 import 'package:pub_dev/package/model_properties.dart';
 import 'package:pub_dev/package/models.dart';
+import 'package:pub_dev/scorecard/backend.dart';
 import 'package:pub_dev/shared/datastore.dart';
 import 'package:pub_semver/pub_semver.dart';
 import 'package:test/test.dart';
+
+import '../shared/test_services.dart';
 
 void main() {
   group('models', () {
@@ -163,6 +168,15 @@ version: 1.0.9
       expect(msd.major, 2);
       expect(msd.minor, 12);
       expect(msd.channel, isNull);
+    });
+  });
+
+  group('PackageView', () {
+    testWithProfile('do not forget to update change method', fn: () async {
+      final view = await scoreCardBackend.getPackageView('oxygen');
+      final original = json.decode(json.encode(view!.toJson()));
+      final updated = json.decode(json.encode(view.change().toJson()));
+      expect(updated, original);
     });
   });
 }


### PR DESCRIPTION
- Fixes #5316
- Rendering logic migrated to use `LatestReleases` which should become the source of truth for such decisions.
- Added published timestamps alongside the versions, so that it is less confusing which version was published at the `Updated: ` label.

Screenshot from staging:

<img width="210" alt="image" src="https://user-images.githubusercontent.com/4778111/144619915-f4490a04-a899-4e99-a7e0-e34a2a8a84c3.png">
 