### PR TITLE
Move null-safe search option into query text.

### DIFF
--- a/app/lib/frontend/templates/views/pkg/index.dart
+++ b/app/lib/frontend/templates/views/pkg/index.dart
@@ -116,7 +116,9 @@ d.Node _searchFormContainer({
             sectionTag: 'advanced',
             label: 'Advanced',
             isActive: openSections.contains('advanced') ||
-                searchForm.hasActiveAdvanced,
+                searchForm.hasActiveAdvanced ||
+                searchForm.parsedQuery.tagsPredicate
+                    .hasTag(PackageVersionTags.isNullSafe),
             children: [
               _formLinkedCheckbox(
                 id: 'search-form-checkbox-discontinued',
@@ -130,11 +132,11 @@ d.Node _searchFormContainer({
                 toggledSearchForm: searchForm.toggleUnlisted(),
                 isChecked: searchForm.includeUnlisted,
               ),
-              _formLinkedCheckbox(
-                id: 'search-form-checkbox-null-safe',
+              _tagBasedCheckbox(
+                tagPrefix: 'is',
+                tagValue: 'null-safe',
                 label: 'Supports null safety',
-                toggledSearchForm: searchForm.toggleNullSafe(),
-                isChecked: searchForm.nullSafe,
+                searchForm: searchForm,
               ),
             ],
           ),

--- a/app/test/frontend/golden/pkg_index_page_experimental.html
+++ b/app/test/frontend/golden/pkg_index_page_experimental.html
@@ -318,7 +318,7 @@
               <div class="search-form-linked-checkbox">
                 <div class="mdc-form-field">
                   <div class="mdc-checkbox">
-                    <input id="search-form-checkbox-null-safe" class="mdc-checkbox__native-control" type="checkbox"/>
+                    <input id="search-form-checkbox-is-null-safe" class="mdc-checkbox__native-control" type="checkbox"/>
                     <div class="mdc-checkbox__background">
                       <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
                         <path class="mdc-checkbox__checkmark-path" fill="none" d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
@@ -327,8 +327,8 @@
                     </div>
                     <div class="mdc-checkbox__ripple"></div>
                   </div>
-                  <label for="search-form-checkbox-null-safe">
-                    <a href="/packages?q=sdk%3Adart&amp;unlisted=1&amp;null-safe=1">Supports null safety</a>
+                  <label for="search-form-checkbox-is-null-safe">
+                    <a href="/packages?q=sdk%3Adart+is%3Anull-safe&amp;unlisted=1" data-tag="is:null-safe">Supports null safety</a>
                   </label>
                 </div>
               </div>

--- a/pkg/pub_integration/test/search_update_test.dart
+++ b/pkg/pub_integration/test/search_update_test.dart
@@ -189,6 +189,15 @@ void main() {
           await page.click('#search-form-checkbox-discontinued');
           await page.waitForNavigation(wait: Until.networkIdle);
           expect(page.url, '$origin/packages?q=platform%3Aandroid+pkg');
+
+          // toggle is:null-safe
+          await page.click('#search-form-checkbox-is-null-safe');
+          await page.waitForNavigation(wait: Until.networkIdle);
+          expect(page.url,
+              '$origin/packages?q=platform%3Aandroid+pkg+is%3Anull-safe');
+          await page.click('#search-form-checkbox-is-null-safe');
+          await page.waitForNavigation(wait: Until.networkIdle);
+          expect(page.url, '$origin/packages?q=platform%3Aandroid+pkg');
         },
       );
     });


### PR DESCRIPTION
Keeps the request parameter for the current search, only applied for new search UI.