### PR TITLE
git gc is no longer needed on local Flutter repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ AppEngine version, listed here to ease deployment and troubleshooting.
  * Upgraded preview Dart analysis SDK to `2.17.0-182.1.beta`.
  * Upgraded pana to `0.21.9`.
  * Upgraded dependencies, including `analyzer` and `pub_semver`.
+ * Note: stopped calling `git gc` in Flutter analysis SDK repositories.
 
 ## `20220310t134700-all`
  * Bumped runtimeVersion to `2022.03.08`.

--- a/app/lib/shared/tool_env.dart
+++ b/app/lib/shared/tool_env.dart
@@ -118,25 +118,7 @@ Future<_ToolEnvRef> _createToolEnvRef() async {
         'FLUTTER_ROOT': activeConfiguration.tools!.previewFlutterSdkPath!,
     },
   );
-
-  // Flutter fetches the latest git objects when checking for new version.
-  // git stores these pack files not efficiently, and GC is not triggered by
-  // any other git operations. Forcing GC here helps to bound the required
-  // space.
-  //
-  // This should be removed once this PR reaches the stable branch:
-  // https://github.com/flutter/flutter/pull/76107
-  await _gitGc(activeConfiguration.tools?.stableFlutterSdkPath);
-  await _gitGc(activeConfiguration.tools?.previewFlutterSdkPath);
   return _ToolEnvRef(cacheDir, stableToolEnv, previewToolEnv);
-}
-
-Future<void> _gitGc(String? path) async {
-  if (path != null &&
-      Directory(path).existsSync() &&
-      Directory('$path/.git').existsSync()) {
-    await runProc(['git', 'gc'], workingDirectory: path);
-  }
 }
 
 Future<int> _calcDirectorySize(Directory dir) async {

--- a/tool/setup-flutter.sh
+++ b/tool/setup-flutter.sh
@@ -20,4 +20,4 @@ git clone -b "$2" --single-branch https://github.com/flutter/flutter.git flutter
 
 # Downloads the Dart SDK and disables analytics tracking – which we always want.
 # This will add 400 MB.
-./flutter/bin/flutter config --no-analytics
+./flutter/bin/flutter --no-version-check config --no-analytics


### PR DESCRIPTION
Previously, the version check in Flutter caused the git repository of the cloned Flutter SDK to grow (while it was fetching the extra commits, but not applying them). Since https://github.com/flutter/flutter/pull/76107 has been merged, and we started using both `--no-version-check` for all Flutter command in pana, and also set `CI=true` for analysis and dartdoc, there seems to be no need to keep doing `git gc`.