### PR TITLE
Switch 'X ago' labels to <a> link.

### DIFF
--- a/app/lib/frontend/dom/dom.dart
+++ b/app/lib/frontend/dom/dom.dart
@@ -95,9 +95,13 @@ Node xAgoTimestamp(DateTime timestamp, {String? datePrefix}) {
     if (datePrefix != null) datePrefix,
     shortDateFormat.format(timestamp),
   ].join(' ');
-  return span(
+  return a(
     classes: ['-x-ago'],
-    attributes: {'title': title},
+    attributes: {
+      'title': title,
+      'aria-label': 'Switch between date and elapsed time.',
+      'aria-role': 'button',
+    },
     text: formatXAgo(clock.now().difference(timestamp)),
   );
 }

--- a/app/test/frontend/golden/analysis_tab_aborted.html
+++ b/app/test/frontend/golden/analysis_tab_aborted.html
@@ -24,7 +24,7 @@
   </div>
   <p class="analysis-info">
     We analyzed this package
-    <span class="-x-ago" title="on %%timestamp-date%%">%%x-ago%%</span>
+    <a class="-x-ago" title="on %%timestamp-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
     , and awarded it 0 pub points (of a possible 0):
   </p>
   <div class="pkg-report"></div>

--- a/app/test/frontend/golden/my_activity_log_page.html
+++ b/app/test/frontend/golden/my_activity_log_page.html
@@ -145,7 +145,7 @@
                   <p>admin@pub.dev</p>
                   <p>
                     Joined
-                    <span class="-x-ago" title="on %%user-created-date%%">%%x-ago%%</span>
+                    <a class="-x-ago" title="on %%user-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
                   </p>
                 </div>
               </div>
@@ -184,7 +184,7 @@
                     <tbody>
                       <tr>
                         <td class="date">
-                          <span class="-x-ago" title="%%user-created-date%%">%%x-ago%%</span>
+                          <a class="-x-ago" title="%%user-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
                         </td>
                         <td class="summary">
                           <div class="markdown-body">
@@ -202,7 +202,7 @@
                       </tr>
                       <tr>
                         <td class="date">
-                          <span class="-x-ago" title="%%user-created-date%%">%%x-ago%%</span>
+                          <a class="-x-ago" title="%%user-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
                         </td>
                         <td class="summary">
                           <div class="markdown-body">
@@ -220,7 +220,7 @@
                       </tr>
                       <tr>
                         <td class="date">
-                          <span class="-x-ago" title="%%user-created-date%%">%%x-ago%%</span>
+                          <a class="-x-ago" title="%%user-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
                         </td>
                         <td class="summary">
                           <div class="markdown-body">
@@ -238,7 +238,7 @@
                       </tr>
                       <tr>
                         <td class="date">
-                          <span class="-x-ago" title="%%user-created-date%%">%%x-ago%%</span>
+                          <a class="-x-ago" title="%%user-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
                         </td>
                         <td class="summary">
                           <div class="markdown-body">
@@ -256,7 +256,7 @@
                       </tr>
                       <tr>
                         <td class="date">
-                          <span class="-x-ago" title="%%user-created-date%%">%%x-ago%%</span>
+                          <a class="-x-ago" title="%%user-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
                         </td>
                         <td class="summary">
                           <div class="markdown-body">
@@ -274,7 +274,7 @@
                       </tr>
                       <tr>
                         <td class="date">
-                          <span class="-x-ago" title="%%user-created-date%%">%%x-ago%%</span>
+                          <a class="-x-ago" title="%%user-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
                         </td>
                         <td class="summary">
                           <div class="markdown-body">
@@ -292,7 +292,7 @@
                       </tr>
                       <tr>
                         <td class="date">
-                          <span class="-x-ago" title="%%user-created-date%%">%%x-ago%%</span>
+                          <a class="-x-ago" title="%%user-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
                         </td>
                         <td class="summary">
                           <div class="markdown-body">
@@ -310,7 +310,7 @@
                       </tr>
                       <tr>
                         <td class="date">
-                          <span class="-x-ago" title="%%user-created-date%%">%%x-ago%%</span>
+                          <a class="-x-ago" title="%%user-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
                         </td>
                         <td class="summary">
                           <div class="markdown-body">

