### PR TITLE
Use pkg/indexed_blob for dartdoc content serving.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ AppEngine version, listed here to ease deployment and troubleshooting.
 ## Next Release (replace with git tag when deployed)
  * Bumped runtimeVersion to `2022.01.06`.
  * Upgraded pana to `0.21.5`.
+ * NOTE: Started to use `pkg/indexed_blob` to generate and serve `dartdoc` content.
 
 ## `20220106t124300-all`
  * Bumped runtimeVersion to `2021.12.17`.

--- a/app/lib/dartdoc/backend.dart
+++ b/app/lib/dartdoc/backend.dart
@@ -25,6 +25,9 @@ import '../shared/versions.dart' as shared_versions;
 import 'models.dart';
 import 'storage_path.dart' as storage_path;
 
+/// Exposed because the HTTP handler needs to know these files
+/// are served not from the blob.
+/// TODO: refactor after we are using only blobs in all accepted runtimes.
 const archiveFilePath = 'package.tar.gz';
 const blobFilePath = 'blob-data.gz';
 const blobIndexV1FilePath = 'index-v1.json';

--- a/app/lib/dartdoc/dartdoc_runner.dart
+++ b/app/lib/dartdoc/dartdoc_runner.dart
@@ -7,6 +7,7 @@ import 'dart:convert' as convert;
 import 'dart:io';
 
 import 'package:clock/clock.dart';
+import 'package:indexed_blob/indexed_blob.dart';
 import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
 import 'package:pana/pana.dart' hide Pubspec, ReportStatus;
@@ -37,9 +38,6 @@ import 'models.dart';
 
 final Logger _logger = Logger('pub.dartdoc.runner');
 
-const statusFilePath = 'status.json';
-const _archiveFilePath = 'package.tar.gz';
-const _buildLogFilePath = 'log.txt';
 const _packageTimeout = Duration(minutes: 10);
 final _packageTimeoutExtended = _packageTimeout * 2;
 const _pubDataFileName = 'pub-data.json';
@@ -260,12 +258,15 @@ class DartdocJobProcessor extends JobProcessor {
         await Directory.systemTemp.createTemp('pub-dartlang-dartdoc');
     final tempDirPath = tempDir.resolveSymbolicLinksSync();
     final pkgPath = p.join(tempDirPath, 'pkg');
-    final tarDir = p.join(tempDirPath, 'output');
-    final outputDir = p.join(tarDir, job.packageName, job.packageVersion);
+    final tarBaseDir = p.join(tempDirPath, 'output');
+    final dartdocContentDir =
+        p.join(tarBaseDir, job.packageName, job.packageVersion);
+    final uploadDir = p.join(tempDirPath, 'upload');
 
     // directories need to be created
-    await Directory(outputDir).create(recursive: true);
     await Directory(pkgPath).create(recursive: true);
+    await Directory(dartdocContentDir).create(recursive: true);
+    await Directory(uploadDir).create(recursive: true);
 
     final latestVersion =
         await packageBackend.getLatestVersion(job.packageName!);
@@ -301,6 +302,7 @@ class DartdocJobProcessor extends JobProcessor {
             version: job.packageVersion!,
             destination: pkgPath,
           );
+          final uuid = createUuid();
 
           // Resolve dependencies only for non-legacy package versions.
           if (!packageStatus.isLegacy) {
@@ -316,7 +318,7 @@ class DartdocJobProcessor extends JobProcessor {
           // Generate docs only for packages that have healthy dependencies.
           if (depsResolved) {
             dartdocResult = await _generateDocs(
-                toolEnv, logger, job, pkgPath, outputDir, logFileOutput,
+                toolEnv, logger, job, pkgPath, dartdocContentDir, logFileOutput,
                 usesPreviewSdk: packageStatus.usesPreviewAnalysisSdk);
             hasContent =
                 dartdocResult!.hasIndexHtml && dartdocResult!.hasIndexJson;
@@ -331,7 +333,7 @@ class DartdocJobProcessor extends JobProcessor {
                 packageName: job.packageName!,
                 packageVersion: job.packageVersion!,
                 isLatestStable: job.isLatestStable,
-              )).customizeDir(outputDir);
+              )).customizeDir(dartdocContentDir);
               logFileOutput.write('Content customization completed.\n\n');
             } catch (e, st) {
               // Do not block on customization failure.
@@ -339,20 +341,20 @@ class DartdocJobProcessor extends JobProcessor {
               logFileOutput.write('Content customization failed.\n\n');
             }
 
-            await _blob(outputDir, logFileOutput);
-            await _tar(tempDirPath, tarDir, outputDir, logFileOutput);
+            await _blob(uuid, dartdocContentDir, uploadDir, logFileOutput);
+            await _tar(tempDirPath, tarBaseDir, uploadDir, logFileOutput);
           } else {
             logFileOutput.write('No content found!\n\n');
           }
 
