### PR TITLE
Integrity check for PackageVersion.retracted timestamp.

### DIFF
--- a/app/lib/shared/integrity.dart
+++ b/app/lib/shared/integrity.dart
@@ -443,8 +443,8 @@ class IntegrityChecker {
     if (_invalidUsers.contains(pv.uploader)) {
       yield 'PackageVersion "${pv.qualifiedVersionKey}" has invalid uploader: User "${pv.uploader}".';
     }
-    if (pv.isRetracted is! bool) {
-      yield 'PackageVersion "${pv.qualifiedVersionKey}" has an `isRetracted` property which is not a bool.';
+    if (pv.isRetracted && pv.retracted == null) {
+      yield 'PackageVersion "${pv.qualifiedVersionKey}" is retracted, but `retracted` property is null.';
     }
     if (!envConfig.isRunningLocally) {
       final info = await tarballStorage.info(pv.package, pv.version!);


### PR DESCRIPTION
The bool check is no longer relevant, but we also need a timestamp check if the version is retracted.