### PR TITLE
Updated exception message when a package upload is blocked based on its name.

### DIFF
--- a/app/lib/package/name_tracker.dart
+++ b/app/lib/package/name_tracker.dart
@@ -74,7 +74,7 @@ class NameTracker {
 
   /// Names that are reserved due to moderated packages having these names.
   final _reservedNames = <String>{};
-  final _conflictingNames = <String>{};
+  final _conflictingNames = <String, String>{};
   final _firstScanCompleter = Completer();
   _NameTrackerUpdater? _updater;
 
@@ -83,7 +83,7 @@ class NameTracker {
   /// Add a package name to the tracker.
   void add(TrackedPackage pkg) {
     _names.add(pkg.package);
-    _conflictingNames.addAll(_generateConflictingNames(pkg.package));
+    _addConflictingName(pkg.package);
     final current = _packages[pkg.package];
     if (current == null || current.lastPublished.isBefore(pkg.lastPublished)) {
       _packages[pkg.package] = pkg;
@@ -93,8 +93,14 @@ class NameTracker {
 
   void addReservedName(String name) {
     _reservedNames.add(name);
-    _conflictingNames.addAll(_generateConflictingNames(name));
+    _addConflictingName(name);
     _names.remove(name);
+  }
+
+  void _addConflictingName(String name) {
+    for (final generated in _generateConflictingNames(name)) {
+      _conflictingNames.putIfAbsent(generated, () => name);
+    }
   }
 
   /// Returns the cached list of packages ordered by descending last published date.
@@ -109,26 +115,28 @@ class NameTracker {
   /// Whether the package was already added to the tracker.
   bool _hasPackage(String name) => _names.contains(name);
 
-  /// Whether the [name] has a conflicting package that already exists or
-  /// a conflicting package among the moderated packages.
-  bool _hasConflict(String name) =>
-      _generateConflictingNames(name).any(_conflictingNames.contains) ||
-      _reservedNames.contains(name);
-
   /// Whether to accept the upload attempt of a given package [name].
   ///
   /// Either the package [name] should exists, or it should be different enough
   /// from already existing active or moderated package names. An example for
   /// the rejection: `long_name` will be rejected, if package `longname` or
   /// `lon_gname` exists.
-  Future<bool> accept(String name) async {
+  ///
+  /// Returns the package name that caused rejection or null if it is accepted.
+  Future<String?> accept(String name) async {
     // fast track:
-    if (_hasPackage(name)) return true;
+    if (_hasPackage(name)) return null;
     // Trigger a new scan (if updater is active) to get the packages that may
     // have been uploaded recently.
     await _updater?._scan();
     // normal checks:
-    return _hasPackage(name) || !_hasConflict(name);
+    if (_hasPackage(name)) return null;
+    if (_reservedNames.contains(name)) return name;
+    for (final generated in _generateConflictingNames(name)) {
+      final original = _conflictingNames[generated];
+      if (original != null) return original;
+    }
+    return null;
   }
 
   int get _length => _names.length;

--- a/app/lib/shared/exceptions.dart
+++ b/app/lib/shared/exceptions.dart
@@ -198,6 +198,18 @@ class PackageRejectedException extends ResponseException {
   PackageRejectedException.nameReserved(String package)
       : super._(400, 'PackageRejected', 'Package name $package is reserved.');
 
+  /// The [package] is similar to an active package.
+  PackageRejectedException.similarToActive(
+      String package, String conflicting, String url)
+      : super._(400, 'PackageRejected',
+            'Package name `$package` is too similar to another active package: `$conflicting` ($url).');
+
+  /// The [package] is similar to a moderated or withdrawn package.
+  PackageRejectedException.similarToModerated(
+      String package, String conflicting)
+      : super._(400, 'PackageRejected',
+            'Package name `$package` is too similar to a moderated package: `$conflicting`.');
+
   /// The [package] has reached or has more versions than [limit].
   PackageRejectedException.maxVersionCountReached(String package, int limit)
       : super._(

--- a/app/test/package/name_tracker_test.dart
+++ b/app/test/package/name_tracker_test.dart
@@ -43,8 +43,8 @@ void main() {
     nameTracker.add(TrackedPackage.simple('isolates'));
 
     test('conflicting package: singular', () async {
-      expect(await nameTracker.accept('isolate'), 'isolate');
-      expect(await nameTracker.accept('iso_late'), 'isolate');
+      expect(await nameTracker.accept('isolate'), 'isolates');
+      expect(await nameTracker.accept('iso_late'), 'isolates');
     });
   });
 

--- a/app/test/package/name_tracker_test.dart
+++ b/app/test/package/name_tracker_test.dart
@@ -14,27 +14,27 @@ void main() {
     nameTracker.add(TrackedPackage.simple('j_son'));
 
     test('new package can be published', () async {
-      expect(await nameTracker.accept('new_package'), isTrue);
+      expect(await nameTracker.accept('new_package'), isNull);
     });
 
     test('existing package is accepted and can be published again', () async {
-      expect(await nameTracker.accept('json'), isTrue);
-      expect(await nameTracker.accept('j_son'), isTrue);
+      expect(await nameTracker.accept('json'), isNull);
+      expect(await nameTracker.accept('j_son'), isNull);
     });
 
     test('conflicting package: same name', () async {
-      expect(await nameTracker.accept('j_s_o_n'), isFalse);
-      expect(await nameTracker.accept('js_on'), isFalse);
-      expect(await nameTracker.accept('jso_n'), isFalse);
-      expect(await nameTracker.accept('json_'), isFalse);
-      expect(await nameTracker.accept('_json'), isFalse);
-      expect(await nameTracker.accept('_json_'), isFalse);
-      expect(await nameTracker.accept('_j_s_o_n_'), isFalse);
+      expect(await nameTracker.accept('j_s_o_n'), 'json');
+      expect(await nameTracker.accept('js_on'), 'json');
+      expect(await nameTracker.accept('jso_n'), 'json');
+      expect(await nameTracker.accept('json_'), 'json');
+      expect(await nameTracker.accept('_json'), 'json');
+      expect(await nameTracker.accept('_json_'), 'json');
+      expect(await nameTracker.accept('_j_s_o_n_'), 'json');
     });
 
     test('conflicting package: plural', () async {
-      expect(await nameTracker.accept('jsons'), isFalse);
-      expect(await nameTracker.accept('json__s'), isFalse);
+      expect(await nameTracker.accept('jsons'), 'json');
+      expect(await nameTracker.accept('json__s'), 'json');
     });
   });
 
@@ -43,8 +43,8 @@ void main() {
     nameTracker.add(TrackedPackage.simple('isolates'));
 
     test('conflicting package: singular', () async {
-      expect(await nameTracker.accept('isolate'), isFalse);
-      expect(await nameTracker.accept('iso_late'), isFalse);
+      expect(await nameTracker.accept('isolate'), 'isolate');
+      expect(await nameTracker.accept('iso_late'), 'isolate');
     });
   });
 

--- a/app/test/package/upload_test.dart
+++ b/app/test/package/upload_test.dart
@@ -371,10 +371,10 @@ void main() {
       testWithProfile('similar package names are rejected', fn: () async {
         await accountBackend.withBearerToken(adminAtPubDevAuthToken, () async {
           expect(await fn('ox_ygen'),
-              'PackageRejected(400): Package name is too similar to another active or moderated package.');
+              'PackageRejected(400): Package name `ox_ygen` is too similar to another active package: `oxygen` (https://pub.dev/packages/oxygen).');
 
           expect(await fn('ox_y_ge_n'),
-              'PackageRejected(400): Package name is too similar to another active or moderated package.');
+              'PackageRejected(400): Package name `ox_y_ge_n` is too similar to another active package: `oxygen` (https://pub.dev/packages/oxygen).');
         });
       });
 
@@ -384,10 +384,10 @@ void main() {
           await nameTracker.scanDatastore();
 
           expect(await fn('neon'),
-              'PackageRejected(400): Package name is too similar to another active or moderated package.');
+              'PackageRejected(400): Package name `neon` is too similar to a moderated package: `neon`.');
 
           expect(await fn('ne_on'),
-              'PackageRejected(400): Package name is too similar to another active or moderated package.');
+              'PackageRejected(400): Package name `ne_on` is too similar to a moderated package: `neon`.');
         });
       });
 


### PR DESCRIPTION
- Fixes #5390.
- Needs a bit more tracking in `NameTracker`.
- Linking to the package page only if it is visible/active.
