### PR TITLE
Properly detect deployment failures

### DIFF
--- a/tool/.deploy.sh
+++ b/tool/.deploy.sh
@@ -1,6 +1,11 @@
-#!/bin/bash -e
+#!/bin/bash
 
 # This script is used by .deploy.yaml
+
+# Always exit on error
+set -e
+# Print an error message, if exiting non-zero
+trap 'if [ $? -ne 0 ]; then echo "Deployment failed!"; fi' EXIT
 
 # This only works with PROJECT_ID defined
 if [ -z "$PROJECT_ID" ]; then


### PR DESCRIPTION
Using `#!/bin/bash -e` doesn't work when it is invoked using `bash tool/deploy.sh`.
So it's safer to use `set -e`.