### PR TITLE
Remove *-in-prerelease tags.

### DIFF
--- a/app/lib/search/backend.dart
+++ b/app/lib/search/backend.dart
@@ -120,21 +120,9 @@ class SearchBackend {
       ...p.getTags(),
       ...pv.getTags(),
       ...?scoreCard?.panaReport?.derivedTags?.expand(expandPanaTag),
-      ...prereleaseTags
-          .expand(expandPanaTag)
-          .map(PackageTags.convertToPrereleaseTag),
-      ...previewTags
-          .expand(expandPanaTag)
-          .map(PackageTags.convertToPrereleaseTag),
+      ...prereleaseTags.expand(expandPanaTag),
+      ...previewTags.expand(expandPanaTag),
     };
-
-    // This is a temporary workaround to expose latest stable versions with
-    // null-safety support.
-    // TODO: Cleanup after we've implemented better search support for this.
-    if (tags.contains(PackageVersionTags.isNullSafe)) {
-      tags.add(
-          PackageTags.convertToPrereleaseTag(PackageVersionTags.isNullSafe));
-    }
 
     final pubDataContent = await dartdocBackend.getTextContent(
         packageName, 'latest', 'pub-data.json',

--- a/app/lib/search/search_form.dart
+++ b/app/lib/search/search_form.dart
@@ -181,8 +181,7 @@ class SearchForm {
             tag == PackageTags.showHidden);
     final tagsPredicate = TagsPredicate(
       requiredTags: [
-        if (nullSafe)
-          PackageTags.convertToPrereleaseTag(PackageVersionTags.isNullSafe),
+        if (nullSafe) PackageVersionTags.isNullSafe,
         if (context.isFlutterFavorites) PackageTags.isFlutterFavorite,
         if (SdkTagValue.isNotAny(context.sdk)) 'sdk:${context.sdk}',
         ...runtimes.map((v) => 'runtime:$v'),

--- a/app/lib/shared/tags.dart
+++ b/app/lib/shared/tags.dart
@@ -43,9 +43,6 @@ abstract class PackageTags {
 
   /// The `publisher:<publisherId>` tag.
   static String publisherTag(String publisherId) => 'publisher:$publisherId';
-
-  /// Transforms the tag with the suffix of `-in-prerelease`.
-  static String convertToPrereleaseTag(String tag) => '$tag-in-prerelease';
 }
 
 /// Collection of version-related tags.


### PR DESCRIPTION
In the context of search, we can treat all latest-* version as something that adds up, and search for any of the tagged features should expose the package in the results. Removing the tag conversion, to reduce the memory use and make it slightly faster.