### PR TITLE
Dynamically load Google Identity Service library.

### DIFF
--- a/app/lib/frontend/templates/views/shared/layout.dart
+++ b/app/lib/frontend/templates/views/shared/layout.dart
@@ -121,14 +121,7 @@ d.Node pageLayoutNode({
             ),
             d.meta(
                 name: 'google-signin-client_id', content: oauthClientId ?? ''),
-            if (requestContext.experimentalFlags.useGisSignIn)
-              d.script(
-                src: 'https://accounts.google.com/gsi/client',
-                async: true,
-                defer: true,
-                onload: 'pubGsiClientInit()',
-              )
-            else
+            if (!requestContext.experimentalFlags.useGisSignIn)
               d.script(
                 src:
                     'https://apis.google.com/js/platform.js?onload=pubAuthInit',

--- a/pkg/web_app/lib/src/account.dart
+++ b/pkg/web_app/lib/src/account.dart
@@ -45,17 +45,25 @@ void setupAccount() {
     }));
   };
 
-  // Initialization hook that will run after the Google Identity Service library
-  // is loaded and initialized. Method name is passed in as an attribute in the DOM.
-  context['pubGsiClientInit'] = () {
-    window.console.log('GIS client loaded.');
-    // TODO: implement initialization
-    // Some resources:
-    // - https://developers.googleblog.com/2022/03/gis-jsweb-authz-migration.html
-    // - https://developers.google.com/identity/gsi/web/guides/overview
-    // - https://developers.google.com/identity/gsi/web/guides/migration#object_migration_reference_for_user_sign-in
-    // - https://developers.google.com/identity/gsi/web/reference/js-reference
-  };
+  final hasPubAuthInitScript = document.head!
+      .querySelectorAll('script')
+      .any((e) => e is ScriptElement && e.src.contains('onload=pubAuthInit'));
+  if (!hasPubAuthInitScript) {
+    // Initialization hook that will run after the Google Identity Service library
+    // is loaded and initialized. Method name is passed in as an attribute in the DOM.
+    final script = ScriptElement()
+      ..src = 'https://accounts.google.com/gsi/client'
+      ..addEventListener('load', (_) {
+        window.console.log('GIS client loaded.');
+        // TODO: implement initialization of the Google Identity Service library.
+        // Some resources:
+        // - https://developers.googleblog.com/2022/03/gis-jsweb-authz-migration.html
+        // - https://developers.google.com/identity/gsi/web/guides/overview
+        // - https://developers.google.com/identity/gsi/web/guides/migration#object_migration_reference_for_user_sign-in
+        // - https://developers.google.com/identity/gsi/web/reference/js-reference
+      });
+    document.head!.append(script);
+  }
 }
 
 void _initFailed() {


### PR DESCRIPTION
- #5573
- The `onload` introduced in #5934 won't work with our Content Security Policy, unless we enable `unsecure-inline`.
- The new script doesn't support the `?onload=<fn>` parameter that the old one did.
- CSP hashes/nonces does not work with `onload=fn()` attributes, so it seems we need to do this dynamically. If it later turns out that we don't need this callback, we can revert the library loading part to `<script>` element.