### PR TITLE
Migrate packageBackend.download to pub API client in tests.

### DIFF
--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -671,14 +671,6 @@ class PackageBackend {
   }
 
   @visibleForTesting
-  Stream<List<int>> download(String package, String version) {
-    // TODO: Should we first test for existence?
-    // Maybe with a cache?
-    final cv = canonicalizeVersion(version);
-    return _bucket.read(tarballObjectName(package, cv!));
-  }
-
-  @visibleForTesting
   Future<PackageVersion> upload(Stream<List<int>> data) async {
     await requireAuthenticatedUser();
     final guid = createUuid();

--- a/app/test/package/upload_test.dart
+++ b/app/test/package/upload_test.dart
@@ -20,6 +20,7 @@ import 'package:pub_dev/service/secret/backend.dart';
 import 'package:pub_dev/shared/configuration.dart';
 import 'package:pub_dev/shared/exceptions.dart';
 import 'package:pub_dev/tool/test_profile/models.dart';
+import 'package:pub_dev/tool/utils/pub_api_client.dart';
 import 'package:test/test.dart';
 import 'package:yaml/yaml.dart';
 
@@ -503,11 +504,10 @@ void main() {
           expect(lastPublished.package, 'oxygen');
           expect(lastPublished.latestVersion, '3.0.0');
 
-          final stream = packageBackend.download('oxygen', '3.0.0');
-          final chunks = await stream.toList();
-          final bytes = chunks.fold<List<int>>(
-              <int>[], (buffer, chunk) => buffer..addAll(chunk));
-          expect(bytes, tarball);
+          await withHttpPubApiClient(fn: (client) async {
+            final bytes = await client.fetchPackage('oxygen', '3.0.0');
+            expect(bytes, tarball);
+          });
         });
       });
     });


### PR DESCRIPTION
Migrating other `withPubApiClient` (which uses local non-HTTP bridge) was not straightforward, added a TODO to get back to it later.
