### PR TITLE
Make redirect url optional for UploaderSigner

### DIFF
--- a/app/lib/fake/backend/fake_upload_signer_service.dart
+++ b/app/lib/fake/backend/fake_upload_signer_service.dart
@@ -15,8 +15,8 @@ class FakeUploadSignerService implements UploadSignerService {
   Future<UploadInfo> buildUpload(
     String bucket,
     String object,
-    Duration lifetime,
-    String successRedirectUrl, {
+    Duration lifetime, {
+    String? successRedirectUrl,
     String predefinedAcl = 'project-private',
     int maxUploadSize = UploadSignerService.maxUploadSize,
   }) async {
@@ -24,7 +24,8 @@ class FakeUploadSignerService implements UploadSignerService {
       url: Uri.parse('$_storagePrefix/$bucket/$object').toString(),
       fields: <String, String>{
         'key': '$bucket/$object',
-        'success_action_redirect': successRedirectUrl,
+        if (successRedirectUrl != null)
+          'success_action_redirect': successRedirectUrl,
       },
     );
   }

--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -708,7 +708,12 @@ class PackageBackend {
 
     _logger
         .info('Redirecting pub client to google cloud storage (uuid: $guid)');
-    return uploadSigner.buildUpload(bucket, object, lifetime, '$url');
+    return uploadSigner.buildUpload(
+      bucket,
+      object,
+      lifetime,
+      successRedirectUrl: '$url',
+    );
   }
 
   /// Finishes the upload of a package.

--- a/app/lib/package/upload_signer_service.dart
+++ b/app/lib/package/upload_signer_service.dart
@@ -53,10 +53,14 @@ abstract class UploadSignerService {
   static const int maxUploadSize = 100 * 1024 * 1024;
   static final Uri _uploadUrl = Uri.parse('https://storage.googleapis.com');
 
-  Future<UploadInfo> buildUpload(String bucket, String object,
-      Duration lifetime, String successRedirectUrl,
-      {String predefinedAcl = 'project-private',
-      int maxUploadSize = maxUploadSize}) async {
+  Future<UploadInfo> buildUpload(
+    String bucket,
+    String object,
+    Duration lifetime, {
+    String? successRedirectUrl,
+    String predefinedAcl = 'project-private',
+    int maxUploadSize = maxUploadSize,
+  }) async {
     final now = clock.now().toUtc();
     final expirationString = now.add(lifetime).toIso8601String();
 
@@ -65,7 +69,8 @@ abstract class UploadSignerService {
       {'key': object},
       {'acl': predefinedAcl},
       {'expires': expirationString},
-      {'success_action_redirect': successRedirectUrl},
+      if (successRedirectUrl != null)
+        {'success_action_redirect': successRedirectUrl},
       ['content-length-range', 0, maxUploadSize],
     ];
 
@@ -85,7 +90,8 @@ abstract class UploadSignerService {
       'GoogleAccessId': result.googleAccessId,
       'policy': policyString,
       'signature': signatureString,
-      'success_action_redirect': successRedirectUrl,
+      if (successRedirectUrl != null)
+        'success_action_redirect': successRedirectUrl,
     };
 
     return UploadInfo(url: _uploadUrl.toString(), fields: fields);


### PR DESCRIPTION
When migrating to uniform bucket storage we probably also have to do away with: `String predefinedAcl = 'project-private',`

Because ACLs aren't allowed when using uniform access policies on GCS.