### PR TITLE
Opaque external search id.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ AppEngine version, listed here to ease deployment and troubleshooting.
 
 ## Next Release (replace with git tag when deployed)
  * Bumped runtimeVersion to `2021.12.08`.
+ * NOTE: Started to populate and backfill `User.externalSearchUserId`.
+         Started to use `User.externalSearchUserId` in search.
 
 ## `20211206t162600-all`
  * Renamed `retracted` field in API response object `VersionInfo`.

--- a/app/lib/account/backend.dart
+++ b/app/lib/account/backend.dart
@@ -155,14 +155,7 @@ class AccountBackend {
       throw Exception('More than one User exists for email: $email');
     }
     if (users.isNotEmpty) return users.single;
-    final user = User()
-      ..parentKey = _db.emptyKey
-      ..id = createUuid()
-      ..email = email
-      ..created = DateTime.now().toUtc()
-      ..isBlocked = false
-      ..isDeleted = false;
-
+    final user = User.init(emptyKey: _db.emptyKey, email: email);
     await _db.commit(inserts: [user]);
     return user;
   }
@@ -404,14 +397,11 @@ class AccountBackend {
       }
 
       // Create new user with oauth2 user_id mapping
-      final user = User()
-        ..parentKey = emptyKey
-        ..id = createUuid()
-        ..oauthUserId = auth.oauthUserId
-        ..email = auth.email
-        ..created = DateTime.now().toUtc()
-        ..isBlocked = false
-        ..isDeleted = false;
+      final user = User.init(
+        emptyKey: emptyKey,
+        email: auth.email,
+        oauthUserId: auth.oauthUserId,
+      );
 
       tx.insert(user);
       tx.insert(

--- a/app/lib/account/models.dart
+++ b/app/lib/account/models.dart
@@ -7,6 +7,7 @@ import 'package:ulid/ulid.dart';
 
 import '../frontend/static_files.dart';
 import '../shared/datastore.dart' as db;
+import '../shared/utils.dart' show createUuid;
 
 part 'models.g.dart';
 
@@ -51,6 +52,28 @@ class User extends db.ExpandoModel<String> {
   /// to perform any action.
   @db.BoolProperty(required: true)
   bool isBlocked = false;
+
+  /// The user's unique identifier stored in external systems, e.g. third-party
+  /// search index.
+  ///
+  /// The value is a random (v4) UUID identifier.
+  @db.StringProperty()
+  String? externalSearchUserId;
+
+  User();
+
+  User.init({
+    required db.Key emptyKey,
+    required this.email,
+    this.oauthUserId,
+  }) {
+    parentKey = emptyKey;
+    id = createUuid();
+    isBlocked = false;
+    isDeleted = false;
+    created = DateTime.now().toUtc();
+    externalSearchUserId = createUuid();
+  }
 }
 
 /// Maps Oauth user_id to User.id
@@ -119,6 +142,10 @@ class UserSession extends db.ExpandoModel<String> {
   @db.StringProperty(required: true)
   String? userId;
 
+  // TODO: set to true after external ID becomes filled
+  @db.StringProperty(required: false)
+  String? externalSearchUserId;
+
   @db.StringProperty(required: true)
   String? email;
 
@@ -155,6 +182,9 @@ class UserSessionData {
   /// The v4 (random) UUID String of the [User] that has this session.
   final String? userId;
 
+  /// The v4 (random) UUID String of the [User] used for external search identifier.
+  final String? externalSearchUserId;
+
   /// The email address of the [User].
   final String? email;
 
@@ -173,6 +203,7 @@ class UserSessionData {
   UserSessionData({
     required this.sessionId,
     this.userId,
+    this.externalSearchUserId,
     this.email,
     this.name,
     this.imageUrl,
@@ -184,6 +215,7 @@ class UserSessionData {
     return UserSessionData(
       sessionId: session.sessionId,
       userId: session.userId,
+      externalSearchUserId: session.externalSearchUserId,
       email: session.email,
       name: session.name,
       imageUrl: session.imageUrl,

--- a/app/lib/account/models.g.dart
+++ b/app/lib/account/models.g.dart
@@ -24,6 +24,7 @@ UserSessionData _$UserSessionDataFromJson(Map<String, dynamic> json) =>
     UserSessionData(
       sessionId: json['sessionId'] as String,
       userId: json['userId'] as String?,
+      externalSearchUserId: json['externalSearchUserId'] as String?,
       email: json['email'] as String?,
       name: json['name'] as String?,
       imageUrl: json['imageUrl'] as String?,
@@ -35,6 +36,7 @@ Map<String, dynamic> _$UserSessionDataToJson(UserSessionData instance) =>
     <String, dynamic>{
       'sessionId': instance.sessionId,
       'userId': instance.userId,
+      'externalSearchUserId': instance.externalSearchUserId,
       'email': instance.email,
       'name': instance.name,
       'imageUrl': instance.imageUrl,

--- a/app/lib/admin/backend.dart
+++ b/app/lib/admin/backend.dart
@@ -267,6 +267,7 @@ class AdminBackend {
       u
         ..oauthUserId = null
         ..created = null
+        ..externalSearchUserId = null
         ..isDeleted = true;
       tx.queueMutations(inserts: [u], deletes: deleteKeys);
     });

--- a/app/lib/frontend/handlers/account.dart
+++ b/app/lib/frontend/handlers/account.dart
@@ -224,7 +224,10 @@ Future<shelf.Response> accountPackagesPageHandler(shelf.Request request) async {
       await publisherBackend.listPublishersForUser(userSessionData!.userId!);
   final searchForm = SearchForm.parse(
     SearchContext.myPackages([
+      // TODO: remove internal userId after search has been migrated to use external ids
       userSessionData!.userId!,
+      if (userSessionData!.externalSearchUserId != null)
+        userSessionData!.externalSearchUserId!,
       ...page.publishers!.map((p) => p.publisherId),
     ]),
     request.requestedUri.queryParameters,

--- a/app/lib/search/backend.dart
+++ b/app/lib/search/backend.dart
@@ -167,7 +167,9 @@ class SearchBackend {
       uploaderUserIds: [
         // TODO: remove internal IDs after search is migrated to use external IDs
         ...?p.uploaders,
-        ...uploaderUsers.map((u) => u?.externalSearchUserId).whereType<String>(),
+        ...uploaderUsers
+            .map((u) => u?.externalSearchUserId)
+            .whereType<String>(),
       ],
       apiDocPages: apiDocPages,
       timestamp: DateTime.now().toUtc(),

--- a/app/lib/shared/integrity.dart
+++ b/app/lib/shared/integrity.dart
@@ -61,7 +61,7 @@ class IntegrityChecker {
   Stream<String> _checkUsers() async* {
     _logger.info('Scanning Users...');
     final gmailComEmails = <String>{};
-    await for (User user in _db.query<User>().run()) {
+    await for (final user in _db.query<User>().run()) {
       _userToOauth[user.userId] = user.oauthUserId;
       final email = user.email;
       if (email == null || email.isEmpty || !looksLikeEmail(email)) {
@@ -95,6 +95,8 @@ class IntegrityChecker {
         if (user.created != null) {
           yield 'User "${user.userId}" is deleted, but `created` time is still set.';
         }
+      } else {
+        // TODO: add check for externalSearchUserId after it is backfilled
       }
     }
   }

--- a/app/lib/tool/backfill/backfill_new_fields.dart
+++ b/app/lib/tool/backfill/backfill_new_fields.dart
@@ -4,6 +4,10 @@
 
 import 'package:logging/logging.dart';
 
+import '../../account/models.dart';
+import '../../shared/datastore.dart';
+import '../../shared/utils.dart';
+
 final _logger = Logger('backfill_new_fields');
 
 /// Backfills new fields that are introduced in a release.
@@ -12,5 +16,23 @@ final _logger = Logger('backfill_new_fields');
 /// CHANGELOG.md must be updated with the new fields, and the next
 /// release could remove the backfill from here.
 Future<void> backfillNewFields() async {
-  _logger.info('Nothing to backfill.');
+  await _backfillUserFields();
+}
+
+Future<void> _backfillUserFields() async {
+  _logger.info('Backfill User fields.');
+  await for (final user in dbService.query<User>().run()) {
+    if (!user.isDeleted && user.externalSearchUserId == null) {
+      await _backfillExternalUserId(user.key);
+    }
+  }
+}
+
+Future<void> _backfillExternalUserId(Key<String> key) async {
+  await withRetryTransaction(dbService, (tx) async {
+    final user = await tx.lookupValue<User>(key);
+    if (user.externalSearchUserId != null) return;
+    user.externalSearchUserId = createUuid();
+    tx.insert(user);
+  });
 }

--- a/app/lib/tool/neat_task/pub_dev_tasks.dart
+++ b/app/lib/tool/neat_task/pub_dev_tasks.dart
@@ -27,7 +27,7 @@ final _logger = Logger('pub_dev_tasks');
 /// Periodic task that are not tied to a specific service.
 void _setupGenericPeriodicTasks() {
   // Backfills the fields that are new to the current release.
-  _daily(
+  _weekly(
     name: 'backfill-new-fields',
     isRuntimeVersioned: true,
     task: backfillNewFields,


### PR DESCRIPTION
Decouples search index from `User.userId`, making it possible to be hosted on external services.
