### PR TITLE
Required 'LICENSE' in the new versions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ AppEngine version, listed here to ease deployment and troubleshooting.
  * Upgraded dartdoc to `6.0.0`.
  * Upgraded stable Dart analysis SDK to `2.17.6`.
  * Upgraded stable Flutter analysis SDK to `3.0.5`.
+ * NOTE: `LICENSE` is a required file in the new versions.
 
 ## `20220705t102600-all`
  * Bumped runtimeVersion to `2022.07.05`.

--- a/pkg/pub_package_reader/lib/pub_package_reader.dart
+++ b/pkg/pub_package_reader/lib/pub_package_reader.dart
@@ -127,7 +127,7 @@ Future<PackageSummary> summarizePackageArchive(
   }
 
   // processing pubspec.yaml
-  final pubspecPath = tar.firstFileNameOrNull(['pubspec.yaml']);
+  final pubspecPath = tar.firstMatchingFileNameOrNull(['pubspec.yaml']);
   if (pubspecPath == null) {
     issues.add(ArchiveIssue('pubspec.yaml is missing.'));
     return PackageSummary(issues: issues);
@@ -199,11 +199,11 @@ Future<PackageSummary> summarizePackageArchive(
     return PackageSummary(issues: issues);
   }
 
-  String? readmePath = tar.firstFileNameOrNull(readmeFileNames);
-  String? changelogPath = tar.firstFileNameOrNull(changelogFileNames);
+  String? readmePath = tar.firstMatchingFileNameOrNull(readmeFileNames);
+  String? changelogPath = tar.firstMatchingFileNameOrNull(changelogFileNames);
   String? examplePath =
-      tar.firstFileNameOrNull(exampleFileCandidates(pubspec.name));
-  String? licensePath = tar.firstFileNameOrNull(licenseFileNames);
+      tar.firstMatchingFileNameOrNull(exampleFileCandidates(pubspec.name));
+  String? licensePath = tar.firstMatchingFileNameOrNull(['LICENSE']);
 
   final contentBytes = await tar.scanAndReadFiles(
     [readmePath, changelogPath, examplePath, licensePath]
@@ -240,6 +240,7 @@ Future<PackageSummary> summarizePackageArchive(
     examplePath = null;
   }
   final licenseContent = tryParseContentBytes(licensePath);
+  issues.addAll(requireNonEmptyLicense(licensePath, licenseContent));
   if (licenseContent == null) {
     licensePath = null;
   }
@@ -265,7 +266,6 @@ Future<PackageSummary> summarizePackageArchive(
   issues.addAll(validateDependencies(pubspec));
   issues.addAll(forbidGitDependencies(pubspec));
   issues.addAll(requireIosFolderOrFlutter2_20(pubspec, tar.fileNames));
-  issues.addAll(requireNonEmptyLicense(licensePath, licenseContent));
   issues.addAll(checkScreenshots(pubspec, tar.fileNames));
   issues.addAll(validateKnownTemplateReadme(readmePath, readmeContent));
 
@@ -671,16 +671,16 @@ Iterable<ArchiveIssue> requireIosFolderOrFlutter2_20(
 
 Iterable<ArchiveIssue> requireNonEmptyLicense(
     String? path, String? content) sync* {
-  if (path == null) {
-    yield ArchiveIssue('LICENSE file not found.');
+  if (path == null || path != 'LICENSE') {
+    yield ArchiveIssue('`LICENSE` file not found.');
     return;
   }
   if (content == null || content.trim().isEmpty) {
-    yield ArchiveIssue('LICENSE file `$path` has no content.');
+    yield ArchiveIssue('`LICENSE` file has no content.');
     return;
   }
   if (content.toLowerCase().contains('todo: add your license here.')) {
-    yield ArchiveIssue('LICENSE file `$path` contains generic TODO.');
+    yield ArchiveIssue('`LICENSE` file contains generic TODO.');
     return;
   }
 }

--- a/pkg/pub_package_reader/lib/src/file_names.dart
+++ b/pkg/pub_package_reader/lib/src/file_names.dart
@@ -32,9 +32,3 @@ List<String> exampleFileCandidates(String package) {
     ...textFileNameCandidates('example/readme'),
   ];
 }
-
-final licenseFileNames = <String>[
-  ...textFileNameCandidates('LICENSE'),
-  ...textFileNameCandidates('COPYING'),
-  ...textFileNameCandidates('UNLICENSE'),
-];

--- a/pkg/pub_package_reader/lib/src/tar_utils.dart
+++ b/pkg/pub_package_reader/lib/src/tar_utils.dart
@@ -38,6 +38,9 @@ class TarArchive {
               MapEntry<String, String>(_normalize(key), _normalize(value))),
         );
 
+  late final _lowerCaseFileNames = Map<String, String>.fromEntries(
+      fileNames.map((e) => MapEntry(e.toLowerCase(), e)));
+
   /// Scans the tar archive and reads the content of the files identified by [names].
   ///
   /// For each file, if [maxLength] is reached, the content is returned up-to the
@@ -90,17 +93,14 @@ class TarArchive {
     return content;
   }
 
-  // Searches in scanned files for a file name [name] and compare in a
-  // case-insensitive manner.
-  //
-  // Returns `null` if not found otherwise the correct filename.
-  String? firstFileNameOrNull(Iterable<String> names) {
-    for (String name in names) {
-      final String nameLowercase = name.toLowerCase();
-      for (final filename in fileNames) {
-        if (filename.toLowerCase() == nameLowercase) {
-          return filename;
-        }
+  /// Returns the first matching file name from [names], ignoring the case.
+  ///
+  /// Returns `null` if there was no matching file.
+  String? firstMatchingFileNameOrNull(Iterable<String> names) {
+    for (final name in names) {
+      final originalName = _lowerCaseFileNames[name.toLowerCase()];
+      if (originalName != null) {
+        return originalName;
       }
     }
     return null;

--- a/pkg/pub_package_reader/test/package_archive_test.dart
+++ b/pkg/pub_package_reader/test/package_archive_test.dart
@@ -589,6 +589,10 @@ $dependencies
       expect(requireNonEmptyLicense(null, null), isNotEmpty);
     });
 
+    test('non-default license', () {
+      expect(requireNonEmptyLicense('LICENSE.txt', 'BSD license'), isNotEmpty);
+    });
+
     test('empty file', () {
       expect(requireNonEmptyLicense('LICENSE', ''), isNotEmpty);
       expect(requireNonEmptyLicense('LICENSE', '\n  \n'), isNotEmpty);


### PR DESCRIPTION
- Fixes #5826.
- Optimized (and renamed) `firstFileNameOrNull`, with a slight change: if there are multiple file versions with the same lowercase form, previously we've used the first matching, now we are using the last one (due to a change from for loop to a map, where the last entry overrides the previous ones).