### PR TITLE
Change copy mouse cursor to pointer.

### DIFF
--- a/pkg/web_css/lib/src/_base.scss
+++ b/pkg/web_css/lib/src/_base.scss
@@ -196,7 +196,7 @@ pre {
     background-repeat: no-repeat;
     background-size: 16px 16px;
 
-    cursor: copy;
+    cursor: pointer;
 
     opacity: 0.15;
     transition: opacity 0.5s;

--- a/pkg/web_css/lib/src/_pkg.scss
+++ b/pkg/web_css/lib/src/_pkg.scss
@@ -284,7 +284,7 @@
     display: block;
     width: 20px;
     height: 20px;
-    cursor: copy;
+    cursor: pointer;
     opacity: 0.1;
     transition: opacity 0.3s;
 


### PR DESCRIPTION
- Fixes #5813.
- Also fixes generic copy icon in `<pre>` blocks.