### PR TITLE
Fix inconsistent query text after search + back button.

### DIFF
--- a/pkg/pub_integration/lib/src/headless_env.dart
+++ b/pkg/pub_integration/lib/src/headless_env.dart
@@ -260,6 +260,12 @@ extension PageExt on Page {
     final origin = _pageOriginExpando[this];
     return await goto('$origin$path', wait: Until.networkIdle);
   }
+
+  /// Returns the [property] value of the first elemented by [selector].
+  Future<String> propertyValue(String selector, String property) async {
+    final h = await $(selector);
+    return await h.propertyValue(property);
+  }
 }
 
 extension ElementHandleExt on ElementHandle {

--- a/pkg/pub_integration/test/search_update_test.dart
+++ b/pkg/pub_integration/test/search_update_test.dart
@@ -200,6 +200,59 @@ void main() {
           expect(page.url, '$origin/packages?q=platform%3Aandroid+pkg');
         },
       );
+
+      // back button working with checkboxes
+      await headlessEnv.withPage(
+        fn: (page) async {
+          await page.gotoOrigin('/experimental?enabled=1');
+          await page.gotoOrigin('/packages');
+
+          await page.focus('input[name="q"]');
+          await page.keyboard.type('pkg');
+          await page.keyboard.press(Key.enter);
+          await page.waitForNavigation(wait: Until.networkIdle);
+          expect(page.url, '$origin/packages?q=pkg');
+          expect(await page.propertyValue('input[name="q"]', 'value'), 'pkg');
+
+          await page.click('#search-form-checkbox-platform-android');
+          await page.waitForNavigation(wait: Until.networkIdle);
+          expect(page.url, '$origin/packages?q=pkg+platform%3Aandroid');
+          expect(await page.propertyValue('input[name="q"]', 'value'),
+              'pkg platform:android');
+
+          await page.goBack(wait: Until.networkIdle);
+          expect(page.url, '$origin/packages?q=pkg');
+          expect(await page.propertyValue('input[name="q"]', 'value'), 'pkg');
+        },
+      );
+
+      // back button updating the URL and the input text
+      await headlessEnv.withPage(
+        fn: (page) async {
+          await page.gotoOrigin('/experimental?enabled=1');
+          await page.gotoOrigin('/packages');
+
+          await page.focus('input[name="q"]');
+          await page.keyboard.type('pkg');
+          await page.keyboard.press(Key.enter);
+          await page.waitForNavigation(wait: Until.networkIdle);
+          expect(page.url, '$origin/packages?q=pkg');
+          expect(await page.propertyValue('input[name="q"]', 'value'), 'pkg');
+
+          await page.focus('input[name="q"]');
+          await page.keyboard.press(Key.arrowDown);
+          await page.keyboard.press(Key.backspace);
+          await page.keyboard.press(Key.backspace);
+          await page.keyboard.press(Key.enter);
+          await page.waitForNavigation(wait: Until.networkIdle);
+          expect(page.url, '$origin/packages?q=p');
+          expect(await page.propertyValue('input[name="q"]', 'value'), 'p');
+
+          await page.goBack(wait: Until.networkIdle);
+          expect(page.url, '$origin/packages?q=pkg');
+          expect(await page.propertyValue('input[name="q"]', 'value'), 'pkg');
+        },
+      );
     });
   }, timeout: Timeout.factor(testTimeoutFactor));
 }

--- a/pkg/web_app/lib/script.dart
+++ b/pkg/web_app/lib/script.dart
@@ -20,6 +20,12 @@ void main() {
   setupAccount();
   _setupAllEvents();
   setupPageUpdater(_setupAllEvents);
+  // event triggered after a page is displayed:
+  // - after the initial load or,
+  // - from cache via back button.
+  window.onPageShow.listen((_) {
+    adjustQueryTextAfterPageShow();
+  });
 }
 
 void _setupAllEvents() {

--- a/pkg/web_app/lib/src/search.dart
+++ b/pkg/web_app/lib/src/search.dart
@@ -64,7 +64,7 @@ void _setEventForSearchInput() {
 /// When using the back button, or pulling a page state from cache or history,
 /// the query text on the page may differ from the text inside the main input
 /// field.
-/// 
+///
 /// This method adjusts the input field's text to match the query parameter,
 /// as if the page was freshly loaded.
 void adjustQueryTextAfterPageShow() {

--- a/pkg/web_app/lib/src/search.dart
+++ b/pkg/web_app/lib/src/search.dart
@@ -61,6 +61,12 @@ void _setEventForSearchInput() {
   });
 }
 
+/// When using the back button, or pulling a page state from cache or history,
+/// the query text on the page may differ from the text inside the main input
+/// field.
+/// 
+/// This method adjusts the input field's text to match the query parameter,
+/// as if the page was freshly loaded.
 void adjustQueryTextAfterPageShow() {
   final q = document.querySelector('input[name="q"]') as InputElement?;
   if (q == null) return null;

--- a/pkg/web_app/lib/src/search.dart
+++ b/pkg/web_app/lib/src/search.dart
@@ -61,6 +61,15 @@ void _setEventForSearchInput() {
   });
 }
 
+void adjustQueryTextAfterPageShow() {
+  final q = document.querySelector('input[name="q"]') as InputElement?;
+  if (q == null) return null;
+  final uri = Uri.tryParse(window.location.href);
+  if (q.value != uri?.queryParameters['q']) {
+    q.value = uri?.queryParameters['q'] ?? q.value;
+  }
+}
+
 void _setEventsForSearchForm() {
   // When a search form checkbox has a linked search label,
   //checking the checkbox will trigger a click on the link.


### PR DESCRIPTION
When navigating forward and back using both the old or the new search, we may end up with a page where the URL's query parameter is different from content inside the search form's input field. I've looked into other state handling methods, but it seems to me that neither of them work for such cases, however, we can use the `onPageShow` event to make sure the input field is consistent with the URL.