### PR TITLE
Refactor API client creation in test: removing with* methods.

### DIFF
--- a/app/lib/tool/utils/pub_api_client.dart
+++ b/app/lib/tool/utils/pub_api_client.dart
@@ -3,19 +3,16 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:gcloud/service_scope.dart';
-import 'package:meta/meta.dart';
 
 import '../../frontend/handlers/pubapi.client.dart';
 import '../../shared/configuration.dart';
 
 import 'http.dart';
 
-/// Creates an API client to the configured endpoint with [authToken].
-/// The client will be closed when the current scope is exited.
+/// Creates an API client with [authToken] that uses the configured HTTP endpoints.
 ///
-/// TODO: migrate callers to use [withHttpPubApiClient] instead.
-@visibleForTesting
-PubApiClient createLocalPubApiClient({String? authToken}) {
+/// Services scopes are used to automatically close the client once we exit the current scope.
+PubApiClient createPubApiClient({String? authToken}) {
   final httpClient =
       httpClientWithAuthorization(tokenProvider: () async => authToken);
   registerScopeExitCallback(() async => httpClient.close());

--- a/app/lib/tool/utils/pub_api_client.dart
+++ b/app/lib/tool/utils/pub_api_client.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:gcloud/service_scope.dart';
+import 'package:meta/meta.dart';
 
 import '../../frontend/handlers/pubapi.client.dart';
 import '../../shared/configuration.dart';
@@ -12,6 +13,7 @@ import 'http.dart';
 /// Creates an API client with [authToken] that uses the configured HTTP endpoints.
 ///
 /// Services scopes are used to automatically close the client once we exit the current scope.
+@visibleForTesting
 PubApiClient createPubApiClient({String? authToken}) {
   final httpClient =
       httpClientWithAuthorization(tokenProvider: () async => authToken);

--- a/app/test/account/consent_backend_test.dart
+++ b/app/test/account/consent_backend_test.dart
@@ -9,7 +9,6 @@ import 'package:pub_dev/account/consent_backend.dart';
 import 'package:pub_dev/account/models.dart';
 import 'package:pub_dev/audit/backend.dart';
 import 'package:pub_dev/audit/models.dart';
-import 'package:pub_dev/tool/utils/pub_api_client.dart';
 import 'package:test/test.dart';
 
 import '../shared/test_models.dart';
@@ -48,13 +47,10 @@ void main() {
 
     testWithProfile('Uploader invite accepted', fn: () async {
       final consentId = await inviteUploader();
-      await withHttpPubApiClient(
-          bearerToken: userAtPubDevAuthToken,
-          fn: (client) async {
-            final rs = await client.resolveConsent(
-                consentId!, account_api.ConsentResult(granted: true));
-            expect(rs.granted, true);
-          });
+      final client = createPubApiClient(authToken: userAtPubDevAuthToken);
+      final rs = await client.resolveConsent(
+          consentId!, account_api.ConsentResult(granted: true));
+      expect(rs.granted, true);
 
       final page = await auditBackend.listRecordsForPackage('oxygen');
       final r = page.records.firstWhere(
@@ -65,14 +61,10 @@ void main() {
 
     testWithProfile('Uploader invite rejected', fn: () async {
       final consentId = await inviteUploader();
-
-      await withHttpPubApiClient(
-          bearerToken: userAtPubDevAuthToken,
-          fn: (client) async {
-            final rs = await client.resolveConsent(
-                consentId!, account_api.ConsentResult(granted: false));
-            expect(rs.granted, false);
-          });
+      final client = createPubApiClient(authToken: userAtPubDevAuthToken);
+      final rs = await client.resolveConsent(
+          consentId!, account_api.ConsentResult(granted: false));
+      expect(rs.granted, false);
 
       final page = await auditBackend.listRecordsForPackage('oxygen');
       final r = page.records.firstWhere(
@@ -124,13 +116,10 @@ void main() {
     testWithProfile('Publisher contact accepted', fn: () async {
       final consentId = await inviteContact();
 
-      await withHttpPubApiClient(
-          bearerToken: userAtPubDevAuthToken,
-          fn: (client) async {
-            final rs = await client.resolveConsent(
-                consentId!, account_api.ConsentResult(granted: true));
-            expect(rs.granted, true);
-          });
+      final client = createPubApiClient(authToken: userAtPubDevAuthToken);
+      final rs = await client.resolveConsent(
+          consentId!, account_api.ConsentResult(granted: true));
+      expect(rs.granted, true);
 
       final page = await auditBackend.listRecordsForPublisher('example.com');
       final r = page.records.firstWhere(
@@ -142,13 +131,10 @@ void main() {
     testWithProfile('Publisher contact rejected', fn: () async {
       final consentId = await inviteContact();
 
-      await withHttpPubApiClient(
-          bearerToken: userAtPubDevAuthToken,
-          fn: (client) async {
-            final rs = await client.resolveConsent(
-                consentId!, account_api.ConsentResult(granted: false));
-            expect(rs.granted, false);
-          });
+      final client = createPubApiClient(authToken: userAtPubDevAuthToken);
+      final rs = await client.resolveConsent(
+          consentId!, account_api.ConsentResult(granted: false));
+      expect(rs.granted, false);
 
       final page = await auditBackend.listRecordsForPublisher('example.com');
       final r = page.records.firstWhere(
@@ -202,13 +188,10 @@ void main() {
     testWithProfile('Publisher member accepted', fn: () async {
       final consentId = await inviteMember();
 
-      await withHttpPubApiClient(
-          bearerToken: userAtPubDevAuthToken,
-          fn: (client) async {
-            final rs = await client.resolveConsent(
-                consentId!, account_api.ConsentResult(granted: true));
-            expect(rs.granted, true);
-          });
+      final client = createPubApiClient(authToken: userAtPubDevAuthToken);
+      final rs = await client.resolveConsent(
+          consentId!, account_api.ConsentResult(granted: true));
+      expect(rs.granted, true);
 
       final page = await auditBackend.listRecordsForPublisher('example.com');
       final r = page.records.firstWhere(
@@ -220,13 +203,10 @@ void main() {
     testWithProfile('Publisher member rejected', fn: () async {
       final consentId = await inviteMember();
 
-      await withHttpPubApiClient(
-          bearerToken: userAtPubDevAuthToken,
-          fn: (client) async {
-            final rs = await client.resolveConsent(
-                consentId!, account_api.ConsentResult(granted: false));
-            expect(rs.granted, false);
-          });
+      final client = createPubApiClient(authToken: userAtPubDevAuthToken);
+      final rs = await client.resolveConsent(
+          consentId!, account_api.ConsentResult(granted: false));
+      expect(rs.granted, false);
 
       final page = await auditBackend.listRecordsForPublisher('example.com');
       final r = page.records.firstWhere(

--- a/app/test/account/like_test.dart
+++ b/app/test/account/like_test.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:pub_dev/tool/utils/pub_api_client.dart';
 import 'package:test/test.dart';
 
 import '../shared/handlers_test_utils.dart';
@@ -15,232 +14,181 @@ void main() {
     final pkg2 = 'neon';
 
     testWithProfile('Like package', fn: () async {
-      await withHttpPubApiClient(
-        bearerToken: userAtPubDevAuthToken,
-        fn: (client) async {
-          final rs = await client.getLikePackage(pkg1);
-          expect(rs.package, pkg1);
-          expect(rs.liked, false);
+      final client = createPubApiClient(authToken: userAtPubDevAuthToken);
+      final rs = await client.getLikePackage(pkg1);
+      expect(rs.package, pkg1);
+      expect(rs.liked, false);
 
-          final rs2 = await client.likePackage(pkg1);
-          expect(rs2.package, pkg1);
-          expect(rs2.liked, true);
+      final rs2 = await client.likePackage(pkg1);
+      expect(rs2.package, pkg1);
+      expect(rs2.liked, true);
 
-          final rs3 = await client.getLikePackage(pkg1);
-          expect(rs3.package, pkg1);
-          expect(rs3.liked, true);
-        },
-      );
+      final rs3 = await client.getLikePackage(pkg1);
+      expect(rs3.package, pkg1);
+      expect(rs3.liked, true);
     });
 
     testWithProfile('Like already liked package', fn: () async {
-      await withHttpPubApiClient(
-        bearerToken: userAtPubDevAuthToken,
-        fn: (client) async {
-          final rs = await client.likePackage(pkg1);
-          expect(rs.package, pkg1);
-          expect(rs.liked, true);
+      final client = createPubApiClient(authToken: userAtPubDevAuthToken);
+      final rs = await client.likePackage(pkg1);
+      expect(rs.package, pkg1);
+      expect(rs.liked, true);
 
-          final rs2 = await client.likePackage(pkg1);
-          expect(rs2.package, pkg1);
-          expect(rs2.liked, true);
+      final rs2 = await client.likePackage(pkg1);
+      expect(rs2.package, pkg1);
+      expect(rs2.liked, true);
 
-          final rs3 = await client.getLikePackage(pkg1);
-          expect(rs3.package, pkg1);
-          expect(rs3.liked, true);
-        },
-      );
+      final rs3 = await client.getLikePackage(pkg1);
+      expect(rs3.package, pkg1);
+      expect(rs3.liked, true);
     });
 
     testWithProfile('Like non-existing package', fn: () async {
-      await withHttpPubApiClient(
-        bearerToken: userAtPubDevAuthToken,
-        fn: (client) async {
-          await expectApiException(client.likePackage('non_existing_package'),
-              status: 404);
-        },
-      );
+      final client = createPubApiClient(authToken: userAtPubDevAuthToken);
+      await expectApiException(client.likePackage('non_existing_package'),
+          status: 404);
     });
 
     testWithProfile('List package likes', fn: () async {
-      await withHttpPubApiClient(
-        bearerToken: userAtPubDevAuthToken,
-        fn: (client) async {
-          final rs = await client.listPackageLikes();
-          expect(rs.likedPackages!.isEmpty, true);
+      final client = createPubApiClient(authToken: userAtPubDevAuthToken);
+      final rs = await client.listPackageLikes();
+      expect(rs.likedPackages!.isEmpty, true);
 
-          final rs2 = await client.likePackage(pkg1);
-          expect(rs2.package, pkg1);
-          expect(rs2.liked, true);
+      final rs2 = await client.likePackage(pkg1);
+      expect(rs2.package, pkg1);
+      expect(rs2.liked, true);
 
-          final rs3 = await client.likePackage(pkg2);
-          expect(rs3.package, pkg2);
-          expect(rs3.liked, true);
+      final rs3 = await client.likePackage(pkg2);
+      expect(rs3.package, pkg2);
+      expect(rs3.liked, true);
 
-          final rs4 = await client.listPackageLikes();
-          expect(rs4.likedPackages!.length, 2);
-          expect(rs4.likedPackages!.map((e) => e.package), contains(pkg1));
-          expect(rs4.likedPackages!.map((e) => e.package), contains(pkg2));
-          expect(rs4.likedPackages![0].liked, true);
-          expect(rs4.likedPackages![1].liked, true);
-        },
-      );
+      final rs4 = await client.listPackageLikes();
+      expect(rs4.likedPackages!.length, 2);
+      expect(rs4.likedPackages!.map((e) => e.package), contains(pkg1));
+      expect(rs4.likedPackages!.map((e) => e.package), contains(pkg2));
+      expect(rs4.likedPackages![0].liked, true);
+      expect(rs4.likedPackages![1].liked, true);
     });
 
     testWithProfile('Unlike package', fn: () async {
-      await withHttpPubApiClient(
-        bearerToken: userAtPubDevAuthToken,
-        fn: (client) async {
-          final rs = await client.listPackageLikes();
-          expect(rs.likedPackages!.isEmpty, true);
+      final client = createPubApiClient(authToken: userAtPubDevAuthToken);
+      final rs = await client.listPackageLikes();
+      expect(rs.likedPackages!.isEmpty, true);
 
-          final rs2 = await client.likePackage(pkg1);
-          expect(rs2.package, pkg1);
-          expect(rs2.liked, true);
+      final rs2 = await client.likePackage(pkg1);
+      expect(rs2.package, pkg1);
+      expect(rs2.liked, true);
 
-          final rs3 = await client.likePackage(pkg2);
-          expect(rs3.package, pkg2);
-          expect(rs3.liked, true);
+      final rs3 = await client.likePackage(pkg2);
+      expect(rs3.package, pkg2);
+      expect(rs3.liked, true);
 
-          final rs4 = await client.listPackageLikes();
-          expect(rs4.likedPackages!.length, 2);
-          expect(rs4.likedPackages![0].liked, true);
-          expect(rs4.likedPackages![1].liked, true);
+      final rs4 = await client.listPackageLikes();
+      expect(rs4.likedPackages!.length, 2);
+      expect(rs4.likedPackages![0].liked, true);
+      expect(rs4.likedPackages![1].liked, true);
 
-          await client.unlikePackage(pkg1);
+      await client.unlikePackage(pkg1);
 
-          final rs5 = await client.getLikePackage(pkg1);
-          expect(rs5.package, pkg1);
-          expect(rs5.liked, false);
+      final rs5 = await client.getLikePackage(pkg1);
+      expect(rs5.package, pkg1);
+      expect(rs5.liked, false);
 
-          final rs6 = await client.listPackageLikes();
-          expect(rs6.likedPackages!.length, 1);
-          expect(rs6.likedPackages![0].package, pkg2);
-        },
-      );
+      final rs6 = await client.listPackageLikes();
+      expect(rs6.likedPackages!.length, 1);
+      expect(rs6.likedPackages![0].package, pkg2);
     });
 
     testWithProfile('Unlike non-existing package', fn: () async {
-      await withHttpPubApiClient(
-        bearerToken: userAtPubDevAuthToken,
-        fn: (client) async {
-          await expectApiException(client.unlikePackage('non_existing_package'),
-              status: 404);
-        },
-      );
+      final client = createPubApiClient(authToken: userAtPubDevAuthToken);
+      await expectApiException(client.unlikePackage('non_existing_package'),
+          status: 404);
     });
 
     testWithProfile('Two users don\'t affect each other\'s package likes.',
         fn: () async {
-      await withHttpPubApiClient(
-        bearerToken: userAtPubDevAuthToken,
-        fn: (client) async {
-          await withHttpPubApiClient(
-            bearerToken: adminAtPubDevAuthToken,
-            fn: (client2) async {
-              final rs = await client.listPackageLikes();
-              expect(rs.likedPackages!.isEmpty, true);
+      final client = createPubApiClient(authToken: userAtPubDevAuthToken);
+      final client2 = createPubApiClient(authToken: adminAtPubDevAuthToken);
+      final rs = await client.listPackageLikes();
+      expect(rs.likedPackages!.isEmpty, true);
 
-              final rs1 = await client2.listPackageLikes();
-              expect(rs1.likedPackages!.isEmpty, true);
+      final rs1 = await client2.listPackageLikes();
+      expect(rs1.likedPackages!.isEmpty, true);
 
-              final rs2 = await client.likePackage(pkg1);
-              expect(rs2.package, pkg1);
-              expect(rs2.liked, true);
+      final rs2 = await client.likePackage(pkg1);
+      expect(rs2.package, pkg1);
+      expect(rs2.liked, true);
 
-              final rs3 = await client2.listPackageLikes();
-              expect(rs3.likedPackages!.isEmpty, true);
-            },
-          );
-        },
-      );
+      final rs3 = await client2.listPackageLikes();
+      expect(rs3.likedPackages!.isEmpty, true);
     });
 
     testWithProfile('Package likes property is incremented/decremented.',
         fn: () async {
-      await withHttpPubApiClient(
-        bearerToken: userAtPubDevAuthToken,
-        fn: (client) async {
-          await withHttpPubApiClient(
-            bearerToken: adminAtPubDevAuthToken,
-            fn: (client2) async {
-              final rs = await client.getPackageLikes(pkg1);
-              expect(rs.likes, 0);
-              final rs2 = await client2.getPackageLikes(pkg1);
-              expect(rs2.likes, 0);
+      final client = createPubApiClient(authToken: userAtPubDevAuthToken);
+      final client2 = createPubApiClient(authToken: adminAtPubDevAuthToken);
+      final rs = await client.getPackageLikes(pkg1);
+      expect(rs.likes, 0);
+      final rs2 = await client2.getPackageLikes(pkg1);
+      expect(rs2.likes, 0);
 
-              await client.likePackage(pkg1);
+      await client.likePackage(pkg1);
 
-              final rs3 = await client.getPackageLikes(pkg1);
-              expect(rs3.likes, 1);
-              final rs4 = await client2.getPackageLikes(pkg1);
-              expect(rs4.likes, 1);
+      final rs3 = await client.getPackageLikes(pkg1);
+      expect(rs3.likes, 1);
+      final rs4 = await client2.getPackageLikes(pkg1);
+      expect(rs4.likes, 1);
 
-              await client2.likePackage(pkg1);
+      await client2.likePackage(pkg1);
 
-              final rs5 = await client.getPackageLikes(pkg1);
-              expect(rs5.likes, 2);
-              final rs6 = await client2.getPackageLikes(pkg1);
-              expect(rs6.likes, 2);
+      final rs5 = await client.getPackageLikes(pkg1);
+      expect(rs5.likes, 2);
+      final rs6 = await client2.getPackageLikes(pkg1);
+      expect(rs6.likes, 2);
 
-              await client.unlikePackage(pkg1);
+      await client.unlikePackage(pkg1);
 
-              final rs7 = await client.getPackageLikes(pkg1);
-              expect(rs7.likes, 1);
-              final rs8 = await client2.getPackageLikes(pkg1);
-              expect(rs8.likes, 1);
+      final rs7 = await client.getPackageLikes(pkg1);
+      expect(rs7.likes, 1);
+      final rs8 = await client2.getPackageLikes(pkg1);
+      expect(rs8.likes, 1);
 
-              /// Unliking already unliked package doesn't cause decrement
-              await client.unlikePackage(pkg1);
+      /// Unliking already unliked package doesn't cause decrement
+      await client.unlikePackage(pkg1);
 
-              final rs9 = await client.getPackageLikes(pkg1);
-              expect(rs9.likes, 1);
-              final rs10 = await client2.getPackageLikes(pkg1);
-              expect(rs10.likes, 1);
+      final rs9 = await client.getPackageLikes(pkg1);
+      expect(rs9.likes, 1);
+      final rs10 = await client2.getPackageLikes(pkg1);
+      expect(rs10.likes, 1);
 
-              await client2.unlikePackage(pkg1);
+      await client2.unlikePackage(pkg1);
 
-              final rs11 = await client.getPackageLikes(pkg1);
-              expect(rs11.likes, 0);
-              final rs12 = await client2.getPackageLikes(pkg1);
-              expect(rs12.likes, 0);
-            },
-          );
-        },
-      );
+      final rs11 = await client.getPackageLikes(pkg1);
+      expect(rs11.likes, 0);
+      final rs12 = await client2.getPackageLikes(pkg1);
+      expect(rs12.likes, 0);
     });
 
     testWithProfile('Get number of likes for non-existing package.',
         fn: () async {
-      await withHttpPubApiClient(
-        bearerToken: userAtPubDevAuthToken,
-        fn: (client) async {
-          await expectApiException(
-              client.getPackageLikes('non_existing_package'),
-              status: 404);
-        },
-      );
+      final client = createPubApiClient(authToken: userAtPubDevAuthToken);
+      await expectApiException(client.getPackageLikes('non_existing_package'),
+          status: 404);
     });
 
     testWithProfile(
         'Get number of likes for client without authorization header.',
         fn: () async {
-      await withHttpPubApiClient(
-        fn: (client) async {
-          final rs = await client.getPackageLikes(pkg1);
-          expect(rs.likes, 0);
+      final client = createPubApiClient();
+      final rs = await client.getPackageLikes(pkg1);
+      expect(rs.likes, 0);
 
-          await withHttpPubApiClient(
-            bearerToken: userAtPubDevAuthToken,
-            fn: (authenticatedClient) async {
-              await authenticatedClient.likePackage(pkg1);
-            },
-          );
+      final authenticatedClient =
+          createPubApiClient(authToken: userAtPubDevAuthToken);
+      await authenticatedClient.likePackage(pkg1);
 
-          final rs1 = await client.getPackageLikes(pkg1);
-          expect(rs1.likes, 1);
-        },
-      );
+      final rs1 = await client.getPackageLikes(pkg1);
+      expect(rs1.likes, 1);
     });
   });
 }

--- a/app/test/admin/api_test.dart
+++ b/app/test/admin/api_test.dart
@@ -21,7 +21,6 @@ import 'package:pub_dev/package/models.dart';
 import 'package:pub_dev/publisher/backend.dart';
 import 'package:pub_dev/publisher/models.dart';
 import 'package:pub_dev/shared/exceptions.dart';
-import 'package:pub_dev/tool/utils/pub_api_client.dart';
 import 'package:pub_semver/pub_semver.dart';
 import 'package:test/test.dart';
 
@@ -528,12 +527,12 @@ void main() {
           final consentRow = await dbService.query<Consent>().run().single;
           expect(consentRow.args, ['oxygen', 'is-from-admin-user']);
 
-          await withHttpPubApiClient(
-              bearerToken: createFakeAuthTokenForEmail('someuser@pub.dev'),
-              fn: (c) async {
-                await c.resolveConsent(consentRow.consentId,
-                    account_api.ConsentResult(granted: true));
-              });
+          await createPubApiClient(
+            authToken: createFakeAuthTokenForEmail('someuser@pub.dev'),
+          ).resolveConsent(
+            consentRow.consentId,
+            account_api.ConsentResult(granted: true),
+          );
 
           final records2 = await auditBackend.listRecordsForPackage('oxygen');
           final acceptedAuditRecord = records2.records.firstWhere(

--- a/app/test/package/automated_publishing_test.dart
+++ b/app/test/package/automated_publishing_test.dart
@@ -6,7 +6,6 @@ import 'package:_pub_shared/data/package_api.dart';
 import 'package:pub_dev/audit/backend.dart';
 import 'package:pub_dev/audit/models.dart';
 import 'package:pub_dev/package/backend.dart';
-import 'package:pub_dev/tool/utils/pub_api_client.dart';
 import 'package:test/test.dart';
 
 import '../shared/handlers_test_utils.dart';
@@ -21,95 +20,78 @@ void main() {
     );
 
     testWithProfile('no package', fn: () async {
-      await withHttpPubApiClient(
-        bearerToken: userAtPubDevAuthToken,
-        fn: (client) async {
-          await expectApiException(
-            client.setAutomatedPublishing(
-                'no_such_package', AutomatedPublishing()),
-            status: 404,
-            code: 'NotFound',
-          );
-        },
+      final client = createPubApiClient(authToken: userAtPubDevAuthToken);
+      await expectApiException(
+        client.setAutomatedPublishing('no_such_package', AutomatedPublishing()),
+        status: 404,
+        code: 'NotFound',
       );
     });
 
     testWithProfile('not admin', fn: () async {
-      await withHttpPubApiClient(
-        bearerToken: userAtPubDevAuthToken,
-        fn: (client) async {
-          await expectApiException(
-            client.setAutomatedPublishing('oxygen', AutomatedPublishing()),
-            status: 403,
-            code: 'InsufficientPermissions',
-            message:
-                'Insufficient permissions to perform administrative actions on package `oxygen`.',
-          );
-        },
+      final client = createPubApiClient(authToken: userAtPubDevAuthToken);
+      await expectApiException(
+        client.setAutomatedPublishing('oxygen', AutomatedPublishing()),
+        status: 403,
+        code: 'InsufficientPermissions',
+        message:
+            'Insufficient permissions to perform administrative actions on package `oxygen`.',
       );
     });
 
     testWithProfile('successful update', fn: () async {
-      await withHttpPubApiClient(
-        bearerToken: adminAtPubDevAuthToken,
-        fn: (client) async {
-          final rs = await client.setAutomatedPublishing(
-              'oxygen',
-              AutomatedPublishing(
-                github: GithubPublishing(
-                  isEnabled: true,
-                  repository: 'dart-lang/pub-dev',
-                ),
-              ));
-          expect(rs.toJson(), {
-            'github': {
-              'isEnabled': true,
-              'repository': 'dart-lang/pub-dev',
-            },
-          });
-          final p = await packageBackend.lookupPackage('oxygen');
-          expect(p!.automatedPublishing.toJson(), rs.toJson());
-          final audits = await auditBackend.listRecordsForPackage('oxygen');
-          // check audit log record exists
-          final record = audits.records.firstWhere((e) =>
-              e.kind == AuditLogRecordKind.packagePublicationAutomationUpdated);
-          expect(record.created, isNotNull);
-          expect(record.summary,
-              '`admin@pub.dev` updated the publication automation config of package `oxygen`.');
+      final client = createPubApiClient(authToken: adminAtPubDevAuthToken);
+      final rs = await client.setAutomatedPublishing(
+          'oxygen',
+          AutomatedPublishing(
+            github: GithubPublishing(
+              isEnabled: true,
+              repository: 'dart-lang/pub-dev',
+            ),
+          ));
+      expect(rs.toJson(), {
+        'github': {
+          'isEnabled': true,
+          'repository': 'dart-lang/pub-dev',
         },
-      );
+      });
+      final p = await packageBackend.lookupPackage('oxygen');
+      expect(p!.automatedPublishing.toJson(), rs.toJson());
+      final audits = await auditBackend.listRecordsForPackage('oxygen');
+      // check audit log record exists
+      final record = audits.records.firstWhere((e) =>
+          e.kind == AuditLogRecordKind.packagePublicationAutomationUpdated);
+      expect(record.created, isNotNull);
+      expect(record.summary,
+          '`admin@pub.dev` updated the publication automation config of package `oxygen`.');
     });
 
     testWithProfile('bad project path', fn: () async {
-      await withHttpPubApiClient(
-        bearerToken: adminAtPubDevAuthToken,
-        fn: (client) async {
-          final badPaths = [
-            '/',
-            'a/',
-            '/b',
-            '//',
-            'a/b/c',
-            'a /b',
-            '(/b',
-          ];
-          for (final repository in badPaths) {
-            final rs = client.setAutomatedPublishing(
-                'oxygen',
-                AutomatedPublishing(
-                  github: GithubPublishing(
-                    isEnabled: false,
-                    repository: repository,
-                  ),
-                ));
-            await expectApiException(
-              rs,
-              status: 400,
-              code: 'InvalidInput',
-            );
-          }
-        },
-      );
+      final client = createPubApiClient(authToken: adminAtPubDevAuthToken);
+      final badPaths = [
+        '/',
+        'a/',
+        '/b',
+        '//',
+        'a/b/c',
+        'a /b',
+        '(/b',
+      ];
+      for (final repository in badPaths) {
+        final rs = client.setAutomatedPublishing(
+            'oxygen',
+            AutomatedPublishing(
+              github: GithubPublishing(
+                isEnabled: false,
+                repository: repository,
+              ),
+            ));
+        await expectApiException(
+          rs,
+          status: 400,
+          code: 'InvalidInput',
+        );
+      }
     });
   });
 }

--- a/app/test/package/backend_test.dart
+++ b/app/test/package/backend_test.dart
@@ -17,7 +17,6 @@ import 'package:pub_dev/fake/backend/fake_email_sender.dart';
 import 'package:pub_dev/package/backend.dart';
 import 'package:pub_dev/package/models.dart';
 import 'package:pub_dev/shared/exceptions.dart';
-import 'package:pub_dev/tool/utils/pub_api_client.dart';
 import 'package:test/test.dart';
 
 import '../shared/handlers_test_utils.dart';
@@ -130,27 +129,24 @@ void main() {
   group('backend.repository', () {
     group('api no longer supported', () {
       testWithProfile('uploader add', fn: () async {
-        await withHttpPubApiClient(fn: (client) async {
-          final rs = client.addUploader('oxygen');
-          await expectApiException(
-            rs,
-            status: 403,
-            code: 'OperationForbidden',
-            message: 'https://pub.dev/packages/oxygen/admin',
-          );
-        });
+        final rs = createPubApiClient().addUploader('oxygen');
+        await expectApiException(
+          rs,
+          status: 403,
+          code: 'OperationForbidden',
+          message: 'https://pub.dev/packages/oxygen/admin',
+        );
       });
 
       testWithProfile('uploader remove', fn: () async {
-        await withHttpPubApiClient(fn: (client) async {
-          final rs = client.removeUploader('oxygen', 'admin@pub.dev');
-          await expectApiException(
-            rs,
-            status: 403,
-            code: 'OperationForbidden',
-            message: 'https://pub.dev/packages/oxygen/admin',
-          );
-        });
+        final rs =
+            createPubApiClient().removeUploader('oxygen', 'admin@pub.dev');
+        await expectApiException(
+          rs,
+          status: 403,
+          code: 'OperationForbidden',
+          message: 'https://pub.dev/packages/oxygen/admin',
+        );
       });
     });
 

--- a/app/test/package/retracted_test.dart
+++ b/app/test/package/retracted_test.dart
@@ -8,7 +8,6 @@ import 'package:_pub_shared/data/package_api.dart';
 import 'package:pub_dev/package/backend.dart';
 import 'package:pub_dev/shared/datastore.dart';
 import 'package:pub_dev/tool/test_profile/models.dart';
-import 'package:pub_dev/tool/utils/pub_api_client.dart';
 import 'package:test/test.dart';
 
 import '../shared/handlers_test_utils.dart';
@@ -33,53 +32,38 @@ void main() {
     }
 
     testWithProfile('unauthenticated', fn: () async {
-      await withHttpPubApiClient(
-        fn: (client) async {
-          await expectApiException(
-            client.setVersionOptions('oxygen', '1.2.0', VersionOptions()),
-            status: 401,
-            code: 'MissingAuthentication',
-          );
-        },
+      final client = createPubApiClient();
+      await expectApiException(
+        client.setVersionOptions('oxygen', '1.2.0', VersionOptions()),
+        status: 401,
+        code: 'MissingAuthentication',
       );
     });
 
     testWithProfile('unauthorized', fn: () async {
-      await withHttpPubApiClient(
-        bearerToken: userAtPubDevAuthToken,
-        fn: (client) async {
-          await expectApiException(
-            client.setVersionOptions('oxygen', '1.2.0', VersionOptions()),
-            status: 403,
-            code: 'InsufficientPermissions',
-          );
-        },
+      final client = createPubApiClient(authToken: userAtPubDevAuthToken);
+      await expectApiException(
+        client.setVersionOptions('oxygen', '1.2.0', VersionOptions()),
+        status: 403,
+        code: 'InsufficientPermissions',
       );
     });
 
     testWithProfile('bad package', fn: () async {
-      await withHttpPubApiClient(
-        bearerToken: adminAtPubDevAuthToken,
-        fn: (client) async {
-          await expectApiException(
-            client.setVersionOptions('no_package', '1.2.0', VersionOptions()),
-            status: 404,
-            code: 'NotFound',
-          );
-        },
+      final client = createPubApiClient(authToken: adminAtPubDevAuthToken);
+      await expectApiException(
+        client.setVersionOptions('no_package', '1.2.0', VersionOptions()),
+        status: 404,
+        code: 'NotFound',
       );
     });
 
     testWithProfile('bad version', fn: () async {
-      await withHttpPubApiClient(
-        bearerToken: adminAtPubDevAuthToken,
-        fn: (client) async {
-          await expectApiException(
-            client.setVersionOptions('oxygen', '10.0.0', VersionOptions()),
-            status: 404,
-            code: 'NotFound',
-          );
-        },
+      final client = createPubApiClient(authToken: adminAtPubDevAuthToken);
+      await expectApiException(
+        client.setVersionOptions('oxygen', '10.0.0', VersionOptions()),
+        status: 404,
+        code: 'NotFound',
       );
     });
 
@@ -97,17 +81,13 @@ void main() {
         recentlyRetracted: [],
       );
 
-      await withHttpPubApiClient(
-        bearerToken: adminAtPubDevAuthToken,
-        fn: (client) async {
-          await expectApiException(
-            client.setVersionOptions(
-                'oxygen', '1.0.0', VersionOptions(isRetracted: true)),
-            status: 400,
-            code: 'InvalidInput',
-            message: 'Can\'t retract package "oxygen" version "1.0.0".',
-          );
-        },
+      final client = createPubApiClient(authToken: adminAtPubDevAuthToken);
+      await expectApiException(
+        client.setVersionOptions(
+            'oxygen', '1.0.0', VersionOptions(isRetracted: true)),
+        status: 400,
+        code: 'InvalidInput',
+        message: 'Can\'t retract package "oxygen" version "1.0.0".',
       );
     });
 
@@ -116,34 +96,28 @@ void main() {
         retractable: ['1.0.0', '1.2.0', '2.0.0-dev'],
         recentlyRetracted: [],
       );
-      await withHttpPubApiClient(
-        bearerToken: adminAtPubDevAuthToken,
-        fn: (client) async {
-          await client.setVersionOptions(
-              'oxygen', '1.2.0', VersionOptions(isRetracted: true));
-          await expectVersions(
-            retractable: ['1.0.0', '2.0.0-dev'],
-            recentlyRetracted: ['1.2.0'],
-          );
+      final client = createPubApiClient(authToken: adminAtPubDevAuthToken);
+      await client.setVersionOptions(
+          'oxygen', '1.2.0', VersionOptions(isRetracted: true));
+      await expectVersions(
+        retractable: ['1.0.0', '2.0.0-dev'],
+        recentlyRetracted: ['1.2.0'],
+      );
 
-          final pv2 =
-              await packageBackend.lookupPackageVersion('oxygen', '1.2.0');
-          pv2!.retracted = pv2.created!.subtract(Duration(days: 8));
-          await dbService.commit(inserts: [pv2]);
-          await expectVersions(
-            retractable: ['1.0.0', '2.0.0-dev'],
-            recentlyRetracted: [],
-          );
+      final pv2 = await packageBackend.lookupPackageVersion('oxygen', '1.2.0');
+      pv2!.retracted = pv2.created!.subtract(Duration(days: 8));
+      await dbService.commit(inserts: [pv2]);
+      await expectVersions(
+        retractable: ['1.0.0', '2.0.0-dev'],
+        recentlyRetracted: [],
+      );
 
-          await expectApiException(
-            client.setVersionOptions(
-                'oxygen', '1.2.0', VersionOptions(isRetracted: false)),
-            status: 400,
-            code: 'InvalidInput',
-            message:
-                'Can\'t undo retraction of package "oxygen" version "1.2.0".',
-          );
-        },
+      await expectApiException(
+        client.setVersionOptions(
+            'oxygen', '1.2.0', VersionOptions(isRetracted: false)),
+        status: 400,
+        code: 'InvalidInput',
+        message: 'Can\'t undo retraction of package "oxygen" version "1.2.0".',
       );
     });
 
@@ -152,60 +126,55 @@ void main() {
         retractable: ['1.0.0', '1.2.0', '2.0.0-dev'],
         recentlyRetracted: [],
       );
+      final client = createPubApiClient(authToken: adminAtPubDevAuthToken);
+      final orig = await client.getVersionOptions('oxygen', '1.2.0');
+      expect(orig.isRetracted, isFalse);
+      final origInfo = await client.packageVersionInfo('oxygen', '1.2.0');
+      expect(origInfo.retracted, isNull);
+      final p0Info = PackageData.fromJson(
+          json.decode(utf8.decode(await client.listVersions('oxygen')))
+              as Map<String, dynamic>);
+      expect(p0Info.latest.version, '1.2.0');
 
-      await withHttpPubApiClient(
-        bearerToken: adminAtPubDevAuthToken,
-        fn: (client) async {
-          final orig = await client.getVersionOptions('oxygen', '1.2.0');
-          expect(orig.isRetracted, isFalse);
-          final origInfo = await client.packageVersionInfo('oxygen', '1.2.0');
-          expect(origInfo.retracted, isNull);
-          final p0Info = PackageData.fromJson(
-              json.decode(utf8.decode(await client.listVersions('oxygen')))
-                  as Map<String, dynamic>);
-          expect(p0Info.latest.version, '1.2.0');
-
-          final u1 = await client.setVersionOptions(
-              'oxygen', '1.2.0', VersionOptions(isRetracted: true));
-          expect(u1.isRetracted, isTrue);
-          final u1Info = await client.packageVersionInfo('oxygen', '1.2.0');
-          expect(u1Info.retracted, isTrue);
-          final v1 = await client.packageVersionInfo('oxygen', '1.0.0');
-          expect(v1.retracted, isNull);
-          await expectVersions(
-            retractable: ['1.0.0', '2.0.0-dev'],
-            recentlyRetracted: ['1.2.0'],
-          );
-          final p1Info = PackageData.fromJson(
-              json.decode(utf8.decode(await client.listVersions('oxygen')))
-                  as Map<String, dynamic>);
-          expect(p1Info.latest.version, '1.0.0');
-
-          final u2 = await client.setVersionOptions(
-              'oxygen', '1.2.0', VersionOptions(isRetracted: true));
-          expect(u2.toJson(), u1.toJson());
-          final u2Info = await client.packageVersionInfo('oxygen', '1.2.0');
-          expect(u2Info.retracted, isTrue);
-          await expectVersions(
-            retractable: ['1.0.0', '2.0.0-dev'],
-            recentlyRetracted: ['1.2.0'],
-          );
-
-          final u3 = await client.setVersionOptions(
-              'oxygen', '1.2.0', VersionOptions(isRetracted: false));
-          expect(u3.toJson(), orig.toJson());
-          final u3Info = await client.packageVersionInfo('oxygen', '1.2.0');
-          expect(u3Info.retracted, isNull);
-          await expectVersions(
-            retractable: ['1.0.0', '1.2.0', '2.0.0-dev'],
-            recentlyRetracted: [],
-          );
-          final p3Info = PackageData.fromJson(
-              json.decode(utf8.decode(await client.listVersions('oxygen')))
-                  as Map<String, dynamic>);
-          expect(p3Info.latest.version, '1.2.0');
-        },
+      final u1 = await client.setVersionOptions(
+          'oxygen', '1.2.0', VersionOptions(isRetracted: true));
+      expect(u1.isRetracted, isTrue);
+      final u1Info = await client.packageVersionInfo('oxygen', '1.2.0');
+      expect(u1Info.retracted, isTrue);
+      final v1 = await client.packageVersionInfo('oxygen', '1.0.0');
+      expect(v1.retracted, isNull);
+      await expectVersions(
+        retractable: ['1.0.0', '2.0.0-dev'],
+        recentlyRetracted: ['1.2.0'],
       );
+      final p1Info = PackageData.fromJson(
+          json.decode(utf8.decode(await client.listVersions('oxygen')))
+              as Map<String, dynamic>);
+      expect(p1Info.latest.version, '1.0.0');
+
+      final u2 = await client.setVersionOptions(
+          'oxygen', '1.2.0', VersionOptions(isRetracted: true));
+      expect(u2.toJson(), u1.toJson());
+      final u2Info = await client.packageVersionInfo('oxygen', '1.2.0');
+      expect(u2Info.retracted, isTrue);
+      await expectVersions(
+        retractable: ['1.0.0', '2.0.0-dev'],
+        recentlyRetracted: ['1.2.0'],
+      );
+
+      final u3 = await client.setVersionOptions(
+          'oxygen', '1.2.0', VersionOptions(isRetracted: false));
+      expect(u3.toJson(), orig.toJson());
+      final u3Info = await client.packageVersionInfo('oxygen', '1.2.0');
+      expect(u3Info.retracted, isNull);
+      await expectVersions(
+        retractable: ['1.0.0', '1.2.0', '2.0.0-dev'],
+        recentlyRetracted: [],
+      );
+      final p3Info = PackageData.fromJson(
+          json.decode(utf8.decode(await client.listVersions('oxygen')))
+              as Map<String, dynamic>);
+      expect(p3Info.latest.version, '1.2.0');
     });
 
     testWithProfile('Updates latest version references',
@@ -231,102 +200,98 @@ void main() {
       final origLatestPublished = pkg.latestPublished;
       final origLatestPrereleasePublished = pkg.latestPrereleasePublished;
 
-      await withHttpPubApiClient(
-        bearerToken: adminAtPubDevAuthToken,
-        fn: (client) async {
-          final orig = await client.getVersionOptions('oxygen', '1.2.0');
-          expect(orig.isRetracted, isFalse);
-          final origInfo = await client.packageVersionInfo('oxygen', '1.2.0');
-          expect(origInfo.retracted, isNull);
+      final client = createPubApiClient(authToken: adminAtPubDevAuthToken);
+      final orig = await client.getVersionOptions('oxygen', '1.2.0');
+      expect(orig.isRetracted, isFalse);
+      final origInfo = await client.packageVersionInfo('oxygen', '1.2.0');
+      expect(origInfo.retracted, isNull);
 
-          // Retract latest
-          final u1 = await client.setVersionOptions(
-              'oxygen', '1.2.0', VersionOptions(isRetracted: true));
-          expect(u1.isRetracted, isTrue);
-          final u1Info = await client.packageVersionInfo('oxygen', '1.2.0');
-          expect(u1Info.retracted, isTrue);
+      // Retract latest
+      final u1 = await client.setVersionOptions(
+          'oxygen', '1.2.0', VersionOptions(isRetracted: true));
+      expect(u1.isRetracted, isTrue);
+      final u1Info = await client.packageVersionInfo('oxygen', '1.2.0');
+      expect(u1Info.retracted, isTrue);
 
-          final pkg1 = (await packageBackend.lookupPackage('oxygen'))!;
-          expect(pkg1.latestVersion, '1.0.0');
-          expect(pkg1.latestPublished, isNot(origLatestPublished));
-          expect(pkg1.lastVersionPublished, origLastVersionPublished);
+      final pkg1 = (await packageBackend.lookupPackage('oxygen'))!;
+      expect(pkg1.latestVersion, '1.0.0');
+      expect(pkg1.latestPublished, isNot(origLatestPublished));
+      expect(pkg1.lastVersionPublished, origLastVersionPublished);
 
-          // Restore latest
-          final u2 = await client.setVersionOptions(
-              'oxygen', '1.2.0', VersionOptions(isRetracted: false));
-          expect(u2.isRetracted, isFalse);
-          final u2Info = await client.packageVersionInfo('oxygen', '1.2.0');
-          expect(u2Info.retracted, isNull);
+      // Restore latest
+      final u2 = await client.setVersionOptions(
+          'oxygen', '1.2.0', VersionOptions(isRetracted: false));
+      expect(u2.isRetracted, isFalse);
+      final u2Info = await client.packageVersionInfo('oxygen', '1.2.0');
+      expect(u2Info.retracted, isNull);
 
-          final pkg2 = (await packageBackend.lookupPackage('oxygen'))!;
-          expect(pkg2.latestVersion, '1.2.0');
-          expect(pkg2.latestPublished, origLatestPublished);
-          expect(pkg2.lastVersionPublished, origLastVersionPublished);
+      final pkg2 = (await packageBackend.lookupPackage('oxygen'))!;
+      expect(pkg2.latestVersion, '1.2.0');
+      expect(pkg2.latestPublished, origLatestPublished);
+      expect(pkg2.lastVersionPublished, origLastVersionPublished);
 
-          // Retract latest dev
-          final u3 = await client.setVersionOptions(
-              'oxygen', '2.1.0-dev', VersionOptions(isRetracted: true));
-          expect(u3.isRetracted, isTrue);
-          final u3Info = await client.packageVersionInfo('oxygen', '2.1.0-dev');
-          expect(u3Info.retracted, isTrue);
+      // Retract latest dev
+      final u3 = await client.setVersionOptions(
+          'oxygen', '2.1.0-dev', VersionOptions(isRetracted: true));
+      expect(u3.isRetracted, isTrue);
+      final u3Info = await client.packageVersionInfo('oxygen', '2.1.0-dev');
+      expect(u3Info.retracted, isTrue);
 
-          final pkg3 = (await packageBackend.lookupPackage('oxygen'))!;
-          expect(pkg3.latestPrereleaseVersion, '2.0.0-dev');
-          expect(pkg3.latestPrereleasePublished,
-              isNot(origLatestPrereleasePublished));
-          expect(pkg3.lastVersionPublished, origLastVersionPublished);
+      final pkg3 = (await packageBackend.lookupPackage('oxygen'))!;
+      expect(pkg3.latestPrereleaseVersion, '2.0.0-dev');
+      expect(
+          pkg3.latestPrereleasePublished, isNot(origLatestPrereleasePublished));
+      expect(pkg3.lastVersionPublished, origLastVersionPublished);
 
-          // Retract all dev
-          final u4 = await client.setVersionOptions(
-              'oxygen', '2.0.0-dev', VersionOptions(isRetracted: true));
-          expect(u4.isRetracted, isTrue);
-          final u4Info = await client.packageVersionInfo('oxygen', '2.0.0-dev');
-          expect(u4Info.retracted, isTrue);
+      // Retract all dev
+      final u4 = await client.setVersionOptions(
+          'oxygen', '2.0.0-dev', VersionOptions(isRetracted: true));
+      expect(u4.isRetracted, isTrue);
+      final u4Info = await client.packageVersionInfo('oxygen', '2.0.0-dev');
+      expect(u4Info.retracted, isTrue);
 
-          final pkg4 = (await packageBackend.lookupPackage('oxygen'))!;
-          expect(pkg4.latestPrereleaseVersion, '1.2.0');
-          expect(pkg4.latestPrereleasePublished, origLatestPublished);
-          expect(pkg4.lastVersionPublished, origLastVersionPublished);
+      final pkg4 = (await packageBackend.lookupPackage('oxygen'))!;
+      expect(pkg4.latestPrereleaseVersion, '1.2.0');
+      expect(pkg4.latestPrereleasePublished, origLatestPublished);
+      expect(pkg4.lastVersionPublished, origLastVersionPublished);
 
-          // Restore latest dev
-          final u5 = await client.setVersionOptions(
-              'oxygen', '2.1.0-dev', VersionOptions(isRetracted: false));
-          expect(u5.isRetracted, isFalse);
-          final u5Info = await client.packageVersionInfo('oxygen', '2.1.0-dev');
-          expect(u5Info.retracted, isNull);
+      // Restore latest dev
+      final u5 = await client.setVersionOptions(
+          'oxygen', '2.1.0-dev', VersionOptions(isRetracted: false));
+      expect(u5.isRetracted, isFalse);
+      final u5Info = await client.packageVersionInfo('oxygen', '2.1.0-dev');
+      expect(u5Info.retracted, isNull);
 
-          final pkg5 = (await packageBackend.lookupPackage('oxygen'))!;
-          expect(pkg5.latestPrereleaseVersion, '2.1.0-dev');
-          expect(pkg5.latestPrereleasePublished, origLatestPrereleasePublished);
-          expect(pkg5.lastVersionPublished, origLastVersionPublished);
+      final pkg5 = (await packageBackend.lookupPackage('oxygen'))!;
+      expect(pkg5.latestPrereleaseVersion, '2.1.0-dev');
+      expect(pkg5.latestPrereleasePublished, origLatestPrereleasePublished);
+      expect(pkg5.lastVersionPublished, origLastVersionPublished);
 
-          // Retract all
-          final u6 = await client.setVersionOptions(
-              'oxygen', '1.2.0', VersionOptions(isRetracted: true));
-          expect(u6.isRetracted, isTrue);
-          final u7 = await client.setVersionOptions(
-              'oxygen', '1.0.0', VersionOptions(isRetracted: true));
-          expect(u7.isRetracted, isTrue);
-          final u9 = await client.setVersionOptions(
-              'oxygen', '2.1.0-dev', VersionOptions(isRetracted: true));
-          expect(u9.isRetracted, isTrue);
-          final u6Info = await client.packageVersionInfo('oxygen', '1.0.0');
-          final u7Info = await client.packageVersionInfo('oxygen', '1.2.0');
-          final u8Info = await client.packageVersionInfo('oxygen', '2.0.0-dev');
-          final u9Info = await client.packageVersionInfo('oxygen', '2.1.0-dev');
-          expect(u6Info.retracted, isTrue);
-          expect(u7Info.retracted, isTrue);
-          expect(u8Info.retracted, isTrue);
-          expect(u9Info.retracted, isTrue);
+      // Retract all
+      final u6 = await client.setVersionOptions(
+          'oxygen', '1.2.0', VersionOptions(isRetracted: true));
+      expect(u6.isRetracted, isTrue);
+      final u7 = await client.setVersionOptions(
+          'oxygen', '1.0.0', VersionOptions(isRetracted: true));
+      expect(u7.isRetracted, isTrue);
+      final u9 = await client.setVersionOptions(
+          'oxygen', '2.1.0-dev', VersionOptions(isRetracted: true));
+      expect(u9.isRetracted, isTrue);
+      final u6Info = await client.packageVersionInfo('oxygen', '1.0.0');
+      final u7Info = await client.packageVersionInfo('oxygen', '1.2.0');
+      final u8Info = await client.packageVersionInfo('oxygen', '2.0.0-dev');
+      final u9Info = await client.packageVersionInfo('oxygen', '2.1.0-dev');
+      expect(u6Info.retracted, isTrue);
+      expect(u7Info.retracted, isTrue);
+      expect(u8Info.retracted, isTrue);
+      expect(u9Info.retracted, isTrue);
 
-          final pkg6 = (await packageBackend.lookupPackage('oxygen'))!;
-          expect(pkg6.latestVersion, '1.2.0');
-          expect(pkg6.latestPrereleaseVersion, '2.1.0-dev');
-          expect(pkg6.lastVersionPublished, origLastVersionPublished);
-          expect(pkg6.latestPrereleasePublished, origLatestPrereleasePublished);
-          expect(pkg6.lastVersionPublished, origLastVersionPublished);
-        },
-      );
+      final pkg6 = (await packageBackend.lookupPackage('oxygen'))!;
+      expect(pkg6.latestVersion, '1.2.0');
+      expect(pkg6.latestPrereleaseVersion, '2.1.0-dev');
+      expect(pkg6.lastVersionPublished, origLastVersionPublished);
+      expect(pkg6.latestPrereleasePublished, origLatestPrereleasePublished);
+      expect(pkg6.lastVersionPublished, origLastVersionPublished);
     });
   });
 }

--- a/app/test/package/upload_test.dart
+++ b/app/test/package/upload_test.dart
@@ -20,7 +20,6 @@ import 'package:pub_dev/service/secret/backend.dart';
 import 'package:pub_dev/shared/configuration.dart';
 import 'package:pub_dev/shared/exceptions.dart';
 import 'package:pub_dev/tool/test_profile/models.dart';
-import 'package:pub_dev/tool/utils/pub_api_client.dart';
 import 'package:test/test.dart';
 import 'package:yaml/yaml.dart';
 
@@ -578,10 +577,9 @@ void main() {
           expect(lastPublished.package, 'oxygen');
           expect(lastPublished.latestVersion, '3.0.0');
 
-          await withHttpPubApiClient(fn: (client) async {
-            final bytes = await client.fetchPackage('oxygen', '3.0.0');
-            expect(bytes, tarball);
-          });
+          final bytes =
+              await createPubApiClient().fetchPackage('oxygen', '3.0.0');
+          expect(bytes, tarball);
         });
       });
     });

--- a/app/test/shared/test_services.dart
+++ b/app/test/shared/test_services.dart
@@ -32,6 +32,8 @@ import '../shared/utils.dart';
 import 'handlers_test_utils.dart';
 import 'test_models.dart';
 
+export 'package:pub_dev/tool/utils/pub_api_client.dart' show createPubApiClient;
+
 /// Registers test with [name] and runs it in pkg/fake_gcloud's scope, populated
 /// with [testProfile] data.
 void testWithProfile(
@@ -83,10 +85,6 @@ void testWithProfile(
     );
   }, timeout: timeout);
 }
-
-/// Creates local, non-HTTP-based API client with [authToken].
-PubApiClient createPubApiClient({String? authToken}) =>
-    createLocalPubApiClient(authToken: authToken);
 
 bool _loggingDone = false;
 
@@ -164,26 +162,15 @@ void setupTestsWithCallerAuthorizationIssues(
   AuthSource? authSource,
 }) {
   testWithProfile('No active user', fn: () async {
-    await withHttpPubApiClient(
-      fn: (client) async {
-        final rs = fn(client);
-        await expectApiException(rs,
-            status: 401, code: 'MissingAuthentication');
-      },
-    );
+    final rs = fn(createPubApiClient());
+    await expectApiException(rs, status: 401, code: 'MissingAuthentication');
   });
 
   testWithProfile('Active user is not authorized', fn: () async {
     final token =
         createFakeAuthTokenForEmail('unauthorized@pub.dev', source: authSource);
-    await withHttpPubApiClient(
-      bearerToken: token,
-      fn: (client) async {
-        final rs = fn(client);
-        await expectApiException(rs,
-            status: 403, code: 'InsufficientPermissions');
-      },
-    );
+    final rs = fn(createPubApiClient(authToken: token));
+    await expectApiException(rs, status: 403, code: 'InsufficientPermissions');
   });
 
   testWithProfile('Active user is blocked', fn: () async {
@@ -192,15 +179,10 @@ void setupTestsWithCallerAuthorizationIssues(
     await dbService.commit(inserts: [user..isBlocked = true]);
     final token =
         createFakeAuthTokenForEmail('admin@pub.dev', source: authSource);
-    await withHttpPubApiClient(
-      bearerToken: token,
-      fn: (client) async {
-        final rs = fn(client);
-        await expectApiException(rs,
-            status: 403,
-            code: 'InsufficientPermissions',
-            message: 'User is blocked.');
-      },
-    );
+    final rs = fn(createPubApiClient(authToken: token));
+    await expectApiException(rs,
+        status: 403,
+        code: 'InsufficientPermissions',
+        message: 'User is blocked.');
   });
 }

--- a/app/test/tool/maintenance/remove_orphaned_likes_test.dart
+++ b/app/test/tool/maintenance/remove_orphaned_likes_test.dart
@@ -6,7 +6,6 @@ import 'package:pub_dev/account/backend.dart';
 import 'package:pub_dev/package/models.dart';
 import 'package:pub_dev/shared/datastore.dart';
 import 'package:pub_dev/tool/maintenance/remove_orphaned_likes.dart';
-import 'package:pub_dev/tool/utils/pub_api_client.dart';
 import 'package:test/test.dart';
 
 import '../../shared/test_models.dart';
@@ -15,9 +14,8 @@ import '../../shared/test_services.dart';
 void main() {
   group('Remove orphaned likes', () {
     testWithProfile('finds the like but no need to delete it', fn: () async {
-      await withHttpPubApiClient(
-          bearerToken: userAtPubDevAuthToken,
-          fn: (client) => client.likePackage('oxygen'));
+      await createPubApiClient(authToken: userAtPubDevAuthToken)
+          .likePackage('oxygen');
       final counts = await removeOrphanedLikes(minAgeThreshold: Duration.zero);
       expect(counts.found, 1);
       expect(counts.deleted, 0);
@@ -26,9 +24,8 @@ void main() {
     testWithProfile(
       'finds like without package',
       fn: () async {
-        await withHttpPubApiClient(
-            bearerToken: userAtPubDevAuthToken,
-            fn: (client) => client.likePackage('oxygen'));
+        await createPubApiClient(authToken: userAtPubDevAuthToken)
+            .likePackage('oxygen');
         await dbService.commit(
             deletes: [dbService.emptyKey.append(Package, id: 'oxygen')]);
         final counts =
@@ -44,9 +41,8 @@ void main() {
     testWithProfile(
       'finds like without userid',
       fn: () async {
-        await withHttpPubApiClient(
-            bearerToken: userAtPubDevAuthToken,
-            fn: (client) => client.likePackage('oxygen'));
+        await createPubApiClient(authToken: userAtPubDevAuthToken)
+            .likePackage('oxygen');
         final user = await accountBackend.lookupUserByEmail('user@pub.dev');
         await dbService.commit(deletes: [user.key]);
         final counts =

--- a/app/test/tool/maintenance/update_package_likes_test.dart
+++ b/app/test/tool/maintenance/update_package_likes_test.dart
@@ -9,7 +9,6 @@ import 'package:pub_dev/package/backend.dart';
 import 'package:pub_dev/package/models.dart';
 import 'package:pub_dev/shared/datastore.dart';
 import 'package:pub_dev/tool/maintenance/update_package_likes.dart';
-import 'package:pub_dev/tool/utils/pub_api_client.dart';
 import 'package:test/test.dart';
 
 import '../../shared/test_models.dart';
@@ -26,9 +25,9 @@ void main() {
 
     testWithProfile('no need to change like counts #2', fn: () async {
       final p1 = await packageBackend.lookupPackage('oxygen');
-      await withHttpPubApiClient(
-          bearerToken: userAtPubDevAuthToken,
-          fn: (client) => client.likePackage('oxygen'));
+      await createPubApiClient(
+        authToken: userAtPubDevAuthToken,
+      ).likePackage('oxygen');
       expect(await updatePackageLikes(), 0);
       final p2 = await packageBackend.lookupPackage('oxygen');
       expect(p2!.likes, p1!.likes + 1);


### PR DESCRIPTION
- Related to #5807 and https://github.com/dart-lang/pub-dev/pull/5810#discussion_r887758476
- All tests are migrated, test_profiler's importer is still using the `withHttpApiClient` method.
- I think the scope-based self-closing client is better for the tests, not yet sure if the same is true for the importer.