### PR TITLE
Serve static files with pre-gzipped content.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ AppEngine version, listed here to ease deployment and troubleshooting.
  * Upgraded preview Flutter analysis SDK to `2.11.0-0.1.pre`.
  * Upgraded dartdoc to `5.0.1`.
  * NOTE: override invalid versions at package extraction + backfill.
+ * NOTE: `/static/` files are served with gzipped bytes when the request accepts it.
 
 ## `20220209t173000-all`
  * Bumped runtimeVersion to `2022.02.09`.

--- a/app/lib/frontend/handlers/custom_api.dart
+++ b/app/lib/frontend/handlers/custom_api.dart
@@ -91,7 +91,7 @@ Future<shelf.Response> apiPackageNamesHandler(shelf.Request request) async {
 Future<shelf.Response> apiPackageNameCompletionDataHandler(
     shelf.Request request) async {
   // only accept requests which allow gzip content encoding
-  if (!request.acceptsEncoding('gzip')) {
+  if (!request.acceptsGzipEncoding()) {
     throw NotAcceptableException('Client must accept gzip content.');
   }
 

--- a/app/lib/frontend/handlers/documentation.dart
+++ b/app/lib/frontend/handlers/documentation.dart
@@ -92,7 +92,7 @@ Future<shelf.Response> documentationHandler(shelf.Request request) async {
       HttpHeaders.etagHeader: info.etag,
     };
     if (info.blobId != null) {
-      final sendGzip = request.acceptsEncoding('gzip');
+      final sendGzip = request.acceptsGzipEncoding();
       final content = dartdocBackend.readFromBlob(entry, info);
       return shelf.Response(
         HttpStatus.ok,

--- a/app/lib/frontend/handlers/package.dart
+++ b/app/lib/frontend/handlers/package.dart
@@ -393,7 +393,7 @@ Future<shelf.Response> listVersionsHandler(
   }
 
   final body = await packageBackend.listVersionsCachedBytes(package);
-  if (request.acceptsEncoding('gzip')) {
+  if (request.acceptsGzipEncoding()) {
     return createResponse(body, isGzip: true);
   } else {
     return createResponse(gzip.decode(body), isGzip: false);

--- a/app/lib/frontend/static_files.dart
+++ b/app/lib/frontend/static_files.dart
@@ -189,6 +189,8 @@ class StaticFile {
 
   late final String cacheableUrl =
       Uri(path: requestPath, queryParameters: {'hash': etag}).toString();
+
+  late final gzippedBytes = GZipCodec(level: 9).encode(bytes);
 }
 
 class StaticUrls {

--- a/app/lib/shared/handlers.dart
+++ b/app/lib/shared/handlers.dart
@@ -148,8 +148,8 @@ bool isNotModified(
 extension RequestExt on shelf.Request {
   /// Returns true if the current request declares that it accepts the [encoding].
   ///
-  /// NOTE: the method does not parses the header, only checks whether the String
-  ///       value is present (or everything is accepted).
+  /// NOTE: the method does not parses the header, only checks whether the [encoding]
+  ///       String is present (or everything is accepted).
   bool acceptsEncoding(String encoding) {
     final accepting = headers[HttpHeaders.acceptEncodingHeader];
     if (accepting == null || accepting.isEmpty) {
@@ -159,4 +159,10 @@ extension RequestExt on shelf.Request {
         accepting.split(',').map((p) => p.split(';').first.trim()).toSet();
     return items.contains(encoding);
   }
+
+  /// Returns true if the current request declares that it accepts the `gzip` encoding.
+  ///
+  /// NOTE: the method does not parses the header, only checks whether the `gzip`
+  ///       String is present (or everything is accepted).
+  bool acceptsGzipEncoding() => acceptsEncoding('gzip');
 }


### PR DESCRIPTION
This is essentially free for us, and may be a small win on the load balancer.