### PR TITLE
Almost every static asset behind /static/hash-<hash>/ URL.

### DIFF
--- a/app/lib/frontend/static_files.dart
+++ b/app/lib/frontend/static_files.dart
@@ -202,7 +202,7 @@ class StaticFile {
 
   String get contentAsString => utf8.decode(bytes);
 
-  late final String cacheableUrl =
+  late final String _cacheableUrl =
       Uri(path: requestPath, queryParameters: {'hash': etag}).toString();
 
   late final gzippedBytes = GZipCodec(level: 9).encode(bytes);
@@ -235,18 +235,15 @@ class StaticUrls {
   StaticUrls._();
 
   /// Returns the hashed URL of the static resource like:
-  /// `/static/img/logo.gif => /static/img/logo.gif?hash=etag_hash`
-  String getAssetUrl(
-    String requestPath, {
-    bool usePathHash = false,
-  }) {
+  /// `/static/img/logo.gif => /static/hash-<hash>/img/logo.gif`
+  String getAssetUrl(String requestPath) {
     final file = staticFileCache.getFile(requestPath);
     if (file == null) {
       throw Exception('Static resource not found: $requestPath');
-    } else if (usePathHash && requestPath.startsWith('/static/')) {
+    } else if (requestPath.startsWith('/static/')) {
       return '/static/hash-${staticFileCache.etag}/${requestPath.substring(8)}';
     } else {
-      return file.cacheableUrl;
+      return file._cacheableUrl;
     }
   }
 }

--- a/app/lib/frontend/templates/views/page/standalone.dart
+++ b/app/lib/frontend/templates/views/page/standalone.dart
@@ -11,7 +11,7 @@ d.Node standalonePageNode(
   d.Node content, {
   d.Image? sideImage,
 }) {
-  assert(sideImage == null || sideImage.src.contains('?hash='));
+  assert(sideImage == null || sideImage.src.contains('/static/hash-'));
   final hasSideImage = sideImage != null;
   return d.div(
     classes: ['standalone-wrapper', if (hasSideImage) '-has-side-image'],

--- a/app/lib/frontend/templates/views/shared/layout.dart
+++ b/app/lib/frontend/templates/views/shared/layout.dart
@@ -115,8 +115,7 @@ d.Node pageLayoutNode({
               defer: true,
             ),
             d.script(
-              src: staticUrls.getAssetUrl('/static/js/script.dart.js',
-                  usePathHash: true),
+              src: staticUrls.getAssetUrl('/static/js/script.dart.js'),
               defer: true,
             ),
             d.meta(

--- a/app/test/dartdoc/customization_test.dart
+++ b/app/test/dartdoc/customization_test.dart
@@ -18,7 +18,11 @@ const String goldenDir = 'test/dartdoc/golden';
 final _regenerateGoldens = false;
 
 void main() {
+  String dehashUrl(String c) => c.replaceAll(
+      '/static/hash-${staticFileCache.etag}/', '/static/hash-%%etag%%/');
+
   void expectGoldenFile(String content, String fileName) {
+    content = dehashUrl(content);
     if (fileName.endsWith('.html')) {
       // Making sure it is valid HTML
       final htmlParser = HtmlParser(content, strict: true);
@@ -29,7 +33,9 @@ void main() {
       // If this fails, update the hard-coded customization URL to match it.
       final logoElem = doc.documentElement!.getElementsByTagName('img').first;
       expect(
-          logoElem.attributes['src']!.endsWith(staticUrls.dartLogoSvg), isTrue);
+          logoElem.attributes['src']!
+              .endsWith(dehashUrl(staticUrls.dartLogoSvg)),
+          isTrue);
 
       // Pretty printing output using XML formatter.
       final xmlRoot = _toXml(doc.documentElement!);

--- a/app/test/dartdoc/dartdoc_report_test.dart
+++ b/app/test/dartdoc/dartdoc_report_test.dart
@@ -32,7 +32,7 @@ void main() {
       expect(reports.last, isNull);
       final report = reports[1]!;
       expect(report.dartdocEntry, isNotNull);
-      expect(report.dartdocEntry!.totalSize, 440);
+      expect(report.dartdocEntry!.totalSize, 416);
       expect(report.documentationSection!.grantedPoints, 10);
       expect(report.documentationSection!.maxPoints, 10);
       expect(
@@ -47,7 +47,7 @@ void main() {
 
       expect(entries.first, isNotNull);
       expect(entries.last, isNull);
-      expect(entries[1]!.totalSize, 440);
+      expect(entries[1]!.totalSize, 416);
     });
   });
 }

--- a/app/test/dartdoc/golden/dygraph_0.1.1_index.out.html
+++ b/app/test/dartdoc/golden/dygraph_0.1.1_index.out.html
@@ -2,14 +2,14 @@
   <head>
     <meta name="robots" content="noindex"/>
     <script async="async" src="https://www.googletagmanager.com/gtm.js?id=GTM-MX6DBN9"/>
-    <script src="/static/js/gtm.js?hash=haghe0d3b0u12tpur6h3r5fabermv6eb"/>
+    <script src="/static/hash-%%etag%%/js/gtm.js"/>
     <meta charset="utf-8"/>
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1, user-scalable=no"/>
     <meta name="generator" content="made with love by dartdoc 0.32.1"/>
     <meta name="description" content="dygraph API docs, for the Dart programming language."/>
     <title>dygraph - Dart API docs</title>
-    <link rel="stylesheet" type="text/css" href="/static/css/github-markdown.css?hash=t2ti0tfkd3q7dsh5njovil42c3bnhf5s"/>
+    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/github-markdown.css"/>
     <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet"/>
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet"/>
     <link rel="stylesheet" href="static-assets/github.css"/>
@@ -23,7 +23,7 @@
     <header id="title">
       <button id="sidenav-left-toggle" type="button"></button>
       <a class="hidden-xs" href="/">
-        <img src="/static/img/dart-logo.svg?hash=gqea88bp2ii6tqf5rn5p8jtg22mma809" style="height: 30px; margin-right: 1em;"/>
+        <img src="/static/hash-%%etag%%/img/dart-logo.svg" style="height: 30px; margin-right: 1em;"/>
       </a>
       <ol class="breadcrumbs gt-separated dark hidden-xs">
         <li>

--- a/app/test/dartdoc/golden/pana_0.12.2_index.out.html
+++ b/app/test/dartdoc/golden/pana_0.12.2_index.out.html
@@ -2,7 +2,7 @@
   <head>
     <meta name="robots" content="noindex"/>
     <script async="async" src="https://www.googletagmanager.com/gtm.js?id=GTM-MX6DBN9"/>
-    <script src="/static/js/gtm.js?hash=haghe0d3b0u12tpur6h3r5fabermv6eb"/>
+    <script src="/static/hash-%%etag%%/js/gtm.js"/>
     <meta charset="utf-8"/>
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1, user-scalable=no"/>
@@ -12,7 +12,7 @@
     <link rel="alternate" href="/documentation/pana/latest/"/>
     <link rel="canonical" href="https://pub.dev/documentation/pana/0.12.2/"/>
     <link rel="preconnect" href="https://fonts.gstatic.com"/>
-    <link rel="stylesheet" type="text/css" href="/static/css/github-markdown.css?hash=t2ti0tfkd3q7dsh5njovil42c3bnhf5s"/>
+    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/github-markdown.css"/>
     <link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,300;0,400;0,500;0,700;1,400&amp;display=swap" rel="stylesheet"/>
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet"/>
     <link rel="stylesheet" href="static-assets/github.css?v1"/>
@@ -25,7 +25,7 @@
     <header id="title">
       <button id="sidenav-left-toggle" type="button"></button>
       <a class="hidden-xs" href="/">
-        <img src="/static/img/dart-logo.svg?hash=gqea88bp2ii6tqf5rn5p8jtg22mma809" style="height: 30px; margin-right: 1em;"/>
+        <img src="/static/hash-%%etag%%/img/dart-logo.svg" style="height: 30px; margin-right: 1em;"/>
       </a>
       <ol class="breadcrumbs gt-separated dark hidden-xs">
         <li>

--- a/app/test/dartdoc/golden/pana_0.12.2_license_file_class.out.html
+++ b/app/test/dartdoc/golden/pana_0.12.2_license_file_class.out.html
@@ -2,7 +2,7 @@
   <head>
     <meta name="robots" content="noindex"/>
     <script async="async" src="https://www.googletagmanager.com/gtm.js?id=GTM-MX6DBN9"/>
-    <script src="/static/js/gtm.js?hash=haghe0d3b0u12tpur6h3r5fabermv6eb"/>
+    <script src="/static/hash-%%etag%%/js/gtm.js"/>
     <meta charset="utf-8"/>
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1, user-scalable=no"/>
@@ -23,7 +23,7 @@
     <header id="title">
       <button id="sidenav-left-toggle" type="button"></button>
       <a class="hidden-xs" href="/">
-        <img src="/static/img/dart-logo.svg?hash=gqea88bp2ii6tqf5rn5p8jtg22mma809" style="height: 30px; margin-right: 1em;"/>
+        <img src="/static/hash-%%etag%%/img/dart-logo.svg" style="height: 30px; margin-right: 1em;"/>
       </a>
       <ol class="breadcrumbs gt-separated dark hidden-xs">
         <li>

--- a/app/test/dartdoc/golden/pana_0.12.2_license_file_constructor.out.html
+++ b/app/test/dartdoc/golden/pana_0.12.2_license_file_constructor.out.html
@@ -2,7 +2,7 @@
   <head>
     <meta name="robots" content="noindex"/>
     <script async="async" src="https://www.googletagmanager.com/gtm.js?id=GTM-MX6DBN9"/>
-    <script src="/static/js/gtm.js?hash=haghe0d3b0u12tpur6h3r5fabermv6eb"/>
+    <script src="/static/hash-%%etag%%/js/gtm.js"/>
     <meta charset="utf-8"/>
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1, user-scalable=no"/>
@@ -23,7 +23,7 @@
     <header id="title">
       <button id="sidenav-left-toggle" type="button"></button>
       <a class="hidden-xs" href="/">
-        <img src="/static/img/dart-logo.svg?hash=gqea88bp2ii6tqf5rn5p8jtg22mma809" style="height: 30px; margin-right: 1em;"/>
+        <img src="/static/hash-%%etag%%/img/dart-logo.svg" style="height: 30px; margin-right: 1em;"/>
       </a>
       <ol class="breadcrumbs gt-separated dark hidden-xs">
         <li>

--- a/app/test/dartdoc/golden/pana_0.12.2_license_file_name_field.out.html
+++ b/app/test/dartdoc/golden/pana_0.12.2_license_file_name_field.out.html
@@ -2,7 +2,7 @@
   <head>
     <meta name="robots" content="noindex"/>
     <script async="async" src="https://www.googletagmanager.com/gtm.js?id=GTM-MX6DBN9"/>
-    <script src="/static/js/gtm.js?hash=haghe0d3b0u12tpur6h3r5fabermv6eb"/>
+    <script src="/static/hash-%%etag%%/js/gtm.js"/>
     <meta charset="utf-8"/>
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1, user-scalable=no"/>
@@ -23,7 +23,7 @@
     <header id="title">
       <button id="sidenav-left-toggle" type="button"></button>
       <a class="hidden-xs" href="/">
-        <img src="/static/img/dart-logo.svg?hash=gqea88bp2ii6tqf5rn5p8jtg22mma809" style="height: 30px; margin-right: 1em;"/>
+        <img src="/static/hash-%%etag%%/img/dart-logo.svg" style="height: 30px; margin-right: 1em;"/>
       </a>
       <ol class="breadcrumbs gt-separated dark hidden-xs">
         <li>

--- a/app/test/dartdoc/golden/pana_0.12.2_pretty_json.out.html
+++ b/app/test/dartdoc/golden/pana_0.12.2_pretty_json.out.html
@@ -2,7 +2,7 @@
   <head>
     <meta name="robots" content="noindex"/>
     <script async="async" src="https://www.googletagmanager.com/gtm.js?id=GTM-MX6DBN9"/>
-    <script src="/static/js/gtm.js?hash=haghe0d3b0u12tpur6h3r5fabermv6eb"/>
+    <script src="/static/hash-%%etag%%/js/gtm.js"/>
     <meta charset="utf-8"/>
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1, user-scalable=no"/>
@@ -23,7 +23,7 @@
     <header id="title">
       <button id="sidenav-left-toggle" type="button"></button>
       <a class="hidden-xs" href="/">
-        <img src="/static/img/dart-logo.svg?hash=gqea88bp2ii6tqf5rn5p8jtg22mma809" style="height: 30px; margin-right: 1em;"/>
+        <img src="/static/hash-%%etag%%/img/dart-logo.svg" style="height: 30px; margin-right: 1em;"/>
       </a>
       <ol class="breadcrumbs gt-separated dark hidden-xs">
         <li>

--- a/app/test/frontend/golden/authorized_page.html
+++ b/app/test/frontend/golden/authorized_page.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
   <head>
     <script src="https://www.googletagmanager.com/gtm.js?id=GTM-MX6DBN9" async="async"></script>
-    <script src="/static/js/gtm.js?hash=mocked_hash_451823545"></script>
+    <script src="/static/hash-%%etag%%/js/gtm.js"></script>
     <meta charset="utf-8"/>
     <meta http-equiv="x-ua-compatible" content="ie=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
@@ -10,26 +10,26 @@
     <meta name="twitter:card" content="summary"/>
     <meta name="twitter:site" content="@dart_lang"/>
     <meta name="twitter:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
-    <meta name="twitter:image" content="https://pub.dev/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta name="twitter:image" content="https://pub.dev/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <meta property="og:type" content="website"/>
     <meta property="og:site_name" content="Dart packages"/>
     <meta property="og:title" content="Pub Authorized Successfully"/>
     <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
-    <meta property="og:image" content="https://pub.dev/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta property="og:image" content="https://pub.dev/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <title>Pub Authorized Successfully</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Google+Sans:300,400,500|Google+Sans+Display:400|Roboto:300,400,500,700|Roboto+Mono:300,400,700&amp;display=swap"/>
-    <meta content="/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta content="/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
-    <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/osd.xml?hash=mocked_hash_869379763"/>
+    <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/hash-%%etag%%/osd.xml"/>
     <meta name="description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
-    <link rel="stylesheet" type="text/css" href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842"/>
-    <link rel="stylesheet" type="text/css" href="/static/css/style.css?hash=mocked_hash_537099079"/>
-    <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
+    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/material/material-components-web.min.css"/>
+    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/style.css"/>
+    <script src="/static/hash-%%etag%%/material/material-components-web.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <meta name="google-signin-client_id" content=""/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
-    <link rel="preload" href="/static/highlight/highlight-with-init.js?hash=mocked_hash_670483893" as="script"/>
+    <link rel="preload" href="/static/hash-%%etag%%/highlight/highlight-with-init.js" as="script"/>
   </head>
   <body>
     <noscript>
@@ -38,7 +38,7 @@
     <div class="site-header">
       <button class="hamburger" aria-label="menu toggle"></button>
       <a class="logo" href="/">
-        <img class="site-logo" src="/static/img/pub-dev-logo-2x.png?hash=mocked_hash_685890546" alt="pub logo" width="135" height="30"/>
+        <img class="site-logo" src="/static/hash-%%etag%%/img/pub-dev-logo-2x.png" alt="pub logo" width="135" height="30"/>
       </a>
       <div class="site-header-space"></div>
       <div class="site-header-mask"></div>
@@ -77,7 +77,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Pub.dev
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="/help/search" rel="noopener" target="_blank">Searching for packages</a>
@@ -87,7 +87,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Flutter
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://flutter.io/using-packages/" rel="noopener" target="_blank">Using packages</a>
@@ -98,7 +98,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Dart
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://dart.dev/tools/pub/get-started" rel="noopener" target="_blank">Using packages</a>
@@ -125,12 +125,12 @@
       <a class="link sep" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link sep" href="/help">Help</a>
       <a class="link icon sep" href="/feed.atom">
-        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
+        <img class="inline-icon" src="/static/hash-%%etag%%/img/rss-feed-icon.svg" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
       </a>
       <a class="link icon github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">
-        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
+        <img class="inline-icon" src="/static/hash-%%etag%%/img/bug-report-white-96px.png" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
       </a>
     </footer>
-    <script src="/static/highlight/highlight-with-init.js?hash=mocked_hash_670483893" defer="defer"></script>
+    <script src="/static/hash-%%etag%%/highlight/highlight-with-init.js" defer="defer"></script>
   </body>
 </html>

--- a/app/test/frontend/golden/consent_page.html
+++ b/app/test/frontend/golden/consent_page.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
   <head>
     <script src="https://www.googletagmanager.com/gtm.js?id=GTM-MX6DBN9" async="async"></script>
-    <script src="/static/js/gtm.js?hash=mocked_hash_451823545"></script>
+    <script src="/static/hash-%%etag%%/js/gtm.js"></script>
     <meta charset="utf-8"/>
     <meta http-equiv="x-ua-compatible" content="ie=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
@@ -10,22 +10,22 @@
     <meta name="twitter:card" content="summary"/>
     <meta name="twitter:site" content="@dart_lang"/>
     <meta name="twitter:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
-    <meta name="twitter:image" content="https://pub.dev/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta name="twitter:image" content="https://pub.dev/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <meta property="og:type" content="website"/>
     <meta property="og:site_name" content="Dart packages"/>
     <meta property="og:title" content="Consent"/>
     <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
-    <meta property="og:image" content="https://pub.dev/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta property="og:image" content="https://pub.dev/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <title>Consent</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Google+Sans:300,400,500|Google+Sans+Display:400|Roboto:300,400,500,700|Roboto+Mono:300,400,700&amp;display=swap"/>
-    <meta content="/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta content="/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
-    <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/osd.xml?hash=mocked_hash_869379763"/>
+    <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/hash-%%etag%%/osd.xml"/>
     <meta name="description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
-    <link rel="stylesheet" type="text/css" href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842"/>
-    <link rel="stylesheet" type="text/css" href="/static/css/style.css?hash=mocked_hash_537099079"/>
-    <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
+    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/material/material-components-web.min.css"/>
+    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/style.css"/>
+    <script src="/static/hash-%%etag%%/material/material-components-web.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <meta name="google-signin-client_id" content=""/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
@@ -38,7 +38,7 @@
     <div class="site-header">
       <button class="hamburger" aria-label="menu toggle"></button>
       <a class="logo" href="/">
-        <img class="site-logo" src="/static/img/pub-dev-logo-2x.png?hash=mocked_hash_685890546" alt="pub logo" width="135" height="30"/>
+        <img class="site-logo" src="/static/hash-%%etag%%/img/pub-dev-logo-2x.png" alt="pub logo" width="135" height="30"/>
       </a>
       <div class="site-header-space"></div>
       <div class="site-header-mask"></div>
@@ -77,7 +77,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Pub.dev
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="/help/search" rel="noopener" target="_blank">Searching for packages</a>
@@ -87,7 +87,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Flutter
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://flutter.io/using-packages/" rel="noopener" target="_blank">Using packages</a>
@@ -98,7 +98,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Dart
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://dart.dev/tools/pub/get-started" rel="noopener" target="_blank">Using packages</a>
@@ -128,10 +128,10 @@
       <a class="link sep" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link sep" href="/help">Help</a>
       <a class="link icon sep" href="/feed.atom">
-        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
+        <img class="inline-icon" src="/static/hash-%%etag%%/img/rss-feed-icon.svg" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
       </a>
       <a class="link icon github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">
-        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
+        <img class="inline-icon" src="/static/hash-%%etag%%/img/bug-report-white-96px.png" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
       </a>
     </footer>
   </body>

--- a/app/test/frontend/golden/create_publisher_page.html
+++ b/app/test/frontend/golden/create_publisher_page.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
   <head>
     <script src="https://www.googletagmanager.com/gtm.js?id=GTM-MX6DBN9" async="async"></script>
-    <script src="/static/js/gtm.js?hash=mocked_hash_451823545"></script>
+    <script src="/static/hash-%%etag%%/js/gtm.js"></script>
     <meta charset="utf-8"/>
     <meta http-equiv="x-ua-compatible" content="ie=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
@@ -10,22 +10,22 @@
     <meta name="twitter:card" content="summary"/>
     <meta name="twitter:site" content="@dart_lang"/>
     <meta name="twitter:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
-    <meta name="twitter:image" content="https://pub.dev/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta name="twitter:image" content="https://pub.dev/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <meta property="og:type" content="website"/>
     <meta property="og:site_name" content="Dart packages"/>
     <meta property="og:title" content="Create publisher"/>
     <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
-    <meta property="og:image" content="https://pub.dev/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta property="og:image" content="https://pub.dev/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <title>Create publisher</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Google+Sans:300,400,500|Google+Sans+Display:400|Roboto:300,400,500,700|Roboto+Mono:300,400,700&amp;display=swap"/>
-    <meta content="/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta content="/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
-    <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/osd.xml?hash=mocked_hash_869379763"/>
+    <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/hash-%%etag%%/osd.xml"/>
     <meta name="description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
-    <link rel="stylesheet" type="text/css" href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842"/>
-    <link rel="stylesheet" type="text/css" href="/static/css/style.css?hash=mocked_hash_537099079"/>
-    <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
+    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/material/material-components-web.min.css"/>
+    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/style.css"/>
+    <script src="/static/hash-%%etag%%/material/material-components-web.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <meta name="google-signin-client_id" content=""/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
@@ -37,7 +37,7 @@
     <div class="site-header">
       <button class="hamburger" aria-label="menu toggle"></button>
       <a class="logo" href="/">
-        <img class="site-logo" src="/static/img/pub-dev-logo-2x.png?hash=mocked_hash_685890546" alt="pub logo" width="135" height="30"/>
+        <img class="site-logo" src="/static/hash-%%etag%%/img/pub-dev-logo-2x.png" alt="pub logo" width="135" height="30"/>
       </a>
       <div class="site-header-space"></div>
       <div class="site-header-mask"></div>
@@ -76,7 +76,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Pub.dev
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="/help/search" rel="noopener" target="_blank">Searching for packages</a>
@@ -86,7 +86,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Flutter
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://flutter.io/using-packages/" rel="noopener" target="_blank">Using packages</a>
@@ -97,7 +97,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Dart
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://dart.dev/tools/pub/get-started" rel="noopener" target="_blank">Using packages</a>
@@ -190,10 +190,10 @@
       <a class="link sep" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link sep" href="/help">Help</a>
       <a class="link icon sep" href="/feed.atom">
-        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
+        <img class="inline-icon" src="/static/hash-%%etag%%/img/rss-feed-icon.svg" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
       </a>
       <a class="link icon github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">
-        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
+        <img class="inline-icon" src="/static/hash-%%etag%%/img/bug-report-white-96px.png" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
       </a>
     </footer>
   </body>

--- a/app/test/frontend/golden/error_page.html
+++ b/app/test/frontend/golden/error_page.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
   <head>
     <script src="https://www.googletagmanager.com/gtm.js?id=GTM-MX6DBN9" async="async"></script>
-    <script src="/static/js/gtm.js?hash=mocked_hash_451823545"></script>
+    <script src="/static/hash-%%etag%%/js/gtm.js"></script>
     <meta charset="utf-8"/>
     <meta http-equiv="x-ua-compatible" content="ie=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
@@ -10,22 +10,22 @@
     <meta name="twitter:card" content="summary"/>
     <meta name="twitter:site" content="@dart_lang"/>
     <meta name="twitter:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
-    <meta name="twitter:image" content="https://pub.dev/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta name="twitter:image" content="https://pub.dev/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <meta property="og:type" content="website"/>
     <meta property="og:site_name" content="Dart packages"/>
     <meta property="og:title" content="error_title"/>
     <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
-    <meta property="og:image" content="https://pub.dev/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta property="og:image" content="https://pub.dev/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <title>error_title</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Google+Sans:300,400,500|Google+Sans+Display:400|Roboto:300,400,500,700|Roboto+Mono:300,400,700&amp;display=swap"/>
-    <meta content="/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta content="/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
-    <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/osd.xml?hash=mocked_hash_869379763"/>
+    <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/hash-%%etag%%/osd.xml"/>
     <meta name="description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
-    <link rel="stylesheet" type="text/css" href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842"/>
-    <link rel="stylesheet" type="text/css" href="/static/css/style.css?hash=mocked_hash_537099079"/>
-    <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
+    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/material/material-components-web.min.css"/>
+    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/style.css"/>
+    <script src="/static/hash-%%etag%%/material/material-components-web.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <meta name="google-signin-client_id" content=""/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
@@ -37,7 +37,7 @@
     <div class="site-header">
       <button class="hamburger" aria-label="menu toggle"></button>
       <a class="logo" href="/">
-        <img class="site-logo" src="/static/img/pub-dev-logo-2x.png?hash=mocked_hash_685890546" alt="pub logo" width="135" height="30"/>
+        <img class="site-logo" src="/static/hash-%%etag%%/img/pub-dev-logo-2x.png" alt="pub logo" width="135" height="30"/>
       </a>
       <div class="site-header-space"></div>
       <div class="site-header-mask"></div>
@@ -71,7 +71,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Pub.dev
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="/help/search" rel="noopener" target="_blank">Searching for packages</a>
@@ -81,7 +81,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Flutter
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://flutter.io/using-packages/" rel="noopener" target="_blank">Using packages</a>
@@ -92,7 +92,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Dart
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://dart.dev/tools/pub/get-started" rel="noopener" target="_blank">Using packages</a>
@@ -123,10 +123,10 @@
       <a class="link sep" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link sep" href="/help">Help</a>
       <a class="link icon sep" href="/feed.atom">
-        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
+        <img class="inline-icon" src="/static/hash-%%etag%%/img/rss-feed-icon.svg" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
       </a>
       <a class="link icon github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">
-        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
+        <img class="inline-icon" src="/static/hash-%%etag%%/img/bug-report-white-96px.png" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
       </a>
     </footer>
   </body>

--- a/app/test/frontend/golden/help_page.html
+++ b/app/test/frontend/golden/help_page.html
@@ -2,31 +2,31 @@
 <html lang="en-us">
   <head>
     <script src="https://www.googletagmanager.com/gtm.js?id=GTM-MX6DBN9" async="async"></script>
-    <script src="/static/js/gtm.js?hash=mocked_hash_451823545"></script>
+    <script src="/static/hash-%%etag%%/js/gtm.js"></script>
     <meta charset="utf-8"/>
     <meta http-equiv="x-ua-compatible" content="ie=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <meta name="twitter:card" content="summary"/>
     <meta name="twitter:site" content="@dart_lang"/>
     <meta name="twitter:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
-    <meta name="twitter:image" content="https://pub.dev/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta name="twitter:image" content="https://pub.dev/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <meta property="og:type" content="website"/>
     <meta property="og:site_name" content="Dart packages"/>
     <meta property="og:title" content="Help | Dart packages"/>
     <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
-    <meta property="og:image" content="https://pub.dev/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta property="og:image" content="https://pub.dev/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <meta property="og:url" content="https://pub.dev/help"/>
     <title>Help | Dart packages</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Google+Sans:300,400,500|Google+Sans+Display:400|Roboto:300,400,500,700|Roboto+Mono:300,400,700&amp;display=swap"/>
-    <meta content="/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta content="/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
-    <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/osd.xml?hash=mocked_hash_869379763"/>
+    <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/hash-%%etag%%/osd.xml"/>
     <link rel="canonical" href="https://pub.dev/help"/>
     <meta name="description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
-    <link rel="stylesheet" type="text/css" href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842"/>
-    <link rel="stylesheet" type="text/css" href="/static/css/style.css?hash=mocked_hash_537099079"/>
-    <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
+    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/material/material-components-web.min.css"/>
+    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/style.css"/>
+    <script src="/static/hash-%%etag%%/material/material-components-web.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <meta name="google-signin-client_id" content=""/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
@@ -38,7 +38,7 @@
     <div class="site-header">
       <button class="hamburger" aria-label="menu toggle"></button>
       <a class="logo" href="/">
-        <img class="site-logo" src="/static/img/pub-dev-logo-2x.png?hash=mocked_hash_685890546" alt="pub logo" width="135" height="30"/>
+        <img class="site-logo" src="/static/hash-%%etag%%/img/pub-dev-logo-2x.png" alt="pub logo" width="135" height="30"/>
       </a>
       <div class="site-header-space"></div>
       <div class="site-header-mask"></div>
@@ -77,7 +77,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Pub.dev
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="/help/search" rel="noopener" target="_blank">Searching for packages</a>
@@ -87,7 +87,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Flutter
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://flutter.io/using-packages/" rel="noopener" target="_blank">Using packages</a>
@@ -98,7 +98,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Dart
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://dart.dev/tools/pub/get-started" rel="noopener" target="_blank">Using packages</a>
@@ -111,7 +111,7 @@
     <main class="container">
       <div class="standalone-wrapper -has-side-image">
         <div class="standalone-side-image-block">
-          <img class="standalone-side-image" src="/static/img/packages-side.png?hash=mocked_hash_335626183" alt="cover image decorating the page" width="400" height="400"/>
+          <img class="standalone-side-image" src="/static/hash-%%etag%%/img/packages-side.png" alt="cover image decorating the page" width="400" height="400"/>
         </div>
         <div class="standalone-content">
           <h1 class="hash-header" id="help">
@@ -148,10 +148,10 @@
       <a class="link sep" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link sep" href="/help">Help</a>
       <a class="link icon sep" href="/feed.atom">
-        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
+        <img class="inline-icon" src="/static/hash-%%etag%%/img/rss-feed-icon.svg" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
       </a>
       <a class="link icon github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">
-        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
+        <img class="inline-icon" src="/static/hash-%%etag%%/img/bug-report-white-96px.png" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
       </a>
     </footer>
   </body>

--- a/app/test/frontend/golden/landing_page.html
+++ b/app/test/frontend/golden/landing_page.html
@@ -2,36 +2,36 @@
 <html lang="en-us">
   <head>
     <script src="https://www.googletagmanager.com/gtm.js?id=GTM-MX6DBN9" async="async"></script>
-    <script src="/static/js/gtm.js?hash=mocked_hash_451823545"></script>
+    <script src="/static/hash-%%etag%%/js/gtm.js"></script>
     <meta charset="utf-8"/>
     <meta http-equiv="x-ua-compatible" content="ie=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <meta name="twitter:card" content="summary"/>
     <meta name="twitter:site" content="@dart_lang"/>
     <meta name="twitter:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
-    <meta name="twitter:image" content="https://pub.dev/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta name="twitter:image" content="https://pub.dev/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <meta property="og:type" content="website"/>
     <meta property="og:site_name" content="Dart packages"/>
     <meta property="og:title" content="Dart packages"/>
     <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
-    <meta property="og:image" content="https://pub.dev/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta property="og:image" content="https://pub.dev/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <meta property="og:url" content="https://pub.dev/"/>
     <title>Dart packages</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Google+Sans:300,400,500|Google+Sans+Display:400|Roboto:300,400,500,700|Roboto+Mono:300,400,700&amp;display=swap"/>
-    <meta content="/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta content="/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
-    <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/osd.xml?hash=mocked_hash_869379763"/>
+    <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/hash-%%etag%%/osd.xml"/>
     <link rel="canonical" href="https://pub.dev/"/>
     <meta name="description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
-    <link rel="stylesheet" type="text/css" href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842"/>
-    <link rel="stylesheet" type="text/css" href="/static/css/style.css?hash=mocked_hash_537099079"/>
-    <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
+    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/material/material-components-web.min.css"/>
+    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/style.css"/>
+    <script src="/static/hash-%%etag%%/material/material-components-web.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <meta name="google-signin-client_id" content=""/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
-    <link rel="preload" href="/static/img/hero-bg-static.svg?hash=mocked_hash_434391776" as="image"/>
-    <link rel="preload" href="/static/img/square-bg-full-2x.png?hash=mocked_hash_779845367" as="image"/>
+    <link rel="preload" href="/static/hash-%%etag%%/img/hero-bg-static.svg" as="image"/>
+    <link rel="preload" href="/static/hash-%%etag%%/img/square-bg-full-2x.png" as="image"/>
   </head>
   <body class="page-landing">
     <noscript>
@@ -71,7 +71,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Pub.dev
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="/help/search" rel="noopener" target="_blank">Searching for packages</a>
@@ -81,7 +81,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Flutter
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://flutter.io/using-packages/" rel="noopener" target="_blank">Using packages</a>
@@ -92,7 +92,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Dart
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://dart.dev/tools/pub/get-started" rel="noopener" target="_blank">Using packages</a>
@@ -105,7 +105,7 @@
     <div class="_banner-bg">
       <div class="container home-banner">
         <h2 class="_visuallyhidden">pub.dev package manager</h2>
-        <img class="logo" src="/static/img/pub-dev-logo.svg?hash=mocked_hash_207464415" alt="pub.dev package manager" width="328" height="70"/>
+        <img class="logo" src="/static/hash-%%etag%%/img/pub-dev-logo.svg" alt="pub.dev package manager" width="328" height="70"/>
         <form class="search-bar banner-item" action="/packages">
           <input class="input" name="q" placeholder="Search packages" autocomplete="on" autofocus="autofocus"/>
           <button class="icon" aria-label="search"></button>
@@ -117,7 +117,7 @@
           <a href="https://flutter.dev/" rel="noopener" target="_blank">Flutter</a>
           apps.
         </p>
-        <img src="/static/img/supported-by-google.png?hash=mocked_hash_305864058" alt="Supported by Google" width="218" height="36"/>
+        <img src="/static/hash-%%etag%%/img/supported-by-google.png" alt="Supported by Google" width="218" height="36"/>
       </div>
     </div>
     <main class="landing-main">
@@ -147,7 +147,7 @@
       </div>
       <div class="home-block home-block-mp">
         <div class="home-block-image">
-          <img src="/static/img/landing-01.png?hash=mocked_hash_885315573" alt="decoration image for package section" width="351" height="240"/>
+          <img src="/static/hash-%%etag%%/img/landing-01.png" alt="decoration image for package section" width="351" height="240"/>
         </div>
         <div class="home-block-content">
           <h1 class="home-block-title">Most popular packages</h1>
@@ -162,7 +162,7 @@
               </div>
               <div class="mini-list-item-footer">
                 <div class="mini-list-item-publisher">
-                  <img class="publisher-badge" src="/static/img/verified-publisher-gray.svg?hash=mocked_hash_248900311" alt="verified publisher badge" width="16" height="16" title="Published by a pub.dev verified publisher"/>
+                  <img class="publisher-badge" src="/static/hash-%%etag%%/img/verified-publisher-gray.svg" alt="verified publisher badge" width="16" height="16" title="Published by a pub.dev verified publisher"/>
                   <a class="publisher-link" href="/publishers/example.com" data-ga-click-event="landing-most-popular-card-publisher">example.com</a>
                 </div>
               </div>
@@ -191,8 +191,8 @@
               <a href="https://youtube.com/watch?v=video-id&amp;list=PLjxrf2q8roU1quF6ny8oFHJ2gBdrYN_AK" rel="noopener" target="_blank" title="POW description" data-ga-click-event="package-of-the-week-video">
                 <img class="pow-video-thumbnail" src="http://youtube.com/image/thumbnail?i=123&amp;s=4" alt="POW Title" width="260" height="195"/>
                 <div class="pow-video-overlay">
-                  <img class="pow-video-overlay-img-active" src="/static/img/youtube-play-red.png?hash=mocked_hash_325144362" alt="youtube video play icon - active" width="76" height="53"/>
-                  <img class="pow-video-overlay-img-inactive" src="/static/img/youtube-play-black.png?hash=mocked_hash_405283570" alt="youtube video play icon - inactive" width="76" height="53"/>
+                  <img class="pow-video-overlay-img-active" src="/static/hash-%%etag%%/img/youtube-play-red.png" alt="youtube video play icon - active" width="76" height="53"/>
+                  <img class="pow-video-overlay-img-inactive" src="/static/hash-%%etag%%/img/youtube-play-black.png" alt="youtube video play icon - inactive" width="76" height="53"/>
                 </div>
               </a>
             </div>
@@ -212,10 +212,10 @@
       <a class="link sep" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link sep" href="/help">Help</a>
       <a class="link icon sep" href="/feed.atom">
-        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
+        <img class="inline-icon" src="/static/hash-%%etag%%/img/rss-feed-icon.svg" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
       </a>
       <a class="link icon github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">
-        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
+        <img class="inline-icon" src="/static/hash-%%etag%%/img/bug-report-white-96px.png" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
       </a>
     </footer>
     <script type="application/ld+json">{"@context":"http\u003a\u002f\u002fschema.org","@type":"WebSite","url":"https\u003a\u002f\u002fpub.dev\u002f","potentialAction":{"@type":"SearchAction","target":"https\u003a\u002f\u002fpub.dev\u002fpackages\u003fq\u003d\u007bsearch\u005fterm\u005fstring\u007d","query-input":"required name\u003dsearch\u005fterm\u005fstring"}}</script>

--- a/app/test/frontend/golden/my_activity_log_page.html
+++ b/app/test/frontend/golden/my_activity_log_page.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
   <head>
     <script src="https://www.googletagmanager.com/gtm.js?id=GTM-MX6DBN9" async="async"></script>
-    <script src="/static/js/gtm.js?hash=mocked_hash_451823545"></script>
+    <script src="/static/hash-%%etag%%/js/gtm.js"></script>
     <meta charset="utf-8"/>
     <meta http-equiv="x-ua-compatible" content="ie=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
@@ -10,22 +10,22 @@
     <meta name="twitter:card" content="summary"/>
     <meta name="twitter:site" content="@dart_lang"/>
     <meta name="twitter:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
-    <meta name="twitter:image" content="https://pub.dev/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta name="twitter:image" content="https://pub.dev/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <meta property="og:type" content="website"/>
     <meta property="og:site_name" content="Dart packages"/>
     <meta property="og:title" content="My activity log"/>
     <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
-    <meta property="og:image" content="https://pub.dev/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta property="og:image" content="https://pub.dev/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <title>My activity log</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Google+Sans:300,400,500|Google+Sans+Display:400|Roboto:300,400,500,700|Roboto+Mono:300,400,700&amp;display=swap"/>
-    <meta content="/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta content="/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
-    <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/osd.xml?hash=mocked_hash_869379763"/>
+    <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/hash-%%etag%%/osd.xml"/>
     <meta name="description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
-    <link rel="stylesheet" type="text/css" href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842"/>
-    <link rel="stylesheet" type="text/css" href="/static/css/style.css?hash=mocked_hash_537099079"/>
-    <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
+    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/material/material-components-web.min.css"/>
+    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/style.css"/>
+    <script src="/static/hash-%%etag%%/material/material-components-web.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <meta name="google-signin-client_id" content=""/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
@@ -37,7 +37,7 @@
     <div class="site-header">
       <button class="hamburger" aria-label="menu toggle"></button>
       <a class="logo" href="/">
-        <img class="site-logo" src="/static/img/pub-dev-logo-2x.png?hash=mocked_hash_685890546" alt="pub logo" width="135" height="30"/>
+        <img class="site-logo" src="/static/hash-%%etag%%/img/pub-dev-logo-2x.png" alt="pub logo" width="135" height="30"/>
       </a>
       <div class="site-header-space"></div>
       <div class="site-header-mask"></div>
@@ -85,7 +85,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Pub.dev
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="/help/search" rel="noopener" target="_blank">Searching for packages</a>
@@ -95,7 +95,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Flutter
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://flutter.io/using-packages/" rel="noopener" target="_blank">Using packages</a>
@@ -106,7 +106,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Dart
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://dart.dev/tools/pub/get-started" rel="noopener" target="_blank">Using packages</a>
@@ -342,10 +342,10 @@
       <a class="link sep" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link sep" href="/help">Help</a>
       <a class="link icon sep" href="/feed.atom">
-        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
+        <img class="inline-icon" src="/static/hash-%%etag%%/img/rss-feed-icon.svg" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
       </a>
       <a class="link icon github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">
-        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
+        <img class="inline-icon" src="/static/hash-%%etag%%/img/bug-report-white-96px.png" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
       </a>
     </footer>
   </body>

--- a/app/test/frontend/golden/my_liked_packages.html
+++ b/app/test/frontend/golden/my_liked_packages.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
   <head>
     <script src="https://www.googletagmanager.com/gtm.js?id=GTM-MX6DBN9" async="async"></script>
-    <script src="/static/js/gtm.js?hash=mocked_hash_451823545"></script>
+    <script src="/static/hash-%%etag%%/js/gtm.js"></script>
     <meta charset="utf-8"/>
     <meta http-equiv="x-ua-compatible" content="ie=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
@@ -10,22 +10,22 @@
     <meta name="twitter:card" content="summary"/>
     <meta name="twitter:site" content="@dart_lang"/>
     <meta name="twitter:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
-    <meta name="twitter:image" content="https://pub.dev/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta name="twitter:image" content="https://pub.dev/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <meta property="og:type" content="website"/>
     <meta property="og:site_name" content="Dart packages"/>
     <meta property="og:title" content="My liked packages"/>
     <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
-    <meta property="og:image" content="https://pub.dev/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta property="og:image" content="https://pub.dev/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <title>My liked packages</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Google+Sans:300,400,500|Google+Sans+Display:400|Roboto:300,400,500,700|Roboto+Mono:300,400,700&amp;display=swap"/>
-    <meta content="/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta content="/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
-    <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/osd.xml?hash=mocked_hash_869379763"/>
+    <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/hash-%%etag%%/osd.xml"/>
     <meta name="description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
-    <link rel="stylesheet" type="text/css" href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842"/>
-    <link rel="stylesheet" type="text/css" href="/static/css/style.css?hash=mocked_hash_537099079"/>
-    <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
+    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/material/material-components-web.min.css"/>
+    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/style.css"/>
+    <script src="/static/hash-%%etag%%/material/material-components-web.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <meta name="google-signin-client_id" content=""/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
@@ -37,7 +37,7 @@
     <div class="site-header">
       <button class="hamburger" aria-label="menu toggle"></button>
       <a class="logo" href="/">
-        <img class="site-logo" src="/static/img/pub-dev-logo-2x.png?hash=mocked_hash_685890546" alt="pub logo" width="135" height="30"/>
+        <img class="site-logo" src="/static/hash-%%etag%%/img/pub-dev-logo-2x.png" alt="pub logo" width="135" height="30"/>
       </a>
       <div class="site-header-space"></div>
       <div class="site-header-mask"></div>
@@ -85,7 +85,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Pub.dev
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="/help/search" rel="noopener" target="_blank">Searching for packages</a>
@@ -95,7 +95,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Flutter
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://flutter.io/using-packages/" rel="noopener" target="_blank">Using packages</a>
@@ -106,7 +106,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Dart
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://dart.dev/tools/pub/get-started" rel="noopener" target="_blank">Using packages</a>
@@ -182,9 +182,9 @@
                           <a href="/packages/super_package">super_package</a>
                         </h3>
                         <div class="packages-icons">
-                          <button class="mdc-button mdc-button--unelevated -pub-like-button" data-mdc-auto-init="MDCRipple" data-package="super_package" data-thumb_up_outlined="/static/img/thumb-up-24px.svg?hash=mocked_hash_808020279" data-thumb_up_filled="/static/img/thumb-up-filled-24px.svg?hash=mocked_hash_368133424">
+                          <button class="mdc-button mdc-button--unelevated -pub-like-button" data-mdc-auto-init="MDCRipple" data-package="super_package" data-thumb_up_outlined="/static/hash-%%etag%%/img/thumb-up-24px.svg" data-thumb_up_filled="/static/hash-%%etag%%/img/thumb-up-filled-24px.svg">
                             <div class="mdc-button__ripple"></div>
-                            <img class="mdc-button__icon -pub-like-button-img" src="/static/img/thumb-up-filled-24px.svg?hash=mocked_hash_368133424" alt="thumb up icon" width="24" height="24" aria-hidden="true"/>
+                            <img class="mdc-button__icon -pub-like-button-img" src="/static/hash-%%etag%%/img/thumb-up-filled-24px.svg" alt="thumb up icon" width="24" height="24" aria-hidden="true"/>
                             <span class="mdc-button__label -pub-like-button-label">Unlike</span>
                           </button>
                         </div>
@@ -200,9 +200,9 @@
                           <a href="/packages/another_package">another_package</a>
                         </h3>
                         <div class="packages-icons">
-                          <button class="mdc-button mdc-button--unelevated -pub-like-button" data-mdc-auto-init="MDCRipple" data-package="another_package" data-thumb_up_outlined="/static/img/thumb-up-24px.svg?hash=mocked_hash_808020279" data-thumb_up_filled="/static/img/thumb-up-filled-24px.svg?hash=mocked_hash_368133424">
+                          <button class="mdc-button mdc-button--unelevated -pub-like-button" data-mdc-auto-init="MDCRipple" data-package="another_package" data-thumb_up_outlined="/static/hash-%%etag%%/img/thumb-up-24px.svg" data-thumb_up_filled="/static/hash-%%etag%%/img/thumb-up-filled-24px.svg">
                             <div class="mdc-button__ripple"></div>
-                            <img class="mdc-button__icon -pub-like-button-img" src="/static/img/thumb-up-filled-24px.svg?hash=mocked_hash_368133424" alt="thumb up icon" width="24" height="24" aria-hidden="true"/>
+                            <img class="mdc-button__icon -pub-like-button-img" src="/static/hash-%%etag%%/img/thumb-up-filled-24px.svg" alt="thumb up icon" width="24" height="24" aria-hidden="true"/>
                             <span class="mdc-button__label -pub-like-button-label">Unlike</span>
                           </button>
                         </div>
@@ -229,10 +229,10 @@
       <a class="link sep" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link sep" href="/help">Help</a>
       <a class="link icon sep" href="/feed.atom">
-        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
+        <img class="inline-icon" src="/static/hash-%%etag%%/img/rss-feed-icon.svg" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
       </a>
       <a class="link icon github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">
-        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
+        <img class="inline-icon" src="/static/hash-%%etag%%/img/bug-report-white-96px.png" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
       </a>
     </footer>
   </body>

--- a/app/test/frontend/golden/my_packages.html
+++ b/app/test/frontend/golden/my_packages.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
   <head>
     <script src="https://www.googletagmanager.com/gtm.js?id=GTM-MX6DBN9" async="async"></script>
-    <script src="/static/js/gtm.js?hash=mocked_hash_451823545"></script>
+    <script src="/static/hash-%%etag%%/js/gtm.js"></script>
     <meta charset="utf-8"/>
     <meta http-equiv="x-ua-compatible" content="ie=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
@@ -10,22 +10,22 @@
     <meta name="twitter:card" content="summary"/>
     <meta name="twitter:site" content="@dart_lang"/>
     <meta name="twitter:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
-    <meta name="twitter:image" content="https://pub.dev/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta name="twitter:image" content="https://pub.dev/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <meta property="og:type" content="website"/>
     <meta property="og:site_name" content="Dart packages"/>
     <meta property="og:title" content="My packages | starting with oxygen"/>
     <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
-    <meta property="og:image" content="https://pub.dev/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta property="og:image" content="https://pub.dev/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <title>My packages | starting with oxygen</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Google+Sans:300,400,500|Google+Sans+Display:400|Roboto:300,400,500,700|Roboto+Mono:300,400,700&amp;display=swap"/>
-    <meta content="/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta content="/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
-    <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/osd.xml?hash=mocked_hash_869379763"/>
+    <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/hash-%%etag%%/osd.xml"/>
     <meta name="description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
-    <link rel="stylesheet" type="text/css" href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842"/>
-    <link rel="stylesheet" type="text/css" href="/static/css/style.css?hash=mocked_hash_537099079"/>
-    <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
+    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/material/material-components-web.min.css"/>
+    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/style.css"/>
+    <script src="/static/hash-%%etag%%/material/material-components-web.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <meta name="google-signin-client_id" content=""/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
@@ -37,7 +37,7 @@
     <div class="site-header">
       <button class="hamburger" aria-label="menu toggle"></button>
       <a class="logo" href="/">
-        <img class="site-logo" src="/static/img/pub-dev-logo-2x.png?hash=mocked_hash_685890546" alt="pub logo" width="135" height="30"/>
+        <img class="site-logo" src="/static/hash-%%etag%%/img/pub-dev-logo-2x.png" alt="pub logo" width="135" height="30"/>
       </a>
       <div class="site-header-space"></div>
       <div class="site-header-mask"></div>
@@ -85,7 +85,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Pub.dev
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="/help/search" rel="noopener" target="_blank">Searching for packages</a>
@@ -95,7 +95,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Flutter
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://flutter.io/using-packages/" rel="noopener" target="_blank">Using packages</a>
@@ -106,7 +106,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Dart
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://dart.dev/tools/pub/get-started" rel="noopener" target="_blank">Using packages</a>
@@ -186,7 +186,7 @@
                           <a href="/packages/oxygen">oxygen</a>
                         </h3>
                         <div class="packages-recent">
-                          <img class="packages-recent-icon" src="/static/img/schedule-icon.svg?hash=mocked_hash_164576935" alt="icon indicating recent time" width="10" height="10" title="new package"/>
+                          <img class="packages-recent-icon" src="/static/hash-%%etag%%/img/schedule-icon.svg" alt="icon indicating recent time" width="10" height="10" title="new package"/>
                           Added
                           <b>%%x-ago%%</b>
                         </div>
@@ -250,7 +250,7 @@
                           <a href="/packages/neon">neon</a>
                         </h3>
                         <div class="packages-recent">
-                          <img class="packages-recent-icon" src="/static/img/schedule-icon.svg?hash=mocked_hash_164576935" alt="icon indicating recent time" width="10" height="10" title="new package"/>
+                          <img class="packages-recent-icon" src="/static/hash-%%etag%%/img/schedule-icon.svg" alt="icon indicating recent time" width="10" height="10" title="new package"/>
                           Added
                           <b>%%x-ago%%</b>
                         </div>
@@ -288,7 +288,7 @@
                           )
                         </span>
                         <span class="packages-metadata-block">
-                          <img class="package-vp-icon" src="/static/img/verified-publisher-icon.svg?hash=mocked_hash_1044149352" alt="shield icon for verified publishers" width="14" height="14" title="Published by a pub.dev verified publisher"/>
+                          <img class="package-vp-icon" src="/static/hash-%%etag%%/img/verified-publisher-icon.svg" alt="shield icon for verified publishers" width="14" height="14" title="Published by a pub.dev verified publisher"/>
                           <a href="/publishers/example.com">example.com</a>
                         </span>
                       </p>
@@ -329,10 +329,10 @@
       <a class="link sep" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link sep" href="/help">Help</a>
       <a class="link icon sep" href="/feed.atom">
-        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
+        <img class="inline-icon" src="/static/hash-%%etag%%/img/rss-feed-icon.svg" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
       </a>
       <a class="link icon github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">
-        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
+        <img class="inline-icon" src="/static/hash-%%etag%%/img/bug-report-white-96px.png" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
       </a>
     </footer>
   </body>

--- a/app/test/frontend/golden/my_publishers.html
+++ b/app/test/frontend/golden/my_publishers.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
   <head>
     <script src="https://www.googletagmanager.com/gtm.js?id=GTM-MX6DBN9" async="async"></script>
-    <script src="/static/js/gtm.js?hash=mocked_hash_451823545"></script>
+    <script src="/static/hash-%%etag%%/js/gtm.js"></script>
     <meta charset="utf-8"/>
     <meta http-equiv="x-ua-compatible" content="ie=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
@@ -10,22 +10,22 @@
     <meta name="twitter:card" content="summary"/>
     <meta name="twitter:site" content="@dart_lang"/>
     <meta name="twitter:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
-    <meta name="twitter:image" content="https://pub.dev/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta name="twitter:image" content="https://pub.dev/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <meta property="og:type" content="website"/>
     <meta property="og:site_name" content="Dart packages"/>
     <meta property="og:title" content="My publishers"/>
     <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
-    <meta property="og:image" content="https://pub.dev/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta property="og:image" content="https://pub.dev/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <title>My publishers</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Google+Sans:300,400,500|Google+Sans+Display:400|Roboto:300,400,500,700|Roboto+Mono:300,400,700&amp;display=swap"/>
-    <meta content="/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta content="/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
-    <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/osd.xml?hash=mocked_hash_869379763"/>
+    <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/hash-%%etag%%/osd.xml"/>
     <meta name="description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
-    <link rel="stylesheet" type="text/css" href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842"/>
-    <link rel="stylesheet" type="text/css" href="/static/css/style.css?hash=mocked_hash_537099079"/>
-    <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
+    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/material/material-components-web.min.css"/>
+    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/style.css"/>
+    <script src="/static/hash-%%etag%%/material/material-components-web.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <meta name="google-signin-client_id" content=""/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
@@ -37,7 +37,7 @@
     <div class="site-header">
       <button class="hamburger" aria-label="menu toggle"></button>
       <a class="logo" href="/">
-        <img class="site-logo" src="/static/img/pub-dev-logo-2x.png?hash=mocked_hash_685890546" alt="pub logo" width="135" height="30"/>
+        <img class="site-logo" src="/static/hash-%%etag%%/img/pub-dev-logo-2x.png" alt="pub logo" width="135" height="30"/>
       </a>
       <div class="site-header-space"></div>
       <div class="site-header-mask"></div>
@@ -85,7 +85,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Pub.dev
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="/help/search" rel="noopener" target="_blank">Searching for packages</a>
@@ -95,7 +95,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Flutter
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://flutter.io/using-packages/" rel="noopener" target="_blank">Using packages</a>
@@ -106,7 +106,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Dart
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://dart.dev/tools/pub/get-started" rel="noopener" target="_blank">Using packages</a>
@@ -208,10 +208,10 @@
       <a class="link sep" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link sep" href="/help">Help</a>
       <a class="link icon sep" href="/feed.atom">
-        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
+        <img class="inline-icon" src="/static/hash-%%etag%%/img/rss-feed-icon.svg" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
       </a>
       <a class="link icon github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">
-        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
+        <img class="inline-icon" src="/static/hash-%%etag%%/img/bug-report-white-96px.png" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
       </a>
     </footer>
   </body>

--- a/app/test/frontend/golden/pkg_activity_log_page.html
+++ b/app/test/frontend/golden/pkg_activity_log_page.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
   <head>
     <script src="https://www.googletagmanager.com/gtm.js?id=GTM-MX6DBN9" async="async"></script>
-    <script src="/static/js/gtm.js?hash=mocked_hash_451823545"></script>
+    <script src="/static/hash-%%etag%%/js/gtm.js"></script>
     <meta charset="utf-8"/>
     <meta http-equiv="x-ua-compatible" content="ie=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
@@ -10,27 +10,27 @@
     <meta name="twitter:card" content="summary"/>
     <meta name="twitter:site" content="@dart_lang"/>
     <meta name="twitter:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
-    <meta name="twitter:image" content="https://pub.dev/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta name="twitter:image" content="https://pub.dev/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <meta property="og:type" content="website"/>
     <meta property="og:site_name" content="Dart packages"/>
     <meta property="og:title" content="oxygen package - Admin"/>
     <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
-    <meta property="og:image" content="https://pub.dev/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta property="og:image" content="https://pub.dev/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <title>oxygen package - Admin</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Google+Sans:300,400,500|Google+Sans+Display:400|Roboto:300,400,500,700|Roboto+Mono:300,400,700&amp;display=swap"/>
-    <meta content="/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta content="/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
-    <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/osd.xml?hash=mocked_hash_869379763"/>
+    <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/hash-%%etag%%/osd.xml"/>
     <meta name="description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
-    <link rel="stylesheet" type="text/css" href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842"/>
-    <link rel="stylesheet" type="text/css" href="/static/css/style.css?hash=mocked_hash_537099079"/>
-    <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
+    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/material/material-components-web.min.css"/>
+    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/style.css"/>
+    <script src="/static/hash-%%etag%%/material/material-components-web.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <meta name="google-signin-client_id" content=""/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
     <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJveHlnZW4iLCJ2ZXJzaW9uIjoiMS4yLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlfX0="/>
-    <link rel="preload" href="/static/highlight/highlight-with-init.js?hash=mocked_hash_670483893" as="script"/>
+    <link rel="preload" href="/static/hash-%%etag%%/highlight/highlight-with-init.js" as="script"/>
   </head>
   <body>
     <noscript>
@@ -39,7 +39,7 @@
     <div class="site-header">
       <button class="hamburger" aria-label="menu toggle"></button>
       <a class="logo" href="/">
-        <img class="site-logo" src="/static/img/pub-dev-logo-2x.png?hash=mocked_hash_685890546" alt="pub logo" width="135" height="30"/>
+        <img class="site-logo" src="/static/hash-%%etag%%/img/pub-dev-logo-2x.png" alt="pub logo" width="135" height="30"/>
       </a>
       <div class="site-header-space"></div>
       <div class="site-header-mask"></div>
@@ -78,7 +78,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Pub.dev
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="/help/search" rel="noopener" target="_blank">Searching for packages</a>
@@ -88,7 +88,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Flutter
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://flutter.io/using-packages/" rel="noopener" target="_blank">Using packages</a>
@@ -99,7 +99,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Dart
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://dart.dev/tools/pub/get-started" rel="noopener" target="_blank">Using packages</a>
@@ -118,7 +118,7 @@
                 <h1 class="title">
                   oxygen 1.2.0
                   <span class="pkg-page-title-copy">
-                    <img class="pkg-page-title-copy-icon" src="/static/img/content-copy-icon.svg?hash=mocked_hash_1005735992" alt="icon indicating copy to clipboard operation" width="18" height="18" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>
+                    <img class="pkg-page-title-copy-icon" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="icon indicating copy to clipboard operation" width="18" height="18" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>
                     <div class="pkg-page-title-copy-feedback">
                       <span class="code">oxygen: ^1.2.0</span>
                       copied to clipboard
@@ -158,8 +158,8 @@
                   </div>
                   <div class="detail-like">
                     <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false">
-                      <img class="mdc-icon-button__icon" src="/static/img/like-inactive.svg?hash=mocked_hash_1066096316" alt="icon indicating liked status (inactive)" width="18" height="18"/>
-                      <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/img/like-active.svg?hash=mocked_hash_986617859" alt="icon indicating liked status (active)" width="18" height="18"/>
+                      <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="icon indicating liked status (inactive)" width="18" height="18"/>
+                      <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="icon indicating liked status (active)" width="18" height="18"/>
                     </button>
                     <span class="likes-count">
                       <span id="likes-count">0</span>
@@ -333,12 +333,12 @@
       <a class="link sep" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link sep" href="/help">Help</a>
       <a class="link icon sep" href="/feed.atom">
-        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
+        <img class="inline-icon" src="/static/hash-%%etag%%/img/rss-feed-icon.svg" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
       </a>
       <a class="link icon github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">
-        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
+        <img class="inline-icon" src="/static/hash-%%etag%%/img/bug-report-white-96px.png" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
       </a>
     </footer>
-    <script src="/static/highlight/highlight-with-init.js?hash=mocked_hash_670483893" defer="defer"></script>
+    <script src="/static/hash-%%etag%%/highlight/highlight-with-init.js" defer="defer"></script>
   </body>
 </html>

--- a/app/test/frontend/golden/pkg_admin_page.html
+++ b/app/test/frontend/golden/pkg_admin_page.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
   <head>
     <script src="https://www.googletagmanager.com/gtm.js?id=GTM-MX6DBN9" async="async"></script>
-    <script src="/static/js/gtm.js?hash=mocked_hash_451823545"></script>
+    <script src="/static/hash-%%etag%%/js/gtm.js"></script>
     <meta charset="utf-8"/>
     <meta http-equiv="x-ua-compatible" content="ie=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
@@ -10,27 +10,27 @@
     <meta name="twitter:card" content="summary"/>
     <meta name="twitter:site" content="@dart_lang"/>
     <meta name="twitter:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
-    <meta name="twitter:image" content="https://pub.dev/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta name="twitter:image" content="https://pub.dev/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <meta property="og:type" content="website"/>
     <meta property="og:site_name" content="Dart packages"/>
     <meta property="og:title" content="oxygen package - Admin"/>
     <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
-    <meta property="og:image" content="https://pub.dev/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta property="og:image" content="https://pub.dev/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <title>oxygen package - Admin</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Google+Sans:300,400,500|Google+Sans+Display:400|Roboto:300,400,500,700|Roboto+Mono:300,400,700&amp;display=swap"/>
-    <meta content="/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta content="/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
-    <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/osd.xml?hash=mocked_hash_869379763"/>
+    <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/hash-%%etag%%/osd.xml"/>
     <meta name="description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
-    <link rel="stylesheet" type="text/css" href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842"/>
-    <link rel="stylesheet" type="text/css" href="/static/css/style.css?hash=mocked_hash_537099079"/>
-    <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
+    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/material/material-components-web.min.css"/>
+    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/style.css"/>
+    <script src="/static/hash-%%etag%%/material/material-components-web.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <meta name="google-signin-client_id" content=""/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
     <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJveHlnZW4iLCJ2ZXJzaW9uIjoiMS4yLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlfX0="/>
-    <link rel="preload" href="/static/highlight/highlight-with-init.js?hash=mocked_hash_670483893" as="script"/>
+    <link rel="preload" href="/static/hash-%%etag%%/highlight/highlight-with-init.js" as="script"/>
   </head>
   <body>
     <noscript>
@@ -39,7 +39,7 @@
     <div class="site-header">
       <button class="hamburger" aria-label="menu toggle"></button>
       <a class="logo" href="/">
-        <img class="site-logo" src="/static/img/pub-dev-logo-2x.png?hash=mocked_hash_685890546" alt="pub logo" width="135" height="30"/>
+        <img class="site-logo" src="/static/hash-%%etag%%/img/pub-dev-logo-2x.png" alt="pub logo" width="135" height="30"/>
       </a>
       <div class="site-header-space"></div>
       <div class="site-header-mask"></div>
@@ -78,7 +78,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Pub.dev
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="/help/search" rel="noopener" target="_blank">Searching for packages</a>
@@ -88,7 +88,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Flutter
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://flutter.io/using-packages/" rel="noopener" target="_blank">Using packages</a>
@@ -99,7 +99,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Dart
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://dart.dev/tools/pub/get-started" rel="noopener" target="_blank">Using packages</a>
@@ -118,7 +118,7 @@
                 <h1 class="title">
                   oxygen 1.2.0
                   <span class="pkg-page-title-copy">
-                    <img class="pkg-page-title-copy-icon" src="/static/img/content-copy-icon.svg?hash=mocked_hash_1005735992" alt="icon indicating copy to clipboard operation" width="18" height="18" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>
+                    <img class="pkg-page-title-copy-icon" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="icon indicating copy to clipboard operation" width="18" height="18" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>
                     <div class="pkg-page-title-copy-feedback">
                       <span class="code">oxygen: ^1.2.0</span>
                       copied to clipboard
@@ -158,8 +158,8 @@
                   </div>
                   <div class="detail-like">
                     <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false">
-                      <img class="mdc-icon-button__icon" src="/static/img/like-inactive.svg?hash=mocked_hash_1066096316" alt="icon indicating liked status (inactive)" width="18" height="18"/>
-                      <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/img/like-active.svg?hash=mocked_hash_986617859" alt="icon indicating liked status (active)" width="18" height="18"/>
+                      <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="icon indicating liked status (inactive)" width="18" height="18"/>
+                      <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="icon indicating liked status (active)" width="18" height="18"/>
                     </button>
                     <span class="likes-count">
                       <span id="likes-count">0</span>
@@ -522,12 +522,12 @@
       <a class="link sep" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link sep" href="/help">Help</a>
       <a class="link icon sep" href="/feed.atom">
-        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
+        <img class="inline-icon" src="/static/hash-%%etag%%/img/rss-feed-icon.svg" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
       </a>
       <a class="link icon github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">
-        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
+        <img class="inline-icon" src="/static/hash-%%etag%%/img/bug-report-white-96px.png" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
       </a>
     </footer>
-    <script src="/static/highlight/highlight-with-init.js?hash=mocked_hash_670483893" defer="defer"></script>
+    <script src="/static/hash-%%etag%%/highlight/highlight-with-init.js" defer="defer"></script>
   </body>
 </html>

--- a/app/test/frontend/golden/pkg_changelog_page.html
+++ b/app/test/frontend/golden/pkg_changelog_page.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
   <head>
     <script src="https://www.googletagmanager.com/gtm.js?id=GTM-MX6DBN9" async="async"></script>
-    <script src="/static/js/gtm.js?hash=mocked_hash_451823545"></script>
+    <script src="/static/hash-%%etag%%/js/gtm.js"></script>
     <meta charset="utf-8"/>
     <meta http-equiv="x-ua-compatible" content="ie=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
@@ -10,28 +10,28 @@
     <meta name="twitter:card" content="summary"/>
     <meta name="twitter:site" content="@dart_lang"/>
     <meta name="twitter:description" content="oxygen is awesome"/>
-    <meta name="twitter:image" content="https://pub.dev/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta name="twitter:image" content="https://pub.dev/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <meta property="og:type" content="website"/>
     <meta property="og:site_name" content="Dart packages"/>
     <meta property="og:title" content="oxygen | Dart Package"/>
     <meta property="og:description" content="oxygen is awesome"/>
-    <meta property="og:image" content="https://pub.dev/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta property="og:image" content="https://pub.dev/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <title>oxygen | Dart Package</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Google+Sans:300,400,500|Google+Sans+Display:400|Roboto:300,400,500,700|Roboto+Mono:300,400,700&amp;display=swap"/>
-    <meta content="/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta content="/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
-    <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/osd.xml?hash=mocked_hash_869379763"/>
+    <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/hash-%%etag%%/osd.xml"/>
     <link rel="canonical" href="https://pub.dev/packages/oxygen/changelog"/>
     <meta name="description" content="oxygen is awesome"/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
-    <link rel="stylesheet" type="text/css" href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842"/>
-    <link rel="stylesheet" type="text/css" href="/static/css/style.css?hash=mocked_hash_537099079"/>
-    <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
+    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/material/material-components-web.min.css"/>
+    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/style.css"/>
+    <script src="/static/hash-%%etag%%/material/material-components-web.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <meta name="google-signin-client_id" content=""/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
     <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJveHlnZW4iLCJ2ZXJzaW9uIjoiMS4yLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlfX0="/>
-    <link rel="preload" href="/static/highlight/highlight-with-init.js?hash=mocked_hash_670483893" as="script"/>
+    <link rel="preload" href="/static/hash-%%etag%%/highlight/highlight-with-init.js" as="script"/>
   </head>
   <body>
     <noscript>
@@ -40,7 +40,7 @@
     <div class="site-header">
       <button class="hamburger" aria-label="menu toggle"></button>
       <a class="logo" href="/">
-        <img class="site-logo" src="/static/img/pub-dev-logo-2x.png?hash=mocked_hash_685890546" alt="pub logo" width="135" height="30"/>
+        <img class="site-logo" src="/static/hash-%%etag%%/img/pub-dev-logo-2x.png" alt="pub logo" width="135" height="30"/>
       </a>
       <div class="site-header-space"></div>
       <div class="site-header-mask"></div>
@@ -79,7 +79,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Pub.dev
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="/help/search" rel="noopener" target="_blank">Searching for packages</a>
@@ -89,7 +89,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Flutter
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://flutter.io/using-packages/" rel="noopener" target="_blank">Using packages</a>
@@ -100,7 +100,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Dart
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://dart.dev/tools/pub/get-started" rel="noopener" target="_blank">Using packages</a>
@@ -119,7 +119,7 @@
                 <h1 class="title">
                   oxygen 1.2.0
                   <span class="pkg-page-title-copy">
-                    <img class="pkg-page-title-copy-icon" src="/static/img/content-copy-icon.svg?hash=mocked_hash_1005735992" alt="icon indicating copy to clipboard operation" width="18" height="18" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>
+                    <img class="pkg-page-title-copy-icon" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="icon indicating copy to clipboard operation" width="18" height="18" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>
                     <div class="pkg-page-title-copy-feedback">
                       <span class="code">oxygen: ^1.2.0</span>
                       copied to clipboard
@@ -159,8 +159,8 @@
                   </div>
                   <div class="detail-like">
                     <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false">
-                      <img class="mdc-icon-button__icon" src="/static/img/like-inactive.svg?hash=mocked_hash_1066096316" alt="icon indicating liked status (inactive)" width="18" height="18"/>
-                      <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/img/like-active.svg?hash=mocked_hash_986617859" alt="icon indicating liked status (active)" width="18" height="18"/>
+                      <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="icon indicating liked status (inactive)" width="18" height="18"/>
+                      <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="icon indicating liked status (active)" width="18" height="18"/>
                     </button>
                     <span class="likes-count">
                       <span id="likes-count">0</span>
@@ -347,12 +347,12 @@
       <a class="link sep" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link sep" href="/help">Help</a>
       <a class="link icon sep" href="/feed.atom">
-        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
+        <img class="inline-icon" src="/static/hash-%%etag%%/img/rss-feed-icon.svg" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
       </a>
       <a class="link icon github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">
-        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
+        <img class="inline-icon" src="/static/hash-%%etag%%/img/bug-report-white-96px.png" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
       </a>
     </footer>
-    <script src="/static/highlight/highlight-with-init.js?hash=mocked_hash_670483893" defer="defer"></script>
+    <script src="/static/hash-%%etag%%/highlight/highlight-with-init.js" defer="defer"></script>
   </body>
 </html>

--- a/app/test/frontend/golden/pkg_example_page.html
+++ b/app/test/frontend/golden/pkg_example_page.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
   <head>
     <script src="https://www.googletagmanager.com/gtm.js?id=GTM-MX6DBN9" async="async"></script>
-    <script src="/static/js/gtm.js?hash=mocked_hash_451823545"></script>
+    <script src="/static/hash-%%etag%%/js/gtm.js"></script>
     <meta charset="utf-8"/>
     <meta http-equiv="x-ua-compatible" content="ie=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
@@ -10,28 +10,28 @@
     <meta name="twitter:card" content="summary"/>
     <meta name="twitter:site" content="@dart_lang"/>
     <meta name="twitter:description" content="oxygen is awesome"/>
-    <meta name="twitter:image" content="https://pub.dev/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta name="twitter:image" content="https://pub.dev/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <meta property="og:type" content="website"/>
     <meta property="og:site_name" content="Dart packages"/>
     <meta property="og:title" content="oxygen | Dart Package"/>
     <meta property="og:description" content="oxygen is awesome"/>
-    <meta property="og:image" content="https://pub.dev/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta property="og:image" content="https://pub.dev/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <title>oxygen | Dart Package</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Google+Sans:300,400,500|Google+Sans+Display:400|Roboto:300,400,500,700|Roboto+Mono:300,400,700&amp;display=swap"/>
-    <meta content="/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta content="/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
-    <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/osd.xml?hash=mocked_hash_869379763"/>
+    <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/hash-%%etag%%/osd.xml"/>
     <link rel="canonical" href="https://pub.dev/packages/oxygen/example"/>
     <meta name="description" content="oxygen is awesome"/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
-    <link rel="stylesheet" type="text/css" href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842"/>
-    <link rel="stylesheet" type="text/css" href="/static/css/style.css?hash=mocked_hash_537099079"/>
-    <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
+    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/material/material-components-web.min.css"/>
+    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/style.css"/>
+    <script src="/static/hash-%%etag%%/material/material-components-web.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <meta name="google-signin-client_id" content=""/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
     <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJveHlnZW4iLCJ2ZXJzaW9uIjoiMS4yLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlfX0="/>
-    <link rel="preload" href="/static/highlight/highlight-with-init.js?hash=mocked_hash_670483893" as="script"/>
+    <link rel="preload" href="/static/hash-%%etag%%/highlight/highlight-with-init.js" as="script"/>
   </head>
   <body>
     <noscript>
@@ -40,7 +40,7 @@
     <div class="site-header">
       <button class="hamburger" aria-label="menu toggle"></button>
       <a class="logo" href="/">
-        <img class="site-logo" src="/static/img/pub-dev-logo-2x.png?hash=mocked_hash_685890546" alt="pub logo" width="135" height="30"/>
+        <img class="site-logo" src="/static/hash-%%etag%%/img/pub-dev-logo-2x.png" alt="pub logo" width="135" height="30"/>
       </a>
       <div class="site-header-space"></div>
       <div class="site-header-mask"></div>
@@ -79,7 +79,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Pub.dev
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="/help/search" rel="noopener" target="_blank">Searching for packages</a>
@@ -89,7 +89,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Flutter
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://flutter.io/using-packages/" rel="noopener" target="_blank">Using packages</a>
@@ -100,7 +100,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Dart
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://dart.dev/tools/pub/get-started" rel="noopener" target="_blank">Using packages</a>
@@ -119,7 +119,7 @@
                 <h1 class="title">
                   oxygen 1.2.0
                   <span class="pkg-page-title-copy">
-                    <img class="pkg-page-title-copy-icon" src="/static/img/content-copy-icon.svg?hash=mocked_hash_1005735992" alt="icon indicating copy to clipboard operation" width="18" height="18" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>
+                    <img class="pkg-page-title-copy-icon" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="icon indicating copy to clipboard operation" width="18" height="18" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>
                     <div class="pkg-page-title-copy-feedback">
                       <span class="code">oxygen: ^1.2.0</span>
                       copied to clipboard
@@ -159,8 +159,8 @@
                   </div>
                   <div class="detail-like">
                     <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false">
-                      <img class="mdc-icon-button__icon" src="/static/img/like-inactive.svg?hash=mocked_hash_1066096316" alt="icon indicating liked status (inactive)" width="18" height="18"/>
-                      <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/img/like-active.svg?hash=mocked_hash_986617859" alt="icon indicating liked status (active)" width="18" height="18"/>
+                      <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="icon indicating liked status (inactive)" width="18" height="18"/>
+                      <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="icon indicating liked status (active)" width="18" height="18"/>
                     </button>
                     <span class="likes-count">
                       <span id="likes-count">0</span>
@@ -342,12 +342,12 @@
       <a class="link sep" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link sep" href="/help">Help</a>
       <a class="link icon sep" href="/feed.atom">
-        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
+        <img class="inline-icon" src="/static/hash-%%etag%%/img/rss-feed-icon.svg" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
       </a>
       <a class="link icon github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">
-        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
+        <img class="inline-icon" src="/static/hash-%%etag%%/img/bug-report-white-96px.png" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
       </a>
     </footer>
-    <script src="/static/highlight/highlight-with-init.js?hash=mocked_hash_670483893" defer="defer"></script>
+    <script src="/static/hash-%%etag%%/highlight/highlight-with-init.js" defer="defer"></script>
   </body>
 </html>

--- a/app/test/frontend/golden/pkg_index_page.html
+++ b/app/test/frontend/golden/pkg_index_page.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
   <head>
     <script src="https://www.googletagmanager.com/gtm.js?id=GTM-MX6DBN9" async="async"></script>
-    <script src="/static/js/gtm.js?hash=mocked_hash_451823545"></script>
+    <script src="/static/hash-%%etag%%/js/gtm.js"></script>
     <meta charset="utf-8"/>
     <meta http-equiv="x-ua-compatible" content="ie=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
@@ -10,23 +10,23 @@
     <meta name="twitter:card" content="summary"/>
     <meta name="twitter:site" content="@dart_lang"/>
     <meta name="twitter:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
-    <meta name="twitter:image" content="https://pub.dev/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta name="twitter:image" content="https://pub.dev/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <meta property="og:type" content="website"/>
     <meta property="og:site_name" content="Dart packages"/>
     <meta property="og:title" content="Search results for sdk:dart."/>
     <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
-    <meta property="og:image" content="https://pub.dev/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta property="og:image" content="https://pub.dev/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <title>Search results for sdk:dart.</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Google+Sans:300,400,500|Google+Sans+Display:400|Roboto:300,400,500,700|Roboto+Mono:300,400,700&amp;display=swap"/>
-    <meta content="/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta content="/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
-    <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/osd.xml?hash=mocked_hash_869379763"/>
+    <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/hash-%%etag%%/osd.xml"/>
     <link rel="canonical" href="https://pub.dev/packages?q=sdk%3Adart"/>
     <meta name="description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
-    <link rel="stylesheet" type="text/css" href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842"/>
-    <link rel="stylesheet" type="text/css" href="/static/css/style.css?hash=mocked_hash_537099079"/>
-    <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
+    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/material/material-components-web.min.css"/>
+    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/style.css"/>
+    <script src="/static/hash-%%etag%%/material/material-components-web.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <meta name="google-signin-client_id" content=""/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
@@ -38,7 +38,7 @@
     <div class="site-header">
       <button class="hamburger" aria-label="menu toggle"></button>
       <a class="logo" href="/">
-        <img class="site-logo" src="/static/img/pub-dev-logo-2x.png?hash=mocked_hash_685890546" alt="pub logo" width="135" height="30"/>
+        <img class="site-logo" src="/static/hash-%%etag%%/img/pub-dev-logo-2x.png" alt="pub logo" width="135" height="30"/>
       </a>
       <div class="site-header-space"></div>
       <div class="site-header-mask"></div>
@@ -72,7 +72,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Pub.dev
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="/help/search" rel="noopener" target="_blank">Searching for packages</a>
@@ -82,7 +82,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Flutter
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://flutter.io/using-packages/" rel="noopener" target="_blank">Using packages</a>
@@ -93,7 +93,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Dart
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://dart.dev/tools/pub/get-started" rel="noopener" target="_blank">Using packages</a>
@@ -109,8 +109,8 @@
           <input class="input" name="q" placeholder="Search packages" autocomplete="on" value="sdk:dart"/>
           <button class="icon" aria-label="search"></button>
           <div class="search-filters-btn-wrapper -active">
-            <img class="search-filters-btn search-filters-btn-inactive" src="/static/img/search-filters-inactive.svg?hash=mocked_hash_963166179" alt="icon to toggle the display of search filters (inactive)" width="42" height="42"/>
-            <img class="search-filters-btn search-filters-btn-active" src="/static/img/search-filters-active.svg?hash=mocked_hash_397783636" alt="icon to toggle the display of search filters (active)" width="42" height="42"/>
+            <img class="search-filters-btn search-filters-btn-inactive" src="/static/hash-%%etag%%/img/search-filters-inactive.svg" alt="icon to toggle the display of search filters (inactive)" width="42" height="42"/>
+            <img class="search-filters-btn search-filters-btn-active" src="/static/hash-%%etag%%/img/search-filters-active.svg" alt="icon to toggle the display of search filters (active)" width="42" height="42"/>
           </div>
         </form>
       </div>
@@ -121,7 +121,7 @@
           <div class="search-form-section foldable -active">
             <h3 class="search-form-section-header foldable-button">
               <span class="search-form-section-header-label">Platforms</span>
-              <img class="foldable-icon" src="/static/img/search-form-foldable-icon.svg?hash=mocked_hash_663371761" alt="fold toggle icon (up/down arrow)" width="13" height="6"/>
+              <img class="foldable-icon" src="/static/hash-%%etag%%/img/search-form-foldable-icon.svg" alt="fold toggle icon (up/down arrow)" width="13" height="6"/>
             </h3>
             <div class="foldable-content">
               <div class="search-form-linked-checkbox" title="Show only packages that support the Android platform.">
@@ -231,7 +231,7 @@
           <div class="search-form-section foldable -active" data-section-tag="sdks">
             <h3 class="search-form-section-header foldable-button">
               <span class="search-form-section-header-label">SDKs</span>
-              <img class="foldable-icon" src="/static/img/search-form-foldable-icon.svg?hash=mocked_hash_663371761" alt="fold toggle icon (up/down arrow)" width="13" height="6"/>
+              <img class="foldable-icon" src="/static/hash-%%etag%%/img/search-form-foldable-icon.svg" alt="fold toggle icon (up/down arrow)" width="13" height="6"/>
             </h3>
             <div class="foldable-content">
               <div class="search-form-linked-checkbox" title="Show only packages that support the Dart SDK.">
@@ -273,7 +273,7 @@
           <div class="search-form-section foldable" data-section-tag="advanced">
             <h3 class="search-form-section-header foldable-button">
               <span class="search-form-section-header-label">Advanced</span>
-              <img class="foldable-icon" src="/static/img/search-form-foldable-icon.svg?hash=mocked_hash_663371761" alt="fold toggle icon (up/down arrow)" width="13" height="6"/>
+              <img class="foldable-icon" src="/static/hash-%%etag%%/img/search-form-foldable-icon.svg" alt="fold toggle icon (up/down arrow)" width="13" height="6"/>
             </h3>
             <div class="foldable-content">
               <div class="search-form-linked-checkbox" title="Show only Flutter Favorite packages.">
@@ -373,7 +373,7 @@
                   <a href="/packages/oxygen">oxygen</a>
                 </h3>
                 <div class="packages-recent">
-                  <img class="packages-recent-icon" src="/static/img/schedule-icon.svg?hash=mocked_hash_164576935" alt="icon indicating recent time" width="10" height="10" title="new package"/>
+                  <img class="packages-recent-icon" src="/static/hash-%%etag%%/img/schedule-icon.svg" alt="icon indicating recent time" width="10" height="10" title="new package"/>
                   Added
                   <b>%%x-ago%%</b>
                 </div>
@@ -437,7 +437,7 @@
                   <a href="/packages/flutter_titanium">flutter_titanium</a>
                 </h3>
                 <div class="packages-recent">
-                  <img class="packages-recent-icon" src="/static/img/schedule-icon.svg?hash=mocked_hash_164576935" alt="icon indicating recent time" width="10" height="10" title="new package"/>
+                  <img class="packages-recent-icon" src="/static/hash-%%etag%%/img/schedule-icon.svg" alt="icon indicating recent time" width="10" height="10" title="new package"/>
                   Added
                   <b>%%x-ago%%</b>
                 </div>
@@ -525,10 +525,10 @@
       <a class="link sep" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link sep" href="/help">Help</a>
       <a class="link icon sep" href="/feed.atom">
-        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
+        <img class="inline-icon" src="/static/hash-%%etag%%/img/rss-feed-icon.svg" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
       </a>
       <a class="link icon github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">
-        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
+        <img class="inline-icon" src="/static/hash-%%etag%%/img/bug-report-white-96px.png" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
       </a>
     </footer>
   </body>

--- a/app/test/frontend/golden/pkg_install_page.html
+++ b/app/test/frontend/golden/pkg_install_page.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
   <head>
     <script src="https://www.googletagmanager.com/gtm.js?id=GTM-MX6DBN9" async="async"></script>
-    <script src="/static/js/gtm.js?hash=mocked_hash_451823545"></script>
+    <script src="/static/hash-%%etag%%/js/gtm.js"></script>
     <meta charset="utf-8"/>
     <meta http-equiv="x-ua-compatible" content="ie=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
@@ -10,28 +10,28 @@
     <meta name="twitter:card" content="summary"/>
     <meta name="twitter:site" content="@dart_lang"/>
     <meta name="twitter:description" content="oxygen is awesome"/>
-    <meta name="twitter:image" content="https://pub.dev/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta name="twitter:image" content="https://pub.dev/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <meta property="og:type" content="website"/>
     <meta property="og:site_name" content="Dart packages"/>
     <meta property="og:title" content="oxygen | Dart Package"/>
     <meta property="og:description" content="oxygen is awesome"/>
-    <meta property="og:image" content="https://pub.dev/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta property="og:image" content="https://pub.dev/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <title>oxygen | Dart Package</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Google+Sans:300,400,500|Google+Sans+Display:400|Roboto:300,400,500,700|Roboto+Mono:300,400,700&amp;display=swap"/>
-    <meta content="/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta content="/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
-    <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/osd.xml?hash=mocked_hash_869379763"/>
+    <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/hash-%%etag%%/osd.xml"/>
     <link rel="canonical" href="https://pub.dev/packages/oxygen/install"/>
     <meta name="description" content="oxygen is awesome"/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
-    <link rel="stylesheet" type="text/css" href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842"/>
-    <link rel="stylesheet" type="text/css" href="/static/css/style.css?hash=mocked_hash_537099079"/>
-    <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
+    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/material/material-components-web.min.css"/>
+    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/style.css"/>
+    <script src="/static/hash-%%etag%%/material/material-components-web.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <meta name="google-signin-client_id" content=""/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
     <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJveHlnZW4iLCJ2ZXJzaW9uIjoiMS4yLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlfX0="/>
-    <link rel="preload" href="/static/highlight/highlight-with-init.js?hash=mocked_hash_670483893" as="script"/>
+    <link rel="preload" href="/static/hash-%%etag%%/highlight/highlight-with-init.js" as="script"/>
   </head>
   <body>
     <noscript>
@@ -40,7 +40,7 @@
     <div class="site-header">
       <button class="hamburger" aria-label="menu toggle"></button>
       <a class="logo" href="/">
-        <img class="site-logo" src="/static/img/pub-dev-logo-2x.png?hash=mocked_hash_685890546" alt="pub logo" width="135" height="30"/>
+        <img class="site-logo" src="/static/hash-%%etag%%/img/pub-dev-logo-2x.png" alt="pub logo" width="135" height="30"/>
       </a>
       <div class="site-header-space"></div>
       <div class="site-header-mask"></div>
@@ -79,7 +79,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Pub.dev
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="/help/search" rel="noopener" target="_blank">Searching for packages</a>
@@ -89,7 +89,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Flutter
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://flutter.io/using-packages/" rel="noopener" target="_blank">Using packages</a>
@@ -100,7 +100,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Dart
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://dart.dev/tools/pub/get-started" rel="noopener" target="_blank">Using packages</a>
@@ -119,7 +119,7 @@
                 <h1 class="title">
                   oxygen 1.2.0
                   <span class="pkg-page-title-copy">
-                    <img class="pkg-page-title-copy-icon" src="/static/img/content-copy-icon.svg?hash=mocked_hash_1005735992" alt="icon indicating copy to clipboard operation" width="18" height="18" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>
+                    <img class="pkg-page-title-copy-icon" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="icon indicating copy to clipboard operation" width="18" height="18" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>
                     <div class="pkg-page-title-copy-feedback">
                       <span class="code">oxygen: ^1.2.0</span>
                       copied to clipboard
@@ -159,8 +159,8 @@
                   </div>
                   <div class="detail-like">
                     <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false">
-                      <img class="mdc-icon-button__icon" src="/static/img/like-inactive.svg?hash=mocked_hash_1066096316" alt="icon indicating liked status (inactive)" width="18" height="18"/>
-                      <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/img/like-active.svg?hash=mocked_hash_986617859" alt="icon indicating liked status (active)" width="18" height="18"/>
+                      <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="icon indicating liked status (inactive)" width="18" height="18"/>
+                      <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="icon indicating liked status (active)" width="18" height="18"/>
                     </button>
                     <span class="likes-count">
                       <span id="likes-count">0</span>
@@ -370,12 +370,12 @@
       <a class="link sep" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link sep" href="/help">Help</a>
       <a class="link icon sep" href="/feed.atom">
-        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
+        <img class="inline-icon" src="/static/hash-%%etag%%/img/rss-feed-icon.svg" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
       </a>
       <a class="link icon github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">
-        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
+        <img class="inline-icon" src="/static/hash-%%etag%%/img/bug-report-white-96px.png" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
       </a>
     </footer>
-    <script src="/static/highlight/highlight-with-init.js?hash=mocked_hash_670483893" defer="defer"></script>
+    <script src="/static/hash-%%etag%%/highlight/highlight-with-init.js" defer="defer"></script>
   </body>
 </html>

--- a/app/test/frontend/golden/pkg_score_page.html
+++ b/app/test/frontend/golden/pkg_score_page.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
   <head>
     <script src="https://www.googletagmanager.com/gtm.js?id=GTM-MX6DBN9" async="async"></script>
-    <script src="/static/js/gtm.js?hash=mocked_hash_451823545"></script>
+    <script src="/static/hash-%%etag%%/js/gtm.js"></script>
     <meta charset="utf-8"/>
     <meta http-equiv="x-ua-compatible" content="ie=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
@@ -10,28 +10,28 @@
     <meta name="twitter:card" content="summary"/>
     <meta name="twitter:site" content="@dart_lang"/>
     <meta name="twitter:description" content="oxygen is awesome"/>
-    <meta name="twitter:image" content="https://pub.dev/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta name="twitter:image" content="https://pub.dev/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <meta property="og:type" content="website"/>
     <meta property="og:site_name" content="Dart packages"/>
     <meta property="og:title" content="oxygen | Dart Package"/>
     <meta property="og:description" content="oxygen is awesome"/>
-    <meta property="og:image" content="https://pub.dev/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta property="og:image" content="https://pub.dev/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <title>oxygen | Dart Package</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Google+Sans:300,400,500|Google+Sans+Display:400|Roboto:300,400,500,700|Roboto+Mono:300,400,700&amp;display=swap"/>
-    <meta content="/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta content="/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
-    <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/osd.xml?hash=mocked_hash_869379763"/>
+    <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/hash-%%etag%%/osd.xml"/>
     <link rel="canonical" href="https://pub.dev/packages/oxygen/score"/>
     <meta name="description" content="oxygen is awesome"/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
-    <link rel="stylesheet" type="text/css" href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842"/>
-    <link rel="stylesheet" type="text/css" href="/static/css/style.css?hash=mocked_hash_537099079"/>
-    <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
+    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/material/material-components-web.min.css"/>
+    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/style.css"/>
+    <script src="/static/hash-%%etag%%/material/material-components-web.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <meta name="google-signin-client_id" content=""/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
     <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJveHlnZW4iLCJ2ZXJzaW9uIjoiMS4yLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlfX0="/>
-    <link rel="preload" href="/static/highlight/highlight-with-init.js?hash=mocked_hash_670483893" as="script"/>
+    <link rel="preload" href="/static/hash-%%etag%%/highlight/highlight-with-init.js" as="script"/>
   </head>
   <body>
     <noscript>
@@ -40,7 +40,7 @@
     <div class="site-header">
       <button class="hamburger" aria-label="menu toggle"></button>
       <a class="logo" href="/">
-        <img class="site-logo" src="/static/img/pub-dev-logo-2x.png?hash=mocked_hash_685890546" alt="pub logo" width="135" height="30"/>
+        <img class="site-logo" src="/static/hash-%%etag%%/img/pub-dev-logo-2x.png" alt="pub logo" width="135" height="30"/>
       </a>
       <div class="site-header-space"></div>
       <div class="site-header-mask"></div>
@@ -79,7 +79,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Pub.dev
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="/help/search" rel="noopener" target="_blank">Searching for packages</a>
@@ -89,7 +89,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Flutter
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://flutter.io/using-packages/" rel="noopener" target="_blank">Using packages</a>
@@ -100,7 +100,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Dart
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://dart.dev/tools/pub/get-started" rel="noopener" target="_blank">Using packages</a>
@@ -119,7 +119,7 @@
                 <h1 class="title">
                   oxygen 1.2.0
                   <span class="pkg-page-title-copy">
-                    <img class="pkg-page-title-copy-icon" src="/static/img/content-copy-icon.svg?hash=mocked_hash_1005735992" alt="icon indicating copy to clipboard operation" width="18" height="18" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>
+                    <img class="pkg-page-title-copy-icon" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="icon indicating copy to clipboard operation" width="18" height="18" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>
                     <div class="pkg-page-title-copy-feedback">
                       <span class="code">oxygen: ^1.2.0</span>
                       copied to clipboard
@@ -159,8 +159,8 @@
                   </div>
                   <div class="detail-like">
                     <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false">
-                      <img class="mdc-icon-button__icon" src="/static/img/like-inactive.svg?hash=mocked_hash_1066096316" alt="icon indicating liked status (inactive)" width="18" height="18"/>
-                      <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/img/like-active.svg?hash=mocked_hash_986617859" alt="icon indicating liked status (active)" width="18" height="18"/>
+                      <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="icon indicating liked status (inactive)" width="18" height="18"/>
+                      <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="icon indicating liked status (active)" width="18" height="18"/>
                     </button>
                     <span class="likes-count">
                       <span id="likes-count">0</span>
@@ -242,21 +242,21 @@
                     <div class="pkg-report-section foldable">
                       <div class="pkg-report-header foldable-button" data-ga-click-event="toggle-report-section-convention">
                         <div class="pkg-report-header-icon">
-                          <img class="pkg-report-icon" src="/static/img/report-missing-icon-red.svg?hash=mocked_hash_289300077" alt="icon indicating section status" width="18" height="18"/>
+                          <img class="pkg-report-icon" src="/static/hash-%%etag%%/img/report-missing-icon-red.svg" alt="icon indicating section status" width="18" height="18"/>
                         </div>
                         <div class="pkg-report-header-title">Fake conventions</div>
                         <div class="pkg-report-header-score -is-red">
                           <span class="pkg-report-header-score-granted">8</span>
                           /
                           <span class="pkg-report-header-score-max">30</span>
-                          <img class="foldable-icon" src="/static/img/report-foldable-icon.svg?hash=mocked_hash_525278376" alt="icon to trigger folding of the section" width="13" height="6"/>
+                          <img class="foldable-icon" src="/static/hash-%%etag%%/img/report-foldable-icon.svg" alt="icon to trigger folding of the section" width="13" height="6"/>
                         </div>
                       </div>
                       <div class="foldable-content">
                         <div class="pkg-report-content">
                           <div class="pkg-report-content-summary markdown-body">
                             <h3>
-                              <img class="report-summary-icon" src="/static/img/report-missing-icon-yellow.svg?hash=mocked_hash_616530614"/>
+                              <img class="report-summary-icon" src="/static/hash-%%etag%%/img/report-missing-icon-yellow.svg"/>
                               8/30 points: Package layout
                             </h3>
                             <ul>
@@ -269,28 +269,28 @@
                     <div class="pkg-report-section foldable">
                       <div class="pkg-report-header foldable-button" data-ga-click-event="toggle-report-section-documentation">
                         <div class="pkg-report-header-icon">
-                          <img class="pkg-report-icon" src="/static/img/report-ok-icon-green.svg?hash=mocked_hash_415427754" alt="icon indicating section status" width="18" height="18"/>
+                          <img class="pkg-report-icon" src="/static/hash-%%etag%%/img/report-ok-icon-green.svg" alt="icon indicating section status" width="18" height="18"/>
                         </div>
                         <div class="pkg-report-header-title">Fake documentation</div>
                         <div class="pkg-report-header-score">
                           <span class="pkg-report-header-score-granted">35</span>
                           /
                           <span class="pkg-report-header-score-max">40</span>
-                          <img class="foldable-icon" src="/static/img/report-foldable-icon.svg?hash=mocked_hash_525278376" alt="icon to trigger folding of the section" width="13" height="6"/>
+                          <img class="foldable-icon" src="/static/hash-%%etag%%/img/report-foldable-icon.svg" alt="icon to trigger folding of the section" width="13" height="6"/>
                         </div>
                       </div>
                       <div class="foldable-content">
                         <div class="pkg-report-content">
                           <div class="pkg-report-content-summary markdown-body">
                             <h3>
-                              <img class="report-summary-icon" src="/static/img/report-missing-icon-yellow.svg?hash=mocked_hash_616530614"/>
+                              <img class="report-summary-icon" src="/static/hash-%%etag%%/img/report-missing-icon-yellow.svg"/>
                               25/30 points: Example
                             </h3>
                             <ul>
                               <li>Example score randomly set to 25...</li>
                             </ul>
                             <h3>
-                              <img class="report-summary-icon" src="/static/img/report-ok-icon-green.svg?hash=mocked_hash_415427754"/>
+                              <img class="report-summary-icon" src="/static/hash-%%etag%%/img/report-ok-icon-green.svg"/>
                               10/10 points: 20% or more of the public API has dartdoc comments
                             </h3>
                             <ul>
@@ -434,12 +434,12 @@
       <a class="link sep" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link sep" href="/help">Help</a>
       <a class="link icon sep" href="/feed.atom">
-        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
+        <img class="inline-icon" src="/static/hash-%%etag%%/img/rss-feed-icon.svg" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
       </a>
       <a class="link icon github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">
-        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
+        <img class="inline-icon" src="/static/hash-%%etag%%/img/bug-report-white-96px.png" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
       </a>
     </footer>
-    <script src="/static/highlight/highlight-with-init.js?hash=mocked_hash_670483893" defer="defer"></script>
+    <script src="/static/hash-%%etag%%/highlight/highlight-with-init.js" defer="defer"></script>
   </body>
 </html>

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
   <head>
     <script src="https://www.googletagmanager.com/gtm.js?id=GTM-MX6DBN9" async="async"></script>
-    <script src="/static/js/gtm.js?hash=mocked_hash_451823545"></script>
+    <script src="/static/hash-%%etag%%/js/gtm.js"></script>
     <meta charset="utf-8"/>
     <meta http-equiv="x-ua-compatible" content="ie=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
@@ -10,28 +10,28 @@
     <meta name="twitter:card" content="summary"/>
     <meta name="twitter:site" content="@dart_lang"/>
     <meta name="twitter:description" content="oxygen is awesome"/>
-    <meta name="twitter:image" content="https://pub.dev/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta name="twitter:image" content="https://pub.dev/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <meta property="og:type" content="website"/>
     <meta property="og:site_name" content="Dart packages"/>
     <meta property="og:title" content="oxygen | Dart Package"/>
     <meta property="og:description" content="oxygen is awesome"/>
-    <meta property="og:image" content="https://pub.dev/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta property="og:image" content="https://pub.dev/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <title>oxygen | Dart Package</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Google+Sans:300,400,500|Google+Sans+Display:400|Roboto:300,400,500,700|Roboto+Mono:300,400,700&amp;display=swap"/>
-    <meta content="/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta content="/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
-    <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/osd.xml?hash=mocked_hash_869379763"/>
+    <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/hash-%%etag%%/osd.xml"/>
     <link rel="canonical" href="https://pub.dev/packages/oxygen"/>
     <meta name="description" content="oxygen is awesome"/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
-    <link rel="stylesheet" type="text/css" href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842"/>
-    <link rel="stylesheet" type="text/css" href="/static/css/style.css?hash=mocked_hash_537099079"/>
-    <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
+    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/material/material-components-web.min.css"/>
+    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/style.css"/>
+    <script src="/static/hash-%%etag%%/material/material-components-web.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <meta name="google-signin-client_id" content=""/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
     <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJveHlnZW4iLCJ2ZXJzaW9uIjoiMS4yLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlfX0="/>
-    <link rel="preload" href="/static/highlight/highlight-with-init.js?hash=mocked_hash_670483893" as="script"/>
+    <link rel="preload" href="/static/hash-%%etag%%/highlight/highlight-with-init.js" as="script"/>
   </head>
   <body>
     <noscript>
@@ -40,7 +40,7 @@
     <div class="site-header">
       <button class="hamburger" aria-label="menu toggle"></button>
       <a class="logo" href="/">
-        <img class="site-logo" src="/static/img/pub-dev-logo-2x.png?hash=mocked_hash_685890546" alt="pub logo" width="135" height="30"/>
+        <img class="site-logo" src="/static/hash-%%etag%%/img/pub-dev-logo-2x.png" alt="pub logo" width="135" height="30"/>
       </a>
       <div class="site-header-space"></div>
       <div class="site-header-mask"></div>
@@ -79,7 +79,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Pub.dev
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="/help/search" rel="noopener" target="_blank">Searching for packages</a>
@@ -89,7 +89,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Flutter
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://flutter.io/using-packages/" rel="noopener" target="_blank">Using packages</a>
@@ -100,7 +100,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Dart
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://dart.dev/tools/pub/get-started" rel="noopener" target="_blank">Using packages</a>
@@ -119,7 +119,7 @@
                 <h1 class="title">
                   oxygen 1.2.0
                   <span class="pkg-page-title-copy">
-                    <img class="pkg-page-title-copy-icon" src="/static/img/content-copy-icon.svg?hash=mocked_hash_1005735992" alt="icon indicating copy to clipboard operation" width="18" height="18" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>
+                    <img class="pkg-page-title-copy-icon" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="icon indicating copy to clipboard operation" width="18" height="18" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>
                     <div class="pkg-page-title-copy-feedback">
                       <span class="code">oxygen: ^1.2.0</span>
                       copied to clipboard
@@ -159,8 +159,8 @@
                   </div>
                   <div class="detail-like">
                     <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false">
-                      <img class="mdc-icon-button__icon" src="/static/img/like-inactive.svg?hash=mocked_hash_1066096316" alt="icon indicating liked status (inactive)" width="18" height="18"/>
-                      <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/img/like-active.svg?hash=mocked_hash_986617859" alt="icon indicating liked status (active)" width="18" height="18"/>
+                      <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="icon indicating liked status (inactive)" width="18" height="18"/>
+                      <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="icon indicating liked status (active)" width="18" height="18"/>
                     </button>
                     <span class="likes-count">
                       <span id="likes-count">0</span>
@@ -341,12 +341,12 @@
       <a class="link sep" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link sep" href="/help">Help</a>
       <a class="link icon sep" href="/feed.atom">
-        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
+        <img class="inline-icon" src="/static/hash-%%etag%%/img/rss-feed-icon.svg" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
       </a>
       <a class="link icon github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">
-        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
+        <img class="inline-icon" src="/static/hash-%%etag%%/img/bug-report-white-96px.png" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
       </a>
     </footer>
-    <script src="/static/highlight/highlight-with-init.js?hash=mocked_hash_670483893" defer="defer"></script>
+    <script src="/static/hash-%%etag%%/highlight/highlight-with-init.js" defer="defer"></script>
   </body>
 </html>

--- a/app/test/frontend/golden/pkg_show_page_discontinued.html
+++ b/app/test/frontend/golden/pkg_show_page_discontinued.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
   <head>
     <script src="https://www.googletagmanager.com/gtm.js?id=GTM-MX6DBN9" async="async"></script>
-    <script src="/static/js/gtm.js?hash=mocked_hash_451823545"></script>
+    <script src="/static/hash-%%etag%%/js/gtm.js"></script>
     <meta charset="utf-8"/>
     <meta http-equiv="x-ua-compatible" content="ie=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
@@ -10,28 +10,28 @@
     <meta name="twitter:card" content="summary"/>
     <meta name="twitter:site" content="@dart_lang"/>
     <meta name="twitter:description" content="pkg is awesome"/>
-    <meta name="twitter:image" content="https://pub.dev/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta name="twitter:image" content="https://pub.dev/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <meta property="og:type" content="website"/>
     <meta property="og:site_name" content="Dart packages"/>
     <meta property="og:title" content="pkg | Dart Package"/>
     <meta property="og:description" content="pkg is awesome"/>
-    <meta property="og:image" content="https://pub.dev/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta property="og:image" content="https://pub.dev/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <title>pkg | Dart Package</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Google+Sans:300,400,500|Google+Sans+Display:400|Roboto:300,400,500,700|Roboto+Mono:300,400,700&amp;display=swap"/>
-    <meta content="/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta content="/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
-    <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/osd.xml?hash=mocked_hash_869379763"/>
+    <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/hash-%%etag%%/osd.xml"/>
     <link rel="canonical" href="https://pub.dev/packages/pkg"/>
     <meta name="description" content="pkg is awesome"/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
-    <link rel="stylesheet" type="text/css" href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842"/>
-    <link rel="stylesheet" type="text/css" href="/static/css/style.css?hash=mocked_hash_537099079"/>
-    <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
+    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/material/material-components-web.min.css"/>
+    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/style.css"/>
+    <script src="/static/hash-%%etag%%/material/material-components-web.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <meta name="google-signin-client_id" content=""/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
     <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJwa2ciLCJ2ZXJzaW9uIjoiMS4wLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOnRydWV9fQ=="/>
-    <link rel="preload" href="/static/highlight/highlight-with-init.js?hash=mocked_hash_670483893" as="script"/>
+    <link rel="preload" href="/static/hash-%%etag%%/highlight/highlight-with-init.js" as="script"/>
   </head>
   <body>
     <noscript>
@@ -40,7 +40,7 @@
     <div class="site-header">
       <button class="hamburger" aria-label="menu toggle"></button>
       <a class="logo" href="/">
-        <img class="site-logo" src="/static/img/pub-dev-logo-2x.png?hash=mocked_hash_685890546" alt="pub logo" width="135" height="30"/>
+        <img class="site-logo" src="/static/hash-%%etag%%/img/pub-dev-logo-2x.png" alt="pub logo" width="135" height="30"/>
       </a>
       <div class="site-header-space"></div>
       <div class="site-header-mask"></div>
@@ -79,7 +79,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Pub.dev
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="/help/search" rel="noopener" target="_blank">Searching for packages</a>
@@ -89,7 +89,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Flutter
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://flutter.io/using-packages/" rel="noopener" target="_blank">Using packages</a>
@@ -100,7 +100,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Dart
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://dart.dev/tools/pub/get-started" rel="noopener" target="_blank">Using packages</a>
@@ -119,7 +119,7 @@
                 <h1 class="title">
                   pkg 1.0.0
                   <span class="pkg-page-title-copy">
-                    <img class="pkg-page-title-copy-icon" src="/static/img/content-copy-icon.svg?hash=mocked_hash_1005735992" alt="icon indicating copy to clipboard operation" width="18" height="18" title="Copy &quot;pkg: ^1.0.0&quot; to clipboard" data-copy-content="pkg: ^1.0.0" data-ga-click-event="copy-package-version"/>
+                    <img class="pkg-page-title-copy-icon" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="icon indicating copy to clipboard operation" width="18" height="18" title="Copy &quot;pkg: ^1.0.0&quot; to clipboard" data-copy-content="pkg: ^1.0.0" data-ga-click-event="copy-package-version"/>
                     <div class="pkg-page-title-copy-feedback">
                       <span class="code">pkg: ^1.0.0</span>
                       copied to clipboard
@@ -138,8 +138,8 @@
                   </div>
                   <div class="detail-like">
                     <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false">
-                      <img class="mdc-icon-button__icon" src="/static/img/like-inactive.svg?hash=mocked_hash_1066096316" alt="icon indicating liked status (inactive)" width="18" height="18"/>
-                      <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/img/like-active.svg?hash=mocked_hash_986617859" alt="icon indicating liked status (active)" width="18" height="18"/>
+                      <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="icon indicating liked status (inactive)" width="18" height="18"/>
+                      <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="icon indicating liked status (active)" width="18" height="18"/>
                     </button>
                     <span class="likes-count">
                       <span id="likes-count">0</span>
@@ -320,12 +320,12 @@
       <a class="link sep" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link sep" href="/help">Help</a>
       <a class="link icon sep" href="/feed.atom">
-        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
+        <img class="inline-icon" src="/static/hash-%%etag%%/img/rss-feed-icon.svg" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
       </a>
       <a class="link icon github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">
-        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
+        <img class="inline-icon" src="/static/hash-%%etag%%/img/bug-report-white-96px.png" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
       </a>
     </footer>
-    <script src="/static/highlight/highlight-with-init.js?hash=mocked_hash_670483893" defer="defer"></script>
+    <script src="/static/hash-%%etag%%/highlight/highlight-with-init.js" defer="defer"></script>
   </body>
 </html>

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
   <head>
     <script src="https://www.googletagmanager.com/gtm.js?id=GTM-MX6DBN9" async="async"></script>
-    <script src="/static/js/gtm.js?hash=mocked_hash_451823545"></script>
+    <script src="/static/hash-%%etag%%/js/gtm.js"></script>
     <meta charset="utf-8"/>
     <meta http-equiv="x-ua-compatible" content="ie=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
@@ -10,28 +10,28 @@
     <meta name="twitter:card" content="summary"/>
     <meta name="twitter:site" content="@dart_lang"/>
     <meta name="twitter:description" content="flutter_titanium is awesome"/>
-    <meta name="twitter:image" content="https://pub.dev/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta name="twitter:image" content="https://pub.dev/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <meta property="og:type" content="website"/>
     <meta property="og:site_name" content="Dart packages"/>
     <meta property="og:title" content="flutter_titanium | Flutter Package"/>
     <meta property="og:description" content="flutter_titanium is awesome"/>
-    <meta property="og:image" content="https://pub.dev/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta property="og:image" content="https://pub.dev/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <title>flutter_titanium | Flutter Package</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Google+Sans:300,400,500|Google+Sans+Display:400|Roboto:300,400,500,700|Roboto+Mono:300,400,700&amp;display=swap"/>
-    <meta content="/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
-    <link rel="shortcut icon" href="/static/img/flutter-logo-32x32.png?hash=mocked_hash_318836230"/>
-    <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/osd.xml?hash=mocked_hash_869379763"/>
+    <meta content="/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
+    <link rel="shortcut icon" href="/static/hash-%%etag%%/img/flutter-logo-32x32.png"/>
+    <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/hash-%%etag%%/osd.xml"/>
     <link rel="canonical" href="https://pub.dev/packages/flutter_titanium"/>
     <meta name="description" content="flutter_titanium is awesome"/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
-    <link rel="stylesheet" type="text/css" href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842"/>
-    <link rel="stylesheet" type="text/css" href="/static/css/style.css?hash=mocked_hash_537099079"/>
-    <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
+    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/material/material-components-web.min.css"/>
+    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/style.css"/>
+    <script src="/static/hash-%%etag%%/material/material-components-web.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <meta name="google-signin-client_id" content=""/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
     <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJmbHV0dGVyX3RpdGFuaXVtIiwidmVyc2lvbiI6IjEuMTAuMCIsImxpa2VzIjowLCJpc0Rpc2NvbnRpbnVlZCI6ZmFsc2V9fQ=="/>
-    <link rel="preload" href="/static/highlight/highlight-with-init.js?hash=mocked_hash_670483893" as="script"/>
+    <link rel="preload" href="/static/hash-%%etag%%/highlight/highlight-with-init.js" as="script"/>
   </head>
   <body>
     <noscript>
@@ -40,7 +40,7 @@
     <div class="site-header">
       <button class="hamburger" aria-label="menu toggle"></button>
       <a class="logo" href="/">
-        <img class="site-logo" src="/static/img/pub-dev-logo-2x.png?hash=mocked_hash_685890546" alt="pub logo" width="135" height="30"/>
+        <img class="site-logo" src="/static/hash-%%etag%%/img/pub-dev-logo-2x.png" alt="pub logo" width="135" height="30"/>
       </a>
       <div class="site-header-space"></div>
       <div class="site-header-mask"></div>
@@ -79,7 +79,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Pub.dev
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="/help/search" rel="noopener" target="_blank">Searching for packages</a>
@@ -89,7 +89,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Flutter
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://flutter.io/using-packages/" rel="noopener" target="_blank">Using packages</a>
@@ -100,7 +100,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Dart
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://dart.dev/tools/pub/get-started" rel="noopener" target="_blank">Using packages</a>
@@ -119,7 +119,7 @@
                 <h1 class="title">
                   flutter_titanium 1.10.0
                   <span class="pkg-page-title-copy">
-                    <img class="pkg-page-title-copy-icon" src="/static/img/content-copy-icon.svg?hash=mocked_hash_1005735992" alt="icon indicating copy to clipboard operation" width="18" height="18" title="Copy &quot;flutter_titanium: ^1.10.0&quot; to clipboard" data-copy-content="flutter_titanium: ^1.10.0" data-ga-click-event="copy-package-version"/>
+                    <img class="pkg-page-title-copy-icon" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="icon indicating copy to clipboard operation" width="18" height="18" title="Copy &quot;flutter_titanium: ^1.10.0&quot; to clipboard" data-copy-content="flutter_titanium: ^1.10.0" data-ga-click-event="copy-package-version"/>
                     <div class="pkg-page-title-copy-feedback">
                       <span class="code">flutter_titanium: ^1.10.0</span>
                       copied to clipboard
@@ -147,8 +147,8 @@
                   </div>
                   <div class="detail-like">
                     <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false">
-                      <img class="mdc-icon-button__icon" src="/static/img/like-inactive.svg?hash=mocked_hash_1066096316" alt="icon indicating liked status (inactive)" width="18" height="18"/>
-                      <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/img/like-active.svg?hash=mocked_hash_986617859" alt="icon indicating liked status (active)" width="18" height="18"/>
+                      <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="icon indicating liked status (inactive)" width="18" height="18"/>
+                      <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="icon indicating liked status (active)" width="18" height="18"/>
                     </button>
                     <span class="likes-count">
                       <span id="likes-count">0</span>
@@ -337,12 +337,12 @@
       <a class="link sep" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link sep" href="/help">Help</a>
       <a class="link icon sep" href="/feed.atom">
-        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
+        <img class="inline-icon" src="/static/hash-%%etag%%/img/rss-feed-icon.svg" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
       </a>
       <a class="link icon github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">
-        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
+        <img class="inline-icon" src="/static/hash-%%etag%%/img/bug-report-white-96px.png" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
       </a>
     </footer>
-    <script src="/static/highlight/highlight-with-init.js?hash=mocked_hash_670483893" defer="defer"></script>
+    <script src="/static/hash-%%etag%%/highlight/highlight-with-init.js" defer="defer"></script>
   </body>
 </html>

--- a/app/test/frontend/golden/pkg_show_page_legacy.html
+++ b/app/test/frontend/golden/pkg_show_page_legacy.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
   <head>
     <script src="https://www.googletagmanager.com/gtm.js?id=GTM-MX6DBN9" async="async"></script>
-    <script src="/static/js/gtm.js?hash=mocked_hash_451823545"></script>
+    <script src="/static/hash-%%etag%%/js/gtm.js"></script>
     <meta charset="utf-8"/>
     <meta http-equiv="x-ua-compatible" content="ie=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
@@ -10,28 +10,28 @@
     <meta name="twitter:card" content="summary"/>
     <meta name="twitter:site" content="@dart_lang"/>
     <meta name="twitter:description" content="pkg is awesome"/>
-    <meta name="twitter:image" content="https://pub.dev/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta name="twitter:image" content="https://pub.dev/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <meta property="og:type" content="website"/>
     <meta property="og:site_name" content="Dart packages"/>
     <meta property="og:title" content="pkg | Dart Package"/>
     <meta property="og:description" content="pkg is awesome"/>
-    <meta property="og:image" content="https://pub.dev/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta property="og:image" content="https://pub.dev/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <title>pkg | Dart Package</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Google+Sans:300,400,500|Google+Sans+Display:400|Roboto:300,400,500,700|Roboto+Mono:300,400,700&amp;display=swap"/>
-    <meta content="/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta content="/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
-    <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/osd.xml?hash=mocked_hash_869379763"/>
+    <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/hash-%%etag%%/osd.xml"/>
     <link rel="canonical" href="https://pub.dev/packages/pkg/score"/>
     <meta name="description" content="pkg is awesome"/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
-    <link rel="stylesheet" type="text/css" href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842"/>
-    <link rel="stylesheet" type="text/css" href="/static/css/style.css?hash=mocked_hash_537099079"/>
-    <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
+    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/material/material-components-web.min.css"/>
+    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/style.css"/>
+    <script src="/static/hash-%%etag%%/material/material-components-web.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <meta name="google-signin-client_id" content=""/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
     <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJwa2ciLCJ2ZXJzaW9uIjoiMS4wLjAtbGVnYWN5IiwibGlrZXMiOjAsImlzRGlzY29udGludWVkIjpmYWxzZX19"/>
-    <link rel="preload" href="/static/highlight/highlight-with-init.js?hash=mocked_hash_670483893" as="script"/>
+    <link rel="preload" href="/static/hash-%%etag%%/highlight/highlight-with-init.js" as="script"/>
   </head>
   <body>
     <noscript>
@@ -40,7 +40,7 @@
     <div class="site-header">
       <button class="hamburger" aria-label="menu toggle"></button>
       <a class="logo" href="/">
-        <img class="site-logo" src="/static/img/pub-dev-logo-2x.png?hash=mocked_hash_685890546" alt="pub logo" width="135" height="30"/>
+        <img class="site-logo" src="/static/hash-%%etag%%/img/pub-dev-logo-2x.png" alt="pub logo" width="135" height="30"/>
       </a>
       <div class="site-header-space"></div>
       <div class="site-header-mask"></div>
@@ -79,7 +79,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Pub.dev
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="/help/search" rel="noopener" target="_blank">Searching for packages</a>
@@ -89,7 +89,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Flutter
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://flutter.io/using-packages/" rel="noopener" target="_blank">Using packages</a>
@@ -100,7 +100,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Dart
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://dart.dev/tools/pub/get-started" rel="noopener" target="_blank">Using packages</a>
@@ -119,7 +119,7 @@
                 <h1 class="title">
                   pkg 1.0.0-legacy
                   <span class="pkg-page-title-copy">
-                    <img class="pkg-page-title-copy-icon" src="/static/img/content-copy-icon.svg?hash=mocked_hash_1005735992" alt="icon indicating copy to clipboard operation" width="18" height="18" title="Copy &quot;pkg: ^1.0.0-legacy&quot; to clipboard" data-copy-content="pkg: ^1.0.0-legacy" data-ga-click-event="copy-package-version"/>
+                    <img class="pkg-page-title-copy-icon" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="icon indicating copy to clipboard operation" width="18" height="18" title="Copy &quot;pkg: ^1.0.0-legacy&quot; to clipboard" data-copy-content="pkg: ^1.0.0-legacy" data-ga-click-event="copy-package-version"/>
                     <div class="pkg-page-title-copy-feedback">
                       <span class="code">pkg: ^1.0.0-legacy</span>
                       copied to clipboard
@@ -138,8 +138,8 @@
                   </div>
                   <div class="detail-like">
                     <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false">
-                      <img class="mdc-icon-button__icon" src="/static/img/like-inactive.svg?hash=mocked_hash_1066096316" alt="icon indicating liked status (inactive)" width="18" height="18"/>
-                      <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/img/like-active.svg?hash=mocked_hash_986617859" alt="icon indicating liked status (active)" width="18" height="18"/>
+                      <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="icon indicating liked status (inactive)" width="18" height="18"/>
+                      <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="icon indicating liked status (active)" width="18" height="18"/>
                     </button>
                     <span class="likes-count">
                       <span id="likes-count">0</span>
@@ -329,12 +329,12 @@
       <a class="link sep" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link sep" href="/help">Help</a>
       <a class="link icon sep" href="/feed.atom">
-        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
+        <img class="inline-icon" src="/static/hash-%%etag%%/img/rss-feed-icon.svg" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
       </a>
       <a class="link icon github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">
-        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
+        <img class="inline-icon" src="/static/hash-%%etag%%/img/bug-report-white-96px.png" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
       </a>
     </footer>
-    <script src="/static/highlight/highlight-with-init.js?hash=mocked_hash_670483893" defer="defer"></script>
+    <script src="/static/hash-%%etag%%/highlight/highlight-with-init.js" defer="defer"></script>
   </body>
 </html>

--- a/app/test/frontend/golden/pkg_show_page_publisher.html
+++ b/app/test/frontend/golden/pkg_show_page_publisher.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
   <head>
     <script src="https://www.googletagmanager.com/gtm.js?id=GTM-MX6DBN9" async="async"></script>
-    <script src="/static/js/gtm.js?hash=mocked_hash_451823545"></script>
+    <script src="/static/hash-%%etag%%/js/gtm.js"></script>
     <meta charset="utf-8"/>
     <meta http-equiv="x-ua-compatible" content="ie=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
@@ -10,28 +10,28 @@
     <meta name="twitter:card" content="summary"/>
     <meta name="twitter:site" content="@dart_lang"/>
     <meta name="twitter:description" content="neon is awesome"/>
-    <meta name="twitter:image" content="https://pub.dev/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta name="twitter:image" content="https://pub.dev/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <meta property="og:type" content="website"/>
     <meta property="og:site_name" content="Dart packages"/>
     <meta property="og:title" content="neon | Dart Package"/>
     <meta property="og:description" content="neon is awesome"/>
-    <meta property="og:image" content="https://pub.dev/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta property="og:image" content="https://pub.dev/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <title>neon | Dart Package</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Google+Sans:300,400,500|Google+Sans+Display:400|Roboto:300,400,500,700|Roboto+Mono:300,400,700&amp;display=swap"/>
-    <meta content="/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta content="/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
-    <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/osd.xml?hash=mocked_hash_869379763"/>
+    <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/hash-%%etag%%/osd.xml"/>
     <link rel="canonical" href="https://pub.dev/packages/neon"/>
     <meta name="description" content="neon is awesome"/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
-    <link rel="stylesheet" type="text/css" href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842"/>
-    <link rel="stylesheet" type="text/css" href="/static/css/style.css?hash=mocked_hash_537099079"/>
-    <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
+    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/material/material-components-web.min.css"/>
+    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/style.css"/>
+    <script src="/static/hash-%%etag%%/material/material-components-web.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <meta name="google-signin-client_id" content=""/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
     <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJuZW9uIiwidmVyc2lvbiI6IjEuMC4wIiwibGlrZXMiOjAsInB1Ymxpc2hlcklkIjoiZXhhbXBsZS5jb20iLCJpc0Rpc2NvbnRpbnVlZCI6ZmFsc2V9fQ=="/>
-    <link rel="preload" href="/static/highlight/highlight-with-init.js?hash=mocked_hash_670483893" as="script"/>
+    <link rel="preload" href="/static/hash-%%etag%%/highlight/highlight-with-init.js" as="script"/>
   </head>
   <body>
     <noscript>
@@ -40,7 +40,7 @@
     <div class="site-header">
       <button class="hamburger" aria-label="menu toggle"></button>
       <a class="logo" href="/">
-        <img class="site-logo" src="/static/img/pub-dev-logo-2x.png?hash=mocked_hash_685890546" alt="pub logo" width="135" height="30"/>
+        <img class="site-logo" src="/static/hash-%%etag%%/img/pub-dev-logo-2x.png" alt="pub logo" width="135" height="30"/>
       </a>
       <div class="site-header-space"></div>
       <div class="site-header-mask"></div>
@@ -79,7 +79,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Pub.dev
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="/help/search" rel="noopener" target="_blank">Searching for packages</a>
@@ -89,7 +89,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Flutter
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://flutter.io/using-packages/" rel="noopener" target="_blank">Using packages</a>
@@ -100,7 +100,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Dart
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://dart.dev/tools/pub/get-started" rel="noopener" target="_blank">Using packages</a>
@@ -119,7 +119,7 @@
                 <h1 class="title">
                   neon 1.0.0
                   <span class="pkg-page-title-copy">
-                    <img class="pkg-page-title-copy-icon" src="/static/img/content-copy-icon.svg?hash=mocked_hash_1005735992" alt="icon indicating copy to clipboard operation" width="18" height="18" title="Copy &quot;neon: ^1.0.0&quot; to clipboard" data-copy-content="neon: ^1.0.0" data-ga-click-event="copy-package-version"/>
+                    <img class="pkg-page-title-copy-icon" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="icon indicating copy to clipboard operation" width="18" height="18" title="Copy &quot;neon: ^1.0.0&quot; to clipboard" data-copy-content="neon: ^1.0.0" data-ga-click-event="copy-package-version"/>
                     <div class="pkg-page-title-copy-feedback">
                       <span class="code">neon: ^1.0.0</span>
                       copied to clipboard
@@ -133,7 +133,7 @@
                   </span>
                   •
                   <a class="-pub-publisher" href="/publishers/example.com">
-                    <img class="-pub-publisher-shield" src="/static/img/verified-publisher-blue.svg?hash=mocked_hash_919645162" alt="shield icon for verified publishers" width="15" height="15" title="Published by a pub.dev verified publisher"/>
+                    <img class="-pub-publisher-shield" src="/static/hash-%%etag%%/img/verified-publisher-blue.svg" alt="shield icon for verified publishers" width="15" height="15" title="Published by a pub.dev verified publisher"/>
                     example.com
                   </a>
                 </div>
@@ -143,8 +143,8 @@
                   </div>
                   <div class="detail-like">
                     <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false">
-                      <img class="mdc-icon-button__icon" src="/static/img/like-inactive.svg?hash=mocked_hash_1066096316" alt="icon indicating liked status (inactive)" width="18" height="18"/>
-                      <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/img/like-active.svg?hash=mocked_hash_986617859" alt="icon indicating liked status (active)" width="18" height="18"/>
+                      <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="icon indicating liked status (inactive)" width="18" height="18"/>
+                      <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="icon indicating liked status (active)" width="18" height="18"/>
                     </button>
                     <span class="likes-count">
                       <span id="likes-count">0</span>
@@ -230,7 +230,7 @@
             <h3 class="title">Publisher</h3>
             <p>
               <a href="/publishers/example.com">
-                <img class="-pub-publisher-shield" src="/static/img/verified-publisher-blue.svg?hash=mocked_hash_919645162" alt="shield icon for verified publishers" width="15" height="15" title="Published by a pub.dev verified publisher"/>
+                <img class="-pub-publisher-shield" src="/static/hash-%%etag%%/img/verified-publisher-blue.svg" alt="shield icon for verified publishers" width="15" height="15" title="Published by a pub.dev verified publisher"/>
                 example.com
               </a>
             </p>
@@ -286,7 +286,7 @@
           <h3 class="title">Publisher</h3>
           <p>
             <a href="/publishers/example.com">
-              <img class="-pub-publisher-shield" src="/static/img/verified-publisher-blue.svg?hash=mocked_hash_919645162" alt="shield icon for verified publishers" width="15" height="15" title="Published by a pub.dev verified publisher"/>
+              <img class="-pub-publisher-shield" src="/static/hash-%%etag%%/img/verified-publisher-blue.svg" alt="shield icon for verified publishers" width="15" height="15" title="Published by a pub.dev verified publisher"/>
               example.com
             </a>
           </p>
@@ -321,12 +321,12 @@
       <a class="link sep" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link sep" href="/help">Help</a>
       <a class="link icon sep" href="/feed.atom">
-        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
+        <img class="inline-icon" src="/static/hash-%%etag%%/img/rss-feed-icon.svg" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
       </a>
       <a class="link icon github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">
-        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
+        <img class="inline-icon" src="/static/hash-%%etag%%/img/bug-report-white-96px.png" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
       </a>
     </footer>
-    <script src="/static/highlight/highlight-with-init.js?hash=mocked_hash_670483893" defer="defer"></script>
+    <script src="/static/hash-%%etag%%/highlight/highlight-with-init.js" defer="defer"></script>
   </body>
 </html>

--- a/app/test/frontend/golden/pkg_show_page_retracted.html
+++ b/app/test/frontend/golden/pkg_show_page_retracted.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
   <head>
     <script src="https://www.googletagmanager.com/gtm.js?id=GTM-MX6DBN9" async="async"></script>
-    <script src="/static/js/gtm.js?hash=mocked_hash_451823545"></script>
+    <script src="/static/hash-%%etag%%/js/gtm.js"></script>
     <meta charset="utf-8"/>
     <meta http-equiv="x-ua-compatible" content="ie=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
@@ -10,28 +10,28 @@
     <meta name="twitter:card" content="summary"/>
     <meta name="twitter:site" content="@dart_lang"/>
     <meta name="twitter:description" content="pkg is awesome"/>
-    <meta name="twitter:image" content="https://pub.dev/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta name="twitter:image" content="https://pub.dev/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <meta property="og:type" content="website"/>
     <meta property="og:site_name" content="Dart packages"/>
     <meta property="og:title" content="pkg 1.0.0 | Dart Package"/>
     <meta property="og:description" content="pkg is awesome"/>
-    <meta property="og:image" content="https://pub.dev/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta property="og:image" content="https://pub.dev/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <title>pkg 1.0.0 | Dart Package</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Google+Sans:300,400,500|Google+Sans+Display:400|Roboto:300,400,500,700|Roboto+Mono:300,400,700&amp;display=swap"/>
-    <meta content="/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta content="/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
-    <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/osd.xml?hash=mocked_hash_869379763"/>
+    <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/hash-%%etag%%/osd.xml"/>
     <link rel="canonical" href="https://pub.dev/packages/pkg/versions/1.0.0"/>
     <meta name="description" content="pkg is awesome"/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
-    <link rel="stylesheet" type="text/css" href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842"/>
-    <link rel="stylesheet" type="text/css" href="/static/css/style.css?hash=mocked_hash_537099079"/>
-    <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
+    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/material/material-components-web.min.css"/>
+    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/style.css"/>
+    <script src="/static/hash-%%etag%%/material/material-components-web.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <meta name="google-signin-client_id" content=""/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
     <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJwa2ciLCJ2ZXJzaW9uIjoiMS4wLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlfX0="/>
-    <link rel="preload" href="/static/highlight/highlight-with-init.js?hash=mocked_hash_670483893" as="script"/>
+    <link rel="preload" href="/static/hash-%%etag%%/highlight/highlight-with-init.js" as="script"/>
   </head>
   <body>
     <noscript>
@@ -40,7 +40,7 @@
     <div class="site-header">
       <button class="hamburger" aria-label="menu toggle"></button>
       <a class="logo" href="/">
-        <img class="site-logo" src="/static/img/pub-dev-logo-2x.png?hash=mocked_hash_685890546" alt="pub logo" width="135" height="30"/>
+        <img class="site-logo" src="/static/hash-%%etag%%/img/pub-dev-logo-2x.png" alt="pub logo" width="135" height="30"/>
       </a>
       <div class="site-header-space"></div>
       <div class="site-header-mask"></div>
@@ -79,7 +79,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Pub.dev
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="/help/search" rel="noopener" target="_blank">Searching for packages</a>
@@ -89,7 +89,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Flutter
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://flutter.io/using-packages/" rel="noopener" target="_blank">Using packages</a>
@@ -100,7 +100,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Dart
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://dart.dev/tools/pub/get-started" rel="noopener" target="_blank">Using packages</a>
@@ -119,7 +119,7 @@
                 <h1 class="title">
                   pkg 1.0.0
                   <span class="pkg-page-title-copy">
-                    <img class="pkg-page-title-copy-icon" src="/static/img/content-copy-icon.svg?hash=mocked_hash_1005735992" alt="icon indicating copy to clipboard operation" width="18" height="18" title="Copy &quot;pkg: ^1.0.0&quot; to clipboard" data-copy-content="pkg: ^1.0.0" data-ga-click-event="copy-package-version"/>
+                    <img class="pkg-page-title-copy-icon" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="icon indicating copy to clipboard operation" width="18" height="18" title="Copy &quot;pkg: ^1.0.0&quot; to clipboard" data-copy-content="pkg: ^1.0.0" data-ga-click-event="copy-package-version"/>
                     <div class="pkg-page-title-copy-feedback">
                       <span class="code">pkg: ^1.0.0</span>
                       copied to clipboard
@@ -154,8 +154,8 @@
                   </div>
                   <div class="detail-like">
                     <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false">
-                      <img class="mdc-icon-button__icon" src="/static/img/like-inactive.svg?hash=mocked_hash_1066096316" alt="icon indicating liked status (inactive)" width="18" height="18"/>
-                      <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/img/like-active.svg?hash=mocked_hash_986617859" alt="icon indicating liked status (active)" width="18" height="18"/>
+                      <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="icon indicating liked status (inactive)" width="18" height="18"/>
+                      <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="icon indicating liked status (active)" width="18" height="18"/>
                     </button>
                     <span class="likes-count">
                       <span id="likes-count">0</span>
@@ -336,12 +336,12 @@
       <a class="link sep" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link sep" href="/help">Help</a>
       <a class="link icon sep" href="/feed.atom">
-        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
+        <img class="inline-icon" src="/static/hash-%%etag%%/img/rss-feed-icon.svg" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
       </a>
       <a class="link icon github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">
-        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
+        <img class="inline-icon" src="/static/hash-%%etag%%/img/bug-report-white-96px.png" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
       </a>
     </footer>
-    <script src="/static/highlight/highlight-with-init.js?hash=mocked_hash_670483893" defer="defer"></script>
+    <script src="/static/hash-%%etag%%/highlight/highlight-with-init.js" defer="defer"></script>
   </body>
 </html>

--- a/app/test/frontend/golden/pkg_show_page_retracted_non_retracted_version.html
+++ b/app/test/frontend/golden/pkg_show_page_retracted_non_retracted_version.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
   <head>
     <script src="https://www.googletagmanager.com/gtm.js?id=GTM-MX6DBN9" async="async"></script>
-    <script src="/static/js/gtm.js?hash=mocked_hash_451823545"></script>
+    <script src="/static/hash-%%etag%%/js/gtm.js"></script>
     <meta charset="utf-8"/>
     <meta http-equiv="x-ua-compatible" content="ie=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
@@ -10,28 +10,28 @@
     <meta name="twitter:card" content="summary"/>
     <meta name="twitter:site" content="@dart_lang"/>
     <meta name="twitter:description" content="pkg is awesome"/>
-    <meta name="twitter:image" content="https://pub.dev/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta name="twitter:image" content="https://pub.dev/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <meta property="og:type" content="website"/>
     <meta property="og:site_name" content="Dart packages"/>
     <meta property="og:title" content="pkg | Dart Package"/>
     <meta property="og:description" content="pkg is awesome"/>
-    <meta property="og:image" content="https://pub.dev/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta property="og:image" content="https://pub.dev/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <title>pkg | Dart Package</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Google+Sans:300,400,500|Google+Sans+Display:400|Roboto:300,400,500,700|Roboto+Mono:300,400,700&amp;display=swap"/>
-    <meta content="/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta content="/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
-    <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/osd.xml?hash=mocked_hash_869379763"/>
+    <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/hash-%%etag%%/osd.xml"/>
     <link rel="canonical" href="https://pub.dev/packages/pkg"/>
     <meta name="description" content="pkg is awesome"/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
-    <link rel="stylesheet" type="text/css" href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842"/>
-    <link rel="stylesheet" type="text/css" href="/static/css/style.css?hash=mocked_hash_537099079"/>
-    <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
+    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/material/material-components-web.min.css"/>
+    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/style.css"/>
+    <script src="/static/hash-%%etag%%/material/material-components-web.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <meta name="google-signin-client_id" content=""/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
     <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJwa2ciLCJ2ZXJzaW9uIjoiMi4wLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlfX0="/>
-    <link rel="preload" href="/static/highlight/highlight-with-init.js?hash=mocked_hash_670483893" as="script"/>
+    <link rel="preload" href="/static/hash-%%etag%%/highlight/highlight-with-init.js" as="script"/>
   </head>
   <body>
     <noscript>
@@ -40,7 +40,7 @@
     <div class="site-header">
       <button class="hamburger" aria-label="menu toggle"></button>
       <a class="logo" href="/">
-        <img class="site-logo" src="/static/img/pub-dev-logo-2x.png?hash=mocked_hash_685890546" alt="pub logo" width="135" height="30"/>
+        <img class="site-logo" src="/static/hash-%%etag%%/img/pub-dev-logo-2x.png" alt="pub logo" width="135" height="30"/>
       </a>
       <div class="site-header-space"></div>
       <div class="site-header-mask"></div>
@@ -79,7 +79,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Pub.dev
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="/help/search" rel="noopener" target="_blank">Searching for packages</a>
@@ -89,7 +89,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Flutter
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://flutter.io/using-packages/" rel="noopener" target="_blank">Using packages</a>
@@ -100,7 +100,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Dart
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://dart.dev/tools/pub/get-started" rel="noopener" target="_blank">Using packages</a>
@@ -119,7 +119,7 @@
                 <h1 class="title">
                   pkg 2.0.0
                   <span class="pkg-page-title-copy">
-                    <img class="pkg-page-title-copy-icon" src="/static/img/content-copy-icon.svg?hash=mocked_hash_1005735992" alt="icon indicating copy to clipboard operation" width="18" height="18" title="Copy &quot;pkg: ^2.0.0&quot; to clipboard" data-copy-content="pkg: ^2.0.0" data-ga-click-event="copy-package-version"/>
+                    <img class="pkg-page-title-copy-icon" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="icon indicating copy to clipboard operation" width="18" height="18" title="Copy &quot;pkg: ^2.0.0&quot; to clipboard" data-copy-content="pkg: ^2.0.0" data-ga-click-event="copy-package-version"/>
                     <div class="pkg-page-title-copy-feedback">
                       <span class="code">pkg: ^2.0.0</span>
                       copied to clipboard
@@ -150,8 +150,8 @@
                   </div>
                   <div class="detail-like">
                     <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false">
-                      <img class="mdc-icon-button__icon" src="/static/img/like-inactive.svg?hash=mocked_hash_1066096316" alt="icon indicating liked status (inactive)" width="18" height="18"/>
-                      <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/img/like-active.svg?hash=mocked_hash_986617859" alt="icon indicating liked status (active)" width="18" height="18"/>
+                      <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="icon indicating liked status (inactive)" width="18" height="18"/>
+                      <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="icon indicating liked status (active)" width="18" height="18"/>
                     </button>
                     <span class="likes-count">
                       <span id="likes-count">0</span>
@@ -332,12 +332,12 @@
       <a class="link sep" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link sep" href="/help">Help</a>
       <a class="link icon sep" href="/feed.atom">
-        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
+        <img class="inline-icon" src="/static/hash-%%etag%%/img/rss-feed-icon.svg" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
       </a>
       <a class="link icon github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">
-        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
+        <img class="inline-icon" src="/static/hash-%%etag%%/img/bug-report-white-96px.png" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
       </a>
     </footer>
-    <script src="/static/highlight/highlight-with-init.js?hash=mocked_hash_670483893" defer="defer"></script>
+    <script src="/static/hash-%%etag%%/highlight/highlight-with-init.js" defer="defer"></script>
   </body>
 </html>

--- a/app/test/frontend/golden/pkg_show_version_page.html
+++ b/app/test/frontend/golden/pkg_show_version_page.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
   <head>
     <script src="https://www.googletagmanager.com/gtm.js?id=GTM-MX6DBN9" async="async"></script>
-    <script src="/static/js/gtm.js?hash=mocked_hash_451823545"></script>
+    <script src="/static/hash-%%etag%%/js/gtm.js"></script>
     <meta charset="utf-8"/>
     <meta http-equiv="x-ua-compatible" content="ie=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
@@ -10,28 +10,28 @@
     <meta name="twitter:card" content="summary"/>
     <meta name="twitter:site" content="@dart_lang"/>
     <meta name="twitter:description" content="oxygen is awesome"/>
-    <meta name="twitter:image" content="https://pub.dev/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta name="twitter:image" content="https://pub.dev/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <meta property="og:type" content="website"/>
     <meta property="og:site_name" content="Dart packages"/>
     <meta property="og:title" content="oxygen | Dart Package"/>
     <meta property="og:description" content="oxygen is awesome"/>
-    <meta property="og:image" content="https://pub.dev/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta property="og:image" content="https://pub.dev/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <title>oxygen | Dart Package</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Google+Sans:300,400,500|Google+Sans+Display:400|Roboto:300,400,500,700|Roboto+Mono:300,400,700&amp;display=swap"/>
-    <meta content="/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta content="/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
-    <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/osd.xml?hash=mocked_hash_869379763"/>
+    <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/hash-%%etag%%/osd.xml"/>
     <link rel="canonical" href="https://pub.dev/packages/oxygen"/>
     <meta name="description" content="oxygen is awesome"/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
-    <link rel="stylesheet" type="text/css" href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842"/>
-    <link rel="stylesheet" type="text/css" href="/static/css/style.css?hash=mocked_hash_537099079"/>
-    <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
+    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/material/material-components-web.min.css"/>
+    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/style.css"/>
+    <script src="/static/hash-%%etag%%/material/material-components-web.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <meta name="google-signin-client_id" content=""/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
     <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJveHlnZW4iLCJ2ZXJzaW9uIjoiMS4yLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlfX0="/>
-    <link rel="preload" href="/static/highlight/highlight-with-init.js?hash=mocked_hash_670483893" as="script"/>
+    <link rel="preload" href="/static/hash-%%etag%%/highlight/highlight-with-init.js" as="script"/>
   </head>
   <body>
     <noscript>
@@ -40,7 +40,7 @@
     <div class="site-header">
       <button class="hamburger" aria-label="menu toggle"></button>
       <a class="logo" href="/">
-        <img class="site-logo" src="/static/img/pub-dev-logo-2x.png?hash=mocked_hash_685890546" alt="pub logo" width="135" height="30"/>
+        <img class="site-logo" src="/static/hash-%%etag%%/img/pub-dev-logo-2x.png" alt="pub logo" width="135" height="30"/>
       </a>
       <div class="site-header-space"></div>
       <div class="site-header-mask"></div>
@@ -79,7 +79,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Pub.dev
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="/help/search" rel="noopener" target="_blank">Searching for packages</a>
@@ -89,7 +89,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Flutter
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://flutter.io/using-packages/" rel="noopener" target="_blank">Using packages</a>
@@ -100,7 +100,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Dart
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://dart.dev/tools/pub/get-started" rel="noopener" target="_blank">Using packages</a>
@@ -119,7 +119,7 @@
                 <h1 class="title">
                   oxygen 1.2.0
                   <span class="pkg-page-title-copy">
-                    <img class="pkg-page-title-copy-icon" src="/static/img/content-copy-icon.svg?hash=mocked_hash_1005735992" alt="icon indicating copy to clipboard operation" width="18" height="18" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>
+                    <img class="pkg-page-title-copy-icon" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="icon indicating copy to clipboard operation" width="18" height="18" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>
                     <div class="pkg-page-title-copy-feedback">
                       <span class="code">oxygen: ^1.2.0</span>
                       copied to clipboard
@@ -159,8 +159,8 @@
                   </div>
                   <div class="detail-like">
                     <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false">
-                      <img class="mdc-icon-button__icon" src="/static/img/like-inactive.svg?hash=mocked_hash_1066096316" alt="icon indicating liked status (inactive)" width="18" height="18"/>
-                      <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/img/like-active.svg?hash=mocked_hash_986617859" alt="icon indicating liked status (active)" width="18" height="18"/>
+                      <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="icon indicating liked status (inactive)" width="18" height="18"/>
+                      <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="icon indicating liked status (active)" width="18" height="18"/>
                     </button>
                     <span class="likes-count">
                       <span id="likes-count">0</span>
@@ -341,12 +341,12 @@
       <a class="link sep" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link sep" href="/help">Help</a>
       <a class="link icon sep" href="/feed.atom">
-        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
+        <img class="inline-icon" src="/static/hash-%%etag%%/img/rss-feed-icon.svg" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
       </a>
       <a class="link icon github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">
-        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
+        <img class="inline-icon" src="/static/hash-%%etag%%/img/bug-report-white-96px.png" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
       </a>
     </footer>
-    <script src="/static/highlight/highlight-with-init.js?hash=mocked_hash_670483893" defer="defer"></script>
+    <script src="/static/hash-%%etag%%/highlight/highlight-with-init.js" defer="defer"></script>
   </body>
 </html>

--- a/app/test/frontend/golden/pkg_versions_page.html
+++ b/app/test/frontend/golden/pkg_versions_page.html
@@ -2,36 +2,36 @@
 <html lang="en-us">
   <head>
     <script src="https://www.googletagmanager.com/gtm.js?id=GTM-MX6DBN9" async="async"></script>
-    <script src="/static/js/gtm.js?hash=mocked_hash_451823545"></script>
+    <script src="/static/hash-%%etag%%/js/gtm.js"></script>
     <meta charset="utf-8"/>
     <meta http-equiv="x-ua-compatible" content="ie=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <meta name="twitter:card" content="summary"/>
     <meta name="twitter:site" content="@dart_lang"/>
     <meta name="twitter:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
-    <meta name="twitter:image" content="https://pub.dev/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta name="twitter:image" content="https://pub.dev/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <meta property="og:type" content="website"/>
     <meta property="og:site_name" content="Dart packages"/>
     <meta property="og:title" content="oxygen package - All Versions"/>
     <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
-    <meta property="og:image" content="https://pub.dev/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta property="og:image" content="https://pub.dev/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <meta property="og:url" content="https://pub.dev/packages/oxygen/versions"/>
     <title>oxygen package - All Versions</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Google+Sans:300,400,500|Google+Sans+Display:400|Roboto:300,400,500,700|Roboto+Mono:300,400,700&amp;display=swap"/>
-    <meta content="/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta content="/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
-    <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/osd.xml?hash=mocked_hash_869379763"/>
+    <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/hash-%%etag%%/osd.xml"/>
     <link rel="canonical" href="https://pub.dev/packages/oxygen/versions"/>
     <meta name="description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
-    <link rel="stylesheet" type="text/css" href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842"/>
-    <link rel="stylesheet" type="text/css" href="/static/css/style.css?hash=mocked_hash_537099079"/>
-    <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
+    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/material/material-components-web.min.css"/>
+    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/style.css"/>
+    <script src="/static/hash-%%etag%%/material/material-components-web.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <meta name="google-signin-client_id" content=""/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
     <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJveHlnZW4iLCJ2ZXJzaW9uIjoiMS4yLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlfX0="/>
-    <link rel="preload" href="/static/highlight/highlight-with-init.js?hash=mocked_hash_670483893" as="script"/>
+    <link rel="preload" href="/static/hash-%%etag%%/highlight/highlight-with-init.js" as="script"/>
   </head>
   <body>
     <noscript>
@@ -40,7 +40,7 @@
     <div class="site-header">
       <button class="hamburger" aria-label="menu toggle"></button>
       <a class="logo" href="/">
-        <img class="site-logo" src="/static/img/pub-dev-logo-2x.png?hash=mocked_hash_685890546" alt="pub logo" width="135" height="30"/>
+        <img class="site-logo" src="/static/hash-%%etag%%/img/pub-dev-logo-2x.png" alt="pub logo" width="135" height="30"/>
       </a>
       <div class="site-header-space"></div>
       <div class="site-header-mask"></div>
@@ -79,7 +79,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Pub.dev
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="/help/search" rel="noopener" target="_blank">Searching for packages</a>
@@ -89,7 +89,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Flutter
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://flutter.io/using-packages/" rel="noopener" target="_blank">Using packages</a>
@@ -100,7 +100,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Dart
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://dart.dev/tools/pub/get-started" rel="noopener" target="_blank">Using packages</a>
@@ -119,7 +119,7 @@
                 <h1 class="title">
                   oxygen 1.2.0
                   <span class="pkg-page-title-copy">
-                    <img class="pkg-page-title-copy-icon" src="/static/img/content-copy-icon.svg?hash=mocked_hash_1005735992" alt="icon indicating copy to clipboard operation" width="18" height="18" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>
+                    <img class="pkg-page-title-copy-icon" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="icon indicating copy to clipboard operation" width="18" height="18" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>
                     <div class="pkg-page-title-copy-feedback">
                       <span class="code">oxygen: ^1.2.0</span>
                       copied to clipboard
@@ -159,8 +159,8 @@
                   </div>
                   <div class="detail-like">
                     <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false">
-                      <img class="mdc-icon-button__icon" src="/static/img/like-inactive.svg?hash=mocked_hash_1066096316" alt="icon indicating liked status (inactive)" width="18" height="18"/>
-                      <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/img/like-active.svg?hash=mocked_hash_986617859" alt="icon indicating liked status (active)" width="18" height="18"/>
+                      <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="icon indicating liked status (inactive)" width="18" height="18"/>
+                      <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="icon indicating liked status (active)" width="18" height="18"/>
                     </button>
                     <span class="likes-count">
                       <span id="likes-count">0</span>
@@ -248,12 +248,12 @@
                         </td>
                         <td class="documentation">
                           <a href="/documentation/oxygen/1.2.0/" rel="nofollow" title="Go to the documentation of oxygen 1.2.0">
-                            <img class="version-table-icon" src="/static/img/description-24px.svg?hash=mocked_hash_130979311" alt="Go to the documentation of oxygen 1.2.0" width="24" height="24" data-failed-icon="/static/img/documentation-failed-icon.svg?hash=mocked_hash_57143192"/>
+                            <img class="version-table-icon" src="/static/hash-%%etag%%/img/description-24px.svg" alt="Go to the documentation of oxygen 1.2.0" width="24" height="24" data-failed-icon="/static/hash-%%etag%%/img/documentation-failed-icon.svg"/>
                           </a>
                         </td>
                         <td class="archive">
                           <a href="/packages/oxygen/versions/1.2.0.tar.gz" rel="nofollow" title="Download oxygen 1.2.0 archive">
-                            <img class="version-table-icon" src="/static/img/vertical_align_bottom-24px.svg?hash=mocked_hash_587025884" alt="Download oxygen 1.2.0 archive" width="24" height="24"/>
+                            <img class="version-table-icon" src="/static/hash-%%etag%%/img/vertical_align_bottom-24px.svg" alt="Download oxygen 1.2.0 archive" width="24" height="24"/>
                           </a>
                         </td>
                       </tr>
@@ -268,12 +268,12 @@
                         </td>
                         <td class="documentation">
                           <a href="/documentation/oxygen/1.0.0/" rel="nofollow" title="Go to the documentation of oxygen 1.0.0">
-                            <img class="version-table-icon" src="/static/img/description-24px.svg?hash=mocked_hash_130979311" alt="Go to the documentation of oxygen 1.0.0" width="24" height="24" data-failed-icon="/static/img/documentation-failed-icon.svg?hash=mocked_hash_57143192"/>
+                            <img class="version-table-icon" src="/static/hash-%%etag%%/img/description-24px.svg" alt="Go to the documentation of oxygen 1.0.0" width="24" height="24" data-failed-icon="/static/hash-%%etag%%/img/documentation-failed-icon.svg"/>
                           </a>
                         </td>
                         <td class="archive">
                           <a href="/packages/oxygen/versions/1.0.0.tar.gz" rel="nofollow" title="Download oxygen 1.0.0 archive">
-                            <img class="version-table-icon" src="/static/img/vertical_align_bottom-24px.svg?hash=mocked_hash_587025884" alt="Download oxygen 1.0.0 archive" width="24" height="24"/>
+                            <img class="version-table-icon" src="/static/hash-%%etag%%/img/vertical_align_bottom-24px.svg" alt="Download oxygen 1.0.0 archive" width="24" height="24"/>
                           </a>
                         </td>
                       </tr>
@@ -311,12 +311,12 @@
                         </td>
                         <td class="documentation">
                           <a href="/documentation/oxygen/2.0.0-dev/" rel="nofollow" title="Go to the documentation of oxygen 2.0.0-dev">
-                            <img class="version-table-icon" src="/static/img/description-24px.svg?hash=mocked_hash_130979311" alt="Go to the documentation of oxygen 2.0.0-dev" width="24" height="24" data-failed-icon="/static/img/documentation-failed-icon.svg?hash=mocked_hash_57143192"/>
+                            <img class="version-table-icon" src="/static/hash-%%etag%%/img/description-24px.svg" alt="Go to the documentation of oxygen 2.0.0-dev" width="24" height="24" data-failed-icon="/static/hash-%%etag%%/img/documentation-failed-icon.svg"/>
                           </a>
                         </td>
                         <td class="archive">
                           <a href="/packages/oxygen/versions/2.0.0-dev.tar.gz" rel="nofollow" title="Download oxygen 2.0.0-dev archive">
-                            <img class="version-table-icon" src="/static/img/vertical_align_bottom-24px.svg?hash=mocked_hash_587025884" alt="Download oxygen 2.0.0-dev archive" width="24" height="24"/>
+                            <img class="version-table-icon" src="/static/hash-%%etag%%/img/vertical_align_bottom-24px.svg" alt="Download oxygen 2.0.0-dev archive" width="24" height="24"/>
                           </a>
                         </td>
                       </tr>
@@ -448,12 +448,12 @@
       <a class="link sep" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link sep" href="/help">Help</a>
       <a class="link icon sep" href="/feed.atom">
-        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
+        <img class="inline-icon" src="/static/hash-%%etag%%/img/rss-feed-icon.svg" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
       </a>
       <a class="link icon github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">
-        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
+        <img class="inline-icon" src="/static/hash-%%etag%%/img/bug-report-white-96px.png" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
       </a>
     </footer>
-    <script src="/static/highlight/highlight-with-init.js?hash=mocked_hash_670483893" defer="defer"></script>
+    <script src="/static/hash-%%etag%%/highlight/highlight-with-init.js" defer="defer"></script>
   </body>
 </html>

--- a/app/test/frontend/golden/publisher_activity_log_page.html
+++ b/app/test/frontend/golden/publisher_activity_log_page.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
   <head>
     <script src="https://www.googletagmanager.com/gtm.js?id=GTM-MX6DBN9" async="async"></script>
-    <script src="/static/js/gtm.js?hash=mocked_hash_451823545"></script>
+    <script src="/static/hash-%%etag%%/js/gtm.js"></script>
     <meta charset="utf-8"/>
     <meta http-equiv="x-ua-compatible" content="ie=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
@@ -10,23 +10,23 @@
     <meta name="twitter:card" content="summary"/>
     <meta name="twitter:site" content="@dart_lang"/>
     <meta name="twitter:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
-    <meta name="twitter:image" content="https://pub.dev/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta name="twitter:image" content="https://pub.dev/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <meta property="og:type" content="website"/>
     <meta property="og:site_name" content="Dart packages"/>
     <meta property="og:title" content="Publisher: example.com"/>
     <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
-    <meta property="og:image" content="https://pub.dev/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta property="og:image" content="https://pub.dev/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <title>Publisher: example.com</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Google+Sans:300,400,500|Google+Sans+Display:400|Roboto:300,400,500,700|Roboto+Mono:300,400,700&amp;display=swap"/>
-    <meta content="/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta content="/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
-    <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/osd.xml?hash=mocked_hash_869379763"/>
+    <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/hash-%%etag%%/osd.xml"/>
     <link rel="canonical" href="https://pub.dev/publishers/example.com/activity-log"/>
     <meta name="description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
-    <link rel="stylesheet" type="text/css" href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842"/>
-    <link rel="stylesheet" type="text/css" href="/static/css/style.css?hash=mocked_hash_537099079"/>
-    <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
+    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/material/material-components-web.min.css"/>
+    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/style.css"/>
+    <script src="/static/hash-%%etag%%/material/material-components-web.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <meta name="google-signin-client_id" content=""/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
@@ -39,7 +39,7 @@
     <div class="site-header">
       <button class="hamburger" aria-label="menu toggle"></button>
       <a class="logo" href="/">
-        <img class="site-logo" src="/static/img/pub-dev-logo-2x.png?hash=mocked_hash_685890546" alt="pub logo" width="135" height="30"/>
+        <img class="site-logo" src="/static/hash-%%etag%%/img/pub-dev-logo-2x.png" alt="pub logo" width="135" height="30"/>
       </a>
       <div class="site-header-space"></div>
       <div class="site-header-mask"></div>
@@ -73,7 +73,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Pub.dev
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="/help/search" rel="noopener" target="_blank">Searching for packages</a>
@@ -83,7 +83,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Flutter
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://flutter.io/using-packages/" rel="noopener" target="_blank">Using packages</a>
@@ -94,7 +94,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Dart
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://dart.dev/tools/pub/get-started" rel="noopener" target="_blank">Using packages</a>
@@ -122,11 +122,11 @@
                 <div class="metadata">
                   <p>
                     <span class="detail-header-metadata-ref">
-                      <img class="detail-header-metadata-ref-icon" src="/static/img/link-icon.svg?hash=mocked_hash_709199651" alt="icon indicating a website link" width="14" height="14"/>
+                      <img class="detail-header-metadata-ref-icon" src="/static/hash-%%etag%%/img/link-icon.svg" alt="icon indicating a website link" width="14" height="14"/>
                       <a class="detail-header-metadata-ref-label" href="https://example.com/" rel="ugc">example.com/</a>
                     </span>
                     <span class="detail-header-metadata-ref">
-                      <img class="detail-header-metadata-ref-icon" src="/static/img/email-icon.svg?hash=mocked_hash_308057918" alt="icon indicating an email" width="14" height="14"/>
+                      <img class="detail-header-metadata-ref-icon" src="/static/hash-%%etag%%/img/email-icon.svg" alt="icon indicating an email" width="14" height="14"/>
                       <a class="detail-header-metadata-ref-label" href="mailto:admin@pub.dev">admin@pub.dev</a>
                     </span>
                   </p>
@@ -221,10 +221,10 @@
       <a class="link sep" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link sep" href="/help">Help</a>
       <a class="link icon sep" href="/feed.atom">
-        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
+        <img class="inline-icon" src="/static/hash-%%etag%%/img/rss-feed-icon.svg" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
       </a>
       <a class="link icon github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">
-        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
+        <img class="inline-icon" src="/static/hash-%%etag%%/img/bug-report-white-96px.png" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
       </a>
     </footer>
   </body>

--- a/app/test/frontend/golden/publisher_admin_page.html
+++ b/app/test/frontend/golden/publisher_admin_page.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
   <head>
     <script src="https://www.googletagmanager.com/gtm.js?id=GTM-MX6DBN9" async="async"></script>
-    <script src="/static/js/gtm.js?hash=mocked_hash_451823545"></script>
+    <script src="/static/hash-%%etag%%/js/gtm.js"></script>
     <meta charset="utf-8"/>
     <meta http-equiv="x-ua-compatible" content="ie=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
@@ -10,23 +10,23 @@
     <meta name="twitter:card" content="summary"/>
     <meta name="twitter:site" content="@dart_lang"/>
     <meta name="twitter:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
-    <meta name="twitter:image" content="https://pub.dev/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta name="twitter:image" content="https://pub.dev/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <meta property="og:type" content="website"/>
     <meta property="og:site_name" content="Dart packages"/>
     <meta property="og:title" content="Publisher: example.com"/>
     <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
-    <meta property="og:image" content="https://pub.dev/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta property="og:image" content="https://pub.dev/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <title>Publisher: example.com</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Google+Sans:300,400,500|Google+Sans+Display:400|Roboto:300,400,500,700|Roboto+Mono:300,400,700&amp;display=swap"/>
-    <meta content="/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta content="/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
-    <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/osd.xml?hash=mocked_hash_869379763"/>
+    <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/hash-%%etag%%/osd.xml"/>
     <link rel="canonical" href="https://pub.dev/publishers/example.com/admin"/>
     <meta name="description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
-    <link rel="stylesheet" type="text/css" href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842"/>
-    <link rel="stylesheet" type="text/css" href="/static/css/style.css?hash=mocked_hash_537099079"/>
-    <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
+    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/material/material-components-web.min.css"/>
+    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/style.css"/>
+    <script src="/static/hash-%%etag%%/material/material-components-web.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <meta name="google-signin-client_id" content=""/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
@@ -39,7 +39,7 @@
     <div class="site-header">
       <button class="hamburger" aria-label="menu toggle"></button>
       <a class="logo" href="/">
-        <img class="site-logo" src="/static/img/pub-dev-logo-2x.png?hash=mocked_hash_685890546" alt="pub logo" width="135" height="30"/>
+        <img class="site-logo" src="/static/hash-%%etag%%/img/pub-dev-logo-2x.png" alt="pub logo" width="135" height="30"/>
       </a>
       <div class="site-header-space"></div>
       <div class="site-header-mask"></div>
@@ -73,7 +73,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Pub.dev
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="/help/search" rel="noopener" target="_blank">Searching for packages</a>
@@ -83,7 +83,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Flutter
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://flutter.io/using-packages/" rel="noopener" target="_blank">Using packages</a>
@@ -94,7 +94,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Dart
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://dart.dev/tools/pub/get-started" rel="noopener" target="_blank">Using packages</a>
@@ -122,11 +122,11 @@
                 <div class="metadata">
                   <p>
                     <span class="detail-header-metadata-ref">
-                      <img class="detail-header-metadata-ref-icon" src="/static/img/link-icon.svg?hash=mocked_hash_709199651" alt="icon indicating a website link" width="14" height="14"/>
+                      <img class="detail-header-metadata-ref-icon" src="/static/hash-%%etag%%/img/link-icon.svg" alt="icon indicating a website link" width="14" height="14"/>
                       <a class="detail-header-metadata-ref-label" href="https://example.com/" rel="ugc">example.com/</a>
                     </span>
                     <span class="detail-header-metadata-ref">
-                      <img class="detail-header-metadata-ref-icon" src="/static/img/email-icon.svg?hash=mocked_hash_308057918" alt="icon indicating an email" width="14" height="14"/>
+                      <img class="detail-header-metadata-ref-icon" src="/static/hash-%%etag%%/img/email-icon.svg" alt="icon indicating an email" width="14" height="14"/>
                       <a class="detail-header-metadata-ref-label" href="mailto:admin@pub.dev">admin@pub.dev</a>
                     </span>
                   </p>
@@ -250,10 +250,10 @@
       <a class="link sep" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link sep" href="/help">Help</a>
       <a class="link icon sep" href="/feed.atom">
-        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
+        <img class="inline-icon" src="/static/hash-%%etag%%/img/rss-feed-icon.svg" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
       </a>
       <a class="link icon github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">
-        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
+        <img class="inline-icon" src="/static/hash-%%etag%%/img/bug-report-white-96px.png" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
       </a>
     </footer>
   </body>

--- a/app/test/frontend/golden/publisher_list_page.html
+++ b/app/test/frontend/golden/publisher_list_page.html
@@ -2,31 +2,31 @@
 <html lang="en-us">
   <head>
     <script src="https://www.googletagmanager.com/gtm.js?id=GTM-MX6DBN9" async="async"></script>
-    <script src="/static/js/gtm.js?hash=mocked_hash_451823545"></script>
+    <script src="/static/hash-%%etag%%/js/gtm.js"></script>
     <meta charset="utf-8"/>
     <meta http-equiv="x-ua-compatible" content="ie=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <meta name="twitter:card" content="summary"/>
     <meta name="twitter:site" content="@dart_lang"/>
     <meta name="twitter:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
-    <meta name="twitter:image" content="https://pub.dev/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta name="twitter:image" content="https://pub.dev/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <meta property="og:type" content="website"/>
     <meta property="og:site_name" content="Dart packages"/>
     <meta property="og:title" content="Publishers"/>
     <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
-    <meta property="og:image" content="https://pub.dev/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta property="og:image" content="https://pub.dev/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <meta property="og:url" content="https://pub.dev/publishers"/>
     <title>Publishers</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Google+Sans:300,400,500|Google+Sans+Display:400|Roboto:300,400,500,700|Roboto+Mono:300,400,700&amp;display=swap"/>
-    <meta content="/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta content="/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
-    <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/osd.xml?hash=mocked_hash_869379763"/>
+    <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/hash-%%etag%%/osd.xml"/>
     <link rel="canonical" href="https://pub.dev/publishers"/>
     <meta name="description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
-    <link rel="stylesheet" type="text/css" href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842"/>
-    <link rel="stylesheet" type="text/css" href="/static/css/style.css?hash=mocked_hash_537099079"/>
-    <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
+    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/material/material-components-web.min.css"/>
+    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/style.css"/>
+    <script src="/static/hash-%%etag%%/material/material-components-web.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <meta name="google-signin-client_id" content=""/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
@@ -38,7 +38,7 @@
     <div class="site-header">
       <button class="hamburger" aria-label="menu toggle"></button>
       <a class="logo" href="/">
-        <img class="site-logo" src="/static/img/pub-dev-logo-2x.png?hash=mocked_hash_685890546" alt="pub logo" width="135" height="30"/>
+        <img class="site-logo" src="/static/hash-%%etag%%/img/pub-dev-logo-2x.png" alt="pub logo" width="135" height="30"/>
       </a>
       <div class="site-header-space"></div>
       <div class="site-header-mask"></div>
@@ -72,7 +72,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Pub.dev
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="/help/search" rel="noopener" target="_blank">Searching for packages</a>
@@ -82,7 +82,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Flutter
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://flutter.io/using-packages/" rel="noopener" target="_blank">Using packages</a>
@@ -93,7 +93,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Dart
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://dart.dev/tools/pub/get-started" rel="noopener" target="_blank">Using packages</a>
@@ -109,8 +109,8 @@
           <input class="input" name="q" placeholder="Search packages" autocomplete="on" autofocus="autofocus"/>
           <button class="icon" aria-label="search"></button>
           <div class="search-filters-btn-wrapper">
-            <img class="search-filters-btn search-filters-btn-inactive" src="/static/img/search-filters-inactive.svg?hash=mocked_hash_963166179" alt="icon to toggle the display of search filters (inactive)" width="42" height="42"/>
-            <img class="search-filters-btn search-filters-btn-active" src="/static/img/search-filters-active.svg?hash=mocked_hash_397783636" alt="icon to toggle the display of search filters (active)" width="42" height="42"/>
+            <img class="search-filters-btn search-filters-btn-inactive" src="/static/hash-%%etag%%/img/search-filters-inactive.svg" alt="icon to toggle the display of search filters (inactive)" width="42" height="42"/>
+            <img class="search-filters-btn search-filters-btn-active" src="/static/hash-%%etag%%/img/search-filters-active.svg" alt="icon to toggle the display of search filters (active)" width="42" height="42"/>
           </div>
         </form>
       </div>
@@ -155,10 +155,10 @@
       <a class="link sep" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link sep" href="/help">Help</a>
       <a class="link icon sep" href="/feed.atom">
-        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
+        <img class="inline-icon" src="/static/hash-%%etag%%/img/rss-feed-icon.svg" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
       </a>
       <a class="link icon github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">
-        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
+        <img class="inline-icon" src="/static/hash-%%etag%%/img/bug-report-white-96px.png" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
       </a>
     </footer>
   </body>

--- a/app/test/frontend/golden/publisher_packages_page.html
+++ b/app/test/frontend/golden/publisher_packages_page.html
@@ -2,31 +2,31 @@
 <html lang="en-us">
   <head>
     <script src="https://www.googletagmanager.com/gtm.js?id=GTM-MX6DBN9" async="async"></script>
-    <script src="/static/js/gtm.js?hash=mocked_hash_451823545"></script>
+    <script src="/static/hash-%%etag%%/js/gtm.js"></script>
     <meta charset="utf-8"/>
     <meta http-equiv="x-ua-compatible" content="ie=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <meta name="twitter:card" content="summary"/>
     <meta name="twitter:site" content="@dart_lang"/>
     <meta name="twitter:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
-    <meta name="twitter:image" content="https://pub.dev/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta name="twitter:image" content="https://pub.dev/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <meta property="og:type" content="website"/>
     <meta property="og:site_name" content="Dart packages"/>
     <meta property="og:title" content="Packages of publisher example.com"/>
     <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
-    <meta property="og:image" content="https://pub.dev/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta property="og:image" content="https://pub.dev/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <meta property="og:url" content="https://pub.dev/publishers/example.com/packages"/>
     <title>Packages of publisher example.com</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Google+Sans:300,400,500|Google+Sans+Display:400|Roboto:300,400,500,700|Roboto+Mono:300,400,700&amp;display=swap"/>
-    <meta content="/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta content="/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
-    <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/osd.xml?hash=mocked_hash_869379763"/>
+    <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/hash-%%etag%%/osd.xml"/>
     <link rel="canonical" href="https://pub.dev/publishers/example.com/packages"/>
     <meta name="description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
-    <link rel="stylesheet" type="text/css" href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842"/>
-    <link rel="stylesheet" type="text/css" href="/static/css/style.css?hash=mocked_hash_537099079"/>
-    <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
+    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/material/material-components-web.min.css"/>
+    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/style.css"/>
+    <script src="/static/hash-%%etag%%/material/material-components-web.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <meta name="google-signin-client_id" content=""/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
@@ -39,7 +39,7 @@
     <div class="site-header">
       <button class="hamburger" aria-label="menu toggle"></button>
       <a class="logo" href="/">
-        <img class="site-logo" src="/static/img/pub-dev-logo-2x.png?hash=mocked_hash_685890546" alt="pub logo" width="135" height="30"/>
+        <img class="site-logo" src="/static/hash-%%etag%%/img/pub-dev-logo-2x.png" alt="pub logo" width="135" height="30"/>
       </a>
       <div class="site-header-space"></div>
       <div class="site-header-mask"></div>
@@ -73,7 +73,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Pub.dev
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="/help/search" rel="noopener" target="_blank">Searching for packages</a>
@@ -83,7 +83,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Flutter
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://flutter.io/using-packages/" rel="noopener" target="_blank">Using packages</a>
@@ -94,7 +94,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Dart
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://dart.dev/tools/pub/get-started" rel="noopener" target="_blank">Using packages</a>
@@ -122,11 +122,11 @@
                 <div class="metadata">
                   <p>
                     <span class="detail-header-metadata-ref">
-                      <img class="detail-header-metadata-ref-icon" src="/static/img/link-icon.svg?hash=mocked_hash_709199651" alt="icon indicating a website link" width="14" height="14"/>
+                      <img class="detail-header-metadata-ref-icon" src="/static/hash-%%etag%%/img/link-icon.svg" alt="icon indicating a website link" width="14" height="14"/>
                       <a class="detail-header-metadata-ref-label" href="https://example.com/" rel="ugc">example.com/</a>
                     </span>
                     <span class="detail-header-metadata-ref">
-                      <img class="detail-header-metadata-ref-icon" src="/static/img/email-icon.svg?hash=mocked_hash_308057918" alt="icon indicating an email" width="14" height="14"/>
+                      <img class="detail-header-metadata-ref-icon" src="/static/hash-%%etag%%/img/email-icon.svg" alt="icon indicating an email" width="14" height="14"/>
                       <a class="detail-header-metadata-ref-label" href="mailto:admin@pub.dev">admin@pub.dev</a>
                     </span>
                   </p>
@@ -187,7 +187,7 @@
                           <a href="/packages/neon">neon</a>
                         </h3>
                         <div class="packages-recent">
-                          <img class="packages-recent-icon" src="/static/img/schedule-icon.svg?hash=mocked_hash_164576935" alt="icon indicating recent time" width="10" height="10" title="new package"/>
+                          <img class="packages-recent-icon" src="/static/hash-%%etag%%/img/schedule-icon.svg" alt="icon indicating recent time" width="10" height="10" title="new package"/>
                           Added
                           <b>%%x-ago%%</b>
                         </div>
@@ -225,7 +225,7 @@
                           )
                         </span>
                         <span class="packages-metadata-block">
-                          <img class="package-vp-icon" src="/static/img/verified-publisher-icon.svg?hash=mocked_hash_1044149352" alt="shield icon for verified publishers" width="14" height="14" title="Published by a pub.dev verified publisher"/>
+                          <img class="package-vp-icon" src="/static/hash-%%etag%%/img/verified-publisher-icon.svg" alt="shield icon for verified publishers" width="14" height="14" title="Published by a pub.dev verified publisher"/>
                           <a href="/publishers/example.com">example.com</a>
                         </span>
                       </p>
@@ -252,7 +252,7 @@
                           <a href="/packages/flutter_titanium">flutter_titanium</a>
                         </h3>
                         <div class="packages-recent">
-                          <img class="packages-recent-icon" src="/static/img/schedule-icon.svg?hash=mocked_hash_164576935" alt="icon indicating recent time" width="10" height="10" title="new package"/>
+                          <img class="packages-recent-icon" src="/static/hash-%%etag%%/img/schedule-icon.svg" alt="icon indicating recent time" width="10" height="10" title="new package"/>
                           Added
                           <b>%%x-ago%%</b>
                         </div>
@@ -337,10 +337,10 @@
       <a class="link sep" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link sep" href="/help">Help</a>
       <a class="link icon sep" href="/feed.atom">
-        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
+        <img class="inline-icon" src="/static/hash-%%etag%%/img/rss-feed-icon.svg" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
       </a>
       <a class="link icon github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">
-        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
+        <img class="inline-icon" src="/static/hash-%%etag%%/img/bug-report-white-96px.png" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
       </a>
     </footer>
   </body>

--- a/app/test/frontend/golden/search_page.html
+++ b/app/test/frontend/golden/search_page.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
   <head>
     <script src="https://www.googletagmanager.com/gtm.js?id=GTM-MX6DBN9" async="async"></script>
-    <script src="/static/js/gtm.js?hash=mocked_hash_451823545"></script>
+    <script src="/static/hash-%%etag%%/js/gtm.js"></script>
     <meta charset="utf-8"/>
     <meta http-equiv="x-ua-compatible" content="ie=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
@@ -10,23 +10,23 @@
     <meta name="twitter:card" content="summary"/>
     <meta name="twitter:site" content="@dart_lang"/>
     <meta name="twitter:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
-    <meta name="twitter:image" content="https://pub.dev/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta name="twitter:image" content="https://pub.dev/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <meta property="og:type" content="website"/>
     <meta property="og:site_name" content="Dart packages"/>
     <meta property="og:title" content="Search results for foobar."/>
     <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
-    <meta property="og:image" content="https://pub.dev/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta property="og:image" content="https://pub.dev/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <title>Search results for foobar.</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Google+Sans:300,400,500|Google+Sans+Display:400|Roboto:300,400,500,700|Roboto+Mono:300,400,700&amp;display=swap"/>
-    <meta content="/static/img/pub-dev-icon-cover-image.png?hash=mocked_hash_355802124"/>
+    <meta content="/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
-    <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/osd.xml?hash=mocked_hash_869379763"/>
+    <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/static/hash-%%etag%%/osd.xml"/>
     <link rel="canonical" href="https://pub.dev/packages?q=foobar&amp;sort=top"/>
     <meta name="description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
-    <link rel="stylesheet" type="text/css" href="/static/material/material-components-web.min.css?hash=mocked_hash_335393842"/>
-    <link rel="stylesheet" type="text/css" href="/static/css/style.css?hash=mocked_hash_537099079"/>
-    <script src="/static/material/material-components-web.min.js?hash=mocked_hash_942790516" defer="defer"></script>
+    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/material/material-components-web.min.css"/>
+    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/style.css"/>
+    <script src="/static/hash-%%etag%%/material/material-components-web.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <meta name="google-signin-client_id" content=""/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
@@ -38,7 +38,7 @@
     <div class="site-header">
       <button class="hamburger" aria-label="menu toggle"></button>
       <a class="logo" href="/">
-        <img class="site-logo" src="/static/img/pub-dev-logo-2x.png?hash=mocked_hash_685890546" alt="pub logo" width="135" height="30"/>
+        <img class="site-logo" src="/static/hash-%%etag%%/img/pub-dev-logo-2x.png" alt="pub logo" width="135" height="30"/>
       </a>
       <div class="site-header-space"></div>
       <div class="site-header-mask"></div>
@@ -72,7 +72,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Pub.dev
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="/help/search" rel="noopener" target="_blank">Searching for packages</a>
@@ -82,7 +82,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Flutter
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://flutter.io/using-packages/" rel="noopener" target="_blank">Using packages</a>
@@ -93,7 +93,7 @@
         <div class="nav-container nav-help-container-mobile foldable">
           <h3 class="foldable-button">
             Dart
-            <img class="foldable-icon" src="/static/img/nav-mobile-foldable-icon.svg?hash=mocked_hash_806401648" alt="icon to toggle folding of the section" width="13" height="6"/>
+            <img class="foldable-icon" src="/static/hash-%%etag%%/img/nav-mobile-foldable-icon.svg" alt="icon to toggle folding of the section" width="13" height="6"/>
           </h3>
           <div class="foldable-content">
             <a class="nav-link" href="https://dart.dev/tools/pub/get-started" rel="noopener" target="_blank">Using packages</a>
@@ -109,8 +109,8 @@
           <input class="input" name="q" placeholder="Search packages" autocomplete="on" value="foobar"/>
           <button class="icon" aria-label="search"></button>
           <div class="search-filters-btn-wrapper">
-            <img class="search-filters-btn search-filters-btn-inactive" src="/static/img/search-filters-inactive.svg?hash=mocked_hash_963166179" alt="icon to toggle the display of search filters (inactive)" width="42" height="42"/>
-            <img class="search-filters-btn search-filters-btn-active" src="/static/img/search-filters-active.svg?hash=mocked_hash_397783636" alt="icon to toggle the display of search filters (active)" width="42" height="42"/>
+            <img class="search-filters-btn search-filters-btn-inactive" src="/static/hash-%%etag%%/img/search-filters-inactive.svg" alt="icon to toggle the display of search filters (inactive)" width="42" height="42"/>
+            <img class="search-filters-btn search-filters-btn-active" src="/static/hash-%%etag%%/img/search-filters-active.svg" alt="icon to toggle the display of search filters (active)" width="42" height="42"/>
           </div>
           <input type="hidden" name="sort" value="top"/>
         </form>
@@ -122,7 +122,7 @@
           <div class="search-form-section foldable -active">
             <h3 class="search-form-section-header foldable-button">
               <span class="search-form-section-header-label">Platforms</span>
-              <img class="foldable-icon" src="/static/img/search-form-foldable-icon.svg?hash=mocked_hash_663371761" alt="fold toggle icon (up/down arrow)" width="13" height="6"/>
+              <img class="foldable-icon" src="/static/hash-%%etag%%/img/search-form-foldable-icon.svg" alt="fold toggle icon (up/down arrow)" width="13" height="6"/>
             </h3>
             <div class="foldable-content">
               <div class="search-form-linked-checkbox" title="Show only packages that support the Android platform.">
@@ -232,7 +232,7 @@
           <div class="search-form-section foldable" data-section-tag="sdks">
             <h3 class="search-form-section-header foldable-button">
               <span class="search-form-section-header-label">SDKs</span>
-              <img class="foldable-icon" src="/static/img/search-form-foldable-icon.svg?hash=mocked_hash_663371761" alt="fold toggle icon (up/down arrow)" width="13" height="6"/>
+              <img class="foldable-icon" src="/static/hash-%%etag%%/img/search-form-foldable-icon.svg" alt="fold toggle icon (up/down arrow)" width="13" height="6"/>
             </h3>
             <div class="foldable-content">
               <div class="search-form-linked-checkbox" title="Show only packages that support the Dart SDK.">
@@ -274,7 +274,7 @@
           <div class="search-form-section foldable" data-section-tag="advanced">
             <h3 class="search-form-section-header foldable-button">
               <span class="search-form-section-header-label">Advanced</span>
-              <img class="foldable-icon" src="/static/img/search-form-foldable-icon.svg?hash=mocked_hash_663371761" alt="fold toggle icon (up/down arrow)" width="13" height="6"/>
+              <img class="foldable-icon" src="/static/hash-%%etag%%/img/search-form-foldable-icon.svg" alt="fold toggle icon (up/down arrow)" width="13" height="6"/>
             </h3>
             <div class="foldable-content">
               <div class="search-form-linked-checkbox" title="Show only Flutter Favorite packages.">
@@ -361,7 +361,7 @@
                   <a href="/packages/oxygen">oxygen</a>
                 </h3>
                 <div class="packages-recent">
-                  <img class="packages-recent-icon" src="/static/img/schedule-icon.svg?hash=mocked_hash_164576935" alt="icon indicating recent time" width="10" height="10" title="new package"/>
+                  <img class="packages-recent-icon" src="/static/hash-%%etag%%/img/schedule-icon.svg" alt="icon indicating recent time" width="10" height="10" title="new package"/>
                   Added
                   <b>%%x-ago%%</b>
                 </div>
@@ -436,7 +436,7 @@
                   <a href="/packages/flutter_titanium">flutter_titanium</a>
                 </h3>
                 <div class="packages-recent">
-                  <img class="packages-recent-icon" src="/static/img/schedule-icon.svg?hash=mocked_hash_164576935" alt="icon indicating recent time" width="10" height="10" title="new package"/>
+                  <img class="packages-recent-icon" src="/static/hash-%%etag%%/img/schedule-icon.svg" alt="icon indicating recent time" width="10" height="10" title="new package"/>
                   Added
                   <b>%%x-ago%%</b>
                 </div>
@@ -544,10 +544,10 @@
       <a class="link sep" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
       <a class="link sep" href="/help">Help</a>
       <a class="link icon sep" href="/feed.atom">
-        <img class="inline-icon" src="/static/img/rss-feed-icon.svg?hash=mocked_hash_795155912" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
+        <img class="inline-icon" src="/static/hash-%%etag%%/img/rss-feed-icon.svg" alt="RSS icon" width="20" height="20" title="RSS/atom feed"/>
       </a>
       <a class="link icon github_issue" href="https://github.com/dart-lang/pub-dev/issues/new">
-        <img class="inline-icon" src="/static/img/bug-report-white-96px.png?hash=mocked_hash_709947442" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
+        <img class="inline-icon" src="/static/hash-%%etag%%/img/bug-report-white-96px.png" alt="bug report icon" width="20" height="20" title="Report an issue with this site"/>
       </a>
     </footer>
   </body>

--- a/app/test/frontend/static_files_test.dart
+++ b/app/test/frontend/static_files_test.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// @Tags(['presubmit-only'])
+@Tags(['presubmit-only'])
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/pkg/pub_integration/lib/src/headless_env.dart
+++ b/pkg/pub_integration/lib/src/headless_env.dart
@@ -158,6 +158,10 @@ class HeadlessEnv {
 
       final uri = Uri.parse(rs.url);
       if (uri.pathSegments.length > 1 && uri.pathSegments.first == 'static') {
+        if (!uri.pathSegments[1].startsWith('hash-')) {
+          serverErrors.add('Static ${rs.url} is without hash URL.');
+        }
+
         final cacheHeader = rs.headers[HttpHeaders.cacheControlHeader];
         if (cacheHeader == null ||
             !cacheHeader.contains('public') ||

--- a/pkg/web_css/lib/src/_base.scss
+++ b/pkg/web_css/lib/src/_base.scss
@@ -188,7 +188,7 @@ pre {
     right: 4px;
     width: 20px;
     height: 20px;
-    background: url("/static/img/content-copy-icon.svg?hash=fg6h81ph6ii0740g39jkvci8jiqi2j4p");
+    background: url("../img/content-copy-icon.svg");
     background-position: center;
     background-repeat: no-repeat;
     background-size: 16px 16px;
@@ -269,7 +269,7 @@ pre {
 
 ._banner-bg {
   background: $color-searchbar-dark-bg;
-  background-image: url("/static/img/hero-bg-static.svg?hash=pvblnkq8qgr4g10hr78tnibbr2qdpuqt");
+  background-image: url("../img/hero-bg-static.svg");
   background-size: cover;
   color: $color-searchbar-dark-fg;
   padding: 10px 0px;

--- a/pkg/web_css/lib/src/_detail_page.scss
+++ b/pkg/web_css/lib/src/_detail_page.scss
@@ -335,7 +335,7 @@ $detail-tabs-tablet-width: calc(100% - 240px);
     &:before {
       content: " ";
       display: block;
-      background: url("/static/img/admin-lock-icon.svg?hash=qv05ca0h6hmlvvp2g8a23qiueaa994u9");
+      background: url("../img/admin-lock-icon.svg");
       background-size: 12px 12px;
       width: 12px;
       height: 12px;

--- a/pkg/web_css/lib/src/_home.scss
+++ b/pkg/web_css/lib/src/_home.scss
@@ -54,7 +54,7 @@
 }
 
 .landing-main {
-  background-image: url('/static/img/square-bg-full-2x.png?hash=40uful0p6884ep2h7lt96a8cf5s68lsh');
+  background-image: url('../img/square-bg-full-2x.png');
   background-position: center top;
   background-repeat: repeat-y;
   background-size: 1440px 2279px;

--- a/pkg/web_css/lib/src/_site_header.scss
+++ b/pkg/web_css/lib/src/_site_header.scss
@@ -104,7 +104,7 @@
       padding: 5px 20px 5px 5px;
       color: $site-header-banner-fg;
       background-color: $site-header-banner-bg;
-      background-image: url("/static/img/search-icon-light.svg?hash=lbddtniv14k12bosn0phhc7jlr5i4rb4");
+      background-image: url("../img/search-icon-light.svg");
       background-repeat: no-repeat;
       background-position: right;
       background-size: 23px 23px;


### PR DESCRIPTION
- following the example of `script.dart.js`, every other resource is hashed with path-based URL
- added integration test to verify that everything under `/static/` is url-hashed
- `/favicon.ico?hash=<hash>` is not inside the `/static/` directory, keeping the query parameter hash for now
- updated CSS references to use relative path
