### PR TITLE
Backfill new buckets with archive files.

### DIFF
--- a/app/lib/shared/storage.dart
+++ b/app/lib/shared/storage.dart
@@ -18,7 +18,13 @@ import 'package:pub_dev/shared/env_config.dart';
 import 'package:retry/retry.dart';
 
 import 'configuration.dart';
-import 'utils.dart' show contentType, jsonUtf8Encoder, retryAsync, DeleteCounts;
+import 'utils.dart'
+    show
+        contentType,
+        jsonUtf8Encoder,
+        retryAsync,
+        ByteArrayEqualsExt,
+        DeleteCounts;
 import 'versions.dart' as versions;
 
 final _gzip = GZipCodec();
@@ -335,5 +341,23 @@ class VersionedJsonStorage {
   void close() {
     _oldGcTimer?.cancel();
     _oldGcTimer = null;
+  }
+}
+
+extension ObjectInfoExt on ObjectInfo {
+  bool hasSameSignatureAs(ObjectInfo? other) {
+    if (other == null) {
+      return false;
+    }
+    if (length != other.length) {
+      return false;
+    }
+    if (crc32CChecksum != other.crc32CChecksum) {
+      return false;
+    }
+    if (!md5Hash.byteToByteEquals(other.md5Hash)) {
+      return false;
+    }
+    return true;
   }
 }

--- a/app/lib/shared/utils.dart
+++ b/app/lib/shared/utils.dart
@@ -382,3 +382,21 @@ class DeleteCounts {
   @override
   String toString() => '$deleted/$found';
 }
+
+extension ByteArrayEqualsExt on List<int> {
+  /// Returns `true` only if the two arrays are identical.
+  bool byteToByteEquals(List<int>? other) {
+    if (other == null) {
+      return false;
+    }
+    if (length != other.length) {
+      return false;
+    }
+    for (var i = 0; i < length; i++) {
+      if (this[i] != other[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/app/lib/tool/backfill/backfill_new_buckets.dart
+++ b/app/lib/tool/backfill/backfill_new_buckets.dart
@@ -1,0 +1,65 @@
+// Copyright (c) 2021, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:gcloud/storage.dart';
+import 'package:logging/logging.dart';
+import 'package:pub_dev/package/backend.dart';
+import 'package:pub_dev/shared/configuration.dart';
+import '../../package/models.dart';
+import '../../shared/datastore.dart';
+import '../../shared/storage.dart';
+
+final _logger = Logger('backfill_new_buckets');
+
+/// Backfills the new package archive buckets:
+/// - canonical package archives
+/// - public package archives
+///
+/// Returns the statistics of the backfill.
+Future<Map<String, int>> backfillNewArchiveBuckets() async {
+  _logger.info('Starting archive bucket backfill.');
+  final oldBucket =
+      storageService.bucket(activeConfiguration.packageBucketName!);
+  final canonicalBucket =
+      storageService.bucket(activeConfiguration.canonicalPackagesBucketName!);
+  final publicBucket =
+      storageService.bucket(activeConfiguration.publicPackagesBucketName!);
+
+  final counts = <String, int>{};
+  void increment(String key) {
+    counts[key] = (counts[key] ?? 0) + 1;
+  }
+
+  await for (final pv in dbService.query<PackageVersion>().run()) {
+    // ignore: invalid_use_of_visible_for_testing_member
+    final objectName = tarballObjectName(pv.package, pv.version!);
+    final oldInfo = await oldBucket.info(objectName);
+
+    Future<void> backfill(String label, Bucket bucket) async {
+      final info = await bucket.tryInfo(objectName);
+      increment('$label-checked');
+      if (info == null) {
+        await storageService.copyObject(
+          oldBucket.absoluteObjectName(objectName),
+          bucket.absoluteObjectName(objectName),
+        );
+        increment('$label-copied');
+      } else {
+        if (!info.hasSameSignatureAs(oldInfo)) {
+          increment('$label-invalid');
+          _logger.severe(
+              '${pv.qualifiedVersionKey} has different archive in $label bucket.');
+        } else {
+          increment('$label-unchanged');
+        }
+      }
+    }
+
+    await backfill('canonical', canonicalBucket);
+    await backfill('public', publicBucket);
+  }
+
+  _logger.info('Archive bucket backfill completed. Status: $counts');
+  return counts;
+}

--- a/app/lib/tool/neat_task/pub_dev_tasks.dart
+++ b/app/lib/tool/neat_task/pub_dev_tasks.dart
@@ -7,6 +7,7 @@ import 'dart:io';
 import 'package:gcloud/service_scope.dart' as ss;
 import 'package:logging/logging.dart';
 import 'package:neat_periodic_task/neat_periodic_task.dart';
+import 'package:pub_dev/tool/backfill/backfill_new_buckets.dart';
 
 import '../../account/backend.dart';
 import '../../account/consent_backend.dart';
@@ -28,6 +29,13 @@ final _logger = Logger('pub_dev_tasks');
 
 /// Periodic task that are not tied to a specific service.
 void _setupGenericPeriodicTasks() {
+  // Backfills package archives into new buckets.
+  _daily(
+    name: 'backfill-new-archive-buckets',
+    isRuntimeVersioned: true,
+    task: backfillNewArchiveBuckets,
+  );
+
   // Backfills the fields that are new to the current release.
   _daily(
     name: 'backfill-new-fields',

--- a/app/test/tool/backfill/backfill_new_buckets_test.dart
+++ b/app/test/tool/backfill/backfill_new_buckets_test.dart
@@ -1,0 +1,54 @@
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:gcloud/storage.dart';
+import 'package:pub_dev/shared/configuration.dart';
+import 'package:pub_dev/tool/backfill/backfill_new_buckets.dart';
+import 'package:test/test.dart';
+
+import '../../shared/test_services.dart';
+
+void main() {
+  group('backfillNewArchiveBuckets', () {
+    testWithProfile('no update', fn: () async {
+      final counts1 = await backfillNewArchiveBuckets();
+      expect(counts1, {
+        'canonical-checked': 6,
+        'canonical-copied': 6,
+        'public-checked': 6,
+        'public-copied': 6,
+      });
+
+      final bucket =
+          storageService.bucket(activeConfiguration.publicPackagesBucketName!);
+      await bucket.delete('packages/oxygen-1.0.0.tar.gz');
+
+      final counts2 = await backfillNewArchiveBuckets();
+      expect(counts2, {
+        'canonical-checked': 6,
+        'canonical-unchanged': 6,
+        'public-checked': 6,
+        'public-unchanged': 5,
+        'public-copied': 1
+      });
+    });
+
+    testWithProfile('invalid archive', fn: () async {
+      await backfillNewArchiveBuckets();
+
+      final bucket =
+          storageService.bucket(activeConfiguration.publicPackagesBucketName!);
+      await bucket.writeBytes('packages/oxygen-1.0.0.tar.gz', <int>[0, 1]);
+
+      final counts = await backfillNewArchiveBuckets();
+      expect(counts, {
+        'canonical-checked': 6,
+        'canonical-unchanged': 6,
+        'public-checked': 6,
+        'public-unchanged': 5,
+        'public-invalid': 1
+      });
+    });
+  });
+}


### PR DESCRIPTION
- #5586
- Related to #5836, using the same helper methods to compare `ObjectInfo` values.
- Backfill reports the number of checks, copied objects, identical objects (only headers are checked) and invalid matches.
- Tests need to be updated to match changes in #5836, the merge order doesn't matter much.