### PR TITLE
Publisher.isBlocked field to prevent blocked/deleted publishers from reuse.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ AppEngine version, listed here to ease deployment and troubleshooting.
  * Bumped runtimeVersion to `2022.05.14`.
  * Upgraded runtime Dart SDK to `2.17.0`.
  * Upgraded dependencies.
+ * NOTE: Started to use and backfill `Publisher.isBlocked`.
 
 ## `20220513t212800-all`
  * Bumped runtimeVersion to `2022.05.13`.

--- a/app/lib/admin/backend.dart
+++ b/app/lib/admin/backend.dart
@@ -87,7 +87,7 @@ class AdminBackend {
         return await executeNotifyService(args);
       case 'recent-uploaders':
         return await executeRecentUploaders(args);
-      case 'block-publisher-and-delete-all-members':
+      case 'block-publisher-and-all-members':
         return await executeBlockPublisherAndAllMembers(args);
       case 'set-package-withheld':
         return await executeSetPackageWithheld(args);

--- a/app/lib/admin/backend.dart
+++ b/app/lib/admin/backend.dart
@@ -30,11 +30,11 @@ import '../shared/email.dart';
 import '../shared/exceptions.dart';
 import '../shared/tags.dart';
 import '../tool/utils/dart_sdk_version.dart';
+import 'tools/block_publisher_and_all_members.dart';
 import 'tools/create_publisher.dart';
 import 'tools/list_package_withheld.dart';
 import 'tools/notify_service.dart';
 import 'tools/recent_uploaders.dart';
-import 'tools/remove_publisher_and_block_all_members.dart';
 import 'tools/set_package_withheld.dart';
 import 'tools/set_secret.dart';
 import 'tools/set_user_blocked.dart';
@@ -87,8 +87,8 @@ class AdminBackend {
         return await executeNotifyService(args);
       case 'recent-uploaders':
         return await executeRecentUploaders(args);
-      case 'remove-publisher-and-delete-all-members':
-        return await executeRemovePublisherAndBlockAllMembers(args);
+      case 'block-publisher-and-delete-all-members':
+        return await executeBlockPublisherAndAllMembers(args);
       case 'set-package-withheld':
         return await executeSetPackageWithheld(args);
       case 'set-secret':

--- a/app/lib/admin/tools/block_publisher_and_all_members.dart
+++ b/app/lib/admin/tools/block_publisher_and_all_members.dart
@@ -46,9 +46,6 @@ Future<String> executeBlockPublisherAndAllMembers(List<String> args) async {
       final p = await tx.lookupValue<Publisher>(publisherKey);
       p.markForBlocked();
       tx.insert(p);
-      for (final m in members) {
-        tx.delete(publisherKey.append(PublisherMember, id: m.userId));
-      }
     });
     output.writeln('Blocked.');
     return output.toString();

--- a/app/lib/admin/tools/block_publisher_and_all_members.dart
+++ b/app/lib/admin/tools/block_publisher_and_all_members.dart
@@ -9,14 +9,13 @@ import 'package:pub_dev/publisher/backend.dart';
 import 'package:pub_dev/publisher/models.dart';
 import 'package:pub_dev/shared/datastore.dart';
 
-Future<String> executeRemovePublisherAndBlockAllMembers(
-    List<String> args) async {
+Future<String> executeBlockPublisherAndAllMembers(List<String> args) async {
   if (args.isEmpty ||
       args.length != 2 ||
       (args[0] != 'delete' && args[0] != 'list')) {
     return 'Remove publisher and blocks all members.\n'
         '  <tools-command> list <publisherId> # list publisher data\n'
-        '  <tools-command> delete <publisherId> # remove publisher and block members\n';
+        '  <tools-command> block <publisherId> # block publisher and all members\n';
   }
   final command = args[0];
   final publisherId = args[1];
@@ -37,19 +36,21 @@ Future<String> executeRemovePublisherAndBlockAllMembers(
 
   if (command == 'list') {
     return output.toString();
-  } else if (command == 'delete') {
+  } else if (command == 'block') {
     for (final m in members) {
       await accountBackend.updateBlockedFlag(m.userId, true);
     }
 
     final publisherKey = dbService.emptyKey.append(Publisher, id: publisherId);
     await withRetryTransaction(dbService, (tx) async {
-      tx.delete(publisherKey);
+      final p = await tx.lookupValue<Publisher>(publisherKey);
+      p.markForBlocked();
+      tx.insert(p);
       for (final m in members) {
         tx.delete(publisherKey.append(PublisherMember, id: m.userId));
       }
     });
-    output.writeln('Deleted.');
+    output.writeln('Blocked.');
     return output.toString();
   } else {
     return 'Unknown command: $command.';

--- a/app/lib/admin/tools/create_publisher.dart
+++ b/app/lib/admin/tools/create_publisher.dart
@@ -60,7 +60,7 @@ Future<String> executeCreatePublisher(List<String> args) async {
           p.updated!.isBefore(now.subtract(Duration(minutes: 10))) ||
           p.contactEmail != user.email ||
           p.description != '' ||
-          p.websiteUrl != _publisherWebsite(publisherId)) {
+          p.websiteUrl != defaultPublisherWebsite(publisherId)) {
         throw ConflictException.publisherAlreadyExists(publisherId);
       }
       // Avoid creating the same publisher again, this end-point is idempotent
@@ -70,15 +70,11 @@ Future<String> executeCreatePublisher(List<String> args) async {
 
     // Create publisher
     tx.queueMutations(inserts: [
-      Publisher()
-        ..parentKey = dbService.emptyKey
-        ..id = publisherId
-        ..created = now
-        ..description = ''
-        ..contactEmail = user.email
-        ..updated = now
-        ..websiteUrl = _publisherWebsite(publisherId)
-        ..isAbandoned = false,
+      Publisher.init(
+        parentKey: dbService.emptyKey,
+        publisherId: publisherId,
+        contactEmail: user.email,
+      ),
       PublisherMember()
         ..parentKey = dbService.emptyKey.append(Publisher, id: publisherId)
         ..id = user.userId
@@ -94,5 +90,3 @@ Future<String> executeCreatePublisher(List<String> args) async {
     return 'Publisher created.';
   });
 }
-
-String _publisherWebsite(String domain) => 'https://$domain/';

--- a/app/lib/frontend/handlers/account.dart
+++ b/app/lib/frontend/handlers/account.dart
@@ -202,8 +202,12 @@ Future<AccountPublisherOptions> accountPublisherOptionsHandler(
     shelf.Request request, String publisherId) async {
   checkPublisherIdParam(publisherId);
   final user = await requireAuthenticatedUser();
+  final publisher = await publisherBackend.getPublisher(publisherId);
+  if (publisher == null) {
+    throw NotFoundException.resource('publisher "$publisherId"');
+  }
   final member =
-      await publisherBackend.getPublisherMember(publisherId, user.userId);
+      await publisherBackend.getPublisherMember(publisher, user.userId);
   final isAdmin = member != null && member.role == PublisherMemberRole.admin;
   return AccountPublisherOptions(isAdmin: isAdmin);
 }

--- a/app/lib/frontend/handlers/publisher.dart
+++ b/app/lib/frontend/handlers/publisher.dart
@@ -105,7 +105,7 @@ Future<shelf.Response> publisherPackagesPageHandler(
     searchForm: searchForm,
     totalCount: totalCount,
     isAdmin: await publisherBackend.isMemberAdmin(
-        publisherId, userSessionData?.userId),
+        publisher, userSessionData?.userId),
     messageFromBackend: searchResult.message,
   );
   if (isLanding && requestContext.uiCacheEnabled) {
@@ -128,7 +128,7 @@ Future<shelf.Response> publisherAdminPageHandler(
     return htmlResponse(renderUnauthenticatedPage());
   }
   final isAdmin = await publisherBackend.isMemberAdmin(
-    publisherId,
+    publisher,
     userSessionData!.userId,
   );
   if (!isAdmin) {
@@ -155,7 +155,7 @@ Future<shelf.Response> publisherActivityLogPageHandler(
     return htmlResponse(renderUnauthenticatedPage());
   }
   final isAdmin = await publisherBackend.isMemberAdmin(
-    publisherId,
+    publisher,
     userSessionData!.userId,
   );
   if (!isAdmin) {

--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -25,7 +25,6 @@ import '../account/models.dart' show User;
 import '../audit/models.dart';
 import '../frontend/email_sender.dart';
 import '../publisher/backend.dart';
-import '../publisher/models.dart';
 import '../service/secret/backend.dart';
 import '../shared/configuration.dart';
 import '../shared/datastore.dart';
@@ -490,12 +489,12 @@ class PackageBackend {
     if (p.publisherId == null) {
       return p.containsUploader(userId);
     } else {
-      final memberKey = db.emptyKey
-          .append(Publisher, id: p.publisherId)
-          .append(PublisherMember, id: userId);
-      final list = await db.lookup<PublisherMember>([memberKey]);
-      final member = list.single;
-      return member?.role == PublisherMemberRole.admin;
+      final publisherId = p.publisherId!;
+      final publisher = await publisherBackend.getPublisher(publisherId);
+      if (publisher == null) {
+        return false;
+      }
+      return await publisherBackend.isMemberAdmin(publisher, userId);
     }
   }
 

--- a/app/lib/publisher/backend.dart
+++ b/app/lib/publisher/backend.dart
@@ -46,11 +46,15 @@ class PublisherBackend {
 
   PublisherBackend(this._db);
 
-  /// Loads a publisher (or returns null if it does not exists).
+  /// Loads a publisher. Returns `null` if it does not exists, or is blocked (not visible).
   Future<Publisher?> getPublisher(String publisherId) async {
     checkPublisherIdParam(publisherId);
     final pKey = _db.emptyKey.append(Publisher, id: publisherId);
-    return await _db.lookupOrNull<Publisher>(pKey);
+    final p = await _db.lookupOrNull<Publisher>(pKey);
+    if (p != null && p.isNotVisible) {
+      return null;
+    }
+    return p;
   }
 
   /// List publishers (in no specific order, it will be listed by their
@@ -61,6 +65,7 @@ class PublisherBackend {
       final query = _db.query<Publisher>();
       final publishers = await query
           .run()
+          .where((p) => p.isVisible)
           .map((p) => PublisherSummary(
                 publisherId: p.publisherId,
                 created: p.created!,
@@ -92,12 +97,15 @@ class PublisherBackend {
         // - search using this for query parameters
         _logger.shout('A user has more than 100 publishers.');
       }
-      final publishers = await _db.lookup<Publisher>(publisherKeys);
-      publishers.sort((a, b) => a!.publisherId.compareTo(b!.publisherId));
+      final publishers = (await _db.lookup<Publisher>(publisherKeys))
+          .whereType<Publisher>()
+          .toList();
+      publishers.sort((a, b) => a.publisherId.compareTo(b.publisherId));
       return PublisherPage(
         publishers: publishers
+            .where((p) => p.isVisible)
             .map((p) => PublisherSummary(
-                  publisherId: p!.publisherId,
+                  publisherId: p.publisherId,
                   created: p.created!,
                 ))
             .toList(),
@@ -107,20 +115,17 @@ class PublisherBackend {
 
   /// Loads the [PublisherMember] instance for [userId] (or returns null if it does not exists).
   Future<PublisherMember?> getPublisherMember(
-      String publisherId, String userId) async {
-    checkPublisherIdParam(publisherId);
+      Publisher publisher, String userId) async {
     ArgumentError.checkNotNull(userId, 'userId');
-    final mKey = _db.emptyKey
-        .append(Publisher, id: publisherId)
-        .append(PublisherMember, id: userId);
+    final mKey = publisher.key.append(PublisherMember, id: userId);
     return await _db.lookupOrNull<PublisherMember>(mKey);
   }
 
   /// Whether the User [userId] has admin permissions on the publisher.
-  Future<bool> isMemberAdmin(String publisherId, String? userId) async {
-    checkPublisherIdParam(publisherId);
+  Future<bool> isMemberAdmin(Publisher publisher, String? userId) async {
+    if (publisher.isNotVisible) return false;
     if (userId == null) return false;
-    final member = await getPublisherMember(publisherId, userId);
+    final member = await getPublisherMember(publisher, userId);
     if (member == null) return false;
     return member.role == PublisherMemberRole.admin;
   }
@@ -181,15 +186,11 @@ class PublisherBackend {
 
       // Create publisher
       tx.queueMutations(inserts: [
-        Publisher()
-          ..parentKey = _db.emptyKey
-          ..id = publisherId
-          ..created = now
-          ..description = ''
-          ..contactEmail = user.email
-          ..updated = now
-          ..websiteUrl = _publisherWebsite(publisherId)
-          ..isAbandoned = false,
+        Publisher.init(
+          parentKey: _db.emptyKey,
+          publisherId: publisherId,
+          contactEmail: user.email,
+        ),
         PublisherMember()
           ..parentKey = _db.emptyKey.append(Publisher, id: publisherId)
           ..id = user.userId
@@ -269,7 +270,7 @@ class PublisherBackend {
             await accountBackend.lookupUsersByEmail(update.contactEmail!);
         if (usersByEmail.isNotEmpty) {
           for (final user in usersByEmail) {
-            if (await isMemberAdmin(publisherId, user.userId)) {
+            if (await isMemberAdmin(p, user.userId)) {
               contactEmailMatchedAdmin = true;
               p.contactEmail = update.contactEmail;
               break;

--- a/app/lib/shared/integrity.dart
+++ b/app/lib/shared/integrity.dart
@@ -172,7 +172,7 @@ class IntegrityChecker {
       _publishers.add(p.publisherId);
       final members =
           await _db.query<PublisherMember>(ancestorKey: p.key).run().toList();
-      if (p.isAbandoned!) {
+      if (p.isAbandoned) {
         _publishersAbandoned.add(p.publisherId);
         if (members.isNotEmpty) {
           yield 'Publisher "${p.publisherId}" is marked as abandoned, '

--- a/app/lib/tool/backfill/backfill_new_fields.dart
+++ b/app/lib/tool/backfill/backfill_new_fields.dart
@@ -3,6 +3,8 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:logging/logging.dart';
+import '../../publisher/models.dart';
+import '../../shared/datastore.dart';
 
 final _logger = Logger('backfill_new_fields');
 
@@ -12,5 +14,17 @@ final _logger = Logger('backfill_new_fields');
 /// CHANGELOG.md must be updated with the new fields, and the next
 /// release could remove the backfill from here.
 Future<void> backfillNewFields() async {
-  _logger.info('No field needs backfill.');
+  _logger.info('Backfilling Publishers...');
+  await for (final p in dbService.query<Publisher>().run()) {
+    await _backfillPublisher(p);
+  }
+}
+
+Future<void> _backfillPublisher(Publisher publisher) async {
+  if (publisher.isBlocked != null) return;
+  await withRetryTransaction(dbService, (tx) async {
+    final p = await tx.lookupValue<Publisher>(publisher.key);
+    p.isBlocked ??= false;
+    tx.insert(p);
+  });
 }

--- a/app/test/account/options_test.dart
+++ b/app/test/account/options_test.dart
@@ -42,8 +42,8 @@ void main() {
 
     testWithProfile('publisher - no publisher', fn: () async {
       final client = createPubApiClient(authToken: adminAtPubDevAuthToken);
-      final rs = await client.accountPublisherOptions('no-domain.com');
-      expect(rs.isAdmin, isFalse);
+      final rs = client.accountPublisherOptions('no-domain.com');
+      await expectApiException(rs, status: 404);
     });
 
     testWithProfile('publisher - not admin', fn: () async {

--- a/app/test/frontend/handlers/publisher_test.dart
+++ b/app/test/frontend/handlers/publisher_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:pub_dev/publisher/models.dart';
+import 'package:pub_dev/shared/datastore.dart';
 import 'package:pub_dev/tool/test_profile/models.dart';
 import 'package:test/test.dart';
 
@@ -32,6 +34,21 @@ void main() {
       await expectHtmlResponse(
         await issueGet('/publishers/no-such-publisher.com/packages'),
         status: 404,
+      );
+    });
+
+    testWithProfile('publisher is blocked', fn: () async {
+      final p = await dbService.lookupValue<Publisher>(
+          dbService.emptyKey.append(Publisher, id: 'example.com'));
+      p.isBlocked = true;
+      await dbService.commit(inserts: [p]);
+      await expectHtmlResponse(
+        await issueGet('/publishers/example.com/packages'),
+        status: 404,
+      );
+      await expectHtmlResponse(
+        await issueGet('/publishers'),
+        absent: ['example.com'],
       );
     });
 

--- a/app/test/publisher/api_test.dart
+++ b/app/test/publisher/api_test.dart
@@ -769,6 +769,17 @@ void _testAdminAuthIssues(Future Function(PubApiClient client) fn) {
     final rs = fn(client);
     await expectApiException(rs, status: 403, code: 'InsufficientPermissions');
   });
+
+  testWithProfile('Publisher is blocked / not visible', fn: () async {
+    final p = await dbService.lookupValue<Publisher>(
+        dbService.emptyKey.append(Publisher, id: 'example.com'));
+    p.isBlocked = true;
+    await dbService.commit(inserts: [p]);
+
+    final client = createPubApiClient(authToken: userAtPubDevAuthToken);
+    final rs = fn(client);
+    await expectApiException(rs, status: 404, code: 'NotFound');
+  });
 }
 
 void _testNoPublisher(Future Function(PubApiClient client) fn) {


### PR DESCRIPTION
- Fixes #5718.
- Flag is applied at lookup, query and also update operations.
- Added backfill, but it can be used with the default value right away.
- Refactored membership and admin role tests to also include the blocked verification while the access right is being checked.