### PR TITLE
Integrity check and periodic update for Package like counts.

### DIFF
--- a/app/lib/shared/integrity.dart
+++ b/app/lib/shared/integrity.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:math' as math;
+
 import 'package:clock/clock.dart';
 import 'package:http/http.dart' as http;
 import 'package:logging/logging.dart';
@@ -549,7 +551,7 @@ class IntegrityChecker {
 
       // Allowing some difference to attribute for the likes created or removed
       // between the package reads and the current counts.
-      if (diff.abs() <= 2) {
+      if (diff.abs() <= math.max(3, counted * 0.10)) {
         continue;
       }
 

--- a/app/lib/shared/integrity.dart
+++ b/app/lib/shared/integrity.dart
@@ -35,6 +35,7 @@ class IntegrityChecker {
   final _deletedUsers = <String>{};
   final _invalidUsers = <String>{};
   final _packages = <String>{};
+  final _packageLikes = <String, int>{};
   final _moderatedPackages = <String>{};
   final _packageReplacedBys = <String, String>{};
   final _packagesWithVersion = <String>{};
@@ -266,6 +267,7 @@ class IntegrityChecker {
     if (p.likes < 0) {
       yield 'Package "${p.name}" has a `likes` property which is not a non-negative integer.';
     }
+    _packageLikes[p.name!] = p.likes;
     final uploaders = p.uploaders;
     if (uploaders != null) {
       for (final userId in uploaders) {
@@ -507,6 +509,7 @@ class IntegrityChecker {
   Stream<String> _checkLikes() async* {
     _logger.info('Scanning Likes...');
 
+    final counts = <String, int>{};
     await for (final like in _db.query<Like>().run()) {
       if (like.packageName == null) {
         yield 'Like entity for user "${like.userId}" and package "${like.package}" has a '
@@ -521,6 +524,36 @@ class IntegrityChecker {
       if (await _packageMissing(like.package)) {
         yield 'User "${like.userId}" likes missing package "${like.package}".';
       }
+
+      counts[like.package] = (counts[like.package] ?? 0) + 1;
+    }
+
+    final allPackages = <String>{
+      ..._packageLikes.keys,
+      ...counts.keys,
+    };
+    for (final package in allPackages) {
+      final counted = counts[package] ?? 0;
+      final originalStored = _packageLikes[package] ?? 0;
+      if (counted == originalStored) {
+        continue;
+      }
+
+      final p = await packageBackend.lookupPackage(package);
+      final updatedStored = p!.likes;
+      if (counted == updatedStored) {
+        continue;
+      }
+
+      final diff = counted - updatedStored;
+
+      // Allowing some difference to attribute for the likes created or removed
+      // between the package reads and the current counts.
+      if (diff.abs() <= 2) {
+        continue;
+      }
+
+      yield 'Package "$package" has like count difference: observed: $counted != stored: $updatedStored.';
     }
   }
 

--- a/app/lib/tool/maintenance/update_package_likes.dart
+++ b/app/lib/tool/maintenance/update_package_likes.dart
@@ -1,0 +1,40 @@
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:logging/logging.dart';
+import 'package:pub_dev/account/models.dart';
+import 'package:pub_dev/package/models.dart';
+import 'package:pub_dev/shared/datastore.dart';
+
+final _logger = Logger('adjust_like_counts');
+
+/// Updates the like count of packages, fixing eventual consistency issues.
+///
+/// Return the number of packages that were updated.
+Future<int> updatePackageLikes() async {
+  _logger.info('Scanning packages for like count consistency...');
+
+  var updatedCount = 0;
+  await for (final p in dbService.query<Package>().run()) {
+    final query = dbService.query<Like>()..filter('packageName =', p.name!);
+    final count = await query.run().fold<int>(0, (sum, like) => sum + 1);
+    if (p.likes == count) {
+      continue;
+    }
+    _logger.info(
+        'Updating likes for package "${p.name}" changing from ${p.likes} to $count.');
+    await withRetryTransaction(dbService, (tx) async {
+      final pkg = await tx.lookupValue<Package>(p.key);
+      if (pkg.updated != p.updated || pkg.likes != p.likes) {
+        _logger.info(
+            'Skipping like update for package "${p.name}": changed since the like verification started.');
+        return;
+      }
+      pkg.likes = count;
+      tx.insert(pkg);
+    });
+    updatedCount++;
+  }
+  return updatedCount;
+}

--- a/app/lib/tool/neat_task/pub_dev_tasks.dart
+++ b/app/lib/tool/neat_task/pub_dev_tasks.dart
@@ -7,7 +7,6 @@ import 'dart:io';
 import 'package:gcloud/service_scope.dart' as ss;
 import 'package:logging/logging.dart';
 import 'package:neat_periodic_task/neat_periodic_task.dart';
-import 'package:pub_dev/tool/maintenance/remove_orphaned_likes.dart';
 
 import '../../account/backend.dart';
 import '../../account/consent_backend.dart';
@@ -20,6 +19,8 @@ import '../../search/backend.dart';
 import '../../shared/datastore.dart';
 import '../../shared/integrity.dart';
 import '../../tool/backfill/backfill_new_fields.dart';
+import '../maintenance/remove_orphaned_likes.dart';
+import '../maintenance/update_package_likes.dart';
 
 import 'datastore_status_provider.dart';
 
@@ -76,6 +77,13 @@ void _setupGenericPeriodicTasks() {
     name: 'remove-orphaned-likes',
     isRuntimeVersioned: false,
     task: removeOrphanedLikes,
+  );
+
+  // Updates Package.likes with the correct new value.
+  _weekly(
+    name: 'update-package-likes',
+    isRuntimeVersioned: false,
+    task: updatePackageLikes,
   );
 }
 

--- a/app/test/tool/maintenance/update_package_likes_test.dart
+++ b/app/test/tool/maintenance/update_package_likes_test.dart
@@ -1,0 +1,66 @@
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:clock/clock.dart';
+import 'package:pub_dev/account/backend.dart';
+import 'package:pub_dev/account/models.dart';
+import 'package:pub_dev/package/backend.dart';
+import 'package:pub_dev/package/models.dart';
+import 'package:pub_dev/shared/datastore.dart';
+import 'package:pub_dev/tool/maintenance/update_package_likes.dart';
+import 'package:pub_dev/tool/utils/pub_api_client.dart';
+import 'package:test/test.dart';
+
+import '../../shared/test_models.dart';
+import '../../shared/test_services.dart';
+
+void main() {
+  group('Adjust like counts', () {
+    testWithProfile('no need to change like counts #1', fn: () async {
+      final p1 = await packageBackend.lookupPackage('oxygen');
+      expect(await updatePackageLikes(), 0);
+      final p2 = await packageBackend.lookupPackage('oxygen');
+      expect(p2!.likes, p1!.likes);
+    });
+
+    testWithProfile('no need to change like counts #2', fn: () async {
+      final p1 = await packageBackend.lookupPackage('oxygen');
+      await withPubApiClient(
+          bearerToken: userAtPubDevAuthToken,
+          fn: (client) => client.likePackage('oxygen'));
+      expect(await updatePackageLikes(), 0);
+      final p2 = await packageBackend.lookupPackage('oxygen');
+      expect(p2!.likes, p1!.likes + 1);
+    });
+
+    testWithProfile('missing like', fn: () async {
+      final p1 = await packageBackend.lookupPackage('oxygen');
+      await withRetryTransaction(dbService, (tx) async {
+        final p = await tx.lookupValue<Package>(
+            dbService.emptyKey.append(Package, id: 'oxygen'));
+        p.likes++;
+        tx.insert(p);
+      });
+      expect(await updatePackageLikes(), 1);
+      final p2 = await packageBackend.lookupPackage('oxygen');
+      expect(p2!.likes, p1!.likes);
+    });
+
+    testWithProfile('extra like', fn: () async {
+      final p1 = await packageBackend.lookupPackage('oxygen');
+      final user =
+          await accountBackend.lookupOrCreateUserByEmail('user@pub.dev');
+      await dbService.commit(inserts: [
+        Like()
+          ..parentKey = user.key
+          ..id = 'oxygen'
+          ..packageName = 'oxygen'
+          ..created = clock.now()
+      ]);
+      expect(await updatePackageLikes(), 1);
+      final p2 = await packageBackend.lookupPackage('oxygen');
+      expect(p2!.likes, p1!.likes + 1);
+    });
+  });
+}


### PR DESCRIPTION
- #5684
- integrity check allows a small difference between observed and stored counts
- periodic task will update the counts when it seems there was no update on the Package entity while the scan was running

Note: right now we don't update the `Package.updated` field when we are updating the likes count. We could have better consistency check if we were to update it, or added a non-indexed additional timestamp to track the latest update of the likes count.