### PR TITLE
Add new license tags to fake pana runner.

### DIFF
--- a/app/lib/fake/backend/fake_pana_runner.dart
+++ b/app/lib/fake/backend/fake_pana_runner.dart
@@ -32,6 +32,24 @@ class FakePanaRunner implements PanaRunner {
     final hasSdkFlutter =
         random.nextInt(packageStatus.usesFlutter ? 20 : 10) > 0;
     final hasValidSdk = hasSdkDart || hasSdkFlutter;
+    final runtimeTags = hasSdkDart
+        ? <String>[
+            if (random.nextInt(5) > 0) 'runtime:native-aot',
+            if (random.nextInt(5) > 0) 'runtime:native-jit',
+            if (random.nextInt(5) > 0) 'runtime:web',
+          ]
+        : <String>[];
+    final platformTags = hasValidSdk
+        ? <String>[
+            if (random.nextInt(5) > 0) 'platform:android',
+            if (random.nextInt(5) > 0) 'platform:ios',
+            if (random.nextInt(5) > 0) 'platform:linux',
+            if (random.nextInt(5) > 0) 'platform:macos',
+            if (random.nextInt(5) > 0) 'platform:web',
+            if (random.nextInt(5) > 0) 'platform:windows',
+          ]
+        : <String>[];
+    final licenseSpdx = random.nextInt(5) == 0 ? 'unknown' : 'BSD-3-Clause';
     return Summary(
       packageName: package,
       packageVersion: Version.parse(version),
@@ -45,16 +63,12 @@ class FakePanaRunner implements PanaRunner {
       allDependencies: <String>[],
       tags: <String>[
         if (hasSdkDart) 'sdk:dart',
-        if (hasSdkDart && random.nextInt(5) > 0) 'runtime:native-aot',
-        if (hasSdkDart && random.nextInt(5) > 0) 'runtime:native-jit',
-        if (hasSdkDart && random.nextInt(5) > 0) 'runtime:web',
         if (hasSdkFlutter) 'sdk:flutter',
-        if (hasValidSdk && random.nextInt(5) > 0) 'platform:android',
-        if (hasValidSdk && random.nextInt(5) > 0) 'platform:ios',
-        if (hasValidSdk && random.nextInt(5) > 0) 'platform:linux',
-        if (hasValidSdk && random.nextInt(5) > 0) 'platform:macos',
-        if (hasValidSdk && random.nextInt(5) > 0) 'platform:web',
-        if (hasValidSdk && random.nextInt(5) > 0) 'platform:windows',
+        ...runtimeTags,
+        ...platformTags,
+        'license:${licenseSpdx.toLowerCase()}',
+        if (licenseSpdx != 'unknown') 'license:fsf-libre',
+        if (licenseSpdx != 'unknown') 'license:osi-approved',
       ],
       report: Report(
         sections: [
@@ -90,6 +104,9 @@ class FakePanaRunner implements PanaRunner {
         ],
       ),
       licenseFile: LicenseFile('LICENSE', 'BSD'),
+      licenses: [
+        License(path: 'LICENSE', spdxIdentifier: licenseSpdx),
+      ],
       errorMessage: null,
       pubspec: null, // will be ignored
     );

--- a/app/test/analyzer/pana_report_test.dart
+++ b/app/test/analyzer/pana_report_test.dart
@@ -24,15 +24,18 @@ void main() {
       final report = reports[1]!;
       expect(report.derivedTags, [
         'sdk:dart',
+        'sdk:flutter',
         'runtime:native-aot',
         'runtime:native-jit',
         'runtime:web',
-        'sdk:flutter',
         'platform:android',
         'platform:ios',
         'platform:macos',
         'platform:web',
         'platform:windows',
+        'license:bsd-3-clause',
+        'license:fsf-libre',
+        'license:osi-approved',
       ]);
       expect(report.report!.grantedPoints, 33);
       expect(report.report!.maxPoints, 60);

--- a/app/test/frontend/golden/pkg_activity_log_page.html
+++ b/app/test/frontend/golden/pkg_activity_log_page.html
@@ -253,7 +253,7 @@
             </p>
             <h3 class="title">License</h3>
             <p>
-              BSD (
+              BSD-3-Clause (
               <a href="/packages/oxygen/license">LICENSE</a>
               )
             </p>
@@ -310,7 +310,7 @@
           </p>
           <h3 class="title">License</h3>
           <p>
-            BSD (
+            BSD-3-Clause (
             <a href="/packages/oxygen/license">LICENSE</a>
             )
           </p>

--- a/app/test/frontend/golden/pkg_admin_page.html
+++ b/app/test/frontend/golden/pkg_admin_page.html
@@ -442,7 +442,7 @@
             </p>
             <h3 class="title">License</h3>
             <p>
-              BSD (
+              BSD-3-Clause (
               <a href="/packages/oxygen/license">LICENSE</a>
               )
             </p>
@@ -499,7 +499,7 @@
           </p>
           <h3 class="title">License</h3>
           <p>
-            BSD (
+            BSD-3-Clause (
             <a href="/packages/oxygen/license">LICENSE</a>
             )
           </p>

--- a/app/test/frontend/golden/pkg_changelog_page.html
+++ b/app/test/frontend/golden/pkg_changelog_page.html
@@ -266,7 +266,7 @@
             </p>
             <h3 class="title">License</h3>
             <p>
-              BSD (
+              BSD-3-Clause (
               <a href="/packages/oxygen/license">LICENSE</a>
               )
             </p>
@@ -324,7 +324,7 @@
           </p>
           <h3 class="title">License</h3>
           <p>
-            BSD (
+            BSD-3-Clause (
             <a href="/packages/oxygen/license">LICENSE</a>
             )
           </p>

--- a/app/test/frontend/golden/pkg_example_page.html
+++ b/app/test/frontend/golden/pkg_example_page.html
@@ -261,7 +261,7 @@
             </p>
             <h3 class="title">License</h3>
             <p>
-              BSD (
+              BSD-3-Clause (
               <a href="/packages/oxygen/license">LICENSE</a>
               )
             </p>
@@ -319,7 +319,7 @@
           </p>
           <h3 class="title">License</h3>
           <p>
-            BSD (
+            BSD-3-Clause (
             <a href="/packages/oxygen/license">LICENSE</a>
             )
           </p>

--- a/app/test/frontend/golden/pkg_install_page.html
+++ b/app/test/frontend/golden/pkg_install_page.html
@@ -289,7 +289,7 @@
             </p>
             <h3 class="title">License</h3>
             <p>
-              BSD (
+              BSD-3-Clause (
               <a href="/packages/oxygen/license">LICENSE</a>
               )
             </p>
@@ -347,7 +347,7 @@
           </p>
           <h3 class="title">License</h3>
           <p>
-            BSD (
+            BSD-3-Clause (
             <a href="/packages/oxygen/license">LICENSE</a>
             )
           </p>

--- a/app/test/frontend/golden/pkg_score_page.html
+++ b/app/test/frontend/golden/pkg_score_page.html
@@ -353,7 +353,7 @@
             </p>
             <h3 class="title">License</h3>
             <p>
-              BSD (
+              BSD-3-Clause (
               <a href="/packages/oxygen/license">LICENSE</a>
               )
             </p>
@@ -411,7 +411,7 @@
           </p>
           <h3 class="title">License</h3>
           <p>
-            BSD (
+            BSD-3-Clause (
             <a href="/packages/oxygen/license">LICENSE</a>
             )
           </p>

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -260,7 +260,7 @@
             </p>
             <h3 class="title">License</h3>
             <p>
-              BSD (
+              BSD-3-Clause (
               <a href="/packages/oxygen/license">LICENSE</a>
               )
             </p>
@@ -318,7 +318,7 @@
           </p>
           <h3 class="title">License</h3>
           <p>
-            BSD (
+            BSD-3-Clause (
             <a href="/packages/oxygen/license">LICENSE</a>
             )
           </p>

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -248,7 +248,7 @@
             </p>
             <h3 class="title">License</h3>
             <p>
-              BSD (
+              BSD-3-Clause (
               <a href="/packages/flutter_titanium/license">LICENSE</a>
               )
             </p>
@@ -310,7 +310,7 @@
           </p>
           <h3 class="title">License</h3>
           <p>
-            BSD (
+            BSD-3-Clause (
             <a href="/packages/flutter_titanium/license">LICENSE</a>
             )
           </p>

--- a/app/test/frontend/golden/pkg_show_page_retracted.html
+++ b/app/test/frontend/golden/pkg_show_page_retracted.html
@@ -255,7 +255,7 @@
             </p>
             <h3 class="title">License</h3>
             <p>
-              BSD (
+              unknown (
               <a href="/packages/pkg/versions/1.0.0/license">LICENSE</a>
               )
             </p>
@@ -313,7 +313,7 @@
           </p>
           <h3 class="title">License</h3>
           <p>
-            BSD (
+            unknown (
             <a href="/packages/pkg/versions/1.0.0/license">LICENSE</a>
             )
           </p>

--- a/app/test/frontend/golden/pkg_show_page_retracted_non_retracted_version.html
+++ b/app/test/frontend/golden/pkg_show_page_retracted_non_retracted_version.html
@@ -251,7 +251,7 @@
             </p>
             <h3 class="title">License</h3>
             <p>
-              BSD (
+              unknown (
               <a href="/packages/pkg/license">LICENSE</a>
               )
             </p>
@@ -309,7 +309,7 @@
           </p>
           <h3 class="title">License</h3>
           <p>
-            BSD (
+            unknown (
             <a href="/packages/pkg/license">LICENSE</a>
             )
           </p>

--- a/app/test/frontend/golden/pkg_show_version_page.html
+++ b/app/test/frontend/golden/pkg_show_version_page.html
@@ -260,7 +260,7 @@
             </p>
             <h3 class="title">License</h3>
             <p>
-              BSD (
+              BSD-3-Clause (
               <a href="/packages/oxygen/license">LICENSE</a>
               )
             </p>
@@ -318,7 +318,7 @@
           </p>
           <h3 class="title">License</h3>
           <p>
-            BSD (
+            BSD-3-Clause (
             <a href="/packages/oxygen/license">LICENSE</a>
             )
           </p>

--- a/app/test/frontend/golden/pkg_versions_page.html
+++ b/app/test/frontend/golden/pkg_versions_page.html
@@ -367,7 +367,7 @@
             </p>
             <h3 class="title">License</h3>
             <p>
-              BSD (
+              BSD-3-Clause (
               <a href="/packages/oxygen/license">LICENSE</a>
               )
             </p>
@@ -425,7 +425,7 @@
           </p>
           <h3 class="title">License</h3>
           <p>
-            BSD (
+            BSD-3-Clause (
             <a href="/packages/oxygen/license">LICENSE</a>
             )
           </p>


### PR DESCRIPTION
- required for adding the new license filters to the UI (#5359)
- restructured tags to prevent breaking the random sequence
