### PR TITLE
Log requests with non-appengine context.

### DIFF
--- a/app/lib/shared/utils.dart
+++ b/app/lib/shared/utils.dart
@@ -354,12 +354,13 @@ String createUuid([List<int>? bytes]) {
 ///
 /// Returns `null` otherwise.
 Map<String, String>? cloudTraceHeaders() {
-  // TODO: remove this once `context` gets fixed to nullable.
   try {
     if (context.traceId == null) return null;
     return {_cloudTraceContextHeader: context.traceId!};
-  } catch (_) {
-    // no-op
+  } catch (e, st) {
+    // TODO: remove try-catch and logging, once `context` gets fixed
+    //       (either in appengine, or in our fake tests).
+    _logger.warning('Request with non-appengine context detected.', e, st);
   }
 }
 


### PR DESCRIPTION
- Follow-up to #5469.
- If production has no such logs for a while, we should enable a constant non-null `context` in tests too.