### PR TITLE
Verify bucket existence and (info) access on startup.

### DIFF
--- a/app/lib/service/services.dart
+++ b/app/lib/service/services.dart
@@ -150,14 +150,8 @@ Future<R> withFakeServices<R>({
       );
     }
     registerActiveConfiguration(configuration!);
-    final bucketsToCreate = [
-      configuration!.canonicalPackagesBucketName!,
-      configuration!.publicPackagesBucketName!,
-      configuration!.incomingPackagesBucketName!,
-      configuration!.packageBucketName!,
-    ];
-    for (final bucketName in bucketsToCreate) {
-      await getOrCreateBucket(storage, bucketName);
+    for (final bucketName in configuration!.allBucketNames) {
+      await storage.createBucket(bucketName);
     }
 
     // register fake services that would have external dependencies
@@ -186,6 +180,11 @@ Future<R> withFakeServices<R>({
 /// tools and integration tests.
 Future<R> _withPubServices<R>(FutureOr<R> Function() fn) async {
   return fork(() async {
+    // verify the existence of all storage buckets
+    for (final bucketName in activeConfiguration.allBucketNames) {
+      await storageService.verifyBucketExistenceAndAccess(bucketName);
+    }
+
     registerAccountBackend(AccountBackend(dbService));
     registerAdminBackend(AdminBackend(dbService));
     registerAnnouncementBackend(AnnouncementBackend());
@@ -194,8 +193,7 @@ Future<R> _withPubServices<R>(FutureOr<R> Function() fn) async {
     registerDartdocBackend(
       DartdocBackend(
         dbService,
-        await getOrCreateBucket(
-            storageService, activeConfiguration.dartdocStorageBucketName!),
+        storageService.bucket(activeConfiguration.dartdocStorageBucketName!),
       ),
     );
     registerDartSdkMemIndex(DartSdkMemIndex());
@@ -205,8 +203,8 @@ Future<R> _withPubServices<R>(FutureOr<R> Function() fn) async {
     registerPackageIndex(InMemoryPackageIndex());
     registerIndexUpdater(IndexUpdater(dbService, packageIndex));
     registerPopularityStorage(
-      PopularityStorage(await getOrCreateBucket(
-          storageService, activeConfiguration.popularityDumpBucketName!)),
+      PopularityStorage(
+          storageService.bucket(activeConfiguration.popularityDumpBucketName!)),
     );
     registerPublisherBackend(PublisherBackend(dbService));
     registerScoreCardBackend(ScoreCardBackend(dbService));
@@ -214,10 +212,10 @@ Future<R> _withPubServices<R>(FutureOr<R> Function() fn) async {
     registerSearchClient(SearchClient());
     registerSearchAdapter(SearchAdapter());
     registerSecretBackend(SecretBackend(dbService));
-    registerSnapshotStorage(SnapshotStorage(await getOrCreateBucket(
-        storageService, activeConfiguration.searchSnapshotBucketName!)));
-    registerImageStorage(ImageStorage(await getOrCreateBucket(
-        storageService, activeConfiguration.imageBucketName!)));
+    registerSnapshotStorage(SnapshotStorage(
+        storageService.bucket(activeConfiguration.searchSnapshotBucketName!)));
+    registerImageStorage(ImageStorage(
+        storageService.bucket(activeConfiguration.imageBucketName!)));
 
     registerYoutubeBackend(YoutubeBackend());
 

--- a/app/lib/shared/configuration.dart
+++ b/app/lib/shared/configuration.dart
@@ -312,6 +312,18 @@ class Configuration {
   factory Configuration.fromJson(Map<String, dynamic> json) =>
       _$ConfigurationFromJson(json);
   Map<String, dynamic> toJson() => _$ConfigurationToJson(this);
+
+  /// All the bucket names inside this configuration.
+  late final allBucketNames = List<String>.unmodifiable(<String>[
+    canonicalPackagesBucketName!,
+    dartdocStorageBucketName!,
+    imageBucketName!,
+    incomingPackagesBucketName!,
+    packageBucketName!,
+    popularityDumpBucketName!,
+    publicPackagesBucketName!,
+    searchSnapshotBucketName!,
+  ]);
 }
 
 /// Data structure to describe an admin user.

--- a/app/test/package/tarball_storage_namer_test.dart
+++ b/app/test/package/tarball_storage_namer_test.dart
@@ -15,7 +15,8 @@ import '../shared/test_services.dart';
 void main() {
   group('Object names', () {
     testWithProfile('namer', fn: () async {
-      final bucket = await getOrCreateBucket(storageService, 'some-pub-bucket');
+      await storageService.createBucket('some-pub-bucket');
+      final bucket = storageService.bucket('some-pub-bucket');
       expect(bucket.objectUrl('path/file.txt'),
           '${activeConfiguration.storageBaseUrl}/some-pub-bucket/path/file.txt');
 


### PR DESCRIPTION
- Fixes #5707.
- We could consider caching the status, in order to reduce the rate of request on the buckets when a new version is being deployed, but otherwise it should be a cheap and safe check.
- We could also do real write-read-delete checks at startup, but there is only a limited additional value there, and it either introduces race conditions with fixed filenames, or may create leftover files with randomized filenames.