### PR TITLE
Consolidate the use of Platform.environment into env_config.dart.

### DIFF
--- a/app/bin/tools/delete_all_staging.dart
+++ b/app/bin/tools/delete_all_staging.dart
@@ -29,7 +29,7 @@ final _argParser = ArgParser()
 
 /// Deletes every (used) entity on staging.
 Future main(List<String> args) async {
-  if (envConfig.gcloudProject != 'dartlang-pub-dev') {
+  if (envConfig.googleCloudProject != 'dartlang-pub-dev') {
     print('**ERROR**: The tool is meant to be used only on staging.');
     return;
   }

--- a/app/lib/search/handlers.dart
+++ b/app/lib/search/handlers.dart
@@ -3,9 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:convert';
 
-import 'package:crypto/crypto.dart';
 import 'package:logging/logging.dart';
 import 'package:pub_dev/search/dart_sdk_mem_index.dart';
 import 'package:shelf/shelf.dart' as shelf;
@@ -84,12 +82,8 @@ Future<shelf.Response> _searchHandler(shelf.Request request) async {
 
   if (request.requestedUri.queryParameters['debug-drift'] == '1') {
     final info = await packageIndex.indexInfo();
-    final instance = envConfig.gaeInstance ?? '-';
     return jsonResponse({
-      'gae': {
-        'version': envConfig.gaeVersion ?? '-',
-        'instanceHash': sha256.convert(utf8.encode(instance)).toString(),
-      },
+      'gae': envConfig.debugMap(includeInstanceHash: true),
       'index': info.toJson(),
       ...result.toJson(),
     });

--- a/app/lib/service/entrypoint/analyzer.dart
+++ b/app/lib/service/entrypoint/analyzer.dart
@@ -34,13 +34,7 @@ class AnalyzerCommand extends Command {
 
   @override
   Future<void> run() async {
-    // Ensure that we're running in the right environment, or is running locally
-    if (envConfig.gaeService != null && envConfig.gaeService != name) {
-      throw StateError(
-        'Cannot start "$name" in "${envConfig.gaeService}" environment',
-      );
-    }
-
+    envConfig.checkServiceEnvironment(name);
     await startIsolates(
       logger: logger,
       frontendEntryPoint: _frontendMain,

--- a/app/lib/service/entrypoint/dartdoc.dart
+++ b/app/lib/service/entrypoint/dartdoc.dart
@@ -34,13 +34,7 @@ class DartdocCommand extends Command {
 
   @override
   Future<void> run() async {
-    // Ensure that we're running in the right environment, or is running locally
-    if (envConfig.gaeService != null && envConfig.gaeService != name) {
-      throw StateError(
-        'Cannot start "$name" in "${envConfig.gaeService}" environment',
-      );
-    }
-
+    envConfig.checkServiceEnvironment(name);
     await startIsolates(
       logger: logger,
       frontendEntryPoint: _frontendMain,

--- a/app/lib/service/entrypoint/frontend.dart
+++ b/app/lib/service/entrypoint/frontend.dart
@@ -37,13 +37,7 @@ class DefaultCommand extends Command {
 
   @override
   Future<void> run() async {
-    // Ensure that we're running in the right environment, or is running locally
-    if (envConfig.gaeService != null && envConfig.gaeService != name) {
-      throw StateError(
-        'Cannot start "$name" in "${envConfig.gaeService}" environment',
-      );
-    }
-
+    envConfig.checkServiceEnvironment(name);
     await startIsolates(
       logger: _logger,
       frontendEntryPoint: _main,

--- a/app/lib/service/entrypoint/search.dart
+++ b/app/lib/service/entrypoint/search.dart
@@ -35,13 +35,7 @@ class SearchCommand extends Command {
 
   @override
   Future<void> run() async {
-    // Ensure that we're running in the right environment, or is running locally
-    if (envConfig.gaeService != null && envConfig.gaeService != name) {
-      throw StateError(
-        'Cannot start "$name" in "${envConfig.gaeService}" environment',
-      );
-    }
-
+    envConfig.checkServiceEnvironment(name);
     await startIsolates(
       logger: _logger,
       frontendEntryPoint: _main,

--- a/app/lib/service/youtube/backend.dart
+++ b/app/lib/service/youtube/backend.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
 import 'dart:math' as math;
 
 import 'package:clock/clock.dart';
@@ -11,9 +10,10 @@ import 'package:gcloud/service_scope.dart' as ss;
 import 'package:googleapis/youtube/v3.dart';
 import 'package:googleapis_auth/auth_io.dart';
 import 'package:meta/meta.dart';
-import 'package:pub_dev/shared/cached_value.dart';
 import 'package:retry/retry.dart';
 
+import '../../shared/cached_value.dart';
+import '../../shared/env_config.dart';
 import '../secret/backend.dart';
 
 /// The playlist ID for the Package of the Week channel.
@@ -107,7 +107,7 @@ class _PkgOfWeekVideoFetcher {
   }
 
   Future<List<PkgOfWeekVideo>> _fetchVideoList() async {
-    final apiKey = Platform.environment['YOUTUBE_API_KEY'] ??
+    final apiKey = envConfig.youtubeApiKey ??
         await secretBackend.lookup(SecretKey.youtubeApiKey);
     if (apiKey == null || apiKey.isEmpty) return <PkgOfWeekVideo>[];
 

--- a/app/lib/shared/configuration.dart
+++ b/app/lib/shared/configuration.dart
@@ -11,6 +11,7 @@ import 'package:json_annotation/json_annotation.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as path;
 import 'package:pub_dev/frontend/static_files.dart';
+import 'package:pub_dev/shared/env_config.dart';
 import 'package:yaml/yaml.dart';
 
 part 'configuration.g.dart';
@@ -192,14 +193,14 @@ class Configuration {
     // This is undocumented for appengine custom runtime, but documented for the
     // other runtimes:
     // https://cloud.google.com/appengine/docs/standard/nodejs/runtime
-    final projectId = Platform.environment['GOOGLE_CLOUD_PROJECT'];
+    final projectId = envConfig.googleCloudProject;
     if (projectId == null || projectId.isEmpty) {
       throw StateError(
         'Environment variable \$GOOGLE_CLOUD_PROJECT must be specified!',
       );
     }
 
-    final configFile =
+    final configFile = envConfig.configPath ??
         path.join(resolveAppDir(), 'config', projectId + '.yaml');
     if (!File(configFile).existsSync()) {
       throw StateError('Could not find configuration file: "$configFile"');

--- a/app/lib/shared/env_config.dart
+++ b/app/lib/shared/env_config.dart
@@ -12,6 +12,8 @@ import 'package:meta/meta.dart';
 final envConfig = _EnvConfig();
 
 /// Configuration from the environment variables.
+///
+/// TODO: consider migrating the values to be non-nullable
 class _EnvConfig {
   /// Service in AppEngine that this process is running in, `null` if running
   /// locally.

--- a/app/lib/shared/handlers.dart
+++ b/app/lib/shared/handlers.dart
@@ -6,6 +6,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:logging/logging.dart';
+import 'package:pub_dev/shared/env_config.dart';
 import 'package:shelf/shelf.dart' as shelf;
 
 import '../frontend/request_context.dart';
@@ -80,10 +81,7 @@ shelf.Response rejectRobotsHandler(shelf.Request request) =>
 /// Combines a response for /debug requests
 shelf.Response debugResponse([Map<String, dynamic>? data]) {
   final map = <String, dynamic>{
-    'env': {
-      'GAE_VERSION': Platform.environment['GAE_VERSION'],
-      'GAE_MEMORY_MB': Platform.environment['GAE_MEMORY_MB'],
-    },
+    'env': envConfig.debugMap(),
     'vm': {
       'numberOfProcessors': Platform.numberOfProcessors,
       'currentRss': ProcessInfo.currentRss,

--- a/app/lib/shared/redis_cache.dart
+++ b/app/lib/shared/redis_cache.dart
@@ -4,7 +4,6 @@
 
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
 import 'dart:math';
 
 import 'package:_pub_shared/data/package_api.dart' show VersionScore;
@@ -13,6 +12,7 @@ import 'package:gcloud/service_scope.dart' as ss;
 import 'package:logging/logging.dart';
 import 'package:neat_cache/cache_provider.dart';
 import 'package:neat_cache/neat_cache.dart';
+import 'package:pub_dev/shared/env_config.dart';
 
 import '../account/models.dart' show LikeData, UserSessionData;
 import '../dartdoc/models.dart' show DartdocEntry, FileInfo;
@@ -292,7 +292,7 @@ void _registerDelayedCachePurgerKey(_DelayedCachePurger value) =>
 /// - otherwise, a local in-memory cache.
 Future<void> setupCache() async {
   // Use in-memory cache, if not running on AppEngine
-  if (Platform.environment.containsKey('GAE_VERSION')) {
+  if (envConfig.isRunningInAppengine) {
     await _registerRedisCache();
   } else {
     _log.warning('using in-memory cache instead of redis');

--- a/app/test/service/youtube/backend_test.dart
+++ b/app/test/service/youtube/backend_test.dart
@@ -2,17 +2,17 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:io';
 import 'dart:math';
 
 import 'package:pub_dev/service/youtube/backend.dart';
+import 'package:pub_dev/shared/env_config.dart';
 import 'package:test/test.dart';
 
 import '../../shared/test_services.dart';
 
 void main() {
   testWithProfile('when a key is specified, it has items', fn: () async {
-    if (Platform.environment.containsKey('YOUTUBE_API_KEY')) {
+    if (envConfig.youtubeApiKey != null) {
       final videos = youtubeBackend.getTopPackageOfWeekVideos(count: 100);
       expect(videos, hasLength(greaterThan(5)));
       // Guard against bad pagination / duplicate ids.

--- a/app/test/shared/misc_source_files_test.dart
+++ b/app/test/shared/misc_source_files_test.dart
@@ -48,6 +48,24 @@ void main() {
     }
   });
 
+  test('Platform.environment only in env_config.dart', () async {
+    final exceptions = [
+      './lib/shared/configuration.dart',
+      './lib/shared/env_config.dart',
+      './test/shared/misc_source_files_test.dart',
+    ];
+    final files = Directory('.')
+        .listSync(recursive: true)
+        .whereType<File>()
+        .where((f) => f.path.endsWith('.dart'));
+    for (final file in files) {
+      final content = await file.readAsString();
+      expect(content.contains('Platform.environment'),
+          exceptions.contains(file.path),
+          reason: '${file.path} contains Platform.environment');
+    }
+  });
+
   test('cache-control is set only in frontend/handlers/headers.dart', () async {
     final exceptions = [
       'lib/frontend/handlers/headers.dart',

--- a/app/test/shared/test_services.dart
+++ b/app/test/shared/test_services.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:io';
-
 import 'package:clock/clock.dart';
 import 'package:gcloud/db.dart';
 import 'package:gcloud/service_scope.dart';
@@ -19,6 +17,7 @@ import 'package:pub_dev/search/handlers.dart';
 import 'package:pub_dev/search/search_client.dart';
 import 'package:pub_dev/search/updater.dart';
 import 'package:pub_dev/service/services.dart';
+import 'package:pub_dev/shared/env_config.dart';
 import 'package:pub_dev/shared/integrity.dart';
 import 'package:pub_dev/tool/test_profile/import_source.dart';
 import 'package:pub_dev/tool/test_profile/importer.dart';
@@ -106,7 +105,7 @@ void setupLogging() {
     return;
   }
   _loggingDone = true;
-  final debugEnv = (Platform.environment['DEBUG'] ?? '').trim();
+  final debugEnv = (envConfig.debug ?? '').trim();
   if (debugEnv.isEmpty) {
     return;
   }

--- a/app/test/task/cloudcompute/googlecloudcompute_test.dart
+++ b/app/test/task/cloudcompute/googlecloudcompute_test.dart
@@ -7,9 +7,9 @@
 // run this as part of normal testing.
 @Tags(['fragile'])
 import 'dart:async';
-import 'dart:io' show Platform;
 
 import 'package:appengine/appengine.dart';
+import 'package:pub_dev/shared/env_config.dart';
 import 'package:pub_dev/task/cloudcompute/cloudcompute.dart';
 import 'package:pub_dev/task/cloudcompute/googlecloudcompute.dart';
 import 'package:test/test.dart';
@@ -24,7 +24,7 @@ void main() {
       // Create CloudCompute instance
       final gce = createGoogleCloudCompute(
         client: authClientService,
-        project: Platform.environment['GOOGLE_CLOUD_PROJECT']!,
+        project: envConfig.googleCloudProject!,
         poolLabel: 'manual-testing',
       );
 
@@ -78,9 +78,9 @@ void main() {
     });
   },
       timeout: Timeout.parse('30m'),
-      skip: Platform.environment['GOOGLE_CLOUD_PROJECT'] == null ||
+      skip: envConfig.googleCloudProject == null ||
               // Avoid running against production by accident
-              Platform.environment['GOOGLE_CLOUD_PROJECT'] == 'dartlang-pub'
+              envConfig.googleCloudProject == 'dartlang-pub'
           ? 'createGoogleCloudCompute testing requires GOOGLE_CLOUD_PROJECT'
           : false);
 }

--- a/app/test/task/global_lock_test.dart
+++ b/app/test/task/global_lock_test.dart
@@ -2,10 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:io' show Platform;
-
 import 'package:appengine/appengine.dart';
 import 'package:clock/clock.dart';
+import 'package:pub_dev/shared/env_config.dart';
 import 'package:pub_dev/task/global_lock.dart' show GlobalLock;
 import 'package:test/test.dart';
 import 'package:ulid/ulid.dart' show Ulid;
@@ -76,10 +75,10 @@ void main() {
       ]);
     });
   },
-      skip: Platform.environment['GOOGLE_CLOUD_PROJECT'] != null &&
-              Platform.environment['GOOGLE_CLOUD_PROJECT']!.isNotEmpty &&
+      skip: envConfig.googleCloudProject != null &&
+              envConfig.googleCloudProject!.isNotEmpty &&
               // Avoid running against production by accident
-              Platform.environment['GOOGLE_CLOUD_PROJECT'] != 'dartlang-pub'
+              envConfig.googleCloudProject != 'dartlang-pub'
           ? false
           : 'GlobalLock testing requires GOOGLE_CLOUD_PROJECT');
 }


### PR DESCRIPTION
- closes #5578 (I think we've reduced the scope and there is not much left to do there)
- also added a test to check if `Platform.environment` is used elsewhere