### PR TITLE
Reject packages with known README.md templates.

### DIFF
--- a/pkg/pub_integration/test/publish_rejection_test.dart
+++ b/pkg/pub_integration/test/publish_rejection_test.dart
@@ -54,7 +54,7 @@ void main() {
         await localDartTool.publish(
           pkgDir,
           expectedError:
-              '`description` contains a generic text fragment coming from package templates (`a sample command-line application`).\n'
+              '`description` contains a generic text fragment coming from package templates (`A sample command-line application`).\n'
               'Please follow the guides to describe your package:\n'
               'https://dart.dev/tools/pub/pubspec#description',
         );

--- a/pkg/pub_package_reader/lib/src/known_templates.dart
+++ b/pkg/pub_package_reader/lib/src/known_templates.dart
@@ -1,0 +1,64 @@
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:pub_package_reader/pub_package_reader.dart';
+
+const _knownTemplateDescriptions = <String>{
+  // ex-stagehand templates, check latest versions in dart-lang/sdk's
+  // pkg/dartdev/lib/src/templates/ directory:
+  'a sample command-line application',
+  'a simple command-line application',
+  'a starting point for dart libraries or applications',
+  'a web server built using the shelf package',
+  'a web app that uses angulardart components',
+  'an absolute bare-bones web app',
+  'a simple stagexl web app',
+  // Flutter templates, check latest version in flutter/flutter's
+  // packages/flutter_tools/lib/src/commands/create.dart directory:
+  'a new flutter project',
+  'a new flutter module project',
+  'a new flutter package project',
+  'a new flutter plugin project',
+  'a new flutter ffi plugin project',
+};
+
+const _knownTemplateReadmes = <String>{
+  'todo: put a short description of the package here',
+  'todo: list what your package can do',
+  'todo: list prerequisites and provide or point to information on how to start using the package',
+  'todo: include short and useful examples for package users',
+  'todo: tell users more about the package',
+};
+
+/// Validates the `description` field in the `pubspec.yaml`.
+Iterable<ArchiveIssue> validateKnownTemplateDescription(
+    String description) sync* {
+  final lower = description.toLowerCase();
+  for (final text in _knownTemplateDescriptions) {
+    if (lower.contains(text)) {
+      yield ArchiveIssue(
+          '`description` contains a generic text fragment coming from package templates (`$text`).\n'
+          'Please follow the guides to describe your package:\n'
+          'https://dart.dev/tools/pub/pubspec#description');
+      break;
+    }
+  }
+}
+
+Iterable<ArchiveIssue> validateKnownTemplateReadme(
+    String? path, String? content) sync* {
+  if (path == null || content == null) {
+    return;
+  }
+  final lower = content.toLowerCase();
+  for (final text in _knownTemplateReadmes) {
+    if (lower.contains(text)) {
+      yield ArchiveIssue(
+          '`$path` contains a generic text fragment coming from package templates (`$text`).\n'
+          'Please follow the guides to write great package pages:\n'
+          'https://dart.dev/guides/libraries/writing-package-pages');
+      break;
+    }
+  }
+}

--- a/pkg/pub_package_reader/lib/src/known_templates.dart
+++ b/pkg/pub_package_reader/lib/src/known_templates.dart
@@ -36,9 +36,12 @@ Iterable<ArchiveIssue> validateKnownTemplateDescription(
     String description) sync* {
   final lower = description.toLowerCase();
   for (final text in _knownTemplateDescriptions) {
-    if (lower.contains(text)) {
+    final firstIndex = lower.indexOf(text);
+    if (firstIndex >= 0) {
+      final origText =
+          description.substring(firstIndex, firstIndex + text.length);
       yield ArchiveIssue(
-          '`description` contains a generic text fragment coming from package templates (`$text`).\n'
+          '`description` contains a generic text fragment coming from package templates (`$origText`).\n'
           'Please follow the guides to describe your package:\n'
           'https://dart.dev/tools/pub/pubspec#description');
       break;
@@ -53,9 +56,11 @@ Iterable<ArchiveIssue> validateKnownTemplateReadme(
   }
   final lower = content.toLowerCase();
   for (final text in _knownTemplateReadmes) {
-    if (lower.contains(text)) {
+    final firstIndex = lower.indexOf(text);
+    if (firstIndex >= 0) {
+      final origText = content.substring(firstIndex, firstIndex + text.length);
       yield ArchiveIssue(
-          '`$path` contains a generic text fragment coming from package templates (`$text`).\n'
+          '`$path` contains a generic text fragment coming from package templates (`$origText`).\n'
           'Please follow the guides to write great package pages:\n'
           'https://dart.dev/guides/libraries/writing-package-pages');
       break;

--- a/pkg/pub_package_reader/test/known_templates_test.dart
+++ b/pkg/pub_package_reader/test/known_templates_test.dart
@@ -1,0 +1,40 @@
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:pub_package_reader/pub_package_reader.dart';
+import 'package:pub_package_reader/src/known_templates.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('description', () {
+    test('known template', () {
+      expect(validateDescription('A sample command-line application.'),
+          isNotEmpty);
+    });
+
+    test('known template with some extra text', () {
+      expect(validateDescription('A sample command-line application by xyz.'),
+          isNotEmpty);
+    });
+  });
+
+  group('readme', () {
+    test('no readme', () {
+      expect(validateKnownTemplateReadme(null, null), isEmpty);
+    });
+
+    test('some readme', () {
+      expect(
+          validateKnownTemplateReadme('README.md', 'This is not a template.'),
+          isEmpty);
+    });
+
+    test('known template', () {
+      expect(
+          validateKnownTemplateReadme('README.md',
+              'TODO: Tell users more about the package, and do not leave such templates in the README.md.'),
+          isNotEmpty);
+    });
+  });
+}

--- a/pkg/pub_package_reader/test/package_archive_test.dart
+++ b/pkg/pub_package_reader/test/package_archive_test.dart
@@ -102,16 +102,6 @@ void main() {
           isNotEmpty);
     });
 
-    test('known template', () {
-      expect(validateDescription('A sample command-line application.'),
-          isNotEmpty);
-    });
-
-    test('known template with some extra text', () {
-      expect(validateDescription('A sample command-line application by xyz.'),
-          isNotEmpty);
-    });
-
     test('valid text', () {
       expect(
           validateDescription(


### PR DESCRIPTION
- #2002
- moved known templates (and some tests) to separate files
- scanned a few new packages, and these strings seem to be part of a default template 