### PR TITLE
Abstractions for managing a pool of VMs executing tasks

### DIFF
--- a/app/dart_test.yaml
+++ b/app/dart_test.yaml
@@ -1,3 +1,8 @@
 tags:
   presubmit-only:
     skip: "Should only be run during presubmit"
+  fragile:
+    skip: 'Only run fragile tests manually with `pub run test -P fragile`'
+    presets:
+      fragile:
+        skip: false # Don't skip when running in -P fragile

--- a/app/lib/task/cloudcompute/cloudcompute.dart
+++ b/app/lib/task/cloudcompute/cloudcompute.dart
@@ -1,0 +1,91 @@
+// Copyright (c) 2021, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// Interface describing an instance.
+abstract class CloudInstance {
+  /// Unique instance name.
+  String get name;
+
+  /// Zone this instance lives in.
+  String get zone;
+
+  /// [DateTime] of when the instance was created.
+  DateTime get created;
+
+  /// State of the instance.
+  InstanceState get state;
+
+  /// Representation for debugging purposes.
+  @override
+  String toString() => 'CloudInstance(${[
+        'name: $name',
+        'zone: $zone',
+        'created: $created',
+        'state: $state',
+      ].join(',')})';
+}
+
+/// Simplified instance state.
+///
+/// In practice we often don't care if an instance _provisioning_ or _staging_.
+/// If an instance is stuck in the [pending] state it's probably because it's
+/// not going to startup.
+///
+/// Similarly, we don't care if an instance is _booting_, _running_, or if the
+/// process running on the instance crashed without terminating the instance.
+/// In all these cases we want delete the instance if it gets stuck long
+/// enought to exhaust allowed execution time.
+///
+/// We also don't care if the instance is _suspending_, _suspended_, _stopping_,
+/// _stopped_ or _terminated_. In these the cases the instance should be
+/// deleted.
+enum InstanceState {
+  /// Instance is pending provisioning or in the process of being provisioned.
+  pending,
+
+  /// Instance is believed to be running (or booting).
+  running,
+
+  /// Instance has been terminated.
+  terminated,
+}
+
+/// Interface for controlling a cloud compute region.
+abstract class CloudCompute {
+  /// List of zones available.
+  List<String> get zones;
+
+  /// Generate an instance name.
+  String generateInstanceName();
+
+  /// Create an instance running [dockerImage] with given [arguments].
+  ///
+  /// The instance will be running in the given [zone] under the given [name].
+  /// Notice that [name] must be unique and will have implementation specific
+  /// limitations, using [generateInstanceName] is adviced.
+  ///
+  /// The _human readable_ [description] will attached to the instance in
+  /// Cloud Console and intended to assist humans inspecting the system.
+  ///
+  /// The future returned may take a long time to resolve (several minutes).
+  /// Any [Exception] thrown by this method should be considered a reason to
+  /// reduce the request rate on the given zone [zone].
+  Future<CloudInstance> createInstance({
+    required String zone,
+    required String name,
+    required String dockerImage,
+    required List<String> arguments,
+    required String description,
+  });
+
+  /// List instances.
+  Stream<CloudInstance> listInstances();
+
+  /// Delete the instance with [name] from [zone].
+  ///
+  /// If this operation fails, it may throw an [Exception] or discard the error.
+  /// Systems should assume deletion is best-effort and periodically list
+  /// instances to delete instances that are no longer needed.
+  Future<void> delete(String zone, String name);
+}

