### PR TITLE
Redirect search from publisher's packages page.

### DIFF
--- a/app/lib/frontend/handlers/publisher.dart
+++ b/app/lib/frontend/handlers/publisher.dart
@@ -13,6 +13,7 @@ import '../../package/search_adapter.dart';
 import '../../publisher/backend.dart';
 import '../../shared/handlers.dart';
 import '../../shared/redis_cache.dart' show cache;
+import '../../shared/tags.dart';
 import '../../shared/urls.dart' as urls;
 import '../request_context.dart';
 import '../templates/listing.dart' show PageLinks;
@@ -55,15 +56,12 @@ Future<shelf.Response> publisherPageHandler(
 /// Handles requests for GET /publishers/<publisherId>/packages [?q=...]
 Future<shelf.Response> publisherPackagesPageHandler(
     shelf.Request request, String publisherId) async {
-  final searchForm = SearchForm.parse(
-    request.requestedUri.queryParameters,
-    context: SearchContext.publisher(publisherId),
-  );
   // Redirect in case of empty search query.
   if (request.requestedUri.query == 'q=') {
     return redirectResponse(request.requestedUri.path);
   }
 
+  // Reply with cached page if available.
   final isLanding = request.requestedUri.queryParameters.isEmpty;
   if (isLanding && requestContext.uiCacheEnabled) {
     final html = await cache.uiPublisherPackagesPage(publisherId).get();
@@ -79,7 +77,24 @@ Future<shelf.Response> publisherPackagesPageHandler(
     return formattedNotFoundHandler(request);
   }
 
-  final searchResult = await searchAdapter.search(searchForm);
+  final searchForm = SearchForm.parse(
+    request.requestedUri.queryParameters,
+    context: SearchContext.publisher(publisherId),
+  );
+  // redirect to proper search page if there is any non-pagination item present
+  if (searchForm.hasNonPagination) {
+    final redirectForm = SearchForm.parse(request.requestedUri.queryParameters)
+        .addRequiredTagIfAbsent(PackageTags.publisherTag(publisherId))
+        .addRequiredTagIfAbsent(PackageTags.showHidden);
+    return redirectResponse(redirectForm.toSearchLink());
+  }
+
+  final appliedSearchForm =
+      SearchForm.parse(request.requestedUri.queryParameters)
+          .toggleRequiredTag(PackageTags.publisherTag(publisherId))
+          .toggleRequiredTag(PackageTags.showHidden);
+
+  final searchResult = await searchAdapter.search(appliedSearchForm);
   final int totalCount = searchResult.totalCount;
   final links = PageLinks(searchForm, totalCount);
 

--- a/app/test/frontend/handlers/publisher_test.dart
+++ b/app/test/frontend/handlers/publisher_test.dart
@@ -2,7 +2,12 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:pub_dev/tool/test_profile/models.dart';
 import 'package:test/test.dart';
+
+import '../../shared/handlers_test_utils.dart';
+import '../../shared/test_services.dart';
+import '_utils.dart';
 
 void main() {
   group('account handlers tests', () {
@@ -15,5 +20,70 @@ void main() {
     // TODO: add test for GET /api/publisher/<publisherId>/members/<userId> API calls
     // TODO: add test for PUT /api/publisher/<publisherId>/members/<userId> API calls
     // TODO: add test for DELETE /api/publisher/<publisherId>/members/<userId> API calls
+
+    testWithProfile('publisher redirect', fn: () async {
+      await expectRedirectResponse(
+        await issueGet('/publishers/example.com'),
+        '/publishers/example.com/packages',
+      );
+    });
+
+    testWithProfile('publisher does not exists', fn: () async {
+      await expectHtmlResponse(
+        await issueGet('/publishers/no-such-publisher.com/packages'),
+        status: 404,
+      );
+    });
+
+    testWithProfile('publisher package with text search', fn: () async {
+      await expectRedirectResponse(
+        await issueGet('/publishers/example.com/packages?q=n'),
+        '/packages?q=publisher%3Aexample.com+show%3Ahidden+n',
+      );
+    });
+
+    testWithProfile('publisher package with tag search', fn: () async {
+      await expectRedirectResponse(
+        await issueGet('/publishers/example.com/packages?q=sdk:dart'),
+        '/packages?q=publisher%3Aexample.com+sdk%3Adart+show%3Ahidden',
+      );
+    });
+
+    testWithProfile('simple publisher packages', fn: () async {
+      await expectHtmlResponse(
+        await issueGet('/publishers/example.com/packages'),
+        present: ['/packages/neon'],
+        absent: ['/packages/oxygen'],
+      );
+    });
+
+    testWithProfile(
+      'paginated publisher packages',
+      testProfile: TestProfile(
+        packages: [
+          TestPackage(name: 'non_publisher'),
+          ...List.generate(
+            11,
+            (i) => TestPackage(
+              name: 'pkg_$i',
+              publisher: 'example.com',
+            ),
+          ),
+        ],
+        defaultUser: 'admin@pub.dev',
+      ),
+      fn: () async {
+        await expectHtmlResponse(
+          await issueGet('/publishers/example.com/packages'),
+          present: ['"/publishers/example.com/packages?page=2"'],
+          absent: ['non_publisher'],
+        );
+        await expectHtmlResponse(
+          await issueGet('/publishers/example.com/packages?page=2'),
+          present: ['"/publishers/example.com/packages"'],
+          absent: ['non_publisher'],
+        );
+      },
+    );
   });
 }

--- a/pkg/_pub_shared/lib/search/search_form.dart
+++ b/pkg/_pub_shared/lib/search/search_form.dart
@@ -365,6 +365,19 @@ class SearchForm {
     );
   }
 
+  SearchForm addRequiredTagIfAbsent(String tag) {
+    if (parsedQuery.tagsPredicate.hasTag(tag)) {
+      return this;
+    } else {
+      return _change(
+        query: parsedQuery
+            .change(
+                tagsPredicate: parsedQuery.tagsPredicate.toggleRequired(tag))
+            .toString(),
+      );
+    }
+  }
+
   bool get hasQuery => query != null && query!.isNotEmpty;
 
   /// The zero-indexed offset for the search results.
@@ -379,6 +392,9 @@ class SearchForm {
   /// Whether any of the non-query settings are non-default
   /// (e.g. clicking on any platforms, SDKs, or advanced filters).
   bool get hasActiveNonQuery => parsedQuery.tagsPredicate.isNotEmpty;
+
+  /// Wether the form has anything other than pagination present.
+  bool get hasNonPagination => query != null || order != null;
 
   /// Converts the query to a user-facing link that (after frontend parsing) will
   /// re-create an identical search query object.


### PR DESCRIPTION
- resolves consistency gotcha's like typing `publisher:x` on a different publisher's packages page
- keeps pagination (for the purpose of keeping the publisher page around for non-admin users)
- keeps the search form pointing to `/publishers/<publisherId>/packages`, but that should change later pointing it directly to `/packages`