### PR TITLE
Parse OpenID supported claims and algorithms metadata.

### DIFF
--- a/app/lib/service/openid/openid_models.dart
+++ b/app/lib/service/openid/openid_models.dart
@@ -45,9 +45,23 @@ class OpenIdProvider {
   @JsonKey(name: 'jwks_uri')
   final String jwksUri;
 
+  /// JSON array containing a list of the Claim Names of the Claims that the
+  /// OpenID Provider MAY be able to supply values for. Note that for privacy
+  /// or other reasons, this might not be an exhaustive list.
+  @JsonKey(name: 'claims_supported')
+  final List<String> claimsSupported;
+
+  /// JSON array containing a list of the JWS signing algorithms (alg values)
+  /// supported by the OP for the ID Token to encode the Claims in a JWT. The
+  /// algorithm RS256 MUST be included.
+  @JsonKey(name: 'id_token_signing_alg_values_supported')
+  final List<String> idTokenSigningAlgValuesSupported;
+
   OpenIdProvider({
     required this.issuer,
     required this.jwksUri,
+    required this.claimsSupported,
+    required this.idTokenSigningAlgValuesSupported,
   });
 
   factory OpenIdProvider.fromJson(Map<String, dynamic> json) =>

--- a/app/lib/service/openid/openid_models.g.dart
+++ b/app/lib/service/openid/openid_models.g.dart
@@ -22,12 +22,22 @@ OpenIdProvider _$OpenIdProviderFromJson(Map<String, dynamic> json) =>
     OpenIdProvider(
       issuer: json['issuer'] as String,
       jwksUri: json['jwks_uri'] as String,
+      claimsSupported: (json['claims_supported'] as List<dynamic>)
+          .map((e) => e as String)
+          .toList(),
+      idTokenSigningAlgValuesSupported:
+          (json['id_token_signing_alg_values_supported'] as List<dynamic>)
+              .map((e) => e as String)
+              .toList(),
     );
 
 Map<String, dynamic> _$OpenIdProviderToJson(OpenIdProvider instance) =>
     <String, dynamic>{
       'issuer': instance.issuer,
       'jwks_uri': instance.jwksUri,
+      'claims_supported': instance.claimsSupported,
+      'id_token_signing_alg_values_supported':
+          instance.idTokenSigningAlgValuesSupported,
     };
 
 JsonWebKeyList _$JsonWebKeyListFromJson(Map<String, dynamic> json) =>

--- a/app/test/service/openid/github_openid_test.dart
+++ b/app/test/service/openid/github_openid_test.dart
@@ -11,6 +11,36 @@ void main() {
   testWithProfile('GitHub key list', fn: () async {
     final data = await fetchGithubOpenIdData();
     expect(data.provider.issuer, 'https://token.actions.githubusercontent.com');
+    expect(data.provider.claimsSupported, [
+      'sub',
+      'aud',
+      'exp',
+      'iat',
+      'iss',
+      'jti',
+      'nbf',
+      'ref',
+      'repository',
+      'repository_id',
+      'repository_owner',
+      'repository_owner_id',
+      'run_id',
+      'run_number',
+      'run_attempt',
+      'actor',
+      'actor_id',
+      'workflow',
+      'head_ref',
+      'base_ref',
+      'event_name',
+      'ref_type',
+      'environment',
+      'job_workflow_ref',
+      'repository_visibility',
+    ]);
+    expect(data.provider.idTokenSigningAlgValuesSupported, [
+      'RS256',
+    ]);
     expect(data.jwks.keys, isNotEmpty);
     final rsaKeys = data.jwks.keys.where((key) => key.kty == 'RSA').toList();
     expect(rsaKeys, isNotEmpty);


### PR DESCRIPTION
- These can be used to quickly verify the token payload before more expensive operations.
- While the list of supported claims is not exhaustive, and items may be missing from the payload, we could shortcut authenticating JWT tokens that have too many different claims than the ones the provider supports.
- The supported algorithm list does not have such ambiguity, we shall just use it.