### PR TITLE
Migrate all API clients to HTTP-only in tests.

### DIFF
--- a/app/lib/service/services.dart
+++ b/app/lib/service/services.dart
@@ -172,11 +172,10 @@ Future<R> withFakeServices<R>({
       if (frontendServer != null) {
         final handler =
             wrapHandler(_logger, createAppHandler(), sanitize: true);
-        // Handle requests in the current zone, keeping the services context.
-        final currentZone = Zone.current;
-        final frontendServerSubscription = frontendServer.server.listen((rq) =>
-            currentZone.run(() => fork(() => handleRequest(rq, handler))));
-        registerScopeExitCallback(frontendServerSubscription.cancel);
+        final fsSubscription = frontendServer.server.listen((rq) async {
+          await fork(() => handleRequest(rq, handler));
+        });
+        registerScopeExitCallback(fsSubscription.cancel);
       }
       return await fn();
     });

--- a/app/lib/tool/test_profile/importer.dart
+++ b/app/lib/tool/test_profile/importer.dart
@@ -37,7 +37,7 @@ Future<void> importProfile({
   for (final p in profile.publishers) {
     final firstMemberEmail = p.members.first.email;
     final token = _fakeToken(firstMemberEmail);
-    await withPubApiClient(
+    await withHttpPubApiClient(
       bearerToken: token,
       pubHostedUrl: pubHostedUrl,
       fn: (client) async {
@@ -65,7 +65,7 @@ Future<void> importProfile({
     lastActiveUploaderEmails[rv.package] = uploaderEmail;
 
     final bytes = await source.getArchiveBytes(rv.package, rv.version);
-    await withPubApiClient(
+    await withHttpPubApiClient(
       bearerToken: _fakeToken(uploaderEmail),
       pubHostedUrl: pubHostedUrl,
       fn: (client) async {
@@ -92,7 +92,7 @@ Future<void> importProfile({
     final packageName = testPackage.name;
     final activeEmail = lastActiveUploaderEmails[packageName];
 
-    await withPubApiClient(
+    await withHttpPubApiClient(
       bearerToken: _fakeToken(activeEmail!),
       pubHostedUrl: pubHostedUrl,
       fn: (client) async {
@@ -123,7 +123,7 @@ Future<void> importProfile({
     );
 
     if (testPackage.isFlutterFavorite ?? false) {
-      await withPubApiClient(
+      await withHttpPubApiClient(
         bearerToken: _fakeToken(adminUserEmail ?? activeEmail),
         pubHostedUrl: pubHostedUrl,
         fn: (client) async {
@@ -140,7 +140,7 @@ Future<void> importProfile({
 
   // create likes
   for (final u in profile.users) {
-    await withPubApiClient(
+    await withHttpPubApiClient(
       bearerToken: _fakeToken(u.email),
       pubHostedUrl: pubHostedUrl,
       fn: (client) async {

--- a/app/lib/tool/utils/pub_api_client.dart
+++ b/app/lib/tool/utils/pub_api_client.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:gcloud/service_scope.dart';
+import 'package:meta/meta.dart';
 
 import '../../frontend/handlers/pubapi.client.dart';
 import '../../shared/configuration.dart';
@@ -13,6 +14,7 @@ import 'http.dart';
 /// The client will be closed when the current scope is exited.
 ///
 /// TODO: migrate callers to use [withHttpPubApiClient] instead.
+@visibleForTesting
 PubApiClient createLocalPubApiClient({String? authToken}) {
   final httpClient =
       httpClientWithAuthorization(tokenProvider: () async => authToken);

--- a/app/lib/tool/utils/pub_api_client.dart
+++ b/app/lib/tool/utils/pub_api_client.dart
@@ -2,44 +2,25 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:gcloud/service_scope.dart';
+
 import '../../frontend/handlers/pubapi.client.dart';
 import '../../shared/configuration.dart';
 
 import 'http.dart';
-import 'http_client_to_shelf_handler.dart';
 
-/// Creates local, non-HTTP-based API client with [authToken].
-PubApiClient createLocalPubApiClient({String? authToken}) =>
-    PubApiClient('http://localhost:0/',
-        client: httpClientToShelfHandler(authToken: authToken));
-
-/// Creates a pub.dev API client and executes [fn], making sure that the HTTP
-/// resources are freed after the callback finishes.
+/// Creates an API client to the configured endpoint with [authToken].
+/// The client will be closed when the current scope is exited.
 ///
-/// If [bearerToken] is specified, the Authorization HTTP header will be sent
-/// with a Bearer token.
-///
-/// If [pubHostedUrl] is specified, the HTTP client will connect to this
-/// endpoint, otherwise only local API calls will be made.
-///
-/// TODO: Migrate callers to use [withHttpPubApiClient] instead.
-Future<R> withPubApiClient<R>({
-  String? bearerToken,
-  String? pubHostedUrl,
-  required Future<R> Function(PubApiClient client) fn,
-}) async {
-  final httpClient = pubHostedUrl == null
-      ? httpClientToShelfHandler(authToken: bearerToken)
-      : httpClientWithAuthorization(tokenProvider: () async => bearerToken);
-  try {
-    final apiClient = PubApiClient(
-      pubHostedUrl ?? 'http://localhost:0/',
-      client: httpClient,
-    );
-    return await fn(apiClient);
-  } finally {
-    httpClient.close();
-  }
+/// TODO: migrate callers to use [withHttpPubApiClient] instead.
+PubApiClient createLocalPubApiClient({String? authToken}) {
+  final httpClient =
+      httpClientWithAuthorization(tokenProvider: () async => authToken);
+  registerScopeExitCallback(() async => httpClient.close());
+  return PubApiClient(
+    activeConfiguration.primaryApiUri!.toString(),
+    client: httpClient,
+  );
 }
 
 /// Creates a pub.dev API client and executes [fn], making sure that the HTTP

--- a/app/test/account/consent_backend_test.dart
+++ b/app/test/account/consent_backend_test.dart
@@ -47,7 +47,7 @@ void main() {
 
     testWithProfile('Uploader invite accepted', fn: () async {
       final consentId = await inviteUploader();
-      await withPubApiClient(
+      await withHttpPubApiClient(
           bearerToken: userAtPubDevAuthToken,
           fn: (client) async {
             final rs = await client.resolveConsent(
@@ -65,7 +65,7 @@ void main() {
     testWithProfile('Uploader invite rejected', fn: () async {
       final consentId = await inviteUploader();
 
-      await withPubApiClient(
+      await withHttpPubApiClient(
           bearerToken: userAtPubDevAuthToken,
           fn: (client) async {
             final rs = await client.resolveConsent(
@@ -123,7 +123,7 @@ void main() {
     testWithProfile('Publisher contact accepted', fn: () async {
       final consentId = await inviteContact();
 
-      await withPubApiClient(
+      await withHttpPubApiClient(
           bearerToken: userAtPubDevAuthToken,
           fn: (client) async {
             final rs = await client.resolveConsent(
@@ -141,7 +141,7 @@ void main() {
     testWithProfile('Publisher contact rejected', fn: () async {
       final consentId = await inviteContact();
 
-      await withPubApiClient(
+      await withHttpPubApiClient(
           bearerToken: userAtPubDevAuthToken,
           fn: (client) async {
             final rs = await client.resolveConsent(
@@ -201,7 +201,7 @@ void main() {
     testWithProfile('Publisher member accepted', fn: () async {
       final consentId = await inviteMember();
 
-      await withPubApiClient(
+      await withHttpPubApiClient(
           bearerToken: userAtPubDevAuthToken,
           fn: (client) async {
             final rs = await client.resolveConsent(
@@ -219,7 +219,7 @@ void main() {
     testWithProfile('Publisher member rejected', fn: () async {
       final consentId = await inviteMember();
 
-      await withPubApiClient(
+      await withHttpPubApiClient(
           bearerToken: userAtPubDevAuthToken,
           fn: (client) async {
             final rs = await client.resolveConsent(

--- a/app/test/tool/maintenance/remove_orphaned_likes_test.dart
+++ b/app/test/tool/maintenance/remove_orphaned_likes_test.dart
@@ -15,7 +15,7 @@ import '../../shared/test_services.dart';
 void main() {
   group('Remove orphaned likes', () {
     testWithProfile('finds the like but no need to delete it', fn: () async {
-      await withPubApiClient(
+      await withHttpPubApiClient(
           bearerToken: userAtPubDevAuthToken,
           fn: (client) => client.likePackage('oxygen'));
       final counts = await removeOrphanedLikes(minAgeThreshold: Duration.zero);
@@ -26,7 +26,7 @@ void main() {
     testWithProfile(
       'finds like without package',
       fn: () async {
-        await withPubApiClient(
+        await withHttpPubApiClient(
             bearerToken: userAtPubDevAuthToken,
             fn: (client) => client.likePackage('oxygen'));
         await dbService.commit(
@@ -44,7 +44,7 @@ void main() {
     testWithProfile(
       'finds like without userid',
       fn: () async {
-        await withPubApiClient(
+        await withHttpPubApiClient(
             bearerToken: userAtPubDevAuthToken,
             fn: (client) => client.likePackage('oxygen'));
         final user =


### PR DESCRIPTION
Both keeping the zone and running inside an additional fork/zone was important to make this happen, but this will keep the services context.