### PR TITLE
JWT time check with 2 minutes threshold.

### DIFF
--- a/app/lib/account/backend.dart
+++ b/app/lib/account/backend.dart
@@ -206,7 +206,7 @@ AuthenticatedGithubAction? _tryAuthenticateGithubAction(String token) {
   if (idToken == null) {
     return null;
   }
-  if (!idToken.payload.verifyTimestamps()) {
+  if (!idToken.payload.isTimely(threshold: Duration(minutes: 2))) {
     return null;
   }
   final payload = GitHubJwtPayload.tryParse(idToken.payload);

--- a/app/lib/service/openid/jwt.dart
+++ b/app/lib/service/openid/jwt.dart
@@ -214,9 +214,8 @@ class JwtPayload extends UnmodifiableMapView<String, dynamic> {
   ///
   /// Returns `false` if the current timestamp is outside of the allowed range.
   /// If the timestamp is missing, we treat it as if it were expired/invalid.
-  bool isTimely({DateTime? now, Duration? threshold}) {
+  bool isTimely({DateTime? now, Duration threshold = Duration.zero}) {
     now ??= clock.now();
-    threshold ??= Duration.zero;
 
     bool isABeforeB(String name, DateTime? a, DateTime? b) {
       if (a == null || b == null) {
@@ -228,7 +227,7 @@ class JwtPayload extends UnmodifiableMapView<String, dynamic> {
       }
       final diff = a.difference(b);
       _logger.info('$name has a time difference of $diff.');
-      return diff < threshold!;
+      return diff < threshold;
     }
 
     return isABeforeB('iat', iat, now) &&

--- a/app/lib/service/openid/jwt.dart
+++ b/app/lib/service/openid/jwt.dart
@@ -214,30 +214,26 @@ class JwtPayload extends UnmodifiableMapView<String, dynamic> {
   ///
   /// Returns `false` if the current timestamp is outside of the allowed range.
   /// If the timestamp is missing, we treat it as if it were expired/invalid.
-  bool verifyTimestamps([DateTime? now]) {
+  bool isTimely({DateTime? now, Duration? threshold}) {
     now ??= clock.now();
+    threshold ??= Duration.zero;
 
     bool isABeforeB(String name, DateTime? a, DateTime? b) {
       if (a == null || b == null) {
-        // TODO: remove debug message after the appropriate difference threshold is selected.
-        print('$name is missing.');
+        _logger.info('JWT does not have "$name" field.');
         return false;
       }
       if (a.isBefore(b) || a == b) {
         return true;
       }
-      // TODO: remove debug message after the appropriate difference threshold is selected.
-      print('$name has a time difference of ${a.difference(b)}.');
-      return false;
+      final diff = a.difference(b);
+      _logger.info('$name has a time difference of $diff.');
+      return diff < threshold!;
     }
 
-    // NOTE: The list ensures that each timestamp is evaluated, all differences will be printed.
-    // TODO: switch to a simple `&&` after the appropriate difference threshold is selected.
-    return [
-      isABeforeB('iat', iat, now),
-      isABeforeB('nbf', nbf, now),
-      isABeforeB('exp', now, exp),
-    ].every((b) => b);
+    return isABeforeB('iat', iat, now) &&
+        isABeforeB('nbf', nbf, now) &&
+        isABeforeB('exp', now, exp);
   }
 }
 

--- a/app/lib/service/openid/jwt.dart
+++ b/app/lib/service/openid/jwt.dart
@@ -222,12 +222,7 @@ class JwtPayload extends UnmodifiableMapView<String, dynamic> {
         _logger.info('JWT does not have "$name" field.');
         return false;
       }
-      if (a.isBefore(b) || a == b) {
-        return true;
-      }
-      final diff = a.difference(b);
-      _logger.info('$name has a time difference of $diff.');
-      return diff < threshold;
+      return a.isBefore(b.add(threshold)) || a == b;
     }
 
     return isABeforeB('iat', iat, now) &&

--- a/app/test/service/openid/github_actions_id_token_test.dart
+++ b/app/test/service/openid/github_actions_id_token_test.dart
@@ -67,12 +67,12 @@ void main() {
 
       // verify payload
       print(token.payload);
-      expect(token.payload.verifyTimestamps(), isTrue);
+      expect(token.payload.isTimely(threshold: Duration(minutes: 1)), isTrue);
       final payload = GitHubJwtPayload(token.payload);
       expect(payload.aud, 'https://example.com');
       // repository check assumes that clones keep the `pub-dev` name:
       expect(payload.repository, endsWith('/pub-dev'));
-      expect(payload.eventName, anyOf(['pull_request', 'push']));
+      expect(payload.eventName, anyOf(['pull_request', 'push', 'schedule']));
       expect(payload.refType, anyOf(['branch']));
       // example `ref`: `refs/pull/38/merge`
       // example `ref`: `refs/head/master`


### PR DESCRIPTION
- renamed method to `isTimely`
- token test uses only a 1-minute threshold, regular backend uses 2-minutes threshold - let's increase it only if we need to
- added `schedule` to the event names in token test (when it is triggered from cron)