### PR TITLE
Expose bad pubspec versions in integrity checks.

### DIFF
--- a/app/lib/package/model_properties.dart
+++ b/app/lib/package/model_properties.dart
@@ -7,6 +7,8 @@ library pub_dartlang_org.model_properties;
 import 'dart:convert';
 
 import 'package:pana/pana.dart' show SdkConstraintStatus;
+import 'package:pub_package_reader/pub_package_reader.dart'
+    show checkStrictVersions;
 import 'package:pub_semver/pub_semver.dart';
 import 'package:pubspec_parse/pubspec_parse.dart' as pubspek
     show Dependency, Pubspec;
@@ -82,6 +84,9 @@ class Pubspec {
     final map = _json!['executables'];
     return map is Map<String, dynamic> ? map : null;
   }
+
+  /// Whether the pubspec has any version value inside that is not formatter properly.
+  bool get hasBadVersionFormat => checkStrictVersions(_inner).isNotEmpty;
 
   /// Returns the minimal SDK version for the Dart SDK.
   ///


### PR DESCRIPTION
- #5334
- This will create two log entry for each package version (one for `PackageVersion.pubspec`, another for `PackageVersionAsset[kind=pubspec].content`). We could group by these, if the amount of warnings is too high.
- The detection and reporting of the version parsing issue is independent of how we want to fix the versions themselves.
