### PR TITLE
Verify JWT signatures with OpenSSL CLI wrapper.

### DIFF
--- a/app/lib/service/openid/openssl_commands.dart
+++ b/app/lib/service/openid/openssl_commands.dart
@@ -3,108 +3,11 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:io';
-import 'dart:typed_data';
 
-import 'package:meta/meta.dart';
 import 'package:pana/pana.dart';
 import 'package:path/path.dart' as p;
 import 'package:pem/pem.dart';
 import 'package:pub_dev/shared/utils.dart';
-
-/// Randomly generated private and public RSA keypair.
-@visibleForTesting
-class RsaKeyPair {
-  final Uint8List privateKey;
-  final Uint8List publicKey;
-
-  RsaKeyPair(this.privateKey, this.publicKey);
-}
-
-/// Generates a new RSA keypair using `openssl`.
-@visibleForTesting
-Future<RsaKeyPair> generateRsaKeyPair({
-  int keySize = 2048,
-}) async {
-  return withTempDirectory((dir) async {
-    final privateKeyPath = p.join(dir.path, 'private.pem');
-    final publicKeyPath = p.join(dir.path, 'public.pem');
-    final pr1 = await runProc(
-      [
-        'openssl',
-        'genrsa',
-        '-out',
-        privateKeyPath,
-        '$keySize',
-      ],
-      timeout: Duration(seconds: 10),
-    );
-    if (pr1.exitCode != 0) {
-      throw Exception('Unable to run openssl:\n${pr1.asJoinedOutput}');
-    }
-    final privateContent = await File(privateKeyPath).readAsString();
-    final privateKeyBytes = decodePemBlocks(PemLabel.privateKey,
-            privateContent.replaceAll(' RSA PRIVATE KEY', ' PRIVATE KEY'))
-        .single;
-
-    final pr2 = await runProc(
-      [
-        'openssl',
-        'rsa',
-        '-in',
-        privateKeyPath,
-        '-pubout',
-        '-out',
-        publicKeyPath,
-      ],
-      timeout: Duration(seconds: 10),
-    );
-    if (pr2.exitCode != 0) {
-      throw Exception('Unable to run openssl:\n${pr1.asJoinedOutput}');
-    }
-    final publicContent = await File(publicKeyPath).readAsString();
-    final publicKeyBytes =
-        decodePemBlocks(PemLabel.publicKey, publicContent).single;
-    return RsaKeyPair(
-      Uint8List.fromList(privateKeyBytes),
-      Uint8List.fromList(publicKeyBytes),
-    );
-  });
-}
-
-/// Signs [input] text with the private RSA key and returns the signature bytes.
-@visibleForTesting
-Future<Uint8List> signTextWithRsa({
-  required String input,
-  required List<int> privateKey,
-}) async {
-  return await withTempDirectory((dir) async {
-    final outputFile = File(p.join(dir.path, 'output.sign'));
-    final inputFile = File(p.join(dir.path, 'input.txt'));
-    await inputFile.writeAsString(input);
-    final privateKeyFile = File(p.join(dir.path, 'private.pem'));
-    await privateKeyFile.writeAsString(
-        encodePemBlock(PemLabel.privateKey, privateKey)
-            .replaceAll(' PRIVATE KEY', ' RSA PRIVATE KEY'));
-    final pr = await runProc(
-      [
-        'openssl',
-        'dgst',
-        '-sha256',
-        '-binary',
-        '-sign',
-        privateKeyFile.path,
-        '-out',
-        outputFile.path,
-        inputFile.path,
-      ],
-      timeout: Duration(seconds: 10),
-    );
-    if (pr.exitCode != 0) {
-      throw Exception('Unable to run openssl:\n${pr.asJoinedOutput}');
-    }
-    return await outputFile.readAsBytes();
-  });
-}
 
 /// Verifies if [signature] is valid for [input], using the RSA public key.
 ///

