### PR TITLE
Block uploader APIs used by pub client tool.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ AppEngine version, listed here to ease deployment and troubleshooting.
  * Upgraded stable Flutter analysis SDK to `3.0.2`.
  * Upgraded preview Dart analysis SDK to `2.18.0-165.1.beta`.
  * NOTE: Updated integrity checks before finalizing migration of `Package.isBlocked`.
+ * NOTE: Blocking uploader API endpoints used by `pub` client tool.
 
 ## `20220608t083800-all`
  * Bumped runtimeVersion to `2022.06.02`.

--- a/app/lib/frontend/handlers/pubapi.dart
+++ b/app/lib/frontend/handlers/pubapi.dart
@@ -10,7 +10,6 @@ import 'package:api_builder/api_builder.dart';
 import 'package:shelf/shelf.dart';
 import 'package:shelf_router/shelf_router.dart';
 
-import '../../account/auth_provider.dart';
 import '../../account/consent_backend.dart';
 import '../../admin/backend.dart';
 import '../../package/backend.dart' hide InviteStatus;
@@ -140,14 +139,8 @@ class PubApi {
   ///     [400 Client Error]
   @EndPoint.post('/api/packages/<package>/uploaders')
   Future<SuccessMessage> addUploader(Request request, String package) async {
-    String? email;
-    try {
-      final body = await request.readAsString();
-      final params = Uri.splitQueryString(body);
-      email = params['email'];
-    } on FormatException catch (_) {}
-    InvalidInputException.checkNotNull(email, 'email');
-    return await packageBackend.addUploader(package, email!);
+    throw NotAcceptableException.pubToolUploaderNotSupported(
+        adminPageUrl: urls.pkgAdminUrl(package, includeHost: true));
   }
 
   /// Removing an existing uploader.
@@ -163,9 +156,10 @@ class PubApi {
     Request request,
     String package,
     String email,
-  ) async =>
-      await packageBackend.removeUploader(package, email,
-          authSource: AuthSource.client);
+  ) async {
+    throw NotAcceptableException.pubToolUploaderNotSupported(
+        adminPageUrl: urls.pkgAdminUrl(package, includeHost: true));
+  }
 
   /// Remove an existing uploader.
   ///
@@ -177,8 +171,7 @@ class PubApi {
     String package,
     RemoveUploaderRequest payload,
   ) async =>
-      await packageBackend.removeUploader(package, payload.email,
-          authSource: AuthSource.website);
+      await packageBackend.removeUploader(package, payload.email);
 
   /// Returns a uploader's invitation status in a JSON form.
   @EndPoint.post('/api/packages/<package>/invite-uploader')

