### PR TITLE
Redirect search from publisher packages page, remove SearchContext.

### DIFF
--- a/app/lib/frontend/handlers/publisher.dart
+++ b/app/lib/frontend/handlers/publisher.dart
@@ -77,32 +77,29 @@ Future<shelf.Response> publisherPackagesPageHandler(
     return formattedNotFoundHandler(request);
   }
 
-  final searchForm = SearchForm.parse(
-    request.requestedUri.queryParameters,
-    context: SearchContext.publisher(publisherId),
-  );
-  // redirect to proper search page if there is any non-pagination item present
-  if (searchForm.hasNonPagination) {
+  final searchForm = SearchForm.parse(request.requestedUri.queryParameters);
+  // redirect to the search page when any search or pagination is present
+  if (searchForm.isNotEmpty) {
     final redirectForm = SearchForm.parse(request.requestedUri.queryParameters)
         .addRequiredTagIfAbsent(PackageTags.publisherTag(publisherId))
         .addRequiredTagIfAbsent(PackageTags.showHidden);
-    return redirectResponse(redirectForm.toSearchLink());
+    return redirectResponse(
+        redirectForm.toSearchLink(page: searchForm.currentPage));
   }
 
-  final appliedSearchForm =
-      SearchForm.parse(request.requestedUri.queryParameters)
-          .toggleRequiredTag(PackageTags.publisherTag(publisherId))
-          .toggleRequiredTag(PackageTags.showHidden);
+  final appliedSearchForm = SearchForm()
+      .toggleRequiredTag(PackageTags.publisherTag(publisherId))
+      .toggleRequiredTag(PackageTags.showHidden);
 
   final searchResult = await searchAdapter.search(appliedSearchForm);
   final int totalCount = searchResult.totalCount;
-  final links = PageLinks(searchForm, totalCount);
+  final links = PageLinks(appliedSearchForm, totalCount);
 
   final html = renderPublisherPackagesPage(
     publisher: publisher,
     searchResultPage: searchResult,
     pageLinks: links,
-    searchForm: searchForm,
+    searchForm: appliedSearchForm,
     totalCount: totalCount,
     isAdmin: await publisherBackend.isMemberAdmin(
         publisher, userSessionData?.userId),

--- a/app/lib/frontend/templates/layout.dart
+++ b/app/lib/frontend/templates/layout.dart
@@ -47,7 +47,6 @@ String renderLayoutPage(
   /// The canonical content link that will be put in the header.
   /// https://support.google.com/webmasters/answer/139066?hl=en
   String? canonicalUrl,
-  String? publisherId,
   SearchForm? searchForm,
   bool noIndex = false,
   PageData? pageData,
@@ -84,7 +83,6 @@ String renderLayoutPage(
     searchBanner: showSearchBanner(type)
         ? _renderSearchBanner(
             type: type,
-            publisherId: publisherId,
             searchForm: searchForm,
           )
         : null,
@@ -99,19 +97,10 @@ String renderLayoutPage(
 
 d.Node _renderSearchBanner({
   required PageType type,
-  required String? publisherId,
   required SearchForm? searchForm,
 }) {
   final queryText = searchForm?.query;
-  String? searchPlaceholder;
-  if (publisherId != null) {
-    searchPlaceholder ??= 'Search $publisherId packages';
-  } else {
-    searchPlaceholder ??= getSdkDict(null).searchPackagesLabel;
-  }
-  final searchFormUrl = publisherId == null
-      ? urls.searchUrl()
-      : urls.publisherPackagesUrl(publisherId);
+  final searchPlaceholder = getSdkDict(null).searchPackagesLabel;
   final searchSort = searchForm?.order?.name;
   return searchBannerNode(
     // When search is active (query text has a non-empty value) users may expect
@@ -119,7 +108,7 @@ d.Node _renderSearchBanner({
     // search field when there is no active search.
     autofocus: queryText == null,
     showSearchFiltersButton: type == PageType.listing,
-    formUrl: searchFormUrl,
+    formUrl: urls.searchUrl(),
     placeholder: searchPlaceholder,
     queryText: queryText,
     sortParam: searchSort,

--- a/app/lib/frontend/templates/package_misc.dart
+++ b/app/lib/frontend/templates/package_misc.dart
@@ -44,7 +44,7 @@ d.Node tagsNodeFromPackageView({
   String? version,
   bool isRetracted = false,
 }) {
-  searchForm = searchForm?.clearContext() ?? SearchForm();
+  searchForm ??= SearchForm();
   final tags = package.tags;
   final sdkTags = tags.where((s) => s.startsWith('sdk:')).toSet().toList();
   final simpleTags = <SimpleTag>[];

--- a/app/lib/frontend/templates/publisher.dart
+++ b/app/lib/frontend/templates/publisher.dart
@@ -92,9 +92,8 @@ String renderPublisherPackagesPage({
         publisherId: publisher.publisherId,
       ),
     ),
-    publisherId: publisher.publisherId,
     searchForm: searchForm,
-    canonicalUrl: searchForm.toSearchLink(),
+    canonicalUrl: urls.publisherPackagesUrl(publisher.publisherId),
     // index only the first page, if it has packages displayed without search query
     noIndex:
         searchResultPage.hasNoHit || isSearch || pageLinks.currentPage! > 1,

--- a/app/lib/package/search_adapter.dart
+++ b/app/lib/package/search_adapter.dart
@@ -120,7 +120,7 @@ class SearchAdapter {
   /// `search` service.
   Future<PackageSearchResult> _fallbackSearch(SearchForm form) async {
     // Some search queries must not be served with the fallback search.
-    if (form.context.publisherId != null) {
+    if (form.parsedQuery.tagsPredicate.isNotEmpty) {
       return PackageSearchResult.empty(
           message: 'Search is temporarily unavailable.');
     }

--- a/app/lib/search/search_service.dart
+++ b/app/lib/search/search_service.dart
@@ -421,21 +421,18 @@ abstract class DependencyTypes {
 
 extension SearchFormExt on SearchForm {
   ServiceSearchQuery toServiceQuery() {
-    final prohibitLegacy = !context.includeAll &&
-        !parsedQuery.tagsPredicate.anyTag((tag) =>
-            tag == PackageVersionTags.isLegacy ||
-            tag == PackageVersionTags.showLegacy ||
-            tag == PackageTags.showHidden);
-    final prohibitDiscontinued = !context.includeAll &&
-        !parsedQuery.tagsPredicate.anyTag((tag) =>
-            tag == PackageTags.isDiscontinued ||
-            tag == PackageTags.showDiscontinued ||
-            tag == PackageTags.showHidden);
-    final prohibitUnlisted = !context.includeAll &&
-        !parsedQuery.tagsPredicate.anyTag((tag) =>
-            tag == PackageTags.isUnlisted ||
-            tag == PackageTags.showUnlisted ||
-            tag == PackageTags.showHidden);
+    final prohibitLegacy = !parsedQuery.tagsPredicate.anyTag((tag) =>
+        tag == PackageVersionTags.isLegacy ||
+        tag == PackageVersionTags.showLegacy ||
+        tag == PackageTags.showHidden);
+    final prohibitDiscontinued = !parsedQuery.tagsPredicate.anyTag((tag) =>
+        tag == PackageTags.isDiscontinued ||
+        tag == PackageTags.showDiscontinued ||
+        tag == PackageTags.showHidden);
+    final prohibitUnlisted = !parsedQuery.tagsPredicate.anyTag((tag) =>
+        tag == PackageTags.isUnlisted ||
+        tag == PackageTags.showUnlisted ||
+        tag == PackageTags.showHidden);
     final tagsPredicate = TagsPredicate(
       prohibitedTags: [
         if (prohibitDiscontinued) PackageTags.isDiscontinued,
@@ -446,7 +443,6 @@ extension SearchFormExt on SearchForm {
     return ServiceSearchQuery.parse(
       query: query,
       tagsPredicate: tagsPredicate,
-      publisherId: context.publisherId,
       offset: offset,
       limit: pageSize,
       order: order,

--- a/app/lib/shared/urls.dart
+++ b/app/lib/shared/urls.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:_pub_shared/search/search_form.dart'
-    show SearchContext, SearchForm, SearchOrder;
+    show SearchForm, SearchOrder;
 import 'package:path/path.dart' as p;
 
 const primaryHost = 'pub.dev';
@@ -172,7 +172,7 @@ String pkgDocUrl(
 
 String publisherUrl(String publisherId) => '/publishers/$publisherId';
 String publisherPackagesUrl(String publisherId) =>
-    SearchContext.publisher(publisherId).toSearchFormPath();
+    '/publishers/$publisherId/packages';
 
 String publisherAdminUrl(String publisherId) =>
     publisherUrl(publisherId) + '/admin';

--- a/app/test/frontend/golden/publisher_packages_page.html
+++ b/app/test/frontend/golden/publisher_packages_page.html
@@ -105,8 +105,8 @@
     <div id="banner-container"></div>
     <div class="_banner-bg">
       <div class="container">
-        <form class="search-bar banner-item" action="/publishers/example.com/packages">
-          <input class="input" name="q" placeholder="Search example.com packages" autocomplete="on" autofocus="autofocus"/>
+        <form class="search-bar banner-item" action="/packages">
+          <input class="input" name="q" placeholder="Search packages" autocomplete="on" autofocus="autofocus"/>
           <button class="icon" aria-label="search"></button>
         </form>
       </div>

--- a/app/test/frontend/handlers/publisher_test.dart
+++ b/app/test/frontend/handlers/publisher_test.dart
@@ -4,7 +4,6 @@
 
 import 'package:pub_dev/publisher/models.dart';
 import 'package:pub_dev/shared/datastore.dart';
-import 'package:pub_dev/tool/test_profile/models.dart';
 import 'package:test/test.dart';
 
 import '../../shared/handlers_test_utils.dart';
@@ -66,6 +65,26 @@ void main() {
       );
     });
 
+    testWithProfile(
+      'publisher packages with pagination',
+      fn: () async {
+        await expectRedirectResponse(
+          await issueGet('/publishers/example.com/packages?page=2'),
+          '/packages?q=publisher%3Aexample.com+show%3Ahidden&page=2',
+        );
+      },
+    );
+
+    testWithProfile(
+      'publisher packages with sort order',
+      fn: () async {
+        await expectRedirectResponse(
+          await issueGet('/publishers/example.com/packages?sort=updated'),
+          '/packages?q=publisher%3Aexample.com+show%3Ahidden&sort=updated',
+        );
+      },
+    );
+
     testWithProfile('simple publisher packages', fn: () async {
       await expectHtmlResponse(
         await issueGet('/publishers/example.com/packages'),
@@ -73,34 +92,5 @@ void main() {
         absent: ['/packages/oxygen'],
       );
     });
-
-    testWithProfile(
-      'paginated publisher packages',
-      testProfile: TestProfile(
-        packages: [
-          TestPackage(name: 'non_publisher'),
-          ...List.generate(
-            11,
-            (i) => TestPackage(
-              name: 'pkg_$i',
-              publisher: 'example.com',
-            ),
-          ),
-        ],
-        defaultUser: 'admin@pub.dev',
-      ),
-      fn: () async {
-        await expectHtmlResponse(
-          await issueGet('/publishers/example.com/packages'),
-          present: ['"/publishers/example.com/packages?page=2"'],
-          absent: ['non_publisher'],
-        );
-        await expectHtmlResponse(
-          await issueGet('/publishers/example.com/packages?page=2'),
-          present: ['"/publishers/example.com/packages"'],
-          absent: ['non_publisher'],
-        );
-      },
-    );
   });
 }

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -567,8 +567,7 @@ void main() {
       'publisher packages page',
       processJobsWithFakeRunners: true,
       fn: () async {
-        final searchForm =
-            SearchForm(context: SearchContext.publisher('example.com'));
+        final searchForm = SearchForm();
         final publisher = (await publisherBackend.getPublisher('example.com'))!;
         final neon = (await scoreCardBackend.getPackageView('neon'))!;
         final titanium =

--- a/pkg/_pub_shared/test/search/search_form_test.dart
+++ b/pkg/_pub_shared/test/search/search_form_test.dart
@@ -199,21 +199,6 @@ void main() {
           '/packages?q=is%3Aflutter-favorite&page=2');
     });
 
-    test('publisher: example.com', () {
-      final query = SearchForm(context: SearchContext.publisher('example.com'));
-      expect(query.toSearchLink(), '/publishers/example.com/packages');
-      expect(query.toSearchLink(page: 2),
-          '/publishers/example.com/packages?page=2');
-    });
-
-    test('publisher: example.com with query', () {
-      final query = SearchForm(
-          context: SearchContext.publisher('example.com'), query: 'json');
-      expect(query.toSearchLink(), '/publishers/example.com/packages?q=json');
-      expect(query.toSearchLink(page: 2),
-          '/publishers/example.com/packages?q=json&page=2');
-    });
-
     test('package prefix: angular', () {
       final query = SearchForm(query: 'package:angular');
       expect(query.parsedQuery.text, isNull);


### PR DESCRIPTION
- Closes #5641 with the simple reduction of search functionality, without further changes on the UI.
- The links on the publisher page will be pointing to the regular search page.
- If there is any search parameter on the publisher page, it will redirect to the regular search page.
- There is no more need for `SearchContext`, as we don't need to have a separate search page for publishers.