--- a/app/lib/service/openid/openssl_commands.dart
+++ b/app/lib/service/openid/openssl_commands.dart
@@ -107,6 +107,11 @@ Future<Uint8List> signTextWithRsa({
 }
 
 /// Verifies if [signature] is valid for [input], using the RSA public key.
+///
+/// The [publicKey] is expected to be in DER-encoded ASN.1 binary format, following
+/// - https://datatracker.ietf.org/doc/html/rfc3447#appendix-A
+/// - https://datatracker.ietf.org/doc/html/rfc7468#section-4
+/// - https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.7
 Future<bool> verifyTextWithRsaSignature({
   required String input,
   required List<int> signature,

--- a/app/lib/service/openid/openssl_commands.dart
+++ b/app/lib/service/openid/openssl_commands.dart
@@ -1,0 +1,145 @@
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:meta/meta.dart';
+import 'package:pana/pana.dart';
+import 'package:path/path.dart' as p;
+import 'package:pem/pem.dart';
+import 'package:pub_dev/shared/utils.dart';
+
+/// Randomly generated private and public RSA keypair.
+@visibleForTesting
+class RsaKeyPair {
+  final Uint8List privateKey;
+  final Uint8List publicKey;
+
+  RsaKeyPair(this.privateKey, this.publicKey);
+}
+
+/// Generates a new RSA keypair using `openssl`.
+@visibleForTesting
+Future<RsaKeyPair> generateRsaKeyPair({
+  int keySize = 2048,
+}) async {
+  return withTempDirectory((dir) async {
+    final privateKeyPath = p.join(dir.path, 'private.pem');
+    final publicKeyPath = p.join(dir.path, 'public.pem');
+    final pr1 = await runProc(
+      [
+        'openssl',
+        'genrsa',
+        '-out',
+        privateKeyPath,
+        '$keySize',
+      ],
+      timeout: Duration(seconds: 10),
+    );
+    if (pr1.exitCode != 0) {
+      throw Exception('Unable to run openssl:\n${pr1.asJoinedOutput}');
+    }
+    final privateContent = await File(privateKeyPath).readAsString();
+    final privateKeyBytes = decodePemBlocks(PemLabel.privateKey,
+            privateContent.replaceAll(' RSA PRIVATE KEY', ' PRIVATE KEY'))
+        .single;
+
+    final pr2 = await runProc(
+      [
+        'openssl',
+        'rsa',
+        '-in',
+        privateKeyPath,
+        '-pubout',
+        '-out',
+        publicKeyPath,
+      ],
+      timeout: Duration(seconds: 10),
+    );
+    if (pr2.exitCode != 0) {
+      throw Exception('Unable to run openssl:\n${pr1.asJoinedOutput}');
+    }
+    final publicContent = await File(publicKeyPath).readAsString();
+    final publicKeyBytes =
+        decodePemBlocks(PemLabel.publicKey, publicContent).single;
+    return RsaKeyPair(
+      Uint8List.fromList(privateKeyBytes),
+      Uint8List.fromList(publicKeyBytes),
+    );
+  });
+}
+
+/// Signs [input] text with the private RSA key and returns the signature bytes.
+@visibleForTesting
+Future<Uint8List> signTextWithRsa({
+  required String input,
+  required List<int> privateKey,
+}) async {
+  return await withTempDirectory((dir) async {
+    final outputFile = File(p.join(dir.path, 'output.sign'));
+    final inputFile = File(p.join(dir.path, 'input.txt'));
+    await inputFile.writeAsString(input);
+    final privateKeyFile = File(p.join(dir.path, 'private.pem'));
+    await privateKeyFile.writeAsString(
+        encodePemBlock(PemLabel.privateKey, privateKey)
+            .replaceAll(' PRIVATE KEY', ' RSA PRIVATE KEY'));
+    final pr = await runProc(
+      [
+        'openssl',
+        'dgst',
+        '-sha256',
+        '-binary',
+        '-sign',
+        privateKeyFile.path,
+        '-out',
+        outputFile.path,
+        inputFile.path,
+      ],
+      timeout: Duration(seconds: 10),
+    );
+    if (pr.exitCode != 0) {
+      throw Exception('Unable to run openssl:\n${pr.asJoinedOutput}');
+    }
+    return await outputFile.readAsBytes();
+  });
+}
+
+/// Verifies if [signature] is valid for [input], using the RSA public key.
+Future<bool> verifyTextWithRsaSignature({
+  required String input,
+  required List<int> signature,
+  required List<int> publicKey,
+}) async {
+  return await withTempDirectory((dir) async {
+    final inputFile = File(p.join(dir.path, 'input.txt'));
+    await inputFile.writeAsString(input);
+    final signatureFile = File(p.join(dir.path, 'input.sign'));
+    await signatureFile.writeAsBytes(signature);
+    final publicKeyFile = File(p.join(dir.path, 'public.pem'));
+    final publicPemContent = encodePemBlock(PemLabel.publicKey, publicKey);
+    await publicKeyFile.writeAsString(publicPemContent);
+    final pr = await runProc(
+      [
+        'openssl',
+        'dgst',
+        '-sha256',
+        '-verify',
+        publicKeyFile.path,
+        '-signature',
+        signatureFile.path,
+        inputFile.path,
+      ],
+      timeout: Duration(seconds: 10),
+    );
+    final output = pr.stdout.toString().trim();
+    if (pr.exitCode != 0) {
+      if (output == 'Verification Failure') {
+        return false;
+      }
+      throw Exception('Unable to run openssl:\n${pr.asJoinedOutput}');
+    }
+    return output == 'Verified OK';
+  });
+}

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -491,6 +491,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.11.1"
+  pem:
+    dependency: "direct main"
+    description:
+      name: pem
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.1"
   petitparser:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -33,6 +33,7 @@ dependencies:
   neat_cache: ^2.0.1
   neat_periodic_task: ^2.0.0
   path: '^1.8.0'
+  pem: ^2.0.1
   pool: '^1.5.0'
   pub_dartdoc_data:
     path: ../pkg/pub_dartdoc_data

--- a/app/test/service/openid/jwt_test.dart
+++ b/app/test/service/openid/jwt_test.dart
@@ -2,10 +2,35 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:pem/pem.dart';
 import 'package:pub_dev/service/openid/jwt.dart';
+import 'package:pub_dev/service/openid/openssl_commands.dart';
 import 'package:test/test.dart';
 
 void main() {
+  // token generated on jwt.io
+  final jwtIoToken =
+      'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIi'
+      'wibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyM'
+      'n0.NHVaYe26MbtOYhSKkoKYdFVomg4i8ZJd8_-RU8VNbftc4TSMb4bXP3l3YlNW'
+      'ACwyXPGffz5aXHc6lty1Y2t4SWRqGteragsVdZufDn5BlnJl9pdR_kdVFUsra2r'
+      'WKEofkZeIC4yWytE58sMIihvo9H1ScmmVwBcQP6XETqYd0aSHp1gOa9RdUPDvoX'
+      'Q5oqygTqVtxaDr6wUFKrKItgBMzWIdNZ6y7O9E0DhEPTbE9rfBo6KTFsHAZnMg4'
+      'k68CDp2woYIaXbmYTWcvbzIuHO7_37GT79XdIwkm95QJ7hYC9RiwrV7mesbY4PA'
+      'ahERJawntho0my942XheVLmGwLMBkQ';
+  // public key to verify the token
+  final jwtIoPublicKeyPem = [
+    '-----BEGIN PUBLIC KEY-----',
+    'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAu1SU1LfVLPHCozMxH2Mo',
+    '4lgOEePzNm0tRgeLezV6ffAt0gunVTLw7onLRnrq0/IzW7yWR7QkrmBL7jTKEn5u',
+    '+qKhbwKfBstIs+bMY2Zkp18gnTxKLxoS2tFczGkPLPgizskuemMghRniWaoLcyeh',
+    'kd3qqGElvW/VDL5AaWTg0nLVkjRo9z+40RQzuVaE8AkAFmxZzow3x+VJYKdjykkJ',
+    '0iT9wCS0DRTXu269V264Vf/3jvredZiKRkgwlL9xNAwxXFg0x/XFw005UWVRIkdg',
+    'cKWTjpBP2dPwVZ4WWC+9aGVd+Gyn1o0CLelf4rEjGoXbAAEgAqeGUxrcIlbjXfbc',
+    'mwIDAQAB',
+    '-----END PUBLIC KEY-----',
+  ].join('\n');
+
   group('JWT parse', () {
     test('invalid format', () {
       expect(JsonWebToken.tryParse(''), isNull);
@@ -13,17 +38,8 @@ void main() {
       expect(JsonWebToken.tryParse('ab.c1.23'), isNull);
     });
 
-    test('successful', () {
-      // token generated on jwt.io
-      final parsed = JsonWebToken.parse(
-          'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIi'
-          'wibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyM'
-          'n0.NHVaYe26MbtOYhSKkoKYdFVomg4i8ZJd8_-RU8VNbftc4TSMb4bXP3l3YlNW'
-          'ACwyXPGffz5aXHc6lty1Y2t4SWRqGteragsVdZufDn5BlnJl9pdR_kdVFUsra2r'
-          'WKEofkZeIC4yWytE58sMIihvo9H1ScmmVwBcQP6XETqYd0aSHp1gOa9RdUPDvoX'
-          'Q5oqygTqVtxaDr6wUFKrKItgBMzWIdNZ6y7O9E0DhEPTbE9rfBo6KTFsHAZnMg4'
-          'k68CDp2woYIaXbmYTWcvbzIuHO7_37GT79XdIwkm95QJ7hYC9RiwrV7mesbY4PA'
-          'ahERJawntho0my942XheVLmGwLMBkQ');
+    test('parse successful', () {
+      final parsed = JsonWebToken.parse(jwtIoToken);
       expect(parsed.header, {
         'alg': 'RS256',
         'typ': 'JWT',
@@ -39,6 +55,18 @@ void main() {
       expect(parsed.iat!.year, 2018);
       expect(parsed.exp, isNull);
       expect(parsed.signature, hasLength(256));
+    });
+
+    test('verify signature', () async {
+      final headerAndPayloadEncoded = jwtIoToken.split('.').take(2).join('.');
+      final parsed = JsonWebToken.parse(jwtIoToken);
+      final isValid = await verifyTextWithRsaSignature(
+        input: headerAndPayloadEncoded,
+        signature: parsed.signature,
+        publicKey:
+            decodePemBlocks(PemLabel.publicKey, jwtIoPublicKeyPem).single,
+      );
+      expect(isValid, isTrue);
     });
   });
 }

--- a/app/test/service/openid/openssl_commands_test.dart
+++ b/app/test/service/openid/openssl_commands_test.dart
@@ -5,6 +5,8 @@
 import 'package:pub_dev/service/openid/openssl_commands.dart';
 import 'package:test/test.dart';
 
+import 'openssl_utils.dart';
+
 void main() {
   group('openssl commands', () {
     test('sign and verify', () async {

--- a/app/test/service/openid/openssl_commands_test.dart
+++ b/app/test/service/openid/openssl_commands_test.dart
@@ -1,0 +1,31 @@
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:pub_dev/service/openid/openssl_commands.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('openssl commands', () {
+    test('sign and verify', () async {
+      final inputText = 'inputText';
+      final pair = await generateRsaKeyPair();
+      final signature = await signTextWithRsa(
+        input: inputText,
+        privateKey: pair.privateKey,
+      );
+      final valid = await verifyTextWithRsaSignature(
+        input: inputText,
+        signature: signature,
+        publicKey: pair.publicKey,
+      );
+      expect(valid, isTrue);
+      final invalid = await verifyTextWithRsaSignature(
+        input: inputText,
+        signature: signature.map((e) => e ~/ 2).toList(),
+        publicKey: pair.publicKey,
+      );
+      expect(invalid, isFalse);
+    });
+  });
+}

--- a/app/test/service/openid/openssl_utils.dart
+++ b/app/test/service/openid/openssl_utils.dart
@@ -1,0 +1,105 @@
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// TODO: remove these utils when the features are implemented and these may not be used anymore.
+
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:pana/pana.dart';
+import 'package:path/path.dart' as p;
+import 'package:pem/pem.dart';
+import 'package:pub_dev/shared/utils.dart';
+
+/// Randomly generated private and public RSA keypair.
+class RsaKeyPair {
+  final Uint8List privateKey;
+  final Uint8List publicKey;
+
+  RsaKeyPair(this.privateKey, this.publicKey);
+}
+
+/// Generates a new RSA keypair using `openssl`.
+Future<RsaKeyPair> generateRsaKeyPair({
+  int keySize = 2048,
+}) async {
+  return withTempDirectory((dir) async {
+    final privateKeyPath = p.join(dir.path, 'private.pem');
+    final publicKeyPath = p.join(dir.path, 'public.pem');
+    final pr1 = await runProc(
+      [
+        'openssl',
+        'genrsa',
+        '-out',
+        privateKeyPath,
+        '$keySize',
+      ],
+      timeout: Duration(seconds: 10),
+    );
+    if (pr1.exitCode != 0) {
+      throw Exception('Unable to run openssl:\n${pr1.asJoinedOutput}');
+    }
+    final privateContent = await File(privateKeyPath).readAsString();
+    final privateKeyBytes = decodePemBlocks(PemLabel.privateKey,
+            privateContent.replaceAll(' RSA PRIVATE KEY', ' PRIVATE KEY'))
+        .single;
+
+    final pr2 = await runProc(
+      [
+        'openssl',
+        'rsa',
+        '-in',
+        privateKeyPath,
+        '-pubout',
+        '-out',
+        publicKeyPath,
+      ],
+      timeout: Duration(seconds: 10),
+    );
+    if (pr2.exitCode != 0) {
+      throw Exception('Unable to run openssl:\n${pr1.asJoinedOutput}');
+    }
+    final publicContent = await File(publicKeyPath).readAsString();
+    final publicKeyBytes =
+        decodePemBlocks(PemLabel.publicKey, publicContent).single;
+    return RsaKeyPair(
+      Uint8List.fromList(privateKeyBytes),
+      Uint8List.fromList(publicKeyBytes),
+    );
+  });
+}
+
+/// Signs [input] text with the private RSA key and returns the signature bytes.
+Future<Uint8List> signTextWithRsa({
+  required String input,
+  required List<int> privateKey,
+}) async {
+  return await withTempDirectory((dir) async {
+    final outputFile = File(p.join(dir.path, 'output.sign'));
+    final inputFile = File(p.join(dir.path, 'input.txt'));
+    await inputFile.writeAsString(input);
+    final privateKeyFile = File(p.join(dir.path, 'private.pem'));
+    await privateKeyFile.writeAsString(
+        encodePemBlock(PemLabel.privateKey, privateKey)
+            .replaceAll(' PRIVATE KEY', ' RSA PRIVATE KEY'));
+    final pr = await runProc(
+      [
+        'openssl',
+        'dgst',
+        '-sha256',
+        '-binary',
+        '-sign',
+        privateKeyFile.path,
+        '-out',
+        outputFile.path,
+        inputFile.path,
+      ],
+      timeout: Duration(seconds: 10),
+    );
+    if (pr.exitCode != 0) {
+      throw Exception('Unable to run openssl:\n${pr.asJoinedOutput}');
+    }
+    return await outputFile.readAsBytes();
+  });
+}


### PR DESCRIPTION
- #5769
- only RSA + SHA256 is used for now
- `package:pem` is used to emit PEM-formatted keys for `openssl` (there is a slight tweaking for `RSA PRIVATE KEY`, I'll create an update for `package:pem`)
- `openssl` key-gen and signing is also implemented, in order to create larger tests
