### PR TITLE
Emphasize 'X ago' spans with CSS styles.

### DIFF
--- a/pkg/web_css/lib/src/_base.scss
+++ b/pkg/web_css/lib/src/_base.scss
@@ -397,9 +397,10 @@ pre {
 
 span.-x-ago {
   cursor: pointer;
+  text-decoration: underline dotted #ccc;
 
   &:hover {
-    text-decoration: underline dotted #ccc;
+    text-decoration: underline #aaa;
   }
 }
 


### PR DESCRIPTION
- as suggested in #5867:
- the dotted style is always present, on hovering we switch to a solid line, with slightly darker color