### PR TITLE
Remove unused code from consent confirmation.

### DIFF
--- a/app/lib/account/consent_backend.dart
+++ b/app/lib/account/consent_backend.dart
@@ -305,8 +305,9 @@ class _PackageUploaderAction extends ConsentAction {
   @override
   Future<void> onAccept(Consent consent) async {
     final packageName = consent.args![0];
+    final fromUserId = consent.fromUserId!;
     final fromUserEmail =
-        (await accountBackend.getEmailOfUserId(consent.fromUserId!))!;
+        (await accountBackend.getEmailOfUserId(fromUserId))!;
     final currentUser = await requireAuthenticatedUser();
     if (currentUser.email != consent.email) {
       throw NotAcceptableException(
@@ -314,7 +315,7 @@ class _PackageUploaderAction extends ConsentAction {
     }
 
     await packageBackend.confirmUploader(
-        consent.fromUserId, fromUserEmail, packageName, currentUser);
+        fromUserId, fromUserEmail, packageName, currentUser);
   }
 
   @override

--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -1163,18 +1163,13 @@ class PackageBackend {
     );
   }
 
-  Future<void> confirmUploader(String? fromUserId, String fromUserEmail,
+  Future<void> confirmUploader(String fromUserId, String fromUserEmail,
       String packageName, User uploader) async {
-    if (fromUserId == null) {
-      final user =
-          await accountBackend.lookupOrCreateUserByEmail(fromUserEmail);
-      fromUserId = user.userId;
-    }
     await withRetryTransaction(db, (tx) async {
       final packageKey = db.emptyKey.append(Package, id: packageName);
       final package = (await tx.lookup([packageKey])).first as Package;
 
-      await _validatePackageUploader(packageName, package, fromUserId!);
+      await _validatePackageUploader(packageName, package, fromUserId);
       if (package.containsUploader(uploader.userId)) {
         // The requested uploaderEmail is already part of the uploaders.
         return;


### PR DESCRIPTION
As we have always forced the `consent.fromUserId` to non-null, the change is a no-op, removing unused code.