### PR TITLE
UserSession cache handling: simpler lookup and batched cleanup.

### DIFF
--- a/app/lib/account/models.dart
+++ b/app/lib/account/models.dart
@@ -197,6 +197,8 @@ class UserSessionData {
 
   Map<String, dynamic> toJson() => _$UserSessionDataToJson(this);
 
+  bool get isExpired => DateTime.now().isAfter(expires);
+
   bool get hasName => name != null && name!.isNotEmpty;
 
   /// Set image size to NxN pixels for faster loading, see:


### PR DESCRIPTION
- As we don't need to extend the UserSession's expiration date, the data in cache can be considered immutable.
- Removing the expiration extension TODO and also using simper lookup logic.
- Cleanup doesn't need to clear cache entries one-by-one, it can just let them be purged by redis, using more efficient batched deletion.