### PR TITLE
Minimal ASN.1 encoder for RSA public keys to DER-encoded bytes (used by PEM)

### DIFF
--- a/app/lib/service/openid/asn1_encoder.dart
+++ b/app/lib/service/openid/asn1_encoder.dart
@@ -64,6 +64,7 @@ List<int> encodeSequence(Iterable<List<int>> parts) {
   ];
 }
 
+/// A constant value that identifies the data structure as RSA public key.
 const _objectIdentifierRsa = <int>[
   0x06,
   0x09,
@@ -78,6 +79,7 @@ const _objectIdentifierRsa = <int>[
   0x01,
 ];
 
+/// A constant value used for `null` values.
 const _nullObject = <int>[0x05, 0x00];
 
 /// Encodes the RSA public key components.

--- a/app/lib/service/openid/asn1_encoder.dart
+++ b/app/lib/service/openid/asn1_encoder.dart
@@ -1,0 +1,100 @@
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// ASN.1 encoder utilities.
+///
+/// Some pointers and useful references:
+/// - https://pub.dev/packages/asn1lib
+/// - https://letsencrypt.org/docs/a-warm-welcome-to-asn1-and-der/
+/// - https://lapo.it/asn1js/
+
+import 'package:meta/meta.dart';
+
+/// Encodes the [length] as single-byte or multi-byte value.
+@visibleForTesting
+List<int> encodeLength(int length) {
+  if (length <= 127) {
+    return [length];
+  } else {
+    final bytesReversed = <int>[];
+    while (length > 0) {
+      bytesReversed.add(length & 0xff);
+      length = length >> 8;
+    }
+    return <int>[
+      0x80 + bytesReversed.length,
+      ...bytesReversed.reversed,
+    ];
+  }
+}
+
+/// Encodes the [bytes] as integer, using the big-endian enconding.
+@visibleForTesting
+List<int> encodeIntegerFromBytes(List<int> bytes) {
+  final padBytes = bytes.isNotEmpty && (bytes.first & 0x80 > 0);
+  final extraLength = padBytes ? 1 : 0;
+  return <int>[
+    0x02,
+    ...encodeLength(bytes.length + extraLength),
+    if (padBytes) 0x00,
+    ...bytes,
+  ];
+}
+
+/// Wraps [bytes] as bit-string container.
+@visibleForTesting
+List<int> encodeBitString(List<int> bytes) {
+  return <int>[
+    0x03,
+    ...encodeLength(bytes.length + 1),
+    0x00,
+    ...bytes,
+  ];
+}
+
+/// Encodes mulitple parts as a sequence.
+@visibleForTesting
+List<int> encodeSequence(Iterable<List<int>> parts) {
+  final totalLength = parts.map((e) => e.length).fold<int>(0, (a, b) => a + b);
+  return <int>[
+    0x30,
+    ...encodeLength(totalLength),
+    ...parts.expand((e) => e),
+  ];
+}
+
+const _objectIdentifierRsa = <int>[
+  0x06,
+  0x09,
+  0x2A,
+  0x86,
+  0x48,
+  0x86,
+  0xF7,
+  0x0D,
+  0x01,
+  0x01,
+  0x01,
+];
+
+const _nullObject = <int>[0x05, 0x00];
+
+/// Encodes the RSA public key components.
+List<int> encodeRsaPublicKey({
+  required List<int> modulus,
+  required List<int> exponent,
+}) {
+  return encodeSequence([
+    encodeSequence([
+      _objectIdentifierRsa,
+      _nullObject,
+    ]),
+    encodeBitString(
+      encodeSequence([
+        encodeIntegerFromBytes(modulus),
+        encodeIntegerFromBytes(exponent),
+      ]),
+    ),
+  ]);
+}

--- a/app/lib/service/openid/asn1_encoder.dart
+++ b/app/lib/service/openid/asn1_encoder.dart
@@ -23,7 +23,7 @@ List<int> encodeLength(int length) {
       length = length >> 8;
     }
     return <int>[
-      0x80 + bytesReversed.length,
+      0x80 & bytesReversed.length,
       ...bytesReversed.reversed,
     ];
   }

--- a/app/lib/service/openid/asn1_encoder.dart
+++ b/app/lib/service/openid/asn1_encoder.dart
@@ -23,7 +23,7 @@ List<int> encodeLength(int length) {
       length = length >> 8;
     }
     return <int>[
-      0x80 & bytesReversed.length,
+      0x80 | bytesReversed.length,
       ...bytesReversed.reversed,
     ];
   }

