### PR TITLE
Require a single LICENSE file (any variant), reject if there are multiple ones.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ AppEngine version, listed here to ease deployment and troubleshooting.
 ## Next Release (replace with git tag when deployed)
  * Bumped runtimeVersion to `2022.07.07`.
  * Upgraded dartdoc to `6.0.0`.
+ * NOTE: Require a single LICENSE file (any variant), reject if there are multiple ones.
 
 ## `20220705t102600-all`
  * Bumped runtimeVersion to `2022.07.05`.

--- a/pkg/pub_package_reader/lib/src/tar_utils.dart
+++ b/pkg/pub_package_reader/lib/src/tar_utils.dart
@@ -38,6 +38,9 @@ class TarArchive {
               MapEntry<String, String>(_normalize(key), _normalize(value))),
         );
 
+  late final _lowerCaseFileNames = Map<String, String>.fromEntries(
+      fileNames.map((e) => MapEntry(e.toLowerCase(), e)));
+
   /// Scans the tar archive and reads the content of the files identified by [names].
   ///
   /// For each file, if [maxLength] is reached, the content is returned up-to the
@@ -90,20 +93,25 @@ class TarArchive {
     return content;
   }
 
-  // Searches in scanned files for a file name [name] and compare in a
-  // case-insensitive manner.
-  //
-  // Returns `null` if not found otherwise the correct filename.
-  String? firstFileNameOrNull(Iterable<String> names) {
-    for (String name in names) {
-      final String nameLowercase = name.toLowerCase();
-      for (final filename in fileNames) {
-        if (filename.toLowerCase() == nameLowercase) {
-          return filename;
-        }
+  /// Returns the first matching file name from [names], ignoring the case.
+  ///
+  /// Returns `null` if there was no matching file.
+  String? firstMatchingFileNameOrNull(Iterable<String> names) {
+    for (final name in names) {
+      final originalName = _lowerCaseFileNames[name.toLowerCase()];
+      if (originalName != null) {
+        return originalName;
       }
     }
     return null;
+  }
+
+  /// List all matching file names, ignoring the case.
+  List<String> listmatchingFileNames(Iterable<String> names) {
+    return names
+        .map((name)=> _lowerCaseFileNames[name.toLowerCase()])
+        .whereType<String>()
+        .toList();
   }
 
   /// Returns the brokens links (that point outside, or to a non-existent file).

--- a/pkg/pub_package_reader/test/package_archive_test.dart
+++ b/pkg/pub_package_reader/test/package_archive_test.dart
@@ -585,6 +585,16 @@ $dependencies
   });
 
   group('require license content', () {
+    test('no license file listed', () {
+      expect(requireSingleLicenseFile([]), isNotEmpty);
+    });
+
+    test('multiple license file listed', () {
+      expect(requireSingleLicenseFile(['LICENSE', 'UNLICENSE']), isNotEmpty);
+      expect(
+          requireSingleLicenseFile(['LICENSE.md', 'LICENSE.txt']), isNotEmpty);
+    });
+
     test('no license file', () {
       expect(requireNonEmptyLicense(null, null), isNotEmpty);
     });


### PR DESCRIPTION
- When a new archive has multiple license files, we'll reject with a message the lists all candidates.
- Optimized (and renamed) `firstFileNameOrNull`, with a slight change: if there are multiple file versions with the same lowercase form, previously we've used the first matching, now we are using the last one (due to a change from `for` loop to a map, where the last entry overrides the previous ones).
