### PR TITLE
Remove exported key-based upload signer.

### DIFF
--- a/app/lib/package/upload_signer_service.dart
+++ b/app/lib/package/upload_signer_service.dart
@@ -27,13 +27,13 @@ void registerUploadSigner(UploadSignerService uploadSigner) =>
 
 /// Creates an upload signer based on the current environment.
 Future<UploadSignerService> createUploadSigner(http.Client authClient) async {
-    final email = activeConfiguration.uploadSignerServiceAccount;
-    if (email == null) {
-      throw AssertionError(
-          'Configuration.uploadSignerServiceAccount must be set.');
-    }
-    return _IamBasedUploadSigner(
-        activeConfiguration.projectId, email, authClient);
+  final email = activeConfiguration.uploadSignerServiceAccount;
+  if (email == null) {
+    throw AssertionError(
+        'Configuration.uploadSignerServiceAccount must be set.');
+  }
+  return _IamBasedUploadSigner(
+      activeConfiguration.projectId, email, authClient);
 }
 
 /// Signs Google Cloud Storage upload URLs.

--- a/app/lib/package/upload_signer_service.dart
+++ b/app/lib/package/upload_signer_service.dart
@@ -6,19 +6,14 @@ library pub_dartlang_org.upload_signer_service;
 
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
 
 import 'package:_pub_shared/data/package_api.dart';
 import 'package:clock/clock.dart';
 import 'package:gcloud/service_scope.dart' as ss;
 import 'package:googleapis/iam/v1.dart' as iam;
-import 'package:googleapis_auth/auth_io.dart' as auth;
-// ignore: implementation_imports
-import 'package:googleapis_auth/src/crypto/rsa_sign.dart';
 import 'package:http/http.dart' as http;
 
 import '../shared/configuration.dart';
-import '../shared/env_config.dart';
 import '../shared/utils.dart' show jsonUtf8Encoder;
 
 /// The registered [UploadSignerService] object.
@@ -32,9 +27,6 @@ void registerUploadSigner(UploadSignerService uploadSigner) =>
 
 /// Creates an upload signer based on the current environment.
 Future<UploadSignerService> createUploadSigner(http.Client authClient) async {
-  if (envConfig.isRunningLocally) {
-    return _ServiceAccountBasedUploadSigner();
-  } else {
     final email = activeConfiguration.uploadSignerServiceAccount;
     if (email == null) {
       throw AssertionError(
@@ -42,7 +34,6 @@ Future<UploadSignerService> createUploadSigner(http.Client authClient) async {
     }
     return _IamBasedUploadSigner(
         activeConfiguration.projectId, email, authClient);
-  }
 }
 
 /// Signs Google Cloud Storage upload URLs.
@@ -101,34 +92,6 @@ abstract class UploadSignerService {
   }
 
   Future<SigningResult> sign(List<int> bytes);
-}
-
-/// Uses [auth.ServiceAccountCredentials] to sign Google Cloud Storage upload
-/// URLs. Connection parameters are inferred from the GCLOUD_PROJECT and the
-/// GCLOUD_KEY environment variables.
-///
-/// See [UploadSignerService] for more information.
-class _ServiceAccountBasedUploadSigner extends UploadSignerService {
-  final String googleAccessId;
-  final RS256Signer signer;
-
-  _ServiceAccountBasedUploadSigner._(this.googleAccessId, this.signer);
-
-  factory _ServiceAccountBasedUploadSigner() {
-    if (envConfig.gcloudKey == null) {
-      throw Exception('Missing GCLOUD_* environments for package:appengine');
-    }
-    final path = envConfig.gcloudKey!;
-    final content = File(path).readAsStringSync();
-    final account = auth.ServiceAccountCredentials.fromJson(content);
-    return _ServiceAccountBasedUploadSigner._(
-        account.email, RS256Signer(account.privateRSAKey));
-  }
-
-  @override
-  Future<SigningResult> sign(List<int> bytes) async {
-    return SigningResult(googleAccessId, signer.sign(bytes));
-  }
 }
 
 /// Uses the [iam.IamApi] to sign Google Cloud Storage upload URLs.

--- a/app/lib/shared/env_config.dart
+++ b/app/lib/shared/env_config.dart
@@ -22,7 +22,6 @@ class EnvConfig {
   ///
   /// NOTE: use only for narrow debug flows.
   final String? gaeInstance;
-  final String? gcloudKey;
   final String? gcloudProject;
 
   // Config Path points to configuration file
@@ -33,7 +32,6 @@ class EnvConfig {
     this.gaeVersion,
     this.gaeInstance,
     this.gcloudProject,
-    this.gcloudKey,
     this.configPath,
   );
 
@@ -43,7 +41,6 @@ class EnvConfig {
       Platform.environment['GAE_VERSION'],
       Platform.environment['GAE_INSTANCE'],
       Platform.environment['GOOGLE_CLOUD_PROJECT'],
-      Platform.environment['GCLOUD_KEY'],
       Platform.environment['PUB_SERVER_CONFIG'],
     );
   }

--- a/app/test/frontend/handlers/publisher_test.dart
+++ b/app/test/frontend/handlers/publisher_test.dart
@@ -45,7 +45,7 @@ void main() {
     testWithProfile('publisher package with tag search', fn: () async {
       await expectRedirectResponse(
         await issueGet('/publishers/example.com/packages?q=sdk:dart'),
-        '/packages?q=publisher%3Aexample.com+sdk%3Adart+show%3Ahidden',
+        '/packages?q=sdk%3Adart+publisher%3Aexample.com+show%3Ahidden',
       );
     });
 


### PR DESCRIPTION
- #5578
- I think this was only used locally, which is now deprecated.