--- a/app/test/service/openid/asn1_encoder_test.dart
+++ b/app/test/service/openid/asn1_encoder_test.dart
@@ -1,0 +1,75 @@
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:pub_dev/service/openid/asn1_encoder.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('length', () {
+    test('zero', () {
+      expect(encodeLength(0), [0]);
+    });
+
+    test('small', () {
+      expect(encodeLength(3), [3]);
+      expect(encodeLength(127), [127]);
+    });
+
+    test('larger', () {
+      expect(encodeLength(128), [0x81, 0x80]);
+      expect(encodeLength(255), [0x81, 0xff]);
+      expect(encodeLength(256), [0x82, 0x01, 0x00]);
+      expect(encodeLength(4999), [0x82, 0x13, 0x87]);
+    });
+  });
+
+  group('integer from bytes', () {
+    test('encode small number', () {
+      expect(
+        encodeIntegerFromBytes([0x11, 0x22, 0x33]),
+        [0x02, 0x03, 0x11, 0x22, 0x33],
+      );
+    });
+
+    test('padding', () {
+      expect(
+        encodeIntegerFromBytes([0x8f]),
+        [0x02, 0x02, 0x00, 0x8f],
+      );
+    });
+  });
+
+  group('sequence', () {
+    test('small sequence', () {
+      expect(
+          encodeSequence([
+            encodeIntegerFromBytes([0x11]),
+            encodeIntegerFromBytes([0x22]),
+            encodeIntegerFromBytes([0x33]),
+          ]),
+          <int>[
+            0x30, // sequence
+            0x09, // length
+            0x02, // 0x11
+            0x01,
+            0x11,
+            0x02, // 0x22
+            0x01,
+            0x22,
+            0x02, // 0x33
+            0x01,
+            0x33,
+          ]);
+    });
+  });
+
+  group('bit string', () {
+    test('bits', () {
+      expect(
+        encodeBitString([0x11, 0x12]),
+        [0x03, 0x03, 0x00, 0x11, 0x12],
+      );
+    });
+  });
+}

--- a/app/test/service/openid/jwt_test.dart
+++ b/app/test/service/openid/jwt_test.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:pem/pem.dart';
+import 'package:convert/convert.dart';
 import 'package:pub_dev/service/openid/jwt.dart';
 import 'package:pub_dev/service/openid/openssl_commands.dart';
 import 'package:test/test.dart';
@@ -63,10 +63,28 @@ void main() {
       final isValid = await verifyTextWithRsaSignature(
         input: headerAndPayloadEncoded,
         signature: parsed.signature,
-        publicKey:
-            decodePemBlocks(PemLabel.publicKey, jwtIoPublicKeyPem).single,
+        publicKey: Asn1RsaPublicKey.parsePemString(jwtIoPublicKeyPem),
       );
       expect(isValid, isTrue);
+    });
+  });
+
+  group('ASN encoding', () {
+    test('known PEM encoding', () {
+      final reference = Asn1RsaPublicKey.parsePemString(jwtIoPublicKeyPem);
+      final n = hex.decode(
+          'bb5494d4b7d52cf1c2a333311f6328e2580e11e3f3366d2d46078b7b357a7df0'
+          '2dd20ba75532f0ee89cb467aead3f2335bbc9647b424ae604bee34ca127e6efa'
+          'a2a16f029f06cb48b3e6cc636664a75f209d3c4a2f1a12dad15ccc690f2cf822'
+          'cec92e7a63208519e259aa0b7327a191ddeaa86125bd6fd50cbe406964e0d272'
+          'd5923468f73fb8d11433b95684f00900166c59ce8c37c7e54960a763ca4909d2'
+          '24fdc024b40d14d7bb6ebd576eb855fff78efade75988a46483094bf71340c31'
+          '5c5834c7f5c5c34d3951655122476070a5938e904fd9d3f0559e16582fbd6865'
+          '5df86ca7d68d022de95fe2b1231a85db00012002a786531adc2256e35df6dc9b');
+      final e = hex.decode('010001');
+      final publicKey = Asn1RsaPublicKey(modulus: n, exponent: e);
+      expect(hex.encode(publicKey.asDerEncodedBytes),
+          hex.encode(reference.asDerEncodedBytes));
     });
   });
 }

--- a/app/test/service/openid/openssl_utils.dart
+++ b/app/test/service/openid/openssl_utils.dart
@@ -10,12 +10,13 @@ import 'dart:typed_data';
 import 'package:pana/pana.dart';
 import 'package:path/path.dart' as p;
 import 'package:pem/pem.dart';
+import 'package:pub_dev/service/openid/openssl_commands.dart';
 import 'package:pub_dev/shared/utils.dart';
 
 /// Randomly generated private and public RSA keypair.
 class RsaKeyPair {
   final Uint8List privateKey;
-  final Uint8List publicKey;
+  final Asn1RsaPublicKey publicKey;
 
   RsaKeyPair(this.privateKey, this.publicKey);
 }
@@ -65,7 +66,7 @@ Future<RsaKeyPair> generateRsaKeyPair({
         decodePemBlocks(PemLabel.publicKey, publicContent).single;
     return RsaKeyPair(
       Uint8List.fromList(privateKeyBytes),
-      Uint8List.fromList(publicKeyBytes),
+      Asn1RsaPublicKey.fromDerEncodedBytes(publicKeyBytes),
     );
   });
 }


### PR DESCRIPTION
- #5769
- JWT providers share their public key using JSON Web Key(s) (JWK), and it contains the RSA key as modulus+exponent pair. We are using `openssl` to verify the JWT signature, and to do this, we need to convert the JWK data to PEM.
- The encoder is using only the minimally required operations to encode from RSA components to ASN.1 + PEM format.
- Uses the known public key (and its extracted components) from jwt.io as test.
