### PR TITLE
Tags rename, cleanup and small fix.

### DIFF
--- a/app/lib/frontend/handlers/landing.dart
+++ b/app/lib/frontend/handlers/landing.dart
@@ -28,7 +28,7 @@ Future<shelf.Response> flutterLandingHandler(shelf.Request request) async {
 
 /// Handles requests for /web
 Future<shelf.Response> webLandingHandler(shelf.Request request) async {
-  return redirectResponse(urls.searchUrl(q: FlutterSdkTag.platformWeb));
+  return redirectResponse(urls.searchUrl(q: PlatformTag.platformWeb));
 }
 
 /// Handles requests for /

--- a/app/lib/frontend/handlers/listing.dart
+++ b/app/lib/frontend/handlers/listing.dart
@@ -57,7 +57,7 @@ Future<shelf.Response> flutterFavoritesPackagesHandlerHtml(
 /// Handles /web/packages
 Future<shelf.Response> webPackagesHandlerHtml(shelf.Request request) async {
   final newUrl = SearchForm(query: request.requestedUri.queryParameters['q'])
-      .toggleRequiredTag(FlutterSdkTag.platformWeb)
+      .toggleRequiredTag(PlatformTag.platformWeb)
       .toSearchLink();
   return redirectResponse(newUrl);
 }

--- a/app/lib/frontend/templates/package_misc.dart
+++ b/app/lib/frontend/templates/package_misc.dart
@@ -91,41 +91,41 @@ d.Node tagsNodeFromPackageView({
   final platformBadgeTag = BadgeTag(
     text: 'Platform',
     subTags: [
-      if (tags.contains(FlutterSdkTag.platformAndroid))
+      if (tags.contains(PlatformTag.platformAndroid))
         BadgeSubTag(
           text: 'Android',
           title: 'Packages compatible with Android platform',
-          href: tagUrl(FlutterSdkTag.platformAndroid),
+          href: tagUrl(PlatformTag.platformAndroid),
         ),
-      if (tags.contains(FlutterSdkTag.platformIos))
+      if (tags.contains(PlatformTag.platformIos))
         BadgeSubTag(
           text: 'iOS',
           title: 'Packages compatible with iOS platform',
-          href: tagUrl(FlutterSdkTag.platformIos),
+          href: tagUrl(PlatformTag.platformIos),
         ),
-      if (tags.contains(FlutterSdkTag.platformLinux))
+      if (tags.contains(PlatformTag.platformLinux))
         BadgeSubTag(
           text: 'Linux',
           title: 'Packages compatible with Linux platform',
-          href: tagUrl(FlutterSdkTag.platformLinux),
+          href: tagUrl(PlatformTag.platformLinux),
         ),
-      if (tags.contains(FlutterSdkTag.platformMacos))
+      if (tags.contains(PlatformTag.platformMacos))
         BadgeSubTag(
           text: 'macOS',
           title: 'Packages compatible with macOS platform',
-          href: tagUrl(FlutterSdkTag.platformMacos),
+          href: tagUrl(PlatformTag.platformMacos),
         ),
-      if (tags.contains(FlutterSdkTag.platformWeb))
+      if (tags.contains(PlatformTag.platformWeb))
         BadgeSubTag(
           text: 'web',
           title: 'Packages compatible with Web platform',
-          href: tagUrl(FlutterSdkTag.platformWeb),
+          href: tagUrl(PlatformTag.platformWeb),
         ),
-      if (tags.contains(FlutterSdkTag.platformWindows))
+      if (tags.contains(PlatformTag.platformWindows))
         BadgeSubTag(
           text: 'Windows',
           title: 'Packages compatible with Windows platform',
-          href: tagUrl(FlutterSdkTag.platformWindows),
+          href: tagUrl(PlatformTag.platformWindows),
         ),
     ],
   );

--- a/app/lib/frontend/templates/views/pkg/index.dart
+++ b/app/lib/frontend/templates/views/pkg/index.dart
@@ -53,32 +53,32 @@ d.Node _searchFormContainer({
             isActive: true,
             children: [
               _platformCheckbox(
-                platform: FlutterSdkPlatform.android,
+                platform: PlatformTagValue.android,
                 label: 'Android',
                 searchForm: searchForm,
               ),
               _platformCheckbox(
-                platform: FlutterSdkPlatform.ios,
+                platform: PlatformTagValue.ios,
                 label: 'iOS',
                 searchForm: searchForm,
               ),
               _platformCheckbox(
-                platform: FlutterSdkPlatform.linux,
+                platform: PlatformTagValue.linux,
                 label: 'Linux',
                 searchForm: searchForm,
               ),
               _platformCheckbox(
-                platform: FlutterSdkPlatform.macos,
+                platform: PlatformTagValue.macos,
                 label: 'macOS',
                 searchForm: searchForm,
               ),
               _platformCheckbox(
-                platform: FlutterSdkPlatform.web,
+                platform: PlatformTagValue.web,
                 label: 'Web',
                 searchForm: searchForm,
               ),
               _platformCheckbox(
-                platform: FlutterSdkPlatform.windows,
+                platform: PlatformTagValue.windows,
                 label: 'Windows',
                 searchForm: searchForm,
               ),

--- a/app/lib/search/result_combiner.dart
+++ b/app/lib/search/result_combiner.dart
@@ -29,7 +29,7 @@ class SearchResultCombiner {
 
     final primaryResult = await primaryIndex.search(query);
     final queryFlutterSdk = query.tagsPredicate.hasNoTagPrefix('sdk:') ||
-        query.tagsPredicate.hasTag(SdkTagValue.flutter);
+        query.tagsPredicate.hasTag(SdkTag.sdkFlutter);
     final sdkLibraryHits = [
       ...await dartSdkMemIndex.search(query.query!, limit: 2),
       if (queryFlutterSdk)

--- a/app/lib/shared/tags.dart
+++ b/app/lib/shared/tags.dart
@@ -71,41 +71,22 @@ abstract class SdkTag {
 abstract class SdkTagValue {
   static const String dart = 'dart';
   static const String flutter = 'flutter';
-  static const String any = 'any';
 
-  static bool isAny(String? value) => value == null || value == any;
-  static bool isNotAny(String? value) => !isAny(value);
   static bool isValidSdk(String value) => value == dart || value == flutter;
 }
 
-/// Collection of Dart SDK runtime tags (with prefix and value).
-abstract class DartSdkTag {
-  static const String runtimeNativeAot = 'runtime:${DartSdkRuntime.nativeAot}';
-  static const String runtimeNativeJit = 'runtime:${DartSdkRuntime.nativeJit}';
-  static const String runtimeWeb = 'runtime:${DartSdkRuntime.web}';
+/// Collection of platform tags (with prefix and value).
+abstract class PlatformTag {
+  static const String platformAndroid = 'platform:${PlatformTagValue.android}';
+  static const String platformIos = 'platform:${PlatformTagValue.ios}';
+  static const String platformMacos = 'platform:${PlatformTagValue.macos}';
+  static const String platformLinux = 'platform:${PlatformTagValue.linux}';
+  static const String platformWeb = 'platform:${PlatformTagValue.web}';
+  static const String platformWindows = 'platform:${PlatformTagValue.windows}';
 }
 
-/// Collection of Dart SDK runtime values.
-abstract class DartSdkRuntime {
-  static const String nativeAot = 'native-aot';
-  static const String nativeJit = 'native-jit';
-  static const String web = 'web';
-}
-
-/// Collection of Flutter SDK platform tags (with prefix and value).
-abstract class FlutterSdkTag {
-  static const String platformAndroid =
-      'platform:${FlutterSdkPlatform.android}';
-  static const String platformIos = 'platform:${FlutterSdkPlatform.ios}';
-  static const String platformMacos = 'platform:${FlutterSdkPlatform.macos}';
-  static const String platformLinux = 'platform:${FlutterSdkPlatform.linux}';
-  static const String platformWeb = 'platform:${FlutterSdkPlatform.web}';
-  static const String platformWindows =
-      'platform:${FlutterSdkPlatform.windows}';
-}
-
-/// Collection of Flutter SDK platform values.
-abstract class FlutterSdkPlatform {
+/// Collection of platform tag values.
+abstract class PlatformTagValue {
   static const String android = 'android';
   static const String ios = 'ios';
   static const String linux = 'linux';


### PR DESCRIPTION
- Fixes tag value in `result_combiner.dart` to query the Flutter SDK for API docs when the `sdk:flutter` tag is specified.
- Removed Dart SDK runtimes, as they are no longer used.
- Renamed platform tags, dropping the Flutter part, as they are now across both SDKs.
- Removed `sdk:any` and related methods, as they are no longer used.