### PR TITLE
AuthenticatedAgent skeleton to prepare credential-less uploads.

### DIFF
--- a/app/lib/account/agent.dart
+++ b/app/lib/account/agent.dart
@@ -6,9 +6,14 @@ import 'package:pub_dev/shared/exceptions.dart';
 
 final _uuidRegExp =
     RegExp(r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$');
-final _knownAgents = {
-  'service:github-actions',
-};
+
+abstract class KnownAgents {
+  static const githubActions = 'service:github-actions';
+
+  static const _values = <String>{
+    githubActions,
+  };
+}
 
 /// Whether the [userId] is valid-looking,
 /// without namespace or other special value.
@@ -18,7 +23,7 @@ bool isValidUserId(String userId) {
 
 /// Whether the [agent] is a valid-looking identifier.
 bool isKnownServiceAgent(String agent) {
-  return _knownAgents.contains(agent);
+  return KnownAgents._values.contains(agent);
 }
 
 /// Whether the [agent] is a valid-looking actor.

--- a/app/lib/account/backend.dart
+++ b/app/lib/account/backend.dart
@@ -122,11 +122,16 @@ abstract class AuthenticatedAgent {
 /// Holds the authenticated Github Action information.
 class AuthenticatedGithubAction implements AuthenticatedAgent {
   final String label;
-  final JsonWebToken jwt;
+
+  /// OIDC `id_token` the request was authenticated with.
+  ///
+  /// The [agentId] of an [AuthenticatedAgent] have always been authenticated using the [idToken].
+  /// Hence, claims on the [idToken] may be used to determine authorization of a request.
+  final JsonWebToken idToken;
 
   AuthenticatedGithubAction({
     required this.label,
-    required this.jwt,
+    required this.idToken,
   });
 
   @override

--- a/app/lib/account/backend.dart
+++ b/app/lib/account/backend.dart
@@ -123,18 +123,28 @@ Future<User> requireAuthenticatedUser({AuthSource? source}) async {
 ///  * A GCP service account may authenticate using an OIDC `id_token`,
 ///  * A Github Action may authenticate using an OIDC `id_token`.
 abstract class AuthenticatedAgent {
-  /// The formatted identfier of the agent, which will be used in logs and audit records.
-  String get emailOrLabel;
-
   /// The unique identifier of the agent.
-  ///
   /// Must pass the [isValidUserIdOrServiceAgent] check.
+  ///
+  /// Examples:
+  ///  * For a regular user we use `User.userId`.
+  ///  * For automated publishing we use [KnownAgents] identifiers.
   String get agentId;
+
+  /// The formatted identfier of the agent, which may be publicly visible
+  /// in logs and audit records.
+  ///
+  /// Examples:
+  ///  * For a regular user we display their `email`.
+  ///  * For a service account we display a description.
+  ///  * For automated publishing we display the service and the origin trigger.
+  String get formattedId;
 }
 
 /// Holds the authenticated Github Action information.
 class AuthenticatedGithubAction implements AuthenticatedAgent {
-  final String label;
+  @override
+  final String formattedId;
 
   /// OIDC `id_token` the request was authenticated with.
   ///
@@ -147,15 +157,12 @@ class AuthenticatedGithubAction implements AuthenticatedAgent {
   final JsonWebToken idToken;
 
   AuthenticatedGithubAction({
-    required this.label,
+    required this.formattedId,
     required this.idToken,
   });
 
   @override
   String get agentId => KnownAgents.githubActions;
-
-  @override
-  String get emailOrLabel => label;
 }
 
 /// Holds the authenticated user information.
@@ -168,7 +175,7 @@ class AuthenticatedUser implements AuthenticatedAgent {
   String get agentId => user.userId;
 
   @override
-  String get emailOrLabel => user.email!;
+  String get formattedId => user.email!;
 }
 
 /// Verifies the current bearer token in the request scope and returns the

--- a/app/lib/audit/models.dart
+++ b/app/lib/audit/models.dart
@@ -212,7 +212,7 @@ class AuditLogRecord extends db.ExpandoModel<String> {
     final summary = [
       'Package `$package` version `$version`',
       if (publisherId != null) ' owned by publisher `$publisherId`',
-      ' was published by `${uploader.emailOrLabel}`.',
+      ' was published by `${uploader.formattedId}`.',
     ].join();
     return AuditLogRecord()
       ..id = createUuid()

--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -555,9 +555,12 @@ class PackageBackend {
     String? userId, {
     AuthenticatedAgent? agent,
   }) async {
-    if (agent != null) {
+    if (agent is AuthenticatedGithubAction) {
       // TODO: check if the JWT token matches the automated publishing settings on the package.
       return false;
+    }
+    if (agent is AuthenticatedUser) {
+      userId ??= agent.user.userId;
     }
     if (userId == null) {
       return false;

--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -550,7 +550,15 @@ class PackageBackend {
   /// publisher admin).
   ///
   /// Returns false if the user is not an admin.
-  Future<bool> isPackageAdmin(Package p, String? userId) async {
+  Future<bool> isPackageAdmin(
+    Package p,
+    String? userId, {
+    AuthenticatedAgent? agent,
+  }) async {
+    if (agent != null) {
+      // TODO: check if the JWT token matches the automated publishing settings on the package.
+      return false;
+    }
     if (userId == null) {
       return false;
     }
@@ -821,7 +829,7 @@ class PackageBackend {
     if (restriction == UploadRestrictionStatus.noUploads) {
       throw PackageRejectedException.uploadRestricted();
     }
-    final user = await requireAuthenticatedUser(source: AuthSource.client);
+    final agent = await requireAuthenticatedAgent(source: AuthSource.client);
     _logger.info('Finishing async upload (uuid: $guid)');
     _logger.info('Reading tarball from cloud storage.');
 
@@ -854,7 +862,10 @@ class PackageBackend {
       }
 
       final pubspec = Pubspec.fromYaml(archive.pubspecContent!);
-      await _verifyPackageName(name: pubspec.name, user: user);
+      await _verifyPackageName(
+        name: pubspec.name,
+        agent: agent,
+      );
 
       // Check if new packages are allowed to be uploaded.
       if (restriction == UploadRestrictionStatus.onlyUpdates &&
@@ -885,11 +896,12 @@ class PackageBackend {
       }
 
       sw.reset();
-      final entities = await _createUploadEntities(db, user, archive,
+      final entities = await _createUploadEntities(db, agent, archive,
           sha256Hash: sha256Hash);
       final version = await _performTarballUpload(
-        user: user,
         entities: entities,
+        agent: agent,
+        archive: archive,
         guid: guid,
         hasCanonicalArchiveObject: canonicalArchiveInfo != null,
       );
@@ -912,7 +924,7 @@ class PackageBackend {
   ///   not authorized to claim such package names.
   Future<void> _verifyPackageName({
     required String name,
-    required User user,
+    required AuthenticatedAgent agent,
   }) async {
     final conflictingName = await nameTracker.accept(name);
     if (conflictingName != null) {
@@ -937,9 +949,11 @@ class PackageBackend {
       }
 
       // reserved package names for the Dart team
-      if (matchesReservedPackageName(name) &&
-          !user.email!.endsWith('@google.com')) {
-        throw PackageRejectedException.nameReserved(name);
+      if (matchesReservedPackageName(name)) {
+        if (agent is! AuthenticatedUser ||
+            !agent.user.email!.endsWith('@google.com')) {
+          throw PackageRejectedException.nameReserved(name);
+        }
       }
     }
   }
@@ -966,8 +980,9 @@ class PackageBackend {
   }
 
   Future<PackageVersion> _performTarballUpload({
-    required User user,
     required _UploadEntities entities,
+    required AuthenticatedAgent agent,
+    required PackageSummary archive,
     required String guid,
     required bool hasCanonicalArchiveObject,
   }) async {
@@ -1002,11 +1017,18 @@ class PackageBackend {
       if (package == null) {
         _logger.info('New package uploaded. [new-package-uploaded]');
         package = Package.fromVersion(newVersion);
-      } else if (!await packageBackend.isPackageAdmin(package!, user.userId)) {
-        _logger.info('User ${user.userId} (${user.email}) is not an uploader '
-            'for package ${package!.name}, rolling transaction back.');
-        throw AuthorizationException.userCannotUploadNewVersion(
-            user.email!, package!.name!);
+      } else {
+        final isAdmin = await packageBackend.isPackageAdmin(
+          package!,
+          agent is AuthenticatedUser ? agent.user.userId : null,
+          agent: agent,
+        );
+        if (!isAdmin) {
+          _logger.info('User ${agent.agentId} (${agent.emailOrLabel}) '
+              'is not an uploader for package ${package!.name}, rolling transaction back.');
+          throw AuthorizationException.userCannotUploadNewVersion(
+              agent.emailOrLabel, package!.name!);
+        }
       }
 
       if (package!.isNotVisible) {
@@ -1057,7 +1079,7 @@ class PackageBackend {
         entities.packageVersionInfo,
         ...entities.assets,
         AuditLogRecord.packagePublished(
-          uploader: user,
+          uploader: agent,
           package: newVersion.package,
           version: newVersion.version!,
           created: newVersion.created!,
@@ -1085,7 +1107,7 @@ class PackageBackend {
       final email = emailSender.sendMessage(createPackageUploadedEmail(
         packageName: newVersion.package,
         packageVersion: newVersion.version!,
-        uploaderEmail: user.email!,
+        agentEmailOrLabel: agent.emailOrLabel,
         authorizedUploaders:
             uploaderEmails.map((email) => EmailAddress(null, email)).toList(),
       ));
@@ -1471,7 +1493,7 @@ class DerivedPackageVersionEntities {
 /// Creates entities from [archive] summary.
 Future<_UploadEntities> _createUploadEntities(
   DatastoreDB db,
-  User user,
+  AuthenticatedAgent agent,
   PackageSummary archive, {
   required List<int> sha256Hash,
 }) async {
@@ -1487,7 +1509,7 @@ Future<_UploadEntities> _createUploadEntities(
     ..created = clock.now().toUtc()
     ..pubspec = pubspec
     ..libraries = archive.libraries
-    ..uploader = user.userId
+    ..uploader = agent.agentId
     ..sha256 = sha256Hash
     ..isRetracted = false;
 

--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -1027,10 +1027,10 @@ class PackageBackend {
           agent: agent,
         );
         if (!isAdmin) {
-          _logger.info('User ${agent.agentId} (${agent.emailOrLabel}) '
+          _logger.info('User ${agent.agentId} (${agent.formattedId}) '
               'is not an uploader for package ${package!.name}, rolling transaction back.');
           throw AuthorizationException.userCannotUploadNewVersion(
-              agent.emailOrLabel, package!.name!);
+              agent.formattedId, package!.name!);
         }
       }
 
@@ -1110,7 +1110,7 @@ class PackageBackend {
       final email = emailSender.sendMessage(createPackageUploadedEmail(
         packageName: newVersion.package,
         packageVersion: newVersion.version!,
-        agentEmailOrLabel: agent.emailOrLabel,
+        formattedId: agent.formattedId,
         authorizedUploaders:
             uploaderEmails.map((email) => EmailAddress(null, email)).toList(),
       ));

--- a/app/lib/shared/email.dart
+++ b/app/lib/shared/email.dart
@@ -135,7 +135,7 @@ String reflowBodyText(String input, {int lineLength = 72}) {
 EmailMessage createPackageUploadedEmail({
   required String packageName,
   required String packageVersion,
-  required String agentEmailOrLabel,
+  required String formattedId,
   required List<EmailAddress> authorizedUploaders,
 }) {
   final url =
@@ -143,7 +143,7 @@ EmailMessage createPackageUploadedEmail({
   final subject = 'Package uploaded: $packageName $packageVersion';
   final bodyText = '''Dear package maintainer,  
 
-$agentEmailOrLabel has published a new version ($packageVersion) of the $packageName package to the Dart package site ($primaryHost).
+$formattedId has published a new version ($packageVersion) of the $packageName package to the Dart package site ($primaryHost).
 
 For details, go to $url
 

--- a/app/lib/shared/email.dart
+++ b/app/lib/shared/email.dart
@@ -135,7 +135,7 @@ String reflowBodyText(String input, {int lineLength = 72}) {
 EmailMessage createPackageUploadedEmail({
   required String packageName,
   required String packageVersion,
-  required String uploaderEmail,
+  required String agentEmailOrLabel,
   required List<EmailAddress> authorizedUploaders,
 }) {
   final url =
@@ -143,7 +143,7 @@ EmailMessage createPackageUploadedEmail({
   final subject = 'Package uploaded: $packageName $packageVersion';
   final bodyText = '''Dear package maintainer,  
 
-$uploaderEmail has published a new version ($packageVersion) of the $packageName package to the Dart package site ($primaryHost).
+$agentEmailOrLabel has published a new version ($packageVersion) of the $packageName package to the Dart package site ($primaryHost).
 
 For details, go to $url
 

--- a/app/test/shared/email_test.dart
+++ b/app/test/shared/email_test.dart
@@ -168,7 +168,7 @@ void main() {
       final message = createPackageUploadedEmail(
         packageName: 'pkg_foo',
         packageVersion: '1.0.0',
-        agentEmailOrLabel: 'uploader@example.com',
+        formattedId: 'uploader@example.com',
         authorizedUploaders: [
           EmailAddress('Joe', 'joe@example.com'),
           EmailAddress(null, 'uploader@example.com')

--- a/app/test/shared/email_test.dart
+++ b/app/test/shared/email_test.dart
@@ -168,7 +168,7 @@ void main() {
       final message = createPackageUploadedEmail(
         packageName: 'pkg_foo',
         packageVersion: '1.0.0',
-        uploaderEmail: 'uploader@example.com',
+        agentEmailOrLabel: 'uploader@example.com',
         authorizedUploaders: [
           EmailAddress('Joe', 'joe@example.com'),
           EmailAddress(null, 'uploader@example.com')


### PR DESCRIPTION
- #5769
- Publishing via JWT/service-agent is not yet enabled, and authorization returns `false` for it, but the PR prepares all the related code to handle either an authenticated `User` or an authenticated agent.
- `AuthenticatedAgent` is only a skeleton for now, will be updated once we connect the dots with JWT tokens from GitHub.
