### PR TITLE
Fix NPE in admin page initialization.

### DIFF
--- a/pkg/web_app/lib/src/admin_pages.dart
+++ b/pkg/web_app/lib/src/admin_pages.dart
@@ -368,13 +368,13 @@ class _PublisherAdminWidget {
     if (!pageData.isPublisherPage) return;
     _updateButton = document.getElementById('-publisher-update-button');
     _descriptionTextArea =
-        document.getElementById('-publisher-description') as TextAreaElement;
+        document.getElementById('-publisher-description') as TextAreaElement?;
     _websiteUrlInput =
-        document.getElementById('-publisher-website-url') as InputElement;
+        document.getElementById('-publisher-website-url') as InputElement?;
     _contactEmailInput =
-        document.getElementById('-publisher-contact-email') as InputElement;
+        document.getElementById('-publisher-contact-email') as InputElement?;
     _inviteMemberInput =
-        document.getElementById('-admin-invite-member-input') as InputElement;
+        document.getElementById('-admin-invite-member-input') as InputElement?;
     _addMemberButton = document.getElementById('-admin-add-member-button');
     _addMemberContent = document.getElementById('-admin-add-member-content');
     _originalContactEmail = _contactEmailInput?.value;


### PR DESCRIPTION
This caused an exception in the browser's JS execution, on publisher pages that were not the `/admin` page. Apparently no functionality was affected, only the admin initialization code failed (which was not used on those pages anyway).
