### PR TITLE
My packages tab without using the search index.

### DIFF
--- a/app/lib/frontend/handlers/account.dart
+++ b/app/lib/frontend/handlers/account.dart
@@ -6,24 +6,23 @@ import 'dart:io';
 
 import 'package:client_data/account_api.dart';
 import 'package:logging/logging.dart';
-import 'package:pub_dev/audit/backend.dart';
 import 'package:shelf/shelf.dart' as shelf;
 
 import '../../account/backend.dart';
 import '../../account/consent_backend.dart';
 import '../../account/session_cookie.dart' as session_cookie;
+import '../../audit/backend.dart';
 import '../../package/backend.dart';
+import '../../package/models.dart';
 import '../../package/search_adapter.dart';
 import '../../publisher/backend.dart';
 import '../../publisher/models.dart';
-import '../../search/search_form.dart';
 import '../../shared/configuration.dart' show activeConfiguration;
 import '../../shared/exceptions.dart';
 import '../../shared/handlers.dart';
 
 import '../templates/admin.dart';
 import '../templates/consent.dart';
-import '../templates/listing.dart';
 import '../templates/misc.dart' show renderUnauthenticatedPage;
 
 final _logger = Logger('account_handler');
@@ -220,28 +219,17 @@ Future<shelf.Response> accountPackagesPageHandler(shelf.Request request) async {
     return redirectResponse(request.requestedUri.path);
   }
 
-  final page =
-      await publisherBackend.listPublishersForUser(userSessionData!.userId!);
-  final searchForm = SearchForm.parse(
-    SearchContext.myPackages([
-      userSessionData!.userId!,
-      ...page.publishers!.map((p) => p.publisherId),
-    ]),
-    request.requestedUri.queryParameters,
-  );
-
-  final searchResult = await searchAdapter.search(searchForm);
-  final int totalCount = searchResult.totalCount;
-  final links = PageLinks(searchForm, totalCount);
+  final next = request.requestedUri.queryParameters['next'];
+  final page = await packageBackend
+      .listPackagesForUser(userSessionData!.userId!, next: next);
+  final hits = await searchAdapter.getPackageViews(page.packages);
 
   final html = renderAccountPackagesPage(
     user: (await accountBackend.lookupUserById(userSessionData!.userId!))!,
     userSessionData: userSessionData!,
-    searchResultPage: searchResult,
-    pageLinks: links,
-    searchForm: searchForm,
-    totalCount: totalCount,
-    messageFromBackend: searchResult.message,
+    startPackage: next,
+    packageHits: hits.whereType<PackageView>().toList(),
+    nextPackage: page.nextPackage,
   );
   return htmlResponse(html);
 }

--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -154,6 +154,26 @@ class PackageBackend {
         .cast();
   }
 
+  /// List all packages where the [userId] is an uploader.
+  Future<PackageListPage> listPackagesForUser(
+    String userId, {
+    String? next,
+    int limit = 10,
+  }) async {
+    final query = db.query<Package>()
+      ..filter('uploaders =', userId)
+      ..order('name')
+      ..limit(limit + 1);
+    if (next != null) {
+      query.filter('name >=', next);
+    }
+    final packages = await query.run().toList();
+    return PackageListPage(
+      packages: packages.take(limit).map((p) => p.name!).toList(),
+      nextPackage: packages.length <= limit ? null : packages.last.name!,
+    );
+  }
+
   /// Returns the latest releases info of a package.
   Future<LatestReleases> latestReleases(Package package) async {
     // TODO: implement runtimeVersion-specific release calculation

--- a/app/lib/package/models.dart
+++ b/app/lib/package/models.dart
@@ -925,3 +925,14 @@ class PackagePageData {
     );
   }
 }
+
+/// Describes the list of packages names and the continuation token for the next page.
+class PackageListPage {
+  final List<String> packages;
+  final String? nextPackage;
+
+  PackageListPage({
+    required this.packages,
+    this.nextPackage,
+  });
+}

--- a/app/lib/package/search_adapter.dart
+++ b/app/lib/package/search_adapter.dart
@@ -62,7 +62,7 @@ class SearchAdapter {
           : _random.nextInt(availablePackages.length);
       packages.add(availablePackages.removeAt(index));
     }
