### PR TITLE
Allow all tag prefixes in search query and in Datastore.

### DIFF
--- a/app/lib/admin/backend.dart
+++ b/app/lib/admin/backend.dart
@@ -34,7 +34,6 @@ import '../scorecard/models.dart';
 import '../shared/configuration.dart';
 import '../shared/datastore.dart';
 import '../shared/exceptions.dart';
-import '../shared/tags.dart';
 import '../tool/utils/dart_sdk_version.dart';
 
 final _logger = Logger('pub.admin.backend');
@@ -530,11 +529,6 @@ class AdminBackend {
   ) async {
     await _requireAdminPermission(AdminPermission.manageAssignedTags);
 
-    InvalidInputException.check(
-      body.assignedTagsAdded
-          .every((tag) => allowedTagPrefixes.any(tag.startsWith)),
-      'Only following tag-prefixes are allowed "${allowedTagPrefixes.join("\", ")}"',
-    );
     InvalidInputException.check(
       body.assignedTagsAdded
           .toSet()

--- a/app/lib/search/search_service.dart
+++ b/app/lib/search/search_service.dart
@@ -26,11 +26,6 @@ const int maxPageLinks = 10;
 /// The maximum length of the search query's text phrase that we'll try to serve.
 const _maxQueryLength = 256;
 
-/// The tag prefixes that we can detect in the user-provided search query.
-final _detectedTagPrefixes = <String>{
-  ...allowedTagPrefixes.expand((s) => [s, '-$s', '+$s']),
-};
-
 /// Statistics about the index content.
 class IndexInfo {
   final bool isReady;
@@ -494,11 +489,10 @@ class ParsedQueryText {
       queryText = queryText.replaceFirst(_packageRegexp, ' ');
     }
 
-    List<String> extractRegExp(RegExp regExp, {bool Function(String?)? where}) {
+    List<String> extractRegExp(RegExp regExp) {
       final values = regExp
           .allMatches(queryText!)
           .map((Match m) => m.group(1))
-          .where((s) => where == null || where(s))
           .cast<String>()
           .toList();
       if (values.isNotEmpty) {
@@ -512,10 +506,7 @@ class ParsedQueryText {
     final allPublishers = extractRegExp(_publisherRegexp);
     final publisher = allPublishers.isEmpty ? null : allPublishers.first;
 
-    final tagValues = extractRegExp(
-      _tagRegExp,
-      where: (tag) => _detectedTagPrefixes.any((p) => tag!.startsWith(p)),
-    );
+    final tagValues = extractRegExp(_tagRegExp);
     final tagsPredicate = TagsPredicate.parseQueryValues(tagValues);
 
     queryText = queryText!.replaceAll(_whitespacesRegExp, ' ').trim();

--- a/app/lib/shared/integrity.dart
+++ b/app/lib/shared/integrity.dart
@@ -19,7 +19,6 @@ import 'configuration.dart';
 import 'datastore.dart';
 import 'email.dart' show looksLikeEmail;
 import 'env_config.dart';
-import 'tags.dart' show allowedTagPrefixes;
 import 'urls.dart' as urls;
 import 'utils.dart' show canonicalizeVersion;
 
@@ -251,12 +250,6 @@ class IntegrityChecker {
       yield 'Package "${p.name}" has an `assignedTags` property which is not a list.';
     }
     final assignedTags = p.assignedTags ?? <String>[];
-    for (final tag in assignedTags) {
-      if (!allowedTagPrefixes.any(tag.startsWith)) {
-        yield 'Package "${p.name}" has assigned tag "$tag" in `assignedTags` '
-            'property, which is not allowed.';
-      }
-    }
     if (assignedTags.length != assignedTags.toSet().length) {
       yield 'Package "${p.name}" has an `assignedTags` property which contains duplicates.';
     }

--- a/app/lib/shared/tags.dart
+++ b/app/lib/shared/tags.dart
@@ -2,20 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// Tag prefixes that are allowed.
-///
-/// Whether a tag is assigned by pub-administrator, package owner, or derived
-/// by pana it must have a prefix listed here. Otherwise, it should be ignore
-/// or an error should be returned to the caller.
-const allowedTagPrefixes = [
-  'is:',
-  'license:',
-  'platform:',
-  'runtime:',
-  'sdk:',
-  'show:',
-];
-
 /// Collection of package-related tags.
 abstract class PackageTags {
   /// Package is marked discontinued | unlisted | legacy.


### PR DESCRIPTION
- Reduces the dependency on tags (fewer things to share with the JS web app).
- Worst case people will misstype their tags in queries and won't get any results.