### PR TITLE
Compensate match score with partial overlaps in the query word and the package name.

### DIFF
--- a/app/lib/search/mem_index.dart
+++ b/app/lib/search/mem_index.dart
@@ -518,7 +518,9 @@ class PackageNameIndex {
       // would cause inconsistencies and empty value in the cache.
       final nameWithoutGaps = _namesWithoutGaps[pkg] ?? _collapseName(pkg);
       final matchedChars = List<bool>.filled(nameWithoutGaps.length, false);
-      var unmatchedNgrams = 0;
+      // Extra weight to compensate partial overlaps between a word and the package name.
+      var matchedExtraWeight = 0;
+      var unmatchedExtraWeight = 0;
 
       bool matchPattern(Pattern pattern) {
         var matched = false;
@@ -531,39 +533,40 @@ class PackageNameIndex {
         return matched;
       }
 
-      // all words must be found inside the collapsed name
-      var matchesPkg = true;
       for (final word in words) {
-        // try singular/plural exact match.
-        var matchedWord = matchPattern(_pluralizePattern(word));
-
-        // try ngram matches
-        if (!matchedWord && word.length > 3) {
-          final parts = ngrams(word, 3, 3);
-          var matchedCount = 0;
-          for (final part in parts) {
-            if (matchPattern(part)) {
-              matchedCount++;
-            }
+        if (matchPattern(_pluralizePattern(word))) {
+          // shortcut calculations, this is a full-length prefix match
+          matchedExtraWeight += word.length;
+          continue;
+        }
+        final parts = word.length <= 3 ? [word] : ngrams(word, 3, 3).toList();
+        var firstUnmatchedIndex = parts.length;
+        var lastUnmatchedIndex = -1;
+        for (var i = 0; i < parts.length; i++) {
+          final part = parts[i];
+          if (!matchPattern(part)) {
+            // increase the unmatched weight
+            unmatchedExtraWeight++;
+            // mark the index for prefix and postfix match calculation
+            firstUnmatchedIndex = math.min(i, firstUnmatchedIndex);
+            lastUnmatchedIndex = i;
           }
-          unmatchedNgrams += parts.length - matchedCount;
-
-          // accept word match if more than half of the n-grams are matched
-          matchedWord = matchedCount > parts.length ~/ 2;
         }
-
-        // failed to match word
-        if (!matchedWord) {
-          matchesPkg = false;
-          break;
-        }
+        // Add the largest of prefix or postfix match as extra weight.
+        final prefixWeight = firstUnmatchedIndex;
+        final postfixWeight = lastUnmatchedIndex == -1
+            ? parts.length
+            : (parts.length - lastUnmatchedIndex - 1);
+        matchedExtraWeight += math.max(prefixWeight, postfixWeight);
       }
 
-      if (!matchesPkg) continue;
       final matchedCharCount = matchedChars.where((c) => c).length;
-      values[pkg] = matchedCharCount / (matchedChars.length + unmatchedNgrams);
+      final totalNgramCount = matchedExtraWeight + unmatchedExtraWeight;
+      final score = (matchedExtraWeight + matchedCharCount) /
+          (totalNgramCount + matchedChars.length);
+      values[pkg] = score;
     }
-    return Score(values);
+    return Score(values).removeLowValues(fraction: 0.5, minValue: 0.5);
   }
 
   Pattern _pluralizePattern(String word) {

--- a/app/lib/search/mem_index.dart
+++ b/app/lib/search/mem_index.dart
@@ -21,7 +21,7 @@ final _textSearchTimeout = Duration(milliseconds: 500);
 
 class InMemoryPackageIndex implements PackageIndex {
   final Map<String, PackageDocument> _packages = <String, PackageDocument>{};
-  final _packageNameIndex = _PackageNameIndex();
+  final _packageNameIndex = PackageNameIndex();
   final TokenIndex _descrIndex = TokenIndex();
   final TokenIndex _readmeIndex = TokenIndex();
   final TokenIndex _apiSymbolIndex = TokenIndex();
@@ -479,12 +479,19 @@ class _TextResults {
 }
 
 /// A simple (non-inverted) index designed for package name lookup.
-class _PackageNameIndex {
+@visibleForTesting
+class PackageNameIndex {
   /// Maps package name to a reduced form of the name:
   /// the same character parts, but without `-`.
   final _namesWithoutGaps = <String, String>{};
 
   String _collapseName(String package) => package.replaceAll('_', '');
+
+  void addAll(Iterable<String> packages) {
+    for (final package in packages) {
+      add(package);
+    }
+  }
 
   /// Add a new [package] to the index.
   void add(String package) {

--- a/app/lib/search/text_utils.dart
+++ b/app/lib/search/text_utils.dart
@@ -136,7 +136,7 @@ bool _isLower(String c) => c.toLowerCase() == c;
 Set<String> ngrams(String input, int minLength, int maxLength) {
   final ngrams = <String>{};
   for (int length = minLength; length <= maxLength; length++) {
-    if (input.length > length) {
+    if (input.length >= length) {
       for (int i = 0; i <= input.length - length; i++) {
         ngrams.add(input.substring(i, i + length));
       }

--- a/app/lib/task/cloudcompute/fakecloudcompute.dart
+++ b/app/lib/task/cloudcompute/fakecloudcompute.dart
@@ -16,7 +16,7 @@ class FakeCloudCompute extends CloudCompute {
   final _instances = <FakeCloudInstance>{};
 
   @override
-  final List<String> zones =  const ['zone-a', 'zone-b'];
+  final List<String> zones = const ['zone-a', 'zone-b'];
 
   @override
   String generateInstanceName() => 'instance-${_nextInstanceId++}';

--- a/app/test/search/exact_name_test.dart
+++ b/app/test/search/exact_name_test.dart
@@ -44,11 +44,14 @@ void main() {
               query: 'build_config', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
         'timestamp': isNotNull,
-        'totalCount': 1,
+        'totalCount': 2,
         'highlightedHit': {'package': 'build_config'},
         'sdkLibraryHits': [],
         'packageHits': [
-          // would be nice if `package:build` would show up here
+          {
+            'package': 'build',
+            'score': closeTo(0.71, 0.01),
+          },
         ],
       });
     });

--- a/app/test/search/flutter_iap_test.dart
+++ b/app/test/search/flutter_iap_test.dart
@@ -54,12 +54,28 @@ void main() {
               query: 'flutter iap', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
         'timestamp': isNotNull,
-        'totalCount': 1,
+        'totalCount': 5,
         'sdkLibraryHits': [],
         'packageHits': [
           {
             'package': 'flutter_iap',
             'score': 1.0,
+          },
+          {
+            'package': 'flutter_blue',
+            'score': closeTo(0.74, 0.01),
+          },
+          {
+            'package': 'flutter_redux',
+            'score': 0.7,
+          },
+          {
+            'package': 'flutter_3d_obj',
+            'score': 0.7,
+          },
+          {
+            'package': 'flutter_web_view',
+            'score': closeTo(0.64, 0.01),
           },
         ],
       });
@@ -71,10 +87,21 @@ void main() {
               query: 'flutter_iap', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
         'timestamp': isNotNull,
-        'totalCount': 1,
+        'totalCount': 5,
         'highlightedHit': {'package': 'flutter_iap'},
         'sdkLibraryHits': [],
-        'packageHits': [],
+        'packageHits': [
+          {
+            'package': 'flutter_blue',
+            'score': closeTo(0.74, 0.01),
+          },
+          {'package': 'flutter_redux', 'score': 0.7},
+          {'package': 'flutter_3d_obj', 'score': 0.7},
+          {
+            'package': 'flutter_web_view',
+            'score': closeTo(0.64, 0.01),
+          },
+        ],
       });
     });
   });

--- a/app/test/search/haversine_test.dart
+++ b/app/test/search/haversine_test.dart
@@ -409,7 +409,7 @@ MIT'''),
         'packageHits': [
           {
             'package': 'haversine',
-            'score': closeTo(0.64, 0.01),
+            'score': closeTo(0.75, 0.01),
           },
         ],
       });

--- a/app/test/search/lombok_test.dart
+++ b/app/test/search/lombok_test.dart
@@ -32,7 +32,7 @@ void main() {
         'packageHits': [
           {
             'package': 'lombok',
-            'score': closeTo(0.63, 0.01),
+            'score': closeTo(0.73, 0.01),
           },
         ],
       });

--- a/app/test/search/mem_index_test.dart
+++ b/app/test/search/mem_index_test.dart
@@ -150,7 +150,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'packageHits': [
           {
             'package': 'chrome_net',
-            'score': closeTo(0.29, 0.01),
+            'score': closeTo(0.32, 0.01),
           },
         ],
       });
@@ -230,11 +230,10 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
           ServiceSearchQuery.parse(query: 't', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
         'timestamp': isNotNull,
-        'totalCount': 2,
+        'totalCount': 1,
         'sdkLibraryHits': [],
         'packageHits': [
-          {'package': 'http', 'score': 0.5},
-          {'package': 'chrome_net', 'score': closeTo(0.11, 0.01)},
+          {'package': 'http', 'score': 0.6},
         ],
       });
     });
@@ -602,13 +601,13 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
           ServiceSearchQuery.parse(query: 'app', order: SearchOrder.text));
       expect(match.allPackageHits.map((e) => e.toJson()), [
         {'package': 'app'},
-        {'package': 'appz', 'score': 0.75},
+        {'package': 'appz', 'score': closeTo(0.86, 0.01)},
       ]);
       final match2 = await index.search(
           ServiceSearchQuery.parse(query: 'appz', order: SearchOrder.text));
       expect(match2.allPackageHits.map((e) => e.toJson()), [
         {'package': 'appz'},
-        // would be nice if `app` would show up here
+        {'package': 'app', 'score': 0.8},
       ]);
     });
   });

--- a/app/test/search/package_name_index_test.dart
+++ b/app/test/search/package_name_index_test.dart
@@ -22,7 +22,7 @@ void main() {
         index.search('fluent').getValues(),
         {
           'fluent': 1.0,
-          'fluent_ui': 0.75,
+          'fluent_ui': closeTo(0.85, 0.01),
         },
       );
     });
@@ -32,7 +32,7 @@ void main() {
         index.search('get').getValues(),
         {
           'get': 1.0,
-          'get_it': 0.6,
+          'get_it': closeTo(0.75, 0.01),
         },
       );
     });
@@ -42,7 +42,7 @@ void main() {
         index.search('modular').getValues(),
         {
           'modular': 1.0,
-          'modular_flutter': 0.5,
+          'modular_flutter': closeTo(0.67, 0.01),
         },
       );
     });
@@ -50,25 +50,28 @@ void main() {
     test('mixed parts: fluent it', () {
       expect(
         index.search('fluent it').getValues(),
-        {},
+        {
+          'fluent': closeTo(0.92, 0.01),
+          'fluent_ui': closeTo(0.80, 0.01),
+        },
       );
     });
 
     test('mixed parts: fluent flutter', () {
       expect(
         index.search('fluent flutter').getValues(),
-        {},
+        {
+          'fluent': closeTo(0.76, 0.01),
+          'fluent_ui': closeTo(0.68, 0.01),
+          'modular_flutter': closeTo(0.60, 0.01),
+        },
       );
     });
 
     test('prefix: f', () {
       expect(
         index.search('f').getValues(),
-        {
-          'fluent': closeTo(0.17, 0.01),
-          'fluent_ui': 0.125,
-          'modular_flutter': closeTo(0.07, 0.01),
-        },
+        {},
       );
     });
 
@@ -76,9 +79,7 @@ void main() {
       expect(
         index.search('fl').getValues(),
         {
-          'fluent': closeTo(0.33, 0.01),
-          'fluent_ui': 0.25,
-          'modular_flutter': closeTo(0.14, 0.01),
+          'fluent': 0.5,
         },
       );
     });
@@ -87,9 +88,8 @@ void main() {
       expect(
         index.search('flu').getValues(),
         {
-          'fluent': 0.5,
-          'fluent_ui': 0.375,
-          'modular_flutter': closeTo(0.21, 0.01),
+          'fluent': closeTo(0.67, 0.01),
+          'fluent_ui': closeTo(0.55, 0.01),
         },
       );
     });
@@ -97,7 +97,9 @@ void main() {
     test('prefix: fluf', () {
       expect(
         index.search('fluf').getValues(),
-        {},
+        {
+          'fluent': closeTo(0.50, 0.01),
+        },
       );
     });
 

--- a/app/test/search/package_name_index_test.dart
+++ b/app/test/search/package_name_index_test.dart
@@ -1,0 +1,118 @@
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:pub_dev/search/mem_index.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('PackageNameIndex', () {
+    final index = PackageNameIndex()
+      ..addAll([
+        'fluent',
+        'fluent_ui',
+        'get',
+        'get_it',
+        'modular',
+        'modular_flutter',
+      ]);
+
+    test('fluent vs fluent_ui', () {
+      expect(
+        index.search('fluent').getValues(),
+        {
+          'fluent': 1.0,
+          'fluent_ui': 0.75,
+        },
+      );
+    });
+
+    test('get vs get_it', () {
+      expect(
+        index.search('get').getValues(),
+        {
+          'get': 1.0,
+          'get_it': 0.6,
+        },
+      );
+    });
+
+    test('modular vs modular_flutter', () {
+      expect(
+        index.search('modular').getValues(),
+        {
+          'modular': 1.0,
+          'modular_flutter': 0.5,
+        },
+      );
+    });
+
+    test('mixed parts: fluent it', () {
+      expect(
+        index.search('fluent it').getValues(),
+        {},
+      );
+    });
+
+    test('mixed parts: fluent flutter', () {
+      expect(
+        index.search('fluent flutter').getValues(),
+        {},
+      );
+    });
+
+    test('prefix: f', () {
+      expect(
+        index.search('f').getValues(),
+        {
+          'fluent': closeTo(0.17, 0.01),
+          'fluent_ui': 0.125,
+          'modular_flutter': closeTo(0.07, 0.01),
+        },
+      );
+    });
+
+    test('prefix: fl', () {
+      expect(
+        index.search('fl').getValues(),
+        {
+          'fluent': closeTo(0.33, 0.01),
+          'fluent_ui': 0.25,
+          'modular_flutter': closeTo(0.14, 0.01),
+        },
+      );
+    });
+
+    test('prefix: flu', () {
+      expect(
+        index.search('flu').getValues(),
+        {
+          'fluent': 0.5,
+          'fluent_ui': 0.375,
+          'modular_flutter': closeTo(0.21, 0.01),
+        },
+      );
+    });
+
+    test('prefix: fluf', () {
+      expect(
+        index.search('fluf').getValues(),
+        {},
+      );
+    });
+
+    test('prefix: fluff', () {
+      expect(
+        index.search('fluff').getValues(),
+        {},
+      );
+    });
+
+    test('prefix: fluffy', () {
+      expect(
+        index.search('fluffy').getValues(),
+        {},
+      );
+    });
+  });
+}

--- a/app/test/search/text_utils_test.dart
+++ b/app/test/search/text_utils_test.dart
@@ -133,14 +133,17 @@ Other useful methods will be added soon...
     test('small input', () {
       expect(ngrams('', 2, 2), isEmpty);
       expect(ngrams('a', 2, 2), isEmpty);
-      expect(ngrams('ab', 2, 2), isEmpty);
+      expect(ngrams('ab', 3, 3), isEmpty);
+      expect(ngrams('ab', 3, 4), isEmpty);
     });
 
     test('2-grams', () {
+      expect(ngrams('ab', 2, 2), {'ab'});
       expect(ngrams('abcdef', 2, 2), {'ab', 'bc', 'cd', 'de', 'ef'});
     });
 
     test('2-3-grams', () {
+      expect(ngrams('ab', 2, 3), {'ab'});
       expect(ngrams('abcdef', 2, 3), {
         'ab',
         'bc',


### PR DESCRIPTION
- fixes a bug in the ngram extraction
- should improve #5571, by adding more weight to prefix/postfix matches of the query word, even for longer package names
- actually improves test cases where previously we were expecting more packages to show up
- only the flutter_iap test seems to be a questionable change, as it exposes more package name with flutter, but maybe that is okay
- should not increase the search/matching complexity too much, although where previously we may have cut short on a non-matching word, we no longer do that