--- a/app/lib/task/cloudcompute/cloudcompute.dart
+++ b/app/lib/task/cloudcompute/cloudcompute.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
@@ -36,8 +36,8 @@ abstract class CloudInstance {
 ///
 /// Similarly, we don't care if an instance is _booting_, _running_, or if the
 /// process running on the instance crashed without terminating the instance.
-/// In all these cases we want delete the instance if it gets stuck long
-/// enought to exhaust allowed execution time.
+/// In all these cases we want to delete the instance if it gets stuck long
+/// enough to exhaust the allowed execution time.
 ///
 /// We also don't care if the instance is _suspending_, _suspended_, _stopping_,
 /// _stopped_ or _terminated_. In these the cases the instance should be
@@ -68,10 +68,10 @@ abstract class CloudCompute {
   /// Notice that [instanceName] must be unique and will have implementation
   /// specific limitations, using [generateInstanceName] is adviced.
   ///
-  /// The _human readable_ [description] will attached to the instance in
+  /// The _human readable_ [description] will be attached to the instance in
   /// Cloud Console and intended to assist humans inspecting the system.
   ///
-  /// The future returned may take a long time to resolve (several minutes).
+  /// The [Future] returned may take a long time to resolve (several minutes).
   /// Any [Exception] thrown by this method should be considered a reason to
   /// reduce the request rate on the given zone [zone].
   Future<CloudInstance> createInstance({

--- a/app/lib/task/cloudcompute/cloudcompute.dart
+++ b/app/lib/task/cloudcompute/cloudcompute.dart
@@ -30,7 +30,7 @@ abstract class CloudInstance {
 
 /// Simplified instance state.
 ///
-/// In practice we often don't care if an instance _provisioning_ or _staging_.
+/// In practice we often don't care if an instance is _provisioning_ or _staging_.
 /// If an instance is stuck in the [pending] state it's probably because it's
 /// not going to startup.
 ///

--- a/app/lib/task/cloudcompute/cloudcompute.dart
+++ b/app/lib/task/cloudcompute/cloudcompute.dart
@@ -5,12 +5,14 @@
 /// Interface describing an instance.
 abstract class CloudInstance {
   /// Unique instance name.
-  String get name;
+  String get instanceName;
 
   /// Zone this instance lives in.
   String get zone;
 
   /// [DateTime] of when the instance was created.
+  ///
+  /// This is "now" until a creation time is reflected in the cloud APIs.
   DateTime get created;
 
   /// State of the instance.
@@ -19,7 +21,7 @@ abstract class CloudInstance {
   /// Representation for debugging purposes.
   @override
   String toString() => 'CloudInstance(${[
-        'name: $name',
+        'name: $instanceName',
         'zone: $zone',
         'created: $created',
         'state: $state',
@@ -61,9 +63,10 @@ abstract class CloudCompute {
 
   /// Create an instance running [dockerImage] with given [arguments].
   ///
-  /// The instance will be running in the given [zone] under the given [name].
-  /// Notice that [name] must be unique and will have implementation specific
-  /// limitations, using [generateInstanceName] is adviced.
+  /// The instance will be running in the given [zone] under the given
+  /// [instanceName].
+  /// Notice that [instanceName] must be unique and will have implementation
+  /// specific limitations, using [generateInstanceName] is adviced.
   ///
   /// The _human readable_ [description] will attached to the instance in
   /// Cloud Console and intended to assist humans inspecting the system.
@@ -73,7 +76,7 @@ abstract class CloudCompute {
   /// reduce the request rate on the given zone [zone].
   Future<CloudInstance> createInstance({
     required String zone,
-    required String name,
+    required String instanceName,
     required String dockerImage,
     required List<String> arguments,
     required String description,
@@ -82,10 +85,10 @@ abstract class CloudCompute {
   /// List instances.
   Stream<CloudInstance> listInstances();
 
-  /// Delete the instance with [name] from [zone].
+  /// Delete the instance with [instanceName] from [zone].
   ///
   /// If this operation fails, it may throw an [Exception] or discard the error.
   /// Systems should assume deletion is best-effort and periodically list
   /// instances to delete instances that are no longer needed.
-  Future<void> delete(String zone, String name);
+  Future<void> delete(String zone, String instanceName);
 }

--- a/app/lib/task/cloudcompute/fakecloudcompute.dart
+++ b/app/lib/task/cloudcompute/fakecloudcompute.dart
@@ -1,0 +1,156 @@
+// Copyright (c) 2021, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:clock/clock.dart';
+import 'package:logging/logging.dart';
+import 'package:meta/meta.dart';
+
+import 'cloudcompute.dart';
+
+final _log = Logger('pub.fakecloudcompute');
+
+@sealed
+class FakeCloudCompute extends CloudCompute {
+  var _nextInstanceId = 1;
+  final _instances = <FakeCloudInstance>{};
+
+  @override
+  final List<String> zones = List.unmodifiable(['zone-a', 'zone-b']);
+
+  @override
+  String generateInstanceName() => 'instance-${_nextInstanceId++}';
+
+  @override
+  Future<FakeCloudInstance> createInstance({
+    required String zone,
+    required String name,
+    required String dockerImage,
+    required List<String> arguments,
+    required String description,
+  }) async {
+    if (!zones.contains(zone)) {
+      throw ArgumentError.value(zone, 'zone', 'must be a valid zone');
+    }
+    // Enforce same limits as GCE
+    if (arguments.fold<int>(0, (a, b) => a + b.length) > 100 * 1024) {
+      throw ArgumentError.value(
+        arguments,
+        'arguments',
+        'must be less than 100KiB',
+      );
+    }
+    if (_instances.any((i) => i.name == name)) {
+      throw StateError('instance "$name" have already been used once!');
+    }
+
+    final instance = FakeCloudInstance._(
+      name: name,
+      zone: zone,
+      created: clock.now().toUtc(),
+      state: InstanceState.pending,
+      dockerImage: dockerImage,
+      arguments: arguments,
+      description: description,
+    );
+    _log.info('Creating instance "$name"');
+    _instances.add(instance);
+    return instance;
+  }
+
+  @override
+  Stream<FakeCloudInstance> listInstances() => Stream.fromIterable(_instances);
+
+  @override
+  Future<void> delete(String zone, String name) async {
+    if (!_instances.any((i) => i.name == name && i.zone == zone)) {
+      // This is not really a problem, GoogleCloudCompute should might throw
+      // some exception about the instance not being found. Exact behavior of
+      // the API is not specified.
+      throw Exception('instance "$name" does not exist');
+    }
+
+    // Let's make the operation take a minute, and then remove the instance!
+    _log.info('Deleting instance "$name"');
+    await Future.delayed(Duration(minutes: 1));
+    _instances.removeWhere((i) => i.name == name && i.zone == zone);
+  }
+
+  /// Change state of instance with [name] to [InstanceState.running].
+  void fakeStartInstance(String name) {
+    if (!_instances.any((i) => i.name == name)) {
+      throw StateError('instance "$name" does not exist');
+    }
+
+    final instance = _instances.firstWhere((i) => i.name == name);
+    _instances.removeWhere((i) => i.name == name);
+    _instances.add(instance._copyWith(state: InstanceState.running));
+  }
+
+  /// Change state of instance with [name] to [InstanceState.terminated].
+  void fakeTerminateInstance(String name) {
+    if (!_instances.any((i) => i.name == name)) {
+      throw StateError('instance "$name" does not exist');
+    }
+
+    final instance = _instances.firstWhere((i) => i.name == name);
+    _instances.removeWhere((i) => i.name == name);
+    _instances.add(instance._copyWith(state: InstanceState.terminated));
+  }
+}
+
+@sealed
+class FakeCloudInstance extends CloudInstance {
+  @override
+  final String name;
+
+  @override
+  final String zone;
+
+  @override
+  final DateTime created;
+
+  @override
+  final InstanceState state;
+
+  /// Docker image that was given to [FakeCloudCompute.createInstance] when this
+  /// instance was created.
+  final String dockerImage;
+
+  /// Arguments that was given to [FakeCloudCompute.createInstance] when this
+  /// instance was created.
+  final List<String> arguments;
+
+  /// Description that was given to [FakeCloudCompute.createInstance] when this
+  /// instance was created.
+  final String description;
+
+  FakeCloudInstance _copyWith({
+    String? name,
+    String? zone,
+    DateTime? created,
+    InstanceState? state,
+    String? dockerImage,
+    List<String>? arguments,
+    String? description,
+  }) =>
+      FakeCloudInstance._(
+        name: name ?? this.name,
+        zone: zone ?? this.zone,
+        created: created ?? this.created,
+        state: state ?? this.state,
+        dockerImage: dockerImage ?? this.dockerImage,
+        arguments: arguments ?? this.arguments,
+        description: description ?? this.description,
+      );
+
+  FakeCloudInstance._({
+    required this.name,
+    required this.zone,
+    required this.created,
+    required this.state,
+    required this.dockerImage,
+    required this.arguments,
+    required this.description,
+  });
+}

--- a/app/lib/task/cloudcompute/fakecloudcompute.dart
+++ b/app/lib/task/cloudcompute/fakecloudcompute.dart
@@ -16,7 +16,7 @@ class FakeCloudCompute extends CloudCompute {
   final _instances = <FakeCloudInstance>{};
 
   @override
-  final List<String> zones = List.unmodifiable(['zone-a', 'zone-b']);
+  final List<String> zones =  const ['zone-a', 'zone-b'];
 
   @override
   String generateInstanceName() => 'instance-${_nextInstanceId++}';
@@ -66,7 +66,7 @@ class FakeCloudCompute extends CloudCompute {
     if (!_instances.any(
       (i) => i.instanceName == instanceName && i.zone == zone,
     )) {
-      // This is not really a problem, GoogleCloudCompute should might throw
+      // This is not really a problem, GoogleCloudCompute should throw
       // some exception about the instance not being found. Exact behavior of
       // the API is not specified.
       throw Exception('instance "$instanceName" does not exist');

--- a/app/lib/task/cloudcompute/googlecloudcompute.dart
+++ b/app/lib/task/cloudcompute/googlecloudcompute.dart
@@ -224,7 +224,11 @@ class _GoogleCloudCompute extends CloudCompute {
     // Max argument string size on Linux is MAX_ARG_STRLEN = 131072
     // In addition the maximum meta-data size supported by GCE is 256KiB
     // We need a few extra bits, so we shall enforce a max size of 100KiB.
-    if (arguments.fold<int>(0, (a, b) => a + b.length) > 100 * 1024) {
+    final argumentsLengthInBytes = arguments
+        .map(utf8.encode)
+        .map((s) => s.length)
+        .fold<int>(0, (a, b) => a + b);
+    if (argumentsLengthInBytes > 100 * 1024) {
       throw ArgumentError.value(
         arguments,
         'arguments',
@@ -455,6 +459,10 @@ class _GoogleCloudCompute extends CloudCompute {
       created = DateTime.parse(instance.creationTimestamp ?? '');
     } on FormatException {
       // Print error and instance to log..
+      _log.severe(
+        'Failed to parse instance.creationTimestamp: '
+        '"${instance.creationTimestamp}"',
+      );
       // Fallback to year zero that way instances will be killed.
       created = DateTime(0);
     }

--- a/app/lib/task/cloudcompute/googlecloudcompute.dart
+++ b/app/lib/task/cloudcompute/googlecloudcompute.dart
@@ -1,0 +1,502 @@
+// Copyright (c) 2021, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:clock/clock.dart';
+import 'package:googleapis/compute/v1.dart' hide Duration;
+import 'package:http/http.dart' as http;
+import 'package:logging/logging.dart' show Logger;
+import 'package:meta/meta.dart';
+import 'package:pub_dev/shared/utils.dart' show createUuid;
+import 'package:pub_dev/task/cloudcompute/cloudcompute.dart';
+import 'package:retry/retry.dart';
+import 'package:ulid/ulid.dart';
+
+final _log = Logger('pub.googlecloudcompute');
+
+/// Hardcoded list of GCE zones to consider for provisioning.
+///
+/// See [list of regions and zones][regions-zones].
+///
+/// [regions-zones]: https://cloud.google.com/compute/docs/regions-zones
+const _googleCloudZones = [
+  'us-central1-a',
+  'us-central1-b',
+  'us-central1-c',
+  'us-central1-f',
+];
+
+/// Hardcoded machine type to use for provisioning instances.
+///
+/// Note. it is important that this _machine type_ is available in the
+/// [_googleCloudZones] listed.
+///
+/// See [predefined machine-types][machines-types].
+///
+/// [machine-types]: https://cloud.google.com/compute/docs/machine-types
+const _googleCloudMachineType = 'e2-standard-2'; // 2 vCPUs 8GB ram
+
+/// OAuth scope needed for the [http.Client] passed to
+/// [createGoogleCloudCompute].
+const googleCloudComputeScope = ComputeApi.cloudPlatformScope;
+
+/// Create a [CloudCompute] abstraction wrapping Google Compute Engine.
+///
+/// The [CloudCompute] abstraction created will manage instance in the given
+/// GCP cloud [project] with labels:
+///  * `owner = 'pub-dev'`, and,
+///  * `pool = poolLabel`.
+///
+/// Similarly, all instances created by this abstraction will be labelled with
+/// `owner` as `'pub-dev'` and `pool` as [poolLabel]. This allows for multiple
+/// pools of machines that don't interfere with eachother. By using a
+/// [poolLabel] such as `'<runtimeVersion>/pana'` we can ensure that the
+/// [CloudCompute] object for pana-tasks doesn't interfere with the other
+/// _runtime versions_ in production.
+///
+/// Instances will use [Container-Optimized OS][c-o-s] to the docker-image
+/// specified at instance creation.
+///
+/// [c-o-s]: https://cloud.google.com/container-optimized-os/docs
+CloudCompute createGoogleCloudCompute({
+  required http.Client client,
+  required String project,
+  required String poolLabel,
+}) {
+  if (poolLabel.isEmpty) {
+    throw ArgumentError.value(poolLabel, 'poolLabel', 'must not be empty');
+  }
+
+  return _GoogleCloudCompute(
+    ComputeApi(client),
+    project,
+    _googleCloudZones,
+    _googleCloudMachineType,
+    poolLabel,
+  );
+}
+
+class _GoogleCloudInstance extends CloudInstance {
+  /// GCP zone this instance exists inside.
+  @override
+  final String zone;
+
+  @override
+  final String name;
+
+  @override
+  final DateTime created;
+
+  @override
+  final InstanceState state;
+
+  _GoogleCloudInstance(
+    this.zone,
+    this.name,
+    this.created,
+    this.state,
+  );
+
+  @override
+  String toString() {
+    return 'GoogleCloudInstance($name, zone: $zone, created: $created, state: $state)';
+  }
+}
+
+class _PendingGoogleCloudInstance extends CloudInstance {
+  /// GCP zone this instance exists inside.
+  @override
+  final String zone;
+
+  @override
+  final String name;
+
+  @override
+  DateTime get created => clock.now();
+
+  @override
+  InstanceState get state => InstanceState.pending;
+
+  _PendingGoogleCloudInstance(this.zone, this.name);
+
+  @override
+  String toString() {
+    return 'GoogleCloudInstance($name, zone: $zone, created: $created, state: $state)';
+  }
+}
+
+Future<T> _retryWithRequestId<T>(Future<T> Function(String rId) fn) async {
+  // As long as we use the same requestId we can call multiple times without
+  // duplicating side-effects on the server (at-least this seems plausible).
+  final requestId = createUuid();
+
+  return await _retry(() => fn(requestId));
+}
+
+Future<T> _retry<T>(Future<T> Function() fn) async {
+  return await retry(
+    fn,
+    retryIf: (e) =>
+        // Guessing the API might honor: https://google.aip.dev/194
+        // So only retry 'UNAVAILABLE' errors, which is 503 according to:
+        // https://github.com/googleapis/api-common-protos/blob/master/google/rpc/code.proto
+        (e is DetailedApiRequestError && e.status == 503) ||
+        // In addition we retry undocumented errors and malformed responses.
+        (e is ApiRequestError && e is! DetailedApiRequestError) ||
+        // If there is a timeout, we also retry.
+        e is TimeoutException ||
+        // Finally, we retry all I/O issues.
+        e is IOException,
+  );
+}
+
+/// Pattern for valid GCE instance names.
+final _validInstanceNamePattern = RegExp(r'^[a-z]([-a-z0-9]*[a-z0-9])?$');
+
+@sealed
+class _GoogleCloudCompute extends CloudCompute {
+  final ComputeApi _api;
+
+  /// GCP project this isntance is managing VMs inside.
+  final String _project;
+
+  /// GCP zones this instance is managing VMs inside.
+  final List<String> _zones;
+
+  /// GCP machine type, see:
+  /// https://cloud.google.com/compute/docs/machine-types
+  final String _machineType;
+
+  /// Value of the `pool` label for VMs managed by this instance.
+  ///
+  /// Instances created must have this `pool` label, same goes for instances
+  /// listed (luckily we can filter in labels in the API).
+  final String _poolLabel;
+
+  /// Instances where a [Future] from the [createInstance] operation is still
+  /// waiting to be resolved.
+  ///
+  /// We shall show such instances in [listInstances] until the [Future]
+  /// returned frm [createInstance] has been resolved.
+  final Set<_PendingGoogleCloudInstance> _pendingInstances = {};
+
+  _GoogleCloudCompute(
+    this._api,
+    this._project,
+    this._zones,
+    this._machineType,
+    this._poolLabel,
+  );
+
+  @override
+  List<String> get zones => List.from(_zones);
+
+  @override
+  String generateInstanceName() => 'worker-${Ulid()}';
+
+  @override
+  Future<CloudInstance> createInstance({
+    required String zone,
+    required String name,
+    required String dockerImage,
+    required List<String> arguments,
+    required String description,
+  }) async {
+    if (!_zones.contains(zone)) {
+      throw ArgumentError.value(
+        zone,
+        'zone',
+        'must be one of CloudCompute.zones',
+      );
+    }
+    if (name.isEmpty || name.length > 63) {
+      throw ArgumentError.value(
+          name, 'name', 'must have a length between 1 and 63');
+    }
+    if (!_validInstanceNamePattern.hasMatch(name)) {
+      throw ArgumentError.value(
+          name, 'name', 'must match pattern: $_validInstanceNamePattern');
+    }
+    // Max argument string size on Linux is MAX_ARG_STRLEN = 131072
+    // In addition the maximum meta-data size supported by GCE is 256KiB
+    // We need a few extra bits, so we shall enforce a max size of 100KiB.
+    if (arguments.fold<int>(0, (a, b) => a + b.length) > 100 * 1024) {
+      throw ArgumentError.value(
+        arguments,
+        'arguments',
+        'must be less than 100KiB',
+      );
+    }
+
+    final cmd = [
+      '/usr/bin/docker',
+      'run',
+      '--rm',
+      '-u',
+      '2000',
+      '--name',
+      'task',
+      dockerImage,
+      ...arguments
+    ];
+    final cloudConfig = [
+      '#cloud-config',
+      'users:',
+      '- name: worker',
+      '  uid: 2000',
+      'runcmd:',
+      '- ${json.encode(cmd)}',
+      '- [\'/sbin/shutdown\', \'now\']',
+      '',
+    ].join('\n');
+
+    final instance = Instance()
+      ..name = name
+      ..description = description
+      ..machineType = 'zones/$zone/machineTypes/$_machineType'
+      ..scheduling = (Scheduling()..preemptible = true)
+      ..labels = {
+        // Labels that allows us to filter instances when listing instances.
+        'owner': 'pub-dev',
+        'pool': _poolLabel,
+      }
+      ..metadata = (Metadata()
+        ..items = [
+          MetadataItems()
+            ..key = 'user-data'
+            ..value = cloudConfig,
+        ])
+      ..serviceAccounts = []
+      ..networkInterfaces = [
+        NetworkInterface()
+          ..network = 'global/networks/default'
+          ..accessConfigs = [
+            AccessConfig()
+              ..type = 'ONE_TO_ONE_NAT'
+              ..name = 'External NAT',
+          ],
+      ]
+      ..disks = [
+        AttachedDisk()
+          ..type = 'PERSISTENT'
+          ..boot = true
+          ..autoDelete = true
+          ..initializeParams = (AttachedDiskInitializeParams()
+            ..labels = {
+              // Labels allows to track disks, in practice they should always
+              // be auto-deleted with instance, but if this fails it's nice to
+              // have a label.
+              'owner': 'pub-dev',
+              'pool': _poolLabel,
+            }
+            ..sourceImage =
+                'projects/cos-cloud/global/images/family/cos-stable'),
+      ];
+
+    _log.info('Creating instance: ${instance.name}');
+    final pendingInstancePlaceHolder = _PendingGoogleCloudInstance(zone, name);
+    _pendingInstances.add(pendingInstancePlaceHolder);
+    try {
+      // https://cloud.google.com/container-optimized-os/docs/how-to/create-configure-instance#creating_an_instance
+      var op = await _retryWithRequestId((rId) => _api.instances
+          .insert(
+            instance,
+            _project,
+            zone,
+            requestId: rId,
+          )
+          .timeout(Duration(minutes: 5)));
+
+      void logWarningsThrowErrors() {
+        // Log warnings if there is any
+        final warnings = op.warnings;
+        if (warnings != null) {
+          for (final w in warnings) {
+            _log.warning(
+              'Warning while creating instance, '
+              'api.instances.insert(name=${instance.name}) '
+              '${w.code}: ${w.message}',
+            );
+          }
+        }
+
+        // Throw first error.
+        final opError = op.error;
+        if (opError != null) {
+          final opErrors = opError.errors;
+          if (opErrors != null && opErrors.isNotEmpty) {
+            throw ApiRequestError(
+              'Error creating instance, '
+              'api.instances.insert(name=${instance.name}), '
+              '${opErrors.first.code}: ${opErrors.first.message}',
+            );
+          }
+        }
+      }
+
+      // Check if we got any errors
+      logWarningsThrowErrors();
+
+      while (op.status != 'DONE') {
+        final start = clock.now();
+        op = await _retry(() => _api.zoneOperations
+            .wait(
+              _project,
+              zone,
+              op.name!,
+            )
+            .timeout(Duration(minutes: 3)));
+        logWarningsThrowErrors();
+
+        if (op.status != 'DONE') {
+          // Ensure at-least two minutes between api.zoneOperations.wait() calls
+          final elapsed = clock.now().difference(start);
+          final remainder = Duration(minutes: 2) - elapsed;
+          if (!remainder.isNegative) {
+            await Future.delayed(remainder);
+          }
+        }
+      }
+      _log.info('Created instance: ${instance.name}');
+
+      return _wrapInstanceWithState(
+        instance,
+        zone,
+        DateTime.tryParse(op.creationTimestamp ?? '') ?? DateTime(0),
+        InstanceState.pending,
+      );
+    } finally {
+      _pendingInstances.remove(pendingInstancePlaceHolder);
+    }
+  }
+
+  @override
+  Future<void> delete(String zone, String name) async {
+    await _retryWithRequestId((rId) => _api.instances.delete(
+          _project,
+          zone,
+          name,
+          requestId: rId,
+        ));
+    // Note. that instances.delete() technically returns a custom long-running
+    // operation, we have no reasonable action to take if deletion fails.
+    // Presumably, the instance would show up in listings again and eventually
+    // be deleted once more (with a new operation, with a new requestId).
+    // TODO: Await the delete operation...
+  }
+
+  @override
+  Stream<CloudInstance> listInstances() {
+    final filter = [
+      'labels.owner = "pub-dev"',
+      'labels.pool = "$_poolLabel"',
+    ].join(' AND ');
+
+    final c = StreamController<CloudInstance>();
+
+    scheduleMicrotask(() async {
+      try {
+        await Future.wait(_zones.map((zone) async {
+          var response = await _retry(() => _api.instances.list(
+                _project,
+                zone,
+                maxResults: 500,
+                filter: filter,
+              ));
+
+          final wrap = (Instance item) => _wrapInstance(item, zone);
+          final pendingInZone = _pendingInstances
+              .where((instance) => instance.zone == zone)
+              .toSet();
+
+          for (final instance in (response.items ?? []).map(wrap)) {
+            c.add(instance);
+            pendingInZone.removeWhere((i) => i.name == instance.name);
+          }
+
+          while ((response.nextPageToken ?? '').isNotEmpty) {
+            response = await _retry(() => _api.instances.list(
+                  _project,
+                  zone,
+                  maxResults: 500,
+                  filter: filter,
+                  pageToken: response.nextPageToken,
+                ));
+            for (final instance in (response.items ?? []).map(wrap)) {
+              c.add(instance);
+              pendingInZone.removeWhere((i) => i.name == instance.name);
+            }
+          }
+
+          // For each of the pending instances in current zone, where name has
+          // not been reported, return the fake pending instance.
+          pendingInZone.forEach(c.add);
+        }));
+      } catch (e, st) {
+        c.addError(e, st);
+      } finally {
+        await c.close();
+      }
+    });
+
+    return c.stream;
+  }
+
+  CloudInstance _wrapInstance(Instance instance, String zone) {
+    DateTime created;
+    try {
+      created = DateTime.parse(instance.creationTimestamp ?? '');
+    } on FormatException {
+      // Print error and instance to log..
+      // Fallback to year zero that way instances will be killed.
+      created = DateTime(0);
+    }
+
+    InstanceState state;
+    switch (instance.status) {
+      // See: https://cloud.google.com/compute/docs/instances/instance-life-cycle
+      // Note that the API specifies that it may return 'SUSPENDING' and
+      // 'SUSPENDED' even though these are undocumented by the life-cycle docs.
+      case 'PROVISIONING':
+      case 'STAGING':
+        state = InstanceState.pending;
+        break;
+      case 'RUNNING':
+        state = InstanceState.running;
+        break;
+      case 'REPAIRING':
+      case 'STOPPING':
+      case 'STOPPED':
+      case 'SUSPENDING': // Undocumented state
+      case 'SUSPENDED': // Undocumented state
+      case 'TERMINATED':
+        state = InstanceState.terminated;
+        break;
+      default:
+        // Unless this happens frequently, it's probably not so bad to always
+        // just treat the instance as dead, and wait for clean-up process to
+        // kill it.
+        _log.severe('Unhandled instance.status="${instance.status}", '
+            'reason: ${instance.statusMessage}');
+        state = InstanceState.terminated;
+    }
+    return _wrapInstanceWithState(instance, zone, created, state);
+  }
+
+  CloudInstance _wrapInstanceWithState(
+    Instance instance,
+    String zone,
+    DateTime created,
+    InstanceState state,
+  ) =>
+      _GoogleCloudInstance(
+        zone,
+        instance.name ?? '',
+        created,
+        state,
+      );
+}

--- a/app/test/shared/test_services.dart
+++ b/app/test/shared/test_services.dart
@@ -42,7 +42,7 @@ void testWithProfile(
   bool processJobsWithFakeRunners = false,
 }) {
   scopedTest(name, () async {
-    _setupLogging();
+    setupLogging();
     await withFakeServices(
       fn: () async {
         registerSearchClient(SearchClient(
@@ -101,7 +101,7 @@ class _LoggerNamePattern {
 ///  * `DEBUG='* -neat_cache'`, will show output from all loggers, except 'neat_cache'.
 ///
 /// Multiple filters can be applied, the last matching filter will be applied.
-void _setupLogging() {
+void setupLogging() {
   if (_loggingDone) {
     return;
   }

--- a/app/test/task/cloudcompute/googlecloudcompute_test.dart
+++ b/app/test/task/cloudcompute/googlecloudcompute_test.dart
@@ -78,9 +78,9 @@ void main() {
     });
   },
       timeout: Timeout.parse('30m'),
-      skip: Platform.environment['GOOGLE_CLOUD_PROJECT'] != null &&
+      skip: Platform.environment['GOOGLE_CLOUD_PROJECT'] == null ||
               // Avoid running against production by accident
-              Platform.environment['GOOGLE_CLOUD_PROJECT'] != 'dartlang-pub'
-          ? false
-          : 'createGoogleCloudCompute testing requires GOOGLE_CLOUD_PROJECT');
+              Platform.environment['GOOGLE_CLOUD_PROJECT'] == 'dartlang-pub'
+          ? 'createGoogleCloudCompute testing requires GOOGLE_CLOUD_PROJECT'
+          : false);
 }

--- a/app/test/task/cloudcompute/googlecloudcompute_test.dart
+++ b/app/test/task/cloudcompute/googlecloudcompute_test.dart
@@ -1,0 +1,86 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Test is fragile because creating instances and waiting for them to start is
+// slow, and something that could throw all sorts of exceptions, we don't want
+// run this as part of normal testing.
+@Tags(['fragile'])
+import 'dart:async';
+import 'dart:io' show Platform;
+
+import 'package:appengine/appengine.dart';
+import 'package:pub_dev/task/cloudcompute/cloudcompute.dart';
+import 'package:pub_dev/task/cloudcompute/googlecloudcompute.dart';
+import 'package:test/test.dart';
+
+import '../../shared/test_services.dart';
+
+void main() {
+  test('CloudCompute from createGoogleCloudCompute()', () async {
+    setupLogging();
+
+    await withAppEngineServices(() async {
+      // Create CloudCompute instance
+      final gce = createGoogleCloudCompute(
+        client: authClientService,
+        project: Platform.environment['GOOGLE_CLOUD_PROJECT']!,
+        poolLabel: 'manual-testing',
+      );
+
+      // Fail if any instances exist
+      var instances = await gce.listInstances().toList();
+      expect(instances, isEmpty);
+
+      // Create instance that terminates
+      scheduleMicrotask(() async {
+        print('creating instance');
+        final instance = await gce.createInstance(
+          name: gce.generateInstanceName(),
+          zone: gce.zones.first,
+          dockerImage: 'busybox:1.31.1',
+          arguments: [
+            'sh',
+            '-c',
+            'whoami; date -R; sleep 5s; date -R; uname -a',
+          ],
+          description: 'test instance that terminates rather quickly',
+        );
+        print('Created instance: ${instance.name}, $instance');
+      });
+
+      // Wait until we have a terminated instance
+      print('### Wait for instance to terminate on its own');
+      while (!instances.any((i) => i.state == InstanceState.terminated)) {
+        instances = await gce.listInstances().toList();
+        print('listInstances():');
+        for (final inst in instances) {
+          print(' - ${inst.name}, state: ${inst.state}');
+        }
+        await Future.delayed(Duration(seconds: 1));
+      }
+      // Delete instances
+      print('### Delete all instances');
+      for (final inst in instances) {
+        await gce.delete(inst.zone, inst.name);
+      }
+
+      // Wait until instances are deleted from listing
+      print('### Wait for instance to disappear from listings');
+      while (instances.isNotEmpty) {
+        instances = await gce.listInstances().toList();
+        print('listInstances():');
+        for (final inst in instances) {
+          print(' - ${inst.name}, state: ${inst.state}');
+        }
+        await Future.delayed(Duration(seconds: 1));
+      }
+    });
+  },
+      timeout: Timeout.parse('30m'),
+      skip: Platform.environment['GOOGLE_CLOUD_PROJECT'] != null &&
+              // Avoid running against production by accident
+              Platform.environment['GOOGLE_CLOUD_PROJECT'] != 'dartlang-pub'
+          ? false
+          : 'createGoogleCloudCompute testing requires GOOGLE_CLOUD_PROJECT');
+}

--- a/app/test/task/cloudcompute/googlecloudcompute_test.dart
+++ b/app/test/task/cloudcompute/googlecloudcompute_test.dart
@@ -36,7 +36,7 @@ void main() {
       scheduleMicrotask(() async {
         print('creating instance');
         final instance = await gce.createInstance(
-          name: gce.generateInstanceName(),
+          instanceName: gce.generateInstanceName(),
           zone: gce.zones.first,
           dockerImage: 'busybox:1.31.1',
           arguments: [
@@ -46,7 +46,7 @@ void main() {
           ],
           description: 'test instance that terminates rather quickly',
         );
-        print('Created instance: ${instance.name}, $instance');
+        print('Created instance: ${instance.instanceName}, $instance');
       });
 
       // Wait until we have a terminated instance
@@ -55,14 +55,14 @@ void main() {
         instances = await gce.listInstances().toList();
         print('listInstances():');
         for (final inst in instances) {
-          print(' - ${inst.name}, state: ${inst.state}');
+          print(' - ${inst.instanceName}, state: ${inst.state}');
         }
         await Future.delayed(Duration(seconds: 1));
       }
       // Delete instances
       print('### Delete all instances');
       for (final inst in instances) {
-        await gce.delete(inst.zone, inst.name);
+        await gce.delete(inst.zone, inst.instanceName);
       }
 
       // Wait until instances are deleted from listing
@@ -71,7 +71,7 @@ void main() {
         instances = await gce.listInstances().toList();
         print('listInstances():');
         for (final inst in instances) {
-          print(' - ${inst.name}, state: ${inst.state}');
+          print(' - ${inst.instanceName}, state: ${inst.state}');
         }
         await Future.delayed(Duration(seconds: 1));
       }


### PR DESCRIPTION
This should allow us to manage multiple separate pools of VMs on GCE. Including listing instances, and thus, recovering state and not forgetting to delete old instances.

Hmm, I guess special care must be taken to delete instances that are created by a previous `runtimeVersion`. Though this might not be important because preemptible instances can only last 24 hours or so.