### PR TITLE
Support restricting automatic publishing to a GitHub environment.

### DIFF
--- a/app/lib/frontend/templates/views/pkg/admin_page.dart
+++ b/app/lib/frontend/templates/views/pkg/admin_page.dart
@@ -168,33 +168,7 @@ d.Node packageAdminPageNode({
       ),
     ],
     if (requestContext.showAdminUIForAutomatedPublishing)
-      d.fragment([
-        d.h2(text: 'Automated publishing'),
-        d.h3(text: 'Publishing from GitHub Actions'),
-        d.div(
-          classes: ['-pub-form-checkbox-row'],
-          child: material.checkbox(
-            id: '-pkg-admin-automated-github-enabled',
-            label: 'Enable publishing from GitHub Actions',
-            checked: package.automatedPublishing.github?.isEnabled ?? false,
-          ),
-        ),
-        d.div(
-          classes: ['-pub-form-textfield-row'],
-          child: material.textField(
-            id: '-pkg-admin-automated-github-repository',
-            label: 'Repository',
-            value: package.automatedPublishing.github?.repository,
-          ),
-        ),
-        d.p(
-          child: material.button(
-            id: '-pkg-admin-automated-button',
-            label: 'Update',
-            raised: true,
-          ),
-        ),
-      ]),
+      _automatedPublishing(package),
     d.h2(text: 'Package Version Retraction'),
     d.div(children: [
       d.markdown(
@@ -254,5 +228,71 @@ d.Node packageAdminPageNode({
         d.markdown(
             'This package has no retracted versions that can be restored.'),
     ]),
+  ]);
+}
+
+d.Node _automatedPublishing(Package package) {
+  final github = package.automatedPublishing.github;
+  return d.fragment([
+    d.h2(text: 'Automated publishing'),
+    d.h3(text: 'Publishing from GitHub Actions'),
+    d.div(
+      classes: [
+        '-pub-form-checkbox-row',
+        '-pub-form-checkbox-toggle-next-sibling',
+      ],
+      child: material.checkbox(
+        id: '-pkg-admin-automated-github-enabled',
+        label: 'Enable publishing from GitHub Actions',
+        checked: github?.isEnabled ?? false,
+      ),
+    ),
+    d.div(
+      classes: [
+        '-pub-form-checkbox-indent',
+        if (!(github?.isEnabled ?? false)) '-pub-form-block-hidden',
+      ],
+      children: [
+        d.div(
+          classes: ['-pub-form-textfield-row'],
+          child: material.textField(
+            id: '-pkg-admin-automated-github-repository',
+            label: 'Repository',
+            value: github?.repository,
+          ),
+        ),
+        d.div(
+          classes: [
+            '-pub-form-checkbox-row',
+            '-pub-form-checkbox-toggle-next-sibling',
+          ],
+          child: material.checkbox(
+            id: '-pkg-admin-automated-github-requireenv',
+            label: 'Require GitHub Actions environment',
+            checked: github?.requireEnvironment ?? false,
+          ),
+        ),
+        d.div(
+          classes: [
+            '-pub-form-checkbox-indent',
+            '-pub-form-textfield-row',
+            if (!(github?.requireEnvironment ?? false))
+              '-pub-form-block-hidden',
+          ],
+          child: material.textField(
+            id: '-pkg-admin-automated-github-environment',
+            label: 'Environment',
+            value: github?.environment,
+          ),
+        ),
+      ],
+    ),
+    d.p(
+      child: material.button(
+        id: '-pkg-admin-automated-button',
+        label: 'Update',
+        raised: true,
+      ),
+    ),
   ]);
 }

