### PR TITLE
Refactor PackageLinks

### DIFF
--- a/app/lib/frontend/templates/package.dart
+++ b/app/lib/frontend/templates/package.dart
@@ -29,7 +29,7 @@ import 'views/pkg/title_content.dart';
 /// from pubspec.yaml).
 d.Node renderPkgInfoBox(PackagePageData data) {
   final package = data.package!;
-  final packageLinks = data.version!.packageLinks;
+  final packageLinks = data.packageLinks;
 
   String? documentationUrl = packageLinks.documentationUrl;
   if (urls.hideUserProvidedDocUrl(documentationUrl)) {
@@ -276,7 +276,7 @@ PageData pkgPageData(Package package, PackageVersion selectedVersion) {
 }
 
 Tab _readmeTab(PackagePageData data) {
-  final baseUrl = data.version!.packageLinks.baseUrl;
+  final baseUrl = data.repositoryBaseUrl;
   final content = data.hasReadme &&
           data.asset != null &&
           data.asset!.kind == AssetKind.readme
@@ -295,7 +295,7 @@ Tab? _changelogTab(PackagePageData data) {
   if (data.asset?.kind != AssetKind.changelog) return null;
   final content = renderFile(
     data.asset!,
-    baseUrl: data.version!.packageLinks.baseUrl,
+    baseUrl: data.repositoryBaseUrl,
     isChangelog: true,
   );
   return Tab.withContent(
@@ -309,7 +309,7 @@ Tab? _changelogTab(PackagePageData data) {
 Tab? _exampleTab(PackagePageData data) {
   if (!data.hasExample) return null;
   if (data.asset?.kind != AssetKind.example) return null;
-  final baseUrl = data.version!.packageLinks.baseUrl;
+  final baseUrl = data.repositoryBaseUrl;
 
   final exampleFilename = data.asset!.path;
   final renderedExample = renderFile(data.asset!, baseUrl: baseUrl);
@@ -356,7 +356,7 @@ Tab _licenseTab(PackagePageData data) {
   final license = data.hasLicense
       ? renderFile(
           data.asset!,
-          baseUrl: data.version!.packageLinks.baseUrl,
+          baseUrl: data.repositoryBaseUrl,
         )
       : d.text('No license file found.');
   return Tab.withContent(
@@ -374,7 +374,7 @@ Tab _pubspecTab(PackagePageData data) {
   final content = data.hasPubspec
       ? renderFile(
           data.asset!,
-          baseUrl: data.version!.packageLinks.baseUrl,
+          baseUrl: data.repositoryBaseUrl,
         )
       : d.text('No pubspec file found.');
   return Tab.withContent(

--- a/app/lib/package/models.dart
+++ b/app/lib/package/models.dart
@@ -464,15 +464,6 @@ class PackageVersion extends db.ExpandoModel<String> {
     return '${description.substring(0, 200)} [...]';
   }
 
-  PackageLinks get packageLinks {
-    return PackageLinks.infer(
-      homepageUrl: pubspec!.homepage,
-      documentationUrl: pubspec!.documentation,
-      repositoryUrl: pubspec!.repository,
-      issueTrackerUrl: pubspec!.issueTracker,
-    );
-  }
-
   QualifiedVersionKey get qualifiedVersionKey {
     return QualifiedVersionKey(
       package: package,
@@ -878,14 +869,14 @@ class PackageLinks {
   final String? issueTrackerUrl;
 
   /// The inferred base URL that can be used to link files from.
-  final String? baseUrl;
+  final String? _baseUrl;
 
-  PackageLinks._({
+  PackageLinks._(
+    this._baseUrl, {
     this.homepageUrl,
     this.documentationUrl,
     this.repositoryUrl,
     this.issueTrackerUrl,
-    this.baseUrl,
   });
 
   factory PackageLinks.infer({
@@ -901,11 +892,11 @@ class PackageLinks {
       repositoryUrl: repositoryUrl,
     );
     return PackageLinks._(
+      baseUrl,
       homepageUrl: homepageUrl,
       documentationUrl: documentationUrl,
       repositoryUrl: repositoryUrl,
       issueTrackerUrl: issueTrackerUrl,
-      baseUrl: baseUrl,
     );
   }
 }
@@ -953,6 +944,23 @@ class PackagePageData {
   bool get hasPubspec => versionInfo!.assets.contains(AssetKind.pubspec);
 
   bool get isLatestStable => version!.version == package!.latestVersion;
+
+  // NOTE: These link are not verified.
+  // TODO: We should rather use full URL verification, possibly in pana
+  //       (to also include it in the report).
+  late final packageLinks = () {
+    final pubspec = version!.pubspec!;
+    return PackageLinks.infer(
+      homepageUrl: pubspec.homepage,
+      documentationUrl: pubspec.documentation,
+      repositoryUrl: pubspec.repository,
+      issueTrackerUrl: pubspec.issueTracker,
+    );
+  }();
+
+  /// The inferred base URL that can be used to link files from.
+  /// TODO: migrate to use pana's RepositoryUrl
+  late final repositoryBaseUrl = packageLinks._baseUrl;
 
   PackageView toPackageView() {
     return _view ??= PackageView.fromModel(


### PR DESCRIPTION
- `repositoryBaseUrl` should use pana's `RepositoryUrl`, as it has better infer logic
- Instead of `PackageLinks`, we should eventually use URL analysis from `pana`, this is a first step to decouple it from `PackageVersion` internals, so that we won't use them by accident.