--- a/app/test/frontend/golden/my_liked_packages.html
+++ b/app/test/frontend/golden/my_liked_packages.html
@@ -145,7 +145,7 @@
                   <p>user@pub.dev</p>
                   <p>
                     Joined
-                    <span class="-x-ago" title="on %%user-created-date%%">%%x-ago%%</span>
+                    <a class="-x-ago" title="on %%user-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
                   </p>
                 </div>
               </div>
@@ -190,7 +190,7 @@
                       </div>
                       <p class="packages-metadata">
                         Liked
-                        <span class="-x-ago" title="on %%liked1-date%%">%%x-ago%%</span>
+                        <a class="-x-ago" title="on %%liked1-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
                       </p>
                     </div>
                     <div class="packages-item">
@@ -208,7 +208,7 @@
                       </div>
                       <p class="packages-metadata">
                         Liked
-                        <span class="-x-ago" title="on %%liked1-date%%">%%x-ago%%</span>
+                        <a class="-x-ago" title="on %%liked1-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
                       </p>
                     </div>
                   </div>

--- a/app/test/frontend/golden/my_packages.html
+++ b/app/test/frontend/golden/my_packages.html
@@ -145,7 +145,7 @@
                   <p>user@pub.dev</p>
                   <p>
                     Joined
-                    <span class="-x-ago" title="on %%oxygen-created-date%%">%%x-ago%%</span>
+                    <a class="-x-ago" title="on %%oxygen-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
                   </p>
                 </div>
               </div>
@@ -219,11 +219,11 @@
                           v
                           <a href="/packages/oxygen">1.2.0</a>
                           (
-                          <span class="-x-ago" title="%%oxygen-created-date%%">%%x-ago%%</span>
+                          <a class="-x-ago" title="%%oxygen-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
                           ) /
                           <a href="/packages/oxygen/versions/2.0.0-dev">2.0.0-dev</a>
                           (
-                          <span class="-x-ago" title="%%oxygen-created-date%%">%%x-ago%%</span>
+                          <a class="-x-ago" title="%%oxygen-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
                           )
                         </span>
                         <span class="packages-metadata-block">
@@ -288,7 +288,7 @@
                           v
                           <a href="/packages/neon">1.0.0</a>
                           (
-                          <span class="-x-ago" title="%%oxygen-created-date%%">%%x-ago%%</span>
+                          <a class="-x-ago" title="%%oxygen-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
                           )
                         </span>
                         <span class="packages-metadata-block">

--- a/app/test/frontend/golden/my_publishers.html
+++ b/app/test/frontend/golden/my_publishers.html
@@ -145,7 +145,7 @@
                   <p>user@pub.dev</p>
                   <p>
                     Joined
-                    <span class="-x-ago" title="on %%user-created-date%%">%%x-ago%%</span>
+                    <a class="-x-ago" title="on %%user-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
                   </p>
                 </div>
               </div>
@@ -180,7 +180,7 @@
                       </h3>
                       <p>
                         Registered
-                        <span class="-x-ago" title="on %%publisher-created-date%%">%%x-ago%%</span>
+                        <a class="-x-ago" title="on %%publisher-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
                         .
                       </p>
                     </div>

--- a/app/test/frontend/golden/pkg_activity_log_page.html
+++ b/app/test/frontend/golden/pkg_activity_log_page.html
@@ -127,7 +127,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <span class="-x-ago" title="%%published-date%%">%%x-ago%%</span>
+                    <a class="-x-ago" title="%%published-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
                   </span>
                   • Latest:
                   <span>

--- a/app/test/frontend/golden/pkg_admin_page.html
+++ b/app/test/frontend/golden/pkg_admin_page.html
@@ -127,7 +127,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <span class="-x-ago" title="%%published-date%%">%%x-ago%%</span>
+                    <a class="-x-ago" title="%%published-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
                   </span>
                   • Latest:
                   <span>

--- a/app/test/frontend/golden/pkg_changelog_page.html
+++ b/app/test/frontend/golden/pkg_changelog_page.html
@@ -128,7 +128,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <span class="-x-ago" title="%%published-date%%">%%x-ago%%</span>
+                    <a class="-x-ago" title="%%published-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
                   </span>
                   • Latest:
                   <span>

--- a/app/test/frontend/golden/pkg_example_page.html
+++ b/app/test/frontend/golden/pkg_example_page.html
@@ -128,7 +128,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <span class="-x-ago" title="%%published-date%%">%%x-ago%%</span>
+                    <a class="-x-ago" title="%%published-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
                   </span>
                   • Latest:
                   <span>

