### PR TITLE
Override invalid versions at package extraction + backfill.

### DIFF
--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -739,6 +739,7 @@ class PackageBackend {
         filename,
         maxContentLength: maxAssetContentLength,
         maxArchiveSize: UploadSignerService.maxUploadSize,
+        created: DateTime.now().toUtc(),
       );
       _logger.info('Package archive scanned in ${sw.elapsed}.');
       if (archive.hasIssues) {

--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -739,7 +739,7 @@ class PackageBackend {
         filename,
         maxContentLength: maxAssetContentLength,
         maxArchiveSize: UploadSignerService.maxUploadSize,
-        created: DateTime.now().toUtc(),
+        created: clock.now().toUtc(),
       );
       _logger.info('Package archive scanned in ${sw.elapsed}.');
       if (archive.hasIssues) {

--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -739,7 +739,7 @@ class PackageBackend {
         filename,
         maxContentLength: maxAssetContentLength,
         maxArchiveSize: UploadSignerService.maxUploadSize,
-        created: clock.now().toUtc(),
+        published: clock.now().toUtc(),
       );
       _logger.info('Package archive scanned in ${sw.elapsed}.');
       if (archive.hasIssues) {

--- a/app/lib/tool/backfill/backfill_new_fields.dart
+++ b/app/lib/tool/backfill/backfill_new_fields.dart
@@ -35,8 +35,10 @@ Future<void> backfillNewFields() async {
           await tarballStorage
               .download(pv.package, pv.version!)
               .pipe(File(archivePath).openWrite());
-          final archive =
-              await summarizePackageArchive(archivePath, created: pv.created!);
+          final archive = await summarizePackageArchive(
+            archivePath,
+            published: pv.created!,
+          );
           final stats = await backfillPackageVersion(
             package: pv.package,
             version: pv.version!,

--- a/app/lib/tool/backfill/backfill_new_fields.dart
+++ b/app/lib/tool/backfill/backfill_new_fields.dart
@@ -2,7 +2,18 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:io';
+
 import 'package:logging/logging.dart';
+import 'package:path/path.dart' as p;
+import 'package:pub_package_reader/pub_package_reader.dart';
+import 'package:retry/retry.dart';
+
+import '../../package/backend.dart';
+import '../../package/models.dart';
+import '../../shared/datastore.dart';
+import '../../shared/utils.dart';
+import 'backfill_packageversions.dart';
 
 final _logger = Logger('backfill_new_fields');
 
@@ -12,5 +23,30 @@ final _logger = Logger('backfill_new_fields');
 /// CHANGELOG.md must be updated with the new fields, and the next
 /// release could remove the backfill from here.
 Future<void> backfillNewFields() async {
-  _logger.info('Nothing to backfill.');
+  _logger.info('Backfill package versions with known version issues...');
+  final query = dbService.query<PackageVersion>();
+  await for (final pv in query.run()) {
+    if (pv.pubspec!.hasBadVersionFormat) {
+      _logger.info(
+          'Starting to backfill package version "${pv.qualifiedVersionKey}"...');
+      await retry(() async {
+        await withTempDirectory((d) async {
+          final archivePath = p.join(d.path, 'archive.tar.gz');
+          await tarballStorage
+              .download(pv.package, pv.version!)
+              .pipe(File(archivePath).openWrite());
+          final archive =
+              await summarizePackageArchive(archivePath, created: pv.created!);
+          final stats = await backfillPackageVersion(
+            package: pv.package,
+            version: pv.version!,
+            archive: archive,
+            versionCreated: pv.created!,
+          );
+          _logger.info(
+              'Backfilled package version "${pv.qualifiedVersionKey}": $stats');
+        });
+      });
+    }
+  }
 }

--- a/app/lib/tool/backfill/backfill_packageversions.dart
+++ b/app/lib/tool/backfill/backfill_packageversions.dart
@@ -141,7 +141,7 @@ Future<PackageSummary> _parseArchive(
   http.Client httpClient,
   String? package,
   String? version,
-  DateTime created,
+  DateTime published,
 ) async {
   final fn = '$package-$version.tar.gz';
   final uri =
@@ -156,7 +156,7 @@ Future<PackageSummary> _parseArchive(
     return await summarizePackageArchive(
       tempFile.path,
       maxContentLength: maxAssetContentLength,
-      created: created,
+      published: published,
     );
   } finally {
     await tempFile.delete();

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -785,5 +785,12 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.1.0"
+  yaml_edit:
+    dependency: transitive
+    description:
+      name: yaml_edit
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.1"
 sdks:
   dart: ">=2.16.0-100.0.dev <3.0.0"

--- a/app/test/tool/backfill/backfill_packageversions_test.dart
+++ b/app/test/tool/backfill/backfill_packageversions_test.dart
@@ -164,7 +164,7 @@ void main() {
         await file.writeAsBytes(rs.bodyBytes);
         final archive = await summarizePackageArchive(
           file.path,
-          created: DateTime(2020, 1, 1),
+          published: DateTime(2020, 1, 1),
         );
         expect(archive.pubspecContent, isNot(contains('>=2-0-0-dev')));
         expect(archive.pubspecContent, contains('>=2.0.0-dev'));

--- a/pkg/pub_package_reader/lib/pub_package_reader.dart
+++ b/pkg/pub_package_reader/lib/pub_package_reader.dart
@@ -131,8 +131,8 @@ Future<PackageSummary> summarizePackageArchive(
     return PackageSummary(issues: issues);
   }
 
-  final pubspecContent = overridePubspecContentIfNeeded(
-    content: await tar.readContentAsString(pubspecPath),
+  final pubspecContent = overridePubspecYamlIfNeeded(
+    pubspecYaml: await tar.readContentAsString(pubspecPath),
     published: published ?? clock.now().toUtc(),
   );
   // Large pubspec content should be rejected, as either a storage limit will be

--- a/pkg/pub_package_reader/lib/pub_package_reader.dart
+++ b/pkg/pub_package_reader/lib/pub_package_reader.dart
@@ -81,11 +81,15 @@ Future<PackageSummary> summarizePackageArchive(
   /// TODO: set this lower once we scan the existing archives
   int maxFileCount = 64 * 1024,
 
-  /// The timestamp when the archive was uploaded and accepted.
+  /// [DateTime] when the archive was uploaded / published.
   ///
-  /// If specified, some packages may get a transparent rewrite of their
-  /// assets to preserve backwards-compatible behavior on pub.dev.
-  DateTime? created,
+  /// Used to ensure that constraints in place when a package was published
+  /// are considered when summarizing assets. Ensuring we preserve
+  /// backwards-compatibility with packages that does not satisfy constraints
+  /// enforced at publish-time today.
+  ///
+  /// Defaults to [DateTime.now], if not specified.
+  DateTime? published,
 }) async {
   final issues = <ArchiveIssue>[];
 

--- a/pkg/pub_package_reader/lib/pub_package_reader.dart
+++ b/pkg/pub_package_reader/lib/pub_package_reader.dart
@@ -4,6 +4,7 @@
 
 import 'dart:convert';
 
+import 'package:clock/clock.dart';
 import 'package:collection/collection.dart' show IterableExtension;
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
@@ -132,7 +133,7 @@ Future<PackageSummary> summarizePackageArchive(
 
   final pubspecContent = overridePubspecContentIfNeeded(
     content: await tar.readContentAsString(pubspecPath),
-    created: created ?? DateTime.now().toUtc(),
+    published: published ?? clock.now().toUtc(),
   );
   // Large pubspec content should be rejected, as either a storage limit will be
   // limiting it, or it will slow down queries and processing for very little

--- a/pkg/pub_package_reader/lib/src/pub_semver_2.1.0_parser.dart
+++ b/pkg/pub_package_reader/lib/src/pub_semver_2.1.0_parser.dart
@@ -1,0 +1,178 @@
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// ignore_for_file: prefer_final_locals
+
+// This library contains the package:pub_semver parsing logic as of v2.1.0.
+// We keep this around to parse and normalize versions and version constraints
+// as they were recognized prior to the fix in package:pub_semver.
+
+import 'package:pub_semver/pub_semver.dart';
+
+/// Parses a comparison operator ("<", ">", "<=", or ">=") at the beginning of
+/// a string.
+final _startComparison = RegExp(r'^[<>]=?');
+
+/// The "compatible with" operator.
+const _compatibleWithChar = '^';
+
+/// Regex that matches a version number at the beginning of a string.
+final _startVersion = RegExp(r'^' // Start at beginning.
+    r'(\d+).(\d+).(\d+)' // Version number.
+    r'(-([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?' // Pre-release.
+    r'(\+([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?'); // Build.
+
+/// Like [_startVersion] but matches the entire string.
+final _completeVersion = RegExp('${_startVersion.pattern}\$');
+
+/// Creates a new [Version] by parsing [text].
+///
+/// Following rules from `package:pub_semver <= 2.1.0`.
+Version parsePossiblyBrokenVersion(String text) {
+  final match = _completeVersion.firstMatch(text);
+  if (match == null) {
+    throw FormatException('Could not parse "$text".');
+  }
+
+  try {
+    var major = int.parse(match[1]!);
+    var minor = int.parse(match[2]!);
+    var patch = int.parse(match[3]!);
+
+    var preRelease = match[5];
+    var build = match[8];
+
+    return Version(major, minor, patch, pre: preRelease, build: build);
+  } on FormatException {
+    throw FormatException('Could not parse "$text".');
+  }
+}
+
+/// Parses a version constraint.
+///
+/// Following rules from `package:pub_semver <= 2.1.0`.
+VersionConstraint parsePossiblyBrokenVersionConstraint(String text) {
+  var originalText = text;
+
+  void skipWhitespace() {
+    text = text.trim();
+  }
+
+  skipWhitespace();
+
+  // Handle the "any" constraint.
+  if (text == 'any') return VersionConstraint.any;
+
+  // Try to parse and consume a version number.
+  Version? matchVersion() {
+    var version = _startVersion.firstMatch(text);
+    if (version == null) return null;
+
+    text = text.substring(version.end);
+    return parsePossiblyBrokenVersion(version[0]!);
+  }
+
+  // Try to parse and consume a comparison operator followed by a version.
+  VersionRange? matchComparison() {
+    var comparison = _startComparison.firstMatch(text);
+    if (comparison == null) return null;
+
+    var op = comparison[0];
+    text = text.substring(comparison.end);
+    skipWhitespace();
+
+    var version = matchVersion();
+    if (version == null) {
+      throw FormatException('Expected version number after "$op" in '
+          '"$originalText", got "$text".');
+    }
+
+    switch (op) {
+      case '<=':
+        return VersionRange(max: version, includeMax: true);
+      case '<':
+        return VersionRange(
+            max: version, includeMax: false, alwaysIncludeMaxPreRelease: true);
+      case '>=':
+        return VersionRange(min: version, includeMin: true);
+      case '>':
+        return VersionRange(min: version, includeMin: false);
+    }
+    throw FallThroughError();
+  }
+
+  // Try to parse the "^" operator followed by a version.
+  VersionConstraint? matchCompatibleWith() {
+    if (!text.startsWith(_compatibleWithChar)) return null;
+
+    text = text.substring(_compatibleWithChar.length);
+    skipWhitespace();
+
+    var version = matchVersion();
+    if (version == null) {
+      throw FormatException('Expected version number after '
+          '"$_compatibleWithChar" in "$originalText", got "$text".');
+    }
+
+    if (text.isNotEmpty) {
+      throw FormatException('Cannot include other constraints with '
+          '"$_compatibleWithChar" constraint in "$originalText".');
+    }
+
+    return VersionConstraint.compatibleWith(version);
+  }
+
+  var compatibleWith = matchCompatibleWith();
+  if (compatibleWith != null) return compatibleWith;
+
+  Version? min;
+  var includeMin = false;
+  Version? max;
+  var includeMax = false;
+
+  for (;;) {
+    skipWhitespace();
+
+    if (text.isEmpty) break;
+
+    var newRange = matchVersion() ?? matchComparison();
+    if (newRange == null) {
+      throw FormatException('Could not parse version "$originalText". '
+          'Unknown text at "$text".');
+    }
+
+    if (newRange.min != null) {
+      if (min == null || newRange.min! > min) {
+        min = newRange.min;
+        includeMin = newRange.includeMin;
+      } else if (newRange.min == min && !newRange.includeMin) {
+        includeMin = false;
+      }
+    }
+
+    if (newRange.max != null) {
+      if (max == null || newRange.max! < max) {
+        max = newRange.max;
+        includeMax = newRange.includeMax;
+      } else if (newRange.max == max && !newRange.includeMax) {
+        includeMax = false;
+      }
+    }
+  }
+
+  if (min == null && max == null) {
+    throw const FormatException('Cannot parse an empty string.');
+  }
+
+  if (min != null && max != null) {
+    if (min > max) return VersionConstraint.empty;
+    if (min == max) {
+      if (includeMin && includeMax) return min;
+      return VersionConstraint.empty;
+    }
+  }
+
+  return VersionRange(
+      min: min, includeMin: includeMin, max: max, includeMax: includeMax);
+}

--- a/pkg/pub_package_reader/lib/src/pubspec_content_override.dart
+++ b/pkg/pub_package_reader/lib/src/pubspec_content_override.dart
@@ -7,7 +7,7 @@ import 'package:pub_semver/pub_semver.dart';
 import 'package:yaml/yaml.dart' as yaml;
 import 'package:yaml_edit/yaml_edit.dart';
 
-final _logger = Logger('pubspec_content_override');
+final _logger = Logger('pubspec_yaml_override');
 
 /// The version regular expression that accepted any character as separator.
 final _lenientRegExp = RegExp(r'(\d+).(\d+).(\d+)' // Version number.
@@ -46,28 +46,28 @@ const _packagesWithBadVersions = <String>{
   'polymer_interop',
 };
 
-/// Override pubspec.yaml content if needed:
+/// Override pubspec.yaml if needed:
 ///
 /// - If the archive was created before 2022-01-01, we may need to update the
 ///   version number, version constraint and SDK constraints, as `pub_semver`
 ///   accepted separator characters other than `.`.
 ///   https://github.com/dart-lang/pub_semver/pull/63
-String overridePubspecContentIfNeeded({
-  required String content,
+String overridePubspecYamlIfNeeded({
+  required String pubspecYaml,
   required DateTime published,
 }) {
   // quick checks to skip overrides
   if (published.year >= 2022) {
-    return content;
+    return pubspecYaml;
   }
 
   try {
-    return _fixupBrokenVersionAndConstraints(content);
+    return _fixupBrokenVersionAndConstraints(pubspecYaml);
   } on FormatException catch (e, st) {
     _logger.info('Unable to parse pubspec.', e, st);
   }
-  // fallback: don't override content
-  return content;
+  // fallback: don't override
+  return pubspecYaml;
 }
 
 /// Fixes broken version and version constraints in [pubspecYaml] and returns a new YAML string.

--- a/pkg/pub_package_reader/lib/src/pubspec_content_override.dart
+++ b/pkg/pub_package_reader/lib/src/pubspec_content_override.dart
@@ -73,11 +73,11 @@ String overridePubspecYamlIfNeeded({
 /// Fixes broken version and version constraints in [pubspecYaml] and returns a new YAML string.
 ///
 /// Prior to [pub_semver#63] version numbers and version constraints were accepted with any
-/// character as separate, instead of requiring  `.` (dot). This occurred because the regular expression
-/// in `package:pub_semver` didn't escape dots as `\.`, but just contained `.` (dot, meaning any character).
+/// character as separator, instead of requiring  `.` (dot). This occurred because the regular expression
+/// in `package:pub_semver` didn't escape dots as `\.`, but just contained `.` (dot, meaning any character). (see https://github.com/dart-lang/pub_semver/commit/cee044a3dc8)
 ///
-/// Thus, package versions published prior to 2022-01-01, maybe contain _version numbers_,
-/// _version constraints_ and _SDK constraints_ that doesn't use `.` (dot) as separator. As removing
+/// Thus, package versions published prior to 2022-01-01, may contain _version numbers_,
+/// _version constraints_ and _SDK constraints_ that don't use `.` (dot) as separator. As removing
 /// these _package versions_ would break existing users, this function will rewrite the version numbers
 /// and version constraints to have a valid format equivalent to how older versions of `pub_semver`
 /// would have interpreted the version number / version constraints.
@@ -122,7 +122,8 @@ String _fixupBrokenVersionAndConstraints(String pubspecYaml) {
 
   final fixedPubspecYaml = editor.toString();
   if (hasBeenUpdated && fixedPubspecYaml == pubspecYaml) {
-    _logger.warning('Updating pubspec.yaml while fixing versions failed.');
+    _logger.warning(
+        'Updating pubspec.yaml in package:$name failed while fixing versions.');
   }
   return fixedPubspecYaml;
 }

--- a/pkg/pub_package_reader/lib/src/pubspec_content_override.dart
+++ b/pkg/pub_package_reader/lib/src/pubspec_content_override.dart
@@ -99,6 +99,7 @@ String _fixupBrokenVersionAndConstraints(String pubspecYaml) {
   }
 
   final editor = YamlEditor(pubspecYaml);
+  var hasBeenUpdated = false;
   for (final c in _detectVersionEditCandidates(root)) {
     final updated = c.value.replaceAllMapped(_lenientRegExp, (match) {
       final major = int.parse(match[1]!);
@@ -110,10 +111,15 @@ String _fixupBrokenVersionAndConstraints(String pubspecYaml) {
     });
     if (updated != c.value) {
       editor.update(c.path, updated);
+      hasBeenUpdated = true;
     }
   }
 
-  return editor.toString();
+  final fixedPubspecYaml = editor.toString();
+  if (hasBeenUpdated && fixedPubspecYaml == pubspecYaml) {
+    _logger.warning('Updating pubspec.yaml while fixing versions failed.');
+  }
+  return fixedPubspecYaml;
 }
 
 class _VersionEditCandidate {

--- a/pkg/pub_package_reader/lib/src/pubspec_content_override.dart
+++ b/pkg/pub_package_reader/lib/src/pubspec_content_override.dart
@@ -90,7 +90,8 @@ String overridePubspecContentIfNeeded({
 String _fixupBrokenVersionAndConstraints(String pubspecYaml) {
   final root = yaml.loadYaml(content);
   if (root is! Map) {
-    _log.warning('Unable to parse YAML for package, in _fixupBrokenVersionAndConstraints!');
+    _log.warning(
+        'Unable to parse YAML for package, in _fixupBrokenVersionAndConstraints!');
     return pubspecYaml; // return original as no changes can be made
   }
 

--- a/pkg/pub_package_reader/lib/src/pubspec_content_override.dart
+++ b/pkg/pub_package_reader/lib/src/pubspec_content_override.dart
@@ -47,7 +47,7 @@ const _packagesWithBadVersions = <String>{
 
 /// Override pubspec.yaml content if needed:
 ///
-/// - If the archive was created before 2022, we may need to update the versions,
+/// - If the archive was created before 2022-01-01, we may need to update the version number, version constraint and SDK constraints,
 ///   as pub_semver accepted separator characters other than `.`.
 String overridePubspecContentIfNeeded({
   required String content,

--- a/pkg/pub_package_reader/lib/src/pubspec_content_override.dart
+++ b/pkg/pub_package_reader/lib/src/pubspec_content_override.dart
@@ -58,9 +58,6 @@ String overridePubspecContentIfNeeded({
   if (created.year >= 2022) {
     return content;
   }
-  if (_packagesWithBadVersions.every((name) => !content.contains(name))) {
-    return content;
-  }
 
   try {
     return _fixupBrokenVersionAndConstraints(content);

--- a/pkg/pub_package_reader/lib/src/pubspec_content_override.dart
+++ b/pkg/pub_package_reader/lib/src/pubspec_content_override.dart
@@ -109,6 +109,12 @@ String _fixupBrokenVersionAndConstraints(String pubspecYaml) {
       return Version(major, minor, patch, pre: pre, build: build).toString();
     });
     if (updated != c.value) {
+      try {
+        Version.parse(updated);
+      } on FormatException catch (e, st) {
+        _logger.shout('Failed to fix broken version in package:$name', e, st);
+        return pubspecYaml;
+      }
       editor.update(c.path, updated);
       hasBeenUpdated = true;
     }

--- a/pkg/pub_package_reader/lib/src/pubspec_content_override.dart
+++ b/pkg/pub_package_reader/lib/src/pubspec_content_override.dart
@@ -110,7 +110,7 @@ String _fixupBrokenVersionAndConstraints(String pubspecYaml) {
     });
     if (updated != c.value) {
       try {
-        Version.parse(updated);
+        VersionConstraint.parse(updated);
       } on FormatException catch (e, st) {
         _logger.shout('Failed to fix broken version in package:$name', e, st);
         return pubspecYaml;

--- a/pkg/pub_package_reader/lib/src/pubspec_content_override.dart
+++ b/pkg/pub_package_reader/lib/src/pubspec_content_override.dart
@@ -1,0 +1,153 @@
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:logging/logging.dart';
+import 'package:pub_semver/pub_semver.dart';
+import 'package:yaml/yaml.dart' as yaml;
+import 'package:yaml_edit/yaml_edit.dart';
+
+final _logger = Logger('pubspec_content_override');
+
+/// The version regular expression that accepted any character as separator.
+final _lenientRegExp = RegExp(r'(\d+).(\d+).(\d+)' // Version number.
+    r'(-([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?' // Pre-release.
+    r'(\+([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?' // Build.
+    );
+
+/// Packages with bad versions:
+const _packagesWithBadVersions = <String>{
+  'assets_audio_player_web',
+  'bloc_pattern',
+  'bokain_models',
+  'built_collection',
+  'built_redux',
+  'built_redux_thunk',
+  'built_value',
+  'built_value_generator',
+  'built_value_test',
+  'built_viewmodel',
+  'built_viewmodel_flutter_built_redux',
+  'built_viewmodel_flutter_redux',
+  'built_viewmodel_generator',
+  'carp_context_package',
+  'codemetrics',
+  'fluttercontactpicker',
+  'interactive_webview',
+  'meta_types',
+  'meta_types_generator',
+  'meta_types_json',
+  'meta_types_json_generator',
+  'meta_types_redux',
+  'meta_types_redux_generator',
+  'mocktail',
+  'mocktail_image_network',
+  'polymer_interop',
+};
+
+/// Override pubspec.yaml content if needed:
+///
+/// - If the archive was created before 2022, we may need to update the versions,
+///   as pub_semver accepted separator characters other than `.`.
+String overridePubspecContentIfNeeded({
+  required String content,
+  required DateTime created,
+}) {
+  // quick checks to skip overrides
+  if (created.year >= 2022) {
+    return content;
+  }
+  if (_packagesWithBadVersions.every((name) => !content.contains(name))) {
+    return content;
+  }
+
+  try {
+    final c = _tryOverrideContent(content);
+    if (c != null && c != content) {
+      _logger.info('Content override for pubspec successful.');
+    }
+    return c ?? content;
+  } on FormatException catch (e, st) {
+    _logger.info('Unable to parse pubspec.', e, st);
+  }
+  // fallback: don't override content
+  return content;
+}
+
+String? _tryOverrideContent(String content) {
+  final root = yaml.loadYaml(content);
+  if (root is! Map) {
+    return null;
+  }
+
+  // sanity check on the name again, now with parsed yaml
+  final name = root['name'];
+  if (name is! String || !_packagesWithBadVersions.contains(name)) {
+    return null;
+  }
+
+  final editor = YamlEditor(content);
+  for (final c in _detectVersionEditCandidates(root)) {
+    final updated = c.value.replaceAllMapped(_lenientRegExp, (match) {
+      final major = int.parse(match[1]!);
+      final minor = int.parse(match[2]!);
+      final patch = int.parse(match[3]!);
+      final pre = match[5];
+      final build = match[8];
+      return Version(major, minor, patch, pre: pre, build: build).toString();
+    });
+    if (updated != c.value) {
+      editor.update(c.path, updated);
+    }
+  }
+
+  return editor.toString();
+}
+
+class _VersionEditCandidate {
+  final List<Object> path;
+  final String value;
+
+  _VersionEditCandidate(this.path, this.value);
+}
+
+List<_VersionEditCandidate> _detectVersionEditCandidates(Map root) {
+  final paths = <_VersionEditCandidate>[];
+
+  final version = root['version'];
+  if (version is String) {
+    paths.add(_VersionEditCandidate(['version'], version));
+  }
+
+  final env = root['environment'];
+  if (env is Map) {
+    for (final key in env.keys.map((k) => k.toString())) {
+      final value = env[key];
+      if (value is String) {
+        paths.add(_VersionEditCandidate(['environment', key], value));
+      }
+    }
+  }
+
+  final dependencyKeys = [
+    'dependencies',
+    'dev_dependencies',
+    'dependency_overrides',
+  ];
+  for (final dependencyKey in dependencyKeys) {
+    final deps = root[dependencyKey];
+    if (deps is Map) {
+      for (final pkg in deps.keys.map((e) => e.toString())) {
+        final value = deps[pkg];
+        if (value is Map && value['version'] is String) {
+          paths.add(_VersionEditCandidate(
+              [dependencyKey, pkg, 'version'], value['version'] as String));
+        } else if (value is String) {
+          paths.add(_VersionEditCandidate([dependencyKey, pkg], value));
+        }
+      }
+    }
+  }
+
+  return paths;
+}

--- a/pkg/pub_package_reader/lib/src/pubspec_content_override.dart
+++ b/pkg/pub_package_reader/lib/src/pubspec_content_override.dart
@@ -74,7 +74,20 @@ String overridePubspecContentIfNeeded({
   return content;
 }
 
-String? _tryOverrideContent(String content) {
+/// Fixes broken version and version constraints in [pubspecYaml] and returns a new YAML string.
+///
+/// Prior to [pub_semver#63] version numbers and version constraints were accepted with any
+/// character as separate, instead of requiring  `.` (dot). This occurred because the regular expression
+/// in `package:pub_semver` didn't escape dots as `\.`, but just contained `.` (dot, meaning any character).
+///
+/// Thus, package versions published prior to 2022-01-01, maybe contain _version numbers_,
+/// _version constraints_ and _SDK constraints_ that doesn't use `.` (dot) as separator. As removing
+/// these _package versions_ would break existing users, this function will rewrite the version numbers
+/// and version constraints to have a valid format equivalent to how older versions of `pub_semver`
+/// would have interpreted the version number / version constraints.
+///
+/// [pub_semver#63]: https://github.com/dart-lang/pub_semver/pull/63
+String _fixupBrokenVersionAndConstraints(String pubspecYaml) {
   final root = yaml.loadYaml(content);
   if (root is! Map) {
     return null;

--- a/pkg/pub_package_reader/lib/src/pubspec_content_override.dart
+++ b/pkg/pub_package_reader/lib/src/pubspec_content_override.dart
@@ -134,7 +134,11 @@ String _fixupBrokenVersionAndConstraints(String pubspecYaml) {
         .join(' ');
     if (updated != c.value) {
       try {
-        VersionConstraint.parse(updated);
+        if (c.isVersion) {
+          Version.parse(updated);
+        } else {
+          VersionConstraint.parse(updated);
+        }
       } on FormatException catch (e, st) {
         _logger.shout('Failed to fix broken version in package:$name', e, st);
         return pubspecYaml;
@@ -176,14 +180,19 @@ String _fixupBrokenVersionAndConstraints(String pubspecYaml) {
         'Updating pubspec.yaml in package:$name failed while fixing versions.');
   }
 
-  return '# overrides applied by pub.dev\n$fixedPubspecYaml';
+  return '# Compatibility rewrites applied by pub.dev\n$fixedPubspecYaml';
 }
 
 class _VersionEditCandidate {
   final List<Object> path;
   final String value;
+  final bool isVersion;
 
-  _VersionEditCandidate(this.path, this.value);
+  _VersionEditCandidate(
+    this.path,
+    this.value, {
+    this.isVersion = false,
+  });
 }
 
 List<_VersionEditCandidate> _detectVersionEditCandidates(Map root) {
@@ -191,7 +200,7 @@ List<_VersionEditCandidate> _detectVersionEditCandidates(Map root) {
 
   final version = root['version'];
   if (version is String) {
-    paths.add(_VersionEditCandidate(['version'], version));
+    paths.add(_VersionEditCandidate(['version'], version, isVersion: true));
   }
 
   final env = root['environment'];

--- a/pkg/pub_package_reader/lib/src/pubspec_content_override.dart
+++ b/pkg/pub_package_reader/lib/src/pubspec_content_override.dart
@@ -176,7 +176,7 @@ String _fixupBrokenVersionAndConstraints(String pubspecYaml) {
         'Updating pubspec.yaml in package:$name failed while fixing versions.');
   }
 
-  return fixedPubspecYaml;
+  return '# overrides applied by pub.dev\n$fixedPubspecYaml';
 }
 
 class _VersionEditCandidate {

--- a/pkg/pub_package_reader/lib/src/pubspec_content_override.dart
+++ b/pkg/pub_package_reader/lib/src/pubspec_content_override.dart
@@ -15,7 +15,8 @@ final _lenientRegExp = RegExp(r'(\d+).(\d+).(\d+)' // Version number.
     r'(\+([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?' // Build.
     );
 
-/// Packages with bad versions:
+/// Packages with bad versions as detected by
+/// https://github.com/dart-lang/pub_semver/pull/63
 const _packagesWithBadVersions = <String>{
   'assets_audio_player_web',
   'bloc_pattern',
@@ -50,12 +51,13 @@ const _packagesWithBadVersions = <String>{
 /// - If the archive was created before 2022-01-01, we may need to update the
 ///   version number, version constraint and SDK constraints, as `pub_semver`
 ///   accepted separator characters other than `.`.
+///   https://github.com/dart-lang/pub_semver/pull/63
 String overridePubspecContentIfNeeded({
   required String content,
-  required DateTime created,
+  required DateTime published,
 }) {
   // quick checks to skip overrides
-  if (created.year >= 2022) {
+  if (published.year >= 2022) {
     return content;
   }
 

--- a/pkg/pub_package_reader/lib/src/pubspec_content_override.dart
+++ b/pkg/pub_package_reader/lib/src/pubspec_content_override.dart
@@ -90,7 +90,8 @@ String overridePubspecContentIfNeeded({
 String _fixupBrokenVersionAndConstraints(String pubspecYaml) {
   final root = yaml.loadYaml(content);
   if (root is! Map) {
-    return null;
+    _log.warning('Unable to parse YAML for package, in _fixupBrokenVersionAndConstraints!');
+    return pubspecYaml; // return original as no changes can be made
   }
 
   // sanity check on the name again, now with parsed yaml

--- a/pkg/pub_package_reader/pubspec.lock
+++ b/pkg/pub_package_reader/pubspec.lock
@@ -365,5 +365,12 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.1.0"
+  yaml_edit:
+    dependency: "direct main"
+    description:
+      name: yaml_edit
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.1"
 sdks:
   dart: ">=2.16.0-100.0.dev <3.0.0"

--- a/pkg/pub_package_reader/pubspec.lock
+++ b/pkg/pub_package_reader/pubspec.lock
@@ -57,6 +57,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.3.5"
+  clock:
+    dependency: "direct main"
+    description:
+      name: clock
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.0"
   collection:
     dependency: "direct main"
     description:

--- a/pkg/pub_package_reader/pubspec.yaml
+++ b/pkg/pub_package_reader/pubspec.yaml
@@ -6,6 +6,7 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
+  clock: ^1.1.0
   logging: '>=0.11.3+1 <2.0.0'
   pub_semver: ^2.0.0
   pubspec_parse: '>=0.1.4 <2.0.0'

--- a/pkg/pub_package_reader/pubspec.yaml
+++ b/pkg/pub_package_reader/pubspec.yaml
@@ -10,6 +10,7 @@ dependencies:
   pub_semver: ^2.0.0
   pubspec_parse: '>=0.1.4 <2.0.0'
   yaml: ^3.0.0
+  yaml_edit: ^2.0.1
   tar: 0.5.1
   collection: ^1.15.0-nullsafety.4
 

--- a/pkg/pub_package_reader/test/pubspec_content_override_test.dart
+++ b/pkg/pub_package_reader/test/pubspec_content_override_test.dart
@@ -28,7 +28,7 @@ void main() {
     String tryOverride(String content) {
       return overridePubspecContentIfNeeded(
         content: content,
-        created: DateTime(2021, 1, 1),
+        published: DateTime(2021, 1, 1),
       );
     }
 

--- a/pkg/pub_package_reader/test/pubspec_content_override_test.dart
+++ b/pkg/pub_package_reader/test/pubspec_content_override_test.dart
@@ -37,9 +37,9 @@ void main() {
     });
 
     test('version, update', () {
-      final updated = tryOverride(pubspec(version: '1,3.0'));
-      expect(updated, contains('version: 1.3.0'));
-      expect(updated, isNot(contains('version: 1,3.0')));
+      final updated = tryOverride(pubspec(version: '1,3.0+1'));
+      expect(updated, contains('version: 1.3.0+1'));
+      expect(updated, isNot(contains('version: 1,3.0+1')));
     });
 
     test('sdk, no change', () {
@@ -58,7 +58,7 @@ void main() {
       final wrong = '">=2,10,0-0 <3,0.0"';
       final content = pubspec(sdk: wrong);
       final updated = tryOverride(content);
-      expect(updated, contains('sdk: ">=2.10.0-0 <3.0.0"'));
+      expect(updated, contains('sdk: ">=2.10.0-0 <2.17.0"'));
       expect(updated, isNot(contains('sdk: $wrong')));
     });
 
@@ -99,7 +99,7 @@ void main() {
         'name: mocktail\n'
         'version: 1.3.5\n'
         'environment:\n'
-        '  sdk: ">=2.12.0-0 <3.0.0+1"\n'
+        '  sdk: ">=2.12.0-0 <2.17.0"\n'
         'dependencies:\n'
         '  path: ^1.0.0\n'
         'dev_dependencies:\n'

--- a/pkg/pub_package_reader/test/pubspec_content_override_test.dart
+++ b/pkg/pub_package_reader/test/pubspec_content_override_test.dart
@@ -26,8 +26,8 @@ void main() {
     }
 
     String tryOverride(String content) {
-      return overridePubspecContentIfNeeded(
-        content: content,
+      return overridePubspecYamlIfNeeded(
+        pubspecYaml: content,
         published: DateTime(2021, 1, 1),
       );
     }

--- a/pkg/pub_package_reader/test/pubspec_content_override_test.dart
+++ b/pkg/pub_package_reader/test/pubspec_content_override_test.dart
@@ -96,7 +96,7 @@ void main() {
       );
       expect(
         tryOverride(content),
-        '# overrides applied by pub.dev\n'
+        '# Compatibility rewrites applied by pub.dev\n'
         'name: mocktail\n'
         'version: 1.3.5\n'
         'environment:\n'

--- a/pkg/pub_package_reader/test/pubspec_content_override_test.dart
+++ b/pkg/pub_package_reader/test/pubspec_content_override_test.dart
@@ -96,6 +96,7 @@ void main() {
       );
       expect(
         tryOverride(content),
+        '# overrides applied by pub.dev\n'
         'name: mocktail\n'
         'version: 1.3.5\n'
         'environment:\n'

--- a/pkg/pub_package_reader/test/pubspec_content_override_test.dart
+++ b/pkg/pub_package_reader/test/pubspec_content_override_test.dart
@@ -1,0 +1,113 @@
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:pub_package_reader/src/pubspec_content_override.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('strict versions', () {
+    String pubspec({
+      String version = '1.2.0',
+      String? sdk,
+      String? pathDep,
+      String? testDep,
+      String? overrideDep,
+    }) {
+      return [
+        'name: mocktail',
+        'version: $version',
+        if (sdk != null) 'environment:\n  sdk: $sdk',
+        if (pathDep != null) 'dependencies:\n  path: $pathDep',
+        if (testDep != null)
+          'dev_dependencies:\n  test:\n    version: $testDep',
+        if (overrideDep != null) 'dependency_overrides:\n  http: $overrideDep',
+      ].join('\n');
+    }
+
+    String tryOverride(String content) {
+      return overridePubspecContentIfNeeded(
+        content: content,
+        created: DateTime(2021, 1, 1),
+      );
+    }
+
+    test('version, no change', () {
+      expect(tryOverride(pubspec()), pubspec());
+    });
+
+    test('version, update', () {
+      final updated = tryOverride(pubspec(version: '1,3.0'));
+      expect(updated, contains('version: 1.3.0'));
+      expect(updated, isNot(contains('version: 1,3.0')));
+    });
+
+    test('sdk, no change', () {
+      final content = pubspec(sdk: '">=2.10.0 <3.0.0"');
+      final updated = tryOverride(content);
+      expect(updated, content);
+    });
+
+    test('sdk any', () {
+      final content = pubspec(sdk: 'any');
+      final updated = tryOverride(content);
+      expect(updated, content);
+    });
+
+    test('sdk, updated', () {
+      final wrong = '">=2,10,0-0 <3,0.0"';
+      final content = pubspec(sdk: wrong);
+      final updated = tryOverride(content);
+      expect(updated, contains('sdk: ">=2.10.0-0 <3.0.0"'));
+      expect(updated, isNot(contains('sdk: $wrong')));
+    });
+
+    test('dependency, no change', () {
+      final content = pubspec(testDep: '^3.0.1+12');
+      final updated = tryOverride(content);
+      expect(updated, content);
+    });
+
+    test('dependency, updated', () {
+      final wrong = '^3.0,1+12';
+      final content = pubspec(testDep: wrong);
+      final updated = tryOverride(content);
+      expect(updated, contains('version: ^3.0.1+12'));
+      expect(updated, isNot(contains('version: $wrong')));
+    });
+
+    test('everything, no change', () {
+      final content = pubspec(
+        sdk: '">=2.12.0-0 <3.0.0+1"',
+        pathDep: '^1.0.0',
+        testDep: 'any',
+        overrideDep: '2.1.0-dev1',
+      );
+      expect(tryOverride(content), content);
+    });
+
+    test('everything, updated', () {
+      final content = pubspec(
+        version: '123-5',
+        sdk: '">=2y12x0-0 <3,0-0+1"',
+        pathDep: '^1a0a0',
+        testDep: '">12345"',
+        overrideDep: '2-1-0-dev1+2',
+      );
+      expect(
+        tryOverride(content),
+        'name: mocktail\n'
+        'version: 1.3.5\n'
+        'environment:\n'
+        '  sdk: ">=2.12.0-0 <3.0.0+1"\n'
+        'dependencies:\n'
+        '  path: ^1.0.0\n'
+        'dev_dependencies:\n'
+        '  test:\n'
+        '    version: ">1.3.5"\n'
+        'dependency_overrides:\n'
+        '  http: 2.1.0-dev1+2',
+      );
+    });
+  });
+}


### PR DESCRIPTION
- #5334
- Uses `package:yaml_edit` to update the `pubspec.yaml`.
- Uses list of packages to narrow down the the `pubspec.yaml` content that may be updated.
- Uses created timestamp to exclude versions that were uploaded after the upload-time fix was deployed (even for the listed package names).
- Package names were queried through pub.dev APIs and checking their parsed pubspec content.
- Scheduled backfill.