### PR TITLE
Trigger a GTM event with in-page search filters.

### DIFF
--- a/app/lib/frontend/templates/views/pkg/index.dart
+++ b/app/lib/frontend/templates/views/pkg/index.dart
@@ -190,6 +190,7 @@ d.Node _tagBasedCheckbox({
     isChecked: searchForm.parsedQuery.tagsPredicate.isRequiredTag(tag),
     isIndeterminate: searchForm.parsedQuery.tagsPredicate.isProhibitedTag(tag),
     tag: tag,
+    action: 'filter-$tagPrefix-$tagValue',
     title: title,
   );
 }
@@ -201,6 +202,7 @@ d.Node _formLinkedCheckbox({
   required bool isChecked,
   bool isIndeterminate = false,
   String? tag,
+  required String? action,
   String? title,
 }) {
   return d.div(
@@ -215,6 +217,7 @@ d.Node _formLinkedCheckbox({
         href: toggledSearchForm.toSearchLink(),
         text: label,
         attributes: {
+          if (action != null) 'data-action': action,
           if (tag != null) 'data-tag': isIndeterminate ? '-$tag' : tag,
         },
       ),

--- a/app/test/frontend/golden/pkg_index_page_experimental.html
+++ b/app/test/frontend/golden/pkg_index_page_experimental.html
@@ -142,7 +142,7 @@
                     <div class="mdc-checkbox__ripple"></div>
                   </div>
                   <label for="search-form-checkbox-platform-android">
-                    <a href="/packages?q=sdk%3Adart+platform%3Aandroid&amp;unlisted=1" data-tag="platform:android">Android</a>
+                    <a href="/packages?q=sdk%3Adart+platform%3Aandroid&amp;unlisted=1" data-action="filter-platform-android" data-tag="platform:android">Android</a>
                   </label>
                 </div>
               </div>
@@ -159,7 +159,7 @@
                     <div class="mdc-checkbox__ripple"></div>
                   </div>
                   <label for="search-form-checkbox-platform-ios">
-                    <a href="/packages?q=sdk%3Adart+platform%3Aios&amp;unlisted=1" data-tag="platform:ios">iOS</a>
+                    <a href="/packages?q=sdk%3Adart+platform%3Aios&amp;unlisted=1" data-action="filter-platform-ios" data-tag="platform:ios">iOS</a>
                   </label>
                 </div>
               </div>
@@ -176,7 +176,7 @@
                     <div class="mdc-checkbox__ripple"></div>
                   </div>
                   <label for="search-form-checkbox-platform-linux">
-                    <a href="/packages?q=sdk%3Adart+platform%3Alinux&amp;unlisted=1" data-tag="platform:linux">Linux</a>
+                    <a href="/packages?q=sdk%3Adart+platform%3Alinux&amp;unlisted=1" data-action="filter-platform-linux" data-tag="platform:linux">Linux</a>
                   </label>
                 </div>
               </div>
@@ -193,7 +193,7 @@
                     <div class="mdc-checkbox__ripple"></div>
                   </div>
                   <label for="search-form-checkbox-platform-macos">
-                    <a href="/packages?q=sdk%3Adart+platform%3Amacos&amp;unlisted=1" data-tag="platform:macos">macOS</a>
+                    <a href="/packages?q=sdk%3Adart+platform%3Amacos&amp;unlisted=1" data-action="filter-platform-macos" data-tag="platform:macos">macOS</a>
                   </label>
                 </div>
               </div>
@@ -210,7 +210,7 @@
                     <div class="mdc-checkbox__ripple"></div>
                   </div>
                   <label for="search-form-checkbox-platform-web">
-                    <a href="/packages?q=sdk%3Adart+platform%3Aweb&amp;unlisted=1" data-tag="platform:web">Web</a>
+                    <a href="/packages?q=sdk%3Adart+platform%3Aweb&amp;unlisted=1" data-action="filter-platform-web" data-tag="platform:web">Web</a>
                   </label>
                 </div>
               </div>
@@ -227,7 +227,7 @@
                     <div class="mdc-checkbox__ripple"></div>
                   </div>
                   <label for="search-form-checkbox-platform-windows">
-                    <a href="/packages?q=sdk%3Adart+platform%3Awindows&amp;unlisted=1" data-tag="platform:windows">Windows</a>
+                    <a href="/packages?q=sdk%3Adart+platform%3Awindows&amp;unlisted=1" data-action="filter-platform-windows" data-tag="platform:windows">Windows</a>
                   </label>
                 </div>
               </div>
@@ -252,7 +252,7 @@
                     <div class="mdc-checkbox__ripple"></div>
                   </div>
                   <label for="search-form-checkbox-sdk-dart">
-                    <a href="/packages?unlisted=1" data-tag="sdk:dart">Dart</a>
+                    <a href="/packages?unlisted=1" data-action="filter-sdk-dart" data-tag="sdk:dart">Dart</a>
                   </label>
                 </div>
               </div>
@@ -269,7 +269,7 @@
                     <div class="mdc-checkbox__ripple"></div>
                   </div>
                   <label for="search-form-checkbox-sdk-flutter">
-                    <a href="/packages?q=sdk%3Adart+sdk%3Aflutter&amp;unlisted=1" data-tag="sdk:flutter">Flutter</a>
+                    <a href="/packages?q=sdk%3Adart+sdk%3Aflutter&amp;unlisted=1" data-action="filter-sdk-flutter" data-tag="sdk:flutter">Flutter</a>
                   </label>
                 </div>
               </div>
@@ -294,7 +294,7 @@
                     <div class="mdc-checkbox__ripple"></div>
                   </div>
                   <label for="search-form-checkbox-show-hidden">
-                    <a href="/packages?q=sdk%3Adart+show%3Ahidden&amp;unlisted=1" data-tag="show:hidden">Include hidden</a>
+                    <a href="/packages?q=sdk%3Adart+show%3Ahidden&amp;unlisted=1" data-action="filter-show-hidden" data-tag="show:hidden">Include hidden</a>
                   </label>
                 </div>
               </div>
@@ -311,7 +311,7 @@
                     <div class="mdc-checkbox__ripple"></div>
                   </div>
                   <label for="search-form-checkbox-is-null-safe">
-                    <a href="/packages?q=sdk%3Adart+is%3Anull-safe&amp;unlisted=1" data-tag="is:null-safe">Supports null safety</a>
+                    <a href="/packages?q=sdk%3Adart+is%3Anull-safe&amp;unlisted=1" data-action="filter-is-null-safe" data-tag="is:null-safe">Supports null safety</a>
                   </label>
                 </div>
               </div>

--- a/pkg/web_app/lib/src/gtm_js.dart
+++ b/pkg/web_app/lib/src/gtm_js.dart
@@ -17,14 +17,13 @@ void _pushMap(Map<String, dynamic> data) {
   _push(jsify(data));
 }
 
-/// Records a GTM [action] with the default [event] name and [category].
-void gtmCustomEventClick({
-  String event = 'custom-event',
-  String category = 'click',
+/// Records a GTM [action] with within a [category].
+void gtmCustomEvent({
+  required String category,
   required String action,
 }) {
   _pushMap({
-    'event': event,
+    'event': 'custom-event', // hardcoded, used in GTM Trigger
     'customEventCategory': category,
     'customEventAction': action,
     'customEventLabel': 'path:${dart_html.window.location.pathname}',

--- a/pkg/web_app/lib/src/gtm_js.dart
+++ b/pkg/web_app/lib/src/gtm_js.dart
@@ -1,0 +1,33 @@
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@JS()
+library gtm_js;
+
+import 'dart:html' as dart_html;
+
+import 'package:js/js.dart';
+import 'package:js/js_util.dart';
+
+@JS('dataLayer.push')
+external void _push(data);
+
+void _pushMap(Map<String, dynamic> data) {
+  _push(jsify(data));
+}
+
+/// Records a GTM [action] with the default [event] name and [category].
+void gtmCustomEventClick({
+  String event = 'custom-event',
+  String category = 'click',
+  required String action,
+}) {
+  _pushMap({
+    'event': event,
+    'customEventCategory': category,
+    'customEventAction': action,
+    'customEventLabel': 'path:${dart_html.window.location.pathname}',
+    'customEventValue': '1',
+  });
+}

--- a/pkg/web_app/lib/src/search.dart
+++ b/pkg/web_app/lib/src/search.dart
@@ -141,7 +141,10 @@ void _setEventsForSearchForm() {
         // notify GTM on the click
         final action = link.dataset['action'];
         if (action != null && action.isNotEmpty) {
-          gtmCustomEventClick(action: '$action-$actionPostfix');
+          gtmCustomEvent(
+            category: 'click',
+            action: '$action-$actionPostfix',
+          );
         }
       }
 

--- a/pkg/web_app/lib/src/search.dart
+++ b/pkg/web_app/lib/src/search.dart
@@ -4,6 +4,8 @@
 
 import 'dart:html';
 
+import 'package:web_app/src/gtm_js.dart';
+
 import 'gtag_js.dart';
 import 'page_updater.dart';
 
@@ -96,10 +98,12 @@ void _setEventsForSearchForm() {
             inputQElem.value ?? originalHrefUri.queryParameters['q'] ?? '';
         queryText = queryText.trim();
         final tag = link.dataset['tag'];
+        var actionPostfix = '-on';
         if (tag != null) {
           // remove or add tag to query string
           if (' $queryText '.contains(' $tag ')) {
             queryText = ' $queryText '.replaceFirst(' $tag ', ' ').trim();
+            actionPostfix = '-off';
           } else {
             queryText = '$queryText $tag'.trim();
           }
@@ -133,6 +137,12 @@ void _setEventsForSearchForm() {
           requestUri: requestUri,
           navigationUrl: windowUri.resolveUri(newUri).toString(),
         );
+
+        // notify GTM on the click
+        final action = link.dataset['action'];
+        if (action != null && action.isNotEmpty) {
+          gtmCustomEventClick(action: '$action-$actionPostfix');
+        }
       }
 
       checkbox.onChange.listen(handleClick);


### PR DESCRIPTION
- #5368
- the action name is coming from the data attribute, so we have good control over it
- the GTM event has the same structure as we have in `gtm.js`
- separate events for going from unchecked->checked (`-on` postfix) vs. checked -> unchecked (`-off` postfix)
