### PR TITLE
Reduce test fragility on fake pana analysis: consistent hashing.

### DIFF
--- a/app/test/analyzer/pana_report_test.dart
+++ b/app/test/analyzer/pana_report_test.dart
@@ -25,11 +25,11 @@ void main() {
       expect(report.derivedTags, [
         'sdk:dart',
         'sdk:flutter',
-        'runtime:native-aot',
         'runtime:native-jit',
         'runtime:web',
         'platform:android',
         'platform:ios',
+        'platform:linux',
         'platform:macos',
         'platform:web',
         'platform:windows',
@@ -37,7 +37,7 @@ void main() {
         'license:fsf-libre',
         'license:osi-approved',
       ]);
-      expect(report.report!.grantedPoints, 33);
+      expect(report.report!.grantedPoints, 44);
       expect(report.report!.maxPoints, 60);
       expect(report.report!.sections.first.summary,
           contains('8/30 points: Package layout'));

--- a/app/test/analyzer/pana_runner_test.dart
+++ b/app/test/analyzer/pana_runner_test.dart
@@ -37,7 +37,7 @@ void main() {
         await processJobsWithFakeDartdocRunner();
         final card = await scoreCardBackend.getScoreCardData('retry', '3.1.0');
 
-        expect(card!.grantedPubPoints, greaterThan(125));
+        expect(card!.grantedPubPoints, greaterThan(120));
         expect(card.maxPubPoints, card.grantedPubPoints);
         expect(
             card.derivedTags?.toSet(),
@@ -54,6 +54,7 @@ void main() {
               'runtime:native-jit',
               'runtime:web',
               'is:null-safe',
+              'license:osi-approved',
             ]));
       },
       timeout: Timeout.factor(8),

--- a/app/test/dartdoc/dartdoc_runner_test.dart
+++ b/app/test/dartdoc/dartdoc_runner_test.dart
@@ -29,8 +29,8 @@ void main() {
         await processJobsWithDartdocRunner();
         final card = await scoreCardBackend.getScoreCardData('retry', '3.1.0');
 
-        expect(card!.grantedPubPoints, 22);
-        expect(card.maxPubPoints, 70);
+        expect(card!.grantedPubPoints, greaterThan(25));
+        expect(card.maxPubPoints, greaterThan(60));
         expect(card.dartdocReport!.documentationSection!.grantedPoints, 10);
         expect(card.dartdocReport!.documentationSection!.maxPoints, 10);
 

--- a/app/test/frontend/golden/my_packages.html
+++ b/app/test/frontend/golden/my_packages.html
@@ -200,7 +200,7 @@
                           </div>
                           <div class="packages-score packages-score-health">
                             <div class="packages-score-value -has-value">
-                              <span class="packages-score-value-number">43</span>
+                              <span class="packages-score-value-number">54</span>
                               <span class="packages-score-value-sign"></span>
                             </div>
                             <div class="packages-score-label">pub points</div>
@@ -242,6 +242,7 @@
                           <span class="tag-badge-main">Platform</span>
                           <a class="tag-badge-sub" href="/packages?q=platform%3Aandroid" title="Packages compatible with Android platform">Android</a>
                           <a class="tag-badge-sub" href="/packages?q=platform%3Aios" title="Packages compatible with iOS platform">iOS</a>
+                          <a class="tag-badge-sub" href="/packages?q=platform%3Alinux" title="Packages compatible with Linux platform">Linux</a>
                           <a class="tag-badge-sub" href="/packages?q=platform%3Amacos" title="Packages compatible with macOS platform">macOS</a>
                           <a class="tag-badge-sub" href="/packages?q=platform%3Aweb" title="Packages compatible with Web platform">web</a>
                           <a class="tag-badge-sub" href="/packages?q=platform%3Awindows" title="Packages compatible with Windows platform">Windows</a>
@@ -268,7 +269,7 @@
                           </div>
                           <div class="packages-score packages-score-health">
                             <div class="packages-score-value -has-value">
-                              <span class="packages-score-value-number">43</span>
+                              <span class="packages-score-value-number">44</span>
                               <span class="packages-score-value-sign"></span>
                             </div>
                             <div class="packages-score-label">pub points</div>
@@ -297,20 +298,18 @@
                         </span>
                         <span class="packages-metadata-block">
                           <img class="packages-metadata-license-icon" src="/static/hash-%%etag%%/img/material-icon-balance.svg" alt="Icon for licenses." width="16" height="16"/>
-                          unknown
+                          BSD-3-Clause
                         </span>
                       </p>
                       <div>
                         <div class="-pub-tag-badge">
                           <span class="tag-badge-main">SDK</span>
                           <a class="tag-badge-sub" href="/packages?q=sdk%3Adart" title="Packages compatible with Dart SDK">Dart</a>
-                          <a class="tag-badge-sub" href="/packages?q=sdk%3Aflutter" title="Packages compatible with Flutter SDK">Flutter</a>
                         </div>
                         <div class="-pub-tag-badge">
                           <span class="tag-badge-main">Platform</span>
                           <a class="tag-badge-sub" href="/packages?q=platform%3Aandroid" title="Packages compatible with Android platform">Android</a>
                           <a class="tag-badge-sub" href="/packages?q=platform%3Aios" title="Packages compatible with iOS platform">iOS</a>
-                          <a class="tag-badge-sub" href="/packages?q=platform%3Alinux" title="Packages compatible with Linux platform">Linux</a>
                           <a class="tag-badge-sub" href="/packages?q=platform%3Amacos" title="Packages compatible with macOS platform">macOS</a>
                           <a class="tag-badge-sub" href="/packages?q=platform%3Aweb" title="Packages compatible with Web platform">web</a>
                           <a class="tag-badge-sub" href="/packages?q=platform%3Awindows" title="Packages compatible with Windows platform">Windows</a>

--- a/app/test/frontend/golden/pkg_activity_log_page.html
+++ b/app/test/frontend/golden/pkg_activity_log_page.html
@@ -151,6 +151,7 @@
                       <span class="tag-badge-main">Platform</span>
                       <a class="tag-badge-sub" href="/packages?q=platform%3Aandroid" title="Packages compatible with Android platform">Android</a>
                       <a class="tag-badge-sub" href="/packages?q=platform%3Aios" title="Packages compatible with iOS platform">iOS</a>
+                      <a class="tag-badge-sub" href="/packages?q=platform%3Alinux" title="Packages compatible with Linux platform">Linux</a>
                       <a class="tag-badge-sub" href="/packages?q=platform%3Amacos" title="Packages compatible with macOS platform">macOS</a>
                       <a class="tag-badge-sub" href="/packages?q=platform%3Aweb" title="Packages compatible with Web platform">web</a>
                       <a class="tag-badge-sub" href="/packages?q=platform%3Awindows" title="Packages compatible with Windows platform">Windows</a>
@@ -223,7 +224,7 @@
               </div>
               <div class="packages-score packages-score-health">
                 <div class="packages-score-value -has-value">
-                  <span class="packages-score-value-number">43</span>
+                  <span class="packages-score-value-number">54</span>
                   <span class="packages-score-value-sign"></span>
                 </div>
                 <div class="packages-score-label">pub points</div>
@@ -280,7 +281,7 @@
             </div>
             <div class="packages-score packages-score-health">
               <div class="packages-score-value -has-value">
-                <span class="packages-score-value-number">43</span>
+                <span class="packages-score-value-number">54</span>
                 <span class="packages-score-value-sign"></span>
               </div>
               <div class="packages-score-label">pub points</div>

--- a/app/test/frontend/golden/pkg_admin_page.html
+++ b/app/test/frontend/golden/pkg_admin_page.html
@@ -151,6 +151,7 @@
                       <span class="tag-badge-main">Platform</span>
                       <a class="tag-badge-sub" href="/packages?q=platform%3Aandroid" title="Packages compatible with Android platform">Android</a>
                       <a class="tag-badge-sub" href="/packages?q=platform%3Aios" title="Packages compatible with iOS platform">iOS</a>
+                      <a class="tag-badge-sub" href="/packages?q=platform%3Alinux" title="Packages compatible with Linux platform">Linux</a>
                       <a class="tag-badge-sub" href="/packages?q=platform%3Amacos" title="Packages compatible with macOS platform">macOS</a>
                       <a class="tag-badge-sub" href="/packages?q=platform%3Aweb" title="Packages compatible with Web platform">web</a>
                       <a class="tag-badge-sub" href="/packages?q=platform%3Awindows" title="Packages compatible with Windows platform">Windows</a>
@@ -412,7 +413,7 @@
               </div>
               <div class="packages-score packages-score-health">
                 <div class="packages-score-value -has-value">
-                  <span class="packages-score-value-number">43</span>
+                  <span class="packages-score-value-number">54</span>
                   <span class="packages-score-value-sign"></span>
                 </div>
                 <div class="packages-score-label">pub points</div>
@@ -469,7 +470,7 @@
             </div>
             <div class="packages-score packages-score-health">
               <div class="packages-score-value -has-value">
-                <span class="packages-score-value-number">43</span>
+                <span class="packages-score-value-number">54</span>
                 <span class="packages-score-value-sign"></span>
               </div>
               <div class="packages-score-label">pub points</div>

--- a/app/test/frontend/golden/pkg_changelog_page.html
+++ b/app/test/frontend/golden/pkg_changelog_page.html
@@ -152,6 +152,7 @@
                       <span class="tag-badge-main">Platform</span>
                       <a class="tag-badge-sub" href="/packages?q=platform%3Aandroid" title="Packages compatible with Android platform">Android</a>
                       <a class="tag-badge-sub" href="/packages?q=platform%3Aios" title="Packages compatible with iOS platform">iOS</a>
+                      <a class="tag-badge-sub" href="/packages?q=platform%3Alinux" title="Packages compatible with Linux platform">Linux</a>
                       <a class="tag-badge-sub" href="/packages?q=platform%3Amacos" title="Packages compatible with macOS platform">macOS</a>
                       <a class="tag-badge-sub" href="/packages?q=platform%3Aweb" title="Packages compatible with Web platform">web</a>
                       <a class="tag-badge-sub" href="/packages?q=platform%3Awindows" title="Packages compatible with Windows platform">Windows</a>
@@ -236,7 +237,7 @@
               </div>
               <div class="packages-score packages-score-health">
                 <div class="packages-score-value -has-value">
-                  <span class="packages-score-value-number">43</span>
+                  <span class="packages-score-value-number">54</span>
                   <span class="packages-score-value-sign"></span>
                 </div>
                 <div class="packages-score-label">pub points</div>
@@ -294,7 +295,7 @@
             </div>
             <div class="packages-score packages-score-health">
               <div class="packages-score-value -has-value">
-                <span class="packages-score-value-number">43</span>
+                <span class="packages-score-value-number">54</span>
                 <span class="packages-score-value-sign"></span>
               </div>
               <div class="packages-score-label">pub points</div>

--- a/app/test/frontend/golden/pkg_example_page.html
+++ b/app/test/frontend/golden/pkg_example_page.html
@@ -152,6 +152,7 @@
                       <span class="tag-badge-main">Platform</span>
                       <a class="tag-badge-sub" href="/packages?q=platform%3Aandroid" title="Packages compatible with Android platform">Android</a>
                       <a class="tag-badge-sub" href="/packages?q=platform%3Aios" title="Packages compatible with iOS platform">iOS</a>
+                      <a class="tag-badge-sub" href="/packages?q=platform%3Alinux" title="Packages compatible with Linux platform">Linux</a>
                       <a class="tag-badge-sub" href="/packages?q=platform%3Amacos" title="Packages compatible with macOS platform">macOS</a>
                       <a class="tag-badge-sub" href="/packages?q=platform%3Aweb" title="Packages compatible with Web platform">web</a>
                       <a class="tag-badge-sub" href="/packages?q=platform%3Awindows" title="Packages compatible with Windows platform">Windows</a>
@@ -231,7 +232,7 @@
               </div>
               <div class="packages-score packages-score-health">
                 <div class="packages-score-value -has-value">
-                  <span class="packages-score-value-number">43</span>
+                  <span class="packages-score-value-number">54</span>
                   <span class="packages-score-value-sign"></span>
                 </div>
                 <div class="packages-score-label">pub points</div>
@@ -289,7 +290,7 @@
             </div>
             <div class="packages-score packages-score-health">
               <div class="packages-score-value -has-value">
-                <span class="packages-score-value-number">43</span>
+                <span class="packages-score-value-number">54</span>
                 <span class="packages-score-value-sign"></span>
               </div>
               <div class="packages-score-label">pub points</div>

--- a/app/test/frontend/golden/pkg_index_page.html
+++ b/app/test/frontend/golden/pkg_index_page.html
@@ -412,7 +412,7 @@
                   </div>
                   <div class="packages-score packages-score-health">
                     <div class="packages-score-value -has-value">
-                      <span class="packages-score-value-number">43</span>
+                      <span class="packages-score-value-number">54</span>
                       <span class="packages-score-value-sign"></span>
                     </div>
                     <div class="packages-score-label">pub points</div>
@@ -454,6 +454,7 @@
                   <span class="tag-badge-main">Platform</span>
                   <a class="tag-badge-sub" href="/packages?q=sdk%3Adart+platform%3Aandroid" title="Packages compatible with Android platform">Android</a>
                   <a class="tag-badge-sub" href="/packages?q=sdk%3Adart+platform%3Aios" title="Packages compatible with iOS platform">iOS</a>
+                  <a class="tag-badge-sub" href="/packages?q=sdk%3Adart+platform%3Alinux" title="Packages compatible with Linux platform">Linux</a>
                   <a class="tag-badge-sub" href="/packages?q=sdk%3Adart+platform%3Amacos" title="Packages compatible with macOS platform">macOS</a>
                   <a class="tag-badge-sub" href="/packages?q=sdk%3Adart+platform%3Aweb" title="Packages compatible with Web platform">web</a>
                   <a class="tag-badge-sub" href="/packages?q=sdk%3Adart+platform%3Awindows" title="Packages compatible with Windows platform">Windows</a>
@@ -480,7 +481,7 @@
                   </div>
                   <div class="packages-score packages-score-health">
                     <div class="packages-score-value -has-value">
-                      <span class="packages-score-value-number">24</span>
+                      <span class="packages-score-value-number">38</span>
                       <span class="packages-score-value-sign"></span>
                     </div>
                     <div class="packages-score-label">pub points</div>
@@ -517,6 +518,8 @@
                 <div class="-pub-tag-badge">
                   <span class="tag-badge-main">Platform</span>
                   <a class="tag-badge-sub" href="/packages?q=sdk%3Adart+platform%3Aandroid" title="Packages compatible with Android platform">Android</a>
+                  <a class="tag-badge-sub" href="/packages?q=sdk%3Adart+platform%3Aios" title="Packages compatible with iOS platform">iOS</a>
+                  <a class="tag-badge-sub" href="/packages?q=sdk%3Adart+platform%3Alinux" title="Packages compatible with Linux platform">Linux</a>
                   <a class="tag-badge-sub" href="/packages?q=sdk%3Adart+platform%3Amacos" title="Packages compatible with macOS platform">macOS</a>
                 </div>
               </div>

--- a/app/test/frontend/golden/pkg_install_page.html
+++ b/app/test/frontend/golden/pkg_install_page.html
@@ -152,6 +152,7 @@
                       <span class="tag-badge-main">Platform</span>
                       <a class="tag-badge-sub" href="/packages?q=platform%3Aandroid" title="Packages compatible with Android platform">Android</a>
                       <a class="tag-badge-sub" href="/packages?q=platform%3Aios" title="Packages compatible with iOS platform">iOS</a>
+                      <a class="tag-badge-sub" href="/packages?q=platform%3Alinux" title="Packages compatible with Linux platform">Linux</a>
                       <a class="tag-badge-sub" href="/packages?q=platform%3Amacos" title="Packages compatible with macOS platform">macOS</a>
                       <a class="tag-badge-sub" href="/packages?q=platform%3Aweb" title="Packages compatible with Web platform">web</a>
                       <a class="tag-badge-sub" href="/packages?q=platform%3Awindows" title="Packages compatible with Windows platform">Windows</a>
@@ -259,7 +260,7 @@
               </div>
               <div class="packages-score packages-score-health">
                 <div class="packages-score-value -has-value">
-                  <span class="packages-score-value-number">43</span>
+                  <span class="packages-score-value-number">54</span>
                   <span class="packages-score-value-sign"></span>
                 </div>
                 <div class="packages-score-label">pub points</div>
@@ -317,7 +318,7 @@
             </div>
             <div class="packages-score packages-score-health">
               <div class="packages-score-value -has-value">
-                <span class="packages-score-value-number">43</span>
+                <span class="packages-score-value-number">54</span>
                 <span class="packages-score-value-sign"></span>
               </div>
               <div class="packages-score-label">pub points</div>

--- a/app/test/frontend/golden/pkg_score_page.html
+++ b/app/test/frontend/golden/pkg_score_page.html
@@ -152,6 +152,7 @@
                       <span class="tag-badge-main">Platform</span>
                       <a class="tag-badge-sub" href="/packages?q=platform%3Aandroid" title="Packages compatible with Android platform">Android</a>
                       <a class="tag-badge-sub" href="/packages?q=platform%3Aios" title="Packages compatible with iOS platform">iOS</a>
+                      <a class="tag-badge-sub" href="/packages?q=platform%3Alinux" title="Packages compatible with Linux platform">Linux</a>
                       <a class="tag-badge-sub" href="/packages?q=platform%3Amacos" title="Packages compatible with macOS platform">macOS</a>
                       <a class="tag-badge-sub" href="/packages?q=platform%3Aweb" title="Packages compatible with Web platform">web</a>
                       <a class="tag-badge-sub" href="/packages?q=platform%3Awindows" title="Packages compatible with Windows platform">Windows</a>
@@ -220,7 +221,7 @@
                     </div>
                     <div class="score-key-figure">
                       <div class="score-key-figure-title">
-                        <span class="score-key-figure-value">43</span>
+                        <span class="score-key-figure-value">54</span>
                         <span class="score-key-figure-supplemental">/ 70</span>
                       </div>
                       <div class="score-key-figure-label">pub points</div>
@@ -236,7 +237,7 @@
                   <p class="analysis-info">
                     We analyzed this package
                     <span class="-x-ago" title="on %%published-date%%">%%x-ago%%</span>
-                    , and awarded it 43 pub points (of a possible 70):
+                    , and awarded it 54 pub points (of a possible 70):
                   </p>
                   <div class="pkg-report">
                     <div class="pkg-report-section foldable">
@@ -246,7 +247,7 @@
                         </div>
                         <div class="pkg-report-header-title">Fake conventions</div>
                         <div class="pkg-report-header-score -is-red">
-                          <span class="pkg-report-header-score-granted">8</span>
+                          <span class="pkg-report-header-score-granted">18</span>
                           /
                           <span class="pkg-report-header-score-max">30</span>
                           <img class="foldable-icon" src="/static/hash-%%etag%%/img/report-foldable-icon.svg" alt="icon to trigger folding of the section" width="13" height="6"/>
@@ -257,10 +258,10 @@
                           <div class="pkg-report-content-summary markdown-body">
                             <h3>
                               <img class="report-summary-icon" src="/static/hash-%%etag%%/img/report-missing-icon-yellow.svg"/>
-                              8/30 points: Package layout
+                              18/30 points: Package layout
                             </h3>
                             <ul>
-                              <li>Package layout score randomly set to 8...</li>
+                              <li>Package layout score randomly set to 18...</li>
                             </ul>
                           </div>
                         </div>
@@ -273,7 +274,7 @@
                         </div>
                         <div class="pkg-report-header-title">Fake documentation</div>
                         <div class="pkg-report-header-score">
-                          <span class="pkg-report-header-score-granted">35</span>
+                          <span class="pkg-report-header-score-granted">36</span>
                           /
                           <span class="pkg-report-header-score-max">40</span>
                           <img class="foldable-icon" src="/static/hash-%%etag%%/img/report-foldable-icon.svg" alt="icon to trigger folding of the section" width="13" height="6"/>
@@ -284,10 +285,10 @@
                           <div class="pkg-report-content-summary markdown-body">
                             <h3>
                               <img class="report-summary-icon" src="/static/hash-%%etag%%/img/report-missing-icon-yellow.svg"/>
-                              25/30 points: Example
+                              26/30 points: Example
                             </h3>
                             <ul>
-                              <li>Example score randomly set to 25...</li>
+                              <li>Example score randomly set to 26...</li>
                             </ul>
                             <h3>
                               <img class="report-summary-icon" src="/static/hash-%%etag%%/img/report-ok-icon-green.svg"/>
@@ -323,7 +324,7 @@
               </div>
               <div class="packages-score packages-score-health">
                 <div class="packages-score-value -has-value">
-                  <span class="packages-score-value-number">43</span>
+                  <span class="packages-score-value-number">54</span>
                   <span class="packages-score-value-sign"></span>
                 </div>
                 <div class="packages-score-label">pub points</div>
@@ -381,7 +382,7 @@
             </div>
             <div class="packages-score packages-score-health">
               <div class="packages-score-value -has-value">
-                <span class="packages-score-value-number">43</span>
+                <span class="packages-score-value-number">54</span>
                 <span class="packages-score-value-sign"></span>
               </div>
               <div class="packages-score-label">pub points</div>

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -152,6 +152,7 @@
                       <span class="tag-badge-main">Platform</span>
                       <a class="tag-badge-sub" href="/packages?q=platform%3Aandroid" title="Packages compatible with Android platform">Android</a>
                       <a class="tag-badge-sub" href="/packages?q=platform%3Aios" title="Packages compatible with iOS platform">iOS</a>
+                      <a class="tag-badge-sub" href="/packages?q=platform%3Alinux" title="Packages compatible with Linux platform">Linux</a>
                       <a class="tag-badge-sub" href="/packages?q=platform%3Amacos" title="Packages compatible with macOS platform">macOS</a>
                       <a class="tag-badge-sub" href="/packages?q=platform%3Aweb" title="Packages compatible with Web platform">web</a>
                       <a class="tag-badge-sub" href="/packages?q=platform%3Awindows" title="Packages compatible with Windows platform">Windows</a>
@@ -230,7 +231,7 @@
               </div>
               <div class="packages-score packages-score-health">
                 <div class="packages-score-value -has-value">
-                  <span class="packages-score-value-number">43</span>
+                  <span class="packages-score-value-number">54</span>
                   <span class="packages-score-value-sign"></span>
                 </div>
                 <div class="packages-score-label">pub points</div>
@@ -288,7 +289,7 @@
             </div>
             <div class="packages-score packages-score-health">
               <div class="packages-score-value -has-value">
-                <span class="packages-score-value-number">43</span>
+                <span class="packages-score-value-number">54</span>
                 <span class="packages-score-value-sign"></span>
               </div>
               <div class="packages-score-label">pub points</div>

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -142,6 +142,8 @@
                     <div class="-pub-tag-badge">
                       <span class="tag-badge-main">Platform</span>
                       <a class="tag-badge-sub" href="/packages?q=platform%3Aandroid" title="Packages compatible with Android platform">Android</a>
+                      <a class="tag-badge-sub" href="/packages?q=platform%3Aios" title="Packages compatible with iOS platform">iOS</a>
+                      <a class="tag-badge-sub" href="/packages?q=platform%3Alinux" title="Packages compatible with Linux platform">Linux</a>
                       <a class="tag-badge-sub" href="/packages?q=platform%3Amacos" title="Packages compatible with macOS platform">macOS</a>
                     </div>
                   </div>
@@ -218,7 +220,7 @@
               </div>
               <div class="packages-score packages-score-health">
                 <div class="packages-score-value -has-value">
-                  <span class="packages-score-value-number">24</span>
+                  <span class="packages-score-value-number">38</span>
                   <span class="packages-score-value-sign"></span>
                 </div>
                 <div class="packages-score-label">pub points</div>
@@ -280,7 +282,7 @@
             </div>
             <div class="packages-score packages-score-health">
               <div class="packages-score-value -has-value">
-                <span class="packages-score-value-number">24</span>
+                <span class="packages-score-value-number">38</span>
                 <span class="packages-score-value-sign"></span>
               </div>
               <div class="packages-score-label">pub points</div>

--- a/app/test/frontend/golden/pkg_show_page_retracted.html
+++ b/app/test/frontend/golden/pkg_show_page_retracted.html
@@ -145,9 +145,10 @@
                     </div>
                     <div class="-pub-tag-badge">
                       <span class="tag-badge-main">Platform</span>
-                      <a class="tag-badge-sub" href="/packages?q=platform%3Aios" title="Packages compatible with iOS platform">iOS</a>
+                      <a class="tag-badge-sub" href="/packages?q=platform%3Aandroid" title="Packages compatible with Android platform">Android</a>
                       <a class="tag-badge-sub" href="/packages?q=platform%3Alinux" title="Packages compatible with Linux platform">Linux</a>
                       <a class="tag-badge-sub" href="/packages?q=platform%3Amacos" title="Packages compatible with macOS platform">macOS</a>
+                      <a class="tag-badge-sub" href="/packages?q=platform%3Aweb" title="Packages compatible with Web platform">web</a>
                       <a class="tag-badge-sub" href="/packages?q=platform%3Awindows" title="Packages compatible with Windows platform">Windows</a>
                     </div>
                     <span class="package-tag retracted" title="This version was retracted.">retracted</span>
@@ -225,7 +226,7 @@
               </div>
               <div class="packages-score packages-score-health">
                 <div class="packages-score-value -has-value">
-                  <span class="packages-score-value-number">36</span>
+                  <span class="packages-score-value-number">17</span>
                   <span class="packages-score-value-sign"></span>
                 </div>
                 <div class="packages-score-label">pub points</div>
@@ -255,7 +256,7 @@
             </p>
             <h3 class="title">License</h3>
             <p>
-              unknown (
+              BSD-3-Clause (
               <a href="/packages/pkg/versions/1.0.0/license">LICENSE</a>
               )
             </p>
@@ -283,7 +284,7 @@
             </div>
             <div class="packages-score packages-score-health">
               <div class="packages-score-value -has-value">
-                <span class="packages-score-value-number">36</span>
+                <span class="packages-score-value-number">17</span>
                 <span class="packages-score-value-sign"></span>
               </div>
               <div class="packages-score-label">pub points</div>
@@ -313,7 +314,7 @@
           </p>
           <h3 class="title">License</h3>
           <p>
-            unknown (
+            BSD-3-Clause (
             <a href="/packages/pkg/versions/1.0.0/license">LICENSE</a>
             )
           </p>

--- a/app/test/frontend/golden/pkg_show_page_retracted_non_retracted_version.html
+++ b/app/test/frontend/golden/pkg_show_page_retracted_non_retracted_version.html
@@ -137,13 +137,13 @@
                     <div class="-pub-tag-badge">
                       <span class="tag-badge-main">SDK</span>
                       <a class="tag-badge-sub" href="/packages?q=sdk%3Adart" title="Packages compatible with Dart SDK">Dart</a>
-                      <a class="tag-badge-sub" href="/packages?q=sdk%3Aflutter" title="Packages compatible with Flutter SDK">Flutter</a>
                     </div>
                     <div class="-pub-tag-badge">
                       <span class="tag-badge-main">Platform</span>
                       <a class="tag-badge-sub" href="/packages?q=platform%3Aandroid" title="Packages compatible with Android platform">Android</a>
                       <a class="tag-badge-sub" href="/packages?q=platform%3Aios" title="Packages compatible with iOS platform">iOS</a>
                       <a class="tag-badge-sub" href="/packages?q=platform%3Alinux" title="Packages compatible with Linux platform">Linux</a>
+                      <a class="tag-badge-sub" href="/packages?q=platform%3Amacos" title="Packages compatible with macOS platform">macOS</a>
                       <a class="tag-badge-sub" href="/packages?q=platform%3Aweb" title="Packages compatible with Web platform">web</a>
                       <a class="tag-badge-sub" href="/packages?q=platform%3Awindows" title="Packages compatible with Windows platform">Windows</a>
                     </div>
@@ -221,7 +221,7 @@
               </div>
               <div class="packages-score packages-score-health">
                 <div class="packages-score-value -has-value">
-                  <span class="packages-score-value-number">43</span>
+                  <span class="packages-score-value-number">33</span>
                   <span class="packages-score-value-sign"></span>
                 </div>
                 <div class="packages-score-label">pub points</div>
@@ -251,7 +251,7 @@
             </p>
             <h3 class="title">License</h3>
             <p>
-              unknown (
+              BSD-3-Clause (
               <a href="/packages/pkg/license">LICENSE</a>
               )
             </p>
@@ -279,7 +279,7 @@
             </div>
             <div class="packages-score packages-score-health">
               <div class="packages-score-value -has-value">
-                <span class="packages-score-value-number">43</span>
+                <span class="packages-score-value-number">33</span>
                 <span class="packages-score-value-sign"></span>
               </div>
               <div class="packages-score-label">pub points</div>
@@ -309,7 +309,7 @@
           </p>
           <h3 class="title">License</h3>
           <p>
-            unknown (
+            BSD-3-Clause (
             <a href="/packages/pkg/license">LICENSE</a>
             )
           </p>

--- a/app/test/frontend/golden/pkg_show_version_page.html
+++ b/app/test/frontend/golden/pkg_show_version_page.html
@@ -152,6 +152,7 @@
                       <span class="tag-badge-main">Platform</span>
                       <a class="tag-badge-sub" href="/packages?q=platform%3Aandroid" title="Packages compatible with Android platform">Android</a>
                       <a class="tag-badge-sub" href="/packages?q=platform%3Aios" title="Packages compatible with iOS platform">iOS</a>
+                      <a class="tag-badge-sub" href="/packages?q=platform%3Alinux" title="Packages compatible with Linux platform">Linux</a>
                       <a class="tag-badge-sub" href="/packages?q=platform%3Amacos" title="Packages compatible with macOS platform">macOS</a>
                       <a class="tag-badge-sub" href="/packages?q=platform%3Aweb" title="Packages compatible with Web platform">web</a>
                       <a class="tag-badge-sub" href="/packages?q=platform%3Awindows" title="Packages compatible with Windows platform">Windows</a>
@@ -230,7 +231,7 @@
               </div>
               <div class="packages-score packages-score-health">
                 <div class="packages-score-value -has-value">
-                  <span class="packages-score-value-number">43</span>
+                  <span class="packages-score-value-number">54</span>
                   <span class="packages-score-value-sign"></span>
                 </div>
                 <div class="packages-score-label">pub points</div>
@@ -288,7 +289,7 @@
             </div>
             <div class="packages-score packages-score-health">
               <div class="packages-score-value -has-value">
-                <span class="packages-score-value-number">43</span>
+                <span class="packages-score-value-number">54</span>
                 <span class="packages-score-value-sign"></span>
               </div>
               <div class="packages-score-label">pub points</div>

--- a/app/test/frontend/golden/pkg_versions_page.html
+++ b/app/test/frontend/golden/pkg_versions_page.html
@@ -152,6 +152,7 @@
                       <span class="tag-badge-main">Platform</span>
                       <a class="tag-badge-sub" href="/packages?q=platform%3Aandroid" title="Packages compatible with Android platform">Android</a>
                       <a class="tag-badge-sub" href="/packages?q=platform%3Aios" title="Packages compatible with iOS platform">iOS</a>
+                      <a class="tag-badge-sub" href="/packages?q=platform%3Alinux" title="Packages compatible with Linux platform">Linux</a>
                       <a class="tag-badge-sub" href="/packages?q=platform%3Amacos" title="Packages compatible with macOS platform">macOS</a>
                       <a class="tag-badge-sub" href="/packages?q=platform%3Aweb" title="Packages compatible with Web platform">web</a>
                       <a class="tag-badge-sub" href="/packages?q=platform%3Awindows" title="Packages compatible with Windows platform">Windows</a>
@@ -337,7 +338,7 @@
               </div>
               <div class="packages-score packages-score-health">
                 <div class="packages-score-value -has-value">
-                  <span class="packages-score-value-number">43</span>
+                  <span class="packages-score-value-number">54</span>
                   <span class="packages-score-value-sign"></span>
                 </div>
                 <div class="packages-score-label">pub points</div>
@@ -395,7 +396,7 @@
             </div>
             <div class="packages-score packages-score-health">
               <div class="packages-score-value -has-value">
-                <span class="packages-score-value-number">43</span>
+                <span class="packages-score-value-number">54</span>
                 <span class="packages-score-value-sign"></span>
               </div>
               <div class="packages-score-label">pub points</div>

--- a/app/test/frontend/golden/publisher_packages_page.html
+++ b/app/test/frontend/golden/publisher_packages_page.html
@@ -201,7 +201,7 @@
                           </div>
                           <div class="packages-score packages-score-health">
                             <div class="packages-score-value -has-value">
-                              <span class="packages-score-value-number">43</span>
+                              <span class="packages-score-value-number">44</span>
                               <span class="packages-score-value-sign"></span>
                             </div>
                             <div class="packages-score-label">pub points</div>
@@ -230,20 +230,18 @@
                         </span>
                         <span class="packages-metadata-block">
                           <img class="packages-metadata-license-icon" src="/static/hash-%%etag%%/img/material-icon-balance.svg" alt="Icon for licenses." width="16" height="16"/>
-                          unknown
+                          BSD-3-Clause
                         </span>
                       </p>
                       <div>
                         <div class="-pub-tag-badge">
                           <span class="tag-badge-main">SDK</span>
                           <a class="tag-badge-sub" href="/packages?q=sdk%3Adart" title="Packages compatible with Dart SDK">Dart</a>
-                          <a class="tag-badge-sub" href="/packages?q=sdk%3Aflutter" title="Packages compatible with Flutter SDK">Flutter</a>
                         </div>
                         <div class="-pub-tag-badge">
                           <span class="tag-badge-main">Platform</span>
                           <a class="tag-badge-sub" href="/packages?q=platform%3Aandroid" title="Packages compatible with Android platform">Android</a>
                           <a class="tag-badge-sub" href="/packages?q=platform%3Aios" title="Packages compatible with iOS platform">iOS</a>
-                          <a class="tag-badge-sub" href="/packages?q=platform%3Alinux" title="Packages compatible with Linux platform">Linux</a>
                           <a class="tag-badge-sub" href="/packages?q=platform%3Amacos" title="Packages compatible with macOS platform">macOS</a>
                           <a class="tag-badge-sub" href="/packages?q=platform%3Aweb" title="Packages compatible with Web platform">web</a>
                           <a class="tag-badge-sub" href="/packages?q=platform%3Awindows" title="Packages compatible with Windows platform">Windows</a>
@@ -270,7 +268,7 @@
                           </div>
                           <div class="packages-score packages-score-health">
                             <div class="packages-score-value -has-value">
-                              <span class="packages-score-value-number">24</span>
+                              <span class="packages-score-value-number">38</span>
                               <span class="packages-score-value-sign"></span>
                             </div>
                             <div class="packages-score-label">pub points</div>
@@ -307,6 +305,8 @@
                         <div class="-pub-tag-badge">
                           <span class="tag-badge-main">Platform</span>
                           <a class="tag-badge-sub" href="/packages?q=platform%3Aandroid" title="Packages compatible with Android platform">Android</a>
+                          <a class="tag-badge-sub" href="/packages?q=platform%3Aios" title="Packages compatible with iOS platform">iOS</a>
+                          <a class="tag-badge-sub" href="/packages?q=platform%3Alinux" title="Packages compatible with Linux platform">Linux</a>
                           <a class="tag-badge-sub" href="/packages?q=platform%3Amacos" title="Packages compatible with macOS platform">macOS</a>
                         </div>
                       </div>

--- a/app/test/frontend/golden/search_page.html
+++ b/app/test/frontend/golden/search_page.html
@@ -400,7 +400,7 @@
                   </div>
                   <div class="packages-score packages-score-health">
                     <div class="packages-score-value -has-value">
-                      <span class="packages-score-value-number">43</span>
+                      <span class="packages-score-value-number">54</span>
                       <span class="packages-score-value-sign"></span>
                     </div>
                     <div class="packages-score-label">pub points</div>
@@ -442,6 +442,7 @@
                   <span class="tag-badge-main">Platform</span>
                   <a class="tag-badge-sub" href="/packages?q=platform%3Aandroid+foobar&amp;sort=top" title="Packages compatible with Android platform">Android</a>
                   <a class="tag-badge-sub" href="/packages?q=platform%3Aios+foobar&amp;sort=top" title="Packages compatible with iOS platform">iOS</a>
+                  <a class="tag-badge-sub" href="/packages?q=platform%3Alinux+foobar&amp;sort=top" title="Packages compatible with Linux platform">Linux</a>
                   <a class="tag-badge-sub" href="/packages?q=platform%3Amacos+foobar&amp;sort=top" title="Packages compatible with macOS platform">macOS</a>
                   <a class="tag-badge-sub" href="/packages?q=platform%3Aweb+foobar&amp;sort=top" title="Packages compatible with Web platform">web</a>
                   <a class="tag-badge-sub" href="/packages?q=platform%3Awindows+foobar&amp;sort=top" title="Packages compatible with Windows platform">Windows</a>
@@ -479,7 +480,7 @@
                   </div>
                   <div class="packages-score packages-score-health">
                     <div class="packages-score-value -has-value">
-                      <span class="packages-score-value-number">24</span>
+                      <span class="packages-score-value-number">38</span>
                       <span class="packages-score-value-sign"></span>
                     </div>
                     <div class="packages-score-label">pub points</div>
@@ -516,6 +517,8 @@
                 <div class="-pub-tag-badge">
                   <span class="tag-badge-main">Platform</span>
                   <a class="tag-badge-sub" href="/packages?q=platform%3Aandroid+foobar&amp;sort=top" title="Packages compatible with Android platform">Android</a>
+                  <a class="tag-badge-sub" href="/packages?q=platform%3Aios+foobar&amp;sort=top" title="Packages compatible with iOS platform">iOS</a>
+                  <a class="tag-badge-sub" href="/packages?q=platform%3Alinux+foobar&amp;sort=top" title="Packages compatible with Linux platform">Linux</a>
                   <a class="tag-badge-sub" href="/packages?q=platform%3Amacos+foobar&amp;sort=top" title="Packages compatible with macOS platform">macOS</a>
                 </div>
               </div>

--- a/app/test/frontend/handlers/listing_test.dart
+++ b/app/test/frontend/handlers/listing_test.dart
@@ -111,11 +111,11 @@ void main() {
         await expectHtmlResponse(
           await issueGet('/packages?q=sdk%3Aflutter'),
           present: [
-            '/packages/package_1',
+            '/packages/package_0',
             '/packages/package_2',
           ],
           absent: [
-            '/packages/package_0',
+            '/packages/package_1',
           ],
         );
       },
@@ -135,7 +135,7 @@ void main() {
         defaultUser: 'admin@pub.dev',
       ),
       fn: () async {
-        final names = ['flutter_pkg2', 'flutter_pkg4', 'flutter_pkg10'];
+        final names = ['flutter_pkg2', 'flutter_pkg4'];
         await expectHtmlResponse(
           await issueGet('/packages?q=sdk%3Aflutter&page=2'),
           present: names.map((name) => '/packages/$name').toList(),

--- a/pkg/pub_integration/test/search_update_test.dart
+++ b/pkg/pub_integration/test/search_update_test.dart
@@ -67,35 +67,30 @@ void main() {
           final i1 = await listingPageInfo(page);
           expect(i1.totalCount, 100);
           expect(i1.packageNames, [
-            'pkg_11',
-            'flutter_pkg_51',
             'pkg_13',
-            'pkg_62',
-            'pkg_34',
-            'pkg_28',
             'pkg_94',
-            'flutter_pkg_66',
-            'flutter_pkg_0',
-            'pkg_73',
+            'pkg_70',
+            'flutter_pkg_48',
+            'pkg_23',
+            'flutter_pkg_39',
+            'pkg_76',
+            'pkg_1',
+            'flutter_pkg_45',
+            'flutter_pkg_57',
           ]);
 
           // click Android
           await page.click('#search-form-checkbox-platform-android');
           await page.waitForNavigation(wait: Until.networkIdle);
           final i2 = await listingPageInfo(page);
-          expect(i2.totalCount, 78);
-          expect(i2.packageNames, [
-            'pkg_11',
-            'flutter_pkg_51',
-            'pkg_13',
-            'pkg_62',
-            'pkg_28',
-            'flutter_pkg_66',
-            'flutter_pkg_0',
-            'pkg_37',
-            'flutter_pkg_84',
-            'pkg_91',
-          ]);
+          expect(i2.totalCount, lessThan(80));
+          expect(i2.totalCount, greaterThan(70));
+          final both1And2 = i1.packageNames
+              .toSet()
+              .intersection(i2.packageNames.toSet())
+              .toList();
+          expect(both1And2, hasLength(lessThan(10)));
+          expect(both1And2, hasLength(greaterThan(5)));
           expect(i2.openSections, isEmpty);
           expect(page.url, '$origin/packages?q=platform%3Aandroid');
 
@@ -110,19 +105,14 @@ void main() {
           await flutterCB3.click();
           await page.waitForNavigation(wait: Until.networkIdle);
           final i3 = await listingPageInfo(page);
-          expect(i3.totalCount, 68);
-          expect(i3.packageNames, [
-            'flutter_pkg_51',
-            'pkg_13',
-            'pkg_62',
-            'flutter_pkg_0',
-            'pkg_37',
-            'flutter_pkg_84',
-            'pkg_91',
-            'pkg_53',
-            'flutter_pkg_36',
-            'pkg_2',
-          ]);
+          expect(i3.totalCount, lessThan(70));
+          expect(i3.totalCount, greaterThan(60));
+          final both2And3 = i2.packageNames
+              .toSet()
+              .intersection(i3.packageNames.toSet())
+              .toList();
+          expect(both2And3, hasLength(lessThan(10)));
+          expect(both2And3, hasLength(greaterThan(5)));
           expect(
               page.url, '$origin/packages?q=platform%3Aandroid+sdk%3Aflutter');
           expect(i3.openSections, ['sdks']);
@@ -146,18 +136,18 @@ void main() {
           await page.waitForNavigation(wait: Until.networkIdle);
           final i5 = await listingPageInfo(page);
           expect(i5.totalCount, i2.totalCount - i3.totalCount);
-          expect(i5.packageNames, [
-            'pkg_11',
-            'pkg_28',
-            'flutter_pkg_66',
-            'pkg_77',
-            'pkg_43',
-            'pkg_23',
-            'flutter_pkg_69',
-            'pkg_19',
-            'pkg_68',
-            'pkg_49',
-          ]);
+          final both2And5 = i2.packageNames
+              .toSet()
+              .intersection(i5.packageNames.toSet())
+              .toList();
+          expect(both2And5, hasLength(lessThan(10)));
+          expect(both2And5, hasLength(greaterThan(0)));
+          final both3And5 = i3.packageNames
+              .toSet()
+              .intersection(i5.packageNames.toSet())
+              .toList();
+          expect(both3And5, isEmpty);
+
           expect(i5.openSections, ['sdks']);
           expect(page.url,
               '$origin/packages?q=platform%3Aandroid+-sdk%3Aflutter+pkg');


### PR DESCRIPTION
- The random in current fake pana analysis is fragile, because if we change any of it (adding/removing items), everything after that may change, as the next random int will be different.
- Instead, each component of the analysis should be "randomized" on its own, and this is now done with this consistent hashing of the package+version+field.
- Updated test to reflect this change, and also modified tests to become less fragile in the future, if any of it may change.