### PR TITLE
Remove self(-update) link from osd.xml

### DIFF
--- a/static/osd.xml
+++ b/static/osd.xml
@@ -22,6 +22,5 @@ BSD-style license that can be found in the LICENSE file.
     <Url type="text/html" template="https://pub.dev/packages">
         <Param name="q" value="{searchTerms}"/>
     </Url>
-    <Url type="application/opensearchdescription+xml" rel="self" template="https://pub.dev/static/osd.xml"/>
     <moz:SearchForm>https://pub.dev</moz:SearchForm>
 </OpenSearchDescription>


### PR DESCRIPTION
- The self-link is broken as the `/static/hash-[hash]` URLs are dynamically generated.
- The self-link is not easy to override, as the hash is generated based on the static files' content. Simpler to just remove this self-reference, which seem to be breaking it, but is not necessary at all.