### PR TITLE
Fix form styles.

### DIFF
--- a/app/lib/frontend/dom/material.dart
+++ b/app/lib/frontend/dom/material.dart
@@ -139,28 +139,31 @@ d.Node textField({
   required String? label,
   String? value,
 }) {
-  return d.fragment([
-    if (label != null) d.label(attributes: {'for': id}, text: label),
-    d.div(
-      classes: ['mdc-text-field', 'mdc-text-field--outlined'],
-      attributes: {'data-mdc-auto-init': 'MDCTextField'},
-      children: [
-        d.input(
-          type: 'text',
-          id: id,
-          classes: ['mdc-text-field__input'],
-          value: value,
-        ),
-        d.div(
-          classes: ['mdc-notched-outline'],
-          children: [
-            d.div(classes: ['mdc-notched-outline__leading'], text: ''),
-            d.div(classes: ['mdc-notched-outline__trailing'], text: ''),
-          ],
-        ),
-      ],
-    ),
-  ]);
+  return d.div(
+    classes: ['mdc-form-field'],
+    children: [
+      if (label != null) d.label(attributes: {'for': id}, text: label),
+      d.div(
+        classes: ['mdc-text-field', 'mdc-text-field--outlined'],
+        attributes: {'data-mdc-auto-init': 'MDCTextField'},
+        children: [
+          d.input(
+            type: 'text',
+            id: id,
+            classes: ['mdc-text-field__input'],
+            value: value,
+          ),
+          d.div(
+            classes: ['mdc-notched-outline'],
+            children: [
+              d.div(classes: ['mdc-notched-outline__leading'], text: ''),
+              d.div(classes: ['mdc-notched-outline__trailing'], text: ''),
+            ],
+          ),
+        ],
+      ),
+    ],
+  );
 }
 
 /// Renders a material text area.