--- a/app/test/frontend/golden/pkg_index_page.html
+++ b/app/test/frontend/golden/pkg_index_page.html
@@ -431,11 +431,11 @@
                   v
                   <a href="/packages/oxygen">1.2.0</a>
                   (
-                  <span class="-x-ago" title="%%oxygen-created-date%%">%%x-ago%%</span>
+                  <a class="-x-ago" title="%%oxygen-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
                   ) /
                   <a href="/packages/oxygen/versions/2.0.0-dev">2.0.0-dev</a>
                   (
-                  <span class="-x-ago" title="%%oxygen-created-date%%">%%x-ago%%</span>
+                  <a class="-x-ago" title="%%oxygen-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
                   )
                 </span>
                 <span class="packages-metadata-block">
@@ -500,7 +500,7 @@
                   v
                   <a href="/packages/flutter_titanium">1.10.0</a>
                   (
-                  <span class="-x-ago" title="%%oxygen-created-date%%">%%x-ago%%</span>
+                  <a class="-x-ago" title="%%oxygen-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
                   )
                 </span>
                 <span class="packages-metadata-block">

--- a/app/test/frontend/golden/pkg_install_page.html
+++ b/app/test/frontend/golden/pkg_install_page.html
@@ -128,7 +128,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <span class="-x-ago" title="%%published-date%%">%%x-ago%%</span>
+                    <a class="-x-ago" title="%%published-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
                   </span>
                   • Latest:
                   <span>

--- a/app/test/frontend/golden/pkg_score_page.html
+++ b/app/test/frontend/golden/pkg_score_page.html
@@ -128,7 +128,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <span class="-x-ago" title="%%published-date%%">%%x-ago%%</span>
+                    <a class="-x-ago" title="%%published-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
                   </span>
                   • Latest:
                   <span>
@@ -235,7 +235,7 @@
                   </div>
                   <p class="analysis-info">
                     We analyzed this package
-                    <span class="-x-ago" title="on %%published-date%%">%%x-ago%%</span>
+                    <a class="-x-ago" title="on %%published-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
                     , and awarded it 54 pub points (of a possible 70):
                   </p>
                   <div class="pkg-report">

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -128,7 +128,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <span class="-x-ago" title="%%published-date%%">%%x-ago%%</span>
+                    <a class="-x-ago" title="%%published-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
                   </span>
                   • Latest:
                   <span>

--- a/app/test/frontend/golden/pkg_show_page_discontinued.html
+++ b/app/test/frontend/golden/pkg_show_page_discontinued.html
@@ -128,7 +128,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <span class="-x-ago" title="%%published-date%%">%%x-ago%%</span>
+                    <a class="-x-ago" title="%%published-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
                   </span>
                 </div>
                 <div class="detail-tags-and-like">

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -128,7 +128,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <span class="-x-ago" title="%%published-date%%">%%x-ago%%</span>
+                    <a class="-x-ago" title="%%published-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
                   </span>
                 </div>
                 <div class="detail-tags-and-like">

--- a/app/test/frontend/golden/pkg_show_page_legacy.html
+++ b/app/test/frontend/golden/pkg_show_page_legacy.html
@@ -128,7 +128,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <span class="-x-ago" title="%%published-date%%">%%x-ago%%</span>
+                    <a class="-x-ago" title="%%published-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
                   </span>
                 </div>
                 <div class="detail-tags-and-like">

--- a/app/test/frontend/golden/pkg_show_page_publisher.html
+++ b/app/test/frontend/golden/pkg_show_page_publisher.html
@@ -128,7 +128,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <span class="-x-ago" title="%%published-date%%">%%x-ago%%</span>
+                    <a class="-x-ago" title="%%published-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
                   </span>
                   •
                   <a class="-pub-publisher" href="/publishers/example.com">

--- a/app/test/frontend/golden/pkg_show_page_retracted.html
+++ b/app/test/frontend/golden/pkg_show_page_retracted.html
@@ -128,7 +128,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <span class="-x-ago" title="%%published-date%%">%%x-ago%%</span>
+                    <a class="-x-ago" title="%%published-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
                   </span>
                   • Latest:
                   <span>

