### PR TITLE
Rename: awaiting status -> pending.

### DIFF
--- a/app/lib/frontend/handlers/custom_api.dart
+++ b/app/lib/frontend/handlers/custom_api.dart
@@ -51,7 +51,7 @@ Future<shelf.Response> apiDocumentationHandler(
     final entry = dartdocEntries[i];
     final hasDocumentation = entry != null && entry.hasContent;
     final status =
-        entry == null ? 'awaiting' : (entry.hasContent ? 'success' : 'failed');
+        entry == null ? 'pending' : (entry.hasContent ? 'success' : 'failed');
     versionsData.add({
       'version': versions.versions[i].version,
       'status': status,

--- a/app/lib/frontend/templates/package_misc.dart
+++ b/app/lib/frontend/templates/package_misc.dart
@@ -224,8 +224,8 @@ d.Node tagsNodeFromPackageView({
       ],
     ));
   }
-  if (badgeTags.isEmpty && package.isAwaiting!) {
-    simpleTags.add(SimpleTag.awaiting());
+  if (badgeTags.isEmpty && package.isPending) {
+    simpleTags.add(SimpleTag.pending());
   }
   if (simpleTags.isEmpty && badgeTags.isEmpty) {
     simpleTags.add(SimpleTag.unidentified(

--- a/app/lib/frontend/templates/views/pkg/info_box.dart
+++ b/app/lib/frontend/templates/views/pkg/info_box.dart
@@ -36,7 +36,7 @@ d.Node packageInfoBoxNode({
   if (data.versionInfo?.hasLicense ?? false) {
     var licenseFile = data.scoreCard?.panaReport?.licenseFile;
     if (licenseFile != null && data.scoreCard?.panaReport == null) {
-      licenseFile = LicenseFile('LICENSE', 'awaiting analysis');
+      licenseFile = LicenseFile('LICENSE', 'pending analysis');
     }
     licenseFile ??= LicenseFile('LICENSE', 'unknown');
     license = _licenseNode(

--- a/app/lib/frontend/templates/views/pkg/score_tab.dart
+++ b/app/lib/frontend/templates/views/pkg/score_tab.dart
@@ -20,7 +20,7 @@ d.Node scoreTabNode({
   }
 
   final report = card.getJoinedReport();
-  final showAwaiting = !card.isSkipped && report == null;
+  final showPending = !card.isSkipped && report == null;
   final showReport = !card.isSkipped && report != null;
 
   final toolEnvInfo = _renderToolEnvInfoNode(
@@ -59,7 +59,7 @@ d.Node scoreTabNode({
             'The package version is not analyzed, because it does not support Dart 2. '
             'Until this is resolved, the package will receive a pub score of 0.',
       ),
-    if (showAwaiting)
+    if (showPending)
       d.p(
         classes: ['analysis-info'],
         text: 'The analysis of the package has not been completed yet.',
@@ -243,7 +243,7 @@ d.Node _pubPointsKeyFigureNode(Report? report) {
   if (report == null) {
     return _keyFigureNode(
       value: '',
-      supplemental: 'awaiting',
+      supplemental: 'pending',
       label: 'pub points',
     );
   }

--- a/app/lib/frontend/templates/views/pkg/tags.dart
+++ b/app/lib/frontend/templates/views/pkg/tags.dart
@@ -63,11 +63,12 @@ class SimpleTag {
     );
   }
 
-  factory SimpleTag.awaiting() {
+  factory SimpleTag.pending() {
     return SimpleTag(
       status: 'missing',
-      text: '[awaiting]',
-      title: 'Analysis should be ready soon.',
+      text: '[pending analysis]',
+      title:
+          "This version was scheduled for analysis, but it hasn't completed yet.",
     );
   }
 

--- a/app/lib/package/models.dart
+++ b/app/lib/package/models.dart
@@ -706,7 +706,7 @@ class PackageView extends Object with FlagMixin {
   @override
   final List<String>? flags;
   final String? publisherId;
-  final bool? isAwaiting;
+  final bool isPending;
 
   final int? likes;
 
@@ -732,14 +732,15 @@ class PackageView extends Object with FlagMixin {
     this.created,
     this.flags,
     this.publisherId,
-    this.isAwaiting = false,
+    bool? isPending,
     this.likes,
     this.grantedPubPoints,
     this.maxPubPoints,
     this.popularity,
     List<String>? tags,
     this.apiPages,
-  }) : tags = tags ?? <String>[];
+  })  : isPending = isPending ?? false,
+        tags = tags ?? <String>[];
 
   factory PackageView.fromJson(Map<String, dynamic> json) =>
       _$PackageViewFromJson(json);
@@ -753,7 +754,7 @@ class PackageView extends Object with FlagMixin {
   }) {
     final hasPanaReport = scoreCard?.reportTypes != null &&
         scoreCard!.reportTypes!.contains(ReportType.pana);
-    final isAwaiting =
+    final isPending =
         // Job processing has not created any card yet.
         (scoreCard == null) ||
             // The uploader has recently removed the "discontinued" flag, but the
@@ -768,7 +769,7 @@ class PackageView extends Object with FlagMixin {
       created: package.created,
       flags: scoreCard?.flags,
       publisherId: package.publisherId,
-      isAwaiting: isAwaiting,
+      isPending: isPending,
       likes: package.likes,
       grantedPubPoints: scoreCard?.grantedPubPoints,
       maxPubPoints: scoreCard?.maxPubPoints,
@@ -792,7 +793,7 @@ class PackageView extends Object with FlagMixin {
       created: created,
       flags: flags,
       publisherId: publisherId,
-      isAwaiting: isAwaiting,
+      isPending: isPending,
       likes: likes,
       grantedPubPoints: grantedPubPoints,
       maxPubPoints: maxPubPoints,

--- a/app/lib/package/models.g.dart
+++ b/app/lib/package/models.g.dart
@@ -46,7 +46,7 @@ PackageView _$PackageViewFromJson(Map<String, dynamic> json) => PackageView(
       flags:
           (json['flags'] as List<dynamic>?)?.map((e) => e as String).toList(),
       publisherId: json['publisherId'] as String?,
-      isAwaiting: json['isAwaiting'] as bool? ?? false,
+      isPending: json['isPending'] as bool?,
       likes: json['likes'] as int?,
       grantedPubPoints: json['grantedPubPoints'] as int?,
       maxPubPoints: json['maxPubPoints'] as int?,
@@ -72,7 +72,7 @@ Map<String, dynamic> _$PackageViewToJson(PackageView instance) {
   writeNotNull('created', instance.created?.toIso8601String());
   writeNotNull('flags', instance.flags);
   writeNotNull('publisherId', instance.publisherId);
-  writeNotNull('isAwaiting', instance.isAwaiting);
+  val['isPending'] = instance.isPending;
   writeNotNull('likes', instance.likes);
   writeNotNull('grantedPubPoints', instance.grantedPubPoints);
   writeNotNull('maxPubPoints', instance.maxPubPoints);

--- a/app/test/frontend/golden/analysis_tab_outdated.html
+++ b/app/test/frontend/golden/analysis_tab_outdated.html
@@ -10,7 +10,7 @@
     <div class="score-key-figure">
       <div class="score-key-figure-title">
         <span class="score-key-figure-value"></span>
-        <span class="score-key-figure-supplemental">awaiting</span>
+        <span class="score-key-figure-supplemental">pending</span>
       </div>
       <div class="score-key-figure-label">pub points</div>
     </div>

--- a/app/test/frontend/golden/pkg_show_page_legacy.html
+++ b/app/test/frontend/golden/pkg_show_page_legacy.html
@@ -201,7 +201,7 @@
                     <div class="score-key-figure">
                       <div class="score-key-figure-title">
                         <span class="score-key-figure-value"></span>
-                        <span class="score-key-figure-supplemental">awaiting</span>
+                        <span class="score-key-figure-supplemental">pending</span>
                       </div>
                       <div class="score-key-figure-label">pub points</div>
                     </div>

--- a/app/test/frontend/golden/pkg_show_page_publisher.html
+++ b/app/test/frontend/golden/pkg_show_page_publisher.html
@@ -140,7 +140,7 @@
                 </div>
                 <div class="detail-tags-and-like">
                   <div class="detail-tags">
-                    <span class="package-tag missing" title="Analysis should be ready soon.">[awaiting]</span>
+                    <span class="package-tag missing" title="This version was scheduled for analysis, but it hasn't completed yet.">[pending analysis]</span>
                   </div>
                   <div class="detail-like">
                     <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false">

--- a/pkg/web_app/lib/src/dartdoc_status.dart
+++ b/pkg/web_app/lib/src/dartdoc_status.dart
@@ -47,9 +47,9 @@ void updateDartdocStatus() {
               if (docCol == null) return;
               final docLink = docCol.querySelector('a') as AnchorElement?;
               if (docLink == null) return;
-              if (status == 'awaiting') {
+              if (status == 'pending') {
                 docCol.dataset[_hasDocumentationAttr] = '...';
-                docLink.text = 'awaiting';
+                docLink.text = 'pending';
               } else if (hasDocumentation) {
                 docCol.dataset[_hasDocumentationAttr] = '1';
               } else {


### PR DESCRIPTION
- The rename inside `PackageView` is safe, as we only store it in runtime-versioned cache.
- The rename in documentation API is technically breaking, but only for a limited time window, and only if the user gets to load the old web_app with the new API or vice-versa during partially-migrated traffic.
- Otherwise only labels change.