-    return (await _getPackageViews(packages)).cast<PackageView>();
+    return (await getPackageViews(packages)).cast<PackageView>();
   }
 
   /// Performs search using the `search` service and lookup package info and
@@ -153,7 +153,8 @@ class SearchAdapter {
   /// the latest stable version.
   ///
   /// If the package does not exist, it will return null in the given index.
-  Future<List<PackageView?>> _getPackageViews(List<String> packages) async {
+  /// TODO: move this method (and the pool) to [ScoreCardBackend].
+  Future<List<PackageView?>> getPackageViews(Iterable<String> packages) async {
     final futures = <Future<PackageView?>>[];
     for (final p in packages) {
       futures.add(

--- a/app/lib/shared/urls.dart
+++ b/app/lib/shared/urls.dart
@@ -346,7 +346,10 @@ String? displayableUrl(String? url) {
   return url;
 }
 
-String myPackagesUrl() => '/my-packages';
+String myPackagesUrl({String? next}) => Uri(
+      path: '/my-packages',
+      queryParameters: next == null ? null : {'next': next},
+    ).toString();
 String myLikedPackagesUrl() => '/my-liked-packages';
 String myPublishersUrl() => '/my-publishers';
 String myActivityLogUrl() => '/my-activity-log';

--- a/app/test/frontend/golden/my_packages.html
+++ b/app/test/frontend/golden/my_packages.html
@@ -13,10 +13,10 @@
     <meta name="twitter:image" content="https://pub.dev/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
     <meta property="og:type" content="website"/>
     <meta property="og:site_name" content="Dart packages"/>
-    <meta property="og:title" content="My packages"/>
+    <meta property="og:title" content="My packages | starting with oxygen"/>
     <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <meta property="og:image" content="https://pub.dev/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
-    <title>My packages</title>
+    <title>My packages | starting with oxygen</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Google+Sans:300,400,500|Google+Sans+Display:400|Roboto:300,400,500,700|Roboto+Mono:300,400,700&amp;display=swap"/>
     <meta content="/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
     <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
@@ -176,29 +176,6 @@
             <div class="detail-container detail-body-main">
               <div class="detail-tabs-content">
                 <section class="tab-content detail-tab-my-packages-content -active">
-                  <div class="listing-info">
-                    <div class="listing-info-count">
-                      <span class="info-identifier">Results</span>
-                      <span class="count">2</span>
-                      packages owned by
-                      <code>you</code>
-                    </div>
-                    <div class="sort-control hoverable">
-                      <div class="info-identifier" title="Packages are sorted by the combination of their overall score and their specificity to the selected platform.">
-                        Sort by
-                        <span class="sort-control-selected">listing relevance</span>
-                      </div>
-                      <div class="sort-control-popup">
-                        <div class="sort-control-option selected" data-value="listing_relevance">listing relevance</div>
-                        <div class="sort-control-option" data-value="top">overall score</div>
-                        <div class="sort-control-option" data-value="updated">recently updated</div>
-                        <div class="sort-control-option" data-value="created">newest package</div>
-                        <div class="sort-control-option" data-value="like">most likes</div>
-                        <div class="sort-control-option" data-value="points">most pub points</div>
-                        <div class="sort-control-option" data-value="popularity">popularity</div>
-                      </div>
-                    </div>
-                  </div>
                   <div class="packages">
                     <div class="packages-item">
                       <div class="packages-header">
@@ -329,23 +306,9 @@
                       </div>
                     </div>
                   </div>
-                  <ul class="pagination">
-                    <li class="-disabled">
-                      <a rel="prev">
-                        <span>«</span>
-                      </a>
-                    </li>
-                    <li class="-active">
-                      <a>
-                        <span>1</span>
-                      </a>
-                    </li>
-                    <li class="-disabled">
-                      <a rel="next">
-                        <span>»</span>
-                      </a>
-                    </li>
-                  </ul>
+                  <div>
+                    <a href="/my-packages?next=package_after_neon">Next...</a>
+                  </div>
                 </section>
               </div>
             </div>

--- a/app/test/frontend/golden/my_packages.html
+++ b/app/test/frontend/golden/my_packages.html
@@ -176,6 +176,11 @@
             <div class="detail-container detail-body-main">
               <div class="detail-tabs-content">
                 <section class="tab-content detail-tab-my-packages-content -active">
+                  <p>
+                    List of your packages starting with
+                    <code>oxygen</code>
+                    :
+                  </p>
                   <div class="packages">
                     <div class="packages-item">
                       <div class="packages-header">
@@ -307,7 +312,7 @@
                     </div>
                   </div>
                   <div>
-                    <a href="/my-packages?next=package_after_neon">Next...</a>
+                    <a class="link-button" href="/my-packages?next=package_after_neon">Next...</a>
                   </div>
                 </section>
               </div>

--- a/app/test/frontend/handlers/account_test.dart
+++ b/app/test/frontend/handlers/account_test.dart
@@ -5,6 +5,7 @@
 import 'package:pub_dev/frontend/static_files.dart';
 import 'package:test/test.dart';
 
+import '../../shared/test_models.dart';
 import '../../shared/test_services.dart';
 import '_utils.dart';
 
@@ -13,6 +14,29 @@ void main() {
     // TODO: add test for /consent page
     // TODO: add test for GET /api/account/consent/<consentId> API calls
     // TODO: add test for PUT /api/account/consent/<consentId> API calls
+
+    testWithProfile('/my-packages', fn: () async {
+      final cookie = await acquireSessionCookie(adminAtPubDevAuthToken);
+      await expectHtmlResponse(
+        await issueGet(
+          '/my-packages',
+          headers: {'cookie': cookie},
+        ),
+        present: ['/packages/flutter_titanium'],
+      );
+    });
+
+    testWithProfile('/my-packages?next=o', fn: () async {
+      final cookie = await acquireSessionCookie(adminAtPubDevAuthToken);
+      await expectHtmlResponse(
+        await issueGet(
+          '/my-packages?next=o',
+          headers: {'cookie': cookie},
+        ),
+        present: ['/packages/oxygen'],
+        absent: ['/packages/flutter_titanium'],
+      );
+    });
   });
 
   group('pub client authorization landing page', () {

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -48,7 +48,7 @@ import 'handlers/_utils.dart';
 
 const String goldenDir = 'test/frontend/golden';
 
-final _regenerateGoldens = true;
+final _regenerateGoldens = false;
 
 void main() {
   setUpAll(() => updateLocalBuiltFilesIfNeeded());

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -48,7 +48,7 @@ import 'handlers/_utils.dart';
 
 const String goldenDir = 'test/frontend/golden';
 
-final _regenerateGoldens = false;
+final _regenerateGoldens = true;
 
 void main() {
   setUpAll(() => updateLocalBuiltFilesIfNeeded());
@@ -668,20 +668,12 @@ void main() {
             imageUrl: 'pub.dev/user-img-url.png',
           );
           registerUserSessionData(session);
-          final searchForm =
-              SearchForm(context: SearchContext.myPackages([user.userId]));
-          final String html = renderAccountPackagesPage(
+          final html = renderAccountPackagesPage(
             user: user,
             userSessionData: session,
-            searchResultPage: SearchResultPage(
-              searchForm,
-              2,
-              packageHits: [oxygen!, neon!],
-            ),
-            pageLinks: PageLinks(searchForm, 10),
-            searchForm: searchForm,
-            totalCount: 2,
-            messageFromBackend: null,
+            packageHits: [oxygen!, neon!],
+            startPackage: 'oxygen',
+            nextPackage: 'package_after_neon',
           );
           expectGoldenFile(html, 'my_packages.html', timestamps: {
             'oxygen-created': oxygen.created,

--- a/index.yaml
+++ b/index.yaml
@@ -44,6 +44,11 @@ indexes:
   - name: state
   - name: lockedUntil
 
+- kind: Package
+  properties:
+  - name: uploaders
+  - name: name
+
 - kind: PackageVersion
   ancestor: yes
   properties:

--- a/pkg/web_css/lib/src/_base.scss
+++ b/pkg/web_css/lib/src/_base.scss
@@ -93,6 +93,13 @@ a {
   &:hover {
     opacity: 0.8;
   }
+
+  &.link-button {
+    background: $color-link;
+    color: white;
+    display: inline-block;
+    padding: 4px 12px;
+  }
 }
 
 main {


### PR DESCRIPTION
- #5342
- An alternative index and listing could be to use the last `updated` timestamp with `?after=<date>` continuation.
- Deployed to staging, if you have <10 packages, you can partially test it with `?next=xyz`
- Further search index cleanup in a subsequent PR.