### PR TITLE
Mandatory alt tag for images

### DIFF
--- a/app/lib/frontend/dom/dom.dart
+++ b/app/lib/frontend/dom/dom.dart
@@ -362,28 +362,39 @@ Node i({
   );
 }
 
+class Image {
+  final String src;
+  final String alt;
+  final int? width;
+  final int? height;
+
+  Image({
+    required this.src,
+    required this.alt,
+    this.width,
+    this.height,
+  });
+}
+
 /// Creates an `<img>` Element using the default [DomContext].
 Node img({
   String? id,
   Iterable<String>? classes,
   Map<String, String>? attributes,
   Iterable<Node>? children,
-  String? src,
+  required Image image,
   String? title,
-  String? alt,
-  int? width,
-  int? height,
 }) {
   return dom.element(
     'img',
     id: id,
     classes: classes,
     attributes: <String, String>{
-      if (src != null) 'src': src,
+      'src': image.src,
+      'alt': image.alt,
+      if (image.width != null) 'width': image.width.toString(),
+      if (image.height != null) 'height': image.height.toString(),
       if (title != null) 'title': title,
-      if (alt != null) 'alt': alt,
-      if (width != null) 'width': width.toString(),
-      if (height != null) 'height': height.toString(),
       if (attributes != null) ...attributes,
     },
     children: children,

--- a/app/lib/frontend/dom/material.dart
+++ b/app/lib/frontend/dom/material.dart
@@ -12,10 +12,10 @@ d.Node button({
   bool raised = false,
   bool unelevated = false,
   Map<String, String>? attributes,
-  String? iconUrl,
+  d.Image? icon,
   required String label,
 }) {
-  final isSimpleLabel = iconUrl == null && customTypeClass == null;
+  final isSimpleLabel = icon == null && customTypeClass == null;
   return d.element(
     'button',
     id: id,
@@ -34,13 +34,13 @@ d.Node button({
         ? [d.text(label)]
         : [
             d.div(classes: ['mdc-button__ripple']),
-            if (iconUrl != null)
+            if (icon != null)
               d.img(
                 classes: [
                   'mdc-button__icon',
                   if (customTypeClass != null) '$customTypeClass-img',
                 ],
-                src: iconUrl,
+                image: icon,
                 attributes: {'aria-hidden': 'true'},
               ),
             d.span(
@@ -73,10 +73,8 @@ d.Node iconButton({
   required String id,
   required bool isOn,
   Map<String, String>? attributes,
-  required int iconWidth,
-  required int iconHeight,
-  required String onIconUrl,
-  required String offIconUrl,
+  required d.Image onIcon,
+  required d.Image offIcon,
 }) {
   return d.element(
     'button',
@@ -89,19 +87,11 @@ d.Node iconButton({
     children: [
       d.img(
         classes: ['mdc-icon-button__icon'],
-        src: offIconUrl,
-        attributes: {
-          'width': '$iconWidth',
-          'height': '$iconHeight',
-        },
+        image: offIcon,
       ),
       d.img(
         classes: ['mdc-icon-button__icon', 'mdc-icon-button__icon--on'],
-        src: onIconUrl,
-        attributes: {
-          'width': '$iconWidth',
-          'height': '$iconHeight',
-        },
+        image: onIcon,
       ),
     ],
   );

--- a/app/lib/frontend/templates/admin.dart
+++ b/app/lib/frontend/templates/admin.dart
@@ -201,7 +201,10 @@ Tab _myActivityLogLink() => Tab.withLink(
 d.Node _accountDetailHeader(User user, UserSessionData userSessionData) {
   return renderDetailHeader(
     title: userSessionData.name,
-    imageUrl: userSessionData.imageUrlOfSize(200),
+    image: d.Image(
+      src: userSessionData.imageUrlOfSize(200),
+      alt: 'user profile picture',
+    ),
     metadataNode: d.fragment([
       d.p(text: user.email!),
       d.p(children: [

--- a/app/lib/frontend/templates/detail_page.dart
+++ b/app/lib/frontend/templates/detail_page.dart
@@ -15,7 +15,7 @@ final wideHeaderDetailPageClassName = '-wide-header-detail-page';
 d.Node renderDetailHeader({
   String? title,
   d.Node? titleNode,
-  String? imageUrl,
+  d.Image? image,
   int? packageLikes,
   bool? isLiked,
   bool isFlutterFavorite = false,
@@ -35,7 +35,7 @@ d.Node renderDetailHeader({
     titleNode: titleNode ?? d.text(title!),
     metadataNode: metadataNode,
     tagsNode: tagsNode,
-    imageUrl: imageUrl,
+    image: image,
     isLoose: isLoose,
     isLiked: isLiked == true,
     likeCount: packageLikes,

--- a/app/lib/frontend/templates/misc.dart
+++ b/app/lib/frontend/templates/misc.dart
@@ -32,6 +32,11 @@ final _helpScoringMarkdown = _readDocContent('help-scoring.md');
 final _helpSearchMarkdown = _readDocContent('help-search.md');
 final _helpPublishingMarkdown = _readDocContent('help-publishing.md');
 
+late final _sideImage = d.Image(
+  src: static_files.staticUrls.packagesSideImage,
+  alt: 'cover image decorating the page',
+);
+
 /// Renders the response where the real content is only provided for logged-in users.
 String renderUnauthenticatedPage() {
   return renderLayoutPage(
@@ -58,7 +63,7 @@ String renderHelpApiPage() {
     PageType.standalone,
     standalonePageNode(
       _apiMarkdown,
-      sideImageUrl: static_files.staticUrls.packagesSideImage,
+      sideImage: _sideImage,
     ),
     title: 'pub.dev API',
     canonicalUrl: '/help/api',
@@ -71,7 +76,7 @@ String renderHelpPage() {
     PageType.standalone,
     standalonePageNode(
       _helpMarkdown,
-      sideImageUrl: static_files.staticUrls.packagesSideImage,
+      sideImage: _sideImage,
     ),
     title: 'Help | Dart packages',
     canonicalUrl: '/help',
@@ -84,7 +89,7 @@ String renderHelpScoringPage() {
     PageType.standalone,
     standalonePageNode(
       _helpScoringMarkdown,
-      sideImageUrl: static_files.staticUrls.packagesSideImage,
+      sideImage: _sideImage,
     ),
     title: 'Scoring | Dart packages',
     canonicalUrl: '/help/scoring',
@@ -97,7 +102,7 @@ String renderHelpSearchPage() {
     PageType.standalone,
     standalonePageNode(
       _helpSearchMarkdown,
-      sideImageUrl: static_files.staticUrls.packagesSideImage,
+      sideImage: _sideImage,
     ),
     title: 'Search | Dart packages',
     canonicalUrl: '/help/search',
@@ -110,7 +115,7 @@ String renderHelpPublishingPage() {
     PageType.standalone,
     standalonePageNode(
       _helpPublishingMarkdown,
-      sideImageUrl: static_files.staticUrls.packagesSideImage,
+      sideImage: _sideImage,
     ),
     title: 'Publishing | Dart packages',
     canonicalUrl: '/help/publishing',

--- a/app/lib/frontend/templates/package_misc.dart
+++ b/app/lib/frontend/templates/package_misc.dart
@@ -21,7 +21,12 @@ final coreLibraryBadgeNode = packageBadgeNode(label: 'Core library');
 /// Renders the Flutter Favorite badge, used by package listing.
 final flutterFavoriteBadgeNode = packageBadgeNode(
   label: 'Flutter Favorite',
-  iconUrl: staticUrls.flutterLogo32x32,
+  icon: d.Image(
+    src: staticUrls.flutterLogo32x32,
+    alt: 'Flutter logo',
+    width: 13,
+    height: 13,
+  ),
 );
 
 /// Renders the null-safe badge used by package listing and package page.

--- a/app/lib/frontend/templates/views/landing/mini_list.dart
+++ b/app/lib/frontend/templates/views/landing/mini_list.dart
@@ -52,8 +52,11 @@ d.Node _footer(String sectionTag, PackageView p) {
           children: [
             d.img(
               classes: ['publisher-badge'],
-              src: staticUrls
-                  .getAssetUrl('/static/img/verified-publisher-gray.svg'),
+              image: d.Image(
+                src: staticUrls
+                    .getAssetUrl('/static/img/verified-publisher-gray.svg'),
+                alt: 'verified publisher badge',
+              ),
               title: 'Published by a pub.dev verified publisher',
             ),
             d.a(

--- a/app/lib/frontend/templates/views/landing/page.dart
+++ b/app/lib/frontend/templates/views/landing/page.dart
@@ -32,7 +32,10 @@ d.Node landingPageNode({
     if (_isNotEmptyList(mostPopularPackages))
       _block(
         shortId: 'mp',
-        imageUrl: staticUrls.getAssetUrl('/static/img/landing-01.png'),
+        image: d.Image(
+          src: staticUrls.getAssetUrl('/static/img/landing-01.png'),
+          alt: 'decoration image for package section',
+        ),
         title: 'Most popular packages',
         info: d
             .text('Some of the most downloaded packages over the past 60 days'),
@@ -43,7 +46,10 @@ d.Node landingPageNode({
     if (_isNotEmptyList(topFlutterPackages))
       _block(
         shortId: 'tf',
-        imageUrl: staticUrls.getAssetUrl('/static/img/landing-02.png'),
+        image: d.Image(
+          src: staticUrls.getAssetUrl('/static/img/landing-02.png'),
+          alt: 'decoration image for package section',
+        ),
         imageGoesAfterContent: true,
         title: 'Top Flutter packages',
         info: d.text(
@@ -55,7 +61,10 @@ d.Node landingPageNode({
     if (_isNotEmptyList(topDartPackages))
       _block(
         shortId: 'td',
-        imageUrl: staticUrls.getAssetUrl('/static/img/landing-03.png'),
+        image: d.Image(
+          src: staticUrls.getAssetUrl('/static/img/landing-03.png'),
+          alt: 'decoration image for package section',
+        ),
         title: 'Top Dart packages',
         info: d
             .text('Some of the top packages for any Dart-based app or program'),
@@ -82,7 +91,7 @@ bool _isNotEmptyList(List? l) => l != null && l.isNotEmpty;
 
 d.Node _block({
   required String shortId,
-  String? imageUrl,
+  d.Image? image,
   bool imageGoesAfterContent = false,
   required String title,
   required d.Node info,
@@ -96,10 +105,10 @@ d.Node _block({
     classes: ['home-block', 'home-block-$shortId'],
     children: [
       // image: before content
-      if (imageUrl != null && !imageGoesAfterContent)
+      if (image != null && !imageGoesAfterContent)
         d.div(
           classes: ['home-block-image'],
-          child: d.img(src: imageUrl),
+          child: d.img(image: image),
         ),
       // content
       d.div(
@@ -122,10 +131,10 @@ d.Node _block({
         ],
       ),
       // image: after content
-      if (imageUrl != null && imageGoesAfterContent)
+      if (image != null && imageGoesAfterContent)
         d.div(
           classes: ['home-block-image'],
-          child: d.img(src: imageUrl),
+          child: d.img(image: image),
         ),
     ],
   );

--- a/app/lib/frontend/templates/views/landing/pow_video_list.dart
+++ b/app/lib/frontend/templates/views/landing/pow_video_list.dart
@@ -21,27 +21,35 @@ d.Node videoListNode(List<PkgOfWeekVideo> videos) {
           children: [
             d.img(
               classes: ['pow-video-thumbnail'],
-              src: v.thumbnailUrl,
-              alt: v.title,
-              width: 260,
-              height: 195,
+              image: d.Image(
+                src: v.thumbnailUrl,
+                alt: v.title,
+                width: 260,
+                height: 195,
+              ),
             ),
             d.div(
               classes: ['pow-video-overlay'],
               children: [
                 d.img(
                   classes: ['pow-video-overlay-img-active'],
-                  src: staticUrls
-                      .getAssetUrl('/static/img/youtube-play-red.png'),
-                  width: 76,
-                  height: 53,
+                  image: d.Image(
+                    src: staticUrls
+                        .getAssetUrl('/static/img/youtube-play-red.png'),
+                    alt: 'youtube video play icon - active',
+                    width: 76,
+                    height: 53,
+                  ),
                 ),
                 d.img(
                   classes: ['pow-video-overlay-img-inactive'],
-                  src: staticUrls
-                      .getAssetUrl('/static/img/youtube-play-black.png'),
-                  width: 76,
-                  height: 53,
+                  image: d.Image(
+                    src: staticUrls
+                        .getAssetUrl('/static/img/youtube-play-black.png'),
+                    alt: 'youtube video play icon - inactive',
+                    width: 76,
+                    height: 53,
+                  ),
                 ),
               ],
             ),

--- a/app/lib/frontend/templates/views/page/standalone.dart
+++ b/app/lib/frontend/templates/views/page/standalone.dart
@@ -6,20 +6,23 @@ import '../../../dom/dom.dart' as d;
 
 /// Renders the standalone page template with [content].
 ///
-/// [sideImageUrl] should already contain the `?hash` request parameter for caching.
+/// [sideImage] should already contain the `?hash` request parameter for caching.
 d.Node standalonePageNode(
   d.Node content, {
-  String? sideImageUrl,
+  d.Image? sideImage,
 }) {
-  assert(sideImageUrl == null || sideImageUrl.contains('?hash='));
-  final hasSideImage = sideImageUrl != null;
+  assert(sideImage == null || sideImage.src.contains('?hash='));
+  final hasSideImage = sideImage != null;
   return d.div(
     classes: ['standalone-wrapper', if (hasSideImage) '-has-side-image'],
     children: [
       if (hasSideImage)
         d.div(
           classes: ['standalone-side-image-block'],
-          child: d.img(classes: ['standalone-side-image'], src: sideImageUrl),
+          child: d.img(
+            classes: ['standalone-side-image'],
+            image: sideImage!,
+          ),
         ),
       d.div(classes: ['standalone-content'], child: content),
     ],

--- a/app/lib/frontend/templates/views/pkg/badge.dart
+++ b/app/lib/frontend/templates/views/pkg/badge.dart
@@ -7,18 +7,16 @@ import '../../../dom/dom.dart' as d;
 d.Node packageBadgeNode({
   required String label,
   String? title,
-  String? iconUrl,
+  d.Image? icon,
 }) {
   return d.span(
     classes: ['package-badge'],
     attributes: title != null ? <String, String>{'title': title} : null,
     children: [
-      if (iconUrl != null)
+      if (icon != null)
         d.img(
           classes: ['package-badge-icon'],
-          src: iconUrl,
-          width: 13,
-          height: 13,
+          image: icon,
         ),
       d.text(label),
     ],

--- a/app/lib/frontend/templates/views/pkg/header.dart
+++ b/app/lib/frontend/templates/views/pkg/header.dart
@@ -34,8 +34,11 @@ Iterable<d.Node> _publisher(String publisherId) {
         d.img(
           classes: ['-pub-publisher-shield'],
           title: 'Published by a pub.dev verified publisher',
-          src:
-              staticUrls.getAssetUrl('/static/img/verified-publisher-blue.svg'),
+          image: d.Image(
+            src: staticUrls
+                .getAssetUrl('/static/img/verified-publisher-blue.svg'),
+            alt: 'shield icon for verified publishers',
+          ),
         ),
         d.text(publisherId),
       ],

--- a/app/lib/frontend/templates/views/pkg/index.dart
+++ b/app/lib/frontend/templates/views/pkg/index.dart
@@ -234,8 +234,11 @@ d.Node _filterSection({
           d.span(classes: ['search-form-section-header-label'], text: label),
           d.img(
             classes: ['foldable-icon'],
-            src: staticUrls
-                .getAssetUrl('/static/img/search-form-foldable-icon.svg'),
+            image: d.Image(
+              src: staticUrls
+                  .getAssetUrl('/static/img/search-form-foldable-icon.svg'),
+              alt: 'fold toggle icon (up/down arrow)',
+            ),
           ),
         ],
       ),
@@ -284,7 +287,10 @@ d.Node _searchControls(SearchForm searchForm, d.Node? subSdkButtons) {
                 d.text('Advanced '),
                 d.img(
                   classes: ['search-controls-more-carot'],
-                  src: staticUrls.getAssetUrl('/static/img/carot-up.svg'),
+                  image: d.Image(
+                    src: staticUrls.getAssetUrl('/static/img/carot-up.svg'),
+                    alt: 'toggle button for advanced search (carot up)',
+                  ),
                 ),
               ],
             ),

--- a/app/lib/frontend/templates/views/pkg/info_box.dart
+++ b/app/lib/frontend/templates/views/pkg/info_box.dart
@@ -87,8 +87,11 @@ d.Node _publisher(String publisherId) {
         d.img(
           classes: ['-pub-publisher-shield'],
           title: 'Published by a pub.dev verified publisher',
-          src:
-              staticUrls.getAssetUrl('/static/img/verified-publisher-blue.svg'),
+          image: d.Image(
+            src: staticUrls
+                .getAssetUrl('/static/img/verified-publisher-blue.svg'),
+            alt: 'shield icon for verified publishers',
+          ),
         ),
         d.text(publisherId),
       ],

--- a/app/lib/frontend/templates/views/pkg/liked_package_list.dart
+++ b/app/lib/frontend/templates/views/pkg/liked_package_list.dart
@@ -41,7 +41,7 @@ d.Node likedPackageListNode(List<LikeData> likes) {
                     'data-thumb_up_outlined': thumbUpOutlinedUrl,
                     'data-thumb_up_filled': thumbUpFilledUrl,
                   },
-                  iconUrl: thumbUpFilledUrl,
+                  icon: d.Image(src: thumbUpFilledUrl, alt: 'thumb up icon'),
                   label: 'Unlike',
                 ),
               ),

--- a/app/lib/frontend/templates/views/pkg/package_list.dart
+++ b/app/lib/frontend/templates/views/pkg/package_list.dart
@@ -97,8 +97,11 @@ d.Node _packageItem(PackageView view) {
       ], children: [
         d.img(
           classes: ['package-vp-icon'],
-          src:
-              staticUrls.getAssetUrl('/static/img/verified-publisher-icon.svg'),
+          image: d.Image(
+            src: staticUrls
+                .getAssetUrl('/static/img/verified-publisher-icon.svg'),
+            alt: 'shield icon for verified publishers',
+          ),
           title: 'Published by a pub.dev verified publisher',
         ),
         d.a(href: urls.publisherUrl(view.publisherId!), text: view.publisherId),
@@ -157,7 +160,11 @@ d.Node _item({
               children: [
                 d.img(
                   classes: ['packages-recent-icon'],
-                  src: staticUrls.getAssetUrl('/static/img/schedule-icon.svg'),
+                  image: d.Image(
+                    src:
+                        staticUrls.getAssetUrl('/static/img/schedule-icon.svg'),
+                    alt: 'icon indicating recent time',
+                  ),
                   title: 'new package',
                 ),
                 d.text(' Added '),

--- a/app/lib/frontend/templates/views/pkg/score_tab.dart
+++ b/app/lib/frontend/templates/views/pkg/score_tab.dart
@@ -104,7 +104,10 @@ d.Node _section(ReportSection section) {
               classes: ['pkg-report-header-icon'],
               child: d.img(
                 classes: ['pkg-report-icon'],
-                src: _statusIconUrls[section.status],
+                image: d.Image(
+                  src: _statusIconUrls[section.status]!,
+                  alt: 'icon indicating section status',
+                ),
               ),
             ),
             d.div(classes: ['pkg-report-header-title'], text: section.title),
@@ -124,8 +127,11 @@ d.Node _section(ReportSection section) {
                     text: '${section.maxPoints}'),
                 d.img(
                   classes: ['foldable-icon'],
-                  src: staticUrls
-                      .getAssetUrl('/static/img/report-foldable-icon.svg'),
+                  image: d.Image(
+                    src: staticUrls
+                        .getAssetUrl('/static/img/report-foldable-icon.svg'),
+                    alt: 'icon to trigger folding of the section',
+                  ),
                 ),
               ],
             ),

--- a/app/lib/frontend/templates/views/pkg/title_content.dart
+++ b/app/lib/frontend/templates/views/pkg/title_content.dart
@@ -20,7 +20,10 @@ d.Node titleContentNode({
             'data-copy-content': '$package: ^$version',
             'data-ga-click-event': 'copy-package-version',
           },
-          src: staticUrls.getAssetUrl('/static/img/content-copy-icon.svg'),
+          image: d.Image(
+            src: staticUrls.getAssetUrl('/static/img/content-copy-icon.svg'),
+            alt: 'icon indicating copy to clipboard operation',
+          ),
           title: 'Copy "$package: ^$version" to clipboard',
         ),
         d.div(

--- a/app/lib/frontend/templates/views/pkg/versions/version_row.dart
+++ b/app/lib/frontend/templates/views/pkg/versions/version_row.dart
@@ -50,8 +50,10 @@ d.Node versionRowNode(String package, VersionInfo version, Pubspec pubspec) {
           title: 'Go to the documentation of $package ${version.version}',
           child: d.img(
             classes: ['version-table-icon'],
-            src: staticUrls.documentationIcon,
-            alt: 'Go to the documentation of $package ${version.version}',
+            image: d.Image(
+              src: staticUrls.documentationIcon,
+              alt: 'Go to the documentation of $package ${version.version}',
+            ),
             attributes: {
               'data-failed-icon': staticUrls.documentationFailedIcon,
             },
@@ -66,8 +68,10 @@ d.Node versionRowNode(String package, VersionInfo version, Pubspec pubspec) {
           title: 'Download $package ${version.version} archive',
           child: d.img(
             classes: ['version-table-icon'],
-            src: staticUrls.downloadIcon,
-            alt: 'Download $package ${version.version} archive',
+            image: d.Image(
+              src: staticUrls.downloadIcon,
+              alt: 'Download $package ${version.version} archive',
+            ),
           ),
         ),
       ),

--- a/app/lib/frontend/templates/views/publisher/header_metadata.dart
+++ b/app/lib/frontend/templates/views/publisher/header_metadata.dart
@@ -22,12 +22,14 @@ d.Node publisherHeaderMetadataNode(Publisher publisher) {
           href: websiteUri.toString(),
           rel: websiteRel,
           label: websiteDisplayable!,
+          iconAlt: 'icon indicating a website link',
         ),
       if (publisher.hasContactEmail)
         _ref(
           href: 'mailto:${publisher.contactEmail}',
           label: publisher.contactEmail!,
           iconPath: '/static/img/email-icon.svg',
+          iconAlt: 'icon indicating an email',
         ),
     ]),
     d.p(
@@ -44,13 +46,17 @@ d.Node _ref({
   String? rel,
   required String label,
   String? iconPath,
+  required String iconAlt,
 }) {
   return d.span(classes: [
     'detail-header-metadata-ref'
   ], children: [
     d.img(
       classes: ['detail-header-metadata-ref-icon'],
-      src: staticUrls.getAssetUrl(iconPath ?? '/static/img/link-icon.svg'),
+      image: d.Image(
+        src: staticUrls.getAssetUrl(iconPath ?? '/static/img/link-icon.svg'),
+        alt: iconAlt,
+      ),
     ),
     d.a(
       classes: ['detail-header-metadata-ref-label'],

--- a/app/lib/frontend/templates/views/shared/detail/header.dart
+++ b/app/lib/frontend/templates/views/shared/detail/header.dart
@@ -12,7 +12,7 @@ d.Node detailHeaderNode({
   required d.Node titleNode,
   required d.Node? metadataNode,
   required d.Node? tagsNode,
-  required String? imageUrl,
+  required d.Image? image,
   required bool isLiked,
   required int? likeCount,
   required bool isFlutterFavorite,
@@ -36,14 +36,20 @@ d.Node detailHeaderNode({
                 d.img(
                   classes: ['ff-banner', 'ff-banner-desktop'],
                   title: 'Package is a Flutter Favorite',
-                  src: staticUrls
-                      .getAssetUrl('/static/img/ff-banner-desktop-2x.png'),
+                  image: d.Image(
+                    src: staticUrls
+                        .getAssetUrl('/static/img/ff-banner-desktop-2x.png'),
+                    alt: 'large Flutter Favorite logo',
+                  ),
                 ),
                 d.img(
                   classes: ['ff-banner', 'ff-banner-mobile'],
                   title: 'Package is a Flutter Favorite',
-                  src: staticUrls
-                      .getAssetUrl('/static/img/ff-banner-mobile-2x.png'),
+                  image: d.Image(
+                    src: staticUrls
+                        .getAssetUrl('/static/img/ff-banner-mobile-2x.png'),
+                    alt: 'small Flutter Favorite logo',
+                  ),
                 ),
               ],
             ),
@@ -59,10 +65,13 @@ d.Node detailHeaderNode({
         child: d.div(
           classes: ['detail-header-outer-block'],
           children: [
-            if (imageUrl != null && imageUrl.isNotEmpty)
+            if (image != null)
               d.div(
                 classes: ['detail-header-image-block'],
-                child: d.img(classes: ['detail-header-image'], src: imageUrl),
+                child: d.img(
+                  classes: ['detail-header-image'],
+                  image: image,
+                ),
               ),
             d.div(
               classes: ['detail-header-content-block'],
@@ -82,12 +91,20 @@ d.Node detailHeaderNode({
                             material.iconButton(
                               id: '-pub-like-icon-button',
                               isOn: isLiked,
-                              iconWidth: 18,
-                              iconHeight: 18,
-                              onIconUrl: staticUrls
-                                  .getAssetUrl('/static/img/like-active.svg'),
-                              offIconUrl: staticUrls
-                                  .getAssetUrl('/static/img/like-inactive.svg'),
+                              onIcon: d.Image(
+                                src: staticUrls
+                                    .getAssetUrl('/static/img/like-active.svg'),
+                                alt: 'icon indicating liked status (active)',
+                                width: 18,
+                                height: 18,
+                              ),
+                              offIcon: d.Image(
+                                src: staticUrls.getAssetUrl(
+                                    '/static/img/like-inactive.svg'),
+                                alt: 'icon indicating liked status (inactive)',
+                                width: 18,
+                                height: 18,
+                              ),
                               attributes: {
                                 'aria-label': isLiked
                                     ? 'Unlike this package'

--- a/app/lib/frontend/templates/views/shared/layout.dart
+++ b/app/lib/frontend/templates/views/shared/layout.dart
@@ -181,11 +181,13 @@ d.Node pageLayoutNode({
                         ),
                         d.img(
                           classes: ['logo'],
-                          src: staticUrls
-                              .getAssetUrl('/static/img/pub-dev-logo.svg'),
-                          alt: 'pub.dev package manager',
-                          width: 328,
-                          height: 70,
+                          image: d.Image(
+                            src: staticUrls
+                                .getAssetUrl('/static/img/pub-dev-logo.svg'),
+                            alt: 'pub.dev package manager',
+                            width: 328,
+                            height: 70,
+                          ),
                         ),
                       ]),
                     searchBanner,
@@ -193,11 +195,13 @@ d.Node pageLayoutNode({
                       d.fragment([
                         landingBlurb!,
                         d.img(
-                          src: staticUrls.getAssetUrl(
-                              '/static/img/supported-by-google.png'),
-                          alt: 'Supported by Google',
-                          width: 218,
-                          height: 36,
+                          image: d.Image(
+                            src: staticUrls.getAssetUrl(
+                                '/static/img/supported-by-google.png'),
+                            alt: 'Supported by Google',
+                            width: 218,
+                            height: 36,
+                          ),
                         ),
                       ]),
                   ],
@@ -228,18 +232,15 @@ d.Node _siteFooterNode() {
   d.Node link(String href, String label, {bool sep = true}) =>
       d.a(classes: ['link', if (sep) 'sep'], href: href, text: label);
 
-  d.Node icon(String linkHref, List<String> classes, String iconSrc,
-          String title) =>
+  d.Node icon(
+          String linkHref, List<String> classes, d.Image icon, String title) =>
       d.a(
         classes: ['link', 'icon', ...classes],
         href: linkHref,
         child: d.img(
-          src: iconSrc,
           classes: ['inline-icon'],
           title: title,
-          alt: title,
-          width: 20,
-          height: 20,
+          image: icon,
         ),
       );
 
@@ -257,13 +258,23 @@ d.Node _siteFooterNode() {
       icon(
         '/feed.atom',
         ['sep'],
-        staticUrls.getAssetUrl('/static/img/rss-feed-icon.svg'),
+        d.Image(
+          src: staticUrls.getAssetUrl('/static/img/rss-feed-icon.svg'),
+          alt: 'RSS icon',
+          width: 20,
+          height: 20,
+        ),
         'RSS/atom feed',
       ),
       icon(
         'https://github.com/dart-lang/pub-dev/issues/new',
         ['github_issue'],
-        staticUrls.getAssetUrl('/static/img/bug-report-white-96px.png'),
+        d.Image(
+          src: staticUrls.getAssetUrl('/static/img/bug-report-white-96px.png'),
+          alt: 'bug report icon',
+          width: 20,
+          height: 20,
+        ),
         'Report an issue with this site',
       ),
     ],

--- a/app/lib/frontend/templates/views/shared/search_banner.dart
+++ b/app/lib/frontend/templates/views/shared/search_banner.dart
@@ -40,13 +40,19 @@ d.Node searchBannerNode({
           children: [
             d.img(
               classes: ['search-filters-btn', 'search-filters-btn-inactive'],
-              src: staticUrls
-                  .getAssetUrl('/static/img/search-filters-inactive.svg'),
+              image: d.Image(
+                src: staticUrls
+                    .getAssetUrl('/static/img/search-filters-inactive.svg'),
+                alt: 'icon to toggle the display of search filters (inactive)',
+              ),
             ),
             d.img(
               classes: ['search-filters-btn', 'search-filters-btn-active'],
-              src: staticUrls
-                  .getAssetUrl('/static/img/search-filters-active.svg'),
+              image: d.Image(
+                src: staticUrls
+                    .getAssetUrl('/static/img/search-filters-active.svg'),
+                alt: 'icon to toggle the display of search filters (active)',
+              ),
             ),
           ],
         ),

--- a/app/lib/frontend/templates/views/shared/search_tabs.dart
+++ b/app/lib/frontend/templates/views/shared/search_tabs.dart
@@ -35,7 +35,10 @@ d.Node searchTabsNode(Iterable<SearchTab> tabs) {
           if (tab.active)
             d.img(
               classes: ['filter-icon'],
-              src: staticUrls.getAssetUrl('/static/img/checkmark-icon.svg'),
+              image: d.Image(
+                src: staticUrls.getAssetUrl('/static/img/checkmark-icon.svg'),
+                alt: 'icon with a checkmark - indicating active status',
+              ),
             ),
           d.text(tab.text),
         ],

--- a/app/lib/frontend/templates/views/shared/site_header.dart
+++ b/app/lib/frontend/templates/views/shared/site_header.dart
@@ -25,10 +25,12 @@ d.Node siteHeaderNode({
           href: '/',
           child: d.img(
             classes: ['site-logo'],
-            alt: 'pub logo',
-            src: staticUrls.pubDevLogo2xPng,
-            width: 135,
-            height: 30,
+            image: d.Image(
+              src: staticUrls.pubDevLogo2xPng,
+              alt: 'pub logo',
+              width: 135,
+              height: 30,
+            ),
           ),
         ),
       d.div(classes: ['site-header-space']),
@@ -133,8 +135,10 @@ d.Node _userBlock(UserSessionData userSession) {
               children: [
                 d.img(
                   classes: ['nav-profile-img', 'nav-profile-img-mobile'],
-                  src: userSession.imageUrl,
-                  alt: 'Profile Image',
+                  image: d.Image(
+                    src: userSession.imageUrl ?? '',
+                    alt: 'Profile Image',
+                  ),
                 ),
                 d.div(
                   classes: ['nav-account-title'],
@@ -214,8 +218,11 @@ d.Node _foldableMobileLinks(String label, Iterable<d.Node> children) {
           d.text('$label '),
           d.img(
             classes: ['foldable-icon'],
-            src: staticUrls
-                .getAssetUrl('/static/img/nav-mobile-foldable-icon.svg'),
+            image: d.Image(
+              src: staticUrls
+                  .getAssetUrl('/static/img/nav-mobile-foldable-icon.svg'),
+              alt: 'icon to toggle folding of the section',
+            ),
           ),
         ],
       ),

--- a/app/test/frontend/golden/authorized_page.html
+++ b/app/test/frontend/golden/authorized_page.html
@@ -78,7 +78,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Pub.dev
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="/help/search" rel="noopener" target="_blank">Searching for packages</a>
@@ -88,7 +88,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Flutter
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://flutter.io/using-packages/" rel="noopener" target="_blank">Using packages</a>
@@ -99,7 +99,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Dart
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://dart.dev/tools/pub/get-started" rel="noopener" target="_blank">Using packages</a>
@@ -126,10 +126,10 @@
       <a class="link sep" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link sep" href="/help">Help</a>
       <a class="link icon sep" href="/feed.atom">
-        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" title="RSS/atom feed" alt="RSS/atom feed" width="20" height="20"/>
+        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
       </a>
       <a class="link icon github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">
-        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" title="Report an issue with this site" alt="Report an issue with this site" width="20" height="20"/>
+        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
       </a>
     </footer>
     <script src="/static/highlight/highlight-with-init.js?hash=mocked_hash_670483893" defer="defer"></script>

--- a/app/test/frontend/golden/consent_page.html
+++ b/app/test/frontend/golden/consent_page.html
@@ -79,7 +79,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Pub.dev
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="/help/search" rel="noopener" target="_blank">Searching for packages</a>
@@ -89,7 +89,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Flutter
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://flutter.io/using-packages/" rel="noopener" target="_blank">Using packages</a>
@@ -100,7 +100,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Dart
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://dart.dev/tools/pub/get-started" rel="noopener" target="_blank">Using packages</a>
@@ -130,10 +130,10 @@
       <a class="link sep" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link sep" href="/help">Help</a>
       <a class="link icon sep" href="/feed.atom">
-        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" title="RSS/atom feed" alt="RSS/atom feed" width="20" height="20"/>
+        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
       </a>
       <a class="link icon github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">
-        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" title="Report an issue with this site" alt="Report an issue with this site" width="20" height="20"/>
+        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
       </a>
     </footer>
   </body>

--- a/app/test/frontend/golden/create_publisher_page.html
+++ b/app/test/frontend/golden/create_publisher_page.html
@@ -78,7 +78,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Pub.dev
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="/help/search" rel="noopener" target="_blank">Searching for packages</a>
@@ -88,7 +88,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Flutter
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://flutter.io/using-packages/" rel="noopener" target="_blank">Using packages</a>
@@ -99,7 +99,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Dart
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://dart.dev/tools/pub/get-started" rel="noopener" target="_blank">Using packages</a>
@@ -192,10 +192,10 @@
       <a class="link sep" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link sep" href="/help">Help</a>
       <a class="link icon sep" href="/feed.atom">
-        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" title="RSS/atom feed" alt="RSS/atom feed" width="20" height="20"/>
+        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
       </a>
       <a class="link icon github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">
-        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" title="Report an issue with this site" alt="Report an issue with this site" width="20" height="20"/>
+        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
       </a>
     </footer>
   </body>

--- a/app/test/frontend/golden/error_page.html
+++ b/app/test/frontend/golden/error_page.html
@@ -73,7 +73,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Pub.dev
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="/help/search" rel="noopener" target="_blank">Searching for packages</a>
@@ -83,7 +83,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Flutter
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://flutter.io/using-packages/" rel="noopener" target="_blank">Using packages</a>
@@ -94,7 +94,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Dart
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://dart.dev/tools/pub/get-started" rel="noopener" target="_blank">Using packages</a>
@@ -128,10 +128,10 @@
       <a class="link sep" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link sep" href="/help">Help</a>
       <a class="link icon sep" href="/feed.atom">
-        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" title="RSS/atom feed" alt="RSS/atom feed" width="20" height="20"/>
+        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
       </a>
       <a class="link icon github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">
-        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" title="Report an issue with this site" alt="Report an issue with this site" width="20" height="20"/>
+        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
       </a>
     </footer>
   </body>

--- a/app/test/frontend/golden/help_page.html
+++ b/app/test/frontend/golden/help_page.html
@@ -79,7 +79,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Pub.dev
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="/help/search" rel="noopener" target="_blank">Searching for packages</a>
@@ -89,7 +89,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Flutter
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://flutter.io/using-packages/" rel="noopener" target="_blank">Using packages</a>
@@ -100,7 +100,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Dart
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://dart.dev/tools/pub/get-started" rel="noopener" target="_blank">Using packages</a>
@@ -113,7 +113,7 @@
     <main class="container">
       <div class="standalone-wrapper -has-side-image">
         <div class="standalone-side-image-block">
-          <img class="standalone-side-image" src="/static/img/packages-side.png?hash=mocked_hash_335626183"/>
+          <img class="standalone-side-image" src="/static/img/packages-side.png?hash=mocked_hash_335626183" alt="cover image decorating the page"/>
         </div>
         <div class="standalone-content">
           <h1 class="hash-header" id="help">
@@ -150,10 +150,10 @@
       <a class="link sep" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link sep" href="/help">Help</a>
       <a class="link icon sep" href="/feed.atom">
-        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" title="RSS/atom feed" alt="RSS/atom feed" width="20" height="20"/>
+        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
       </a>
       <a class="link icon github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">
-        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" title="Report an issue with this site" alt="Report an issue with this site" width="20" height="20"/>
+        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
       </a>
     </footer>
   </body>

--- a/app/test/frontend/golden/landing_page.html
+++ b/app/test/frontend/golden/landing_page.html
@@ -71,7 +71,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Pub.dev
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="/help/search" rel="noopener" target="_blank">Searching for packages</a>
@@ -81,7 +81,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Flutter
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://flutter.io/using-packages/" rel="noopener" target="_blank">Using packages</a>
@@ -92,7 +92,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Dart
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://dart.dev/tools/pub/get-started" rel="noopener" target="_blank">Using packages</a>
@@ -150,7 +150,7 @@
       </div>
       <div class="home-block home-block-mp">
         <div class="home-block-image">
-          <img src="/static/img/landing-01.png?hash=mocked_hash_885315573"/>
+          <img src="/static/img/landing-01.png?hash=mocked_hash_885315573" alt="decoration image for package section"/>
         </div>
         <div class="home-block-content">
           <h1 class="home-block-title">Most popular packages</h1>
@@ -165,7 +165,7 @@
               </div>
               <div class="mini-list-item-footer">
                 <div class="mini-list-item-publisher">
-                  <img class="publisher-badge" src="/static/img/verified-publisher-gray.svg?hash=mocked_hash_248900311" title="Published by a pub.dev verified publisher"/>
+                  <img class="publisher-badge" src="/static/img/verified-publisher-gray.svg?hash=mocked_hash_248900311" alt="verified publisher badge" title="Published by a pub.dev verified publisher"/>
                   <a class="publisher-link" href="/publishers/example.com" data-ga-click-event="landing-most-popular-card-publisher">example.com</a>
                 </div>
               </div>
@@ -194,8 +194,8 @@
               <a href="https://youtube.com/watch?v=video-id&amp;list=PLjxrf2q8roU1quF6ny8oFHJ2gBdrYN_AK" rel="noopener" target="_blank" title="POW description" data-ga-click-event="package-of-the-week-video">
                 <img class="pow-video-thumbnail" src="http://youtube.com/image/thumbnail?i=123&amp;s=4" alt="POW Title" width="260" height="195"/>
                 <div class="pow-video-overlay">
-                  <img class="pow-video-overlay-img-active" src="/static/img/youtube-play-red.png?hash=mocked_hash_325144362" width="76" height="53"/>
-                  <img class="pow-video-overlay-img-inactive" src="/static/img/youtube-play-black.png?hash=mocked_hash_405283570" width="76" height="53"/>
+                  <img class="pow-video-overlay-img-active" src="/static/img/youtube-play-red.png?hash=mocked_hash_325144362" alt="youtube video play icon - active" width="76" height="53"/>
+                  <img class="pow-video-overlay-img-inactive" src="/static/img/youtube-play-black.png?hash=mocked_hash_405283570" alt="youtube video play icon - inactive" width="76" height="53"/>
                 </div>
               </a>
             </div>
@@ -215,10 +215,10 @@
       <a class="link sep" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link sep" href="/help">Help</a>
       <a class="link icon sep" href="/feed.atom">
-        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" title="RSS/atom feed" alt="RSS/atom feed" width="20" height="20"/>
+        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
       </a>
       <a class="link icon github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">
-        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" title="Report an issue with this site" alt="Report an issue with this site" width="20" height="20"/>
+        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
       </a>
     </footer>
     <script type="application/ld+json">{"@context":"http:\u002f\u002fschema.org","@type":"WebSite","url":"https:\u002f\u002fpub.dev\u002f","potentialAction":{"@type":"SearchAction","target":"https:\u002f\u002fpub.dev\u002fpackages\u003fq\u003d{search\u005fterm\u005fstring}","query-input":"required name\u003dsearch\u005fterm\u005fstring"}}</script>

--- a/app/test/frontend/golden/my_activity_log_page.html
+++ b/app/test/frontend/golden/my_activity_log_page.html
@@ -82,7 +82,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Pub.dev
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="/help/search" rel="noopener" target="_blank">Searching for packages</a>
@@ -92,7 +92,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Flutter
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://flutter.io/using-packages/" rel="noopener" target="_blank">Using packages</a>
@@ -103,7 +103,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Dart
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://dart.dev/tools/pub/get-started" rel="noopener" target="_blank">Using packages</a>
@@ -146,7 +146,7 @@
           <div class="detail-container">
             <div class="detail-header-outer-block">
               <div class="detail-header-image-block">
-                <img class="detail-header-image" src="pub.dev/user-img-url.png=s400"/>
+                <img class="detail-header-image" src="pub.dev/user-img-url.png=s400" alt="user profile picture"/>
               </div>
               <div class="detail-header-content-block">
                 <h1 class="title">Pub User</h1>
@@ -350,10 +350,10 @@
       <a class="link sep" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link sep" href="/help">Help</a>
       <a class="link icon sep" href="/feed.atom">
-        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" title="RSS/atom feed" alt="RSS/atom feed" width="20" height="20"/>
+        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
       </a>
       <a class="link icon github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">
-        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" title="Report an issue with this site" alt="Report an issue with this site" width="20" height="20"/>
+        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
       </a>
     </footer>
   </body>

--- a/app/test/frontend/golden/my_liked_packages.html
+++ b/app/test/frontend/golden/my_liked_packages.html
@@ -82,7 +82,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Pub.dev
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="/help/search" rel="noopener" target="_blank">Searching for packages</a>
@@ -92,7 +92,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Flutter
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://flutter.io/using-packages/" rel="noopener" target="_blank">Using packages</a>
@@ -103,7 +103,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Dart
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://dart.dev/tools/pub/get-started" rel="noopener" target="_blank">Using packages</a>
@@ -146,7 +146,7 @@
           <div class="detail-container">
             <div class="detail-header-outer-block">
               <div class="detail-header-image-block">
-                <img class="detail-header-image" src="pub.dev/user-img-url.png=s400"/>
+                <img class="detail-header-image" src="pub.dev/user-img-url.png=s400" alt="user profile picture"/>
               </div>
               <div class="detail-header-content-block">
                 <h1 class="title">Pub User</h1>
@@ -192,7 +192,7 @@
                         <div class="packages-icons">
                           <button class="mdc-button mdc-button--unelevated -pub-like-button" data-mdc-auto-init="MDCRipple" data-package="super_package" data-thumb_up_outlined="/static/img/thumb-up-24px.svg?hash=mocked_hash_808020279" data-thumb_up_filled="/static/img/thumb-up-filled-24px.svg?hash=mocked_hash_368133424">
                             <div class="mdc-button__ripple"></div>
-                            <img class="mdc-button__icon -pub-like-button-img" src="/static/img/thumb-up-filled-24px.svg?hash=mocked_hash_368133424" aria-hidden="true"/>
+                            <img class="mdc-button__icon -pub-like-button-img" src="/static/img/thumb-up-filled-24px.svg?hash=mocked_hash_368133424" alt="thumb up icon" aria-hidden="true"/>
                             <span class="mdc-button__label -pub-like-button-label">Unlike</span>
                           </button>
                         </div>
@@ -210,7 +210,7 @@
                         <div class="packages-icons">
                           <button class="mdc-button mdc-button--unelevated -pub-like-button" data-mdc-auto-init="MDCRipple" data-package="another_package" data-thumb_up_outlined="/static/img/thumb-up-24px.svg?hash=mocked_hash_808020279" data-thumb_up_filled="/static/img/thumb-up-filled-24px.svg?hash=mocked_hash_368133424">
                             <div class="mdc-button__ripple"></div>
-                            <img class="mdc-button__icon -pub-like-button-img" src="/static/img/thumb-up-filled-24px.svg?hash=mocked_hash_368133424" aria-hidden="true"/>
+                            <img class="mdc-button__icon -pub-like-button-img" src="/static/img/thumb-up-filled-24px.svg?hash=mocked_hash_368133424" alt="thumb up icon" aria-hidden="true"/>
                             <span class="mdc-button__label -pub-like-button-label">Unlike</span>
                           </button>
                         </div>
@@ -237,10 +237,10 @@
       <a class="link sep" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link sep" href="/help">Help</a>
       <a class="link icon sep" href="/feed.atom">
-        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" title="RSS/atom feed" alt="RSS/atom feed" width="20" height="20"/>
+        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
       </a>
       <a class="link icon github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">
-        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" title="Report an issue with this site" alt="Report an issue with this site" width="20" height="20"/>
+        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
       </a>
     </footer>
   </body>

--- a/app/test/frontend/golden/my_packages.html
+++ b/app/test/frontend/golden/my_packages.html
@@ -82,7 +82,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Pub.dev
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="/help/search" rel="noopener" target="_blank">Searching for packages</a>
@@ -92,7 +92,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Flutter
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://flutter.io/using-packages/" rel="noopener" target="_blank">Using packages</a>
@@ -103,7 +103,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Dart
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://dart.dev/tools/pub/get-started" rel="noopener" target="_blank">Using packages</a>
@@ -146,7 +146,7 @@
           <div class="detail-container">
             <div class="detail-header-outer-block">
               <div class="detail-header-image-block">
-                <img class="detail-header-image" src="pub.dev/user-img-url.png=s400"/>
+                <img class="detail-header-image" src="pub.dev/user-img-url.png=s400" alt="user profile picture"/>
               </div>
               <div class="detail-header-content-block">
                 <h1 class="title">Pub User</h1>
@@ -212,7 +212,7 @@
                           <a href="/packages/oxygen">oxygen</a>
                         </h3>
                         <div class="packages-recent">
-                          <img class="packages-recent-icon" src="/static/img/schedule-icon.svg?hash=mocked_hash_164576935" title="new package"/>
+                          <img class="packages-recent-icon" src="/static/img/schedule-icon.svg?hash=mocked_hash_164576935" alt="icon indicating recent time" title="new package"/>
                           Added
                           <b>%%x-ago%%</b>
                         </div>
@@ -268,7 +268,7 @@
                           <a href="/packages/neon">neon</a>
                         </h3>
                         <div class="packages-recent">
-                          <img class="packages-recent-icon" src="/static/img/schedule-icon.svg?hash=mocked_hash_164576935" title="new package"/>
+                          <img class="packages-recent-icon" src="/static/img/schedule-icon.svg?hash=mocked_hash_164576935" alt="icon indicating recent time" title="new package"/>
                           Added
                           <b>%%x-ago%%</b>
                         </div>
@@ -306,7 +306,7 @@
                           )
                         </span>
                         <span class="packages-metadata-block">
-                          <img class="package-vp-icon" src="/static/img/verified-publisher-icon.svg?hash=mocked_hash_1044149352" title="Published by a pub.dev verified publisher"/>
+                          <img class="package-vp-icon" src="/static/img/verified-publisher-icon.svg?hash=mocked_hash_1044149352" alt="shield icon for verified publishers" title="Published by a pub.dev verified publisher"/>
                           <a href="/publishers/example.com">example.com</a>
                         </span>
                       </p>
@@ -351,10 +351,10 @@
       <a class="link sep" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link sep" href="/help">Help</a>
       <a class="link icon sep" href="/feed.atom">
-        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" title="RSS/atom feed" alt="RSS/atom feed" width="20" height="20"/>
+        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
       </a>
       <a class="link icon github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">
-        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" title="Report an issue with this site" alt="Report an issue with this site" width="20" height="20"/>
+        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
       </a>
     </footer>
   </body>

--- a/app/test/frontend/golden/my_publishers.html
+++ b/app/test/frontend/golden/my_publishers.html
@@ -82,7 +82,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Pub.dev
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="/help/search" rel="noopener" target="_blank">Searching for packages</a>
@@ -92,7 +92,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Flutter
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://flutter.io/using-packages/" rel="noopener" target="_blank">Using packages</a>
@@ -103,7 +103,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Dart
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://dart.dev/tools/pub/get-started" rel="noopener" target="_blank">Using packages</a>
@@ -146,7 +146,7 @@
           <div class="detail-container">
             <div class="detail-header-outer-block">
               <div class="detail-header-image-block">
-                <img class="detail-header-image" src="pub.dev/user-img-url.png=s400"/>
+                <img class="detail-header-image" src="pub.dev/user-img-url.png=s400" alt="user profile picture"/>
               </div>
               <div class="detail-header-content-block">
                 <h1 class="title">Pub User</h1>
@@ -216,10 +216,10 @@
       <a class="link sep" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link sep" href="/help">Help</a>
       <a class="link icon sep" href="/feed.atom">
-        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" title="RSS/atom feed" alt="RSS/atom feed" width="20" height="20"/>
+        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
       </a>
       <a class="link icon github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">
-        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" title="Report an issue with this site" alt="Report an issue with this site" width="20" height="20"/>
+        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
       </a>
     </footer>
   </body>

--- a/app/test/frontend/golden/pkg_activity_log_page.html
+++ b/app/test/frontend/golden/pkg_activity_log_page.html
@@ -79,7 +79,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Pub.dev
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="/help/search" rel="noopener" target="_blank">Searching for packages</a>
@@ -89,7 +89,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Flutter
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://flutter.io/using-packages/" rel="noopener" target="_blank">Using packages</a>
@@ -100,7 +100,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Dart
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://dart.dev/tools/pub/get-started" rel="noopener" target="_blank">Using packages</a>
@@ -119,7 +119,7 @@
                 <h1 class="title">
                   oxygen 1.2.0
                   <span class="pkg-page-title-copy">
-                    <img class="pkg-page-title-copy-icon" src="/static/img/content-copy-icon.svg?hash=mocked_hash_1005735992" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>
+                    <img class="pkg-page-title-copy-icon" src="/static/img/content-copy-icon.svg?hash=mocked_hash_1005735992" alt="icon indicating copy to clipboard operation" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>
                     <div class="pkg-page-title-copy-feedback">
                       <span class="code">oxygen: ^1.2.0</span>
                       copied to clipboard
@@ -151,8 +151,8 @@
                   </div>
                   <div class="detail-like">
                     <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false">
-                      <img class="mdc-icon-button__icon" src="/static/img/like-inactive.svg?hash=mocked_hash_1066096316" width="18" height="18"/>
-                      <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/img/like-active.svg?hash=mocked_hash_986617859" width="18" height="18"/>
+                      <img class="mdc-icon-button__icon" src="/static/img/like-inactive.svg?hash=mocked_hash_1066096316" alt="icon indicating liked status (inactive)" width="18" height="18"/>
+                      <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/img/like-active.svg?hash=mocked_hash_986617859" alt="icon indicating liked status (active)" width="18" height="18"/>
                     </button>
                     <span class="likes-count">
                       <span id="likes-count">0</span>
@@ -318,10 +318,10 @@
       <a class="link sep" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link sep" href="/help">Help</a>
       <a class="link icon sep" href="/feed.atom">
-        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" title="RSS/atom feed" alt="RSS/atom feed" width="20" height="20"/>
+        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
       </a>
       <a class="link icon github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">
-        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" title="Report an issue with this site" alt="Report an issue with this site" width="20" height="20"/>
+        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
       </a>
     </footer>
     <script src="/static/highlight/highlight-with-init.js?hash=mocked_hash_670483893" defer="defer"></script>

--- a/app/test/frontend/golden/pkg_admin_page.html
+++ b/app/test/frontend/golden/pkg_admin_page.html
@@ -79,7 +79,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Pub.dev
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="/help/search" rel="noopener" target="_blank">Searching for packages</a>
@@ -89,7 +89,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Flutter
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://flutter.io/using-packages/" rel="noopener" target="_blank">Using packages</a>
@@ -100,7 +100,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Dart
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://dart.dev/tools/pub/get-started" rel="noopener" target="_blank">Using packages</a>
@@ -119,7 +119,7 @@
                 <h1 class="title">
                   oxygen 1.2.0
                   <span class="pkg-page-title-copy">
-                    <img class="pkg-page-title-copy-icon" src="/static/img/content-copy-icon.svg?hash=mocked_hash_1005735992" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>
+                    <img class="pkg-page-title-copy-icon" src="/static/img/content-copy-icon.svg?hash=mocked_hash_1005735992" alt="icon indicating copy to clipboard operation" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>
                     <div class="pkg-page-title-copy-feedback">
                       <span class="code">oxygen: ^1.2.0</span>
                       copied to clipboard
@@ -151,8 +151,8 @@
                   </div>
                   <div class="detail-like">
                     <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false">
-                      <img class="mdc-icon-button__icon" src="/static/img/like-inactive.svg?hash=mocked_hash_1066096316" width="18" height="18"/>
-                      <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/img/like-active.svg?hash=mocked_hash_986617859" width="18" height="18"/>
+                      <img class="mdc-icon-button__icon" src="/static/img/like-inactive.svg?hash=mocked_hash_1066096316" alt="icon indicating liked status (inactive)" width="18" height="18"/>
+                      <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/img/like-active.svg?hash=mocked_hash_986617859" alt="icon indicating liked status (active)" width="18" height="18"/>
                     </button>
                     <span class="likes-count">
                       <span id="likes-count">0</span>
@@ -507,10 +507,10 @@
       <a class="link sep" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link sep" href="/help">Help</a>
       <a class="link icon sep" href="/feed.atom">
-        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" title="RSS/atom feed" alt="RSS/atom feed" width="20" height="20"/>
+        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
       </a>
       <a class="link icon github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">
-        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" title="Report an issue with this site" alt="Report an issue with this site" width="20" height="20"/>
+        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
       </a>
     </footer>
     <script src="/static/highlight/highlight-with-init.js?hash=mocked_hash_670483893" defer="defer"></script>

--- a/app/test/frontend/golden/pkg_changelog_page.html
+++ b/app/test/frontend/golden/pkg_changelog_page.html
@@ -80,7 +80,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Pub.dev
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="/help/search" rel="noopener" target="_blank">Searching for packages</a>
@@ -90,7 +90,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Flutter
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://flutter.io/using-packages/" rel="noopener" target="_blank">Using packages</a>
@@ -101,7 +101,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Dart
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://dart.dev/tools/pub/get-started" rel="noopener" target="_blank">Using packages</a>
@@ -120,7 +120,7 @@
                 <h1 class="title">
                   oxygen 1.2.0
                   <span class="pkg-page-title-copy">
-                    <img class="pkg-page-title-copy-icon" src="/static/img/content-copy-icon.svg?hash=mocked_hash_1005735992" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>
+                    <img class="pkg-page-title-copy-icon" src="/static/img/content-copy-icon.svg?hash=mocked_hash_1005735992" alt="icon indicating copy to clipboard operation" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>
                     <div class="pkg-page-title-copy-feedback">
                       <span class="code">oxygen: ^1.2.0</span>
                       copied to clipboard
@@ -152,8 +152,8 @@
                   </div>
                   <div class="detail-like">
                     <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false">
-                      <img class="mdc-icon-button__icon" src="/static/img/like-inactive.svg?hash=mocked_hash_1066096316" width="18" height="18"/>
-                      <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/img/like-active.svg?hash=mocked_hash_986617859" width="18" height="18"/>
+                      <img class="mdc-icon-button__icon" src="/static/img/like-inactive.svg?hash=mocked_hash_1066096316" alt="icon indicating liked status (inactive)" width="18" height="18"/>
+                      <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/img/like-active.svg?hash=mocked_hash_986617859" alt="icon indicating liked status (active)" width="18" height="18"/>
                     </button>
                     <span class="likes-count">
                       <span id="likes-count">0</span>
@@ -332,10 +332,10 @@
       <a class="link sep" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link sep" href="/help">Help</a>
       <a class="link icon sep" href="/feed.atom">
-        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" title="RSS/atom feed" alt="RSS/atom feed" width="20" height="20"/>
+        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
       </a>
       <a class="link icon github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">
-        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" title="Report an issue with this site" alt="Report an issue with this site" width="20" height="20"/>
+        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
       </a>
     </footer>
     <script src="/static/highlight/highlight-with-init.js?hash=mocked_hash_670483893" defer="defer"></script>

--- a/app/test/frontend/golden/pkg_example_page.html
+++ b/app/test/frontend/golden/pkg_example_page.html
@@ -80,7 +80,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Pub.dev
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="/help/search" rel="noopener" target="_blank">Searching for packages</a>
@@ -90,7 +90,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Flutter
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://flutter.io/using-packages/" rel="noopener" target="_blank">Using packages</a>
@@ -101,7 +101,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Dart
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://dart.dev/tools/pub/get-started" rel="noopener" target="_blank">Using packages</a>
@@ -120,7 +120,7 @@
                 <h1 class="title">
                   oxygen 1.2.0
                   <span class="pkg-page-title-copy">
-                    <img class="pkg-page-title-copy-icon" src="/static/img/content-copy-icon.svg?hash=mocked_hash_1005735992" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>
+                    <img class="pkg-page-title-copy-icon" src="/static/img/content-copy-icon.svg?hash=mocked_hash_1005735992" alt="icon indicating copy to clipboard operation" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>
                     <div class="pkg-page-title-copy-feedback">
                       <span class="code">oxygen: ^1.2.0</span>
                       copied to clipboard
@@ -152,8 +152,8 @@
                   </div>
                   <div class="detail-like">
                     <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false">
-                      <img class="mdc-icon-button__icon" src="/static/img/like-inactive.svg?hash=mocked_hash_1066096316" width="18" height="18"/>
-                      <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/img/like-active.svg?hash=mocked_hash_986617859" width="18" height="18"/>
+                      <img class="mdc-icon-button__icon" src="/static/img/like-inactive.svg?hash=mocked_hash_1066096316" alt="icon indicating liked status (inactive)" width="18" height="18"/>
+                      <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/img/like-active.svg?hash=mocked_hash_986617859" alt="icon indicating liked status (active)" width="18" height="18"/>
                     </button>
                     <span class="likes-count">
                       <span id="likes-count">0</span>
@@ -327,10 +327,10 @@
       <a class="link sep" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link sep" href="/help">Help</a>
       <a class="link icon sep" href="/feed.atom">
-        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" title="RSS/atom feed" alt="RSS/atom feed" width="20" height="20"/>
+        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
       </a>
       <a class="link icon github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">
-        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" title="Report an issue with this site" alt="Report an issue with this site" width="20" height="20"/>
+        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
       </a>
     </footer>
     <script src="/static/highlight/highlight-with-init.js?hash=mocked_hash_670483893" defer="defer"></script>

--- a/app/test/frontend/golden/pkg_index_page.html
+++ b/app/test/frontend/golden/pkg_index_page.html
@@ -74,7 +74,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Pub.dev
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="/help/search" rel="noopener" target="_blank">Searching for packages</a>
@@ -84,7 +84,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Flutter
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://flutter.io/using-packages/" rel="noopener" target="_blank">Using packages</a>
@@ -95,7 +95,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Dart
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://dart.dev/tools/pub/get-started" rel="noopener" target="_blank">Using packages</a>
@@ -111,8 +111,8 @@
           <input class="input" name="q" placeholder="Search Flutter packages" autocomplete="on" autofocus="autofocus"/>
           <button class="icon"></button>
           <div class="search-filters-btn-wrapper">
-            <img class="search-filters-btn search-filters-btn-inactive" src="/static/img/search-filters-inactive.svg?hash=mocked_hash_963166179"/>
-            <img class="search-filters-btn search-filters-btn-active" src="/static/img/search-filters-active.svg?hash=mocked_hash_397783636"/>
+            <img class="search-filters-btn search-filters-btn-inactive" src="/static/img/search-filters-inactive.svg?hash=mocked_hash_963166179" alt="icon to toggle the display of search filters (inactive)"/>
+            <img class="search-filters-btn search-filters-btn-active" src="/static/img/search-filters-active.svg?hash=mocked_hash_397783636" alt="icon to toggle the display of search filters (active)"/>
           </div>
           <input id="-search-discontinued-field" type="hidden" name="discontinued" value="1" disabled="disabled"/>
           <input id="-search-unlisted-field" type="hidden" name="unlisted" value="1" disabled="disabled"/>
@@ -128,7 +128,7 @@
               <div class="list-filters">
                 <a class="search-link filter" href="/dart/packages" title="Packages compatible with the Dart SDK">Dart</a>
                 <a class="search-link filter -active" href="/flutter/packages" title="Packages compatible with the Flutter SDK">
-                  <img class="filter-icon" src="/static/img/checkmark-icon.svg?hash=mocked_hash_296261337"/>
+                  <img class="filter-icon" src="/static/img/checkmark-icon.svg?hash=mocked_hash_296261337" alt="icon with a checkmark - indicating active status"/>
                   Flutter
                 </a>
                 <a class="search-link filter" href="/packages" title="Packages compatible with the any SDK">Any</a>
@@ -139,7 +139,7 @@
               <div class="list-filters">
                 <a class="search-link filter" href="/dart/packages" title="Packages compatible with the Dart SDK">Dart</a>
                 <a class="search-link filter -active" href="/flutter/packages" title="Packages compatible with the Flutter SDK">
-                  <img class="filter-icon" src="/static/img/checkmark-icon.svg?hash=mocked_hash_296261337"/>
+                  <img class="filter-icon" src="/static/img/checkmark-icon.svg?hash=mocked_hash_296261337" alt="icon with a checkmark - indicating active status"/>
                   Flutter
                 </a>
                 <a class="search-link filter" href="/packages" title="Packages compatible with the any SDK">Any</a>
@@ -147,7 +147,7 @@
             </div>
             <div class="search-filters-btn search-filters-btn-wrapper search-controls-more" data-ga-click-event="toggle-advanced-search">
               Advanced
-              <img class="search-controls-more-carot" src="/static/img/carot-up.svg?hash=mocked_hash_771440143"/>
+              <img class="search-controls-more-carot" src="/static/img/carot-up.svg?hash=mocked_hash_771440143" alt="toggle button for advanced search (carot up)"/>
             </div>
           </div>
         </div>
@@ -215,7 +215,7 @@
                 <a href="/packages/oxygen">oxygen</a>
               </h3>
               <div class="packages-recent">
-                <img class="packages-recent-icon" src="/static/img/schedule-icon.svg?hash=mocked_hash_164576935" title="new package"/>
+                <img class="packages-recent-icon" src="/static/img/schedule-icon.svg?hash=mocked_hash_164576935" alt="icon indicating recent time" title="new package"/>
                 Added
                 <b>%%x-ago%%</b>
               </div>
@@ -271,7 +271,7 @@
                 <a href="/packages/flutter_titanium">flutter_titanium</a>
               </h3>
               <div class="packages-recent">
-                <img class="packages-recent-icon" src="/static/img/schedule-icon.svg?hash=mocked_hash_164576935" title="new package"/>
+                <img class="packages-recent-icon" src="/static/img/schedule-icon.svg?hash=mocked_hash_164576935" alt="icon indicating recent time" title="new package"/>
                 Added
                 <b>%%x-ago%%</b>
               </div>
@@ -358,10 +358,10 @@
       <a class="link sep" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link sep" href="/help">Help</a>
       <a class="link icon sep" href="/feed.atom">
-        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" title="RSS/atom feed" alt="RSS/atom feed" width="20" height="20"/>
+        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
       </a>
       <a class="link icon github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">
-        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" title="Report an issue with this site" alt="Report an issue with this site" width="20" height="20"/>
+        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
       </a>
     </footer>
   </body>

--- a/app/test/frontend/golden/pkg_index_page_experimental.html
+++ b/app/test/frontend/golden/pkg_index_page_experimental.html
@@ -74,7 +74,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Pub.dev
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="/help/search" rel="noopener" target="_blank">Searching for packages</a>
@@ -84,7 +84,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Flutter
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://flutter.io/using-packages/" rel="noopener" target="_blank">Using packages</a>
@@ -95,7 +95,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Dart
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://dart.dev/tools/pub/get-started" rel="noopener" target="_blank">Using packages</a>
@@ -111,8 +111,8 @@
           <input class="input" name="q" placeholder="Search packages" autocomplete="on" value="sdk:dart"/>
           <button class="icon"></button>
           <div class="search-filters-btn-wrapper -active">
-            <img class="search-filters-btn search-filters-btn-inactive" src="/static/img/search-filters-inactive.svg?hash=mocked_hash_963166179"/>
-            <img class="search-filters-btn search-filters-btn-active" src="/static/img/search-filters-active.svg?hash=mocked_hash_397783636"/>
+            <img class="search-filters-btn search-filters-btn-inactive" src="/static/img/search-filters-inactive.svg?hash=mocked_hash_963166179" alt="icon to toggle the display of search filters (inactive)"/>
+            <img class="search-filters-btn search-filters-btn-active" src="/static/img/search-filters-active.svg?hash=mocked_hash_397783636" alt="icon to toggle the display of search filters (active)"/>
           </div>
           <input id="-search-discontinued-field" type="hidden" name="discontinued" value="1" disabled="disabled"/>
           <input id="-search-unlisted-field" type="hidden" name="unlisted" value="1"/>
@@ -126,7 +126,7 @@
           <div class="search-form-section foldable -active">
             <h3 class="search-form-section-header foldable-button">
               <span class="search-form-section-header-label">Platforms</span>
-              <img class="foldable-icon" src="/static/img/search-form-foldable-icon.svg?hash=mocked_hash_663371761"/>
+              <img class="foldable-icon" src="/static/img/search-form-foldable-icon.svg?hash=mocked_hash_663371761" alt="fold toggle icon (up/down arrow)"/>
             </h3>
             <div class="foldable-content">
               <div class="search-form-linked-checkbox">
@@ -236,7 +236,7 @@
           <div class="search-form-section foldable -active" data-section-tag="sdks">
             <h3 class="search-form-section-header foldable-button">
               <span class="search-form-section-header-label">SDKs</span>
-              <img class="foldable-icon" src="/static/img/search-form-foldable-icon.svg?hash=mocked_hash_663371761"/>
+              <img class="foldable-icon" src="/static/img/search-form-foldable-icon.svg?hash=mocked_hash_663371761" alt="fold toggle icon (up/down arrow)"/>
             </h3>
             <div class="foldable-content">
               <div class="search-form-linked-checkbox">
@@ -278,7 +278,7 @@
           <div class="search-form-section foldable -active" data-section-tag="advanced">
             <h3 class="search-form-section-header foldable-button">
               <span class="search-form-section-header-label">Advanced</span>
-              <img class="foldable-icon" src="/static/img/search-form-foldable-icon.svg?hash=mocked_hash_663371761"/>
+              <img class="foldable-icon" src="/static/img/search-form-foldable-icon.svg?hash=mocked_hash_663371761" alt="fold toggle icon (up/down arrow)"/>
             </h3>
             <div class="foldable-content">
               <div class="search-form-linked-checkbox">
@@ -378,7 +378,7 @@
                   <a href="/packages/oxygen">oxygen</a>
                 </h3>
                 <div class="packages-recent">
-                  <img class="packages-recent-icon" src="/static/img/schedule-icon.svg?hash=mocked_hash_164576935" title="new package"/>
+                  <img class="packages-recent-icon" src="/static/img/schedule-icon.svg?hash=mocked_hash_164576935" alt="icon indicating recent time" title="new package"/>
                   Added
                   <b>%%x-ago%%</b>
                 </div>
@@ -442,7 +442,7 @@
                   <a href="/packages/flutter_titanium">flutter_titanium</a>
                 </h3>
                 <div class="packages-recent">
-                  <img class="packages-recent-icon" src="/static/img/schedule-icon.svg?hash=mocked_hash_164576935" title="new package"/>
+                  <img class="packages-recent-icon" src="/static/img/schedule-icon.svg?hash=mocked_hash_164576935" alt="icon indicating recent time" title="new package"/>
                   Added
                   <b>%%x-ago%%</b>
                 </div>
@@ -534,10 +534,10 @@
       <a class="link sep" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link sep" href="/help">Help</a>
       <a class="link icon sep" href="/feed.atom">
-        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" title="RSS/atom feed" alt="RSS/atom feed" width="20" height="20"/>
+        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
       </a>
       <a class="link icon github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">
-        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" title="Report an issue with this site" alt="Report an issue with this site" width="20" height="20"/>
+        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
       </a>
     </footer>
   </body>

--- a/app/test/frontend/golden/pkg_install_page.html
+++ b/app/test/frontend/golden/pkg_install_page.html
@@ -80,7 +80,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Pub.dev
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="/help/search" rel="noopener" target="_blank">Searching for packages</a>
@@ -90,7 +90,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Flutter
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://flutter.io/using-packages/" rel="noopener" target="_blank">Using packages</a>
@@ -101,7 +101,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Dart
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://dart.dev/tools/pub/get-started" rel="noopener" target="_blank">Using packages</a>
@@ -120,7 +120,7 @@
                 <h1 class="title">
                   oxygen 1.2.0
                   <span class="pkg-page-title-copy">
-                    <img class="pkg-page-title-copy-icon" src="/static/img/content-copy-icon.svg?hash=mocked_hash_1005735992" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>
+                    <img class="pkg-page-title-copy-icon" src="/static/img/content-copy-icon.svg?hash=mocked_hash_1005735992" alt="icon indicating copy to clipboard operation" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>
                     <div class="pkg-page-title-copy-feedback">
                       <span class="code">oxygen: ^1.2.0</span>
                       copied to clipboard
@@ -152,8 +152,8 @@
                   </div>
                   <div class="detail-like">
                     <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false">
-                      <img class="mdc-icon-button__icon" src="/static/img/like-inactive.svg?hash=mocked_hash_1066096316" width="18" height="18"/>
-                      <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/img/like-active.svg?hash=mocked_hash_986617859" width="18" height="18"/>
+                      <img class="mdc-icon-button__icon" src="/static/img/like-inactive.svg?hash=mocked_hash_1066096316" alt="icon indicating liked status (inactive)" width="18" height="18"/>
+                      <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/img/like-active.svg?hash=mocked_hash_986617859" alt="icon indicating liked status (active)" width="18" height="18"/>
                     </button>
                     <span class="likes-count">
                       <span id="likes-count">0</span>
@@ -349,10 +349,10 @@
       <a class="link sep" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link sep" href="/help">Help</a>
       <a class="link icon sep" href="/feed.atom">
-        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" title="RSS/atom feed" alt="RSS/atom feed" width="20" height="20"/>
+        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
       </a>
       <a class="link icon github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">
-        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" title="Report an issue with this site" alt="Report an issue with this site" width="20" height="20"/>
+        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
       </a>
     </footer>
     <script src="/static/highlight/highlight-with-init.js?hash=mocked_hash_670483893" defer="defer"></script>

--- a/app/test/frontend/golden/pkg_score_page.html
+++ b/app/test/frontend/golden/pkg_score_page.html
@@ -80,7 +80,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Pub.dev
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="/help/search" rel="noopener" target="_blank">Searching for packages</a>
@@ -90,7 +90,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Flutter
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://flutter.io/using-packages/" rel="noopener" target="_blank">Using packages</a>
@@ -101,7 +101,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Dart
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://dart.dev/tools/pub/get-started" rel="noopener" target="_blank">Using packages</a>
@@ -120,7 +120,7 @@
                 <h1 class="title">
                   oxygen 1.2.0
                   <span class="pkg-page-title-copy">
-                    <img class="pkg-page-title-copy-icon" src="/static/img/content-copy-icon.svg?hash=mocked_hash_1005735992" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>
+                    <img class="pkg-page-title-copy-icon" src="/static/img/content-copy-icon.svg?hash=mocked_hash_1005735992" alt="icon indicating copy to clipboard operation" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>
                     <div class="pkg-page-title-copy-feedback">
                       <span class="code">oxygen: ^1.2.0</span>
                       copied to clipboard
@@ -152,8 +152,8 @@
                   </div>
                   <div class="detail-like">
                     <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false">
-                      <img class="mdc-icon-button__icon" src="/static/img/like-inactive.svg?hash=mocked_hash_1066096316" width="18" height="18"/>
-                      <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/img/like-active.svg?hash=mocked_hash_986617859" width="18" height="18"/>
+                      <img class="mdc-icon-button__icon" src="/static/img/like-inactive.svg?hash=mocked_hash_1066096316" alt="icon indicating liked status (inactive)" width="18" height="18"/>
+                      <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/img/like-active.svg?hash=mocked_hash_986617859" alt="icon indicating liked status (active)" width="18" height="18"/>
                     </button>
                     <span class="likes-count">
                       <span id="likes-count">0</span>
@@ -235,14 +235,14 @@
                     <div class="pkg-report-section foldable">
                       <div class="pkg-report-header foldable-button" data-ga-click-event="toggle-report-section-convention">
                         <div class="pkg-report-header-icon">
-                          <img class="pkg-report-icon" src="/static/img/report-missing-icon-red.svg?hash=mocked_hash_289300077"/>
+                          <img class="pkg-report-icon" src="/static/img/report-missing-icon-red.svg?hash=mocked_hash_289300077" alt="icon indicating section status"/>
                         </div>
                         <div class="pkg-report-header-title">Fake conventions</div>
                         <div class="pkg-report-header-score -is-red">
                           <span class="pkg-report-header-score-granted">8</span>
                           /
                           <span class="pkg-report-header-score-max">30</span>
-                          <img class="foldable-icon" src="/static/img/report-foldable-icon.svg?hash=mocked_hash_525278376"/>
+                          <img class="foldable-icon" src="/static/img/report-foldable-icon.svg?hash=mocked_hash_525278376" alt="icon to trigger folding of the section"/>
                         </div>
                       </div>
                       <div class="foldable-content">
@@ -262,14 +262,14 @@
                     <div class="pkg-report-section foldable">
                       <div class="pkg-report-header foldable-button" data-ga-click-event="toggle-report-section-documentation">
                         <div class="pkg-report-header-icon">
-                          <img class="pkg-report-icon" src="/static/img/report-ok-icon-green.svg?hash=mocked_hash_415427754"/>
+                          <img class="pkg-report-icon" src="/static/img/report-ok-icon-green.svg?hash=mocked_hash_415427754" alt="icon indicating section status"/>
                         </div>
                         <div class="pkg-report-header-title">Fake documentation</div>
                         <div class="pkg-report-header-score">
                           <span class="pkg-report-header-score-granted">35</span>
                           /
                           <span class="pkg-report-header-score-max">40</span>
-                          <img class="foldable-icon" src="/static/img/report-foldable-icon.svg?hash=mocked_hash_525278376"/>
+                          <img class="foldable-icon" src="/static/img/report-foldable-icon.svg?hash=mocked_hash_525278376" alt="icon to trigger folding of the section"/>
                         </div>
                       </div>
                       <div class="foldable-content">
@@ -419,10 +419,10 @@
       <a class="link sep" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link sep" href="/help">Help</a>
       <a class="link icon sep" href="/feed.atom">
-        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" title="RSS/atom feed" alt="RSS/atom feed" width="20" height="20"/>
+        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
       </a>
       <a class="link icon github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">
-        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" title="Report an issue with this site" alt="Report an issue with this site" width="20" height="20"/>
+        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
       </a>
     </footer>
     <script src="/static/highlight/highlight-with-init.js?hash=mocked_hash_670483893" defer="defer"></script>

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -80,7 +80,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Pub.dev
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="/help/search" rel="noopener" target="_blank">Searching for packages</a>
@@ -90,7 +90,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Flutter
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://flutter.io/using-packages/" rel="noopener" target="_blank">Using packages</a>
@@ -101,7 +101,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Dart
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://dart.dev/tools/pub/get-started" rel="noopener" target="_blank">Using packages</a>
@@ -120,7 +120,7 @@
                 <h1 class="title">
                   oxygen 1.2.0
                   <span class="pkg-page-title-copy">
-                    <img class="pkg-page-title-copy-icon" src="/static/img/content-copy-icon.svg?hash=mocked_hash_1005735992" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>
+                    <img class="pkg-page-title-copy-icon" src="/static/img/content-copy-icon.svg?hash=mocked_hash_1005735992" alt="icon indicating copy to clipboard operation" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>
                     <div class="pkg-page-title-copy-feedback">
                       <span class="code">oxygen: ^1.2.0</span>
                       copied to clipboard
@@ -152,8 +152,8 @@
                   </div>
                   <div class="detail-like">
                     <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false">
-                      <img class="mdc-icon-button__icon" src="/static/img/like-inactive.svg?hash=mocked_hash_1066096316" width="18" height="18"/>
-                      <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/img/like-active.svg?hash=mocked_hash_986617859" width="18" height="18"/>
+                      <img class="mdc-icon-button__icon" src="/static/img/like-inactive.svg?hash=mocked_hash_1066096316" alt="icon indicating liked status (inactive)" width="18" height="18"/>
+                      <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/img/like-active.svg?hash=mocked_hash_986617859" alt="icon indicating liked status (active)" width="18" height="18"/>
                     </button>
                     <span class="likes-count">
                       <span id="likes-count">0</span>
@@ -326,10 +326,10 @@
       <a class="link sep" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link sep" href="/help">Help</a>
       <a class="link icon sep" href="/feed.atom">
-        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" title="RSS/atom feed" alt="RSS/atom feed" width="20" height="20"/>
+        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
       </a>
       <a class="link icon github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">
-        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" title="Report an issue with this site" alt="Report an issue with this site" width="20" height="20"/>
+        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
       </a>
     </footer>
     <script src="/static/highlight/highlight-with-init.js?hash=mocked_hash_670483893" defer="defer"></script>

--- a/app/test/frontend/golden/pkg_show_page_discontinued.html
+++ b/app/test/frontend/golden/pkg_show_page_discontinued.html
@@ -80,7 +80,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Pub.dev
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="/help/search" rel="noopener" target="_blank">Searching for packages</a>
@@ -90,7 +90,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Flutter
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://flutter.io/using-packages/" rel="noopener" target="_blank">Using packages</a>
@@ -101,7 +101,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Dart
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://dart.dev/tools/pub/get-started" rel="noopener" target="_blank">Using packages</a>
@@ -120,7 +120,7 @@
                 <h1 class="title">
                   pkg 1.0.0
                   <span class="pkg-page-title-copy">
-                    <img class="pkg-page-title-copy-icon" src="/static/img/content-copy-icon.svg?hash=mocked_hash_1005735992" title="Copy &quot;pkg: ^1.0.0&quot; to clipboard" data-copy-content="pkg: ^1.0.0" data-ga-click-event="copy-package-version"/>
+                    <img class="pkg-page-title-copy-icon" src="/static/img/content-copy-icon.svg?hash=mocked_hash_1005735992" alt="icon indicating copy to clipboard operation" title="Copy &quot;pkg: ^1.0.0&quot; to clipboard" data-copy-content="pkg: ^1.0.0" data-ga-click-event="copy-package-version"/>
                     <div class="pkg-page-title-copy-feedback">
                       <span class="code">pkg: ^1.0.0</span>
                       copied to clipboard
@@ -139,8 +139,8 @@
                   </div>
                   <div class="detail-like">
                     <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false">
-                      <img class="mdc-icon-button__icon" src="/static/img/like-inactive.svg?hash=mocked_hash_1066096316" width="18" height="18"/>
-                      <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/img/like-active.svg?hash=mocked_hash_986617859" width="18" height="18"/>
+                      <img class="mdc-icon-button__icon" src="/static/img/like-inactive.svg?hash=mocked_hash_1066096316" alt="icon indicating liked status (inactive)" width="18" height="18"/>
+                      <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/img/like-active.svg?hash=mocked_hash_986617859" alt="icon indicating liked status (active)" width="18" height="18"/>
                     </button>
                     <span class="likes-count">
                       <span id="likes-count">0</span>
@@ -313,10 +313,10 @@
       <a class="link sep" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link sep" href="/help">Help</a>
       <a class="link icon sep" href="/feed.atom">
-        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" title="RSS/atom feed" alt="RSS/atom feed" width="20" height="20"/>
+        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
       </a>
       <a class="link icon github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">
-        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" title="Report an issue with this site" alt="Report an issue with this site" width="20" height="20"/>
+        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
       </a>
     </footer>
     <script src="/static/highlight/highlight-with-init.js?hash=mocked_hash_670483893" defer="defer"></script>

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -80,7 +80,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Pub.dev
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="/help/search" rel="noopener" target="_blank">Searching for packages</a>
@@ -90,7 +90,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Flutter
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://flutter.io/using-packages/" rel="noopener" target="_blank">Using packages</a>
@@ -101,7 +101,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Dart
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://dart.dev/tools/pub/get-started" rel="noopener" target="_blank">Using packages</a>
@@ -120,7 +120,7 @@
                 <h1 class="title">
                   flutter_titanium 1.10.0
                   <span class="pkg-page-title-copy">
-                    <img class="pkg-page-title-copy-icon" src="/static/img/content-copy-icon.svg?hash=mocked_hash_1005735992" title="Copy &quot;flutter_titanium: ^1.10.0&quot; to clipboard" data-copy-content="flutter_titanium: ^1.10.0" data-ga-click-event="copy-package-version"/>
+                    <img class="pkg-page-title-copy-icon" src="/static/img/content-copy-icon.svg?hash=mocked_hash_1005735992" alt="icon indicating copy to clipboard operation" title="Copy &quot;flutter_titanium: ^1.10.0&quot; to clipboard" data-copy-content="flutter_titanium: ^1.10.0" data-ga-click-event="copy-package-version"/>
                     <div class="pkg-page-title-copy-feedback">
                       <span class="code">flutter_titanium: ^1.10.0</span>
                       copied to clipboard
@@ -148,8 +148,8 @@
                   </div>
                   <div class="detail-like">
                     <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false">
-                      <img class="mdc-icon-button__icon" src="/static/img/like-inactive.svg?hash=mocked_hash_1066096316" width="18" height="18"/>
-                      <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/img/like-active.svg?hash=mocked_hash_986617859" width="18" height="18"/>
+                      <img class="mdc-icon-button__icon" src="/static/img/like-inactive.svg?hash=mocked_hash_1066096316" alt="icon indicating liked status (inactive)" width="18" height="18"/>
+                      <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/img/like-active.svg?hash=mocked_hash_986617859" alt="icon indicating liked status (active)" width="18" height="18"/>
                     </button>
                     <span class="likes-count">
                       <span id="likes-count">0</span>
@@ -330,10 +330,10 @@
       <a class="link sep" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link sep" href="/help">Help</a>
       <a class="link icon sep" href="/feed.atom">
-        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" title="RSS/atom feed" alt="RSS/atom feed" width="20" height="20"/>
+        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
       </a>
       <a class="link icon github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">
-        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" title="Report an issue with this site" alt="Report an issue with this site" width="20" height="20"/>
+        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
       </a>
     </footer>
     <script src="/static/highlight/highlight-with-init.js?hash=mocked_hash_670483893" defer="defer"></script>

--- a/app/test/frontend/golden/pkg_show_page_legacy.html
+++ b/app/test/frontend/golden/pkg_show_page_legacy.html
@@ -80,7 +80,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Pub.dev
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="/help/search" rel="noopener" target="_blank">Searching for packages</a>
@@ -90,7 +90,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Flutter
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://flutter.io/using-packages/" rel="noopener" target="_blank">Using packages</a>
@@ -101,7 +101,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Dart
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://dart.dev/tools/pub/get-started" rel="noopener" target="_blank">Using packages</a>
@@ -120,7 +120,7 @@
                 <h1 class="title">
                   pkg 1.0.0-legacy
                   <span class="pkg-page-title-copy">
-                    <img class="pkg-page-title-copy-icon" src="/static/img/content-copy-icon.svg?hash=mocked_hash_1005735992" title="Copy &quot;pkg: ^1.0.0-legacy&quot; to clipboard" data-copy-content="pkg: ^1.0.0-legacy" data-ga-click-event="copy-package-version"/>
+                    <img class="pkg-page-title-copy-icon" src="/static/img/content-copy-icon.svg?hash=mocked_hash_1005735992" alt="icon indicating copy to clipboard operation" title="Copy &quot;pkg: ^1.0.0-legacy&quot; to clipboard" data-copy-content="pkg: ^1.0.0-legacy" data-ga-click-event="copy-package-version"/>
                     <div class="pkg-page-title-copy-feedback">
                       <span class="code">pkg: ^1.0.0-legacy</span>
                       copied to clipboard
@@ -139,8 +139,8 @@
                   </div>
                   <div class="detail-like">
                     <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false">
-                      <img class="mdc-icon-button__icon" src="/static/img/like-inactive.svg?hash=mocked_hash_1066096316" width="18" height="18"/>
-                      <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/img/like-active.svg?hash=mocked_hash_986617859" width="18" height="18"/>
+                      <img class="mdc-icon-button__icon" src="/static/img/like-inactive.svg?hash=mocked_hash_1066096316" alt="icon indicating liked status (inactive)" width="18" height="18"/>
+                      <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/img/like-active.svg?hash=mocked_hash_986617859" alt="icon indicating liked status (active)" width="18" height="18"/>
                     </button>
                     <span class="likes-count">
                       <span id="likes-count">0</span>
@@ -322,10 +322,10 @@
       <a class="link sep" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link sep" href="/help">Help</a>
       <a class="link icon sep" href="/feed.atom">
-        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" title="RSS/atom feed" alt="RSS/atom feed" width="20" height="20"/>
+        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
       </a>
       <a class="link icon github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">
-        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" title="Report an issue with this site" alt="Report an issue with this site" width="20" height="20"/>
+        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
       </a>
     </footer>
     <script src="/static/highlight/highlight-with-init.js?hash=mocked_hash_670483893" defer="defer"></script>

--- a/app/test/frontend/golden/pkg_show_page_publisher.html
+++ b/app/test/frontend/golden/pkg_show_page_publisher.html
@@ -80,7 +80,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Pub.dev
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="/help/search" rel="noopener" target="_blank">Searching for packages</a>
@@ -90,7 +90,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Flutter
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://flutter.io/using-packages/" rel="noopener" target="_blank">Using packages</a>
@@ -101,7 +101,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Dart
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://dart.dev/tools/pub/get-started" rel="noopener" target="_blank">Using packages</a>
@@ -120,7 +120,7 @@
                 <h1 class="title">
                   neon 1.0.0
                   <span class="pkg-page-title-copy">
-                    <img class="pkg-page-title-copy-icon" src="/static/img/content-copy-icon.svg?hash=mocked_hash_1005735992" title="Copy &quot;neon: ^1.0.0&quot; to clipboard" data-copy-content="neon: ^1.0.0" data-ga-click-event="copy-package-version"/>
+                    <img class="pkg-page-title-copy-icon" src="/static/img/content-copy-icon.svg?hash=mocked_hash_1005735992" alt="icon indicating copy to clipboard operation" title="Copy &quot;neon: ^1.0.0&quot; to clipboard" data-copy-content="neon: ^1.0.0" data-ga-click-event="copy-package-version"/>
                     <div class="pkg-page-title-copy-feedback">
                       <span class="code">neon: ^1.0.0</span>
                       copied to clipboard
@@ -134,7 +134,7 @@
                   </span>
                   •
                   <a class="-pub-publisher" href="/publishers/example.com">
-                    <img class="-pub-publisher-shield" src="/static/img/verified-publisher-blue.svg?hash=mocked_hash_919645162" title="Published by a pub.dev verified publisher"/>
+                    <img class="-pub-publisher-shield" src="/static/img/verified-publisher-blue.svg?hash=mocked_hash_919645162" alt="shield icon for verified publishers" title="Published by a pub.dev verified publisher"/>
                     example.com
                   </a>
                 </div>
@@ -144,8 +144,8 @@
                   </div>
                   <div class="detail-like">
                     <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false">
-                      <img class="mdc-icon-button__icon" src="/static/img/like-inactive.svg?hash=mocked_hash_1066096316" width="18" height="18"/>
-                      <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/img/like-active.svg?hash=mocked_hash_986617859" width="18" height="18"/>
+                      <img class="mdc-icon-button__icon" src="/static/img/like-inactive.svg?hash=mocked_hash_1066096316" alt="icon indicating liked status (inactive)" width="18" height="18"/>
+                      <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/img/like-active.svg?hash=mocked_hash_986617859" alt="icon indicating liked status (active)" width="18" height="18"/>
                     </button>
                     <span class="likes-count">
                       <span id="likes-count">0</span>
@@ -231,7 +231,7 @@
             <h3 class="title">Publisher</h3>
             <p>
               <a href="/publishers/example.com">
-                <img class="-pub-publisher-shield" src="/static/img/verified-publisher-blue.svg?hash=mocked_hash_919645162" title="Published by a pub.dev verified publisher"/>
+                <img class="-pub-publisher-shield" src="/static/img/verified-publisher-blue.svg?hash=mocked_hash_919645162" alt="shield icon for verified publishers" title="Published by a pub.dev verified publisher"/>
                 example.com
               </a>
             </p>
@@ -287,7 +287,7 @@
           <h3 class="title">Publisher</h3>
           <p>
             <a href="/publishers/example.com">
-              <img class="-pub-publisher-shield" src="/static/img/verified-publisher-blue.svg?hash=mocked_hash_919645162" title="Published by a pub.dev verified publisher"/>
+              <img class="-pub-publisher-shield" src="/static/img/verified-publisher-blue.svg?hash=mocked_hash_919645162" alt="shield icon for verified publishers" title="Published by a pub.dev verified publisher"/>
               example.com
             </a>
           </p>
@@ -322,10 +322,10 @@
       <a class="link sep" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link sep" href="/help">Help</a>
       <a class="link icon sep" href="/feed.atom">
-        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" title="RSS/atom feed" alt="RSS/atom feed" width="20" height="20"/>
+        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
       </a>
       <a class="link icon github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">
-        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" title="Report an issue with this site" alt="Report an issue with this site" width="20" height="20"/>
+        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
       </a>
     </footer>
     <script src="/static/highlight/highlight-with-init.js?hash=mocked_hash_670483893" defer="defer"></script>

--- a/app/test/frontend/golden/pkg_show_page_retracted.html
+++ b/app/test/frontend/golden/pkg_show_page_retracted.html
@@ -80,7 +80,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Pub.dev
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="/help/search" rel="noopener" target="_blank">Searching for packages</a>
@@ -90,7 +90,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Flutter
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://flutter.io/using-packages/" rel="noopener" target="_blank">Using packages</a>
@@ -101,7 +101,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Dart
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://dart.dev/tools/pub/get-started" rel="noopener" target="_blank">Using packages</a>
@@ -120,7 +120,7 @@
                 <h1 class="title">
                   pkg 1.0.0
                   <span class="pkg-page-title-copy">
-                    <img class="pkg-page-title-copy-icon" src="/static/img/content-copy-icon.svg?hash=mocked_hash_1005735992" title="Copy &quot;pkg: ^1.0.0&quot; to clipboard" data-copy-content="pkg: ^1.0.0" data-ga-click-event="copy-package-version"/>
+                    <img class="pkg-page-title-copy-icon" src="/static/img/content-copy-icon.svg?hash=mocked_hash_1005735992" alt="icon indicating copy to clipboard operation" title="Copy &quot;pkg: ^1.0.0&quot; to clipboard" data-copy-content="pkg: ^1.0.0" data-ga-click-event="copy-package-version"/>
                     <div class="pkg-page-title-copy-feedback">
                       <span class="code">pkg: ^1.0.0</span>
                       copied to clipboard
@@ -148,8 +148,8 @@
                   </div>
                   <div class="detail-like">
                     <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false">
-                      <img class="mdc-icon-button__icon" src="/static/img/like-inactive.svg?hash=mocked_hash_1066096316" width="18" height="18"/>
-                      <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/img/like-active.svg?hash=mocked_hash_986617859" width="18" height="18"/>
+                      <img class="mdc-icon-button__icon" src="/static/img/like-inactive.svg?hash=mocked_hash_1066096316" alt="icon indicating liked status (inactive)" width="18" height="18"/>
+                      <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/img/like-active.svg?hash=mocked_hash_986617859" alt="icon indicating liked status (active)" width="18" height="18"/>
                     </button>
                     <span class="likes-count">
                       <span id="likes-count">0</span>
@@ -322,10 +322,10 @@
       <a class="link sep" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link sep" href="/help">Help</a>
       <a class="link icon sep" href="/feed.atom">
-        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" title="RSS/atom feed" alt="RSS/atom feed" width="20" height="20"/>
+        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
       </a>
       <a class="link icon github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">
-        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" title="Report an issue with this site" alt="Report an issue with this site" width="20" height="20"/>
+        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
       </a>
     </footer>
     <script src="/static/highlight/highlight-with-init.js?hash=mocked_hash_670483893" defer="defer"></script>

--- a/app/test/frontend/golden/pkg_show_page_retracted_non_retracted_version.html
+++ b/app/test/frontend/golden/pkg_show_page_retracted_non_retracted_version.html
@@ -80,7 +80,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Pub.dev
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="/help/search" rel="noopener" target="_blank">Searching for packages</a>
@@ -90,7 +90,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Flutter
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://flutter.io/using-packages/" rel="noopener" target="_blank">Using packages</a>
@@ -101,7 +101,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Dart
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://dart.dev/tools/pub/get-started" rel="noopener" target="_blank">Using packages</a>
@@ -120,7 +120,7 @@
                 <h1 class="title">
                   pkg 2.0.0
                   <span class="pkg-page-title-copy">
-                    <img class="pkg-page-title-copy-icon" src="/static/img/content-copy-icon.svg?hash=mocked_hash_1005735992" title="Copy &quot;pkg: ^2.0.0&quot; to clipboard" data-copy-content="pkg: ^2.0.0" data-ga-click-event="copy-package-version"/>
+                    <img class="pkg-page-title-copy-icon" src="/static/img/content-copy-icon.svg?hash=mocked_hash_1005735992" alt="icon indicating copy to clipboard operation" title="Copy &quot;pkg: ^2.0.0&quot; to clipboard" data-copy-content="pkg: ^2.0.0" data-ga-click-event="copy-package-version"/>
                     <div class="pkg-page-title-copy-feedback">
                       <span class="code">pkg: ^2.0.0</span>
                       copied to clipboard
@@ -143,8 +143,8 @@
                   </div>
                   <div class="detail-like">
                     <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false">
-                      <img class="mdc-icon-button__icon" src="/static/img/like-inactive.svg?hash=mocked_hash_1066096316" width="18" height="18"/>
-                      <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/img/like-active.svg?hash=mocked_hash_986617859" width="18" height="18"/>
+                      <img class="mdc-icon-button__icon" src="/static/img/like-inactive.svg?hash=mocked_hash_1066096316" alt="icon indicating liked status (inactive)" width="18" height="18"/>
+                      <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/img/like-active.svg?hash=mocked_hash_986617859" alt="icon indicating liked status (active)" width="18" height="18"/>
                     </button>
                     <span class="likes-count">
                       <span id="likes-count">0</span>
@@ -317,10 +317,10 @@
       <a class="link sep" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link sep" href="/help">Help</a>
       <a class="link icon sep" href="/feed.atom">
-        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" title="RSS/atom feed" alt="RSS/atom feed" width="20" height="20"/>
+        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
       </a>
       <a class="link icon github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">
-        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" title="Report an issue with this site" alt="Report an issue with this site" width="20" height="20"/>
+        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
       </a>
     </footer>
     <script src="/static/highlight/highlight-with-init.js?hash=mocked_hash_670483893" defer="defer"></script>

--- a/app/test/frontend/golden/pkg_show_version_page.html
+++ b/app/test/frontend/golden/pkg_show_version_page.html
@@ -80,7 +80,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Pub.dev
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="/help/search" rel="noopener" target="_blank">Searching for packages</a>
@@ -90,7 +90,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Flutter
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://flutter.io/using-packages/" rel="noopener" target="_blank">Using packages</a>
@@ -101,7 +101,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Dart
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://dart.dev/tools/pub/get-started" rel="noopener" target="_blank">Using packages</a>
@@ -120,7 +120,7 @@
                 <h1 class="title">
                   oxygen 1.2.0
                   <span class="pkg-page-title-copy">
-                    <img class="pkg-page-title-copy-icon" src="/static/img/content-copy-icon.svg?hash=mocked_hash_1005735992" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>
+                    <img class="pkg-page-title-copy-icon" src="/static/img/content-copy-icon.svg?hash=mocked_hash_1005735992" alt="icon indicating copy to clipboard operation" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>
                     <div class="pkg-page-title-copy-feedback">
                       <span class="code">oxygen: ^1.2.0</span>
                       copied to clipboard
@@ -152,8 +152,8 @@
                   </div>
                   <div class="detail-like">
                     <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false">
-                      <img class="mdc-icon-button__icon" src="/static/img/like-inactive.svg?hash=mocked_hash_1066096316" width="18" height="18"/>
-                      <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/img/like-active.svg?hash=mocked_hash_986617859" width="18" height="18"/>
+                      <img class="mdc-icon-button__icon" src="/static/img/like-inactive.svg?hash=mocked_hash_1066096316" alt="icon indicating liked status (inactive)" width="18" height="18"/>
+                      <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/img/like-active.svg?hash=mocked_hash_986617859" alt="icon indicating liked status (active)" width="18" height="18"/>
                     </button>
                     <span class="likes-count">
                       <span id="likes-count">0</span>
@@ -326,10 +326,10 @@
       <a class="link sep" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link sep" href="/help">Help</a>
       <a class="link icon sep" href="/feed.atom">
-        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" title="RSS/atom feed" alt="RSS/atom feed" width="20" height="20"/>
+        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
       </a>
       <a class="link icon github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">
-        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" title="Report an issue with this site" alt="Report an issue with this site" width="20" height="20"/>
+        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
       </a>
     </footer>
     <script src="/static/highlight/highlight-with-init.js?hash=mocked_hash_670483893" defer="defer"></script>

--- a/app/test/frontend/golden/pkg_versions_page.html
+++ b/app/test/frontend/golden/pkg_versions_page.html
@@ -80,7 +80,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Pub.dev
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="/help/search" rel="noopener" target="_blank">Searching for packages</a>
@@ -90,7 +90,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Flutter
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://flutter.io/using-packages/" rel="noopener" target="_blank">Using packages</a>
@@ -101,7 +101,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Dart
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://dart.dev/tools/pub/get-started" rel="noopener" target="_blank">Using packages</a>
@@ -120,7 +120,7 @@
                 <h1 class="title">
                   oxygen 1.2.0
                   <span class="pkg-page-title-copy">
-                    <img class="pkg-page-title-copy-icon" src="/static/img/content-copy-icon.svg?hash=mocked_hash_1005735992" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>
+                    <img class="pkg-page-title-copy-icon" src="/static/img/content-copy-icon.svg?hash=mocked_hash_1005735992" alt="icon indicating copy to clipboard operation" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>
                     <div class="pkg-page-title-copy-feedback">
                       <span class="code">oxygen: ^1.2.0</span>
                       copied to clipboard
@@ -152,8 +152,8 @@
                   </div>
                   <div class="detail-like">
                     <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false">
-                      <img class="mdc-icon-button__icon" src="/static/img/like-inactive.svg?hash=mocked_hash_1066096316" width="18" height="18"/>
-                      <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/img/like-active.svg?hash=mocked_hash_986617859" width="18" height="18"/>
+                      <img class="mdc-icon-button__icon" src="/static/img/like-inactive.svg?hash=mocked_hash_1066096316" alt="icon indicating liked status (inactive)" width="18" height="18"/>
+                      <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/img/like-active.svg?hash=mocked_hash_986617859" alt="icon indicating liked status (active)" width="18" height="18"/>
                     </button>
                     <span class="likes-count">
                       <span id="likes-count">0</span>
@@ -433,10 +433,10 @@
       <a class="link sep" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link sep" href="/help">Help</a>
       <a class="link icon sep" href="/feed.atom">
-        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" title="RSS/atom feed" alt="RSS/atom feed" width="20" height="20"/>
+        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
       </a>
       <a class="link icon github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">
-        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" title="Report an issue with this site" alt="Report an issue with this site" width="20" height="20"/>
+        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
       </a>
     </footer>
     <script src="/static/highlight/highlight-with-init.js?hash=mocked_hash_670483893" defer="defer"></script>

--- a/app/test/frontend/golden/platform_tabs_list.html
+++ b/app/test/frontend/golden/platform_tabs_list.html
@@ -3,7 +3,7 @@
     <a class="search-link filter" href="/dart/packages" title="Packages compatible with the Dart SDK">Dart</a>
     <a class="search-link filter" href="/flutter/packages" title="Packages compatible with the Flutter SDK">Flutter</a>
     <a class="search-link filter -active" href="/packages" title="Packages compatible with the any SDK">
-      <img class="filter-icon" src="/static/img/checkmark-icon.svg?hash=mocked_hash_296261337"/>
+      <img class="filter-icon" src="/static/img/checkmark-icon.svg?hash=mocked_hash_296261337" alt="icon with a checkmark - indicating active status"/>
       Any
     </a>
   </div>

--- a/app/test/frontend/golden/platform_tabs_search.html
+++ b/app/test/frontend/golden/platform_tabs_search.html
@@ -2,7 +2,7 @@
   <div class="list-filters">
     <a class="search-link filter" href="/dart/packages?q=foo" title="Packages compatible with the Dart SDK">Dart</a>
     <a class="search-link filter -active" href="/flutter/packages?q=foo" title="Packages compatible with the Flutter SDK">
-      <img class="filter-icon" src="/static/img/checkmark-icon.svg?hash=mocked_hash_296261337"/>
+      <img class="filter-icon" src="/static/img/checkmark-icon.svg?hash=mocked_hash_296261337" alt="icon with a checkmark - indicating active status"/>
       Flutter
     </a>
     <a class="search-link filter" href="/packages?q=foo" title="Packages compatible with the any SDK">Any</a>

--- a/app/test/frontend/golden/publisher_activity_log_page.html
+++ b/app/test/frontend/golden/publisher_activity_log_page.html
@@ -75,7 +75,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Pub.dev
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="/help/search" rel="noopener" target="_blank">Searching for packages</a>
@@ -85,7 +85,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Flutter
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://flutter.io/using-packages/" rel="noopener" target="_blank">Using packages</a>
@@ -96,7 +96,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Dart
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://dart.dev/tools/pub/get-started" rel="noopener" target="_blank">Using packages</a>
@@ -127,11 +127,11 @@
                 <div class="metadata">
                   <p>
                     <span class="detail-header-metadata-ref">
-                      <img class="detail-header-metadata-ref-icon" src="/static/img/link-icon.svg?hash=mocked_hash_709199651"/>
+                      <img class="detail-header-metadata-ref-icon" src="/static/img/link-icon.svg?hash=mocked_hash_709199651" alt="icon indicating a website link"/>
                       <a class="detail-header-metadata-ref-label" href="https://example.com/" rel="ugc">example.com/</a>
                     </span>
                     <span class="detail-header-metadata-ref">
-                      <img class="detail-header-metadata-ref-icon" src="/static/img/email-icon.svg?hash=mocked_hash_308057918"/>
+                      <img class="detail-header-metadata-ref-icon" src="/static/img/email-icon.svg?hash=mocked_hash_308057918" alt="icon indicating an email"/>
                       <a class="detail-header-metadata-ref-label" href="mailto:admin@pub.dev">admin@pub.dev</a>
                     </span>
                   </p>
@@ -226,10 +226,10 @@
       <a class="link sep" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link sep" href="/help">Help</a>
       <a class="link icon sep" href="/feed.atom">
-        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" title="RSS/atom feed" alt="RSS/atom feed" width="20" height="20"/>
+        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
       </a>
       <a class="link icon github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">
-        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" title="Report an issue with this site" alt="Report an issue with this site" width="20" height="20"/>
+        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
       </a>
     </footer>
   </body>

--- a/app/test/frontend/golden/publisher_admin_page.html
+++ b/app/test/frontend/golden/publisher_admin_page.html
@@ -75,7 +75,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Pub.dev
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="/help/search" rel="noopener" target="_blank">Searching for packages</a>
@@ -85,7 +85,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Flutter
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://flutter.io/using-packages/" rel="noopener" target="_blank">Using packages</a>
@@ -96,7 +96,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Dart
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://dart.dev/tools/pub/get-started" rel="noopener" target="_blank">Using packages</a>
@@ -127,11 +127,11 @@
                 <div class="metadata">
                   <p>
                     <span class="detail-header-metadata-ref">
-                      <img class="detail-header-metadata-ref-icon" src="/static/img/link-icon.svg?hash=mocked_hash_709199651"/>
+                      <img class="detail-header-metadata-ref-icon" src="/static/img/link-icon.svg?hash=mocked_hash_709199651" alt="icon indicating a website link"/>
                       <a class="detail-header-metadata-ref-label" href="https://example.com/" rel="ugc">example.com/</a>
                     </span>
                     <span class="detail-header-metadata-ref">
-                      <img class="detail-header-metadata-ref-icon" src="/static/img/email-icon.svg?hash=mocked_hash_308057918"/>
+                      <img class="detail-header-metadata-ref-icon" src="/static/img/email-icon.svg?hash=mocked_hash_308057918" alt="icon indicating an email"/>
                       <a class="detail-header-metadata-ref-label" href="mailto:admin@pub.dev">admin@pub.dev</a>
                     </span>
                   </p>
@@ -255,10 +255,10 @@
       <a class="link sep" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link sep" href="/help">Help</a>
       <a class="link icon sep" href="/feed.atom">
-        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" title="RSS/atom feed" alt="RSS/atom feed" width="20" height="20"/>
+        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
       </a>
       <a class="link icon github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">
-        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" title="Report an issue with this site" alt="Report an issue with this site" width="20" height="20"/>
+        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
       </a>
     </footer>
   </body>

--- a/app/test/frontend/golden/publisher_list_page.html
+++ b/app/test/frontend/golden/publisher_list_page.html
@@ -74,7 +74,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Pub.dev
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="/help/search" rel="noopener" target="_blank">Searching for packages</a>
@@ -84,7 +84,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Flutter
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://flutter.io/using-packages/" rel="noopener" target="_blank">Using packages</a>
@@ -95,7 +95,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Dart
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://dart.dev/tools/pub/get-started" rel="noopener" target="_blank">Using packages</a>
@@ -111,8 +111,8 @@
           <input class="input" name="q" placeholder="Search packages" autocomplete="on" autofocus="autofocus"/>
           <button class="icon"></button>
           <div class="search-filters-btn-wrapper">
-            <img class="search-filters-btn search-filters-btn-inactive" src="/static/img/search-filters-inactive.svg?hash=mocked_hash_963166179"/>
-            <img class="search-filters-btn search-filters-btn-active" src="/static/img/search-filters-active.svg?hash=mocked_hash_397783636"/>
+            <img class="search-filters-btn search-filters-btn-inactive" src="/static/img/search-filters-inactive.svg?hash=mocked_hash_963166179" alt="icon to toggle the display of search filters (inactive)"/>
+            <img class="search-filters-btn search-filters-btn-active" src="/static/img/search-filters-active.svg?hash=mocked_hash_397783636" alt="icon to toggle the display of search filters (active)"/>
           </div>
           <input id="-search-discontinued-field" type="hidden" name="discontinued" value="1" disabled="disabled"/>
           <input id="-search-unlisted-field" type="hidden" name="unlisted" value="1" disabled="disabled"/>
@@ -160,10 +160,10 @@
       <a class="link sep" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link sep" href="/help">Help</a>
       <a class="link icon sep" href="/feed.atom">
-        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" title="RSS/atom feed" alt="RSS/atom feed" width="20" height="20"/>
+        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
       </a>
       <a class="link icon github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">
-        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" title="Report an issue with this site" alt="Report an issue with this site" width="20" height="20"/>
+        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
       </a>
     </footer>
   </body>

--- a/app/test/frontend/golden/publisher_packages_page.html
+++ b/app/test/frontend/golden/publisher_packages_page.html
@@ -75,7 +75,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Pub.dev
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="/help/search" rel="noopener" target="_blank">Searching for packages</a>
@@ -85,7 +85,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Flutter
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://flutter.io/using-packages/" rel="noopener" target="_blank">Using packages</a>
@@ -96,7 +96,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Dart
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://dart.dev/tools/pub/get-started" rel="noopener" target="_blank">Using packages</a>
@@ -127,11 +127,11 @@
                 <div class="metadata">
                   <p>
                     <span class="detail-header-metadata-ref">
-                      <img class="detail-header-metadata-ref-icon" src="/static/img/link-icon.svg?hash=mocked_hash_709199651"/>
+                      <img class="detail-header-metadata-ref-icon" src="/static/img/link-icon.svg?hash=mocked_hash_709199651" alt="icon indicating a website link"/>
                       <a class="detail-header-metadata-ref-label" href="https://example.com/" rel="ugc">example.com/</a>
                     </span>
                     <span class="detail-header-metadata-ref">
-                      <img class="detail-header-metadata-ref-icon" src="/static/img/email-icon.svg?hash=mocked_hash_308057918"/>
+                      <img class="detail-header-metadata-ref-icon" src="/static/img/email-icon.svg?hash=mocked_hash_308057918" alt="icon indicating an email"/>
                       <a class="detail-header-metadata-ref-label" href="mailto:admin@pub.dev">admin@pub.dev</a>
                     </span>
                   </p>
@@ -192,7 +192,7 @@
                           <a href="/packages/neon">neon</a>
                         </h3>
                         <div class="packages-recent">
-                          <img class="packages-recent-icon" src="/static/img/schedule-icon.svg?hash=mocked_hash_164576935" title="new package"/>
+                          <img class="packages-recent-icon" src="/static/img/schedule-icon.svg?hash=mocked_hash_164576935" alt="icon indicating recent time" title="new package"/>
                           Added
                           <b>%%x-ago%%</b>
                         </div>
@@ -230,7 +230,7 @@
                           )
                         </span>
                         <span class="packages-metadata-block">
-                          <img class="package-vp-icon" src="/static/img/verified-publisher-icon.svg?hash=mocked_hash_1044149352" title="Published by a pub.dev verified publisher"/>
+                          <img class="package-vp-icon" src="/static/img/verified-publisher-icon.svg?hash=mocked_hash_1044149352" alt="shield icon for verified publishers" title="Published by a pub.dev verified publisher"/>
                           <a href="/publishers/example.com">example.com</a>
                         </span>
                       </p>
@@ -247,7 +247,7 @@
                           <a href="/packages/flutter_titanium">flutter_titanium</a>
                         </h3>
                         <div class="packages-recent">
-                          <img class="packages-recent-icon" src="/static/img/schedule-icon.svg?hash=mocked_hash_164576935" title="new package"/>
+                          <img class="packages-recent-icon" src="/static/img/schedule-icon.svg?hash=mocked_hash_164576935" alt="icon indicating recent time" title="new package"/>
                           Added
                           <b>%%x-ago%%</b>
                         </div>
@@ -332,10 +332,10 @@
       <a class="link sep" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link sep" href="/help">Help</a>
       <a class="link icon sep" href="/feed.atom">
-        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" title="RSS/atom feed" alt="RSS/atom feed" width="20" height="20"/>
+        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
       </a>
       <a class="link icon github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">
-        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" title="Report an issue with this site" alt="Report an issue with this site" width="20" height="20"/>
+        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
       </a>
     </footer>
   </body>

--- a/app/test/frontend/golden/search_page.html
+++ b/app/test/frontend/golden/search_page.html
@@ -74,7 +74,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Pub.dev
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="/help/search" rel="noopener" target="_blank">Searching for packages</a>
@@ -84,7 +84,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Flutter
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://flutter.io/using-packages/" rel="noopener" target="_blank">Using packages</a>
@@ -95,7 +95,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Dart
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648"/>
+            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://dart.dev/tools/pub/get-started" rel="noopener" target="_blank">Using packages</a>
@@ -111,8 +111,8 @@
           <input class="input" name="q" placeholder="Search packages" autocomplete="on" value="foobar"/>
           <button class="icon"></button>
           <div class="search-filters-btn-wrapper">
-            <img class="search-filters-btn search-filters-btn-inactive" src="/static/img/search-filters-inactive.svg?hash=mocked_hash_963166179"/>
-            <img class="search-filters-btn search-filters-btn-active" src="/static/img/search-filters-active.svg?hash=mocked_hash_397783636"/>
+            <img class="search-filters-btn search-filters-btn-inactive" src="/static/img/search-filters-inactive.svg?hash=mocked_hash_963166179" alt="icon to toggle the display of search filters (inactive)"/>
+            <img class="search-filters-btn search-filters-btn-active" src="/static/img/search-filters-active.svg?hash=mocked_hash_397783636" alt="icon to toggle the display of search filters (active)"/>
           </div>
           <input type="hidden" name="sort" value="top"/>
           <input id="-search-discontinued-field" type="hidden" name="discontinued" value="1" disabled="disabled"/>
@@ -130,7 +130,7 @@
                 <a class="search-link filter" href="/dart/packages?q=foobar&amp;sort=top" title="Packages compatible with the Dart SDK">Dart</a>
                 <a class="search-link filter" href="/flutter/packages?q=foobar&amp;sort=top" title="Packages compatible with the Flutter SDK">Flutter</a>
                 <a class="search-link filter -active" href="/packages?q=foobar&amp;sort=top" title="Packages compatible with the any SDK">
-                  <img class="filter-icon" src="/static/img/checkmark-icon.svg?hash=mocked_hash_296261337"/>
+                  <img class="filter-icon" src="/static/img/checkmark-icon.svg?hash=mocked_hash_296261337" alt="icon with a checkmark - indicating active status"/>
                   Any
                 </a>
               </div>
@@ -141,14 +141,14 @@
                 <a class="search-link filter" href="/dart/packages?q=foobar&amp;sort=top" title="Packages compatible with the Dart SDK">Dart</a>
                 <a class="search-link filter" href="/flutter/packages?q=foobar&amp;sort=top" title="Packages compatible with the Flutter SDK">Flutter</a>
                 <a class="search-link filter -active" href="/packages?q=foobar&amp;sort=top" title="Packages compatible with the any SDK">
-                  <img class="filter-icon" src="/static/img/checkmark-icon.svg?hash=mocked_hash_296261337"/>
+                  <img class="filter-icon" src="/static/img/checkmark-icon.svg?hash=mocked_hash_296261337" alt="icon with a checkmark - indicating active status"/>
                   Any
                 </a>
               </div>
             </div>
             <div class="search-filters-btn search-filters-btn-wrapper search-controls-more" data-ga-click-event="toggle-advanced-search">
               Advanced
-              <img class="search-controls-more-carot" src="/static/img/carot-up.svg?hash=mocked_hash_771440143"/>
+              <img class="search-controls-more-carot" src="/static/img/carot-up.svg?hash=mocked_hash_771440143" alt="toggle button for advanced search (carot up)"/>
             </div>
           </div>
         </div>
@@ -202,7 +202,7 @@
                 <a href="/packages/oxygen">oxygen</a>
               </h3>
               <div class="packages-recent">
-                <img class="packages-recent-icon" src="/static/img/schedule-icon.svg?hash=mocked_hash_164576935" title="new package"/>
+                <img class="packages-recent-icon" src="/static/img/schedule-icon.svg?hash=mocked_hash_164576935" alt="icon indicating recent time" title="new package"/>
                 Added
                 <b>%%x-ago%%</b>
               </div>
@@ -269,7 +269,7 @@
                 <a href="/packages/flutter_titanium">flutter_titanium</a>
               </h3>
               <div class="packages-recent">
-                <img class="packages-recent-icon" src="/static/img/schedule-icon.svg?hash=mocked_hash_164576935" title="new package"/>
+                <img class="packages-recent-icon" src="/static/img/schedule-icon.svg?hash=mocked_hash_164576935" alt="icon indicating recent time" title="new package"/>
                 Added
                 <b>%%x-ago%%</b>
               </div>
@@ -376,10 +376,10 @@
       <a class="link sep" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link sep" href="/help">Help</a>
       <a class="link icon sep" href="/feed.atom">
-        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" title="RSS/atom feed" alt="RSS/atom feed" width="20" height="20"/>
+        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
       </a>
       <a class="link icon github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">
-        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" title="Report an issue with this site" alt="Report an issue with this site" width="20" height="20"/>
+        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
       </a>
     </footer>
   </body>


### PR DESCRIPTION
- It is better to use a separate object for it, otherwise we would have cases where both the image url and the `alt` text is optional, and could be misused. 
- Improves accessibility (#5263), and it is a prelude to mandatory image dimensions (#5262).
- We can't use the same text that goes into `title`, as it is fundamentally different how we describe what's on the image, and what it's function is e.g. on clicking on it.
- The alternative names of the images may not be consistent over the codebase, but a follow-up refactoring could collect them into a single place where it is easier to review and update them.
