### PR TITLE
Code cleanup and improvements in the removePackage().

### DIFF
--- a/app/lib/admin/backend.dart
+++ b/app/lib/admin/backend.dart
@@ -14,7 +14,6 @@ import 'package:logging/logging.dart';
 import 'package:pool/pool.dart';
 import 'package:pub_dev/audit/models.dart';
 import 'package:pub_dev/shared/email.dart';
-import 'package:pub_semver/pub_semver.dart';
 
 import '../account/backend.dart';
 import '../account/models.dart';


### PR DESCRIPTION
- `PackageVersion` entities are deleted outside of the main transaction, after their datastore archive has been deleted.
- Better granularity `deleteWithQuery` from the newer `datastore.dart` wrapper (although still not size-based), as too large entities could have prevented the deletions.