--- a/app/lib/frontend/handlers/pubapi.dart
+++ b/app/lib/frontend/handlers/pubapi.dart
@@ -139,7 +139,7 @@ class PubApi {
   ///     [400 Client Error]
   @EndPoint.post('/api/packages/<package>/uploaders')
   Future<SuccessMessage> addUploader(Request request, String package) async {
-    throw NotAcceptableException.pubToolUploaderNotSupported(
+    throw OperationForbiddenException.pubToolUploaderNotSupported(
         adminPageUrl: urls.pkgAdminUrl(package, includeHost: true));
   }
 
@@ -157,7 +157,7 @@ class PubApi {
     String package,
     String email,
   ) async {
-    throw NotAcceptableException.pubToolUploaderNotSupported(
+    throw OperationForbiddenException.pubToolUploaderNotSupported(
         adminPageUrl: urls.pkgAdminUrl(package, includeHost: true));
   }
 

--- a/app/lib/shared/exceptions.dart
+++ b/app/lib/shared/exceptions.dart
@@ -36,16 +36,6 @@ class NotFoundException extends ResponseException {
 class NotAcceptableException extends ResponseException {
   NotAcceptableException(String message)
       : super._(406, 'NotAcceptable', message);
-
-  /// Thrown on API calls from the `pub` client using `uploaders add` or `uploaders remove`.
-  factory NotAcceptableException.pubToolUploaderNotSupported({
-    required String adminPageUrl,
-  }) {
-    return NotAcceptableException(
-        'pub.dev site no longer supports adding/removing uploaders through the `pub` tool.\n'
-        'Use the package admin page to manage uploaders:\n'
-        '$adminPageUrl');
-  }
 }
 
 /// Thrown when request input is invalid, bad payload, wrong querystring, etc.
@@ -305,6 +295,17 @@ class OperationForbiddenException extends ResponseException {
   OperationForbiddenException.lastUploaderRemoveError()
       : super._(403, 'OperationForbidden',
             'Cannot remove last uploader of a package.');
+
+  /// Thrown on API calls from the `pub` client using `uploaders add` or `uploaders remove`.
+  OperationForbiddenException.pubToolUploaderNotSupported({
+    required String adminPageUrl,
+  }) : super._(
+          403,
+          'OperationForbidden',
+          'pub.dev site no longer supports adding/removing uploaders through the `pub` tool.\n'
+              'Use the package admin page to manage uploaders:\n'
+              '$adminPageUrl',
+        );
 }
 
 /// Thrown when authentication failed, credentials is missing or invalid.

--- a/app/lib/shared/exceptions.dart
+++ b/app/lib/shared/exceptions.dart
@@ -36,6 +36,16 @@ class NotFoundException extends ResponseException {
 class NotAcceptableException extends ResponseException {
   NotAcceptableException(String message)
       : super._(406, 'NotAcceptable', message);
+
+  /// Thrown on API calls from the `pub` client using `uploaders add` or `uploaders remove`.
+  factory NotAcceptableException.pubToolUploaderNotSupported({
+    required String adminPageUrl,
+  }) {
+    return NotAcceptableException(
+        'pub.dev site no longer supports adding/removing uploaders through the `pub` tool.\n'
+        'Use the package admin page to manage uploaders:\n'
+        '$adminPageUrl');
+  }
 }
 
 /// Thrown when request input is invalid, bad payload, wrong querystring, etc.
@@ -283,15 +293,6 @@ class OperationForbiddenException extends ResponseException {
             'OperationForbidden',
             'Previous invite is still active, next notification can be sent '
                 'on ${nextNotification.toIso8601String()}.');
-
-  /// The uploader has been invited, but the operation can't complete until they
-  /// accept it.
-  OperationForbiddenException.uploaderInviteSent(String email)
-      : super._(
-            403,
-            'OperationForbidden',
-            "We've sent an invitation email to $email.\n"
-                "They'll be added as an uploader after they accept the invitation.");
 
   /// The user tried to remove themselves from the list of uploaders and we
   /// don't allow that.

--- a/app/lib/shared/urls.dart
+++ b/app/lib/shared/urls.dart
@@ -122,8 +122,16 @@ String pkgVersionsUrl(String package) =>
 String pkgScoreUrl(String package, {String? version}) =>
     pkgPageUrl(package, version: version, pkgPageTab: PkgPageTab.score);
 
-String pkgAdminUrl(String package) =>
-    pkgPageUrl(package, pkgPageTab: PkgPageTab.admin);
+String pkgAdminUrl(
+  String package, {
+  bool? includeHost,
+}) =>
+    pkgPageUrl(
+      package,
+      pkgPageTab: PkgPageTab.admin,
+      includeHost: includeHost ?? false,
+    );
+
 String pkgActivityLogUrl(String package) =>
     pkgPageUrl(package, pkgPageTab: PkgPageTab.activityLog);
 

--- a/app/test/package/backend_test.dart
+++ b/app/test/package/backend_test.dart
@@ -131,8 +131,8 @@ void main() {
           final rs = client.addUploader('oxygen');
           await expectApiException(
             rs,
-            status: 406,
-            code: 'NotAcceptable',
+            status: 403,
+            code: 'OperationForbidden',
             message: 'https://pub.dev/packages/oxygen/admin',
           );
         });
@@ -143,8 +143,8 @@ void main() {
           final rs = client.removeUploader('oxygen', 'admin@pub.dev');
           await expectApiException(
             rs,
-            status: 406,
-            code: 'NotAcceptable',
+            status: 403,
+            code: 'OperationForbidden',
             message: 'https://pub.dev/packages/oxygen/admin',
           );
         });


### PR DESCRIPTION
- #5827
- I'm not sure if `NotAcceptableException` is the best choice here, maybe `OperationForbiddenException` could be used instead.
