### PR TITLE
Escape ld+json content with manual JSON builder.

### DIFF
--- a/app/lib/frontend/dom/dom.dart
+++ b/app/lib/frontend/dom/dom.dart
@@ -136,7 +136,7 @@ Node codeSnippet({
 Node ldJson(Map<String, dynamic> content) {
   final sb = StringBuffer();
 
-  /// Build the JSON content by manually escaping most untrusted characters,
+  /// Build the JSON content by manually escaping dangerous characters,
   /// and also building the object and list structures.
   void write(dynamic value) {
     if (value is String) {

--- a/app/lib/frontend/dom/dom.dart
+++ b/app/lib/frontend/dom/dom.dart
@@ -169,7 +169,8 @@ Node ldJson(Map<String, dynamic> content) {
     } else if (value is bool || value is num || value == null) {
       sb.write(json.encode(value));
     } else {
-      throw ArgumentError('Unexpected value: $value');
+      throw ArgumentError(
+          'Value `$value` could not be translated to JSON, unexpected type: `${value.runtimeType}`.');
     }
   }
 

--- a/app/lib/frontend/dom/dom.dart
+++ b/app/lib/frontend/dom/dom.dart
@@ -16,8 +16,7 @@ final _elementRegExp = _attributeRegExp;
 // As we want to store rawJson inside a HTML Element, it is better
 // to escape all non-trusteded characters inside it. Non-trusted
 // characters must include `</!>` characters.
-final _ldJsonEscapedCharactersRegExp =
-    RegExp(r'[^0-9a-zA-Z ,@\:\{\}\[\]\.\-"]');
+final _ldJsonEscapedCharactersRegExp = RegExp(r'[^0-9a-zA-Z ,@\.\-]');
 
 /// The DOM context to use while constructing nodes.
 ///
@@ -135,17 +134,49 @@ Node codeSnippet({
 
 /// Creates a DOM element with ld+json `<script>` content.
 Node ldJson(Map<String, dynamic> content) {
-  final rawJson = json.encode(content);
-  final rawHtml = rawJson.replaceAllMapped(
-    _ldJsonEscapedCharactersRegExp,
-    (m) {
-      final code = m[0]!.codeUnitAt(0);
-      return r'\u' + code.toRadixString(16).padLeft(4, '0');
-    },
-  );
+  final sb = StringBuffer();
+
+  /// Build the JSON content by manually escaping most untrusted characters,
+  /// and also building the object and list structures.
+  void write(dynamic value) {
+    if (value is String) {
+      sb.write('"');
+      sb.write(value.replaceAllMapped(
+        _ldJsonEscapedCharactersRegExp,
+        (m) {
+          final code = m[0]!.codeUnitAt(0);
+          return r'\u' + code.toRadixString(16).padLeft(4, '0');
+        },
+      ));
+      sb.write('"');
+    } else if (value is List) {
+      sb.write('[');
+      for (var i = 0; i < value.length; i++) {
+        if (i > 0) sb.write(',');
+        write(value[i]);
+      }
+      sb.write(']');
+    } else if (value is Map) {
+      final entries = value.entries.toList();
+      sb.write('{');
+      for (var i = 0; i < entries.length; i++) {
+        if (i > 0) sb.write(',');
+        write(entries[i].key);
+        sb.write(':');
+        write(entries[i].value);
+      }
+      sb.write('}');
+    } else if (value is bool || value is num || value == null) {
+      sb.write(json.encode(value));
+    } else {
+      throw ArgumentError('Unexpected value: $value');
+    }
+  }
+
+  write(content);
   return script(
     type: 'application/ld+json',
-    child: unsafeRawHtml(rawHtml),
+    child: unsafeRawHtml(sb.toString()),
   );
 }
 

--- a/app/test/frontend/golden/landing_page.html
+++ b/app/test/frontend/golden/landing_page.html
@@ -221,6 +221,6 @@
         <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
       </a>
     </footer>
-    <script type="application/ld+json">{"@context":"http:\u002f\u002fschema.org","@type":"WebSite","url":"https:\u002f\u002fpub.dev\u002f","potentialAction":{"@type":"SearchAction","target":"https:\u002f\u002fpub.dev\u002fpackages\u003fq\u003d{search\u005fterm\u005fstring}","query-input":"required name\u003dsearch\u005fterm\u005fstring"}}</script>
+    <script type="application/ld+json">{"@context":"http\u003a\u002f\u002fschema.org","@type":"WebSite","url":"https\u003a\u002f\u002fpub.dev\u002f","potentialAction":{"@type":"SearchAction","target":"https\u003a\u002f\u002fpub.dev\u002fpackages\u003fq\u003d\u007bsearch\u005fterm\u005fstring\u007d","query-input":"required name\u003dsearch\u005fterm\u005fstring"}}</script>
   </body>
 </html>

--- a/app/test/frontend/golden/pkg_changelog_page.html
+++ b/app/test/frontend/golden/pkg_changelog_page.html
@@ -273,7 +273,7 @@
             </p>
           </aside>
         </div>
-        <script type="application/ld+json">{"@context":"http:\u002f\u002fschema.org","@type":"SoftwareSourceCode","name":"oxygen","version":"1.2.0","description":"oxygen - oxygen is awesome","url":"https:\u002f\u002fpub.dev\u002fpackages\u002foxygen","dateCreated":"%%published-timestamp%%","dateModified":"%%updated-timestamp%%","programmingLanguage":"Dart","image":"https:\u002f\u002fpub.dev\u002fstatic\u002fimg\u002fpub-dev-icon-cover-image.png","license":"https:\u002f\u002fpub.dev\u002fpackages\u002foxygen\u002flicense"}</script>
+        <script type="application/ld+json">{"@context":"http\u003a\u002f\u002fschema.org","@type":"SoftwareSourceCode","name":"oxygen","version":"1.2.0","description":"oxygen - oxygen is awesome","url":"https\u003a\u002f\u002fpub.dev\u002fpackages\u002foxygen","dateCreated":"%%published-escaped-timestamp%%","dateModified":"%%updated-escaped-timestamp%%","programmingLanguage":"Dart","image":"https\u003a\u002f\u002fpub.dev\u002fstatic\u002fimg\u002fpub-dev-icon-cover-image.png","license":"https\u003a\u002f\u002fpub.dev\u002fpackages\u002foxygen\u002flicense"}</script>
       </div>
       <div class="detail-metadata">
         <h3 class="detail-metadata-title">

--- a/app/test/frontend/golden/pkg_example_page.html
+++ b/app/test/frontend/golden/pkg_example_page.html
@@ -268,7 +268,7 @@
             </p>
           </aside>
         </div>
-        <script type="application/ld+json">{"@context":"http:\u002f\u002fschema.org","@type":"SoftwareSourceCode","name":"oxygen","version":"1.2.0","description":"oxygen - oxygen is awesome","url":"https:\u002f\u002fpub.dev\u002fpackages\u002foxygen","dateCreated":"%%published-timestamp%%","dateModified":"%%updated-timestamp%%","programmingLanguage":"Dart","image":"https:\u002f\u002fpub.dev\u002fstatic\u002fimg\u002fpub-dev-icon-cover-image.png","license":"https:\u002f\u002fpub.dev\u002fpackages\u002foxygen\u002flicense"}</script>
+        <script type="application/ld+json">{"@context":"http\u003a\u002f\u002fschema.org","@type":"SoftwareSourceCode","name":"oxygen","version":"1.2.0","description":"oxygen - oxygen is awesome","url":"https\u003a\u002f\u002fpub.dev\u002fpackages\u002foxygen","dateCreated":"%%published-escaped-timestamp%%","dateModified":"%%updated-escaped-timestamp%%","programmingLanguage":"Dart","image":"https\u003a\u002f\u002fpub.dev\u002fstatic\u002fimg\u002fpub-dev-icon-cover-image.png","license":"https\u003a\u002f\u002fpub.dev\u002fpackages\u002foxygen\u002flicense"}</script>
       </div>
       <div class="detail-metadata">
         <h3 class="detail-metadata-title">

--- a/app/test/frontend/golden/pkg_install_page.html
+++ b/app/test/frontend/golden/pkg_install_page.html
@@ -296,7 +296,7 @@
             </p>
           </aside>
         </div>
-        <script type="application/ld+json">{"@context":"http:\u002f\u002fschema.org","@type":"SoftwareSourceCode","name":"oxygen","version":"1.2.0","description":"oxygen - oxygen is awesome","url":"https:\u002f\u002fpub.dev\u002fpackages\u002foxygen","dateCreated":"%%published-timestamp%%","dateModified":"%%updated-timestamp%%","programmingLanguage":"Dart","image":"https:\u002f\u002fpub.dev\u002fstatic\u002fimg\u002fpub-dev-icon-cover-image.png","license":"https:\u002f\u002fpub.dev\u002fpackages\u002foxygen\u002flicense"}</script>
+        <script type="application/ld+json">{"@context":"http\u003a\u002f\u002fschema.org","@type":"SoftwareSourceCode","name":"oxygen","version":"1.2.0","description":"oxygen - oxygen is awesome","url":"https\u003a\u002f\u002fpub.dev\u002fpackages\u002foxygen","dateCreated":"%%published-escaped-timestamp%%","dateModified":"%%updated-escaped-timestamp%%","programmingLanguage":"Dart","image":"https\u003a\u002f\u002fpub.dev\u002fstatic\u002fimg\u002fpub-dev-icon-cover-image.png","license":"https\u003a\u002f\u002fpub.dev\u002fpackages\u002foxygen\u002flicense"}</script>
       </div>
       <div class="detail-metadata">
         <h3 class="detail-metadata-title">

--- a/app/test/frontend/golden/pkg_score_page.html
+++ b/app/test/frontend/golden/pkg_score_page.html
@@ -360,7 +360,7 @@
             </p>
           </aside>
         </div>
-        <script type="application/ld+json">{"@context":"http:\u002f\u002fschema.org","@type":"SoftwareSourceCode","name":"oxygen","version":"1.2.0","description":"oxygen - oxygen is awesome","url":"https:\u002f\u002fpub.dev\u002fpackages\u002foxygen","dateCreated":"%%published-timestamp%%","dateModified":"%%updated-timestamp%%","programmingLanguage":"Dart","image":"https:\u002f\u002fpub.dev\u002fstatic\u002fimg\u002fpub-dev-icon-cover-image.png","license":"https:\u002f\u002fpub.dev\u002fpackages\u002foxygen\u002flicense"}</script>
+        <script type="application/ld+json">{"@context":"http\u003a\u002f\u002fschema.org","@type":"SoftwareSourceCode","name":"oxygen","version":"1.2.0","description":"oxygen - oxygen is awesome","url":"https\u003a\u002f\u002fpub.dev\u002fpackages\u002foxygen","dateCreated":"%%published-escaped-timestamp%%","dateModified":"%%updated-escaped-timestamp%%","programmingLanguage":"Dart","image":"https\u003a\u002f\u002fpub.dev\u002fstatic\u002fimg\u002fpub-dev-icon-cover-image.png","license":"https\u003a\u002f\u002fpub.dev\u002fpackages\u002foxygen\u002flicense"}</script>
       </div>
       <div class="detail-metadata">
         <h3 class="detail-metadata-title">

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -267,7 +267,7 @@
             </p>
           </aside>
         </div>
-        <script type="application/ld+json">{"@context":"http:\u002f\u002fschema.org","@type":"SoftwareSourceCode","name":"oxygen","version":"1.2.0","description":"oxygen - oxygen is awesome","url":"https:\u002f\u002fpub.dev\u002fpackages\u002foxygen","dateCreated":"%%published-timestamp%%","dateModified":"%%updated-timestamp%%","programmingLanguage":"Dart","image":"https:\u002f\u002fpub.dev\u002fstatic\u002fimg\u002fpub-dev-icon-cover-image.png","license":"https:\u002f\u002fpub.dev\u002fpackages\u002foxygen\u002flicense"}</script>
+        <script type="application/ld+json">{"@context":"http\u003a\u002f\u002fschema.org","@type":"SoftwareSourceCode","name":"oxygen","version":"1.2.0","description":"oxygen - oxygen is awesome","url":"https\u003a\u002f\u002fpub.dev\u002fpackages\u002foxygen","dateCreated":"%%published-escaped-timestamp%%","dateModified":"%%updated-escaped-timestamp%%","programmingLanguage":"Dart","image":"https\u003a\u002f\u002fpub.dev\u002fstatic\u002fimg\u002fpub-dev-icon-cover-image.png","license":"https\u003a\u002f\u002fpub.dev\u002fpackages\u002foxygen\u002flicense"}</script>
       </div>
       <div class="detail-metadata">
         <h3 class="detail-metadata-title">

--- a/app/test/frontend/golden/pkg_show_page_discontinued.html
+++ b/app/test/frontend/golden/pkg_show_page_discontinued.html
@@ -246,7 +246,7 @@
             </p>
           </aside>
         </div>
-        <script type="application/ld+json">{"@context":"http:\u002f\u002fschema.org","@type":"SoftwareSourceCode","name":"pkg","version":"1.0.0","description":"pkg - pkg is awesome","url":"https:\u002f\u002fpub.dev\u002fpackages\u002fpkg","dateCreated":"%%published-timestamp%%","dateModified":"%%published-timestamp%%","programmingLanguage":"Dart","image":"https:\u002f\u002fpub.dev\u002fstatic\u002fimg\u002fpub-dev-icon-cover-image.png","license":"https:\u002f\u002fpub.dev\u002fpackages\u002fpkg\u002flicense"}</script>
+        <script type="application/ld+json">{"@context":"http\u003a\u002f\u002fschema.org","@type":"SoftwareSourceCode","name":"pkg","version":"1.0.0","description":"pkg - pkg is awesome","url":"https\u003a\u002f\u002fpub.dev\u002fpackages\u002fpkg","dateCreated":"%%published-escaped-timestamp%%","dateModified":"%%published-escaped-timestamp%%","programmingLanguage":"Dart","image":"https\u003a\u002f\u002fpub.dev\u002fstatic\u002fimg\u002fpub-dev-icon-cover-image.png","license":"https\u003a\u002f\u002fpub.dev\u002fpackages\u002fpkg\u002flicense"}</script>
       </div>
       <div class="detail-metadata">
         <h3 class="detail-metadata-title">

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -260,7 +260,7 @@
             </p>
           </aside>
         </div>
-        <script type="application/ld+json">{"@context":"http:\u002f\u002fschema.org","@type":"SoftwareSourceCode","name":"flutter\u005ftitanium","version":"1.10.0","description":"flutter\u005ftitanium - flutter\u005ftitanium is awesome","url":"https:\u002f\u002fpub.dev\u002fpackages\u002fflutter\u005ftitanium","dateCreated":"%%published-timestamp%%","dateModified":"%%updated-timestamp%%","programmingLanguage":"Dart","image":"https:\u002f\u002fpub.dev\u002fstatic\u002fimg\u002fpub-dev-icon-cover-image.png","license":"https:\u002f\u002fpub.dev\u002fpackages\u002fflutter\u005ftitanium\u002flicense"}</script>
+        <script type="application/ld+json">{"@context":"http\u003a\u002f\u002fschema.org","@type":"SoftwareSourceCode","name":"flutter\u005ftitanium","version":"1.10.0","description":"flutter\u005ftitanium - flutter\u005ftitanium is awesome","url":"https\u003a\u002f\u002fpub.dev\u002fpackages\u002fflutter\u005ftitanium","dateCreated":"%%published-escaped-timestamp%%","dateModified":"%%updated-escaped-timestamp%%","programmingLanguage":"Dart","image":"https\u003a\u002f\u002fpub.dev\u002fstatic\u002fimg\u002fpub-dev-icon-cover-image.png","license":"https\u003a\u002f\u002fpub.dev\u002fpackages\u002fflutter\u005ftitanium\u002flicense"}</script>
       </div>
       <div class="detail-metadata">
         <h3 class="detail-metadata-title">

--- a/app/test/frontend/golden/pkg_show_page_legacy.html
+++ b/app/test/frontend/golden/pkg_show_page_legacy.html
@@ -260,7 +260,7 @@
             </p>
           </aside>
         </div>
-        <script type="application/ld+json">{"@context":"http:\u002f\u002fschema.org","@type":"SoftwareSourceCode","name":"pkg","version":"1.0.0-legacy","description":"pkg - pkg is awesome","url":"https:\u002f\u002fpub.dev\u002fpackages\u002fpkg","dateCreated":"%%published-timestamp%%","dateModified":"%%published-timestamp%%","programmingLanguage":"Dart","image":"https:\u002f\u002fpub.dev\u002fstatic\u002fimg\u002fpub-dev-icon-cover-image.png","license":"https:\u002f\u002fpub.dev\u002fpackages\u002fpkg\u002flicense"}</script>
+        <script type="application/ld+json">{"@context":"http\u003a\u002f\u002fschema.org","@type":"SoftwareSourceCode","name":"pkg","version":"1.0.0-legacy","description":"pkg - pkg is awesome","url":"https\u003a\u002f\u002fpub.dev\u002fpackages\u002fpkg","dateCreated":"%%published-escaped-timestamp%%","dateModified":"%%published-escaped-timestamp%%","programmingLanguage":"Dart","image":"https\u003a\u002f\u002fpub.dev\u002fstatic\u002fimg\u002fpub-dev-icon-cover-image.png","license":"https\u003a\u002f\u002fpub.dev\u002fpackages\u002fpkg\u002flicense"}</script>
       </div>
       <div class="detail-metadata">
         <h3 class="detail-metadata-title">

--- a/app/test/frontend/golden/pkg_show_page_publisher.html
+++ b/app/test/frontend/golden/pkg_show_page_publisher.html
@@ -253,7 +253,7 @@
             </p>
           </aside>
         </div>
-        <script type="application/ld+json">{"@context":"http:\u002f\u002fschema.org","@type":"SoftwareSourceCode","name":"neon","version":"1.0.0","description":"neon - neon is awesome","url":"https:\u002f\u002fpub.dev\u002fpackages\u002fneon","dateCreated":"%%published-timestamp%%","dateModified":"%%published-timestamp%%","programmingLanguage":"Dart","image":"https:\u002f\u002fpub.dev\u002fstatic\u002fimg\u002fpub-dev-icon-cover-image.png","license":"https:\u002f\u002fpub.dev\u002fpackages\u002fneon\u002flicense"}</script>
+        <script type="application/ld+json">{"@context":"http\u003a\u002f\u002fschema.org","@type":"SoftwareSourceCode","name":"neon","version":"1.0.0","description":"neon - neon is awesome","url":"https\u003a\u002f\u002fpub.dev\u002fpackages\u002fneon","dateCreated":"%%published-escaped-timestamp%%","dateModified":"%%published-escaped-timestamp%%","programmingLanguage":"Dart","image":"https\u003a\u002f\u002fpub.dev\u002fstatic\u002fimg\u002fpub-dev-icon-cover-image.png","license":"https\u003a\u002f\u002fpub.dev\u002fpackages\u002fneon\u002flicense"}</script>
       </div>
       <div class="detail-metadata">
         <h3 class="detail-metadata-title">

--- a/app/test/frontend/golden/pkg_show_page_retracted.html
+++ b/app/test/frontend/golden/pkg_show_page_retracted.html
@@ -262,7 +262,7 @@
             </p>
           </aside>
         </div>
-        <script type="application/ld+json">{"@context":"http:\u002f\u002fschema.org","@type":"SoftwareSourceCode","name":"pkg","version":"1.0.0","description":"pkg - pkg is awesome","url":"https:\u002f\u002fpub.dev\u002fpackages\u002fpkg","dateCreated":"%%published-timestamp%%","dateModified":"%%published-timestamp%%","programmingLanguage":"Dart","image":"https:\u002f\u002fpub.dev\u002fstatic\u002fimg\u002fpub-dev-icon-cover-image.png","license":"https:\u002f\u002fpub.dev\u002fpackages\u002fpkg\u002fversions\u002f1.0.0\u002flicense"}</script>
+        <script type="application/ld+json">{"@context":"http\u003a\u002f\u002fschema.org","@type":"SoftwareSourceCode","name":"pkg","version":"1.0.0","description":"pkg - pkg is awesome","url":"https\u003a\u002f\u002fpub.dev\u002fpackages\u002fpkg","dateCreated":"%%published-escaped-timestamp%%","dateModified":"%%published-escaped-timestamp%%","programmingLanguage":"Dart","image":"https\u003a\u002f\u002fpub.dev\u002fstatic\u002fimg\u002fpub-dev-icon-cover-image.png","license":"https\u003a\u002f\u002fpub.dev\u002fpackages\u002fpkg\u002fversions\u002f1.0.0\u002flicense"}</script>
       </div>
       <div class="detail-metadata">
         <h3 class="detail-metadata-title">

--- a/app/test/frontend/golden/pkg_show_page_retracted_non_retracted_version.html
+++ b/app/test/frontend/golden/pkg_show_page_retracted_non_retracted_version.html
@@ -258,7 +258,7 @@
             </p>
           </aside>
         </div>
-        <script type="application/ld+json">{"@context":"http:\u002f\u002fschema.org","@type":"SoftwareSourceCode","name":"pkg","version":"2.0.0","description":"pkg - pkg is awesome","url":"https:\u002f\u002fpub.dev\u002fpackages\u002fpkg","dateCreated":"%%published-timestamp%%","dateModified":"%%updated-timestamp%%","programmingLanguage":"Dart","image":"https:\u002f\u002fpub.dev\u002fstatic\u002fimg\u002fpub-dev-icon-cover-image.png","license":"https:\u002f\u002fpub.dev\u002fpackages\u002fpkg\u002flicense"}</script>
+        <script type="application/ld+json">{"@context":"http\u003a\u002f\u002fschema.org","@type":"SoftwareSourceCode","name":"pkg","version":"2.0.0","description":"pkg - pkg is awesome","url":"https\u003a\u002f\u002fpub.dev\u002fpackages\u002fpkg","dateCreated":"%%published-escaped-timestamp%%","dateModified":"%%updated-escaped-timestamp%%","programmingLanguage":"Dart","image":"https\u003a\u002f\u002fpub.dev\u002fstatic\u002fimg\u002fpub-dev-icon-cover-image.png","license":"https\u003a\u002f\u002fpub.dev\u002fpackages\u002fpkg\u002flicense"}</script>
       </div>
       <div class="detail-metadata">
         <h3 class="detail-metadata-title">

--- a/app/test/frontend/golden/pkg_show_version_page.html
+++ b/app/test/frontend/golden/pkg_show_version_page.html
@@ -267,7 +267,7 @@
             </p>
           </aside>
         </div>
-        <script type="application/ld+json">{"@context":"http:\u002f\u002fschema.org","@type":"SoftwareSourceCode","name":"oxygen","version":"1.2.0","description":"oxygen - oxygen is awesome","url":"https:\u002f\u002fpub.dev\u002fpackages\u002foxygen","dateCreated":"%%published-timestamp%%","dateModified":"%%updated-timestamp%%","programmingLanguage":"Dart","image":"https:\u002f\u002fpub.dev\u002fstatic\u002fimg\u002fpub-dev-icon-cover-image.png","license":"https:\u002f\u002fpub.dev\u002fpackages\u002foxygen\u002flicense"}</script>
+        <script type="application/ld+json">{"@context":"http\u003a\u002f\u002fschema.org","@type":"SoftwareSourceCode","name":"oxygen","version":"1.2.0","description":"oxygen - oxygen is awesome","url":"https\u003a\u002f\u002fpub.dev\u002fpackages\u002foxygen","dateCreated":"%%published-escaped-timestamp%%","dateModified":"%%updated-escaped-timestamp%%","programmingLanguage":"Dart","image":"https\u003a\u002f\u002fpub.dev\u002fstatic\u002fimg\u002fpub-dev-icon-cover-image.png","license":"https\u003a\u002f\u002fpub.dev\u002fpackages\u002foxygen\u002flicense"}</script>
       </div>
       <div class="detail-metadata">
         <h3 class="detail-metadata-title">

--- a/app/test/frontend/golden/pkg_versions_page.html
+++ b/app/test/frontend/golden/pkg_versions_page.html
@@ -374,7 +374,7 @@
             </p>
           </aside>
         </div>
-        <script type="application/ld+json">{"@context":"http:\u002f\u002fschema.org","@type":"SoftwareSourceCode","name":"oxygen","version":"1.2.0","description":"oxygen - oxygen is awesome","url":"https:\u002f\u002fpub.dev\u002fpackages\u002foxygen","dateCreated":"%%package-created-timestamp%%","dateModified":"%%version-created-timestamp%%","programmingLanguage":"Dart","image":"https:\u002f\u002fpub.dev\u002fstatic\u002fimg\u002fpub-dev-icon-cover-image.png","license":"https:\u002f\u002fpub.dev\u002fpackages\u002foxygen\u002flicense"}</script>
+        <script type="application/ld+json">{"@context":"http\u003a\u002f\u002fschema.org","@type":"SoftwareSourceCode","name":"oxygen","version":"1.2.0","description":"oxygen - oxygen is awesome","url":"https\u003a\u002f\u002fpub.dev\u002fpackages\u002foxygen","dateCreated":"%%package-created-escaped-timestamp%%","dateModified":"%%version-created-escaped-timestamp%%","programmingLanguage":"Dart","image":"https\u003a\u002f\u002fpub.dev\u002fstatic\u002fimg\u002fpub-dev-icon-cover-image.png","license":"https\u003a\u002f\u002fpub.dev\u002fpackages\u002foxygen\u002flicense"}</script>
       </div>
       <div class="detail-metadata">
         <h3 class="detail-metadata-title">

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -97,6 +97,8 @@ void main() {
           replacedContent = replacedContent
               .replaceAll(shortDateFormat.format(value), '%%$key-date%%')
               .replaceAll(value.toIso8601String(), '%%$key-timestamp%%')
+              .replaceAll(value.toIso8601String().replaceAll(':', r'\u003a'),
+                  '%%$key-escaped-timestamp%%')
               .replaceAll(formatXAgo(age), '%%x-ago%%');
         }
       });


### PR DESCRIPTION
- Fixes #5402.
- Using `json` encoder + second encoder doesn't work, as we want to double-encode some characters, but not the escape `\`. Detecting it correctly seems to need implementing a proper parser to do it right.
- Instead, this code emits the JSON structure `{`..`}`, `[`..`]`, `key: value` pairs directly, and also encodes the strings with unicode escaping for almost all of the characters, making sure that both the JSON and the HTML structures are escaped.
