### PR TITLE
Backfilling from archive also updates PackageVersion.pubspec

### DIFF
--- a/app/lib/package/models.dart
+++ b/app/lib/package/models.dart
@@ -462,6 +462,7 @@ class PackageVersion extends db.ExpandoModel<String> {
     var changed = false;
     if (pubspecContentAsYaml != null) {
       final newPubspec = Pubspec.fromYaml(pubspecContentAsYaml);
+      // TODO: consider deep compare of the pubspec data
       if (pubspec!.jsonString != newPubspec.jsonString) {
         pubspec = newPubspec;
         changed = true;

--- a/app/lib/package/models.dart
+++ b/app/lib/package/models.dart
@@ -454,6 +454,22 @@ class PackageVersion extends db.ExpandoModel<String> {
     );
   }
 
+  /// Updates the current instance with the newly derived data.
+  /// Returns true if the current instance changed.
+  bool updateIfChanged({
+    required String? pubspecContentAsYaml,
+  }) {
+    var changed = false;
+    if (pubspecContentAsYaml != null) {
+      final newPubspec = Pubspec.fromYaml(pubspecContentAsYaml);
+      if (pubspec!.jsonString != newPubspec.jsonString) {
+        pubspec = newPubspec;
+        changed = true;
+      }
+    }
+    return changed;
+  }
+
   /// List of tags from the flags on the current [PackageVersion] entity.
   List<String> getTags() {
     return <String>[

--- a/app/test/tool/backfill/backfill_packageversions_test.dart
+++ b/app/test/tool/backfill/backfill_packageversions_test.dart
@@ -115,6 +115,9 @@ void main() {
         final originalPvContent = pv.pubspec!.jsonString;
         final originalAssetContent = asset.textContent;
 
+        // Inject non-normalized version number in the pubspec asset.
+        // This ensures that we can cleanup from:
+        // https://github.com/dart-lang/pub_semver/pull/63
         pv.pubspec = Pubspec.fromYaml('name: x');
         asset.textContent = 'name: x\nversion: 1,2,3\n';
         await dbService.commit(inserts: [pv, asset]);


### PR DESCRIPTION
- Part of #5334, to make sure if we change the package reader, we'll get a consistent override/backfill.