--- a/app/lib/frontend/templates/views/pkg/admin_page.dart
+++ b/app/lib/frontend/templates/views/pkg/admin_page.dart
@@ -104,7 +104,7 @@ d.Node packageAdminPageNode({
               d.li(text: 'Invite and remove uploaders of this package'),
             ]),
             d.div(
-              classes: ['-pub-form-row'],
+              classes: ['-pub-form-textfield-row'],
               child: material.textField(
                 id: '-pkg-admin-invite-uploader-input',
                 label: 'Email address',
@@ -121,10 +121,13 @@ d.Node packageAdminPageNode({
         'to inform users that the package is no longer maintained. '
         '*Discontinued packages* remain available to package users, but they don\'t appear '
         'in search results on pub.dev unless the user specifies advanced search options.'),
-    material.checkbox(
-      id: '-admin-is-discontinued-checkbox',
-      label: 'Mark "discontinued"',
-      checked: package.isDiscontinued,
+    d.div(
+      classes: ['-pub-form-checkbox-row'],
+      child: material.checkbox(
+        id: '-admin-is-discontinued-checkbox',
+        label: 'Mark "discontinued"',
+        checked: package.isDiscontinued,
+      ),
     ),
     if (package.isDiscontinued) ...[
       d.h3(text: 'Suggested replacement'),
@@ -135,7 +138,7 @@ d.Node packageAdminPageNode({
           text: 'Designating a replacement package is optional, '
               'and only serves to guide existing package users.'),
       d.div(
-        classes: ['-pub-form-row'],
+        classes: ['-pub-form-textfield-row'],
         children: [
           material.textField(
             id: '-package-replaced-by',
@@ -155,10 +158,13 @@ d.Node packageAdminPageNode({
       d.markdown(
           'A package that\'s marked as *unlisted* doesn\'t normally appear in search results on pub.dev. '
           'Unlisted packages remain publicly available, and users can search for them using advanced search options.'),
-      material.checkbox(
-        id: '-admin-is-unlisted-checkbox',
-        label: 'Mark "unlisted"',
-        checked: package.isUnlisted,
+      d.div(
+        classes: ['-pub-form-checkbox-row'],
+        child: material.checkbox(
+          id: '-admin-is-unlisted-checkbox',
+          label: 'Mark "unlisted"',
+          checked: package.isUnlisted,
+        ),
       ),
     ],
     if (requestContext.showAdminUIForAutomatedPublishing)
@@ -166,7 +172,7 @@ d.Node packageAdminPageNode({
         d.h2(text: 'Automated publishing'),
         d.h3(text: 'Publishing from GitHub Actions'),
         d.div(
-          classes: ['-pub-form-row'],
+          classes: ['-pub-form-checkbox-row'],
           child: material.checkbox(
             id: '-pkg-admin-automated-github-enabled',
             label: 'Enable publishing from GitHub Actions',
@@ -174,7 +180,7 @@ d.Node packageAdminPageNode({
           ),
         ),
         d.div(
-          classes: ['-pub-form-row'],
+          classes: ['-pub-form-textfield-row'],
           child: material.textField(
             id: '-pkg-admin-automated-github-repository',
             label: 'Repository',

--- a/app/lib/frontend/templates/views/publisher/admin_page.dart
+++ b/app/lib/frontend/templates/views/publisher/admin_page.dart
@@ -16,7 +16,7 @@ d.Node publisherAdminPageNode({
   return d.fragment([
     d.h2(text: 'Publisher information'),
     d.div(
-      classes: ['-pub-form-row'],
+      classes: ['-pub-form-textfield-row'],
       child: material.textArea(
         id: '-publisher-description',
         label: 'Description',
@@ -26,7 +26,7 @@ d.Node publisherAdminPageNode({
       ),
     ),
     d.div(
-      classes: ['-pub-form-row'],
+      classes: ['-pub-form-textfield-row'],
       child: material.textField(
         id: '-publisher-website-url',
         label: 'Website',
@@ -34,7 +34,7 @@ d.Node publisherAdminPageNode({
       ),
     ),
     d.div(
-      classes: ['-pub-form-row'],
+      classes: ['-pub-form-textfield-row'],
       child: material.textField(
         id: '-publisher-contact-email',
         label: 'Contact email',
@@ -106,7 +106,7 @@ d.Node publisherAdminPageNode({
           ],
         ),
         d.div(
-          classes: ['-pub-form-row'],
+          classes: ['-pub-form-textfield-row'],
           child: material.textField(
             id: '-admin-invite-member-input',
             label: 'Email address',

--- a/app/lib/frontend/templates/views/publisher/create_page.dart
+++ b/app/lib/frontend/templates/views/publisher/create_page.dart
@@ -90,7 +90,7 @@ final createPublisherPageNode = d.fragment([
     ]),
   ]),
   d.div(
-    classes: ['-pub-form-row'],
+    classes: ['-pub-form-textfield-row'],
     children: [
       material.textField(
         id: '-publisher-id',

--- a/app/test/frontend/golden/create_publisher_page.html
+++ b/app/test/frontend/golden/create_publisher_page.html
@@ -163,13 +163,15 @@
           </ul>
         </li>
       </ul>
-      <div class="-pub-form-row">
-        <label for="-publisher-id">Domain Name</label>
-        <div class="mdc-text-field mdc-text-field--outlined" data-mdc-auto-init="MDCTextField">
-          <input id="-publisher-id" class="mdc-text-field__input" type="text"/>
-          <div class="mdc-notched-outline">
-            <div class="mdc-notched-outline__leading"></div>
-            <div class="mdc-notched-outline__trailing"></div>
+      <div class="-pub-form-textfield-row">
+        <div class="mdc-form-field">
+          <label for="-publisher-id">Domain Name</label>
+          <div class="mdc-text-field mdc-text-field--outlined" data-mdc-auto-init="MDCTextField">
+            <input id="-publisher-id" class="mdc-text-field__input" type="text"/>
+            <div class="mdc-notched-outline">
+              <div class="mdc-notched-outline__leading"></div>
+              <div class="mdc-notched-outline__trailing"></div>
+            </div>
           </div>
         </div>
         <button id="-admin-create-publisher" class="mdc-button mdc-button--raised" data-mdc-auto-init="MDCRipple">Create publisher</button>

--- a/app/test/frontend/golden/pkg_admin_page.html
+++ b/app/test/frontend/golden/pkg_admin_page.html
@@ -280,13 +280,15 @@
                         <li>Upload new versions of this package</li>
                         <li>Invite and remove uploaders of this package</li>
                       </ul>
-                      <div class="-pub-form-row">
-                        <label for="-pkg-admin-invite-uploader-input">Email address</label>
-                        <div class="mdc-text-field mdc-text-field--outlined" data-mdc-auto-init="MDCTextField">
-                          <input id="-pkg-admin-invite-uploader-input" class="mdc-text-field__input" type="text"/>
-                          <div class="mdc-notched-outline">
-                            <div class="mdc-notched-outline__leading"></div>
-                            <div class="mdc-notched-outline__trailing"></div>
+                      <div class="-pub-form-textfield-row">
+                        <div class="mdc-form-field">
+                          <label for="-pkg-admin-invite-uploader-input">Email address</label>
+                          <div class="mdc-text-field mdc-text-field--outlined" data-mdc-auto-init="MDCTextField">
+                            <input id="-pkg-admin-invite-uploader-input" class="mdc-text-field__input" type="text"/>
+                            <div class="mdc-notched-outline">
+                              <div class="mdc-notched-outline__leading"></div>
+                              <div class="mdc-notched-outline__trailing"></div>
+                            </div>
                           </div>
                         </div>
                       </div>
@@ -301,18 +303,20 @@
                     <em>Discontinued packages</em>
                     remain available to package users, but they don't appear in search results on pub.dev unless the user specifies advanced search options.
                   </p>
-                  <div class="mdc-form-field">
-                    <div class="mdc-checkbox">
-                      <input id="-admin-is-discontinued-checkbox" class="mdc-checkbox__native-control" type="checkbox"/>
-                      <div class="mdc-checkbox__background">
-                        <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
-                          <path class="mdc-checkbox__checkmark-path" fill="none" d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
-                        </svg>
-                        <div class="mdc-checkbox__mixedmark"></div>
+                  <div class="-pub-form-checkbox-row">
+                    <div class="mdc-form-field">
+                      <div class="mdc-checkbox">
+                        <input id="-admin-is-discontinued-checkbox" class="mdc-checkbox__native-control" type="checkbox"/>
+                        <div class="mdc-checkbox__background">
+                          <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
+                            <path class="mdc-checkbox__checkmark-path" fill="none" d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
+                          </svg>
+                          <div class="mdc-checkbox__mixedmark"></div>
+                        </div>
+                        <div class="mdc-checkbox__ripple"></div>
                       </div>
-                      <div class="mdc-checkbox__ripple"></div>
+                      <label for="-admin-is-discontinued-checkbox">Mark "discontinued"</label>
                     </div>
-                    <label for="-admin-is-discontinued-checkbox">Mark "discontinued"</label>
                   </div>
                   <h3>Unlisted</h3>
                   <p>
@@ -320,18 +324,20 @@
                     <em>unlisted</em>
                     doesn't normally appear in search results on pub.dev. Unlisted packages remain publicly available, and users can search for them using advanced search options.
                   </p>
-                  <div class="mdc-form-field">
-                    <div class="mdc-checkbox">
-                      <input id="-admin-is-unlisted-checkbox" class="mdc-checkbox__native-control" type="checkbox"/>
-                      <div class="mdc-checkbox__background">
-                        <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
-                          <path class="mdc-checkbox__checkmark-path" fill="none" d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
-                        </svg>
-                        <div class="mdc-checkbox__mixedmark"></div>
+                  <div class="-pub-form-checkbox-row">
+                    <div class="mdc-form-field">
+                      <div class="mdc-checkbox">
+                        <input id="-admin-is-unlisted-checkbox" class="mdc-checkbox__native-control" type="checkbox"/>
+                        <div class="mdc-checkbox__background">
+                          <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
+                            <path class="mdc-checkbox__checkmark-path" fill="none" d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
+                          </svg>
+                          <div class="mdc-checkbox__mixedmark"></div>
+                        </div>
+                        <div class="mdc-checkbox__ripple"></div>
                       </div>
-                      <div class="mdc-checkbox__ripple"></div>
+                      <label for="-admin-is-unlisted-checkbox">Mark "unlisted"</label>
                     </div>
-                    <label for="-admin-is-unlisted-checkbox">Mark "unlisted"</label>
                   </div>
                   <h2>Package Version Retraction</h2>
                   <div>

--- a/app/test/frontend/golden/publisher_admin_page.html
+++ b/app/test/frontend/golden/publisher_admin_page.html
@@ -157,7 +157,7 @@
               <div class="detail-tabs-content">
                 <section class="tab-content detail-tab-admin-content -active">
                   <h2>Publisher information</h2>
-                  <div class="-pub-form-row">
+                  <div class="-pub-form-textfield-row">
                     <label for="-publisher-description">Description</label>
                     <div class="mdc-text-field mdc-text-field--textarea" data-mdc-auto-init="MDCTextField">
                       <div class="mdc-text-field-character-counter">0 / 4096</div>
@@ -168,23 +168,27 @@
                       </div>
                     </div>
                   </div>
-                  <div class="-pub-form-row">
-                    <label for="-publisher-website-url">Website</label>
-                    <div class="mdc-text-field mdc-text-field--outlined" data-mdc-auto-init="MDCTextField">
-                      <input id="-publisher-website-url" class="mdc-text-field__input" type="text" value="https://example.com/"/>
-                      <div class="mdc-notched-outline">
-                        <div class="mdc-notched-outline__leading"></div>
-                        <div class="mdc-notched-outline__trailing"></div>
+                  <div class="-pub-form-textfield-row">
+                    <div class="mdc-form-field">
+                      <label for="-publisher-website-url">Website</label>
+                      <div class="mdc-text-field mdc-text-field--outlined" data-mdc-auto-init="MDCTextField">
+                        <input id="-publisher-website-url" class="mdc-text-field__input" type="text" value="https://example.com/"/>
+                        <div class="mdc-notched-outline">
+                          <div class="mdc-notched-outline__leading"></div>
+                          <div class="mdc-notched-outline__trailing"></div>
+                        </div>
                       </div>
                     </div>
                   </div>
-                  <div class="-pub-form-row">
-                    <label for="-publisher-contact-email">Contact email</label>
-                    <div class="mdc-text-field mdc-text-field--outlined" data-mdc-auto-init="MDCTextField">
-                      <input id="-publisher-contact-email" class="mdc-text-field__input" type="text" value="admin@pub.dev"/>
-                      <div class="mdc-notched-outline">
-                        <div class="mdc-notched-outline__leading"></div>
-                        <div class="mdc-notched-outline__trailing"></div>
+                  <div class="-pub-form-textfield-row">
+                    <div class="mdc-form-field">
+                      <label for="-publisher-contact-email">Contact email</label>
+                      <div class="mdc-text-field mdc-text-field--outlined" data-mdc-auto-init="MDCTextField">
+                        <input id="-publisher-contact-email" class="mdc-text-field__input" type="text" value="admin@pub.dev"/>
+                        <div class="mdc-notched-outline">
+                          <div class="mdc-notched-outline__leading"></div>
+                          <div class="mdc-notched-outline__trailing"></div>
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -222,13 +226,15 @@
                       <li>Upload new versions of packages owned by this publisher</li>
                       <li>Add and remove members of this publisher</li>
                     </ul>
-                    <div class="-pub-form-row">
-                      <label for="-admin-invite-member-input">Email address</label>
-                      <div class="mdc-text-field mdc-text-field--outlined" data-mdc-auto-init="MDCTextField">
-                        <input id="-admin-invite-member-input" class="mdc-text-field__input" type="text"/>
-                        <div class="mdc-notched-outline">
-                          <div class="mdc-notched-outline__leading"></div>
-                          <div class="mdc-notched-outline__trailing"></div>
+                    <div class="-pub-form-textfield-row">
+                      <div class="mdc-form-field">
+                        <label for="-admin-invite-member-input">Email address</label>
+                        <div class="mdc-text-field mdc-text-field--outlined" data-mdc-auto-init="MDCTextField">
+                          <input id="-admin-invite-member-input" class="mdc-text-field__input" type="text"/>
+                          <div class="mdc-notched-outline">
+                            <div class="mdc-notched-outline__leading"></div>
+                            <div class="mdc-notched-outline__trailing"></div>
+                          </div>
                         </div>
                       </div>
                     </div>

--- a/pkg/web_css/lib/src/_form.scss
+++ b/pkg/web_css/lib/src/_form.scss
@@ -19,9 +19,19 @@
   margin-right: 16px;
 }
 
-.-pub-form-row {
+.-pub-form-checkbox-row,
+.-pub-form-textfield-row {
   margin-top: 20px;
+}
 
+.-pub-form-checkbox-row {
+  label {
+    display: inline-block;
+    margin-bottom: 6px;
+  }
+}
+
+.-pub-form-textfield-row {
   label {
     display: block;
     margin-bottom: 8px;


### PR DESCRIPTION
- Adding missing `mdc-form-field` to material text field.
- Split of `-pub-form-row` into `-pub-form-checkbox-row` and `-pub-form-textfield-row`, as the two requires different label styling.
- Re-aligns the checkbox label for discontinued and other flags too.
- #5769