--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -482,7 +482,7 @@ class PackageBackend {
         final isEnabled = github.isEnabled ?? false;
         // normalize input values
         final repository = github.repository?.trim() ?? '';
-        github.repository = repository;
+        github.repository = repository.isEmpty ? null : repository;
         final requireEnvironment = github.requireEnvironment ?? false;
         github.requireEnvironment = requireEnvironment ? true : null;
         final environment = github.environment?.trim() ?? '';

--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -56,6 +56,8 @@ final _defaultMaxVersionsPerPackage = 1000;
 final Logger _logger = Logger('pub.cloud_repository');
 final _validGithubUserOrRepoRegExp =
     RegExp(r'^[a-z0-9\-\._]+$', caseSensitive: false);
+final _validGithubEnvironment =
+    RegExp(r'^[a-z0-9\-\._]+$', caseSensitive: false);
 
 /// Sets the package backend service.
 void registerPackageBackend(PackageBackend backend) =>
@@ -481,6 +483,9 @@ class PackageBackend {
         // normalize input values
         final repository = github.repository?.trim() ?? '';
         github.repository = repository;
+        final requireEnvironment = github.requireEnvironment ?? false;
+        final environment = github.environment?.trim() ?? '';
+        github.environment = environment;
 
         InvalidInputException.check(!isEnabled || repository.isNotEmpty,
             'The `repository` field must not be empty when enabled.');
@@ -493,6 +498,16 @@ class PackageBackend {
               _validGithubUserOrRepoRegExp.hasMatch(parts[0]) &&
                   _validGithubUserOrRepoRegExp.hasMatch(parts[1]),
               'The `repository` field has invalid characters.');
+        }
+
+        InvalidInputException.check(
+            !requireEnvironment || environment.isNotEmpty,
+            'The `environment` field must not be empty when enabled.');
+
+        if (environment.isNotEmpty) {
+          InvalidInputException.check(
+              _validGithubEnvironment.hasMatch(environment),
+              'The `environment` field has invalid characters.');
         }
       }
 
