### PR TITLE
Partial fix of exact phrase matches.

### DIFF
--- a/app/lib/search/mem_index.dart
+++ b/app/lib/search/mem_index.dart
@@ -416,8 +416,7 @@ class InMemoryPackageIndex implements PackageIndex {
           .removeLowValues(fraction: 0.2, minValue: 0.01);
 
       // filter results based on exact phrases
-      final phrases =
-          extractExactPhrases(text).map(normalizeBeforeIndexing).toList();
+      final phrases = extractExactPhrases(text);
       if (!aborted && phrases.isNotEmpty) {
         final Map<String, double> matched = <String, double>{};
         for (String package in score.getKeys()) {

--- a/app/test/search/mem_index_test.dart
+++ b/app/test/search/mem_index_test.dart
@@ -172,6 +172,32 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
       });
     });
 
+    test('exact phrase: multiple words with matching cases', () async {
+      final result = await index
+          .search(ServiceSearchQuery.parse(query: '"AsyncCache class"'));
+      expect(json.decode(json.encode(result)), {
+        'timestamp': isNotNull,
+        'totalCount': 1,
+        'sdkLibraryHits': [],
+        'packageHits': [
+          {'package': 'async', 'score': closeTo(0.38, 0.01)},
+        ],
+      });
+    });
+
+    test('exact phrase: multiple words with non-matching cases', () async {
+      final result = await index
+          .search(ServiceSearchQuery.parse(query: '"asynccache Class"'));
+      expect(json.decode(json.encode(result)), {
+        'timestamp': isNotNull,
+        'totalCount': 0,
+        'sdkLibraryHits': [],
+        'packageHits': [
+          // TODO: make sure package:async shows up
+        ],
+      });
+    });
+
     test('exact phrase with dot: "once on demand."', () async {
       final result = await index
           .search(ServiceSearchQuery.parse(query: '"once on demand."'));


### PR DESCRIPTION
- Fixes #5384 by not normalizing the query text.
- Added a test that indicates the correct behavior in the future: to also match different cases. I think this may be part of a new search backend, but it would be costly to do in memory (to store another version of the text just for such use-case).