### PR TITLE
Remove issue tracker URL override

### DIFF
--- a/app/lib/package/overrides.dart
+++ b/app/lib/package/overrides.dart
@@ -73,19 +73,6 @@ const devDependencyPackages = <String>{
   'test_process',
 };
 
-// TODO: remove this after all of the flutter plugins have a proper issue tracker entry in their pubspec.yaml
-const _issueTrackerUrlOverrides = <String, String>{
-  'https://github.com/flutter/plugins/issues':
-      'https://github.com/flutter/flutter/issues',
-};
-
-String? overrideIssueTrackerUrl(String? url) {
-  if (url == null) {
-    return null;
-  }
-  return _issueTrackerUrlOverrides[url] ?? url;
-}
-
 /// A package is soft-removed when we keep it in the archives and index, but we
 /// won't serve the package or the documentation page, or any data about it.
 bool isSoftRemoved(String packageName) =>

--- a/app/lib/shared/urls.dart
+++ b/app/lib/shared/urls.dart
@@ -4,7 +4,6 @@
 
 import 'package:path/path.dart' as p;
 
-import '../package/overrides.dart';
 import '../search/search_form.dart' show SearchContext, SearchForm, SearchOrder;
 
 const primaryHost = 'pub.dev';
@@ -256,12 +255,11 @@ String? inferIssueTrackerUrl(String? baseUrl) {
       return null;
     }
     segments.add('issues');
-    final url = Uri(
+    return Uri(
       scheme: 'https',
       host: uri.host,
       pathSegments: segments,
     ).toString();
-    return overrideIssueTrackerUrl(url);
   }
   return null;
 }


### PR DESCRIPTION
After a random sampling, flutter/plugins seems to have custom issue tracker url in every package.