### PR TITLE
Upload package archive to canonical and public bucket too.

### DIFF
--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -871,10 +871,12 @@ class PackageBackend {
           await _canonicalBucket.tryInfo(canonicalArchivePath);
       if (canonicalArchiveInfo != null) {
         final file = File(filename);
+        // Quick and cheap test in case the file is obviously different than the canonical archive.
         if (canonicalArchiveInfo.length != await file.length()) {
           throw PackageRejectedException.versionExists(
               pubspec.name, versionString);
         }
+        // Actually fetch the archive bytes and do full comparison.
         final objectBytes =
             await _canonicalBucket.readAsBytes(canonicalArchivePath);
         final fileBytes = await file.readAsBytes();

--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -870,15 +870,10 @@ class PackageBackend {
       final canonicalArchiveInfo =
           await _canonicalBucket.tryInfo(canonicalArchivePath);
       if (canonicalArchiveInfo != null) {
-        final file = File(filename);
-        // Quick and cheap test in case the file is obviously different than the canonical archive.
-        if (canonicalArchiveInfo.length != await file.length()) {
-          throw PackageRejectedException.versionExists(
-              pubspec.name, versionString);
-        }
         // Actually fetch the archive bytes and do full comparison.
         final objectBytes =
             await _canonicalBucket.readAsBytes(canonicalArchivePath);
+        final file = File(filename);
         final fileBytes = await file.readAsBytes();
         if (!fileBytes.byteToByteEquals(objectBytes)) {
           throw PackageRejectedException.versionExists(

--- a/app/lib/service/services.dart
+++ b/app/lib/service/services.dart
@@ -221,6 +221,8 @@ Future<R> _withPubServices<R>(FutureOr<R> Function() fn) async {
       storageService,
       storageService.bucket(activeConfiguration.packageBucketName!),
       storageService.bucket(activeConfiguration.incomingPackagesBucketName!),
+      storageService.bucket(activeConfiguration.canonicalPackagesBucketName!),
+      storageService.bucket(activeConfiguration.publicPackagesBucketName!),
     ));
     await setupCache();
 

--- a/app/lib/tool/maintenance/update_public_bucket.dart
+++ b/app/lib/tool/maintenance/update_public_bucket.dart
@@ -1,0 +1,43 @@
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:gcloud/storage.dart';
+import 'package:logging/logging.dart';
+import 'package:pub_dev/package/backend.dart';
+import 'package:pub_dev/package/models.dart';
+import 'package:pub_dev/shared/configuration.dart';
+import 'package:pub_dev/shared/datastore.dart';
+import 'package:pub_dev/shared/storage.dart';
+
+final _logger = Logger('update_public_buckets');
+
+/// Updates the public package archive:
+/// - copies missing archive objects from canonical to public
+///
+/// Return the number of objects that were updated.
+Future<int> updatePublicArchiveBucket() async {
+  _logger.info('Scanning PackageVersions for public bucket updates...');
+
+  var updated = 0;
+  final canonicalBucket =
+      storageService.bucket(activeConfiguration.canonicalPackagesBucketName!);
+  final publicBucket =
+      storageService.bucket(activeConfiguration.publicPackagesBucketName!);
+
+  await for (final pv in dbService.query<PackageVersion>().run()) {
+    // ignore: invalid_use_of_visible_for_testing_member
+    final objectName = tarballObjectName(pv.package, pv.version!);
+    final publicInfo = await publicBucket.tryInfo(objectName);
+
+    if (publicInfo == null) {
+      _logger.warning('Updating missing object in public bucket: $objectName');
+      await storageService.copyObject(
+        canonicalBucket.absoluteObjectName(objectName),
+        publicBucket.absoluteObjectName(objectName),
+      );
+      updated++;
+    }
+  }
+  return updated;
+}

--- a/app/lib/tool/neat_task/pub_dev_tasks.dart
+++ b/app/lib/tool/neat_task/pub_dev_tasks.dart
@@ -8,6 +8,7 @@ import 'package:gcloud/service_scope.dart' as ss;
 import 'package:logging/logging.dart';
 import 'package:neat_periodic_task/neat_periodic_task.dart';
 import 'package:pub_dev/tool/backfill/backfill_new_buckets.dart';
+import 'package:pub_dev/tool/maintenance/update_public_bucket.dart';
 
 import '../../account/backend.dart';
 import '../../account/consent_backend.dart';
@@ -70,6 +71,14 @@ void _setupGenericPeriodicTasks() {
     name: 'update-package-versions',
     isRuntimeVersioned: false,
     task: () async => await packageBackend.updateAllPackageVersions(),
+  );
+
+  // Updates the public archive bucket from the canonical bucket, for the
+  // unlikely case where an archive may be missing.
+  _daily(
+    name: 'update-public-archive-bucket',
+    isRuntimeVersioned: false,
+    task: updatePublicArchiveBucket,
   );
 
   // Deletes task status entities where the status hasn't been updated

--- a/app/test/tool/backfill/backfill_new_buckets_test.dart
+++ b/app/test/tool/backfill/backfill_new_buckets_test.dart
@@ -12,20 +12,23 @@ import '../../shared/test_services.dart';
 void main() {
   group('backfillNewArchiveBuckets', () {
     testWithProfile('no update', fn: () async {
-      final counts1 = await backfillNewArchiveBuckets();
-      expect(counts1, {
+      final counts = await backfillNewArchiveBuckets();
+      expect(counts, {
         'canonical-checked': 6,
         'canonical-unchanged': 6,
         'public-checked': 6,
         'public-unchanged': 6,
       });
+    });
 
+    testWithProfile('single update', fn: () async {
+      await backfillNewArchiveBuckets();
       final bucket =
           storageService.bucket(activeConfiguration.publicPackagesBucketName!);
       await bucket.delete('packages/oxygen-1.0.0.tar.gz');
 
-      final counts2 = await backfillNewArchiveBuckets();
-      expect(counts2, {
+      final counts = await backfillNewArchiveBuckets();
+      expect(counts, {
         'canonical-checked': 6,
         'canonical-unchanged': 6,
         'public-checked': 6,

--- a/app/test/tool/backfill/backfill_new_buckets_test.dart
+++ b/app/test/tool/backfill/backfill_new_buckets_test.dart
@@ -15,9 +15,9 @@ void main() {
       final counts1 = await backfillNewArchiveBuckets();
       expect(counts1, {
         'canonical-checked': 6,
-        'canonical-copied': 6,
+        'canonical-unchanged': 6,
         'public-checked': 6,
-        'public-copied': 6,
+        'public-unchanged': 6,
       });
 
       final bucket =

--- a/app/test/tool/maintenance/update_public_bucket_test.dart
+++ b/app/test/tool/maintenance/update_public_bucket_test.dart
@@ -1,0 +1,28 @@
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:gcloud/storage.dart';
+import 'package:pub_dev/shared/configuration.dart';
+import 'package:pub_dev/tool/maintenance/update_public_bucket.dart';
+import 'package:test/test.dart';
+
+import '../../shared/test_services.dart';
+
+void main() {
+  group('update public bucket', () {
+    testWithProfile('no update', fn: () async {
+      final updated = await updatePublicArchiveBucket();
+      expect(updated, 0);
+    });
+
+    testWithProfile('missing file', fn: () async {
+      final bucket =
+          storageService.bucket(activeConfiguration.publicPackagesBucketName!);
+      await bucket.delete('packages/oxygen-1.0.0.tar.gz');
+
+      final updated = await updatePublicArchiveBucket();
+      expect(updated, 1);
+    });
+  });
+}


### PR DESCRIPTION
- #5586
- The upload practically happens as part of the transaction callback, because if there is any issue with the storage buckets, the transaction won't get committed, and the failure state is still acceptable without further changes of other code paths.
- Kept the same objectname pattern (`packages/<package>-<version>.tar.gz`).
- When there is a canonical archive binary, and attempt to update it with the same content is not blocked (e.g. repeating a failed transaction), but different archive is not accepted.
- Integrity verification will check for the object's metadata in each bucket, but won't do a byte-to-byte comparison yet. 