### PR TITLE
Introducing `InvalidInputException.checkPackageName`

### DIFF
--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -1494,11 +1494,7 @@ class TarballStorageNamer {
 
 /// Verify that the [package] and the optional [version] parameter looks as acceptable input.
 void checkPackageVersionParams(String package, [String? version]) {
-  InvalidInputException.checkNotNull(package, 'package');
-  InvalidInputException.check(
-      package.trim() == package, 'Invalid package name.');
-  InvalidInputException.checkStringLength(package, 'package',
-      minimum: 1, maximum: 64);
+  InvalidInputException.checkPackageName(package);
   if (version != null) {
     InvalidInputException.check(version.trim() == version, 'Invalid version.');
     InvalidInputException.checkStringLength(version, 'version',

--- a/app/lib/shared/exceptions.dart
+++ b/app/lib/shared/exceptions.dart
@@ -15,7 +15,6 @@ library exceptions;
 
 import 'package:api_builder/api_builder.dart' show ApiResponseException;
 import 'package:pub_dev/shared/utils.dart';
-import 'package:pub_semver/pub_semver.dart';
 
 /// Base class for all exceptions that are intercepted by HTTP handler wrappers.
 abstract class ResponseException extends ApiResponseException {

--- a/app/lib/shared/exceptions.dart
+++ b/app/lib/shared/exceptions.dart
@@ -158,14 +158,19 @@ class InvalidInputException extends ResponseException {
     _check(_ulidPattern.hasMatch(value), () => '"$name" is not a valid ulid.');
   }
 
+  /// Pattern for both new and existing package names.
+  ///
+  /// This allows upper-case characters in package names, because that exist in
+  /// some existing packages.
+  static final _packageNamePattern = RegExp(r'^[a-zA-Z_][a-zA-Z0-9_]*$');
+
   /// Throw [InvalidInputException] if [package] is not an allowed package name.
   static void checkPackageName(String? package) {
     // TODO: Reuse logic from validatePackageName in pub_package_reader.dart
-    //       This is for new existing packages! Not only new packages!
+    //       This is for new and existing packages! Not only new packages!
     checkNotNull(package, 'package');
     checkStringLength(package!, 'package', minimum: 1, maximum: 64);
-    checkMatchPattern(package, 'package', RegExp(r'^[a-zA-Z0-9_]+$'));
-    checkMatchPattern(package, 'package', RegExp(r'^[a-zA-Z_]'));
+    checkMatchPattern(package, 'package', _packageNamePattern);
   }
 
   /// Throw [InvalidInputException] if [version] is not a valid semantic version

--- a/app/test/account/like_test.dart
+++ b/app/test/account/like_test.dart
@@ -46,7 +46,7 @@ void main() {
 
     testWithProfile('Like non-existing package', fn: () async {
       final client = createPubApiClient(authToken: userAtPubDevAuthToken);
-      await expectApiException(client.likePackage('non-existing_package'),
+      await expectApiException(client.likePackage('non_existing_package'),
           status: 404);
     });
 
@@ -102,7 +102,7 @@ void main() {
 
     testWithProfile('Unlike non-existing package', fn: () async {
       final client = createPubApiClient(authToken: userAtPubDevAuthToken);
-      await expectApiException(client.unlikePackage('non-existing_package'),
+      await expectApiException(client.unlikePackage('non_existing_package'),
           status: 404);
     });
 
@@ -175,7 +175,7 @@ void main() {
     testWithProfile('Get number of likes for non-existing package.',
         fn: () async {
       final client = createPubApiClient(authToken: userAtPubDevAuthToken);
-      await expectApiException(client.getPackageLikes('non-existing_package'),
+      await expectApiException(client.getPackageLikes('non_existing_package'),
           status: 404);
     });
 


### PR DESCRIPTION
This makes it easier to protect APIs against garbage package names.
Thus, we produce better error messages and protect ourselves against
weir behavior whenever we expect something that should be a valid
package name.