### PR TITLE
Slight format change for likes, moved to pkg/_pub_shared

### DIFF
--- a/app/lib/frontend/templates/views/shared/detail/header.dart
+++ b/app/lib/frontend/templates/views/shared/detail/header.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:intl/intl.dart';
+import 'package:_pub_shared/format/number_format.dart';
 
 import '../../../../dom/dom.dart' as d;
 import '../../../../dom/material.dart' as material;
@@ -140,5 +140,5 @@ d.Node detailHeaderNode({
 // keep in-sync with pkg/web_app/lib/src/likes.dart
 String? _formatPackageLikes(int? likesCount) {
   if (likesCount == null) return null;
-  return NumberFormat.compact().format(likesCount);
+  return formatWithSuffix(likesCount);
 }

--- a/app/test/frontend/static_files_test.dart
+++ b/app/test/frontend/static_files_test.dart
@@ -153,7 +153,7 @@ void main() {
     test('script.dart.js size check', () {
       final file = cache.getFile('/static/js/script.dart.js');
       expect(file, isNotNull);
-      expect((file!.bytes.length / 1024).round(), closeTo(338, 1));
+      expect((file!.bytes.length / 1024).round(), closeTo(337, 1));
     });
   });
 }

--- a/pkg/_pub_shared/lib/format/number_format.dart
+++ b/pkg/_pub_shared/lib/format/number_format.dart
@@ -1,0 +1,20 @@
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// Formats an int [value] to human readable chunk and suffix.
+/// The chunk will have a single digit precision, and will be
+/// rounded down, in order to prevent exaggerated counts.
+String formatWithSuffix(int value) {
+  if (value >= 1000000) {
+    return '${_toFixed(value, 1000000)}m';
+  } else if (value >= 1000) {
+    return '${_toFixed(value, 1000)}k';
+  } else {
+    return value.toString();
+  }
+}
+
+String _toFixed(int value, int d) {
+  return (((value * 10) ~/ d) / 10).toStringAsFixed(1);
+}

--- a/pkg/_pub_shared/test/format/number_format_test.dart
+++ b/pkg/_pub_shared/test/format/number_format_test.dart
@@ -1,0 +1,32 @@
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:_pub_shared/format/number_format.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('0-999', () {
+    expect(formatWithSuffix(0), '0');
+    expect(formatWithSuffix(1), '1');
+    expect(formatWithSuffix(23), '23');
+    expect(formatWithSuffix(999), '999');
+  });
+
+  test('1000-999999', () {
+    expect(formatWithSuffix(1000), '1.0k');
+    expect(formatWithSuffix(1049), '1.0k');
+    expect(formatWithSuffix(1050), '1.0k');
+    expect(formatWithSuffix(1099), '1.0k');
+    expect(formatWithSuffix(1100), '1.1k');
+    expect(formatWithSuffix(23456), '23.4k');
+    expect(formatWithSuffix(999499), '999.4k');
+    expect(formatWithSuffix(999500), '999.5k');
+    expect(formatWithSuffix(999999), '999.9k');
+  });
+
+  test('1000000-', () {
+    expect(formatWithSuffix(999999 + 1), '1.0m');
+    expect(formatWithSuffix(1234000), '1.2m');
+  });
+}

--- a/pkg/web_app/lib/src/likes.dart
+++ b/pkg/web_app/lib/src/likes.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:html';
 
-import 'package:intl/intl.dart' deferred as intl;
+import 'package:_pub_shared/format/number_format.dart';
 import 'package:mdc_web/mdc_web.dart' show MDCIconButtonToggle;
 
 import 'api_client/api_client.dart' deferred as api_client;
@@ -53,10 +53,9 @@ void setupLikes() {
   int likesDelta = 0;
 
   // keep in-sync with app/lib/frontend/templates/views/shared/detail/header.dart
-  Future<String> likesString() async {
-    await intl.loadLibrary();
+  String likesString() {
     final likesCount = pageData.pkgData!.likes + likesDelta;
-    return intl.NumberFormat.compact().format(likesCount);
+    return formatWithSuffix(likesCount);
   }
 
   iconButtonToggle.listen(MDCIconButtonToggle.changeEvent, (Event e) async {
@@ -65,12 +64,12 @@ void setupLikes() {
     if (iconButtonToggle.on ?? false) {
       // The button has shifted to on.
       likesDelta++;
-      likes!.innerText = await likesString();
+      likes!.innerText = likesString();
       _enqueue(() => api_client.client.likePackage(pageData.pkgData!.package));
     } else {
       // The button has shifted to off.
       likesDelta--;
-      likes!.innerText = await likesString();
+      likes!.innerText = likesString();
       _enqueue(
           () => api_client.client.unlikePackage(pageData.pkgData!.package));
     }

--- a/pkg/web_app/pubspec.lock
+++ b/pkg/web_app/pubspec.lock
@@ -99,13 +99,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.3.5"
-  clock:
-    dependency: transitive
-    description:
-      name: clock
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.1.0"
   code_builder:
     dependency: transitive
     description:
@@ -218,13 +211,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "4.0.0"
-  intl:
-    dependency: "direct main"
-    description:
-      name: intl
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.17.0"
   io:
     dependency: transitive
     description:

--- a/pkg/web_app/pubspec.yaml
+++ b/pkg/web_app/pubspec.yaml
@@ -11,7 +11,6 @@ dependencies:
     path: ../api_builder
   collection: ^1.0.0
   http: ^0.13.0
-  intl: ^0.17.0
   js: ^0.6.1
   markdown: ^4.0.0
   mdc_web: ^0.6.0


### PR DESCRIPTION
- format changes to use only a single digit, e.g. from `XYZ.00` to `XYZ.0`
- always rounding values downward to never misrepresent the current value
- reduces ~1.5kb of main JS file, and removes ~96kb of split part