### PR TITLE
Block Zalgo in description on upload.

### DIFF
--- a/pkg/pub_package_reader/lib/pub_package_reader.dart
+++ b/pkg/pub_package_reader/lib/pub_package_reader.dart
@@ -312,7 +312,16 @@ Iterable<ArchiveIssue> validatePackageVersion(Version? version) sync* {
 /// https://en.wikipedia.org/wiki/Zalgo_text
 Iterable<ArchiveIssue> validateZalgo(String field, String? text) sync* {
   if (text == null) return;
-  bool isDiacritic(int code) => code >= 0x0300 && code <= 0x036F;
+  // Checks if the code is in the combining character unicode ranges:
+  // https://en.wikipedia.org/wiki/Combining_character
+  bool isDiacritic(int code) =>
+      (code >= 0x0300 && code <= 0x036F) ||
+      (code >= 0x1AB0 && code <= 0x1AFF) ||
+      (code >= 0x1DC0 && code <= 0x1DFF) ||
+      (code >= 0x20D0 && code <= 0x20FF) ||
+      (code >= 0xFE20 && code <= 0xFE2F) ||
+      (code == 0x3099) ||
+      (code == 0x309A);
   final codes = text.codeUnits;
   for (var i = 1; i < codes.length; i++) {
     // checks for consecutive diacritical marks

--- a/pkg/pub_package_reader/test/package_archive_test.dart
+++ b/pkg/pub_package_reader/test/package_archive_test.dart
@@ -58,6 +58,19 @@ void main() {
     });
   });
 
+  group('Zalgo text', () {
+    test('allows CJK', () {
+      expect(
+          validateZalgo('field',
+              '文字 Chinese (Hanzi), 漢字 Japanese (Kanji), 漢字 Korean (Hanja)'),
+          isEmpty);
+    });
+
+    test('blocks Zalgo', () {
+      expect(validateZalgo('field', 'z͎͗ͣḁ̵̑l̉̃ͦg̐̓̒o͓̔ͥ'), isNotEmpty);
+    });
+  });
+
   group('sdk version range', () {
     test('accepted ranges', () {
       void isAccepted(String range) {


### PR DESCRIPTION
The algorithm to detect the weird text is simple: when a text contains two subsequent diacritical mark, we consider it as zalgo-like and reject. We may fine-tune this later, if needed, but it seems to be a good sanity-check.