### PR TITLE
Remove duplicate fields from ScoreCard(Data) and simpler report update.

### DIFF
--- a/app/lib/frontend/templates/views/pkg/score_tab.dart
+++ b/app/lib/frontend/templates/views/pkg/score_tab.dart
@@ -20,7 +20,7 @@ d.Node scoreTabNode({
     return d.i(text: 'Awaiting analysis to complete.');
   }
 
-  final report = card.getJoinedReport();
+  final report = card.report;
   final showPending = !card.isSkipped && report == null;
   final showReport = !card.isSkipped && report != null;
 

--- a/app/lib/scorecard/backend.dart
+++ b/app/lib/scorecard/backend.dart
@@ -220,11 +220,6 @@ class ScoreCardBackend {
 
       scoreCard.popularityScore = popularityStorage.lookup(packageName);
 
-      scoreCard.updateReports(
-        panaReport: panaReport,
-        dartdocReport: dartdocReport,
-      );
-
       bool reportIsTooBig(String reportType, List<int>? bytes) {
         if (bytes == null || bytes.isEmpty) return false;
         final size = bytes.length;
@@ -240,56 +235,57 @@ class ScoreCardBackend {
       }
 
       if (panaReport != null &&
-          reportIsTooBig(ReportType.pana, scoreCard.panaReportJsonGz)) {
-        scoreCard.updateReports(
-          panaReport: PanaReport(
-            timestamp: clock.now().toUtc(),
-            panaRuntimeInfo: null,
-            reportStatus: ReportStatus.aborted,
-            derivedTags: <String>[],
-            allDependencies: <String>[],
-            licenseFile: null,
-            licenses: null,
-            report: pana.Report(
-              sections: [
-                pana.ReportSection(
-                  id: 'error',
-                  title: 'Report exceeded size limit.',
-                  grantedPoints: panaReport.report?.grantedPoints ?? 0,
-                  maxPoints: panaReport.report?.maxPoints ?? 1,
-                  status: pana.ReportStatus.partial,
-                  summary: 'The `pana` report exceeded size limit. '
-                      'A log about the issue has been filed, the site admins will address it soon.',
-                ),
-              ],
-            ),
-            flags: <String>[],
-            urlProblems: <pana.UrlProblem>[],
-            repository: null,
-            screenshots: null,
+          reportIsTooBig(ReportType.pana, panaReport!.asBytes)) {
+        panaReport = PanaReport(
+          timestamp: clock.now().toUtc(),
+          panaRuntimeInfo: null,
+          reportStatus: ReportStatus.aborted,
+          derivedTags: <String>[],
+          allDependencies: <String>[],
+          licenseFile: null,
+          licenses: null,
+          report: pana.Report(
+            sections: [
+              pana.ReportSection(
+                id: 'error',
+                title: 'Report exceeded size limit.',
+                grantedPoints: panaReport!.report?.grantedPoints ?? 0,
+                maxPoints: panaReport!.report?.maxPoints ?? 1,
+                status: pana.ReportStatus.partial,
+                summary: 'The `pana` report exceeded size limit. '
+                    'A log about the issue has been filed, the site admins will address it soon.',
+              ),
+            ],
           ),
+          flags: <String>[],
+          urlProblems: <pana.UrlProblem>[],
+          repository: null,
+          screenshots: null,
         );
       }
       if (dartdocReport != null &&
-          reportIsTooBig(ReportType.dartdoc, scoreCard.dartdocReportJsonGz)) {
-        scoreCard.updateReports(
-          dartdocReport: DartdocReport(
-            timestamp: dartdocReport.timestamp,
-            reportStatus: ReportStatus.aborted,
-            dartdocEntry: null,
-            documentationSection: pana.ReportSection(
-              id: pana.ReportSectionId.documentation,
-              title: pana.documentationSectionTitle,
-              grantedPoints:
-                  dartdocReport.documentationSection?.grantedPoints ?? 0,
-              maxPoints: dartdocReport.documentationSection?.maxPoints ?? 10,
-              status: pana.ReportStatus.partial,
-              summary: 'The `dartdoc` report exceeded size limit. '
-                  'A log about the issue has been filed, the site admins will address it soon.',
-            ),
+          reportIsTooBig(ReportType.dartdoc, dartdocReport!.asBytes)) {
+        dartdocReport = DartdocReport(
+          timestamp: dartdocReport!.timestamp,
+          reportStatus: ReportStatus.aborted,
+          dartdocEntry: null,
+          documentationSection: pana.ReportSection(
+            id: pana.ReportSectionId.documentation,
+            title: pana.documentationSectionTitle,
+            grantedPoints:
+                dartdocReport!.documentationSection?.grantedPoints ?? 0,
+            maxPoints: dartdocReport!.documentationSection?.maxPoints ?? 10,
+            status: pana.ReportStatus.partial,
+            summary: 'The `dartdoc` report exceeded size limit. '
+                'A log about the issue has been filed, the site admins will address it soon.',
           ),
         );
       }
+
+      scoreCard.updateReports(
+        panaReport: panaReport,
+        dartdocReport: dartdocReport,
+      );
 
       tx.insert(scoreCard);
     });

--- a/app/lib/scorecard/models.g.dart
+++ b/app/lib/scorecard/models.g.dart
@@ -20,12 +20,7 @@ ScoreCardData _$ScoreCardDataFromJson(Map<String, dynamic> json) =>
       packageVersionCreated: json['packageVersionCreated'] == null
           ? null
           : DateTime.parse(json['packageVersionCreated'] as String),
-      grantedPubPoints: json['grantedPubPoints'] as int?,
-      maxPubPoints: json['maxPubPoints'] as int?,
       popularityScore: (json['popularityScore'] as num?)?.toDouble(),
-      derivedTags: (json['derivedTags'] as List<dynamic>?)
-          ?.map((e) => e as String)
-          .toList(),
       flags:
           (json['flags'] as List<dynamic>?)?.map((e) => e as String).toList(),
       dartdocReport: json['dartdocReport'] == null
@@ -46,10 +41,7 @@ Map<String, dynamic> _$ScoreCardDataToJson(ScoreCardData instance) =>
       'packageCreated': instance.packageCreated?.toIso8601String(),
       'packageVersionCreated':
           instance.packageVersionCreated?.toIso8601String(),
-      'grantedPubPoints': instance.grantedPubPoints,
-      'maxPubPoints': instance.maxPubPoints,
       'popularityScore': instance.popularityScore,
-      'derivedTags': instance.derivedTags,
       'flags': instance.flags,
       'dartdocReport': instance.dartdocReport,
       'panaReport': instance.panaReport,

--- a/app/test/scorecard/report_size_test.dart
+++ b/app/test/scorecard/report_size_test.dart
@@ -56,10 +56,7 @@ void main() {
           'updated': isNotNull,
           'packageCreated': isNotNull,
           'packageVersionCreated': isNotNull,
-          'grantedPubPoints': 20,
-          'maxPubPoints': 20,
           'popularityScore': isNotNull,
-          'derivedTags': isEmpty,
           'flags': [],
           'dartdocReport': isNotNull,
           'panaReport': {


### PR DESCRIPTION
- The fields removed from `ScoreCard` are not used for any lookup (they are not indexed).
- The update of the reports is simpler if we only update it once.
- Related to #5519.