### PR TITLE
Local HTTP server for unit tests.

### DIFF
--- a/app/lib/service/services.dart
+++ b/app/lib/service/services.dart
@@ -121,6 +121,7 @@ Future<R> withFakeServices<R>({
   }
   datastore ??= MemDatastore();
   storage ??= MemStorage();
+  // TODO: update `package:gcloud` to have a typed fork.
   return await fork(() async {
     register(#appengine.context, FakeClientContext());
     registerDbService(RetryDatastoreDB(DatastoreDB(datastore!)));
@@ -144,6 +145,7 @@ Future<R> withFakeServices<R>({
         primarySiteUri: frontendServerUri,
       );
       serveRequests(frontendServer.server, (rq) async {
+        // TODO: find a way where we don't need to re-initialize all of the fake services.
         return await withFakeServices(
           fn: () async {
             return await (createAppHandler()(rq));

--- a/app/lib/shared/configuration.dart
+++ b/app/lib/shared/configuration.dart
@@ -238,7 +238,11 @@ class Configuration {
   }
 
   /// Configuration for tests.
-  factory Configuration.test({String? storageBaseUrl}) {
+  factory Configuration.test({
+    String? storageBaseUrl,
+    Uri? primaryApiUri,
+    Uri? primarySiteUri,
+  }) {
     return Configuration(
       projectId: 'dartlang-pub-test',
       packageBucketName: 'fake-bucket-pub',
@@ -256,8 +260,8 @@ class Configuration {
       uploadSignerServiceAccount: null,
       blockRobots: true,
       productionHosts: ['localhost'],
-      primaryApiUri: Uri.parse('https://pub.dartlang.org/'),
-      primarySiteUri: Uri.parse('https://pub.dev/'),
+      primaryApiUri: primaryApiUri ?? Uri.parse('https://pub.dartlang.org/'),
+      primarySiteUri: primarySiteUri ?? Uri.parse('https://pub.dev/'),
       admins: [
         AdminId(
           oauthUserId: 'admin-pub-dev',

--- a/app/test/frontend/handlers/_utils.dart
+++ b/app/test/frontend/handlers/_utils.dart
@@ -11,6 +11,7 @@ import 'package:_pub_shared/validation/html/html_validation.dart';
 import 'package:gcloud/service_scope.dart' as ss;
 import 'package:logging/logging.dart';
 import 'package:pub_dev/frontend/handlers.dart';
+import 'package:pub_dev/shared/configuration.dart';
 import 'package:pub_dev/shared/handler_helpers.dart';
 import 'package:pub_dev/shared/urls.dart';
 import 'package:shelf/shelf.dart' as shelf;
@@ -42,11 +43,13 @@ Future<shelf.Response> issueGet(
 Future<shelf.Response> issueHttp(
   String method,
   String path, {
+  String? scheme,
   String? host,
   Map<String, String>? headers,
   dynamic body,
 }) async {
-  final uri = host == null ? '$siteRoot$path' : 'https://$host$path';
+  final uri =
+      host == null ? '$siteRoot$path' : '${scheme ?? 'https'}://$host$path';
   final request = shelf.Request(
     method,
     Uri.parse(uri),
@@ -70,6 +73,8 @@ Future<String> acquireSessionCookie(String token) async {
     body: json.encode({
       'accessToken': token,
     }),
+    scheme: activeConfiguration.primarySiteUri.scheme,
+    host: activeConfiguration.primarySiteUri.host,
   );
   expect(rs.statusCode, 200);
   final cookieHeader = rs.headers['set-cookie'];

--- a/app/test/frontend/handlers/account_test.dart
+++ b/app/test/frontend/handlers/account_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:pub_dev/frontend/static_files.dart';
+import 'package:pub_dev/shared/configuration.dart';
 import 'package:test/test.dart';
 
 import '../../shared/test_models.dart';
@@ -46,6 +47,7 @@ void main() {
         await issueGet(
           '/my-packages',
           headers: {'cookie': cookie},
+          host: activeConfiguration.primaryApiUri!.host,
         ),
         present: ['/packages/flutter_titanium'],
       );
@@ -57,6 +59,7 @@ void main() {
         await issueGet(
           '/my-packages?next=o',
           headers: {'cookie': cookie},
+          host: activeConfiguration.primaryApiUri!.host,
         ),
         present: ['/packages/oxygen'],
         absent: ['/packages/flutter_titanium'],

--- a/app/test/frontend/handlers/atom_feed_test.dart
+++ b/app/test/frontend/handlers/atom_feed_test.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:pub_dev/shared/configuration.dart';
 import 'package:test/test.dart';
 import 'package:xml/xml.dart';
 
@@ -34,41 +35,47 @@ void main() {
           '  <title>v1.2.0 of oxygen</title>\n'
           '  <updated>(.*)</updated>\n'
           '  <content>oxygen is awesome</content>\n'
-          '  <link href="https://pub.dev/packages/oxygen" rel="alternate" title="oxygen"/>\n'
+          '  <link href="${activeConfiguration.primarySiteUri}/packages/oxygen" rel="alternate" title="oxygen"/>\n'
           '</entry>');
       expect(
-          oxygenExpr
-              .hasMatch(entries[1].toXmlString(pretty: true, indent: '  ')),
-          isTrue);
+        oxygenExpr.hasMatch(entries[1].toXmlString(pretty: true, indent: '  ')),
+        isTrue,
+        reason: entries[1].toXmlString(),
+      );
 
       final neonExpr = RegExp('<entry>\n'
           '  <id>urn:uuid:5f920595-c067-404a-bb19-2b0918372eb6</id>\n'
           '  <title>v1.0.0 of neon</title>\n'
           '  <updated>(.*)</updated>\n'
           '  <content>neon is awesome</content>\n'
-          '  <link href="https://pub.dev/packages/neon" rel="alternate" title="neon"/>\n'
+          '  <link href="${activeConfiguration.primarySiteUri}/packages/neon" rel="alternate" title="neon"/>\n'
           '</entry>');
       expect(
-          neonExpr.hasMatch(entries[4].toXmlString(pretty: true, indent: '  ')),
-          isTrue);
+        neonExpr.hasMatch(entries[4].toXmlString(pretty: true, indent: '  ')),
+        isTrue,
+        reason: entries[4].toXmlString(),
+      );
 
       entries.forEach((e) => e.parent!.children.remove(e));
 
       final restExp = RegExp('<feed xmlns="http://www.w3.org/2005/Atom">\n'
-          '  <id>https://pub.dev/feed.atom</id>\n'
+          '  <id>${activeConfiguration.primarySiteUri}/feed.atom</id>\n'
           '  <title>Pub Packages for Dart</title>\n'
           '  <updated>(.*)</updated>\n'
           '  <author>\n'
           '    <name>Dart Team</name>\n'
           '  </author>\n'
-          '  <link href="https://pub.dev/" rel="alternate"/>\n'
-          '  <link href="https://pub.dev/feed.atom" rel="self"/>\n'
+          '  <link href="${activeConfiguration.primarySiteUri}/" rel="alternate"/>\n'
+          '  <link href="${activeConfiguration.primarySiteUri}/feed.atom" rel="self"/>\n'
           '  <generator version="0.1.0">Pub Feed Generator</generator>\n'
           '  <subtitle>Last Updated Packages</subtitle>\n'
           '(\\s*)'
           '</feed>');
-      expect(restExp.hasMatch(feed.toXmlString(pretty: true, indent: '  ')),
-          isTrue);
+      expect(
+        restExp.hasMatch(feed.toXmlString(pretty: true, indent: '  ')),
+        isTrue,
+        reason: feed.toXmlString(),
+      );
     });
   });
 }

--- a/app/test/frontend/handlers/custom_api_test.dart
+++ b/app/test/frontend/handlers/custom_api_test.dart
@@ -5,6 +5,7 @@
 import 'package:clock/clock.dart';
 import 'package:pub_dev/package/backend.dart';
 import 'package:pub_dev/package/name_tracker.dart';
+import 'package:pub_dev/shared/configuration.dart';
 import 'package:pub_dev/shared/datastore.dart';
 import 'package:pub_dev/shared/urls.dart' as urls;
 import 'package:test/test.dart';
@@ -34,10 +35,11 @@ void main() {
                   'dependencies': {}
                 },
                 'archive_url':
-                    'https://pub.dartlang.org/packages/oxygen/versions/1.2.0.tar.gz',
-                'package_url': 'https://pub.dartlang.org/api/packages/oxygen',
+                    '${activeConfiguration.primaryApiUri}/packages/oxygen/versions/1.2.0.tar.gz',
+                'package_url':
+                    '${activeConfiguration.primaryApiUri}/api/packages/oxygen',
                 'url':
-                    'https://pub.dartlang.org/api/packages/oxygen/versions/1.2.0'
+                    '${activeConfiguration.primaryApiUri}/api/packages/oxygen/versions/1.2.0'
               }
             },
             {
@@ -55,11 +57,11 @@ void main() {
                   }
                 },
                 'archive_url':
-                    'https://pub.dartlang.org/packages/flutter_titanium/versions/1.10.0.tar.gz',
+                    '${activeConfiguration.primaryApiUri}/packages/flutter_titanium/versions/1.10.0.tar.gz',
                 'package_url':
-                    'https://pub.dartlang.org/api/packages/flutter_titanium',
+                    '${activeConfiguration.primaryApiUri}/api/packages/flutter_titanium',
                 'url':
-                    'https://pub.dartlang.org/api/packages/flutter_titanium/versions/1.10.0'
+                    '${activeConfiguration.primaryApiUri}/api/packages/flutter_titanium/versions/1.10.0'
               }
             },
             {
@@ -75,10 +77,11 @@ void main() {
                   'dependencies': {}
                 },
                 'archive_url':
-                    'https://pub.dartlang.org/packages/neon/versions/1.0.0.tar.gz',
-                'package_url': 'https://pub.dartlang.org/api/packages/neon',
+                    '${activeConfiguration.primaryApiUri}/packages/neon/versions/1.0.0.tar.gz',
+                'package_url':
+                    '${activeConfiguration.primaryApiUri}/api/packages/neon',
                 'url':
-                    'https://pub.dartlang.org/api/packages/neon/versions/1.0.0'
+                    '${activeConfiguration.primaryApiUri}/api/packages/neon/versions/1.0.0'
               }
             }
           ]


### PR DESCRIPTION
- Fixes #5583.
- Opens a new port for the frontend HTTP server and accepts request that are forwarded with the correct scoping to the local services.
- Does not force each local HTTP request through HTTP (will be done in a subsequent change).
- Adjusted tests to handle dynamic local ports.