### PR TITLE
Prepare the use of Google Identity Services client library (CSP, experimental flag, init callback).

### DIFF
--- a/app/lib/frontend/dom/dom.dart
+++ b/app/lib/frontend/dom/dom.dart
@@ -644,6 +644,7 @@ Node script({
   String? src,
   bool async = false,
   bool defer = false,
+  String? onload,
 }) =>
     dom.element(
       'script',
@@ -654,6 +655,7 @@ Node script({
         if (src != null) 'src': src,
         if (async) 'async': 'async',
         if (defer) 'defer': 'defer',
+        if (onload != null) 'onload': onload,
         if (attributes != null) ...attributes,
       },
       children: _children(children, child, text),

--- a/app/lib/frontend/request_context.dart
+++ b/app/lib/frontend/request_context.dart
@@ -27,11 +27,15 @@ class RequestContext {
   /// pollution by visually changing the site).
   final bool uiCacheEnabled;
 
+  /// Whether to use the new Google Identity Services library.
+  final bool useGisSignIn;
+
   const RequestContext({
     this.indentJson = false,
     this.isExperimental = false,
     this.blockRobots = true,
     this.uiCacheEnabled = false,
+    this.useGisSignIn = false,
   });
 
   /// Whether to show the admin UI for automated publishing admin UI.

--- a/app/lib/frontend/templates/views/shared/layout.dart
+++ b/app/lib/frontend/templates/views/shared/layout.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:pub_dev/frontend/request_context.dart';
+
 import '../../../../shared/urls.dart' as urls;
 import '../../../dom/dom.dart' as d;
 import '../../../static_files.dart' show staticUrls;
@@ -119,10 +121,19 @@ d.Node pageLayoutNode({
             ),
             d.meta(
                 name: 'google-signin-client_id', content: oauthClientId ?? ''),
-            d.script(
-              src: 'https://apis.google.com/js/platform.js?onload=pubAuthInit',
-              defer: true,
-            ),
+            if (requestContext.useGisSignIn)
+              d.script(
+                src: 'https://accounts.google.com/gsi/client',
+                async: true,
+                defer: true,
+                onload: 'pubGsiClientInit()',
+              )
+            else
+              d.script(
+                src:
+                    'https://apis.google.com/js/platform.js?onload=pubAuthInit',
+                defer: true,
+              ),
             if (pageDataEncoded != null)
               d.meta(name: 'pub-page-data', content: pageDataEncoded),
             if (isLanding) ...[

--- a/app/lib/service/csp/default_csp.dart
+++ b/app/lib/service/csp/default_csp.dart
@@ -46,6 +46,9 @@ final _defaultContentSecurityPolicyMap = <String, List<String>>{
     'https://unpkg.com/',
     'https://www.gstatic.com/',
     'https://gstatic.com',
+    // required by Google Identity Services library
+    // https://developers.google.com/identity/gsi/web/guides/get-google-api-clientid#content_security_policy
+    'https://accounts.google.com/gsi/client',
   ],
   'style-src': <String>[
     "'self'",
@@ -56,6 +59,9 @@ final _defaultContentSecurityPolicyMap = <String, List<String>>{
     'https://gstatic.com',
     'https://www.gstatic.com/',
     'https://tagmanager.google.com',
+    // required by Google Identity Services library
+    // https://developers.google.com/identity/gsi/web/guides/get-google-api-clientid#content_security_policy
+    'https://accounts.google.com/gsi/style',
   ],
 };
 

--- a/app/lib/shared/configuration.dart
+++ b/app/lib/shared/configuration.dart
@@ -324,6 +324,9 @@ class Configuration {
     publicPackagesBucketName!,
     searchSnapshotBucketName!,
   ]);
+
+  late final isProduction = projectId == 'dartlang-pub';
+  late final isNotProduction = !isProduction;
 }
 
 /// Data structure to describe an admin user.

--- a/app/lib/shared/handler_helpers.dart
+++ b/app/lib/shared/handler_helpers.dart
@@ -9,7 +9,6 @@ import 'package:appengine/appengine.dart';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as path;
 import 'package:pub_dev/frontend/handlers/headers.dart';
-import 'package:pub_dev/shared/env_config.dart';
 import 'package:shelf/shelf.dart' as shelf;
 import 'package:shelf/shelf_io.dart' as shelf_io;
 import 'package:stack_trace/stack_trace.dart';
@@ -132,9 +131,7 @@ shelf.Handler _requestContextWrapper(shelf.Handler handler) {
 
     // The use of the new Google Identity Services library is restricted to
     // staging or running locally, and it is also behind the experimental flag.
-    final isStaging = activeConfiguration.projectId == 'dartlang-pub-dev';
-    final useGisSignIn =
-        isExperimental && (envConfig.isRunningLocally || isStaging);
+    final useGisSignIn = isExperimental && activeConfiguration.isNotProduction;
 
     registerRequestContext(RequestContext(
       indentJson: indentJson,

--- a/app/lib/shared/handler_helpers.dart
+++ b/app/lib/shared/handler_helpers.dart
@@ -132,9 +132,9 @@ shelf.Handler _requestContextWrapper(shelf.Handler handler) {
 
     // The use of the new Google Identity Services library is restricted to
     // staging or running locally, and it is also behind the experimental flag.
-    final useGisSignIn = isExperimental &&
-        (envConfig.isRunningLocally ||
-            activeConfiguration.projectId == 'dartlang-pub-dev');
+    final isStaging = activeConfiguration.projectId == 'dartlang-pub-dev';
+    final useGisSignIn =
+        isExperimental && (envConfig.isRunningLocally || isStaging);
 
     registerRequestContext(RequestContext(
       indentJson: indentJson,

--- a/app/lib/shared/handler_helpers.dart
+++ b/app/lib/shared/handler_helpers.dart
@@ -9,6 +9,7 @@ import 'package:appengine/appengine.dart';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as path;
 import 'package:pub_dev/frontend/handlers/headers.dart';
+import 'package:pub_dev/shared/env_config.dart';
 import 'package:shelf/shelf.dart' as shelf;
 import 'package:shelf/shelf_io.dart' as shelf_io;
 import 'package:stack_trace/stack_trace.dart';
@@ -129,11 +130,18 @@ shelf.Handler _requestContextWrapper(shelf.Handler handler) {
             !hasExperimentalCookie && // don't cache if experimental cookie is enabled
             userSessionData == null; // don't cache if a user session is active
 
+    // The use of the new Google Identity Services library is restricted to
+    // staging or running locally, and it is also behind the experimental flag.
+    final useGisSignIn = isExperimental &&
+        (envConfig.isRunningLocally ||
+            activeConfiguration.projectId == 'dartlang-pub-dev');
+
     registerRequestContext(RequestContext(
       indentJson: indentJson,
       isExperimental: isExperimental,
       blockRobots: !enableRobots,
       uiCacheEnabled: uiCacheEnabled,
+      useGisSignIn: useGisSignIn,
     ));
     return await handler(request);
   };

--- a/pkg/web_app/lib/src/account.dart
+++ b/pkg/web_app/lib/src/account.dart
@@ -44,6 +44,18 @@ void setupAccount() {
       );
     }));
   };
+
+  // Initialization hook that will run after the Google Identity Service library
+  // is loaded and initialized. Method name is passed in as an attribute in the DOM.
+  context['pubGsiClientInit'] = () {
+    window.console.log('GIS client loaded.');
+    // TODO: implement initialization
+    // Some resources:
+    // - https://developers.googleblog.com/2022/03/gis-jsweb-authz-migration.html
+    // - https://developers.google.com/identity/gsi/web/guides/overview
+    // - https://developers.google.com/identity/gsi/web/guides/migration#object_migration_reference_for_user_sign-in
+    // - https://developers.google.com/identity/gsi/web/reference/js-reference
+  };
 }
 
 void _initFailed() {


### PR DESCRIPTION
- This is the boilerplate required for #5573, without any functionality.
- The new library will be enabled on staging, when the experimental flag is on. Should not affect prod, even with the experimental flag set.