### PR TITLE
Credential-less publishing: minimal UI, API and data model.

### DIFF
--- a/app/lib/frontend/handlers/pubapi.client.dart
+++ b/app/lib/frontend/handlers/pubapi.client.dart
@@ -293,6 +293,15 @@ class PubApiClient {
     ));
   }
 
+  Future<_i3.CredentiallessPublishing> setCredentiallessPublishing(
+      String package, _i3.CredentiallessPublishing payload) async {
+    return _i3.CredentiallessPublishing.fromJson(await _client.requestJson(
+      verb: 'put',
+      path: '/api/packages/$package/credentialless-publishing',
+      body: payload.toJson(),
+    ));
+  }
+
   Future<_i3.VersionOptions> getVersionOptions(
       String package, String version) async {
     return _i3.VersionOptions.fromJson(await _client.requestJson(

--- a/app/lib/frontend/handlers/pubapi.dart
+++ b/app/lib/frontend/handlers/pubapi.dart
@@ -358,6 +358,11 @@ class PubApi {
           Request request, String package, PkgOptions body) =>
       putPackageOptionsHandler(request, package, body);
 
+  @EndPoint.put('/api/packages/<package>/credentialless-publishing')
+  Future<CredentiallessPublishing> setCredentiallessPublishing(
+          Request request, String package, CredentiallessPublishing body) =>
+      packageBackend.setCredentiallessPublishing(package, body);
+
   @EndPoint.get('/api/packages/<package>/versions/<version>/options')
   Future<VersionOptions> getVersionOptions(
           Request request, String package, String version) =>

--- a/app/lib/frontend/handlers/pubapi.g.dart
+++ b/app/lib/frontend/handlers/pubapi.g.dart
@@ -524,6 +524,22 @@ Router _$PubApiRouter(PubApi service) {
       return $utilities.unhandledError(e, st);
     }
   });
+  router.add('PUT', r'/api/packages/<package>/credentialless-publishing',
+      (Request request, String package) async {
+    try {
+      final _$result = await service.setCredentiallessPublishing(
+        request,
+        package,
+        await $utilities.decodeJson<CredentiallessPublishing>(
+            request, (o) => CredentiallessPublishing.fromJson(o)),
+      );
+      return $utilities.jsonResponse(_$result.toJson());
+    } on ApiResponseException catch (e) {
+      return e.asApiResponse();
+    } catch (e, st) {
+      return $utilities.unhandledError(e, st);
+    }
+  });
   router.add('GET', r'/api/packages/<package>/versions/<version>/options',
       (Request request, String package, String version) async {
     try {

--- a/app/lib/frontend/request_context.dart
+++ b/app/lib/frontend/request_context.dart
@@ -33,4 +33,7 @@ class RequestContext {
     this.blockRobots = true,
     this.uiCacheEnabled = false,
   });
+
+  /// Whether to show the admin UI for credential-less publishing admin UI.
+  bool get showAdminUIForCredentiallessPublishing => isExperimental;
 }

--- a/app/lib/frontend/templates/views/pkg/admin_page.dart
+++ b/app/lib/frontend/templates/views/pkg/admin_page.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:pub_dev/frontend/request_context.dart';
+
 import '../../../../account/models.dart';
 import '../../../../package/models.dart';
 import '../../../../shared/urls.dart' as urls;
@@ -159,6 +161,25 @@ d.Node packageAdminPageNode({
         checked: package.isUnlisted,
       ),
     ],
+    if (requestContext.showAdminUIForCredentiallessPublishing)
+      d.fragment([
+        d.h2(text: 'Credential-less publishing'),
+        d.div(
+          classes: ['-pub-form-row'],
+          child: material.textField(
+            id: '-pkg-admin-credless-repository',
+            label: 'Repository',
+            value: package.credentiallessPublishing.repository,
+          ),
+        ),
+        d.p(
+          child: material.button(
+            id: '-pkg-admin-credless-button',
+            label: 'Update',
+            raised: true,
+          ),
+        ),
+      ]),
     d.h2(text: 'Package Version Retraction'),
     d.div(children: [
       d.markdown(

--- a/app/lib/package/models.dart
+++ b/app/lib/package/models.dart
@@ -6,6 +6,7 @@ library pub_dartlang_org.appengine_repository.models;
 
 import 'dart:convert';
 
+import 'package:_pub_shared/data/package_api.dart';
 import 'package:clock/clock.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'package:pub_semver/pub_semver.dart';
@@ -140,6 +141,10 @@ class Package extends db.ExpandoModel<String> {
   /// List of versions that have been deleted and must not be re-uploaded again.
   @db.StringListProperty()
   List<String>? deletedVersions;
+
+  /// The JSON-serialized format of the [CredentiallessPublishing].
+  @db.StringProperty(indexed: false)
+  String? credentiallessPublishingJson;
 
   Package();
 
@@ -368,6 +373,22 @@ class Package extends db.ExpandoModel<String> {
             )
           : null,
     );
+  }
+
+  CredentiallessPublishing get credentiallessPublishing {
+    if (credentiallessPublishingJson == null) {
+      return CredentiallessPublishing.empty();
+    }
+    return CredentiallessPublishing.fromJson(
+        json.decode(credentiallessPublishingJson!) as Map<String, dynamic>);
+  }
+
+  set credentiallessPublishing(CredentiallessPublishing? value) {
+    if (value == null) {
+      credentiallessPublishingJson = null;
+    } else {
+      credentiallessPublishingJson = json.encode(value.toJson());
+    }
   }
 }
 

--- a/app/test/package/credentialless_test.dart
+++ b/app/test/package/credentialless_test.dart
@@ -1,0 +1,86 @@
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:_pub_shared/data/package_api.dart';
+import 'package:pub_dev/package/backend.dart';
+import 'package:test/test.dart';
+
+import '../shared/handlers_test_utils.dart';
+import '../shared/test_models.dart';
+import '../shared/test_services.dart';
+
+void main() {
+  group('Update value through API', () {
+    setupTestsWithCallerAuthorizationIssues(
+      (client) => client.setCredentiallessPublishing(
+          'oxygen', CredentiallessPublishing.empty()),
+    );
+
+    testWithProfile('no package', fn: () async {
+      final client = createPubApiClient(authToken: userAtPubDevAuthToken);
+      await expectApiException(
+        client.setCredentiallessPublishing(
+            'no_such_package', CredentiallessPublishing.empty()),
+        status: 404,
+        code: 'NotFound',
+      );
+    });
+
+    testWithProfile('not admin', fn: () async {
+      final client = createPubApiClient(authToken: userAtPubDevAuthToken);
+      await expectApiException(
+        client.setCredentiallessPublishing(
+            'oxygen', CredentiallessPublishing.empty()),
+        status: 403,
+        code: 'InsufficientPermissions',
+        message:
+            'Insufficient permissions to perform administrative actions on package `oxygen`.',
+      );
+    });
+
+    testWithProfile('successful update', fn: () async {
+      final client = createPubApiClient(authToken: adminAtPubDevAuthToken);
+      final rs = await client.setCredentiallessPublishing(
+          'oxygen',
+          CredentiallessPublishing(
+            repository: 'https://github.com/dart-lang/pub-dev',
+          ));
+      expect(rs.toJson(), {
+        'repository': 'https://github.com/dart-lang/pub-dev',
+      });
+      final p = await packageBackend.lookupPackage('oxygen');
+      expect(p!.credentiallessPublishing.toJson(), rs.toJson());
+    });
+
+    testWithProfile('bad repository URL', fn: () async {
+      final client = createPubApiClient(authToken: adminAtPubDevAuthToken);
+      final rs = client.setCredentiallessPublishing(
+          'oxygen',
+          CredentiallessPublishing(
+            repository: 'https://github.com/',
+          ));
+      await expectApiException(
+        rs,
+        status: 400,
+        code: 'InvalidInput',
+        message: 'Unable to parse repository URL.',
+      );
+    });
+
+    testWithProfile('GitLab is not yet supported', fn: () async {
+      final client = createPubApiClient(authToken: adminAtPubDevAuthToken);
+      final rs = client.setCredentiallessPublishing(
+          'oxygen',
+          CredentiallessPublishing(
+            repository: 'https://gitlab.com/user/repo',
+          ));
+      await expectApiException(
+        rs,
+        status: 400,
+        code: 'InvalidInput',
+        message: 'Only GitHub is supported at this time.',
+      );
+    });
+  });
+}

--- a/pkg/_pub_shared/lib/data/package_api.dart
+++ b/pkg/_pub_shared/lib/data/package_api.dart
@@ -48,6 +48,25 @@ class PkgOptions {
   Map<String, dynamic> toJson() => _$PkgOptionsToJson(this);
 }
 
+/// The configuration for a package's credential-less publishing.
+@JsonSerializable()
+class CredentiallessPublishing {
+  String? repository;
+
+  CredentiallessPublishing({
+    required this.repository,
+  });
+
+  CredentiallessPublishing.empty() : repository = null;
+
+  factory CredentiallessPublishing.fromJson(Map<String, dynamic> json) =>
+      _$CredentiallessPublishingFromJson(json);
+
+  Map<String, dynamic> toJson() => _$CredentiallessPublishingToJson(this);
+
+  late final isEnabled = repository != null && repository!.isNotEmpty;
+}
+
 @JsonSerializable()
 class VersionOptions {
   final bool? isRetracted;

--- a/pkg/_pub_shared/lib/data/package_api.g.dart
+++ b/pkg/_pub_shared/lib/data/package_api.g.dart
@@ -32,6 +32,18 @@ Map<String, dynamic> _$PkgOptionsToJson(PkgOptions instance) =>
       'isUnlisted': instance.isUnlisted,
     };
 
+CredentiallessPublishing _$CredentiallessPublishingFromJson(
+        Map<String, dynamic> json) =>
+    CredentiallessPublishing(
+      repository: json['repository'] as String?,
+    );
+
+Map<String, dynamic> _$CredentiallessPublishingToJson(
+        CredentiallessPublishing instance) =>
+    <String, dynamic>{
+      'repository': instance.repository,
+    };
+
 VersionOptions _$VersionOptionsFromJson(Map<String, dynamic> json) =>
     VersionOptions(
       isRetracted: json['isRetracted'] as bool?,

--- a/pkg/web_app/lib/src/admin_pages.dart
+++ b/pkg/web_app/lib/src/admin_pages.dart
@@ -46,6 +46,7 @@ class _PkgAdminWidget {
 
   void init() {
     if (!pageData.isPackagePage) return;
+    _setupCredAuth();
     _setPublisherInput = document.getElementById('-admin-set-publisher-input');
     _setPublisherButton =
         document.getElementById('-admin-set-publisher-button');
@@ -86,6 +87,31 @@ class _PkgAdminWidget {
         in document.querySelectorAll('.-pub-remove-uploader-button')) {
       btn.onClick.listen((_) => _removeUploader(btn.dataset['email']!));
     }
+  }
+
+  void _setupCredAuth() {
+    final credlessRepositoryInput = document
+        .getElementById('-pkg-admin-credless-repository') as InputElement?;
+    final credlessUpdateButton =
+        document.getElementById('-pkg-admin-credless-button');
+    if (credlessUpdateButton == null || credlessRepositoryInput == null) {
+      return;
+    }
+    credlessUpdateButton.onClick.listen((event) async {
+      await api_client.rpc<void>(
+        confirmQuestion: await markdown(
+            'Are you sure you want to update the credential-less publishing settings?'),
+        fn: () async {
+          await api_client.client.setCredentiallessPublishing(
+              pageData.pkgData!.package,
+              CredentiallessPublishing(
+                repository: credlessRepositoryInput.value,
+              ));
+        },
+        successMessage: text('Settings updated. The page will reload.'),
+        onSuccess: (_) => window.location.reload(),
+      );
+    });
   }
 
   Future<void> _inviteUploader() async {

--- a/pkg/web_app/lib/src/api_client/pubapi.client.dart
+++ b/pkg/web_app/lib/src/api_client/pubapi.client.dart
@@ -293,6 +293,15 @@ class PubApiClient {
     ));
   }
 
+  Future<_i3.CredentiallessPublishing> setCredentiallessPublishing(
+      String package, _i3.CredentiallessPublishing payload) async {
+    return _i3.CredentiallessPublishing.fromJson(await _client.requestJson(
+      verb: 'put',
+      path: '/api/packages/$package/credentialless-publishing',
+      body: payload.toJson(),
+    ));
+  }
+
   Future<_i3.VersionOptions> getVersionOptions(
       String package, String version) async {
     return _i3.VersionOptions.fromJson(await _client.requestJson(


### PR DESCRIPTION
- I've opted to do a separate API endpoint, as we will probably need to add more verification steps, and it is likely that we don't want to make the information public, vs. the other flags like `isDiscontinued`.
- However, reusing the options updated audit log record.
- The data and UI is minimal at this point: only using a single repository URL.
