### PR TITLE
Update survey-helper.js

### DIFF
--- a/static/js/survey-helper.js
+++ b/static/js/survey-helper.js
@@ -14,7 +14,7 @@
   });
   helpApi.requestSurvey({
     triggerId: data.triggerId,
-    enableTestingMode: data.testingMode === 'true',
+    enableTestingMode: data.testingMode === 'false',
     callback: function(rscp) {
       if (rscp.surveyData) {
         helpApi.presentSurvey({


### PR DESCRIPTION
I figured that the HaTS survey is triggered too often, and the reason is because the rate limiting was not working. I learned that we should set `enableTestingMode` to `false` from [this documentation](https://g3doc.corp.google.com/company/teams/uservoice/surveys/client/concepts.md?cl=head#testing-mode).