### PR TITLE
Fix fake_time flaky test: skip periodic timer callback when it is no longer active.

### DIFF
--- a/app/test/task/fake_time.dart
+++ b/app/test/task/fake_time.dart
@@ -252,6 +252,11 @@ class _FakeTime extends FakeTime {
 
     // Trigger the callback for the pending timer.
     for (final triggeredTimer in triggeredTimers) {
+      // Skip running periodic timers if they have been cancelled.
+      // TODO: review/refactor trigger sequence so that this doesn't happen
+      if (triggeredTimer._isPeriodic && !triggeredTimer.isActive) {
+        continue;
+      }
       try {
         triggeredTimer._parent.runUnary(
           triggeredTimer._zone,


### PR DESCRIPTION
I have the suspicion that the condition + `continue` will fix the flakes, but couldn't really confirm it locally yet.