--- a/app/test/frontend/golden/pkg_show_page_retracted_non_retracted_version.html
+++ b/app/test/frontend/golden/pkg_show_page_retracted_non_retracted_version.html
@@ -128,7 +128,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <span class="-x-ago" title="%%published-date%%">%%x-ago%%</span>
+                    <a class="-x-ago" title="%%published-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
                   </span>
                 </div>
                 <div class="detail-tags-and-like">

--- a/app/test/frontend/golden/pkg_show_version_page.html
+++ b/app/test/frontend/golden/pkg_show_version_page.html
@@ -128,7 +128,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <span class="-x-ago" title="%%published-date%%">%%x-ago%%</span>
+                    <a class="-x-ago" title="%%published-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
                   </span>
                   • Latest:
                   <span>

--- a/app/test/frontend/golden/pkg_versions_page.html
+++ b/app/test/frontend/golden/pkg_versions_page.html
@@ -128,7 +128,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <span class="-x-ago" title="%%version-created-date%%">%%x-ago%%</span>
+                    <a class="-x-ago" title="%%version-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
                   </span>
                   • Latest:
                   <span>
@@ -213,7 +213,7 @@
                   <p>
                     The latest prerelease was
                     <a href="#prerelease">2.0.0-dev</a>
-                    <span class="-x-ago" title="on %%version-created-date%%">%%x-ago%%</span>
+                    <a class="-x-ago" title="on %%version-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
                     .
                   </p>
                   <h2 id="stable">Stable versions of oxygen</h2>
@@ -244,7 +244,7 @@
                         <td class="badge"></td>
                         <td class="sdk">2.6</td>
                         <td class="uploaded">
-                          <span class="-x-ago" title="%%version-created-date%%">%%x-ago%%</span>
+                          <a class="-x-ago" title="%%version-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
                         </td>
                         <td class="documentation">
                           <a href="/documentation/oxygen/1.2.0/" rel="nofollow" title="Go to the documentation of oxygen 1.2.0">
@@ -264,7 +264,7 @@
                         <td class="badge"></td>
                         <td class="sdk">2.6</td>
                         <td class="uploaded">
-                          <span class="-x-ago" title="%%version-created-date%%">%%x-ago%%</span>
+                          <a class="-x-ago" title="%%version-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
                         </td>
                         <td class="documentation">
                           <a href="/documentation/oxygen/1.0.0/" rel="nofollow" title="Go to the documentation of oxygen 1.0.0">
@@ -307,7 +307,7 @@
                         <td class="badge"></td>
                         <td class="sdk">2.6</td>
                         <td class="uploaded">
-                          <span class="-x-ago" title="%%version-created-date%%">%%x-ago%%</span>
+                          <a class="-x-ago" title="%%version-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
                         </td>
                         <td class="documentation">
                           <a href="/documentation/oxygen/2.0.0-dev/" rel="nofollow" title="Go to the documentation of oxygen 2.0.0-dev">

--- a/app/test/frontend/golden/publisher_activity_log_page.html
+++ b/app/test/frontend/golden/publisher_activity_log_page.html
@@ -131,7 +131,7 @@
                   </p>
                   <p>
                     Publisher registered
-                    <span class="-x-ago" title="on %%publisher-created-date%%">%%x-ago%%</span>
+                    <a class="-x-ago" title="on %%publisher-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
                   </p>
                 </div>
               </div>
@@ -171,7 +171,7 @@
                     <tbody>
                       <tr>
                         <td class="date">
-                          <span class="-x-ago" title="%%publisher-created-date%%">%%x-ago%%</span>
+                          <a class="-x-ago" title="%%publisher-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
                         </td>
                         <td class="summary">
                           <div class="markdown-body">
@@ -189,7 +189,7 @@
                       </tr>
                       <tr>
                         <td class="date">
-                          <span class="-x-ago" title="%%publisher-created-date%%">%%x-ago%%</span>
+                          <a class="-x-ago" title="%%publisher-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
                         </td>
                         <td class="summary">
                           <div class="markdown-body">

--- a/app/test/frontend/golden/publisher_admin_page.html
+++ b/app/test/frontend/golden/publisher_admin_page.html
@@ -131,7 +131,7 @@
                   </p>
                   <p>
                     Publisher registered
-                    <span class="-x-ago" title="on %%publisher-created-date%%">%%x-ago%%</span>
+                    <a class="-x-ago" title="on %%publisher-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
                   </p>
                 </div>
               </div>

