### PR TITLE
Stricter concurrency handling in ScoreCardBackend.

### DIFF
--- a/app/lib/frontend/handlers/account.dart
+++ b/app/lib/frontend/handlers/account.dart
@@ -14,9 +14,9 @@ import '../../account/session_cookie.dart' as session_cookie;
 import '../../audit/backend.dart';
 import '../../package/backend.dart';
 import '../../package/models.dart';
-import '../../package/search_adapter.dart';
 import '../../publisher/backend.dart';
 import '../../publisher/models.dart';
+import '../../scorecard/backend.dart';
 import '../../shared/configuration.dart' show activeConfiguration;
 import '../../shared/exceptions.dart';
 import '../../shared/handlers.dart';
@@ -222,7 +222,7 @@ Future<shelf.Response> accountPackagesPageHandler(shelf.Request request) async {
   final next = request.requestedUri.queryParameters['next'];
   final page = await packageBackend
       .listPackagesForUser(userSessionData!.userId!, next: next);
-  final hits = await searchAdapter.getPackageViews(page.packages);
+  final hits = await scoreCardBackend.getPackageViews(page.packages);
 
   final html = renderAccountPackagesPage(
     user: (await accountBackend.lookupUserById(userSessionData!.userId!))!,

--- a/app/lib/package/search_adapter.dart
+++ b/app/lib/package/search_adapter.dart
@@ -8,7 +8,6 @@ import 'dart:math';
 import 'package:clock/clock.dart';
 import 'package:gcloud/service_scope.dart' as ss;
 import 'package:logging/logging.dart';
-import 'package:pool/pool.dart';
 
 import '../scorecard/backend.dart';
 import '../search/search_client.dart';
@@ -31,8 +30,6 @@ void registerSearchAdapter(SearchAdapter s) => ss.register(#_search, s);
 /// processes its results, extending the search results with up-to-date package
 /// data.
 class SearchAdapter {
-  final _pool = Pool(16);
-
   /// Lookup the top featured packages with the specific tags and sorting.
   ///
   /// Uses long-term caching and local randomized selection.
@@ -62,7 +59,9 @@ class SearchAdapter {
           : _random.nextInt(availablePackages.length);
       packages.add(availablePackages.removeAt(index));
     }
-    return (await getPackageViews(packages)).cast<PackageView>();
+    return (await scoreCardBackend.getPackageViews(packages))
+        .whereType<PackageView>()
+        .toList();
   }
 
   /// Performs search using the `search` service and lookup package info and
@@ -148,41 +147,17 @@ class SearchAdapter {
             'Search is temporarily impaired, filtering and ranking may be incorrect.');
   }
 
-  /// Returns the [PackageView] instance for each package in [packages], using
-  /// the latest stable version.
-  ///
-  /// If the package does not exist, it will return null in the given index.
-  /// TODO: move this method (and the pool) to [ScoreCardBackend].
-  Future<List<PackageView?>> getPackageViews(Iterable<String> packages) async {
-    final futures = <Future<PackageView?>>[];
-    for (final p in packages) {
-      futures.add(
-          _pool.withResource(() async => scoreCardBackend.getPackageView(p)));
-    }
-    return await Future.wait(futures);
-  }
-
   Future<Map<String, PackageView>> _getPackageViewsFromHits(
       List<PackageHit> hits) async {
+    final views = await scoreCardBackend
+        .getPackageViews(hits.map((h) => h.package).toList());
     final results = <String, PackageView>{};
-    final futures = <Future>[];
-    for (final hit in hits) {
-      final f = _pool.withResource(() async {
-        final view = await scoreCardBackend.getPackageView(hit.package);
-        if (view == null) {
-          // The package may have been deleted, but the index still has it.
-          return;
-        }
-        results[hit.package] = view.change(apiPages: hit.apiPages);
-      });
-      futures.add(f);
+    for (var i = 0; i < hits.length; i++) {
+      final view = views[i];
+      if (view == null) continue;
+      results[view.name!] = view.change(apiPages: hits[i].apiPages);
     }
-    await Future.wait(futures);
     return results;
-  }
-
-  Future<void> close() async {
-    await _pool.close();
   }
 }
 

--- a/app/lib/service/services.dart
+++ b/app/lib/service/services.dart
@@ -206,8 +206,8 @@ Future<void> _withPubServices(FutureOr<void> Function() fn) async {
     registerScopeExitCallback(dartSdkMemIndex.close);
     registerScopeExitCallback(flutterSdkMemIndex.close);
     registerScopeExitCallback(popularityStorage.close);
+    registerScopeExitCallback(scoreCardBackend.close);
     registerScopeExitCallback(searchClient.close);
-    registerScopeExitCallback(searchAdapter.close);
     registerScopeExitCallback(youtubeBackend.close);
 
     // Create a zone-local flag to indicate that services setup has been completed.


### PR DESCRIPTION
- moving `getPackageViews` (loads latest runtime, uses cache) to its logical place
- concurrency of loading the `ScoreCardData` (loads earlier runtimes, no cache here) goes from 4 (request level) to 10 (isolate level), which seems to be a better control over it
