### PR TITLE
Reducing JS size with more deferred libraries.

### DIFF
--- a/app/test/frontend/static_files_test.dart
+++ b/app/test/frontend/static_files_test.dart
@@ -153,7 +153,7 @@ void main() {
     test('script.dart.js size check', () {
       final file = cache.getFile('/static/js/script.dart.js');
       expect(file, isNotNull);
-      expect((file!.bytes.length / 1024).round(), closeTo(337, 1));
+      expect((file!.bytes.length / 1024).round(), closeTo(267, 1));
     });
   });
 }

--- a/pkg/web_app/lib/src/_dom_helper.dart
+++ b/pkg/web_app/lib/src/_dom_helper.dart
@@ -5,8 +5,8 @@
 import 'dart:async';
 import 'dart:html';
 
-import 'package:markdown/markdown.dart' as md;
 import 'package:mdc_web/mdc_web.dart' show MDCDialog;
+import 'deferred/markdown.dart' deferred as md;
 
 /// Displays a message via the modal window.
 Future modalMessage(String title, Element content) async {
@@ -149,20 +149,9 @@ Element _buildDialog({
 Element text(String text) => Element.div()..text = text;
 
 /// Creates an [Element] with Markdown-formatted content.
-Element markdown(String text) => Element.div()
-  ..setInnerHtml(
-    md.markdownToHtml(text),
-    validator: NodeValidator(uriPolicy: _UnsafeUriPolicy()),
-  );
-
-/// Allows any [Uri].
-///
-/// This shouldn't be a problem as we only render HTML we trust.
-class _UnsafeUriPolicy implements UriPolicy {
-  @override
-  bool allowsUri(String uri) {
-    return true;
-  }
+Future<Element> markdown(String text) async {
+  await md.loadLibrary();
+  return md.markdown(text);
 }
 
 /// Get the value of the material dropdown's selected element

--- a/pkg/web_app/lib/src/account.dart
+++ b/pkg/web_app/lib/src/account.dart
@@ -58,7 +58,7 @@ void _signInNotAvailable() {
   document.getElementById('-account-login')?.onClick.listen((_) async {
     await modalMessage(
         'Sign in is not available',
-        markdown(
+        await markdown(
             '`pub.dev` uses third-party cookies and access to Google domains for accounts and sign in. '
             'Please enable third-party cookies and don\'t block content on `pub.dev`.'));
   });

--- a/pkg/web_app/lib/src/admin_pages.dart
+++ b/pkg/web_app/lib/src/admin_pages.dart
@@ -111,7 +111,7 @@ class _PkgAdminWidget {
         await api_client.client.invitePackageUploader(
             pageData.pkgData!.package, InviteUploaderRequest(email: email));
       },
-      successMessage: markdown('`$email` was invited.'),
+      successMessage: await markdown('`$email` was invited.'),
       onSuccess: (_) {
         _inviteUploaderInput!.value = '';
       },
@@ -121,13 +121,13 @@ class _PkgAdminWidget {
 
   Future<void> _removeUploader(String email) async {
     await api_client.rpc<void>(
-      confirmQuestion: markdown(
+      confirmQuestion: await markdown(
           'Are you sure you want to remove uploader `$email` from this package?'),
       fn: () async {
         await api_client.client
             .removeUploader(pageData.pkgData!.package, email);
       },
-      successMessage: markdown(
+      successMessage: await markdown(
           'Uploader `$email` removed from this package. The page will reload.'),
       onSuccess: (_) => window.location.reload(),
     );
@@ -208,7 +208,7 @@ class _PkgAdminWidget {
     }
 
     await api_client.rpc<void>(
-      confirmQuestion: markdown(
+      confirmQuestion: await markdown(
           'Are you sure you want to retract the package version `$version`?'),
       fn: () async {
         await api_client.client.setVersionOptions(pageData.pkgData!.package,
@@ -229,7 +229,7 @@ class _PkgAdminWidget {
     }
 
     await api_client.rpc<void>(
-      confirmQuestion: markdown(
+      confirmQuestion: await markdown(
           'Are you sure you want to restore package version `$version`?'),
       fn: () async {
         print('before setVersionOption');
@@ -260,7 +260,7 @@ class _PkgAdminWidget {
     }
 
     await api_client.rpc<void>(
-      confirmQuestion: markdown(
+      confirmQuestion: await markdown(
           'Are you sure you want to transfer the package to publisher `$publisherId`?'),
       fn: () async {
         final payload = PackagePublisherInfo(publisherId: publisherId);
@@ -301,7 +301,7 @@ class _CreatePublisherWidget {
     }
 
     await api_client.rpc<void>(
-      confirmQuestion: markdown(
+      confirmQuestion: await markdown(
           'Are you sure you want to create publisher for `$publisherId`?'),
       fn: () async {
         final extraScope =
@@ -405,7 +405,7 @@ class _PublisherAdminWidget {
         await api_client.client.invitePublisherMember(
             pageData.publisher!.publisherId, InviteMemberRequest(email: email));
       },
-      successMessage: markdown('`$email` was invited.'),
+      successMessage: await markdown('`$email` was invited.'),
       onSuccess: (_) {
         _inviteMemberInput!.value = '';
       },
@@ -415,13 +415,13 @@ class _PublisherAdminWidget {
 
   Future<void> _removeMember(String userId, String email) async {
     await api_client.rpc<void>(
-      confirmQuestion: markdown(
+      confirmQuestion: await markdown(
           'Are you sure you want to remove `$email` from this publisher?'),
       fn: () async {
         await api_client.client
             .removePublisherMember(pageData.publisher!.publisherId, userId);
       },
-      successMessage: markdown(
+      successMessage: await markdown(
           '`$email` removed from this publisher. The page will reload.'),
       onSuccess: (_) => window.location.reload(),
     );

--- a/pkg/web_app/lib/src/api_client/_rpc.dart
+++ b/pkg/web_app/lib/src/api_client/_rpc.dart
@@ -77,7 +77,7 @@ Future<R?> rpc<R>({
   }
 
   if (error != null) {
-    await modalMessage('Error', markdown(errorMessage!));
+    await modalMessage('Error', await markdown(errorMessage!));
     if (onError != null) {
       return await onError(error);
     } else {

--- a/pkg/web_app/lib/src/api_client/api_client.dart
+++ b/pkg/web_app/lib/src/api_client/api_client.dart
@@ -4,10 +4,8 @@
 
 import 'dart:html';
 
-import 'package:http/http.dart' as http;
-
 import '../_authentication_proxy.dart';
-import '_authenticated_client.dart';
+import '../deferred/http.dart' as http;
 import 'pubapi.client.dart';
 
 export '_rpc.dart';
@@ -27,7 +25,8 @@ PubApiClient get unauthenticatedClient =>
 
 /// The pub API client to use with account credentials.
 PubApiClient get client {
-  return PubApiClient(_baseUrl, client: createAuthenticatedClient(() async {
+  return PubApiClient(_baseUrl,
+      client: http.createAuthenticatedClient(() async {
     // Wait until we're initialized
     await authProxyReady;
 

--- a/pkg/web_app/lib/src/deferred/http.dart
+++ b/pkg/web_app/lib/src/deferred/http.dart
@@ -1,27 +1,26 @@
-// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
-import 'dart:html';
+import 'package:http/browser_client.dart';
+import 'package:http/http.dart';
 
-import 'package:http/browser_client.dart' as browser_client;
-import 'package:http/http.dart' as http;
+export 'package:http/http.dart' show Client;
 
 /// Creates an authenticated [Client] that calls [getToken] to obtain an
 /// bearer-token to use in the `Authorization: Bearer <token>` header.
-http.Client createAuthenticatedClient(Future<String?> Function() getToken) {
+Client createAuthenticatedClient(Future<String?> Function() getToken) {
   return _AuthenticatedClient(getToken);
 }
 
 /// An [Client] which sends a `Bearer` token as `Authorization` header for each request.
-class _AuthenticatedClient extends browser_client.BrowserClient {
+class _AuthenticatedClient extends BrowserClient {
   final Future<String?> Function() _getToken;
-  final _client = browser_client.BrowserClient();
+  final _client = BrowserClient();
   _AuthenticatedClient(this._getToken);
 
   @override
-  Future<http.StreamedResponse> send(http.BaseRequest request) async {
+  Future<StreamedResponse> send(BaseRequest request) async {
     final token = await _getToken();
     // Make new request object and perform the authenticated request.
     final modifiedRequest =
@@ -44,7 +43,7 @@ class _AuthenticatedClient extends browser_client.BrowserClient {
   }
 }
 
-class _RequestImpl extends http.BaseRequest {
+class _RequestImpl extends BaseRequest {
   final Stream<List<int>> _stream;
 
   _RequestImpl(String method, Uri url, [Stream<List<int>>? stream])
@@ -52,8 +51,8 @@ class _RequestImpl extends http.BaseRequest {
         super(method, url);
 
   @override
-  http.ByteStream finalize() {
+  ByteStream finalize() {
     super.finalize();
-    return http.ByteStream(_stream);
+    return ByteStream(_stream);
   }
 }

--- a/pkg/web_app/lib/src/deferred/markdown.dart
+++ b/pkg/web_app/lib/src/deferred/markdown.dart
@@ -1,0 +1,26 @@
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:html';
+
+import 'package:markdown/markdown.dart' as md;
+
+/// Creates an [Element] with Markdown-formatted content.
+Future<Element> markdown(String text) async {
+  return Element.div()
+    ..setInnerHtml(
+      md.markdownToHtml(text),
+      validator: NodeValidator(uriPolicy: _UnsafeUriPolicy()),
+    );
+}
+
+/// Allows any [Uri].
+///
+/// This shouldn't be a problem as we only render HTML we trust.
+class _UnsafeUriPolicy implements UriPolicy {
+  @override
+  bool allowsUri(String uri) {
+    return true;
+  }
+}

--- a/pkg/web_app/lib/src/page_updater.dart
+++ b/pkg/web_app/lib/src/page_updater.dart
@@ -4,7 +4,7 @@
 
 import 'dart:html';
 
-import 'package:http/http.dart' as http;
+import 'package:http/http.dart' deferred as http;
 
 typedef PopStateFn = Function();
 
@@ -62,6 +62,7 @@ Future<void> updateBodyWithHttpGet({
   bool Function()? preupdateCheck,
 }) async {
   try {
+    await http.loadLibrary();
     final page = await http.get(requestUri).timeout(timeout);
     if (page.statusCode == 200) {
       if (preupdateCheck == null || preupdateCheck()) {

--- a/pkg/web_app/lib/src/scroll.dart
+++ b/pkg/web_app/lib/src/scroll.dart
@@ -4,8 +4,6 @@
 
 import 'dart:html';
 
-import 'package:collection/collection.dart';
-
 void setupScroll() {
   _setEventForAnchorScroll();
   window.onHashChange.listen((_) {
@@ -24,10 +22,11 @@ void _scrollToHash() {
       return;
     }
     // if there is an element on the current tab, scroll to it
-    final firstVisible = list.firstWhereOrNull((e) => e.offsetHeight > 0);
-    if (firstVisible != null) {
-      _scrollTo(firstVisible);
-      return;
+    for (final e in list) {
+      if (e.offsetHeight > 0) {
+        _scrollTo(e);
+        return;
+      }
     }
     // fallback, should not happen
     _scrollTo(list.first);

--- a/pkg/web_app/pubspec.lock
+++ b/pkg/web_app/pubspec.lock
@@ -107,7 +107,7 @@ packages:
     source: hosted
     version: "4.1.0"
   collection:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"

--- a/pkg/web_app/pubspec.yaml
+++ b/pkg/web_app/pubspec.yaml
@@ -9,7 +9,6 @@ dependencies:
     path: ../_pub_shared
   api_builder:
     path: ../api_builder
-  collection: ^1.0.0
   http: ^0.13.0
   js: ^0.6.1
   markdown: ^4.0.0


### PR DESCRIPTION
- updated test to differentiate between accepted imports
- deferring `package:http` (~ 35Kb)
- deferring `package:markdown` (~35Kb)
- removing `package:collection` (not much change)
- overall: ~70 Kb reduction (-20%)
