### PR TITLE
Remove special treatment of publisher: prefix from SearchForm and from search index.

### DIFF
--- a/app/lib/search/backend.dart
+++ b/app/lib/search/backend.dart
@@ -155,7 +155,6 @@ class SearchBackend {
       grantedPoints: scoreCard?.grantedPubPoints,
       maxPoints: scoreCard?.maxPubPoints ?? 0,
       dependencies: _buildDependencies(pv.pubspec!, scoreCard),
-      publisherId: p.publisherId,
       apiDocPages: apiDocPages,
       timestamp: clock.now().toUtc(),
     );
@@ -197,7 +196,6 @@ class SearchBackend {
         likeCount: p.likes,
         grantedPoints: 0,
         maxPoints: 0,
-        publisherId: p.publisherId,
         timestamp: clock.now().toUtc(),
       );
     }

--- a/app/lib/search/mem_index.dart
+++ b/app/lib/search/mem_index.dart
@@ -162,15 +162,6 @@ class InMemoryPackageIndex implements PackageIndex {
       });
     }
 
-    // filter on publisher
-    if (query.publisherId != null || query.parsedQuery.publisher != null) {
-      final publisherId = query.publisherId ?? query.parsedQuery.publisher;
-      packages.removeWhere((package) {
-        final doc = _packages[package]!;
-        return doc.publisherId != publisherId;
-      });
-    }
-
     // filter on points
     if (query.minPoints != null && query.minPoints! > 0) {
       packages.removeWhere((package) {

--- a/app/lib/search/search_service.dart
+++ b/app/lib/search/search_service.dart
@@ -87,9 +87,6 @@ class PackageDocument {
 
   final Map<String, String> dependencies;
 
-  /// The publisher id of the package
-  final String? publisherId;
-
   final List<ApiDocPage>? apiDocPages;
 
   /// The creation timestamp of this document.
@@ -108,7 +105,6 @@ class PackageDocument {
     this.grantedPoints = 0,
     this.maxPoints = 0,
     this.dependencies = const {},
-    this.publisherId,
     this.apiDocPages = const [],
     DateTime? timestamp,
   })  : tags = tags ?? const <String>[],

--- a/app/lib/search/search_service.g.dart
+++ b/app/lib/search/search_service.g.dart
@@ -27,7 +27,6 @@ PackageDocument _$PackageDocumentFromJson(Map<String, dynamic> json) =>
             (k, e) => MapEntry(k, e as String),
           ) ??
           const {},
-      publisherId: json['publisherId'] as String?,
       apiDocPages: (json['apiDocPages'] as List<dynamic>?)
               ?.map((e) => ApiDocPage.fromJson(e as Map<String, dynamic>))
               .toList() ??
@@ -51,7 +50,6 @@ Map<String, dynamic> _$PackageDocumentToJson(PackageDocument instance) =>
       'grantedPoints': instance.grantedPoints,
       'maxPoints': instance.maxPoints,
       'dependencies': instance.dependencies,
-      'publisherId': instance.publisherId,
       'apiDocPages': instance.apiDocPages,
       'timestamp': instance.timestamp.toIso8601String(),
     };

--- a/app/test/search/mem_index_test.dart
+++ b/app/test/search/mem_index_test.dart
@@ -54,6 +54,7 @@ The delegating wrapper classes allow users to easily add functionality on top of
           created: DateTime.utc(2015, 04, 01),
           updated: DateTime.utc(2017, 05, 17),
           tags: [
+            'publisher:dart.dev',
             'sdk:dart',
             'sdk:flutter',
             'runtime:native-jit',
@@ -64,7 +65,6 @@ The delegating wrapper classes allow users to easily add functionality on top of
           grantedPoints: 10,
           maxPoints: 110,
           dependencies: {'test': 'dev'},
-          publisherId: 'dart.dev',
         ),
         PackageDocument(
           package: 'chrome_net',

--- a/pkg/_pub_shared/lib/search/search_form.dart
+++ b/pkg/_pub_shared/lib/search/search_form.dart
@@ -10,8 +10,6 @@ const int resultsPerPage = 10;
 final RegExp _whitespacesRegExp = RegExp(r'\s+');
 final RegExp _packageRegexp =
     RegExp('package:([_a-z0-9]+)', caseSensitive: false);
-final RegExp _publisherRegexp =
-    RegExp(r'publisher:([_a-z0-9\.]+)', caseSensitive: false);
 final RegExp _refDependencyRegExp =
     RegExp('dependency:([_a-z0-9]+)', caseSensitive: false);
 final RegExp _allDependencyRegExp =
@@ -188,9 +186,6 @@ class ParsedQueryText {
   /// Dependency match for all dependencies, including transitive ones.
   final List<String> allDependencies;
 
-  /// Match the publisher of the package.
-  final String? publisher;
-
   /// Detected tags in the user-provided query.
   TagsPredicate tagsPredicate;
 
@@ -199,7 +194,6 @@ class ParsedQueryText {
     this.packagePrefix,
     this.refDependencies,
     this.allDependencies,
-    this.publisher,
     this.tagsPredicate,
   );
 
@@ -228,8 +222,6 @@ class ParsedQueryText {
 
     final List<String> dependencies = extractRegExp(_refDependencyRegExp);
     final List<String> allDependencies = extractRegExp(_allDependencyRegExp);
-    final allPublishers = extractRegExp(_publisherRegexp);
-    final publisher = allPublishers.isEmpty ? null : allPublishers.first;
 
     final tagValues = extractRegExp(
       _tagRegExp,
@@ -247,7 +239,6 @@ class ParsedQueryText {
       packagePrefix,
       dependencies,
       allDependencies,
-      publisher,
       tagsPredicate,
     );
   }
@@ -260,7 +251,6 @@ class ParsedQueryText {
       packagePrefix,
       refDependencies,
       allDependencies,
-      publisher,
       tagsPredicate ?? this.tagsPredicate,
     );
   }
@@ -273,7 +263,6 @@ class ParsedQueryText {
       text!.isNotEmpty &&
       packagePrefix == null &&
       !hasAnyDependency &&
-      publisher == null &&
       tagsPredicate.isEmpty;
 
   @override
@@ -283,7 +272,6 @@ class ParsedQueryText {
       if (packagePrefix != null) 'package:$packagePrefix',
       ...refDependencies.map((d) => 'dependency:$d'),
       ...allDependencies.map((d) => 'dependency*:$d'),
-      if (publisher != null) 'publisher:$publisher',
       ...tagsPredicate.toQueryParameters(),
       if (text != null && text!.isNotEmpty) text!,
     ].join(' ');

--- a/pkg/_pub_shared/lib/search/tags.dart
+++ b/pkg/_pub_shared/lib/search/tags.dart
@@ -11,6 +11,7 @@ const allowedTagPrefixes = [
   'is:',
   'license:',
   'platform:',
+  'publisher:',
   'runtime:',
   'sdk:',
   'show:',

--- a/pkg/_pub_shared/test/search/search_form_test.dart
+++ b/pkg/_pub_shared/test/search/search_form_test.dart
@@ -141,7 +141,8 @@ void main() {
     test('only publisher', () {
       final query = SearchForm(query: 'publisher:example.com');
       expect(query.parsedQuery.text, isNull);
-      expect(query.parsedQuery.publisher, 'example.com');
+      expect(query.parsedQuery.tagsPredicate.toQueryParameters(),
+          ['publisher:example.com']);
     });
 
     test('known tag', () {
@@ -172,7 +173,8 @@ void main() {
       expect(query.parsedQuery.text, 'text');
       expect(query.parsedQuery.refDependencies, ['pkg1']);
       expect(query.parsedQuery.allDependencies, []);
-      expect(query.parsedQuery.publisher, 'example.com');
+      expect(query.parsedQuery.tagsPredicate.toQueryParameters(),
+          ['publisher:example.com']);
     });
   });
 


### PR DESCRIPTION
There is no point of having this single field as-is now. We won't have `<publisher1> OR <publisher2>` queries right away, but we could have multiple `-publisher:<x> -publisher:<y>` queries, and maybe, if needed, update the query parsing to allow the OR condition.

The search index already contains the `publisher:<publisherId` tag (and we keep updating it).