@@ -1124,12 +1139,29 @@ class PackageBackend {
     if (githubPublishing == null || (githubPublishing.isEnabled ?? false)) {
       return false;
     }
+
+    // Repository must be set and matching the action's repository.
     final repository = githubPublishing.repository;
-    final repositoryMatches = repository != null &&
-        repository.isNotEmpty &&
-        agent.payload.repository == repository;
-    if (!repositoryMatches) {
+    if (repository == null ||
+        repository.isEmpty ||
+        repository != agent.payload.repository) {
       return false;
+    }
+
+    // TODO: consider allowing other events from
+    //       https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows
+    if (agent.payload.eventName != 'push') {
+      return false;
+    }
+
+    // When environment is configured, it must match the action's environment.
+    if (githubPublishing.requireEnvironment ?? false) {
+      final environment = githubPublishing.environment;
+      if (environment == null ||
+          environment.isEmpty ||
+          environment != agent.payload.environment) {
+        return false;
+      }
     }
 
     // TODO: return `true` once we are happy with the current checks

--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -484,8 +484,9 @@ class PackageBackend {
         final repository = github.repository?.trim() ?? '';
         github.repository = repository;
         final requireEnvironment = github.requireEnvironment ?? false;
+        github.requireEnvironment = requireEnvironment ? true : null;
         final environment = github.environment?.trim() ?? '';
-        github.environment = environment;
+        github.environment = environment.isEmpty ? null : environment;
 
         InvalidInputException.check(!isEnabled || repository.isNotEmpty,
             'The `repository` field must not be empty when enabled.');

--- a/app/lib/service/openid/github_openid.dart
+++ b/app/lib/service/openid/github_openid.dart
@@ -74,6 +74,9 @@ class GitHubJwtPayload {
   /// the kind of git reference given (e.g. "branch")
   final String refType;
 
+  /// name of the environment used by the job
+  final String? environment;
+
   /// The URL used as the `iss` property of JWT payloads.
   static const githubIssuerUrl = 'https://token.actions.githubusercontent.com';
 
@@ -98,7 +101,8 @@ class GitHubJwtPayload {
         repositoryOwner = _parseAsString(map, 'repository_owner'),
         eventName = _parseAsString(map, 'event_name'),
         ref = _parseAsString(map, 'ref'),
-        refType = _parseAsString(map, 'ref_type');
+        refType = _parseAsString(map, 'ref_type'),
+        environment = _parseAsStringOrNull(map, 'environment');
 
   factory GitHubJwtPayload(JwtPayload payload) {
     final missing = _requiredClaims.difference(payload.keys.toSet()).sorted();

--- a/pkg/_pub_shared/lib/data/package_api.dart
+++ b/pkg/_pub_shared/lib/data/package_api.dart
@@ -70,9 +70,17 @@ class GithubPublishing {
   /// The `owner/repository` path of the project on github.com.
   String? repository;
 
+  /// Whether to require the action from a specific environment.
+  bool? requireEnvironment;
+
+  /// The GitHub environment where the publishing is required from.
+  String? environment;
+
   GithubPublishing({
     this.isEnabled,
     this.repository,
+    this.requireEnvironment,
+    this.environment,
   });
 
   factory GithubPublishing.fromJson(Map<String, dynamic> json) =>

--- a/pkg/_pub_shared/lib/data/package_api.g.dart
+++ b/pkg/_pub_shared/lib/data/package_api.g.dart
@@ -56,6 +56,8 @@ GithubPublishing _$GithubPublishingFromJson(Map<String, dynamic> json) =>
     GithubPublishing(
       isEnabled: json['isEnabled'] as bool?,
       repository: json['repository'] as String?,
+      requireEnvironment: json['requireEnvironment'] as bool?,
+      environment: json['environment'] as String?,
     );
 
 Map<String, dynamic> _$GithubPublishingToJson(GithubPublishing instance) {
@@ -69,6 +71,8 @@ Map<String, dynamic> _$GithubPublishingToJson(GithubPublishing instance) {
 
   writeNotNull('isEnabled', instance.isEnabled);
   writeNotNull('repository', instance.repository);
+  writeNotNull('requireEnvironment', instance.requireEnvironment);
+  writeNotNull('environment', instance.environment);
   return val;
 }
 

--- a/pkg/web_app/lib/src/admin_pages.dart
+++ b/pkg/web_app/lib/src/admin_pages.dart
@@ -46,7 +46,7 @@ class _PkgAdminWidget {
 
   void init() {
     if (!pageData.isPackagePage) return;
-    _setupCredAuth();
+    _setupAutomatedPublishing();
     _setPublisherInput = document.getElementById('-admin-set-publisher-input');
     _setPublisherButton =
         document.getElementById('-admin-set-publisher-button');
@@ -89,11 +89,17 @@ class _PkgAdminWidget {
     }
   }
 
-  void _setupCredAuth() {
+  void _setupAutomatedPublishing() {
     final githubEnabledCheckbox = document
         .getElementById('-pkg-admin-automated-github-enabled') as InputElement?;
     final githubRepositoryInput =
         document.getElementById('-pkg-admin-automated-github-repository')
+            as InputElement?;
+    final githubRequireEnvironmentCheckbox =
+        document.getElementById('-pkg-admin-automated-github-requireenv')
+            as InputElement?;
+    final githubEnvironmentInput =
+        document.getElementById('-pkg-admin-automated-github-environment')
             as InputElement?;
     final updateButton = document.getElementById('-pkg-admin-automated-button');
     if (updateButton == null || githubRepositoryInput == null) {
@@ -110,6 +116,8 @@ class _PkgAdminWidget {
                 github: GithubPublishing(
                   isEnabled: githubEnabledCheckbox!.checked,
                   repository: githubRepositoryInput.value,
+                  requireEnvironment: githubRequireEnvironmentCheckbox!.checked,
+                  environment: githubEnvironmentInput!.value,
                 ),
               ));
         },

--- a/pkg/web_app/lib/src/foldable.dart
+++ b/pkg/web_app/lib/src/foldable.dart
@@ -7,6 +7,7 @@ import 'dart:math' show min, max;
 
 void setupFoldable() {
   _setEventForFoldable();
+  _setEventForCheckboxToggle();
 }
 
 /// Elements with the `foldable` class provide a folding content:
@@ -98,4 +99,19 @@ Element? _parentWithClass(Element? elem, String className) {
     elem = elem.parent;
   }
   return elem;
+}
+
+/// Setup events for forms where a checkbox shows/hides the next block based on its state.
+void _setEventForCheckboxToggle() {
+  final toggleRoots = document.body!
+      .querySelectorAll('.-pub-form-checkbox-toggle-next-sibling');
+  for (final elem in toggleRoots) {
+    final input = elem.querySelector('input') as InputElement?;
+    if (input == null) continue;
+    final sibling = elem.nextElementSibling;
+    if (sibling == null) continue;
+    input.onChange.listen((event) {
+      sibling.classes.toggle('-pub-form-block-hidden');
+    });
+  }
 }

--- a/pkg/web_css/lib/src/_form.scss
+++ b/pkg/web_css/lib/src/_form.scss
@@ -48,6 +48,14 @@
   text-align: right;
 }
 
+.-pub-form-checkbox-indent {
+  margin-left: 40px;
+}
+
+.-pub-form-block-hidden {
+  display: none
+}
+
 #-pub-publisher-admin-members-table {
   width: 100%;
   border-width: 0px;


### PR DESCRIPTION
- #5769
- added new fields to the config object stored on the `Package` entity
- added checkbox + field for the `environment` field of the JWT
- updated UI to have a show/hide logic when these checkboxes are clicked
- better exposing the publish-time match failures will be done in a subsequent PR 

<img width="602" alt="image" src="https://user-images.githubusercontent.com/4778111/191790656-de875ec3-fc90-42bf-abd0-2bb777385d5f.png">
