### PR TITLE
Use separators in redis cache prefixes.

### DIFF
--- a/app/lib/shared/redis_cache.dart
+++ b/app/lib/shared/redis_cache.dart
@@ -32,7 +32,7 @@ class CachePatterns {
   final Cache<List<int>> _cache;
   CachePatterns._(Cache<List<int>> cache)
       : _cache = cache
-            .withPrefix('rv-$runtimeVersion')
+            .withPrefix('rv-$runtimeVersion/')
             .withTTL(Duration(minutes: 10));
 
   // NOTE: This class should only contain methods that return Entry<T>, as well
@@ -40,7 +40,7 @@ class CachePatterns {
 
   /// Cache for [UserSessionData].
   Entry<UserSessionData> userSessionData(String sessionId) => _cache
-      .withPrefix('account-usersession')
+      .withPrefix('account-usersession/')
       .withTTL(Duration(hours: 24))
       .withCodec(utf8)
       .withCodec(json)
@@ -51,7 +51,7 @@ class CachePatterns {
 
   /// Cache for [DartdocEntry] objects.
   Entry<DartdocEntry> dartdocEntry(String package, String version) => _cache
-      .withPrefix('dartdoc-entry')
+      .withPrefix('dartdoc-entry/')
       .withTTL(Duration(hours: 24))
       .withCodec(wrapAsCodec(
         encode: (DartdocEntry entry) => entry.asBytes(),
@@ -60,7 +60,7 @@ class CachePatterns {
 
   /// Cache for [FileInfo] objects used by dartdoc.
   Entry<FileInfo> dartdocFileInfo(String objectName) => _cache
-      .withPrefix('dartdoc-fileinfo')
+      .withPrefix('dartdoc-fileinfo/')
       .withTTL(Duration(minutes: 60))
       .withCodec(wrapAsCodec(
         encode: (FileInfo info) => info.asBytes(),
@@ -69,7 +69,7 @@ class CachePatterns {
 
   /// Cache for API summaries used by dartdoc.
   Entry<Map<String, dynamic>> dartdocApiSummary(String package) => _cache
-      .withPrefix('dartdoc-apisummary')
+      .withPrefix('dartdoc-apisummary/')
       .withTTL(Duration(minutes: 60))
       .withCodec(utf8)
       .withCodec(json)
@@ -79,63 +79,63 @@ class CachePatterns {
       ))[package];
 
   Entry<String> uiPackagePage(String package, String? version) => _cache
-      .withPrefix('ui-packagepage')
+      .withPrefix('ui-packagepage/')
       .withTTL(Duration(minutes: 10))
       .withCodec(utf8)['$package-$version'];
 
   Entry<String> uiPackageChangelog(String package, String? version) => _cache
-      .withPrefix('ui-package-changelog')
+      .withPrefix('ui-package-changelog/')
       .withTTL(Duration(minutes: 10))
       .withCodec(utf8)['$package-$version'];
 
   Entry<String> uiPackageExample(String package, String? version) => _cache
-      .withPrefix('ui-package-example')
+      .withPrefix('ui-package-example/')
       .withTTL(Duration(minutes: 10))
       .withCodec(utf8)['$package-$version'];
 
   Entry<String> uiPackageInstall(String package, String? version) => _cache
-      .withPrefix('ui-package-install')
+      .withPrefix('ui-package-install/')
       .withTTL(Duration(minutes: 10))
       .withCodec(utf8)['$package-$version'];
 
   Entry<String> uiPackageLicense(String package, String? version) => _cache
-      .withPrefix('ui-package-license')
+      .withPrefix('ui-package-license/')
       .withTTL(Duration(minutes: 10))
       .withCodec(utf8)['$package-$version'];
 
   Entry<String> uiPackagePubspec(String package, String? version) => _cache
-      .withPrefix('ui-package-pubspec')
+      .withPrefix('ui-package-pubspec/')
       .withTTL(Duration(minutes: 10))
       .withCodec(utf8)['$package-$version'];
 
   Entry<String> uiPackageScore(String package, String? version) => _cache
-      .withPrefix('ui-package-score')
+      .withPrefix('ui-package-score/')
       .withTTL(Duration(minutes: 10))
       .withCodec(utf8)['$package-$version'];
 
   Entry<String> uiPackageVersions(String package) => _cache
-      .withPrefix('ui-package-versions')
+      .withPrefix('ui-package-versions/')
       .withTTL(Duration(minutes: 10))
       .withCodec(utf8)['$package'];
 
   Entry<String> uiIndexPage() => _cache
-      .withPrefix('ui-indexpage')
+      .withPrefix('ui-indexpage/')
       .withTTL(Duration(minutes: 60))
       .withCodec(utf8)['/'];
 
   Entry<String> uiPublisherListPage() => _cache
-      .withPrefix('ui-publisherpage')
+      .withPrefix('ui-publisherpage/')
       .withTTL(Duration(minutes: 60))
       .withCodec(utf8)['/publishers'];
 
   /// The first, non-search page for publisher's packages.
   Entry<String> uiPublisherPackagesPage(String publisherId) => _cache
-      .withPrefix('ui-publisherpage')
+      .withPrefix('ui-publisherpage/')
       .withTTL(Duration(minutes: 60))
       .withCodec(utf8)[publisherId];
 
   Entry<bool> packageVisible(String package) => _cache
-      .withPrefix('package-visible')
+      .withPrefix('package-visible/')
       .withTTL(Duration(days: 7))
       .withCodec(utf8)
       .withCodec(json)
@@ -145,15 +145,15 @@ class CachePatterns {
       ))[package];
 
   Entry<List<int>> packageData(String package) => _cache
-      .withPrefix('api-package-data-by-uri')
+      .withPrefix('api-package-data-by-uri/')
       .withTTL(Duration(minutes: 10))['$package'];
 
   Entry<List<int>> packageDataGz(String package) => _cache
-      .withPrefix('api-package-data-gz-by-uri')
+      .withPrefix('api-package-data-gz-by-uri/')
       .withTTL(Duration(minutes: 10))['$package'];
 
   Entry<VersionScore> versionScore(String package, String? version) => _cache
-      .withPrefix('api-version-score')
+      .withPrefix('api-version-score/')
       .withTTL(Duration(minutes: 60))
       .withCodec(utf8)
       .withCodec(json)
@@ -163,12 +163,12 @@ class CachePatterns {
       ))['$package-$version'];
 
   Entry<String> packageLatestVersion(String package) => _cache
-      .withPrefix('package-latest-version')
+      .withPrefix('package-latest-version/')
       .withTTL(Duration(minutes: 60))
       .withCodec(utf8)[package];
 
   Entry<PackageView> packageView(String package) => _cache
-      .withPrefix('package-view')
+      .withPrefix('package-view/')
       .withTTL(Duration(minutes: 60))
       .withCodec(utf8)
       .withCodec(json)
@@ -178,7 +178,7 @@ class CachePatterns {
       ))[package];
 
   Entry<Map<String, dynamic>> apiPackagesListPage(int page) => _cache
-      .withPrefix('api-packages-list')
+      .withPrefix('api-packages-list/')
       .withTTL(Duration(minutes: 10))
       .withCodec(utf8)
       .withCodec(json)
@@ -190,7 +190,7 @@ class CachePatterns {
   Entry<PackageSearchResult> packageSearchResult(String url, {Duration? ttl}) {
     ttl ??= const Duration(minutes: 1);
     return _cache
-        .withPrefix('search-result')
+        .withPrefix('search-result/')
         .withTTL(ttl)
         .withCodec(utf8)
         .withCodec(json)
@@ -202,7 +202,7 @@ class CachePatterns {
   }
 
   Entry<ScoreCardData> scoreCardData(String package, String version) => _cache
-      .withPrefix('scorecarddata')
+      .withPrefix('scorecarddata/')
       .withCodec(utf8)
       .withCodec(json)
       .withCodec(wrapAsCodec(
@@ -211,7 +211,7 @@ class CachePatterns {
       ))['$package-$version'];
 
   Entry<List<LikeData>> userPackageLikes(String userId) => _cache
-      .withPrefix('user-package-likes')
+      .withPrefix('user-package-likes/')
       .withTTL(Duration(minutes: 60))
       .withCodec(utf8)
       .withCodec(json)
@@ -224,23 +224,23 @@ class CachePatterns {
       ))[userId];
 
   Entry<String> secretValue(String secretId) => _cache
-      .withPrefix('secret-value')
+      .withPrefix('secret-value/')
       .withTTL(Duration(minutes: 60))
       .withCodec(utf8)[secretId];
 
   Entry<String> sitemap(String requestedUri) => _cache
-      .withPrefix('sitemap')
+      .withPrefix('sitemap/')
       .withTTL(Duration(hours: 12))
       .withCodec(utf8)[requestedUri];
 
   Entry<List<int>> packageNameCompletitionDataJsonGz() => _cache
-      .withPrefix('api-package-name-completition-data-json-gz')
+      .withPrefix('api-package-name-completition-data-json-gz/')
       .withTTL(Duration(hours: 8))['-'];
 
   Entry<PublisherPage> allPublishersPage() => publisherPage('-');
 
   Entry<PublisherPage> publisherPage(String userId) => _cache
-      .withPrefix('publisher-page')
+      .withPrefix('publisher-page/')
       .withTTL(Duration(hours: 4))
       .withCodec(utf8)
       .withCodec(json)
@@ -250,7 +250,7 @@ class CachePatterns {
       ))['$userId'];
 
   Entry<String> atomFeedXml() => _cache
-      .withPrefix('atom-feed-xml')
+      .withPrefix('atom-feed-xml/')
       .withTTL(Duration(minutes: 3))
       .withCodec(utf8)['/'];
 
@@ -260,7 +260,7 @@ class CachePatterns {
 
   /// Stores the flag that a [package]'s versions have been scanned for job entities.
   Entry<bool> jobHistoryPackageScanned(String service, String package) => _cache
-      .withPrefix('job-history-package-scanned')
+      .withPrefix('job-history-package-scanned/')
       .withTTL(Duration(days: 7))
       .withCodec(utf8)
       .withCodec(json)

--- a/app/test/shared/misc_source_files_test.dart
+++ b/app/test/shared/misc_source_files_test.dart
@@ -22,4 +22,14 @@ void main() {
       expect(main.contains('void '), isTrue);
     }
   });
+
+  test('redis: separators in prefixes', () {
+    final file = File('lib/shared/redis_cache.dart');
+    final lines = file.readAsLinesSync();
+    for (final line in lines) {
+      if (line.contains('withPrefix')) {
+        expect(line, contains("/')"));
+      }
+    }
+  });
 }


### PR DESCRIPTION
- Fixes #5327.
- Added a test to make sure we'll follow the same pattern in the future.