-          entry = await _createEntry(toolEnv, job, outputDir, usesFlutter,
-              depsResolved, hasContent, sw.elapsed);
+          entry = await _createEntry(uuid, toolEnv, job, dartdocContentDir,
+              uploadDir, usesFlutter, depsResolved, hasContent, sw.elapsed);
           logFileOutput
               .write('entry created: ${entry!.uuid} in ${sw.elapsed}\n\n');
 
           logFileOutput
               .write('completed: ${entry!.timestamp!.toIso8601String()}\n');
-          await _writeLog(outputDir, logFileOutput);
+          await _writeLog(uploadDir, logFileOutput);
         },
       );
 
@@ -369,7 +371,7 @@ class DartdocJobProcessor extends JobProcessor {
               isLatest: entry!.isLatest);
         }
       } else {
-        await dartdocBackend.uploadDir(entry!, outputDir);
+        await dartdocBackend.uploadDir(entry!, uploadDir);
         reportStatus = hasContent ? ReportStatus.success : ReportStatus.failed;
       }
 
@@ -377,7 +379,7 @@ class DartdocJobProcessor extends JobProcessor {
         reportIssueWithLatest(job, 'No content.');
       }
 
-      dartdocData = await _loadPubDartdocData(logger, outputDir);
+      dartdocData = await _loadPubDartdocData(logger, dartdocContentDir);
     } catch (e, st) {
       reportStatus = ReportStatus.aborted;
       if (isLatestStable) {
@@ -534,31 +536,37 @@ class DartdocJobProcessor extends JobProcessor {
   }
 
   Future<DartdocEntry> _createEntry(
+      String uuid,
       ToolEnvironment toolEnv,
       Job job,
-      String outputDir,
+      String dartdocContentDir,
+      String uploadDir,
       bool usesFlutter,
       bool depsResolved,
       bool hasContent,
       Duration runDuration) async {
     int? archiveSize;
     int? totalSize;
+    int? blobSize;
+    int? blobIndexSize;
     if (hasContent) {
-      final archiveFile = File(p.join(outputDir, _archiveFilePath));
+      final archiveFile = File(p.join(uploadDir, archiveFilePath));
       archiveSize = await archiveFile.length();
-      totalSize = await Directory(outputDir)
+      totalSize = await Directory(dartdocContentDir)
           .list(recursive: true)
           .where((fse) => fse is File)
           .cast<File>()
           .asyncMap((file) => file.length())
           .fold<int>(0, (a, b) => a + b);
-      totalSize = totalSize - archiveSize;
+      blobSize = await File(p.join(uploadDir, blobFilePath)).length();
+      blobIndexSize =
+          await File(p.join(uploadDir, blobIndexV1FilePath)).length();
     }
     final now = clock.now();
     final isObsolete = job.isLatestStable == false &&
         job.packageVersionUpdated!.difference(now).abs() > _twoYears;
-    final entry = DartdocEntry(
-      uuid: createUuid(),
+    return DartdocEntry(
+      uuid: uuid,
       packageName: job.packageName!,
       packageVersion: job.packageVersion!,
       isLatest: job.isLatestStable,
@@ -574,16 +582,13 @@ class DartdocJobProcessor extends JobProcessor {
       hasContent: hasContent,
       archiveSize: archiveSize,
       totalSize: totalSize,
+      blobSize: blobSize,
+      blobIndexSize: blobIndexSize,
     );
-
-    // write entry into local file
-    await File(p.join(outputDir, statusFilePath)).writeAsBytes(entry.asBytes());
-
-    return entry;
   }
 
   Future<void> _writeLog(String outputDir, StringBuffer buffer) async {
-    await File(p.join(outputDir, _buildLogFilePath))
+    await File(p.join(outputDir, buildLogFilePath))
         .writeAsString(buffer.toString());
   }
 
@@ -593,7 +598,7 @@ class DartdocJobProcessor extends JobProcessor {
     buffer.write('exit code: ${pr.exitCode}\n');
   }
 
-  Future<void> _tar(String tmpDir, String tarDir, String outputDir,
+  Future<void> _tar(String tmpDir, String tarDir, String uploadDir,
       StringBuffer logFileOutput) async {
     logFileOutput.write('Creating package archive...\n');
     final sw = Stopwatch()..start();
@@ -614,32 +619,34 @@ class DartdocJobProcessor extends JobProcessor {
       }
     }
 
-    final tmpTar = File(p.join(tmpDir, _archiveFilePath));
+    final tmpTar = File(p.join(tmpDir, archiveFilePath));
     await _list()
         .transform(tarWriter)
         .transform(gzip.encoder)
         .pipe(tmpTar.openWrite());
-    await tmpTar.rename(p.join(outputDir, _archiveFilePath));
+    await tmpTar.rename(p.join(uploadDir, archiveFilePath));
     logFileOutput.write('Created package archive in ${sw.elapsed}.\n');
   }
 
-  Future<void> _blob(String outputDir, StringBuffer logFileOutput) async {
+  Future<void> _blob(String blobId, String dartdocContentDir, String uploadDir,
+      StringBuffer logFileOutput) async {
     final sw = Stopwatch()..start();
     logFileOutput.write('Scanning blob content...\n');
-    final files = <String>[];
-    var offset = 0;
-    await for (final entry in Directory(outputDir).list(recursive: true)) {
+    final blobFile = File(p.join(uploadDir, blobFilePath));
+    final builder = IndexedBlobBuilder(blobFile.openWrite());
+    await for (final entry
+        in Directory(dartdocContentDir).list(recursive: true)) {
       if (entry is File) {
-        final path = p.relative(entry.path, from: outputDir);
-        final length = await entry.length();
-        files.add('$path $offset $length');
-        offset += length;
+        final path = p.relative(entry.path, from: dartdocContentDir);
+        await builder.addFile(path, entry.openRead().transform(gzip.encoder));
       }
     }
-    files.sort();
-    final indexLength = files.join('\n').length;
+    final index = await builder.buildIndex(blobId);
+    final indexFile = File(p.join(uploadDir, blobIndexV1FilePath));
+    await indexFile.writeAsBytes(index.asBytes());
+
     logFileOutput.write(
-        'Scanned blob content in ${sw.elapsed}, simple index count: ${files.length}, total length: $indexLength.\n');
+        'Scanned blob content in ${sw.elapsed}, index: ${indexFile.lengthSync()}, blob: ${blobFile.lengthSync()}.\n');
   }
 
   Future<PubDartdocData?> _loadPubDartdocData(

--- a/app/lib/dartdoc/models.dart
+++ b/app/lib/dartdoc/models.dart
@@ -176,9 +176,11 @@ class DartdocEntry {
   final int? totalSize;
 
   /// The size of the compressed blob file.
+  /// If this is null or zero, the blob file is missing.
   final int? blobSize;
 
   /// The size of the compressed blob index file.
+  /// If this is null or zero, the blob file is missing.
   final int? blobIndexSize;
 
   DartdocEntry({

--- a/app/lib/dartdoc/models.dart
+++ b/app/lib/dartdoc/models.dart
@@ -175,6 +175,12 @@ class DartdocEntry {
   /// The size of all the individual files, uncompressed.
   final int? totalSize;
 
+  /// The size of the compressed blob file.
+  final int? blobSize;
+
+  /// The size of the compressed blob index file.
+  final int? blobIndexSize;
+
   DartdocEntry({
     required this.uuid,
     required this.packageName,
@@ -192,6 +198,8 @@ class DartdocEntry {
     this.hasContent = false,
     required this.archiveSize,
     required this.totalSize,
+    this.blobSize,
+    this.blobIndexSize,
   });
 
   factory DartdocEntry.fromJson(Map<String, dynamic> json) =>
@@ -226,6 +234,8 @@ class DartdocEntry {
       hasContent: hasContent,
       archiveSize: archiveSize,
       totalSize: totalSize,
+      blobSize: blobSize,
+      blobIndexSize: blobIndexSize,
     );
   }
 
@@ -236,7 +246,7 @@ class DartdocEntry {
       storage_path.contentPrefix(packageName, packageVersion, uuid);
 
   String objectName(String relativePath) {
-    final isShared = storage_path.isSharedAsset(relativePath);
+    final isShared = !hasBlob && storage_path.isSharedAsset(relativePath);
     if (isShared) {
       return storage_path.sharedAssetObjectName(dartdocVersion!, relativePath);
     } else {
@@ -244,6 +254,12 @@ class DartdocEntry {
           packageName, packageVersion, uuid, relativePath);
     }
   }
+
+  bool get hasBlob =>
+      blobSize != null &&
+      blobSize! > 0 &&
+      blobIndexSize != null &&
+      blobIndexSize! > 0;
 
   List<int> asBytes() => jsonUtf8Encoder.convert(toJson());
 
@@ -278,8 +294,19 @@ class DartdocEntry {
 class FileInfo {
   final DateTime lastModified;
   final String etag;
+  final String? blobId;
+  final int? blobOffset;
+  final int? blobLength;
+  final int? contentLength;
 
-  FileInfo({required this.lastModified, required this.etag});
+  FileInfo({
+    required this.lastModified,
+    required this.etag,
+    this.blobId,
+    this.blobOffset,
+    this.blobLength,
+    this.contentLength,
+  });
 
   factory FileInfo.fromJson(Map<String, dynamic> json) =>
       _$FileInfoFromJson(json);

--- a/app/lib/dartdoc/models.g.dart
+++ b/app/lib/dartdoc/models.g.dart
@@ -27,6 +27,8 @@ DartdocEntry _$DartdocEntryFromJson(Map<String, dynamic> json) => DartdocEntry(
       hasContent: json['hasContent'] as bool? ?? false,
       archiveSize: json['archiveSize'] as int?,
       totalSize: json['totalSize'] as int?,
+      blobSize: json['blobSize'] as int?,
+      blobIndexSize: json['blobIndexSize'] as int?,
     );
 
 Map<String, dynamic> _$DartdocEntryToJson(DartdocEntry instance) =>
@@ -47,14 +49,24 @@ Map<String, dynamic> _$DartdocEntryToJson(DartdocEntry instance) =>
       'hasContent': instance.hasContent,
       'archiveSize': instance.archiveSize,
       'totalSize': instance.totalSize,
+      'blobSize': instance.blobSize,
+      'blobIndexSize': instance.blobIndexSize,
     };
 
 FileInfo _$FileInfoFromJson(Map<String, dynamic> json) => FileInfo(
       lastModified: DateTime.parse(json['lastModified'] as String),
       etag: json['etag'] as String,
+      blobId: json['blobId'] as String?,
+      blobOffset: json['blobOffset'] as int?,
+      blobLength: json['blobLength'] as int?,
+      contentLength: json['contentLength'] as int?,
     );
 
 Map<String, dynamic> _$FileInfoToJson(FileInfo instance) => <String, dynamic>{
       'lastModified': instance.lastModified.toIso8601String(),
       'etag': instance.etag,
+      'blobId': instance.blobId,
+      'blobOffset': instance.blobOffset,
+      'blobLength': instance.blobLength,
+      'contentLength': instance.contentLength,
     };

--- a/app/lib/shared/redis_cache.dart
+++ b/app/lib/shared/redis_cache.dart
@@ -68,6 +68,11 @@ class CachePatterns {
         decode: (data) => FileInfo.fromBytes(data),
       ))[objectName];
 
+  /// Cache for the binary content of the blob index (v1).
+  Entry<List<int>> dartdocBlobIndexV1(String objectName) => _cache
+      .withPrefix('dartdoc-blob-index-v1/')
+      .withTTL(Duration(minutes: 60))[objectName];
+
   /// Cache for API summaries used by dartdoc.
   Entry<Map<String, dynamic>> dartdocApiSummary(String package) => _cache
       .withPrefix('dartdoc-apisummary/')

--- a/app/lib/shared/storage.dart
+++ b/app/lib/shared/storage.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:_discoveryapis_commons/_discoveryapis_commons.dart'
     show DetailedApiRequestError;
@@ -42,6 +43,29 @@ extension BucketExt on Bucket {
     final metadata = ObjectMetadata(acl: acl, contentType: contentType);
     return uploadWithRetry(this, objectName, length, openStream,
         metadata: metadata);
+  }
+
+  /// Reads file content as bytes.
+  Future<Uint8List> readAsBytes(
+    String objectName, {
+    int? offset,
+    int? length,
+  }) async {
+    return retry(
+      () async {
+        final builder = BytesBuilder(copy: false);
+        await for (final chunk
+            in read(objectName, offset: offset, length: length)) {
+          builder.add(chunk);
+        }
+        return builder.toBytes();
+      },
+      retryIf: (e) {
+        return e is DetailedApiRequestError &&
+            e.status != null &&
+            e.status! >= 500;
+      },
+    );
   }
 }
 

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -177,7 +177,7 @@ packages:
     source: path
     version: "0.0.0"
   clock:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: clock
       url: "https://pub.dartlang.org"

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -177,7 +177,7 @@ packages:
     source: path
     version: "0.0.0"
   clock:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
@@ -351,6 +351,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.2.0"
+  indexed_blob:
+    dependency: "direct main"
+    description:
+      path: "../pkg/indexed_blob"
+      relative: true
+    source: path
+    version: "0.0.0"
   intl:
     dependency: "direct main"
     description:
@@ -386,6 +393,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "6.1.1"
+  jsontool:
+    dependency: transitive
+    description:
+      name: jsontool
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.0"
   lints:
     dependency: "direct main"
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -21,6 +21,8 @@ dependencies:
   html: ^0.15.0
   http: ^0.13.0
   http_parser: ^4.0.0
+  indexed_blob:
+    path: ../pkg/indexed_blob
   intl: '^0.17.0'
   json_annotation: '^4.3.0'
   lints: ^1.0.0

--- a/app/test/dartdoc/dartdoc_runner_test.dart
+++ b/app/test/dartdoc/dartdoc_runner_test.dart
@@ -40,6 +40,11 @@ void main() {
         expect(entry.archiveSize, lessThan(50000));
         expect(entry.totalSize, greaterThan(180000));
         expect(entry.totalSize, lessThan(220000));
+        expect(entry.hasBlob, isTrue);
+        expect(entry.blobSize, greaterThan(55000));
+        expect(entry.blobSize, lessThan(70000));
+        expect(entry.blobIndexSize, greaterThan(500));
+        expect(entry.blobIndexSize, lessThan(1000));
 
         // uploaded content check
         final indexHtml = await dartdocBackend.getTextContent(
@@ -56,11 +61,23 @@ void main() {
           timeout: Duration(seconds: 1),
         );
         expect(libraryHtml, contains('retry/RetryOptions-class.html'));
+        expect(indexHtml == libraryHtml, isFalse);
 
         final rs = await issueGet(
             '/documentation/retry/latest/retry/retry-library.html');
         expect(rs.statusCode, 200);
         expect(await rs.readAsString(), libraryHtml);
+
+        final rs2 = await issueGet('/documentation/retry/latest/log.txt');
+        expect(rs2.statusCode, 200);
+        expect(await rs2.readAsString(), contains('entry created:'));
+
+        final rs3 =
+            await issueGet('/documentation/retry/latest/package.tar.gz');
+        expect(rs3.statusCode, 200);
+        final body3 = await rs3.read().toList();
+        final body3Length = body3.map((e) => e.length).reduce((a, b) => a + b);
+        expect(body3Length, entry.archiveSize);
       },
       timeout: Timeout.factor(8),
     );

--- a/pkg/fake_gcloud/lib/mem_storage.dart
+++ b/pkg/fake_gcloud/lib/mem_storage.dart
@@ -245,7 +245,7 @@ class _Bucket implements Bucket {
     } else {
       yield bytes;
     }
-   }
+  }
 
   @override
   Stream<BucketEntry> list({String? prefix, String? delimiter}) async* {

--- a/pkg/fake_gcloud/lib/mem_storage.dart
+++ b/pkg/fake_gcloud/lib/mem_storage.dart
@@ -239,8 +239,13 @@ class _Bucket implements Bucket {
     _validateObjectName(objectName);
     _logger.info('read request for $objectName');
     final file = _files[objectName];
-    yield file!.content;
-  }
+    final bytes = file!.content;
+    if (offset != null) {
+      yield bytes.sublist(offset, offset + length!);
+    } else {
+      yield bytes;
+    }
+   }
 
   @override
   Stream<BucketEntry> list({String? prefix, String? delimiter}) async* {

--- a/pkg/indexed_blob/lib/indexed_blob.dart
+++ b/pkg/indexed_blob/lib/indexed_blob.dart
@@ -323,4 +323,7 @@ class FileRange {
       blobId,
     );
   }
+
+  /// The length of the range in blob.
+  int get length => end - start;
 }


### PR DESCRIPTION
- Closes #5134.
- Uses gzipped segments in the blob file.
- Some files are served outside of the blob (e.g. documentation archive, `log.txt`), and there is a fallback mechanism to also serve files from previously created entries.
- The storage bucket upload and also the cleanup process remains the same, but in effect it should be faster with fewer overall operations.
- The previous model stored and served the shared content (e.g. `shared-assets` directory) in a separate directory. For simplicity, this new model doesn't do this yet. We could later (a) implement it similarly, uploading those to a separate blob file, (b) serve those files through a shared cache.
- The blob file is unlikely to change in the later iterations, but the index file may change. To allow some reasonable upgrade path, it is now named as `index-v1.json`. We could later introduce a second index file and mark its existence in `DartdocEntry` - if needed.