--- a/app/test/frontend/golden/publisher_list_page.html
+++ b/app/test/frontend/golden/publisher_list_page.html
@@ -123,7 +123,7 @@
           </h3>
           <p>
             Registered
-            <span class="-x-ago" title="on Sep 13, 2019">2 years ago</span>
+            <a class="-x-ago" title="on Sep 13, 2019" aria-label="Switch between date and elapsed time." aria-role="button">2 years ago</a>
             .
           </p>
         </div>
@@ -133,7 +133,7 @@
           </h3>
           <p>
             Registered
-            <span class="-x-ago" title="on Sep 19, 2019">2 years ago</span>
+            <a class="-x-ago" title="on Sep 19, 2019" aria-label="Switch between date and elapsed time." aria-role="button">2 years ago</a>
             .
           </p>
         </div>

--- a/app/test/frontend/golden/publisher_packages_page.html
+++ b/app/test/frontend/golden/publisher_packages_page.html
@@ -131,7 +131,7 @@
                   </p>
                   <p>
                     Publisher registered
-                    <span class="-x-ago" title="on %%neon-created-date%%">%%x-ago%%</span>
+                    <a class="-x-ago" title="on %%neon-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
                   </p>
                 </div>
               </div>
@@ -220,7 +220,7 @@
                           v
                           <a href="/packages/neon">1.0.0</a>
                           (
-                          <span class="-x-ago" title="%%neon-created-date%%">%%x-ago%%</span>
+                          <a class="-x-ago" title="%%neon-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
                           )
                         </span>
                         <span class="packages-metadata-block">
@@ -287,7 +287,7 @@
                           v
                           <a href="/packages/flutter_titanium">1.10.0</a>
                           (
-                          <span class="-x-ago" title="%%neon-created-date%%">%%x-ago%%</span>
+                          <a class="-x-ago" title="%%neon-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
                           )
                         </span>
                         <span class="packages-metadata-block">

--- a/app/test/frontend/golden/search_page.html
+++ b/app/test/frontend/golden/search_page.html
@@ -419,11 +419,11 @@
                   v
                   <a href="/packages/oxygen">1.2.0</a>
                   (
-                  <span class="-x-ago" title="%%oxygen-created-date%%">%%x-ago%%</span>
+                  <a class="-x-ago" title="%%oxygen-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
                   ) /
                   <a href="/packages/oxygen/versions/2.0.0-dev">2.0.0-dev</a>
                   (
-                  <span class="-x-ago" title="%%oxygen-created-date%%">%%x-ago%%</span>
+                  <a class="-x-ago" title="%%oxygen-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
                   )
                 </span>
                 <span class="packages-metadata-block">
@@ -499,7 +499,7 @@
                   v
                   <a href="/packages/flutter_titanium">1.10.0</a>
                   (
-                  <span class="-x-ago" title="%%oxygen-created-date%%">%%x-ago%%</span>
+                  <a class="-x-ago" title="%%oxygen-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
                   )
                 </span>
                 <span class="packages-metadata-block">

--- a/pkg/web_app/lib/src/hoverable.dart
+++ b/pkg/web_app/lib/src/hoverable.dart
@@ -117,8 +117,10 @@ void _setEventForPreCodeCopyToClipboard() {
 }
 
 void _setEventForXAgo() {
-  document.querySelectorAll('span.-x-ago').forEach((e) {
-    e.onClick.listen((_) {
+  document.querySelectorAll('a.-x-ago').forEach((e) {
+    e.onClick.listen((event) {
+      event.preventDefault();
+      event.stopPropagation();
       final text = e.text;
       e.text = e.getAttribute('title');
       e.setAttribute('title', text!);

--- a/pkg/web_css/lib/src/_base.scss
+++ b/pkg/web_css/lib/src/_base.scss
@@ -395,13 +395,9 @@ pre {
   text-align: center;
 }
 
-span.-x-ago {
-  cursor: pointer;
+a.-x-ago {
+  color: $site-font-color;
   text-decoration: underline dotted #ccc;
-
-  &:hover {
-    text-decoration: underline #aaa;
-  }
 }
 
 .inline-icon-img {


### PR DESCRIPTION
- An alternative take on #5881 for #5867.
- Using the `aria-` attributes more aligned with the specification.