### PR TITLE
Hash in the path-segments for the caching header of the main.dart.js parts files

### DIFF
--- a/app/lib/frontend/static_files.dart
+++ b/app/lib/frontend/static_files.dart
@@ -355,7 +355,7 @@ Future<void> updateWebCssBuild() async {
 /// It can parse the following formats:
 /// - /static/<url-hash>/path/to/resource
 /// - /static/path/to/resource?hash=<url-hash>
-/// 
+///
 /// TODO: remove after we no longer use url-hash
 class ParsedStaticUrl {
   final String? urlHash;

--- a/app/lib/frontend/static_files.dart
+++ b/app/lib/frontend/static_files.dart
@@ -86,6 +86,7 @@ Directory _resolveDir(String relativePath) =>
 /// Stores static files in memory for fast http serving.
 class StaticFileCache {
   final _files = <String, StaticFile>{};
+  String? _etag;
 
   StaticFileCache();
 
@@ -162,6 +163,7 @@ class StaticFileCache {
   @visibleForTesting
   void addFile(StaticFile file) {
     _files[file.requestPath] = file;
+    _etag = null;
   }
 
   @visibleForTesting
@@ -170,6 +172,16 @@ class StaticFileCache {
   bool hasFile(String requestPath) => _files.containsKey(requestPath);
 
   StaticFile? getFile(String requestPath) => _files[requestPath];
+
+  String get etag => _etag ??= _calculateEtagOfEtags().substring(0, 8);
+
+  String _calculateEtagOfEtags() {
+    final files = List<StaticFile>.from(_files.values);
+    files.sort((a, b) => a.requestPath.compareTo(b.requestPath));
+    final concatenatedEtags = files.map((f) => f.etag).join(' ');
+    final digest = crypto.sha256.convert(utf8.encode(concatenatedEtags));
+    return digest.bytes.map((b) => (b & 31).toRadixString(32)).join();
+  }
 }
 
 /// Stores the content and metadata of a statically served file.
@@ -224,10 +236,15 @@ class StaticUrls {
 
   /// Returns the hashed URL of the static resource like:
   /// `/static/img/logo.gif => /static/img/logo.gif?hash=etag_hash`
-  String getAssetUrl(String requestPath) {
+  String getAssetUrl(
+    String requestPath, {
+    bool usePathHash = false,
+  }) {
     final file = staticFileCache.getFile(requestPath);
     if (file == null) {
       throw Exception('Static resource not found: $requestPath');
+    } else if (usePathHash && requestPath.startsWith('/static/')) {
+      return '/static/hash-${staticFileCache.etag}/${requestPath.substring(8)}';
     } else {
       return file.cacheableUrl;
     }
@@ -331,5 +348,35 @@ Future<void> updateWebCssBuild() async {
         'STDOUT:\n${pr.stdout}\n\n'
         'STDERR:\n${pr.stderr}';
     throw Exception(message);
+  }
+}
+
+@visibleForTesting
+class ParsedStaticUrl {
+  final String? urlHash;
+  final String? pathHash;
+  final String filePath;
+
+  ParsedStaticUrl._({
+    required this.urlHash,
+    required this.pathHash,
+    required this.filePath,
+  });
+
+  factory ParsedStaticUrl.parse(Uri requestedUri) {
+    final normalizedRequestPath = path.normalize(requestedUri.path);
+    final pathSegments =
+        List<String>.from(Uri(path: normalizedRequestPath).pathSegments);
+    String? pathHash;
+    var filePath = normalizedRequestPath;
+    if (pathSegments.length > 2 && pathSegments[1].startsWith('hash-')) {
+      pathHash = pathSegments.removeAt(1).substring(5);
+      filePath = '/${Uri(pathSegments: pathSegments)}';
+    }
+    return ParsedStaticUrl._(
+      urlHash: requestedUri.queryParameters['hash'],
+      pathHash: pathHash,
+      filePath: filePath,
+    );
   }
 }

--- a/app/lib/frontend/static_files.dart
+++ b/app/lib/frontend/static_files.dart
@@ -351,7 +351,12 @@ Future<void> updateWebCssBuild() async {
   }
 }
 
-@visibleForTesting
+/// Parses the static resource URL and returns the parsed hash values.
+/// It can parse the following formats:
+/// - /static/<url-hash>/path/to/resource
+/// - /static/path/to/resource?hash=<url-hash>
+/// 
+/// TODO: remove after we no longer use url-hash
 class ParsedStaticUrl {
   final String? urlHash;
   final String? pathHash;

--- a/app/lib/frontend/templates/views/shared/layout.dart
+++ b/app/lib/frontend/templates/views/shared/layout.dart
@@ -115,7 +115,8 @@ d.Node pageLayoutNode({
               defer: true,
             ),
             d.script(
-              src: staticUrls.getAssetUrl('/static/js/script.dart.js'),
+              src: staticUrls.getAssetUrl('/static/js/script.dart.js',
+                  usePathHash: true),
               defer: true,
             ),
             d.meta(

--- a/app/test/frontend/golden/authorized_page.html
+++ b/app/test/frontend/golden/authorized_page.html
@@ -26,7 +26,7 @@
     <link rel="stylesheet" type="text/css" href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842"/>
     <link rel="stylesheet" type="text/css" href="/static/css/style.css?hash=mocked_hash_537099079"/>
     <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
-    <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
+    <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <meta name="google-signin-client_id" content=""/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
     <link rel="preload" href="/static/highlight/highlight-with-init.js?hash=mocked_hash_670483893" as="script"/>

--- a/app/test/frontend/golden/consent_page.html
+++ b/app/test/frontend/golden/consent_page.html
@@ -26,7 +26,7 @@
     <link rel="stylesheet" type="text/css" href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842"/>
     <link rel="stylesheet" type="text/css" href="/static/css/style.css?hash=mocked_hash_537099079"/>
     <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
-    <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
+    <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <meta name="google-signin-client_id" content=""/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
     <meta name="pub-page-data" content="eyJjb25zZW50SWQiOiIxMjM0LTU2NzgifQ=="/>

--- a/app/test/frontend/golden/create_publisher_page.html
+++ b/app/test/frontend/golden/create_publisher_page.html
@@ -26,7 +26,7 @@
     <link rel="stylesheet" type="text/css" href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842"/>
     <link rel="stylesheet" type="text/css" href="/static/css/style.css?hash=mocked_hash_537099079"/>
     <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
-    <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
+    <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <meta name="google-signin-client_id" content=""/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
   </head>

--- a/app/test/frontend/golden/error_page.html
+++ b/app/test/frontend/golden/error_page.html
@@ -26,7 +26,7 @@
     <link rel="stylesheet" type="text/css" href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842"/>
     <link rel="stylesheet" type="text/css" href="/static/css/style.css?hash=mocked_hash_537099079"/>
     <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
-    <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
+    <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <meta name="google-signin-client_id" content=""/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
   </head>

--- a/app/test/frontend/golden/help_page.html
+++ b/app/test/frontend/golden/help_page.html
@@ -27,7 +27,7 @@
     <link rel="stylesheet" type="text/css" href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842"/>
     <link rel="stylesheet" type="text/css" href="/static/css/style.css?hash=mocked_hash_537099079"/>
     <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
-    <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
+    <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <meta name="google-signin-client_id" content=""/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
   </head>

--- a/app/test/frontend/golden/landing_page.html
+++ b/app/test/frontend/golden/landing_page.html
@@ -27,7 +27,7 @@
     <link rel="stylesheet" type="text/css" href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842"/>
     <link rel="stylesheet" type="text/css" href="/static/css/style.css?hash=mocked_hash_537099079"/>
     <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
-    <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
+    <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <meta name="google-signin-client_id" content=""/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
     <link rel="preload" href="/static/img/hero-bg-static.svg?hash=mocked_hash_434391776" as="image"/>

--- a/app/test/frontend/golden/my_activity_log_page.html
+++ b/app/test/frontend/golden/my_activity_log_page.html
@@ -26,7 +26,7 @@
     <link rel="stylesheet" type="text/css" href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842"/>
     <link rel="stylesheet" type="text/css" href="/static/css/style.css?hash=mocked_hash_537099079"/>
     <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
-    <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
+    <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <meta name="google-signin-client_id" content=""/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
   </head>

--- a/app/test/frontend/golden/my_liked_packages.html
+++ b/app/test/frontend/golden/my_liked_packages.html
@@ -26,7 +26,7 @@
     <link rel="stylesheet" type="text/css" href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842"/>
     <link rel="stylesheet" type="text/css" href="/static/css/style.css?hash=mocked_hash_537099079"/>
     <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
-    <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
+    <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <meta name="google-signin-client_id" content=""/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
   </head>

--- a/app/test/frontend/golden/my_packages.html
+++ b/app/test/frontend/golden/my_packages.html
@@ -26,7 +26,7 @@
     <link rel="stylesheet" type="text/css" href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842"/>
     <link rel="stylesheet" type="text/css" href="/static/css/style.css?hash=mocked_hash_537099079"/>
     <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
-    <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
+    <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <meta name="google-signin-client_id" content=""/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
   </head>

--- a/app/test/frontend/golden/my_publishers.html
+++ b/app/test/frontend/golden/my_publishers.html
@@ -26,7 +26,7 @@
     <link rel="stylesheet" type="text/css" href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842"/>
     <link rel="stylesheet" type="text/css" href="/static/css/style.css?hash=mocked_hash_537099079"/>
     <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
-    <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
+    <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <meta name="google-signin-client_id" content=""/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
   </head>

--- a/app/test/frontend/golden/pkg_activity_log_page.html
+++ b/app/test/frontend/golden/pkg_activity_log_page.html
@@ -26,7 +26,7 @@
     <link rel="stylesheet" type="text/css" href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842"/>
     <link rel="stylesheet" type="text/css" href="/static/css/style.css?hash=mocked_hash_537099079"/>
     <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
-    <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
+    <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <meta name="google-signin-client_id" content=""/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
     <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJveHlnZW4iLCJ2ZXJzaW9uIjoiMS4yLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlfX0="/>

--- a/app/test/frontend/golden/pkg_admin_page.html
+++ b/app/test/frontend/golden/pkg_admin_page.html
@@ -26,7 +26,7 @@
     <link rel="stylesheet" type="text/css" href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842"/>
     <link rel="stylesheet" type="text/css" href="/static/css/style.css?hash=mocked_hash_537099079"/>
     <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
-    <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
+    <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <meta name="google-signin-client_id" content=""/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
     <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJveHlnZW4iLCJ2ZXJzaW9uIjoiMS4yLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlfX0="/>

--- a/app/test/frontend/golden/pkg_changelog_page.html
+++ b/app/test/frontend/golden/pkg_changelog_page.html
@@ -27,7 +27,7 @@
     <link rel="stylesheet" type="text/css" href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842"/>
     <link rel="stylesheet" type="text/css" href="/static/css/style.css?hash=mocked_hash_537099079"/>
     <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
-    <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
+    <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <meta name="google-signin-client_id" content=""/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
     <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJveHlnZW4iLCJ2ZXJzaW9uIjoiMS4yLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlfX0="/>

--- a/app/test/frontend/golden/pkg_example_page.html
+++ b/app/test/frontend/golden/pkg_example_page.html
@@ -27,7 +27,7 @@
     <link rel="stylesheet" type="text/css" href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842"/>
     <link rel="stylesheet" type="text/css" href="/static/css/style.css?hash=mocked_hash_537099079"/>
     <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
-    <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
+    <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <meta name="google-signin-client_id" content=""/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
     <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJveHlnZW4iLCJ2ZXJzaW9uIjoiMS4yLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlfX0="/>

--- a/app/test/frontend/golden/pkg_index_page.html
+++ b/app/test/frontend/golden/pkg_index_page.html
@@ -27,7 +27,7 @@
     <link rel="stylesheet" type="text/css" href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842"/>
     <link rel="stylesheet" type="text/css" href="/static/css/style.css?hash=mocked_hash_537099079"/>
     <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
-    <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
+    <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <meta name="google-signin-client_id" content=""/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
   </head>

--- a/app/test/frontend/golden/pkg_install_page.html
+++ b/app/test/frontend/golden/pkg_install_page.html
@@ -27,7 +27,7 @@
     <link rel="stylesheet" type="text/css" href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842"/>
     <link rel="stylesheet" type="text/css" href="/static/css/style.css?hash=mocked_hash_537099079"/>
     <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
-    <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
+    <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <meta name="google-signin-client_id" content=""/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
     <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJveHlnZW4iLCJ2ZXJzaW9uIjoiMS4yLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlfX0="/>

--- a/app/test/frontend/golden/pkg_score_page.html
+++ b/app/test/frontend/golden/pkg_score_page.html
@@ -27,7 +27,7 @@
     <link rel="stylesheet" type="text/css" href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842"/>
     <link rel="stylesheet" type="text/css" href="/static/css/style.css?hash=mocked_hash_537099079"/>
     <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
-    <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
+    <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <meta name="google-signin-client_id" content=""/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
     <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJveHlnZW4iLCJ2ZXJzaW9uIjoiMS4yLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlfX0="/>

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -27,7 +27,7 @@
     <link rel="stylesheet" type="text/css" href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842"/>
     <link rel="stylesheet" type="text/css" href="/static/css/style.css?hash=mocked_hash_537099079"/>
     <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
-    <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
+    <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <meta name="google-signin-client_id" content=""/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
     <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJveHlnZW4iLCJ2ZXJzaW9uIjoiMS4yLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlfX0="/>

--- a/app/test/frontend/golden/pkg_show_page_discontinued.html
+++ b/app/test/frontend/golden/pkg_show_page_discontinued.html
@@ -27,7 +27,7 @@
     <link rel="stylesheet" type="text/css" href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842"/>
     <link rel="stylesheet" type="text/css" href="/static/css/style.css?hash=mocked_hash_537099079"/>
     <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
-    <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
+    <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <meta name="google-signin-client_id" content=""/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
     <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJwa2ciLCJ2ZXJzaW9uIjoiMS4wLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOnRydWV9fQ=="/>

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -27,7 +27,7 @@
     <link rel="stylesheet" type="text/css" href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842"/>
     <link rel="stylesheet" type="text/css" href="/static/css/style.css?hash=mocked_hash_537099079"/>
     <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
-    <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
+    <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <meta name="google-signin-client_id" content=""/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
     <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJmbHV0dGVyX3RpdGFuaXVtIiwidmVyc2lvbiI6IjEuMTAuMCIsImxpa2VzIjowLCJpc0Rpc2NvbnRpbnVlZCI6ZmFsc2V9fQ=="/>

--- a/app/test/frontend/golden/pkg_show_page_legacy.html
+++ b/app/test/frontend/golden/pkg_show_page_legacy.html
@@ -27,7 +27,7 @@
     <link rel="stylesheet" type="text/css" href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842"/>
     <link rel="stylesheet" type="text/css" href="/static/css/style.css?hash=mocked_hash_537099079"/>
     <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
-    <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
+    <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <meta name="google-signin-client_id" content=""/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
     <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJwa2ciLCJ2ZXJzaW9uIjoiMS4wLjAtbGVnYWN5IiwibGlrZXMiOjAsImlzRGlzY29udGludWVkIjpmYWxzZX19"/>

--- a/app/test/frontend/golden/pkg_show_page_publisher.html
+++ b/app/test/frontend/golden/pkg_show_page_publisher.html
@@ -27,7 +27,7 @@
     <link rel="stylesheet" type="text/css" href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842"/>
     <link rel="stylesheet" type="text/css" href="/static/css/style.css?hash=mocked_hash_537099079"/>
     <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
-    <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
+    <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <meta name="google-signin-client_id" content=""/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
     <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJuZW9uIiwidmVyc2lvbiI6IjEuMC4wIiwibGlrZXMiOjAsInB1Ymxpc2hlcklkIjoiZXhhbXBsZS5jb20iLCJpc0Rpc2NvbnRpbnVlZCI6ZmFsc2V9fQ=="/>

--- a/app/test/frontend/golden/pkg_show_page_retracted.html
+++ b/app/test/frontend/golden/pkg_show_page_retracted.html
@@ -27,7 +27,7 @@
     <link rel="stylesheet" type="text/css" href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842"/>
     <link rel="stylesheet" type="text/css" href="/static/css/style.css?hash=mocked_hash_537099079"/>
     <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
-    <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
+    <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <meta name="google-signin-client_id" content=""/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
     <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJwa2ciLCJ2ZXJzaW9uIjoiMS4wLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlfX0="/>

--- a/app/test/frontend/golden/pkg_show_page_retracted_non_retracted_version.html
+++ b/app/test/frontend/golden/pkg_show_page_retracted_non_retracted_version.html
@@ -27,7 +27,7 @@
     <link rel="stylesheet" type="text/css" href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842"/>
     <link rel="stylesheet" type="text/css" href="/static/css/style.css?hash=mocked_hash_537099079"/>
     <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
-    <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
+    <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <meta name="google-signin-client_id" content=""/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
     <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJwa2ciLCJ2ZXJzaW9uIjoiMi4wLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlfX0="/>

--- a/app/test/frontend/golden/pkg_show_version_page.html
+++ b/app/test/frontend/golden/pkg_show_version_page.html
@@ -27,7 +27,7 @@
     <link rel="stylesheet" type="text/css" href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842"/>
     <link rel="stylesheet" type="text/css" href="/static/css/style.css?hash=mocked_hash_537099079"/>
     <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
-    <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
+    <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <meta name="google-signin-client_id" content=""/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
     <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJveHlnZW4iLCJ2ZXJzaW9uIjoiMS4yLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlfX0="/>

--- a/app/test/frontend/golden/pkg_versions_page.html
+++ b/app/test/frontend/golden/pkg_versions_page.html
@@ -27,7 +27,7 @@
     <link rel="stylesheet" type="text/css" href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842"/>
     <link rel="stylesheet" type="text/css" href="/static/css/style.css?hash=mocked_hash_537099079"/>
     <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
-    <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
+    <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <meta name="google-signin-client_id" content=""/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
     <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJveHlnZW4iLCJ2ZXJzaW9uIjoiMS4yLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlfX0="/>

--- a/app/test/frontend/golden/publisher_activity_log_page.html
+++ b/app/test/frontend/golden/publisher_activity_log_page.html
@@ -27,7 +27,7 @@
     <link rel="stylesheet" type="text/css" href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842"/>
     <link rel="stylesheet" type="text/css" href="/static/css/style.css?hash=mocked_hash_537099079"/>
     <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
-    <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
+    <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <meta name="google-signin-client_id" content=""/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
     <meta name="pub-page-data" content="eyJwdWJsaXNoZXIiOnsicHVibGlzaGVySWQiOiJleGFtcGxlLmNvbSJ9fQ=="/>

--- a/app/test/frontend/golden/publisher_admin_page.html
+++ b/app/test/frontend/golden/publisher_admin_page.html
@@ -27,7 +27,7 @@
     <link rel="stylesheet" type="text/css" href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842"/>
     <link rel="stylesheet" type="text/css" href="/static/css/style.css?hash=mocked_hash_537099079"/>
     <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
-    <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
+    <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <meta name="google-signin-client_id" content=""/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
     <meta name="pub-page-data" content="eyJwdWJsaXNoZXIiOnsicHVibGlzaGVySWQiOiJleGFtcGxlLmNvbSJ9fQ=="/>

--- a/app/test/frontend/golden/publisher_list_page.html
+++ b/app/test/frontend/golden/publisher_list_page.html
@@ -27,7 +27,7 @@
     <link rel="stylesheet" type="text/css" href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842"/>
     <link rel="stylesheet" type="text/css" href="/static/css/style.css?hash=mocked_hash_537099079"/>
     <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
-    <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
+    <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <meta name="google-signin-client_id" content=""/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
   </head>

--- a/app/test/frontend/golden/publisher_packages_page.html
+++ b/app/test/frontend/golden/publisher_packages_page.html
@@ -27,7 +27,7 @@
     <link rel="stylesheet" type="text/css" href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842"/>
     <link rel="stylesheet" type="text/css" href="/static/css/style.css?hash=mocked_hash_537099079"/>
     <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
-    <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
+    <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <meta name="google-signin-client_id" content=""/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
     <meta name="pub-page-data" content="eyJwdWJsaXNoZXIiOnsicHVibGlzaGVySWQiOiJleGFtcGxlLmNvbSJ9fQ=="/>

--- a/app/test/frontend/golden/search_page.html
+++ b/app/test/frontend/golden/search_page.html
@@ -27,7 +27,7 @@
     <link rel="stylesheet" type="text/css" href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842"/>
     <link rel="stylesheet" type="text/css" href="/static/css/style.css?hash=mocked_hash_537099079"/>
     <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
-    <script src="/static/js/script.dart.js?hash=mocked_hash_573569793" defer="defer"></script>
+    <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <meta name="google-signin-client_id" content=""/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
   </head>

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -108,7 +108,9 @@ void main() {
           .replaceAll('Pana <code>$panaVersion</code>,',
               'Pana <code>%%pana-version%%</code>,')
           .replaceAll('Dart <code>$toolStableDartSdkVersion</code>',
-              'Dart <code>%%stable-dart-version%%</code>');
+              'Dart <code>%%stable-dart-version%%</code>')
+          .replaceAll('/static/hash-${staticFileCache.etag}/',
+              '/static/hash-%%etag%%/');
 
       // Pretty printing output using XML parser and formatter.
       final xmlDoc = xml.XmlDocument.parse(

--- a/pkg/pub_integration/lib/src/headless_env.dart
+++ b/pkg/pub_integration/lib/src/headless_env.dart
@@ -155,6 +155,16 @@ class HeadlessEnv {
           serverErrors.add('${rs.request.url} returned bad HTML: $e');
         }
       }
+
+      final uri = Uri.parse(rs.url);
+      if (uri.pathSegments.length > 1 && uri.pathSegments.first == 'static') {
+        final cacheHeader = rs.headers[HttpHeaders.cacheControlHeader];
+        if (cacheHeader == null ||
+            !cacheHeader.contains('public') ||
+            !cacheHeader.contains('max-age')) {
+          serverErrors.add('Static ${rs.url} is without public caching.');
+        }
+      }
     });
 
     // print console messages


### PR DESCRIPTION
- the cache-level etag is calculated from the individual file's etags
- the requested URL pattern is `/static/hash-<etag>/<rest>` parsed into `/static/<rest>` using public cache headers when the `<etag>` matches the current one
- right now only the main.dart.js files are inside that hashed path segment, other files will be migrated in a subsequent PR (it also involves changing a hash-verification test that needs to be updated)
- added a cache header test in puppeteer response evaluation to catch this happening again
- deployed and verified in staging, inclusion and admin works