### PR TITLE
Fix missing space in package header.

### DIFF
--- a/app/lib/frontend/templates/views/pkg/header.dart
+++ b/app/lib/frontend/templates/views/pkg/header.dart
@@ -18,6 +18,7 @@ d.Node packageHeaderNode({
   return d.fragment([
     d.text('Published '),
     d.span(child: d.xAgoTimestamp(published)),
+    d.text(' '),
     if (publisherId != null) ..._publisher(publisherId),
     if (isNullSafe) nullSafeBadgeNode(),
     if (releases != null) ..._releases(packageName, releases),


### PR DESCRIPTION
It is required between the "X ago" label and the next one with a bullet, e.g. the publisher badge.