### PR TITLE
Reduce the use of lookupOrCreateUserByEmail in tests.

### DIFF
--- a/app/lib/account/backend.dart
+++ b/app/lib/account/backend.dart
@@ -8,6 +8,7 @@ import 'dart:convert';
 import 'package:clock/clock.dart';
 import 'package:gcloud/service_scope.dart' as ss;
 import 'package:logging/logging.dart';
+import 'package:meta/meta.dart';
 // ignore: import_of_legacy_library_into_null_safe
 import 'package:neat_cache/neat_cache.dart';
 import 'package:pub_dev/account/agent.dart';
@@ -174,6 +175,13 @@ class AccountBackend {
     email = email.toLowerCase();
     final query = _db.query<User>()..filter('email =', email);
     return await query.run().toList();
+  }
+
+  /// Returns the single `User` entity for the [email].
+  @visibleForTesting
+  Future<User> lookupUserByEmail(String email) async {
+    final users = await lookupUsersByEmail(email);
+    return users.single;
   }
 
   /// Returns the `User` entry for the [email] or creates a new one if it does

--- a/app/test/account/backend_test.dart
+++ b/app/test/account/backend_test.dart
@@ -26,8 +26,7 @@ void main() {
     });
 
     testWithProfile('Successful lookup', fn: () async {
-      final user =
-          await accountBackend.lookupOrCreateUserByEmail('user@pub.dev');
+      final user = await accountBackend.lookupUserByEmail('user@pub.dev');
       final email = await accountBackend.getEmailOfUserId(user.userId);
       expect(email, 'user@pub.dev');
       final u = await accountBackend.lookupUserById(user.userId);
@@ -40,10 +39,12 @@ void main() {
       final oldIds =
           await dbService.query<User>().run().map((u) => u.userId).toList();
 
-      final u =
-          await accountBackend.lookupOrCreateUserByEmail('new-user@pub.dev');
+      final u = await accountBackend.withBearerToken(
+        createFakeAuthTokenForEmail('new-user@pub.dev'),
+        () => requireAuthenticatedUser(),
+      );
       expect(u.userId, hasLength(36));
-      expect(u.oauthUserId, isNull);
+      expect(u.oauthUserId, isNotNull);
       expect(u.email, 'new-user@pub.dev');
 
       final ids =

--- a/app/test/admin/api_test.dart
+++ b/app/test/admin/api_test.dart
@@ -313,8 +313,7 @@ void main() {
     group('Delete user', () {
       setupTestsWithCallerAuthorizationIssues(
         (client) async {
-          final user =
-              await accountBackend.lookupOrCreateUserByEmail('user@pub.dev');
+          final user = await accountBackend.lookupUserByEmail('user@pub.dev');
           await client.adminRemoveUser(user.userId);
         },
         authSource: AuthSource.admin,
@@ -325,8 +324,7 @@ void main() {
         testProfile: defaultTestProfile.changeDefaultUser('user@pub.dev'),
         fn: () async {
           final client = createPubApiClient(authToken: siteAdminToken);
-          final user =
-              await accountBackend.lookupOrCreateUserByEmail('user@pub.dev');
+          final user = await accountBackend.lookupUserByEmail('user@pub.dev');
 
           final rs = await client.adminRemoveUser(user.userId);
           expect(utf8.decode(rs), '{"status":"OK"}');
@@ -351,8 +349,7 @@ void main() {
       testWithProfile('Likes are cleaned up on user deletion', fn: () async {
         final client = createPubApiClient(authToken: siteAdminToken);
 
-        final user =
-            await accountBackend.lookupOrCreateUserByEmail('user@pub.dev');
+        final user = await accountBackend.lookupUserByEmail('user@pub.dev');
         final userClient = createPubApiClient(authToken: userAtPubDevAuthToken);
         await userClient.likePackage('oxygen');
 

--- a/app/test/admin/api_tool_test.dart
+++ b/app/test/admin/api_tool_test.dart
@@ -61,10 +61,8 @@ void main() {
       });
 
       testWithProfile('merge two user ids', fn: () async {
-        final admin =
-            await accountBackend.lookupOrCreateUserByEmail('admin@pub.dev');
-        final user =
-            await accountBackend.lookupOrCreateUserByEmail('user@pub.dev');
+        final admin = await accountBackend.lookupUserByEmail('admin@pub.dev');
+        final user = await accountBackend.lookupUserByEmail('user@pub.dev');
         await withHttpPubApiClient(
           bearerToken: siteAdminToken,
           fn: (client) async {

--- a/app/test/package/backend_test.dart
+++ b/app/test/package/backend_test.dart
@@ -168,8 +168,7 @@ void main() {
       });
 
       testWithProfile('blocked user', fn: () async {
-        final user =
-            await accountBackend.lookupOrCreateUserByEmail('admin@pub.dev');
+        final user = await accountBackend.lookupUserByEmail('admin@pub.dev');
         await dbService.commit(inserts: [user..isBlocked = true]);
         await accountBackend.withBearerToken(adminAtPubDevAuthToken, () async {
           final rs = packageBackend.inviteUploader(
@@ -275,8 +274,7 @@ void main() {
       testWithProfile('cannot remove self', fn: () async {
         // adding extra uploader for the scope of this test
         final pkg = (await packageBackend.lookupPackage('oxygen'))!;
-        final user =
-            await accountBackend.lookupOrCreateUserByEmail('user@pub.dev');
+        final user = await accountBackend.lookupUserByEmail('user@pub.dev');
         pkg.addUploader(user.userId);
         await dbService.commit(inserts: [pkg]);
 
@@ -292,8 +290,7 @@ void main() {
       testWithProfile('successfull', fn: () async {
         // adding extra uploader for the scope of this test
         final pkg = (await packageBackend.lookupPackage('oxygen'))!;
-        final user =
-            await accountBackend.lookupOrCreateUserByEmail('user@pub.dev');
+        final user = await accountBackend.lookupUserByEmail('user@pub.dev');
         pkg.addUploader(user.userId);
         await dbService.commit(inserts: [pkg]);
 

--- a/app/test/package/upload_test.dart
+++ b/app/test/package/upload_test.dart
@@ -103,8 +103,7 @@ void main() {
 
       testWithProfile('successful new package', fn: () async {
         await accountBackend.withBearerToken(userClientToken, () async {
-          final user =
-              await accountBackend.lookupOrCreateUserByEmail('user@pub.dev');
+          final user = await accountBackend.lookupUserByEmail('user@pub.dev');
           final dateBeforeTest = clock.now().toUtc();
           final pubspecContent = generatePubspecYaml('new_package', '1.2.3');
           final bucket = storageService
@@ -198,8 +197,7 @@ void main() {
 
       testWithProfile('package under publisher', fn: () async {
         await accountBackend.withBearerToken(adminClientToken, () async {
-          final user =
-              await accountBackend.lookupOrCreateUserByEmail('admin@pub.dev');
+          final user = await accountBackend.lookupUserByEmail('admin@pub.dev');
           final dateBeforeTest = clock.now().toUtc();
           final pubspecContent = generatePubspecYaml('neon', '7.0.0');
           final bucket = storageService
@@ -284,8 +282,7 @@ void main() {
       });
 
       testWithProfile('user is blocked', fn: () async {
-        final user =
-            await accountBackend.lookupOrCreateUserByEmail('user@pub.dev');
+        final user = await accountBackend.lookupUserByEmail('user@pub.dev');
         await dbService.commit(inserts: [user..isBlocked = true]);
         await accountBackend.withBearerToken(userClientToken, () async {
           final tarball = await packageArchiveBytes(

--- a/app/test/publisher/api_test.dart
+++ b/app/test/publisher/api_test.dart
@@ -272,8 +272,10 @@ void main() {
       });
 
       testWithProfile('User is not admin', fn: () async {
-        final user =
-            await accountBackend.lookupOrCreateUserByEmail('other@pub.dev');
+        final user = await accountBackend.withBearerToken(
+          createFakeAuthTokenForEmail('other@pub.dev'),
+          () => requireAuthenticatedUser(),
+        );
         await dbService.commit(inserts: [
           publisherMember(user.userId, 'example.com', 'not-admin'),
         ]);
@@ -281,8 +283,10 @@ void main() {
       });
 
       testWithProfile('OK', fn: () async {
-        final user =
-            await accountBackend.lookupOrCreateUserByEmail('other@pub.dev');
+        final user = await accountBackend.withBearerToken(
+          createFakeAuthTokenForEmail('other@pub.dev'),
+          () => requireAuthenticatedUser(),
+        );
         await dbService.commit(inserts: [
           publisherMember(user.userId, 'example.com', 'admin'),
         ]);
@@ -304,8 +308,10 @@ void main() {
 
     group('Update all publisher detail', () {
       testWithProfile('OK', fn: () async {
-        final user =
-            await accountBackend.lookupOrCreateUserByEmail('other@pub.dev');
+        final user = await accountBackend.withBearerToken(
+          createFakeAuthTokenForEmail('other@pub.dev'),
+          () => requireAuthenticatedUser(),
+        );
         await dbService.commit(inserts: [
           publisherMember(user.userId, 'example.com', 'admin'),
         ]);
@@ -361,8 +367,10 @@ void main() {
       });
 
       testWithProfile('User is already a member', fn: () async {
-        final user =
-            await accountBackend.lookupOrCreateUserByEmail('other@pub.dev');
+        final user = await accountBackend.withBearerToken(
+          createFakeAuthTokenForEmail('other@pub.dev'),
+          () => requireAuthenticatedUser(),
+        );
         await dbService.commit(inserts: [
           publisherMember(
               user.userId, 'example.com', PublisherMemberRole.admin),
@@ -378,9 +386,11 @@ void main() {
 
       testWithProfile('Pending with Consent, sending new e-mail', fn: () async {
         final adminUser =
-            await accountBackend.lookupOrCreateUserByEmail('admin@pub.dev');
-        final otherUser =
-            await accountBackend.lookupOrCreateUserByEmail('other@pub.dev');
+            await accountBackend.lookupUserByEmail('admin@pub.dev');
+        final otherUser = await accountBackend.withBearerToken(
+          createFakeAuthTokenForEmail('other@pub.dev'),
+          () => requireAuthenticatedUser(),
+        );
         final consent = Consent.init(
           fromUserId: adminUser.userId,
           email: 'other@pub.dev',
@@ -413,8 +423,7 @@ void main() {
       });
 
       testWithProfile('Invite new account', fn: () async {
-        final user =
-            await accountBackend.lookupOrCreateUserByEmail('admin@pub.dev');
+        final user = await accountBackend.lookupUserByEmail('admin@pub.dev');
         final client = createPubApiClient(authToken: adminAtPubDevAuthToken);
         final rs = await client.invitePublisherMember(
             'example.com', InviteMemberRequest(email: 'newuser@example.com'));
@@ -436,8 +445,7 @@ void main() {
       });
 
       testWithProfile('Invite existing account', fn: () async {
-        final user =
-            await accountBackend.lookupOrCreateUserByEmail('admin@pub.dev');
+        final user = await accountBackend.lookupUserByEmail('admin@pub.dev');
         final client = createPubApiClient(authToken: adminAtPubDevAuthToken);
         final rs = await client.invitePublisherMember(
             'example.com', InviteMemberRequest(email: 'user@pub.dev'));
@@ -465,8 +473,7 @@ void main() {
       });
 
       testWithProfile('Accept invite with existing user', fn: () async {
-        final user =
-            await accountBackend.lookupOrCreateUserByEmail('user@pub.dev');
+        final user = await accountBackend.lookupUserByEmail('user@pub.dev');
         final client1 = createPubApiClient(authToken: adminAtPubDevAuthToken);
         await client1.invitePublisherMember(
             'example.com', InviteMemberRequest(email: 'user@pub.dev'));
@@ -513,8 +520,7 @@ void main() {
       });
 
       testWithProfile('Decline invite', fn: () async {
-        final user =
-            await accountBackend.lookupOrCreateUserByEmail('user@pub.dev');
+        final user = await accountBackend.lookupUserByEmail('user@pub.dev');
         final client1 = createPubApiClient(authToken: adminAtPubDevAuthToken);
         await client1.invitePublisherMember(
             'example.com', InviteMemberRequest(email: 'user@pub.dev'));
@@ -567,16 +573,14 @@ void main() {
     group('Get member detail', () {
       _testAdminAuthIssues(
         (client) async {
-          final user =
-              await accountBackend.lookupOrCreateUserByEmail('admin@pub.dev');
+          final user = await accountBackend.lookupUserByEmail('admin@pub.dev');
           return await client.publisherMemberInfo('example.com', user.userId);
         },
       );
 
       _testNoPublisher(
         (client) async {
-          final user =
-              await accountBackend.lookupOrCreateUserByEmail('admin@pub.dev');
+          final user = await accountBackend.lookupUserByEmail('admin@pub.dev');
           return await client.publisherMemberInfo('no-domain.net', user.userId);
         },
       );
@@ -588,8 +592,7 @@ void main() {
       });
 
       testWithProfile('OK', fn: () async {
-        final user =
-            await accountBackend.lookupOrCreateUserByEmail('admin@pub.dev');
+        final user = await accountBackend.lookupUserByEmail('admin@pub.dev');
         final client = createPubApiClient(authToken: adminAtPubDevAuthToken);
         final rs = await client.publisherMemberInfo('example.com', user.userId);
         expect(rs.toJson(), {
@@ -603,8 +606,7 @@ void main() {
     group('Update member detail', () {
       _testAdminAuthIssues(
         (client) async {
-          final user =
-              await accountBackend.lookupOrCreateUserByEmail('user@pub.dev');
+          final user = await accountBackend.lookupUserByEmail('user@pub.dev');
           return await client.updatePublisherMember(
             'example.com',
             user.userId,
@@ -615,8 +617,7 @@ void main() {
 
       _testNoPublisher(
         (client) async {
-          final user =
-              await accountBackend.lookupOrCreateUserByEmail('user@pub.dev');
+          final user = await accountBackend.lookupUserByEmail('user@pub.dev');
           return await client.updatePublisherMember(
             'no-domain.net',
             user.userId,
@@ -626,8 +627,7 @@ void main() {
       );
 
       testWithProfile('Modification of self is blocked', fn: () async {
-        final user =
-            await accountBackend.lookupOrCreateUserByEmail('admin@pub.dev');
+        final user = await accountBackend.lookupUserByEmail('admin@pub.dev');
         final client = createPubApiClient(authToken: adminAtPubDevAuthToken);
         final rs = client.updatePublisherMember(
             'example.com',
@@ -641,16 +641,17 @@ void main() {
       testWithProfile('Modification of unrelated user is blocked',
           fn: () async {
         final client = createPubApiClient(authToken: adminAtPubDevAuthToken);
-        final user =
-            await accountBackend.lookupOrCreateUserByEmail('user@pub.dev');
+        final user = await accountBackend.lookupUserByEmail('user@pub.dev');
         final rs = client.updatePublisherMember(
             'example.com', user.userId, UpdatePublisherMemberRequest());
         await expectApiException(rs, status: 404, code: 'NotFound');
       });
 
       testWithProfile('Role value is not allowed', fn: () async {
-        final user =
-            await accountBackend.lookupOrCreateUserByEmail('other@pub.dev');
+        final user = await accountBackend.withBearerToken(
+          createFakeAuthTokenForEmail('other@pub.dev'),
+          () => requireAuthenticatedUser(),
+        );
         await dbService.commit(inserts: [
           publisherMember(
               user.userId, 'example.com', PublisherMemberRole.admin),
@@ -666,8 +667,10 @@ void main() {
       });
 
       testWithProfile('OK', fn: () async {
-        final user =
-            await accountBackend.lookupOrCreateUserByEmail('other@pub.dev');
+        final user = await accountBackend.withBearerToken(
+          createFakeAuthTokenForEmail('other@pub.dev'),
+          () => requireAuthenticatedUser(),
+        );
         await dbService.commit(inserts: [
           publisherMember(user.userId, 'example.com', 'someotherrole'),
         ]);
@@ -693,32 +696,28 @@ void main() {
     group('Delete member', () {
       _testAdminAuthIssues(
         (client) async {
-          final user =
-              await accountBackend.lookupOrCreateUserByEmail('user@pub.dev');
+          final user = await accountBackend.lookupUserByEmail('user@pub.dev');
           return await client.removePublisherMember('example.com', user.userId);
         },
       );
 
       _testNoPublisher(
         (client) async {
-          final user =
-              await accountBackend.lookupOrCreateUserByEmail('user@pub.dev');
+          final user = await accountBackend.lookupUserByEmail('user@pub.dev');
           return await client.removePublisherMember(
               'no-domain.net', user.userId);
         },
       );
 
       testWithProfile('Modification of self is blocked', fn: () async {
-        final user =
-            await accountBackend.lookupOrCreateUserByEmail('admin@pub.dev');
+        final user = await accountBackend.lookupUserByEmail('admin@pub.dev');
         final client = createPubApiClient(authToken: adminAtPubDevAuthToken);
         final rs = client.removePublisherMember('example.com', user.userId);
         await expectApiException(rs, status: 409, code: 'RequestConflict');
       });
 
       testWithProfile('Remove of non-member is idempotent', fn: () async {
-        final user =
-            await accountBackend.lookupOrCreateUserByEmail('user@pub.dev');
+        final user = await accountBackend.lookupUserByEmail('user@pub.dev');
         final client = createPubApiClient(authToken: adminAtPubDevAuthToken);
         final rs =
             await client.removePublisherMember('example.com', user.userId);
@@ -726,8 +725,10 @@ void main() {
       });
 
       testWithProfile('OK', fn: () async {
-        final user =
-            await accountBackend.lookupOrCreateUserByEmail('other@pub.dev');
+        final user = await accountBackend.withBearerToken(
+          createFakeAuthTokenForEmail('other@pub.dev'),
+          () => requireAuthenticatedUser(),
+        );
         await dbService.commit(inserts: [
           publisherMember(
               user.userId, 'example.com', PublisherMemberRole.admin),
@@ -762,7 +763,7 @@ void _testAdminAuthIssues(Future Function(PubApiClient client) fn) {
   });
 
   testWithProfile('Active user is not an admin yet', fn: () async {
-    final user = await accountBackend.lookupOrCreateUserByEmail('user@pub.dev');
+    final user = await accountBackend.lookupUserByEmail('user@pub.dev');
     await dbService.commit(inserts: [
       publisherMember(user.userId, 'example.com', 'non-admin'),
     ]);

--- a/app/test/tool/maintenance/remove_orphaned_likes_test.dart
+++ b/app/test/tool/maintenance/remove_orphaned_likes_test.dart
@@ -47,8 +47,7 @@ void main() {
         await withHttpPubApiClient(
             bearerToken: userAtPubDevAuthToken,
             fn: (client) => client.likePackage('oxygen'));
-        final user =
-            await accountBackend.lookupOrCreateUserByEmail('user@pub.dev');
+        final user = await accountBackend.lookupUserByEmail('user@pub.dev');
         await dbService.commit(deletes: [user.key]);
         final counts =
             await removeOrphanedLikes(minAgeThreshold: Duration.zero);

--- a/app/test/tool/maintenance/update_package_likes_test.dart
+++ b/app/test/tool/maintenance/update_package_likes_test.dart
@@ -49,8 +49,7 @@ void main() {
 
     testWithProfile('extra like', fn: () async {
       final p1 = await packageBackend.lookupPackage('oxygen');
-      final user =
-          await accountBackend.lookupOrCreateUserByEmail('user@pub.dev');
+      final user = await accountBackend.lookupUserByEmail('user@pub.dev');
       await dbService.commit(inserts: [
         Like()
           ..parentKey = user.key


### PR DESCRIPTION
- Handles the issues in the failing tests of #5850.
- With this change, the only remaining `lookupOrCreateUserByEmail` will be the admin-api's uploader add feature, which we can migrate to use invites (it complicates the acceptance flow a bit, will be done separately).