### PR TITLE
Credential-less publishing: minimal UI, API and data model.

### DIFF
--- a/app/lib/audit/models.dart
+++ b/app/lib/audit/models.dart
@@ -157,6 +157,25 @@ class AuditLogRecord extends db.ExpandoModel<String> {
       ..publishers = [];
   }
 
+  factory AuditLogRecord.packagePublicationAutomationUpdated({
+    required String package,
+    required User user,
+  }) {
+    return AuditLogRecord._init()
+      ..kind = AuditLogRecordKind.packagePublicationAutomationUpdated
+      ..agent = user.userId
+      ..summary =
+          '`${user.email}` updated the publication automation config of package `$package`.'
+      ..data = {
+        'package': package,
+        'user': user.email,
+      }
+      ..users = [user.userId]
+      ..packages = [package]
+      ..packageVersions = []
+      ..publishers = [];
+  }
+
   factory AuditLogRecord.packageVersionOptionsUpdated({
     required String package,
     required String version,
@@ -624,6 +643,10 @@ class AuditLogRecord extends db.ExpandoModel<String> {
 abstract class AuditLogRecordKind {
   /// Event that a package was updated with new options
   static const packageOptionsUpdated = 'package-options-updated';
+
+  /// Event that a package was updated with new automated publishing config.
+  static const packagePublicationAutomationUpdated =
+      'package-publication-automation-updated';
 
   /// Event that a package version was updated with new options
   static const packageVersionOptionsUpdated = 'package-version-options-updated';

--- a/app/lib/frontend/handlers/pubapi.client.dart
+++ b/app/lib/frontend/handlers/pubapi.client.dart
@@ -293,11 +293,11 @@ class PubApiClient {
     ));
   }
 
-  Future<_i3.CredentiallessPublishing> setCredentiallessPublishing(
-      String package, _i3.CredentiallessPublishing payload) async {
-    return _i3.CredentiallessPublishing.fromJson(await _client.requestJson(
+  Future<_i3.AutomatedPublishing> setAutomatedPublishing(
+      String package, _i3.AutomatedPublishing payload) async {
+    return _i3.AutomatedPublishing.fromJson(await _client.requestJson(
       verb: 'put',
-      path: '/api/packages/$package/credentialless-publishing',
+      path: '/api/packages/$package/automated-publishing',
       body: payload.toJson(),
     ));
   }

--- a/app/lib/frontend/handlers/pubapi.client.dart
+++ b/app/lib/frontend/handlers/pubapi.client.dart
@@ -293,6 +293,15 @@ class PubApiClient {
     ));
   }
 
+  Future<_i3.CredentiallessPublishing> setCredentiallessPublishing(
+      String package, _i3.CredentiallessPublishing payload) async {
+    return _i3.CredentiallessPublishing.fromJson(await _client.requestJson(
+      verb: 'put',
+      path: '/api/packages/$package/credentialless-publishing',
+      body: payload.toJson(),
+    ));
+  }
+
   Future<_i3.VersionOptions> getVersionOptions(
       String package, String version) async {
     return _i3.VersionOptions.fromJson(await _client.requestJson(

--- a/app/lib/frontend/handlers/pubapi.dart
+++ b/app/lib/frontend/handlers/pubapi.dart
@@ -358,10 +358,10 @@ class PubApi {
           Request request, String package, PkgOptions body) =>
       putPackageOptionsHandler(request, package, body);
 
-  @EndPoint.put('/api/packages/<package>/credentialless-publishing')
-  Future<CredentiallessPublishing> setCredentiallessPublishing(
-          Request request, String package, CredentiallessPublishing body) =>
-      packageBackend.setCredentiallessPublishing(package, body);
+  @EndPoint.put('/api/packages/<package>/automated-publishing')
+  Future<AutomatedPublishing> setAutomatedPublishing(
+          Request request, String package, AutomatedPublishing body) =>
+      packageBackend.setAutomatedPublishing(package, body);
 
   @EndPoint.get('/api/packages/<package>/versions/<version>/options')
   Future<VersionOptions> getVersionOptions(

--- a/app/lib/frontend/handlers/pubapi.dart
+++ b/app/lib/frontend/handlers/pubapi.dart
@@ -358,6 +358,11 @@ class PubApi {
           Request request, String package, PkgOptions body) =>
       putPackageOptionsHandler(request, package, body);
 
+  @EndPoint.put('/api/packages/<package>/credentialless-publishing')
+  Future<CredentiallessPublishing> setCredentiallessPublishing(
+          Request request, String package, CredentiallessPublishing body) =>
+      packageBackend.setCredentiallessPublishing(package, body);
+
   @EndPoint.get('/api/packages/<package>/versions/<version>/options')
   Future<VersionOptions> getVersionOptions(
           Request request, String package, String version) =>

--- a/app/lib/frontend/handlers/pubapi.g.dart
+++ b/app/lib/frontend/handlers/pubapi.g.dart
@@ -524,14 +524,14 @@ Router _$PubApiRouter(PubApi service) {
       return $utilities.unhandledError(e, st);
     }
   });
-  router.add('PUT', r'/api/packages/<package>/credentialless-publishing',
+  router.add('PUT', r'/api/packages/<package>/automated-publishing',
       (Request request, String package) async {
     try {
-      final _$result = await service.setCredentiallessPublishing(
+      final _$result = await service.setAutomatedPublishing(
         request,
         package,
-        await $utilities.decodeJson<CredentiallessPublishing>(
-            request, (o) => CredentiallessPublishing.fromJson(o)),
+        await $utilities.decodeJson<AutomatedPublishing>(
+            request, (o) => AutomatedPublishing.fromJson(o)),
       );
       return $utilities.jsonResponse(_$result.toJson());
     } on ApiResponseException catch (e) {

--- a/app/lib/frontend/handlers/pubapi.g.dart
+++ b/app/lib/frontend/handlers/pubapi.g.dart
@@ -524,6 +524,22 @@ Router _$PubApiRouter(PubApi service) {
       return $utilities.unhandledError(e, st);
     }
   });
+  router.add('PUT', r'/api/packages/<package>/credentialless-publishing',
+      (Request request, String package) async {
+    try {
+      final _$result = await service.setCredentiallessPublishing(
+        request,
+        package,
+        await $utilities.decodeJson<CredentiallessPublishing>(
+            request, (o) => CredentiallessPublishing.fromJson(o)),
+      );
+      return $utilities.jsonResponse(_$result.toJson());
+    } on ApiResponseException catch (e) {
+      return e.asApiResponse();
+    } catch (e, st) {
+      return $utilities.unhandledError(e, st);
+    }
+  });
   router.add('GET', r'/api/packages/<package>/versions/<version>/options',
       (Request request, String package, String version) async {
     try {

--- a/app/lib/frontend/request_context.dart
+++ b/app/lib/frontend/request_context.dart
@@ -33,4 +33,7 @@ class RequestContext {
     this.blockRobots = true,
     this.uiCacheEnabled = false,
   });
+
+  /// Whether to show the admin UI for credential-less publishing admin UI.
+  bool get showAdminUIForCredentiallessPublishing => isExperimental;
 }

--- a/app/lib/frontend/request_context.dart
+++ b/app/lib/frontend/request_context.dart
@@ -34,6 +34,6 @@ class RequestContext {
     this.uiCacheEnabled = false,
   });
 
-  /// Whether to show the admin UI for credential-less publishing admin UI.
-  bool get showAdminUIForCredentiallessPublishing => isExperimental;
+  /// Whether to show the admin UI for automated publishing admin UI.
+  bool get showAdminUIForAutomatedPublishing => isExperimental;
 }

--- a/app/lib/frontend/templates/views/pkg/admin_page.dart
+++ b/app/lib/frontend/templates/views/pkg/admin_page.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:pub_dev/frontend/request_context.dart';
+
 import '../../../../account/models.dart';
 import '../../../../package/models.dart';
 import '../../../../shared/urls.dart' as urls;
@@ -159,6 +161,35 @@ d.Node packageAdminPageNode({
         checked: package.isUnlisted,
       ),
     ],
+    if (requestContext.showAdminUIForCredentiallessPublishing)
+      d.fragment([
+        d.h2(text: 'Credential-less publishing'),
+        d.h3(text: 'GitHub'),
+        d.div(
+          classes: ['-pub-form-row'],
+          child: material.checkbox(
+            id: '-pkg-admin-credless-github-enabled',
+            label: 'Enable publishing from GitHub',
+            checked:
+                package.credentiallessPublishing.github?.isEnabled ?? false,
+          ),
+        ),
+        d.div(
+          classes: ['-pub-form-row'],
+          child: material.textField(
+            id: '-pkg-admin-credless-github-projectpath',
+            label: 'Project path',
+            value: package.credentiallessPublishing.github?.projectPath,
+          ),
+        ),
+        d.p(
+          child: material.button(
+            id: '-pkg-admin-credless-button',
+            label: 'Update',
+            raised: true,
+          ),
+        ),
+      ]),
     d.h2(text: 'Package Version Retraction'),
     d.div(children: [
       d.markdown(

--- a/app/lib/frontend/templates/views/pkg/admin_page.dart
+++ b/app/lib/frontend/templates/views/pkg/admin_page.dart
@@ -161,30 +161,29 @@ d.Node packageAdminPageNode({
         checked: package.isUnlisted,
       ),
     ],
-    if (requestContext.showAdminUIForCredentiallessPublishing)
+    if (requestContext.showAdminUIForAutomatedPublishing)
       d.fragment([
-        d.h2(text: 'Credential-less publishing'),
-        d.h3(text: 'GitHub'),
+        d.h2(text: 'Automated publishing'),
+        d.h3(text: 'Publishing from GitHub Actions'),
         d.div(
           classes: ['-pub-form-row'],
           child: material.checkbox(
-            id: '-pkg-admin-credless-github-enabled',
-            label: 'Enable publishing from GitHub',
-            checked:
-                package.credentiallessPublishing.github?.isEnabled ?? false,
+            id: '-pkg-admin-automated-github-enabled',
+            label: 'Enable publishing from GitHub Actions',
+            checked: package.automatedPublishing.github?.isEnabled ?? false,
           ),
         ),
         d.div(
           classes: ['-pub-form-row'],
           child: material.textField(
-            id: '-pkg-admin-credless-github-projectpath',
-            label: 'Project path',
-            value: package.credentiallessPublishing.github?.projectPath,
+            id: '-pkg-admin-automated-github-repository',
+            label: 'Repository',
+            value: package.automatedPublishing.github?.repository,
           ),
         ),
         d.p(
           child: material.button(
-            id: '-pkg-admin-credless-button',
+            id: '-pkg-admin-automated-button',
             label: 'Update',
             raised: true,
           ),

--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -486,10 +486,9 @@ class PackageBackend {
       p.automatedPublishing = body;
       p.updated = clock.now().toUtc();
       tx.insert(p);
-      tx.insert(AuditLogRecord.packageOptionsUpdated(
+      tx.insert(AuditLogRecord.packagePublicationAutomationUpdated(
         package: p.name!,
         user: user,
-        options: ['credentialless-publishing'],
       ));
       return p.automatedPublishing;
     });

--- a/app/lib/package/models.dart
+++ b/app/lib/package/models.dart
@@ -142,9 +142,9 @@ class Package extends db.ExpandoModel<String> {
   @db.StringListProperty()
   List<String>? deletedVersions;
 
-  /// The JSON-serialized format of the [CredentiallessPublishing].
+  /// The JSON-serialized format of the [AutomatedPublishing].
   @db.StringProperty(indexed: false)
-  String? credentiallessPublishingJson;
+  String? automatedPublishingJson;
 
   Package();
 
@@ -375,19 +375,19 @@ class Package extends db.ExpandoModel<String> {
     );
   }
 
-  CredentiallessPublishing get credentiallessPublishing {
-    if (credentiallessPublishingJson == null) {
-      return CredentiallessPublishing();
+  AutomatedPublishing get automatedPublishing {
+    if (automatedPublishingJson == null) {
+      return AutomatedPublishing();
     }
-    return CredentiallessPublishing.fromJson(
-        json.decode(credentiallessPublishingJson!) as Map<String, dynamic>);
+    return AutomatedPublishing.fromJson(
+        json.decode(automatedPublishingJson!) as Map<String, dynamic>);
   }
 
-  set credentiallessPublishing(CredentiallessPublishing? value) {
+  set automatedPublishing(AutomatedPublishing? value) {
     if (value == null) {
-      credentiallessPublishingJson = null;
+      automatedPublishingJson = null;
     } else {
-      credentiallessPublishingJson = json.encode(value.toJson());
+      automatedPublishingJson = json.encode(value.toJson());
     }
   }
 }

--- a/app/lib/package/models.dart
+++ b/app/lib/package/models.dart
@@ -6,6 +6,7 @@ library pub_dartlang_org.appengine_repository.models;
 
 import 'dart:convert';
 
+import 'package:_pub_shared/data/package_api.dart';
 import 'package:clock/clock.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'package:pub_semver/pub_semver.dart';
@@ -140,6 +141,10 @@ class Package extends db.ExpandoModel<String> {
   /// List of versions that have been deleted and must not be re-uploaded again.
   @db.StringListProperty()
   List<String>? deletedVersions;
+
+  /// The JSON-serialized format of the [CredentiallessPublishing].
+  @db.StringProperty(indexed: false)
+  String? credentiallessPublishingJson;
 
   Package();
 
@@ -368,6 +373,22 @@ class Package extends db.ExpandoModel<String> {
             )
           : null,
     );
+  }
+
+  CredentiallessPublishing get credentiallessPublishing {
+    if (credentiallessPublishingJson == null) {
+      return CredentiallessPublishing();
+    }
+    return CredentiallessPublishing.fromJson(
+        json.decode(credentiallessPublishingJson!) as Map<String, dynamic>);
+  }
+
+  set credentiallessPublishing(CredentiallessPublishing? value) {
+    if (value == null) {
+      credentiallessPublishingJson = null;
+    } else {
+      credentiallessPublishingJson = json.encode(value.toJson());
+    }
   }
 }
 

--- a/app/test/frontend/static_files_test.dart
+++ b/app/test/frontend/static_files_test.dart
@@ -206,7 +206,7 @@ void main() {
       final partsSize = parts
           .map((p) => cache.getFile(p)!.bytes.length)
           .reduce((a, b) => a + b);
-      expect((partsSize / 1024).round(), closeTo(109, 1));
+      expect((partsSize / 1024).round(), closeTo(111, 1));
     });
   });
 

--- a/app/test/package/automated_publishing_test.dart
+++ b/app/test/package/automated_publishing_test.dart
@@ -13,15 +13,14 @@ import '../shared/test_services.dart';
 void main() {
   group('Update value through API', () {
     setupTestsWithCallerAuthorizationIssues(
-      (client) => client.setCredentiallessPublishing(
-          'oxygen', CredentiallessPublishing()),
+      (client) =>
+          client.setAutomatedPublishing('oxygen', AutomatedPublishing()),
     );
 
     testWithProfile('no package', fn: () async {
       final client = createPubApiClient(authToken: userAtPubDevAuthToken);
       await expectApiException(
-        client.setCredentiallessPublishing(
-            'no_such_package', CredentiallessPublishing()),
+        client.setAutomatedPublishing('no_such_package', AutomatedPublishing()),
         status: 404,
         code: 'NotFound',
       );
@@ -30,8 +29,7 @@ void main() {
     testWithProfile('not admin', fn: () async {
       final client = createPubApiClient(authToken: userAtPubDevAuthToken);
       await expectApiException(
-        client.setCredentiallessPublishing(
-            'oxygen', CredentiallessPublishing()),
+        client.setAutomatedPublishing('oxygen', AutomatedPublishing()),
         status: 403,
         code: 'InsufficientPermissions',
         message:
@@ -41,22 +39,22 @@ void main() {
 
     testWithProfile('successful update', fn: () async {
       final client = createPubApiClient(authToken: adminAtPubDevAuthToken);
-      final rs = await client.setCredentiallessPublishing(
+      final rs = await client.setAutomatedPublishing(
           'oxygen',
-          CredentiallessPublishing(
+          AutomatedPublishing(
             github: GithubPublishing(
               isEnabled: true,
-              projectPath: 'dart-lang/pub-dev',
+              repository: 'dart-lang/pub-dev',
             ),
           ));
       expect(rs.toJson(), {
         'github': {
           'isEnabled': true,
-          'projectPath': 'dart-lang/pub-dev',
+          'repository': 'dart-lang/pub-dev',
         },
       });
       final p = await packageBackend.lookupPackage('oxygen');
-      expect(p!.credentiallessPublishing.toJson(), rs.toJson());
+      expect(p!.automatedPublishing.toJson(), rs.toJson());
     });
 
     testWithProfile('bad project path', fn: () async {
@@ -70,13 +68,13 @@ void main() {
         'a /b',
         '(/b',
       ];
-      for (final projectPath in badPaths) {
-        final rs = client.setCredentiallessPublishing(
+      for (final repository in badPaths) {
+        final rs = client.setAutomatedPublishing(
             'oxygen',
-            CredentiallessPublishing(
+            AutomatedPublishing(
               github: GithubPublishing(
                 isEnabled: false,
-                projectPath: projectPath,
+                repository: repository,
               ),
             ));
         await expectApiException(

--- a/app/test/package/automated_publishing_test.dart
+++ b/app/test/package/automated_publishing_test.dart
@@ -63,7 +63,7 @@ void main() {
           e.kind == AuditLogRecordKind.packagePublicationAutomationUpdated);
       expect(record.created, isNotNull);
       expect(record.summary,
-          '`admin@pub.dev` updated the publication automation config of package `oxygen`');
+          '`admin@pub.dev` updated the publication automation config of package `oxygen`.');
     });
 
     testWithProfile('bad project path', fn: () async {

--- a/app/test/package/automated_publishing_test.dart
+++ b/app/test/package/automated_publishing_test.dart
@@ -3,6 +3,8 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:_pub_shared/data/package_api.dart';
+import 'package:pub_dev/audit/backend.dart';
+import 'package:pub_dev/audit/models.dart';
 import 'package:pub_dev/package/backend.dart';
 import 'package:test/test.dart';
 
@@ -55,6 +57,13 @@ void main() {
       });
       final p = await packageBackend.lookupPackage('oxygen');
       expect(p!.automatedPublishing.toJson(), rs.toJson());
+      final audits = await auditBackend.listRecordsForPackage('oxygen');
+      // check audit log record exists
+      final record = audits.records.firstWhere((e) =>
+          e.kind == AuditLogRecordKind.packagePublicationAutomationUpdated);
+      expect(record.created, isNotNull);
+      expect(record.summary,
+          '`admin@pub.dev` updated the publication automation config of package `oxygen`');
     });
 
     testWithProfile('bad project path', fn: () async {

--- a/app/test/package/credentialless_test.dart
+++ b/app/test/package/credentialless_test.dart
@@ -1,0 +1,90 @@
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:_pub_shared/data/package_api.dart';
+import 'package:pub_dev/package/backend.dart';
+import 'package:test/test.dart';
+
+import '../shared/handlers_test_utils.dart';
+import '../shared/test_models.dart';
+import '../shared/test_services.dart';
+
+void main() {
+  group('Update value through API', () {
+    setupTestsWithCallerAuthorizationIssues(
+      (client) => client.setCredentiallessPublishing(
+          'oxygen', CredentiallessPublishing()),
+    );
+
+    testWithProfile('no package', fn: () async {
+      final client = createPubApiClient(authToken: userAtPubDevAuthToken);
+      await expectApiException(
+        client.setCredentiallessPublishing(
+            'no_such_package', CredentiallessPublishing()),
+        status: 404,
+        code: 'NotFound',
+      );
+    });
+
+    testWithProfile('not admin', fn: () async {
+      final client = createPubApiClient(authToken: userAtPubDevAuthToken);
+      await expectApiException(
+        client.setCredentiallessPublishing(
+            'oxygen', CredentiallessPublishing()),
+        status: 403,
+        code: 'InsufficientPermissions',
+        message:
+            'Insufficient permissions to perform administrative actions on package `oxygen`.',
+      );
+    });
+
+    testWithProfile('successful update', fn: () async {
+      final client = createPubApiClient(authToken: adminAtPubDevAuthToken);
+      final rs = await client.setCredentiallessPublishing(
+          'oxygen',
+          CredentiallessPublishing(
+            github: GithubPublishing(
+              isEnabled: true,
+              projectPath: 'dart-lang/pub-dev',
+            ),
+          ));
+      expect(rs.toJson(), {
+        'github': {
+          'isEnabled': true,
+          'projectPath': 'dart-lang/pub-dev',
+        },
+      });
+      final p = await packageBackend.lookupPackage('oxygen');
+      expect(p!.credentiallessPublishing.toJson(), rs.toJson());
+    });
+
+    testWithProfile('bad project path', fn: () async {
+      final client = createPubApiClient(authToken: adminAtPubDevAuthToken);
+      final badPaths = [
+        '/',
+        'a/',
+        '/b',
+        '//',
+        'a/b/c',
+        'a /b',
+        '(/b',
+      ];
+      for (final projectPath in badPaths) {
+        final rs = client.setCredentiallessPublishing(
+            'oxygen',
+            CredentiallessPublishing(
+              github: GithubPublishing(
+                isEnabled: false,
+                projectPath: projectPath,
+              ),
+            ));
+        await expectApiException(
+          rs,
+          status: 400,
+          code: 'InvalidInput',
+        );
+      }
+    });
+  });
+}

--- a/pkg/_pub_shared/lib/data/package_api.dart
+++ b/pkg/_pub_shared/lib/data/package_api.dart
@@ -50,29 +50,29 @@ class PkgOptions {
 
 /// The configuration for a package's credential-less publishing.
 @JsonSerializable(includeIfNull: false, explicitToJson: true)
-class CredentiallessPublishing {
+class AutomatedPublishing {
   final GithubPublishing? github;
 
-  CredentiallessPublishing({
+  AutomatedPublishing({
     this.github,
   });
 
-  factory CredentiallessPublishing.fromJson(Map<String, dynamic> json) =>
-      _$CredentiallessPublishingFromJson(json);
+  factory AutomatedPublishing.fromJson(Map<String, dynamic> json) =>
+      _$AutomatedPublishingFromJson(json);
 
-  Map<String, dynamic> toJson() => _$CredentiallessPublishingToJson(this);
+  Map<String, dynamic> toJson() => _$AutomatedPublishingToJson(this);
 }
 
 @JsonSerializable(includeIfNull: false, explicitToJson: true)
 class GithubPublishing {
   final bool? isEnabled;
 
-  /// The `user/repository` path of the project on github.com.
-  String? projectPath;
+  /// The `owner/repository` path of the project on github.com.
+  String? repository;
 
   GithubPublishing({
     this.isEnabled,
-    this.projectPath,
+    this.repository,
   });
 
   factory GithubPublishing.fromJson(Map<String, dynamic> json) =>

--- a/pkg/_pub_shared/lib/data/package_api.dart
+++ b/pkg/_pub_shared/lib/data/package_api.dart
@@ -48,6 +48,39 @@ class PkgOptions {
   Map<String, dynamic> toJson() => _$PkgOptionsToJson(this);
 }
 
+/// The configuration for a package's credential-less publishing.
+@JsonSerializable(includeIfNull: false, explicitToJson: true)
+class CredentiallessPublishing {
+  final GithubPublishing? github;
+
+  CredentiallessPublishing({
+    this.github,
+  });
+
+  factory CredentiallessPublishing.fromJson(Map<String, dynamic> json) =>
+      _$CredentiallessPublishingFromJson(json);
+
+  Map<String, dynamic> toJson() => _$CredentiallessPublishingToJson(this);
+}
+
+@JsonSerializable(includeIfNull: false, explicitToJson: true)
+class GithubPublishing {
+  final bool? isEnabled;
+
+  /// The `user/repository` path of the project on github.com.
+  String? projectPath;
+
+  GithubPublishing({
+    this.isEnabled,
+    this.projectPath,
+  });
+
+  factory GithubPublishing.fromJson(Map<String, dynamic> json) =>
+      _$GithubPublishingFromJson(json);
+
+  Map<String, dynamic> toJson() => _$GithubPublishingToJson(this);
+}
+
 @JsonSerializable()
 class VersionOptions {
   final bool? isRetracted;

--- a/pkg/_pub_shared/lib/data/package_api.g.dart
+++ b/pkg/_pub_shared/lib/data/package_api.g.dart
@@ -32,6 +32,48 @@ Map<String, dynamic> _$PkgOptionsToJson(PkgOptions instance) =>
       'isUnlisted': instance.isUnlisted,
     };
 
+CredentiallessPublishing _$CredentiallessPublishingFromJson(
+        Map<String, dynamic> json) =>
+    CredentiallessPublishing(
+      github: json['github'] == null
+          ? null
+          : GithubPublishing.fromJson(json['github'] as Map<String, dynamic>),
+    );
+
+Map<String, dynamic> _$CredentiallessPublishingToJson(
+    CredentiallessPublishing instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('github', instance.github?.toJson());
+  return val;
+}
+
+GithubPublishing _$GithubPublishingFromJson(Map<String, dynamic> json) =>
+    GithubPublishing(
+      isEnabled: json['isEnabled'] as bool?,
+      projectPath: json['projectPath'] as String?,
+    );
+
+Map<String, dynamic> _$GithubPublishingToJson(GithubPublishing instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('isEnabled', instance.isEnabled);
+  writeNotNull('projectPath', instance.projectPath);
+  return val;
+}
+
 VersionOptions _$VersionOptionsFromJson(Map<String, dynamic> json) =>
     VersionOptions(
       isRetracted: json['isRetracted'] as bool?,

--- a/pkg/_pub_shared/lib/data/package_api.g.dart
+++ b/pkg/_pub_shared/lib/data/package_api.g.dart
@@ -32,16 +32,14 @@ Map<String, dynamic> _$PkgOptionsToJson(PkgOptions instance) =>
       'isUnlisted': instance.isUnlisted,
     };
 
-CredentiallessPublishing _$CredentiallessPublishingFromJson(
-        Map<String, dynamic> json) =>
-    CredentiallessPublishing(
+AutomatedPublishing _$AutomatedPublishingFromJson(Map<String, dynamic> json) =>
+    AutomatedPublishing(
       github: json['github'] == null
           ? null
           : GithubPublishing.fromJson(json['github'] as Map<String, dynamic>),
     );
 
-Map<String, dynamic> _$CredentiallessPublishingToJson(
-    CredentiallessPublishing instance) {
+Map<String, dynamic> _$AutomatedPublishingToJson(AutomatedPublishing instance) {
   final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
@@ -57,7 +55,7 @@ Map<String, dynamic> _$CredentiallessPublishingToJson(
 GithubPublishing _$GithubPublishingFromJson(Map<String, dynamic> json) =>
     GithubPublishing(
       isEnabled: json['isEnabled'] as bool?,
-      projectPath: json['projectPath'] as String?,
+      repository: json['repository'] as String?,
     );
 
 Map<String, dynamic> _$GithubPublishingToJson(GithubPublishing instance) {
@@ -70,7 +68,7 @@ Map<String, dynamic> _$GithubPublishingToJson(GithubPublishing instance) {
   }
 
   writeNotNull('isEnabled', instance.isEnabled);
-  writeNotNull('projectPath', instance.projectPath);
+  writeNotNull('repository', instance.repository);
   return val;
 }
 

--- a/pkg/web_app/lib/src/admin_pages.dart
+++ b/pkg/web_app/lib/src/admin_pages.dart
@@ -46,6 +46,7 @@ class _PkgAdminWidget {
 
   void init() {
     if (!pageData.isPackagePage) return;
+    _setupCredAuth();
     _setPublisherInput = document.getElementById('-admin-set-publisher-input');
     _setPublisherButton =
         document.getElementById('-admin-set-publisher-button');
@@ -86,6 +87,38 @@ class _PkgAdminWidget {
         in document.querySelectorAll('.-pub-remove-uploader-button')) {
       btn.onClick.listen((_) => _removeUploader(btn.dataset['email']!));
     }
+  }
+
+  void _setupCredAuth() {
+    final credlessGithubEnabledCheckbox = document
+        .getElementById('-pkg-admin-credless-github-enabled') as InputElement?;
+    final credlessGithubProjectpathInput =
+        document.getElementById('-pkg-admin-credless-github-projektpath')
+            as InputElement?;
+    final credlessUpdateButton =
+        document.getElementById('-pkg-admin-credless-button');
+    if (credlessUpdateButton == null ||
+        credlessGithubProjectpathInput == null) {
+      return;
+    }
+    credlessUpdateButton.onClick.listen((event) async {
+      await api_client.rpc<void>(
+        confirmQuestion: await markdown(
+            'Are you sure you want to update the credential-less publishing settings?'),
+        fn: () async {
+          await api_client.client.setCredentiallessPublishing(
+              pageData.pkgData!.package,
+              CredentiallessPublishing(
+                github: GithubPublishing(
+                  isEnabled: credlessGithubEnabledCheckbox!.checked,
+                  projectPath: credlessGithubProjectpathInput.value,
+                ),
+              ));
+        },
+        successMessage: text('Settings updated. The page will reload.'),
+        onSuccess: (_) => window.location.reload(),
+      );
+    });
   }
 
   Future<void> _inviteUploader() async {

--- a/pkg/web_app/lib/src/admin_pages.dart
+++ b/pkg/web_app/lib/src/admin_pages.dart
@@ -90,32 +90,30 @@ class _PkgAdminWidget {
   }
 
   void _setupCredAuth() {
-    final credlessGithubEnabledCheckbox = document
-        .getElementById('-pkg-admin-credless-github-enabled') as InputElement?;
-    final credlessGithubProjectpathInput =
-        document.getElementById('-pkg-admin-credless-github-projektpath')
+    final githubEnabledCheckbox = document
+        .getElementById('-pkg-admin-automated-github-enabled') as InputElement?;
+    final githubRepositoryInput =
+        document.getElementById('-pkg-admin-automated-github-repository')
             as InputElement?;
-    final credlessUpdateButton =
-        document.getElementById('-pkg-admin-credless-button');
-    if (credlessUpdateButton == null ||
-        credlessGithubProjectpathInput == null) {
+    final updateButton = document.getElementById('-pkg-admin-automated-button');
+    if (updateButton == null || githubRepositoryInput == null) {
       return;
     }
-    credlessUpdateButton.onClick.listen((event) async {
+    updateButton.onClick.listen((event) async {
       await api_client.rpc<void>(
         confirmQuestion: await markdown(
-            'Are you sure you want to update the credential-less publishing settings?'),
+            'Are you sure you want to update the automated publishing config?'),
         fn: () async {
-          await api_client.client.setCredentiallessPublishing(
+          await api_client.client.setAutomatedPublishing(
               pageData.pkgData!.package,
-              CredentiallessPublishing(
+              AutomatedPublishing(
                 github: GithubPublishing(
-                  isEnabled: credlessGithubEnabledCheckbox!.checked,
-                  projectPath: credlessGithubProjectpathInput.value,
+                  isEnabled: githubEnabledCheckbox!.checked,
+                  repository: githubRepositoryInput.value,
                 ),
               ));
         },
-        successMessage: text('Settings updated. The page will reload.'),
+        successMessage: text('Config updated. The page will reload.'),
         onSuccess: (_) => window.location.reload(),
       );
     });

--- a/pkg/web_app/lib/src/api_client/pubapi.client.dart
+++ b/pkg/web_app/lib/src/api_client/pubapi.client.dart
@@ -293,11 +293,11 @@ class PubApiClient {
     ));
   }
 
-  Future<_i3.CredentiallessPublishing> setCredentiallessPublishing(
-      String package, _i3.CredentiallessPublishing payload) async {
-    return _i3.CredentiallessPublishing.fromJson(await _client.requestJson(
+  Future<_i3.AutomatedPublishing> setAutomatedPublishing(
+      String package, _i3.AutomatedPublishing payload) async {
+    return _i3.AutomatedPublishing.fromJson(await _client.requestJson(
       verb: 'put',
-      path: '/api/packages/$package/credentialless-publishing',
+      path: '/api/packages/$package/automated-publishing',
       body: payload.toJson(),
     ));
   }

--- a/pkg/web_app/lib/src/api_client/pubapi.client.dart
+++ b/pkg/web_app/lib/src/api_client/pubapi.client.dart
@@ -293,6 +293,15 @@ class PubApiClient {
     ));
   }
 
+  Future<_i3.CredentiallessPublishing> setCredentiallessPublishing(
+      String package, _i3.CredentiallessPublishing payload) async {
+    return _i3.CredentiallessPublishing.fromJson(await _client.requestJson(
+      verb: 'put',
+      path: '/api/packages/$package/credentialless-publishing',
+      body: payload.toJson(),
+    ));
+  }
+
   Future<_i3.VersionOptions> getVersionOptions(
       String package, String version) async {
     return _i3.VersionOptions.fromJson(await _client.requestJson(


### PR DESCRIPTION
- A slightly different take than #5764.
- Created a new API endpoint to updated it, as we will probably need more verification as we go, and it is likely that we don't want to make the information public, vs. the other flags like `isDiscontinued`.
- However, reusing the options updated audit log record.
- The data and UI is minimal at this point: only using a single projectPath + the enabled checkbox.