### PR TITLE
Upgrade dartdoc and dependencies (incl. markdown)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@ Important changes to data models, configuration, and migrations between each
 AppEngine version, listed here to ease deployment and troubleshooting.
 
 ## Next Release (replace with git tag when deployed)
- * Upgraded pana to `0.21.18`.
  * Bumped runtimeVersion to `2022.09.26`.
+ * Upgraded pana to `0.21.18`.
+ * Upgraded dartdoc to `6.1.1`.
+ * Upgraded dependencies, including `markdown` to `6.0.1`.
 
 ## `20220922t114500-all`
  * Bumped runtimeVersion to `2022.09.22`.

--- a/app/lib/shared/versions.dart
+++ b/app/lib/shared/versions.dart
@@ -68,7 +68,7 @@ final semanticToolStableFlutterSdkVersion =
 final String panaVersion = pana.packageVersion;
 
 // keep in-sync with pkg/pub_dartdoc/pubspec.yaml
-final String dartdocVersion = '6.0.1';
+final String dartdocVersion = '6.1.1';
 
 /// Whether the given runtime version (stored with the dartdoc entry) should
 /// be displayed on the live site (or a coordinated upgrade is in progress).

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -155,13 +155,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "8.4.1"
-  charcode:
-    dependency: transitive
-    description:
-      name: charcode
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -217,7 +210,7 @@ packages:
       name: coverage
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.0"
+    version: "1.6.1"
   crypto:
     dependency: "direct main"
     description:
@@ -392,14 +385,14 @@ packages:
       name: json_annotation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.6.0"
+    version: "4.7.0"
   json_serializable:
     dependency: "direct dev"
     description:
       name: json_serializable
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.3.2"
+    version: "6.4.0"
   jsontool:
     dependency: transitive
     description:
@@ -434,7 +427,7 @@ packages:
       name: markdown
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.0.0"
+    version: "6.0.1"
   matcher:
     dependency: transitive
     description:
@@ -595,7 +588,7 @@ packages:
       name: shelf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.2"
+    version: "1.4.0"
   shelf_packages_handler:
     dependency: transitive
     description:
@@ -644,7 +637,7 @@ packages:
       name: source_gen
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.3"
+    version: "1.2.5"
   source_helper:
     dependency: transitive
     description:
@@ -686,7 +679,7 @@ packages:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   stream_transform:
     dependency: "direct main"
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -27,7 +27,7 @@ dependencies:
   json_annotation: '^4.3.0'
   lints: ^2.0.0
   logging: '>=0.9.3 <2.0.0'
-  markdown: ^6.0.0
+  markdown: ^6.0.1
   meta: ^1.1.2
   mime: '>=0.9.3 <2.0.0'
   neat_cache: ^2.0.1
@@ -73,7 +73,3 @@ dev_dependencies:
   source_gen: '^1.0.0'
   test: ^1.16.5
   xml: ^6.0.0
-
-dependency_overrides:
-  # TODO: remove after https://github.com/dart-lang/markdown/issues/445 gets fixed
-  markdown: ^5.0.0

--- a/app/test/dartdoc/dartdoc_runner_test.dart
+++ b/app/test/dartdoc/dartdoc_runner_test.dart
@@ -36,13 +36,13 @@ void main() {
 
         // size checks
         final entry = card.dartdocReport!.dartdocEntry!;
-        expect(entry.archiveSize, greaterThan(140000));
-        expect(entry.archiveSize, lessThan(150000));
-        expect(entry.totalSize, greaterThan(490000));
-        expect(entry.totalSize, lessThan(530000));
+        expect(entry.archiveSize, greaterThan(155000));
+        expect(entry.archiveSize, lessThan(165000));
+        expect(entry.totalSize, greaterThan(545000));
+        expect(entry.totalSize, lessThan(565000));
         expect(entry.hasBlob, isTrue);
-        expect(entry.blobSize, greaterThan(155000));
-        expect(entry.blobSize, lessThan(175000));
+        expect(entry.blobSize, greaterThan(160000));
+        expect(entry.blobSize, lessThan(180000));
         expect(entry.blobIndexSize, greaterThan(750));
         expect(entry.blobIndexSize, lessThan(1000));
 

--- a/app/test/dartdoc/golden/pana_0.12.2_index.html
+++ b/app/test/dartdoc/golden/pana_0.12.2_index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1, user-scalable=no">
-  <meta name="generator" content="made with love by dartdoc 6.0.1">
+  <meta name="generator" content="made with love by dartdoc 6.1.1">
   <meta name="description" content="pana API docs, for the Dart programming language.">
   <title>pana - Dart API docs</title>
   <link rel="canonical" href="https://pub.dev/documentation/pana/0.12.2/">
@@ -13,7 +13,7 @@
   
   <link rel="preconnect" href="https://fonts.gstatic.com">
   <link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,300;0,400;0,500;0,700;1,400&display=swap" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@48,400,0,0" rel="stylesheet">
   
   <link rel="stylesheet" href="static-assets/github.css?v1">
   <link rel="stylesheet" href="static-assets/styles.css?v1">
@@ -23,12 +23,12 @@
 </head>
 
 
-<body data-base-href="" data-using-base-href="false">
+<body data-base-href="" data-using-base-href="false" class="light-theme">
 
 <div id="overlay-under-drawer"></div>
 
 <header id="title">
-  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <span id="sidenav-left-toggle" class="material-symbols-outlined" role="button" tabindex="0">menu</span>
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="https://github.com/dart-lang/pana">pana package</a></li>
   </ol>
@@ -36,10 +36,16 @@
   <form class="search navbar-right" role="search">
     <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
   </form>
+  <div class="toggle" id="theme-button">
+    <label for="theme">
+      <input type="checkbox" id="theme" value="light-theme">
+      <span class="material-symbols-outlined">
+        brightness_4
+      </span>
+    </label>
+  </div>
 </header>
-
 <main>
-
 
   <div id="dartdoc-main-content" class="main-content">
       

--- a/app/test/dartdoc/golden/pana_0.12.2_index.out.html
+++ b/app/test/dartdoc/golden/pana_0.12.2_index.out.html
@@ -6,7 +6,7 @@
     <meta charset="utf-8"/>
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1, user-scalable=no"/>
-    <meta name="generator" content="made with love by dartdoc 6.0.1"/>
+    <meta name="generator" content="made with love by dartdoc 6.1.1"/>
     <meta name="description" content="pana API docs, for the Dart programming language."/>
     <title>pana - Dart API docs</title>
     <link rel="alternate" href="/documentation/pana/latest/"/>
@@ -14,16 +14,16 @@
     <link rel="preconnect" href="https://fonts.gstatic.com"/>
     <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/github-markdown.css"/>
     <link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,300;0,400;0,500;0,700;1,400&amp;display=swap" rel="stylesheet"/>
-    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet"/>
+    <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@48,400,0,0" rel="stylesheet"/>
     <link rel="stylesheet" href="static-assets/github.css?v1"/>
     <link rel="stylesheet" href="static-assets/styles.css?v1"/>
     <link rel="icon" href="static-assets/favicon.png?v1"/>
   </head>
-  <body data-base-href="" data-using-base-href="false">
+  <body data-base-href="" data-using-base-href="false" class="light-theme">
     <noscript>&lt;iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MX6DBN9" height="0" width="0" style="display:none;visibility:hidden">&lt;/iframe></noscript>
     <div id="overlay-under-drawer"/>
     <header id="title">
-      <button id="sidenav-left-toggle" type="button"></button>
+      <span id="sidenav-left-toggle" class="material-symbols-outlined" role="button" tabindex="0">menu</span>
       <a class="hidden-xs" href="/">
         <img src="/static/hash-%%etag%%/img/dart-logo.svg" style="height: 30px; margin-right: 1em;"/>
       </a>
@@ -37,6 +37,12 @@
       <form class="search navbar-right" role="search">
         <input type="text" id="search-box" autocomplete="off" disabled="" class="form-control typeahead" placeholder="Loading search..."/>
       </form>
+      <div class="toggle" id="theme-button">
+        <label for="theme">
+          <input type="checkbox" id="theme" value="light-theme"/>
+          <span class="material-symbols-outlined">brightness_4</span>
+        </label>
+      </div>
     </header>
     <main>
       <div id="dartdoc-main-content" class="main-content">

--- a/app/test/dartdoc/golden/pana_0.12.2_license_file_class.html
+++ b/app/test/dartdoc/golden/pana_0.12.2_license_file_class.html
@@ -12,7 +12,7 @@
   
   <link rel="preconnect" href="https://fonts.gstatic.com">
   <link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,300;0,400;0,500;0,700;1,400&display=swap" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@48,400,0,0" rel="stylesheet">
   
   <link rel="stylesheet" href="../static-assets/github.css?v1">
   <link rel="stylesheet" href="../static-assets/styles.css?v1">
@@ -22,12 +22,12 @@
 </head>
 
 
-<body data-base-href="../" data-using-base-href="false">
+<body data-base-href="../" data-using-base-href="false" class="light-theme">
 
 <div id="overlay-under-drawer"></div>
 
 <header id="title">
-  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <span id="sidenav-left-toggle" class="material-symbols-outlined" role="button" tabindex="0">menu</span>
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="../index.html">pana</a></li>
     <li><a href="../models/models-library.html">models</a></li>
@@ -37,10 +37,16 @@
   <form class="search navbar-right" role="search">
     <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
   </form>
+  <div class="toggle" id="theme-button">
+    <label for="theme">
+      <input type="checkbox" id="theme" value="light-theme">
+      <span class="material-symbols-outlined">
+        brightness_4
+      </span>
+    </label>
+  </div>
 </header>
-
 <main>
-
 
   <div id="dartdoc-main-content" class="main-content">
       <div>
@@ -76,13 +82,13 @@
 
     <dl class="constructor-summary-list">
         <dt id="LicenseFile" class="callable">
-          <span class="name"><a href="../models/LicenseFile/LicenseFile.html">LicenseFile</a></span><span class="signature">(<span class="parameter" id="-param-path"><span class="type-annotation"><a href="https://api.dart.dev/stable/2.17.0/dart-core/String-class.html">String</a></span> <span class="parameter-name">path</span>, </span><span class="parameter" id="-param-name"><span class="type-annotation"><a href="https://api.dart.dev/stable/2.17.0/dart-core/String-class.html">String</a></span> <span class="parameter-name">name</span>, </span><span class="parameter" id="-param-version">{<span class="type-annotation"><a href="https://api.dart.dev/stable/2.17.0/dart-core/String-class.html">String</a></span> <span class="parameter-name">version</span>, </span><span class="parameter" id="-param-url"><span class="type-annotation"><a href="https://api.dart.dev/stable/2.17.0/dart-core/String-class.html">String</a></span> <span class="parameter-name">url</span>}</span>)</span>
+          <span class="name"><a href="../models/LicenseFile/LicenseFile.html">LicenseFile</a></span><span class="signature">(<span class="parameter" id="-param-path"><span class="type-annotation"><a href="https://api.dart.dev/stable/2.18.0/dart-core/String-class.html">String</a></span> <span class="parameter-name">path</span>, </span><span class="parameter" id="-param-name"><span class="type-annotation"><a href="https://api.dart.dev/stable/2.18.0/dart-core/String-class.html">String</a></span> <span class="parameter-name">name</span>, </span><span class="parameter" id="-param-version">{<span class="type-annotation"><a href="https://api.dart.dev/stable/2.18.0/dart-core/String-class.html">String</a></span> <span class="parameter-name">version</span>, </span><span class="parameter" id="-param-url"><span class="type-annotation"><a href="https://api.dart.dev/stable/2.18.0/dart-core/String-class.html">String</a></span> <span class="parameter-name">url</span>}</span>)</span>
         </dt>
         <dd>
           
         </dd>
         <dt id="LicenseFile.fromJson" class="callable">
-          <span class="name"><a href="../models/LicenseFile/LicenseFile.fromJson.html">LicenseFile.fromJson</a></span><span class="signature">(<span class="parameter" id="fromJson-param-json"><span class="type-annotation"><a href="https://api.dart.dev/stable/2.17.0/dart-core/Map-class.html">Map</a><span class="signature">&lt;<wbr><span class="type-parameter"><a href="https://api.dart.dev/stable/2.17.0/dart-core/String-class.html">String</a></span>, <span class="type-parameter">dynamic</span>&gt;</span></span> <span class="parameter-name">json</span></span>)</span>
+          <span class="name"><a href="../models/LicenseFile/LicenseFile.fromJson.html">LicenseFile.fromJson</a></span><span class="signature">(<span class="parameter" id="fromJson-param-json"><span class="type-annotation"><a href="https://api.dart.dev/stable/2.18.0/dart-core/Map-class.html">Map</a><span class="signature">&lt;<wbr><span class="type-parameter"><a href="https://api.dart.dev/stable/2.18.0/dart-core/String-class.html">String</a></span>, <span class="type-parameter">dynamic</span>&gt;</span></span> <span class="parameter-name">json</span></span>)</span>
         </dt>
         <dd>
           
@@ -97,78 +103,78 @@
       <dl class="properties">
         <dt id="hashCode" class="property">
   <span class="name"><a href="../models/LicenseFile/hashCode.html">hashCode</a></span>
-  <span class="signature">&#8594; <a href="https://api.dart.dev/stable/2.17.0/dart-core/int-class.html">int</a></span> 
+  <span class="signature">&#8594; <a href="https://api.dart.dev/stable/2.18.0/dart-core/int-class.html">int</a></span> 
 
 </dt>
 <dd>
   The hash code for this object.
-  <div class="features">read-only, override</div>
+  <div class="features"><span class="feature">read-only</span><span class="feature">override</span></div>
 
 </dd>
 
         <dt id="name" class="property">
   <span class="name"><a href="../models/LicenseFile/name.html">name</a></span>
-  <span class="signature">&#8594; <a href="https://api.dart.dev/stable/2.17.0/dart-core/String-class.html">String</a></span> 
+  <span class="signature">&#8594; <a href="https://api.dart.dev/stable/2.18.0/dart-core/String-class.html">String</a></span> 
 
 </dt>
 <dd>
   
-  <div class="features">final</div>
+  <div class="features"><span class="feature">final</span></div>
 
 </dd>
 
         <dt id="path" class="property">
   <span class="name"><a href="../models/LicenseFile/path.html">path</a></span>
-  <span class="signature">&#8594; <a href="https://api.dart.dev/stable/2.17.0/dart-core/String-class.html">String</a></span> 
+  <span class="signature">&#8594; <a href="https://api.dart.dev/stable/2.18.0/dart-core/String-class.html">String</a></span> 
 
 </dt>
 <dd>
   
-  <div class="features">final</div>
+  <div class="features"><span class="feature">final</span></div>
 
 </dd>
 
         <dt id="runtimeType" class="property inherited">
-  <span class="name"><a href="https://api.dart.dev/stable/2.17.0/dart-core/Object/runtimeType.html">runtimeType</a></span>
-  <span class="signature">&#8594; <a href="https://api.dart.dev/stable/2.17.0/dart-core/Type-class.html">Type</a></span> 
+  <span class="name"><a href="https://api.dart.dev/stable/2.18.0/dart-core/Object/runtimeType.html">runtimeType</a></span>
+  <span class="signature">&#8594; <a href="https://api.dart.dev/stable/2.18.0/dart-core/Type-class.html">Type</a></span> 
 
 </dt>
 <dd class="inherited">
   A representation of the runtime type of the object.
-  <div class="features">read-only, inherited</div>
+  <div class="features"><span class="feature">read-only</span><span class="feature">inherited</span></div>
 
 </dd>
 
         <dt id="shortFormatted" class="property">
   <span class="name"><a href="../models/LicenseFile/shortFormatted.html">shortFormatted</a></span>
-  <span class="signature">&#8594; <a href="https://api.dart.dev/stable/2.17.0/dart-core/String-class.html">String</a></span> 
+  <span class="signature">&#8594; <a href="https://api.dart.dev/stable/2.18.0/dart-core/String-class.html">String</a></span> 
 
 </dt>
 <dd>
   
-  <div class="features">read-only</div>
+  <div class="features"><span class="feature">read-only</span></div>
 
 </dd>
 
         <dt id="url" class="property">
   <span class="name"><a href="../models/LicenseFile/url.html">url</a></span>
-  <span class="signature">&#8594; <a href="https://api.dart.dev/stable/2.17.0/dart-core/String-class.html">String</a></span> 
+  <span class="signature">&#8594; <a href="https://api.dart.dev/stable/2.18.0/dart-core/String-class.html">String</a></span> 
 
 </dt>
 <dd>
   
-  <div class="features">@<a href="https://pub.dev/documentation/json_annotation/1.2.0/json_annotation/JsonKey-class.html">JsonKey</a>(includeIfNull: false), final</div>
+  <div class="features"><span class="">@<a href="https://pub.dev/documentation/json_annotation/1.2.0/json_annotation/JsonKey-class.html">JsonKey</a>(includeIfNull: false)</span><span class="feature">final</span></div>
 
 </dd>
 
         <dt id="version" class="property">
   <span class="name"><a href="../models/LicenseFile/version.html">version</a></span>
-  <span class="signature">&#8594; <a href="https://api.dart.dev/stable/2.17.0/dart-core/String-class.html">String</a></span> 
+  <span class="signature">&#8594; <a href="https://api.dart.dev/stable/2.18.0/dart-core/String-class.html">String</a></span> 
 
 </dt>
 <dd>
   
-  <div class="features">@<a href="https://pub.dev/documentation/json_annotation/1.2.0/json_annotation/JsonKey-class.html">JsonKey</a>(includeIfNull: false), final</div>
+  <div class="features"><span class="">@<a href="https://pub.dev/documentation/json_annotation/1.2.0/json_annotation/JsonKey-class.html">JsonKey</a>(includeIfNull: false)</span><span class="feature">final</span></div>
 
 </dd>
 
@@ -182,7 +188,7 @@
     <h2>Methods</h2>
     <dl class="callables">
         <dt id="change" class="callable">
-  <span class="name"><a href="../models/LicenseFile/change.html">change</a></span><span class="signature">(<wbr><span class="parameter" id="change-param-url">{<span class="type-annotation"><a href="https://api.dart.dev/stable/2.17.0/dart-core/String-class.html">String</a></span> <span class="parameter-name">url</span>}</span>)
+  <span class="name"><a href="../models/LicenseFile/change.html">change</a></span><span class="signature">(<wbr><span class="parameter" id="change-param-url">{<span class="type-annotation"><a href="https://api.dart.dev/stable/2.18.0/dart-core/String-class.html">String</a></span> <span class="parameter-name">url</span>}</span>)
     <span class="returntype parameter">&#8594; <a href="../models/LicenseFile-class.html">LicenseFile</a></span>
   </span>
   
@@ -195,7 +201,7 @@
 </dd>
 
         <dt id="noSuchMethod" class="callable inherited">
-  <span class="name"><a href="https://api.dart.dev/stable/2.17.0/dart-core/Object/noSuchMethod.html">noSuchMethod</a></span><span class="signature">(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation"><a href="https://api.dart.dev/stable/2.17.0/dart-core/Invocation-class.html">Invocation</a></span> <span class="parameter-name">invocation</span></span>)
+  <span class="name"><a href="https://api.dart.dev/stable/2.18.0/dart-core/Object/noSuchMethod.html">noSuchMethod</a></span><span class="signature">(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation"><a href="https://api.dart.dev/stable/2.18.0/dart-core/Invocation-class.html">Invocation</a></span> <span class="parameter-name">invocation</span></span>)
     <span class="returntype parameter">&#8594; dynamic</span>
   </span>
   
@@ -203,33 +209,33 @@
 </dt>
 <dd class="inherited">
   Invoked when a non-existent method or property is accessed.
-  <div class="features">inherited</div>
+  <div class="features"><span class="feature">inherited</span></div>
 
 </dd>
 
         <dt id="toJson" class="callable inherited">
   <span class="name"><a href="../models/LicenseFile/toJson.html">toJson</a></span><span class="signature">(<wbr>)
-    <span class="returntype parameter">&#8594; <a href="https://api.dart.dev/stable/2.17.0/dart-core/Map-class.html">Map</a><span class="signature">&lt;<wbr><span class="type-parameter"><a href="https://api.dart.dev/stable/2.17.0/dart-core/String-class.html">String</a></span>, <span class="type-parameter">dynamic</span>&gt;</span></span>
+    <span class="returntype parameter">&#8594; <a href="https://api.dart.dev/stable/2.18.0/dart-core/Map-class.html">Map</a><span class="signature">&lt;<wbr><span class="type-parameter"><a href="https://api.dart.dev/stable/2.18.0/dart-core/String-class.html">String</a></span>, <span class="type-parameter">dynamic</span>&gt;</span></span>
   </span>
   
 
 </dt>
 <dd class="inherited">
   
-  <div class="features">inherited</div>
+  <div class="features"><span class="feature">inherited</span></div>
 
 </dd>
 
         <dt id="toString" class="callable">
   <span class="name"><a href="../models/LicenseFile/toString.html">toString</a></span><span class="signature">(<wbr>)
-    <span class="returntype parameter">&#8594; <a href="https://api.dart.dev/stable/2.17.0/dart-core/String-class.html">String</a></span>
+    <span class="returntype parameter">&#8594; <a href="https://api.dart.dev/stable/2.18.0/dart-core/String-class.html">String</a></span>
   </span>
   
 
 </dt>
 <dd>
   A string representation of this object.
-  <div class="features">override</div>
+  <div class="features"><span class="feature">override</span></div>
 
 </dd>
 
@@ -242,15 +248,15 @@
     <h2>Operators</h2>
     <dl class="callables">
         <dt id="operator ==" class="callable">
-  <span class="name"><a href="../models/LicenseFile/operator_equals.html">operator ==</a></span><span class="signature">(<wbr><span class="parameter" id="==-param-other"><span class="type-annotation"><a href="https://api.dart.dev/stable/2.17.0/dart-core/Object-class.html">Object</a></span> <span class="parameter-name">other</span></span>)
-    <span class="returntype parameter">&#8594; <a href="https://api.dart.dev/stable/2.17.0/dart-core/bool-class.html">bool</a></span>
+  <span class="name"><a href="../models/LicenseFile/operator_equals.html">operator ==</a></span><span class="signature">(<wbr><span class="parameter" id="==-param-other"><span class="type-annotation"><a href="https://api.dart.dev/stable/2.18.0/dart-core/Object-class.html">Object</a></span> <span class="parameter-name">other</span></span>)
+    <span class="returntype parameter">&#8594; <a href="https://api.dart.dev/stable/2.18.0/dart-core/bool-class.html">bool</a></span>
   </span>
   
 
 </dt>
 <dd>
   The equality operator.
-  <div class="features">override</div>
+  <div class="features"><span class="feature">override</span></div>
 
 </dd>
 
@@ -327,14 +333,14 @@
           <li><a href="../models/LicenseFile/hashCode.html">hashCode</a></li>
           <li><a href="../models/LicenseFile/name.html">name</a></li>
           <li><a href="../models/LicenseFile/path.html">path</a></li>
-          <li class="inherited"><a href="https://api.dart.dev/stable/2.17.0/dart-core/Object/runtimeType.html">runtimeType</a></li>
+          <li class="inherited"><a href="https://api.dart.dev/stable/2.18.0/dart-core/Object/runtimeType.html">runtimeType</a></li>
           <li><a href="../models/LicenseFile/shortFormatted.html">shortFormatted</a></li>
           <li><a href="../models/LicenseFile/url.html">url</a></li>
           <li><a href="../models/LicenseFile/version.html">version</a></li>
 
         <li class="section-title"><a href="../models/LicenseFile-class.html#instance-methods">Methods</a></li>
           <li><a href="../models/LicenseFile/change.html">change</a></li>
-          <li class="inherited"><a href="https://api.dart.dev/stable/2.17.0/dart-core/Object/noSuchMethod.html">noSuchMethod</a></li>
+          <li class="inherited"><a href="https://api.dart.dev/stable/2.18.0/dart-core/Object/noSuchMethod.html">noSuchMethod</a></li>
           <li class="inherited"><a href="../models/LicenseFile/toJson.html">toJson</a></li>
           <li><a href="../models/LicenseFile/toString.html">toString</a></li>
 

--- a/app/test/dartdoc/golden/pana_0.12.2_license_file_class.out.html
+++ b/app/test/dartdoc/golden/pana_0.12.2_license_file_class.out.html
@@ -12,16 +12,16 @@
     <link rel="canonical" href="https://pub.dev/documentation/pana/0.12.2/models/LicenseFile-class.html"/>
     <link rel="preconnect" href="https://fonts.gstatic.com"/>
     <link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,300;0,400;0,500;0,700;1,400&amp;display=swap" rel="stylesheet"/>
-    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet"/>
+    <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@48,400,0,0" rel="stylesheet"/>
     <link rel="stylesheet" href="../static-assets/github.css?v1"/>
     <link rel="stylesheet" href="../static-assets/styles.css?v1"/>
     <link rel="icon" href="../static-assets/favicon.png?v1"/>
   </head>
-  <body data-base-href="../" data-using-base-href="false">
+  <body data-base-href="../" data-using-base-href="false" class="light-theme">
     <noscript>&lt;iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MX6DBN9" height="0" width="0" style="display:none;visibility:hidden">&lt;/iframe></noscript>
     <div id="overlay-under-drawer"/>
     <header id="title">
-      <button id="sidenav-left-toggle" type="button"></button>
+      <span id="sidenav-left-toggle" class="material-symbols-outlined" role="button" tabindex="0">menu</span>
       <a class="hidden-xs" href="/">
         <img src="/static/hash-%%etag%%/img/dart-logo.svg" style="height: 30px; margin-right: 1em;"/>
       </a>
@@ -41,6 +41,12 @@
       <form class="search navbar-right" role="search">
         <input type="text" id="search-box" autocomplete="off" disabled="" class="form-control typeahead" placeholder="Loading search..."/>
       </form>
+      <div class="toggle" id="theme-button">
+        <label for="theme">
+          <input type="checkbox" id="theme" value="light-theme"/>
+          <span class="material-symbols-outlined">brightness_4</span>
+        </label>
+      </div>
     </header>
     <main>
       <div id="dartdoc-main-content" class="main-content">
@@ -75,14 +81,14 @@
                 (
                 <span class="parameter" id="-param-path">
                   <span class="type-annotation">
-                    <a href="https://api.dart.dev/stable/2.17.0/dart-core/String-class.html">String</a>
+                    <a href="https://api.dart.dev/stable/2.18.0/dart-core/String-class.html">String</a>
                   </span>
                   <span class="parameter-name">path</span>
                   ,
                 </span>
                 <span class="parameter" id="-param-name">
                   <span class="type-annotation">
-                    <a href="https://api.dart.dev/stable/2.17.0/dart-core/String-class.html">String</a>
+                    <a href="https://api.dart.dev/stable/2.18.0/dart-core/String-class.html">String</a>
                   </span>
                   <span class="parameter-name">name</span>
                   ,
@@ -90,14 +96,14 @@
                 <span class="parameter" id="-param-version">
                   {
                   <span class="type-annotation">
-                    <a href="https://api.dart.dev/stable/2.17.0/dart-core/String-class.html">String</a>
+                    <a href="https://api.dart.dev/stable/2.18.0/dart-core/String-class.html">String</a>
                   </span>
                   <span class="parameter-name">version</span>
                   ,
                 </span>
                 <span class="parameter" id="-param-url">
                   <span class="type-annotation">
-                    <a href="https://api.dart.dev/stable/2.17.0/dart-core/String-class.html">String</a>
+                    <a href="https://api.dart.dev/stable/2.18.0/dart-core/String-class.html">String</a>
                   </span>
                   <span class="parameter-name">url</span>
                   }
@@ -114,12 +120,12 @@
                 (
                 <span class="parameter" id="fromJson-param-json">
                   <span class="type-annotation">
-                    <a href="https://api.dart.dev/stable/2.17.0/dart-core/Map-class.html">Map</a>
+                    <a href="https://api.dart.dev/stable/2.18.0/dart-core/Map-class.html">Map</a>
                     <span class="signature">
                       &lt;
                       <wbr/>
                       <span class="type-parameter">
-                        <a href="https://api.dart.dev/stable/2.17.0/dart-core/String-class.html">String</a>
+                        <a href="https://api.dart.dev/stable/2.18.0/dart-core/String-class.html">String</a>
                       </span>
                       ,
                       <span class="type-parameter">dynamic</span>
@@ -145,12 +151,15 @@
               </span>
               <span class="signature">
                 →
-                <a href="https://api.dart.dev/stable/2.17.0/dart-core/int-class.html">int</a>
+                <a href="https://api.dart.dev/stable/2.18.0/dart-core/int-class.html">int</a>
               </span>
             </dt>
             <dd>
               The hash code for this object.
-              <div class="features">read-only, override</div>
+              <div class="features">
+                <span class="feature">read-only</span>
+                <span class="feature">override</span>
+              </div>
             </dd>
             <dt id="name" class="property">
               <span class="name">
@@ -158,11 +167,13 @@
               </span>
               <span class="signature">
                 →
-                <a href="https://api.dart.dev/stable/2.17.0/dart-core/String-class.html">String</a>
+                <a href="https://api.dart.dev/stable/2.18.0/dart-core/String-class.html">String</a>
               </span>
             </dt>
             <dd>
-              <div class="features">final</div>
+              <div class="features">
+                <span class="feature">final</span>
+              </div>
             </dd>
             <dt id="path" class="property">
               <span class="name">
@@ -170,24 +181,29 @@
               </span>
               <span class="signature">
                 →
-                <a href="https://api.dart.dev/stable/2.17.0/dart-core/String-class.html">String</a>
+                <a href="https://api.dart.dev/stable/2.18.0/dart-core/String-class.html">String</a>
               </span>
             </dt>
             <dd>
-              <div class="features">final</div>
+              <div class="features">
+                <span class="feature">final</span>
+              </div>
             </dd>
             <dt id="runtimeType" class="property inherited">
               <span class="name">
-                <a href="https://api.dart.dev/stable/2.17.0/dart-core/Object/runtimeType.html">runtimeType</a>
+                <a href="https://api.dart.dev/stable/2.18.0/dart-core/Object/runtimeType.html">runtimeType</a>
               </span>
               <span class="signature">
                 →
-                <a href="https://api.dart.dev/stable/2.17.0/dart-core/Type-class.html">Type</a>
+                <a href="https://api.dart.dev/stable/2.18.0/dart-core/Type-class.html">Type</a>
               </span>
             </dt>
             <dd class="inherited">
               A representation of the runtime type of the object.
-              <div class="features">read-only, inherited</div>
+              <div class="features">
+                <span class="feature">read-only</span>
+                <span class="feature">inherited</span>
+              </div>
             </dd>
             <dt id="shortFormatted" class="property">
               <span class="name">
@@ -195,11 +211,13 @@
               </span>
               <span class="signature">
                 →
-                <a href="https://api.dart.dev/stable/2.17.0/dart-core/String-class.html">String</a>
+                <a href="https://api.dart.dev/stable/2.18.0/dart-core/String-class.html">String</a>
               </span>
             </dt>
             <dd>
-              <div class="features">read-only</div>
+              <div class="features">
+                <span class="feature">read-only</span>
+              </div>
             </dd>
             <dt id="url" class="property">
               <span class="name">
@@ -207,14 +225,17 @@
               </span>
               <span class="signature">
                 →
-                <a href="https://api.dart.dev/stable/2.17.0/dart-core/String-class.html">String</a>
+                <a href="https://api.dart.dev/stable/2.18.0/dart-core/String-class.html">String</a>
               </span>
             </dt>
             <dd>
               <div class="features">
-                @
-                <a href="https://pub.dev/documentation/json_annotation/1.2.0/json_annotation/JsonKey-class.html">JsonKey</a>
-                (includeIfNull: false), final
+                <span class="">
+                  @
+                  <a href="https://pub.dev/documentation/json_annotation/1.2.0/json_annotation/JsonKey-class.html">JsonKey</a>
+                  (includeIfNull: false)
+                </span>
+                <span class="feature">final</span>
               </div>
             </dd>
             <dt id="version" class="property">
@@ -223,14 +244,17 @@
               </span>
               <span class="signature">
                 →
-                <a href="https://api.dart.dev/stable/2.17.0/dart-core/String-class.html">String</a>
+                <a href="https://api.dart.dev/stable/2.18.0/dart-core/String-class.html">String</a>
               </span>
             </dt>
             <dd>
               <div class="features">
-                @
-                <a href="https://pub.dev/documentation/json_annotation/1.2.0/json_annotation/JsonKey-class.html">JsonKey</a>
-                (includeIfNull: false), final
+                <span class="">
+                  @
+                  <a href="https://pub.dev/documentation/json_annotation/1.2.0/json_annotation/JsonKey-class.html">JsonKey</a>
+                  (includeIfNull: false)
+                </span>
+                <span class="feature">final</span>
               </div>
             </dd>
           </dl>
@@ -248,7 +272,7 @@
                 <span class="parameter" id="change-param-url">
                   {
                   <span class="type-annotation">
-                    <a href="https://api.dart.dev/stable/2.17.0/dart-core/String-class.html">String</a>
+                    <a href="https://api.dart.dev/stable/2.18.0/dart-core/String-class.html">String</a>
                   </span>
                   <span class="parameter-name">url</span>
                   }
@@ -263,14 +287,14 @@
             <dd></dd>
             <dt id="noSuchMethod" class="callable inherited">
               <span class="name">
-                <a href="https://api.dart.dev/stable/2.17.0/dart-core/Object/noSuchMethod.html">noSuchMethod</a>
+                <a href="https://api.dart.dev/stable/2.18.0/dart-core/Object/noSuchMethod.html">noSuchMethod</a>
               </span>
               <span class="signature">
                 (
                 <wbr/>
                 <span class="parameter" id="noSuchMethod-param-invocation">
                   <span class="type-annotation">
-                    <a href="https://api.dart.dev/stable/2.17.0/dart-core/Invocation-class.html">Invocation</a>
+                    <a href="https://api.dart.dev/stable/2.18.0/dart-core/Invocation-class.html">Invocation</a>
                   </span>
                   <span class="parameter-name">invocation</span>
                 </span>
@@ -280,7 +304,9 @@
             </dt>
             <dd class="inherited">
               Invoked when a non-existent method or property is accessed.
-              <div class="features">inherited</div>
+              <div class="features">
+                <span class="feature">inherited</span>
+              </div>
             </dd>
             <dt id="toJson" class="callable inherited">
               <span class="name">
@@ -292,12 +318,12 @@
                 )
                 <span class="returntype parameter">
                   →
-                  <a href="https://api.dart.dev/stable/2.17.0/dart-core/Map-class.html">Map</a>
+                  <a href="https://api.dart.dev/stable/2.18.0/dart-core/Map-class.html">Map</a>
                   <span class="signature">
                     &lt;
                     <wbr/>
                     <span class="type-parameter">
-                      <a href="https://api.dart.dev/stable/2.17.0/dart-core/String-class.html">String</a>
+                      <a href="https://api.dart.dev/stable/2.18.0/dart-core/String-class.html">String</a>
                     </span>
                     ,
                     <span class="type-parameter">dynamic</span>
@@ -307,7 +333,9 @@
               </span>
             </dt>
             <dd class="inherited">
-              <div class="features">inherited</div>
+              <div class="features">
+                <span class="feature">inherited</span>
+              </div>
             </dd>
             <dt id="toString" class="callable">
               <span class="name">
@@ -319,13 +347,15 @@
                 )
                 <span class="returntype parameter">
                   →
-                  <a href="https://api.dart.dev/stable/2.17.0/dart-core/String-class.html">String</a>
+                  <a href="https://api.dart.dev/stable/2.18.0/dart-core/String-class.html">String</a>
                 </span>
               </span>
             </dt>
             <dd>
               A string representation of this object.
-              <div class="features">override</div>
+              <div class="features">
+                <span class="feature">override</span>
+              </div>
             </dd>
           </dl>
         </section>
@@ -341,20 +371,22 @@
                 <wbr/>
                 <span class="parameter" id="==-param-other">
                   <span class="type-annotation">
-                    <a href="https://api.dart.dev/stable/2.17.0/dart-core/Object-class.html">Object</a>
+                    <a href="https://api.dart.dev/stable/2.18.0/dart-core/Object-class.html">Object</a>
                   </span>
                   <span class="parameter-name">other</span>
                 </span>
                 )
                 <span class="returntype parameter">
                   →
-                  <a href="https://api.dart.dev/stable/2.17.0/dart-core/bool-class.html">bool</a>
+                  <a href="https://api.dart.dev/stable/2.18.0/dart-core/bool-class.html">bool</a>
                 </span>
               </span>
             </dt>
             <dd>
               The equality operator.
-              <div class="features">override</div>
+              <div class="features">
+                <span class="feature">override</span>
+              </div>
             </dd>
           </dl>
         </section>
@@ -472,7 +504,7 @@
             <a href="../models/LicenseFile/path.html">path</a>
           </li>
           <li class="inherited">
-            <a href="https://api.dart.dev/stable/2.17.0/dart-core/Object/runtimeType.html">runtimeType</a>
+            <a href="https://api.dart.dev/stable/2.18.0/dart-core/Object/runtimeType.html">runtimeType</a>
           </li>
           <li>
             <a href="../models/LicenseFile/shortFormatted.html">shortFormatted</a>
@@ -490,7 +522,7 @@
             <a href="../models/LicenseFile/change.html">change</a>
           </li>
           <li class="inherited">
-            <a href="https://api.dart.dev/stable/2.17.0/dart-core/Object/noSuchMethod.html">noSuchMethod</a>
+            <a href="https://api.dart.dev/stable/2.18.0/dart-core/Object/noSuchMethod.html">noSuchMethod</a>
           </li>
           <li class="inherited">
             <a href="../models/LicenseFile/toJson.html">toJson</a>

--- a/app/test/dartdoc/golden/pana_0.12.2_license_file_constructor.html
+++ b/app/test/dartdoc/golden/pana_0.12.2_license_file_constructor.html
@@ -12,7 +12,7 @@
   
   <link rel="preconnect" href="https://fonts.gstatic.com">
   <link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,300;0,400;0,500;0,700;1,400&display=swap" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@48,400,0,0" rel="stylesheet">
   
   <link rel="stylesheet" href="../../static-assets/github.css?v1">
   <link rel="stylesheet" href="../../static-assets/styles.css?v1">
@@ -22,12 +22,12 @@
 </head>
 
 
-<body data-base-href="../../" data-using-base-href="false">
+<body data-base-href="../../" data-using-base-href="false" class="light-theme">
 
 <div id="overlay-under-drawer"></div>
 
 <header id="title">
-  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <span id="sidenav-left-toggle" class="material-symbols-outlined" role="button" tabindex="0">menu</span>
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="../../index.html">pana</a></li>
     <li><a href="../../models/models-library.html">models</a></li>
@@ -38,10 +38,16 @@
   <form class="search navbar-right" role="search">
     <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
   </form>
+  <div class="toggle" id="theme-button">
+    <label for="theme">
+      <input type="checkbox" id="theme" value="light-theme">
+      <span class="material-symbols-outlined">
+        brightness_4
+      </span>
+    </label>
+  </div>
 </header>
-
 <main>
-
 
   <div id="dartdoc-main-content" class="main-content">
       <div>
@@ -49,10 +55,10 @@
 </h1></div>
 
     <section class="multi-line-signature">
-      <span class="name ">LicenseFile</span>(<wbr><ol class="parameter-list"><li><span class="parameter" id="-param-path"><span class="type-annotation"><a href="https://api.dart.dev/stable/2.17.0/dart-core/String-class.html">String</a></span> <span class="parameter-name">path</span>, </span></li>
-<li><span class="parameter" id="-param-name"><span class="type-annotation"><a href="https://api.dart.dev/stable/2.17.0/dart-core/String-class.html">String</a></span> <span class="parameter-name">name</span>, </span></li>
-<li><span class="parameter" id="-param-version">{<span class="type-annotation"><a href="https://api.dart.dev/stable/2.17.0/dart-core/String-class.html">String</a></span> <span class="parameter-name">version</span>, </span></li>
-<li><span class="parameter" id="-param-url"><span class="type-annotation"><a href="https://api.dart.dev/stable/2.17.0/dart-core/String-class.html">String</a></span> <span class="parameter-name">url</span>}</span></li>
+      <span class="name ">LicenseFile</span>(<wbr><ol class="parameter-list"><li><span class="parameter" id="-param-path"><span class="type-annotation"><a href="https://api.dart.dev/stable/2.18.0/dart-core/String-class.html">String</a></span> <span class="parameter-name">path</span>, </span></li>
+<li><span class="parameter" id="-param-name"><span class="type-annotation"><a href="https://api.dart.dev/stable/2.18.0/dart-core/String-class.html">String</a></span> <span class="parameter-name">name</span>, </span></li>
+<li><span class="parameter" id="-param-version">{<span class="type-annotation"><a href="https://api.dart.dev/stable/2.18.0/dart-core/String-class.html">String</a></span> <span class="parameter-name">version</span>, </span></li>
+<li><span class="parameter" id="-param-url"><span class="type-annotation"><a href="https://api.dart.dev/stable/2.18.0/dart-core/String-class.html">String</a></span> <span class="parameter-name">url</span>}</span></li>
 </ol>)
     </section>
 
@@ -97,14 +103,14 @@
           <li><a href="../../models/LicenseFile/hashCode.html">hashCode</a></li>
           <li><a href="../../models/LicenseFile/name.html">name</a></li>
           <li><a href="../../models/LicenseFile/path.html">path</a></li>
-          <li class="inherited"><a href="https://api.dart.dev/stable/2.17.0/dart-core/Object/runtimeType.html">runtimeType</a></li>
+          <li class="inherited"><a href="https://api.dart.dev/stable/2.18.0/dart-core/Object/runtimeType.html">runtimeType</a></li>
           <li><a href="../../models/LicenseFile/shortFormatted.html">shortFormatted</a></li>
           <li><a href="../../models/LicenseFile/url.html">url</a></li>
           <li><a href="../../models/LicenseFile/version.html">version</a></li>
 
         <li class="section-title"><a href="../../models/LicenseFile-class.html#instance-methods">Methods</a></li>
           <li><a href="../../models/LicenseFile/change.html">change</a></li>
-          <li class="inherited"><a href="https://api.dart.dev/stable/2.17.0/dart-core/Object/noSuchMethod.html">noSuchMethod</a></li>
+          <li class="inherited"><a href="https://api.dart.dev/stable/2.18.0/dart-core/Object/noSuchMethod.html">noSuchMethod</a></li>
           <li class="inherited"><a href="../../models/LicenseFile/toJson.html">toJson</a></li>
           <li><a href="../../models/LicenseFile/toString.html">toString</a></li>
 

--- a/app/test/dartdoc/golden/pana_0.12.2_license_file_constructor.out.html
+++ b/app/test/dartdoc/golden/pana_0.12.2_license_file_constructor.out.html
@@ -12,16 +12,16 @@
     <link rel="canonical" href="https://pub.dev/documentation/pana/0.12.2/models/LicenseFile/LicenseFile.html"/>
     <link rel="preconnect" href="https://fonts.gstatic.com"/>
     <link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,300;0,400;0,500;0,700;1,400&amp;display=swap" rel="stylesheet"/>
-    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet"/>
+    <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@48,400,0,0" rel="stylesheet"/>
     <link rel="stylesheet" href="../../static-assets/github.css?v1"/>
     <link rel="stylesheet" href="../../static-assets/styles.css?v1"/>
     <link rel="icon" href="../../static-assets/favicon.png?v1"/>
   </head>
-  <body data-base-href="../../" data-using-base-href="false">
+  <body data-base-href="../../" data-using-base-href="false" class="light-theme">
     <noscript>&lt;iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MX6DBN9" height="0" width="0" style="display:none;visibility:hidden">&lt;/iframe></noscript>
     <div id="overlay-under-drawer"/>
     <header id="title">
-      <button id="sidenav-left-toggle" type="button"></button>
+      <span id="sidenav-left-toggle" class="material-symbols-outlined" role="button" tabindex="0">menu</span>
       <a class="hidden-xs" href="/">
         <img src="/static/hash-%%etag%%/img/dart-logo.svg" style="height: 30px; margin-right: 1em;"/>
       </a>
@@ -44,6 +44,12 @@
       <form class="search navbar-right" role="search">
         <input type="text" id="search-box" autocomplete="off" disabled="" class="form-control typeahead" placeholder="Loading search..."/>
       </form>
+      <div class="toggle" id="theme-button">
+        <label for="theme">
+          <input type="checkbox" id="theme" value="light-theme"/>
+          <span class="material-symbols-outlined">brightness_4</span>
+        </label>
+      </div>
     </header>
     <main>
       <div id="dartdoc-main-content" class="main-content">
@@ -61,7 +67,7 @@
             <li>
               <span class="parameter" id="-param-path">
                 <span class="type-annotation">
-                  <a href="https://api.dart.dev/stable/2.17.0/dart-core/String-class.html">String</a>
+                  <a href="https://api.dart.dev/stable/2.18.0/dart-core/String-class.html">String</a>
                 </span>
                 <span class="parameter-name">path</span>
                 ,
@@ -70,7 +76,7 @@
             <li>
               <span class="parameter" id="-param-name">
                 <span class="type-annotation">
-                  <a href="https://api.dart.dev/stable/2.17.0/dart-core/String-class.html">String</a>
+                  <a href="https://api.dart.dev/stable/2.18.0/dart-core/String-class.html">String</a>
                 </span>
                 <span class="parameter-name">name</span>
                 ,
@@ -80,7 +86,7 @@
               <span class="parameter" id="-param-version">
                 {
                 <span class="type-annotation">
-                  <a href="https://api.dart.dev/stable/2.17.0/dart-core/String-class.html">String</a>
+                  <a href="https://api.dart.dev/stable/2.18.0/dart-core/String-class.html">String</a>
                 </span>
                 <span class="parameter-name">version</span>
                 ,
@@ -89,7 +95,7 @@
             <li>
               <span class="parameter" id="-param-url">
                 <span class="type-annotation">
-                  <a href="https://api.dart.dev/stable/2.17.0/dart-core/String-class.html">String</a>
+                  <a href="https://api.dart.dev/stable/2.18.0/dart-core/String-class.html">String</a>
                 </span>
                 <span class="parameter-name">url</span>
                 }
@@ -153,7 +159,7 @@
             <a href="../../models/LicenseFile/path.html">path</a>
           </li>
           <li class="inherited">
-            <a href="https://api.dart.dev/stable/2.17.0/dart-core/Object/runtimeType.html">runtimeType</a>
+            <a href="https://api.dart.dev/stable/2.18.0/dart-core/Object/runtimeType.html">runtimeType</a>
           </li>
           <li>
             <a href="../../models/LicenseFile/shortFormatted.html">shortFormatted</a>
@@ -171,7 +177,7 @@
             <a href="../../models/LicenseFile/change.html">change</a>
           </li>
           <li class="inherited">
-            <a href="https://api.dart.dev/stable/2.17.0/dart-core/Object/noSuchMethod.html">noSuchMethod</a>
+            <a href="https://api.dart.dev/stable/2.18.0/dart-core/Object/noSuchMethod.html">noSuchMethod</a>
           </li>
           <li class="inherited">
             <a href="../../models/LicenseFile/toJson.html">toJson</a>

--- a/app/test/dartdoc/golden/pana_0.12.2_license_file_name_field.html
+++ b/app/test/dartdoc/golden/pana_0.12.2_license_file_name_field.html
@@ -4,15 +4,15 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1, user-scalable=no">
-  <meta name="description" content="API docs for the name property from the LicenseFile class, for the Dart programming language.">
-  <title>name property - LicenseFile class - models library - Dart API</title>
+  <meta name="description" content="API docs for the name property from the LicenseFile extension, for the Dart programming language.">
+  <title>name property - LicenseFile extension - models library - Dart API</title>
   <link rel="canonical" href="https://pub.dev/documentation/pana/0.12.2/models/LicenseFile/name.html">
 
 
   
   <link rel="preconnect" href="https://fonts.gstatic.com">
   <link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,300;0,400;0,500;0,700;1,400&display=swap" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@48,400,0,0" rel="stylesheet">
   
   <link rel="stylesheet" href="../../static-assets/github.css?v1">
   <link rel="stylesheet" href="../../static-assets/styles.css?v1">
@@ -22,12 +22,12 @@
 </head>
 
 
-<body data-base-href="../../" data-using-base-href="false">
+<body data-base-href="../../" data-using-base-href="false" class="light-theme">
 
 <div id="overlay-under-drawer"></div>
 
 <header id="title">
-  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <span id="sidenav-left-toggle" class="material-symbols-outlined" role="button" tabindex="0">menu</span>
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="../../index.html">pana</a></li>
     <li><a href="../../models/models-library.html">models</a></li>
@@ -38,10 +38,16 @@
   <form class="search navbar-right" role="search">
     <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
   </form>
+  <div class="toggle" id="theme-button">
+    <label for="theme">
+      <input type="checkbox" id="theme" value="light-theme">
+      <span class="material-symbols-outlined">
+        brightness_4
+      </span>
+    </label>
+  </div>
 </header>
-
 <main>
-
 
   <div id="dartdoc-main-content" class="main-content">
       <div>
@@ -49,9 +55,9 @@
 </h1></div>
 
         <section class="multi-line-signature">
-          <a href="https://api.dart.dev/stable/2.17.0/dart-core/String-class.html">String</a>
+          <a href="https://api.dart.dev/stable/2.18.0/dart-core/String-class.html">String</a>
           <span class="name ">name</span>
-          <div class="features">final</div>
+          <div class="features"><span class="feature">final</span></div>
 
         </section>
         
@@ -59,9 +65,7 @@
         
 <section class="summary source-code" id="source">
   <h2><span>Implementation</span></h2>
-  <pre class="language-dart"><code class="language-dart">final String name;
-
-</code></pre>
+  <pre class="language-dart"><code class="language-dart">final String name;</code></pre>
 </section>
 
 
@@ -96,14 +100,14 @@
           <li><a href="../../models/LicenseFile/hashCode.html">hashCode</a></li>
           <li><a href="../../models/LicenseFile/name.html">name</a></li>
           <li><a href="../../models/LicenseFile/path.html">path</a></li>
-          <li class="inherited"><a href="https://api.dart.dev/stable/2.17.0/dart-core/Object/runtimeType.html">runtimeType</a></li>
+          <li class="inherited"><a href="https://api.dart.dev/stable/2.18.0/dart-core/Object/runtimeType.html">runtimeType</a></li>
           <li><a href="../../models/LicenseFile/shortFormatted.html">shortFormatted</a></li>
           <li><a href="../../models/LicenseFile/url.html">url</a></li>
           <li><a href="../../models/LicenseFile/version.html">version</a></li>
 
         <li class="section-title"><a href="../../models/LicenseFile-class.html#instance-methods">Methods</a></li>
           <li><a href="../../models/LicenseFile/change.html">change</a></li>
-          <li class="inherited"><a href="https://api.dart.dev/stable/2.17.0/dart-core/Object/noSuchMethod.html">noSuchMethod</a></li>
+          <li class="inherited"><a href="https://api.dart.dev/stable/2.18.0/dart-core/Object/noSuchMethod.html">noSuchMethod</a></li>
           <li class="inherited"><a href="../../models/LicenseFile/toJson.html">toJson</a></li>
           <li><a href="../../models/LicenseFile/toString.html">toString</a></li>
 

--- a/app/test/dartdoc/golden/pana_0.12.2_license_file_name_field.out.html
+++ b/app/test/dartdoc/golden/pana_0.12.2_license_file_name_field.out.html
@@ -6,22 +6,22 @@
     <meta charset="utf-8"/>
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1, user-scalable=no"/>
-    <meta name="description" content="API docs for the name property from the LicenseFile class, for the Dart programming language."/>
-    <title>name property - LicenseFile class - models library - Dart API</title>
+    <meta name="description" content="API docs for the name property from the LicenseFile extension, for the Dart programming language."/>
+    <title>name property - LicenseFile extension - models library - Dart API</title>
     <link rel="alternate" href="/documentation/pana/latest/"/>
     <link rel="canonical" href="https://pub.dev/documentation/pana/0.12.2/models/LicenseFile/name.html"/>
     <link rel="preconnect" href="https://fonts.gstatic.com"/>
     <link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,300;0,400;0,500;0,700;1,400&amp;display=swap" rel="stylesheet"/>
-    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet"/>
+    <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@48,400,0,0" rel="stylesheet"/>
     <link rel="stylesheet" href="../../static-assets/github.css?v1"/>
     <link rel="stylesheet" href="../../static-assets/styles.css?v1"/>
     <link rel="icon" href="../../static-assets/favicon.png?v1"/>
   </head>
-  <body data-base-href="../../" data-using-base-href="false">
+  <body data-base-href="../../" data-using-base-href="false" class="light-theme">
     <noscript>&lt;iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MX6DBN9" height="0" width="0" style="display:none;visibility:hidden">&lt;/iframe></noscript>
     <div id="overlay-under-drawer"/>
     <header id="title">
-      <button id="sidenav-left-toggle" type="button"></button>
+      <span id="sidenav-left-toggle" class="material-symbols-outlined" role="button" tabindex="0">menu</span>
       <a class="hidden-xs" href="/">
         <img src="/static/hash-%%etag%%/img/dart-logo.svg" style="height: 30px; margin-right: 1em;"/>
       </a>
@@ -44,6 +44,12 @@
       <form class="search navbar-right" role="search">
         <input type="text" id="search-box" autocomplete="off" disabled="" class="form-control typeahead" placeholder="Loading search..."/>
       </form>
+      <div class="toggle" id="theme-button">
+        <label for="theme">
+          <input type="checkbox" id="theme" value="light-theme"/>
+          <span class="material-symbols-outlined">brightness_4</span>
+        </label>
+      </div>
     </header>
     <main>
       <div id="dartdoc-main-content" class="main-content">
@@ -54,9 +60,11 @@
           </h1>
         </div>
         <section class="multi-line-signature">
-          <a href="https://api.dart.dev/stable/2.17.0/dart-core/String-class.html">String</a>
+          <a href="https://api.dart.dev/stable/2.18.0/dart-core/String-class.html">String</a>
           <span class="name ">name</span>
-          <div class="features">final</div>
+          <div class="features">
+            <span class="feature">final</span>
+          </div>
         </section>
         <section class="summary source-code" id="source">
           <h2>
@@ -113,7 +121,7 @@
             <a href="../../models/LicenseFile/path.html">path</a>
           </li>
           <li class="inherited">
-            <a href="https://api.dart.dev/stable/2.17.0/dart-core/Object/runtimeType.html">runtimeType</a>
+            <a href="https://api.dart.dev/stable/2.18.0/dart-core/Object/runtimeType.html">runtimeType</a>
           </li>
           <li>
             <a href="../../models/LicenseFile/shortFormatted.html">shortFormatted</a>
@@ -131,7 +139,7 @@
             <a href="../../models/LicenseFile/change.html">change</a>
           </li>
           <li class="inherited">
-            <a href="https://api.dart.dev/stable/2.17.0/dart-core/Object/noSuchMethod.html">noSuchMethod</a>
+            <a href="https://api.dart.dev/stable/2.18.0/dart-core/Object/noSuchMethod.html">noSuchMethod</a>
           </li>
           <li class="inherited">
             <a href="../../models/LicenseFile/toJson.html">toJson</a>

--- a/app/test/dartdoc/golden/pana_0.12.2_pretty_json.html
+++ b/app/test/dartdoc/golden/pana_0.12.2_pretty_json.html
@@ -12,7 +12,7 @@
   
   <link rel="preconnect" href="https://fonts.gstatic.com">
   <link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,300;0,400;0,500;0,700;1,400&display=swap" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@48,400,0,0" rel="stylesheet">
   
   <link rel="stylesheet" href="../static-assets/github.css?v1">
   <link rel="stylesheet" href="../static-assets/styles.css?v1">
@@ -22,12 +22,12 @@
 </head>
 
 
-<body data-base-href="../" data-using-base-href="false">
+<body data-base-href="../" data-using-base-href="false" class="light-theme">
 
 <div id="overlay-under-drawer"></div>
 
 <header id="title">
-  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <span id="sidenav-left-toggle" class="material-symbols-outlined" role="button" tabindex="0">menu</span>
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="../index.html">pana</a></li>
     <li><a href="../pana/pana-library.html">pana</a></li>
@@ -37,10 +37,16 @@
   <form class="search navbar-right" role="search">
     <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
   </form>
+  <div class="toggle" id="theme-button">
+    <label for="theme">
+      <input type="checkbox" id="theme" value="light-theme">
+      <span class="material-symbols-outlined">
+        brightness_4
+      </span>
+    </label>
+  </div>
 </header>
-
 <main>
-
 
   <div id="dartdoc-main-content" class="main-content">
       <div>
@@ -51,7 +57,7 @@
     <section class="multi-line-signature">
         
 
-<span class="returntype"><a href="https://api.dart.dev/stable/2.17.0/dart-core/String-class.html">String</a></span>
+<span class="returntype"><a href="https://api.dart.dev/stable/2.18.0/dart-core/String-class.html">String</a></span>
 <span class="name ">prettyJson</span>(<wbr><ol class="parameter-list"><li><span class="parameter" id="prettyJson-param-obj"><span class="type-annotation">dynamic</span> <span class="parameter-name">obj</span></span></li>
 </ol>)
 

--- a/app/test/dartdoc/golden/pana_0.12.2_pretty_json.out.html
+++ b/app/test/dartdoc/golden/pana_0.12.2_pretty_json.out.html
@@ -12,16 +12,16 @@
     <link rel="canonical" href="https://pub.dev/documentation/pana/0.12.2/pana/prettyJson.html"/>
     <link rel="preconnect" href="https://fonts.gstatic.com"/>
     <link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,300;0,400;0,500;0,700;1,400&amp;display=swap" rel="stylesheet"/>
-    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet"/>
+    <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@48,400,0,0" rel="stylesheet"/>
     <link rel="stylesheet" href="../static-assets/github.css?v1"/>
     <link rel="stylesheet" href="../static-assets/styles.css?v1"/>
     <link rel="icon" href="../static-assets/favicon.png?v1"/>
   </head>
-  <body data-base-href="../" data-using-base-href="false">
+  <body data-base-href="../" data-using-base-href="false" class="light-theme">
     <noscript>&lt;iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MX6DBN9" height="0" width="0" style="display:none;visibility:hidden">&lt;/iframe></noscript>
     <div id="overlay-under-drawer"/>
     <header id="title">
-      <button id="sidenav-left-toggle" type="button"></button>
+      <span id="sidenav-left-toggle" class="material-symbols-outlined" role="button" tabindex="0">menu</span>
       <a class="hidden-xs" href="/">
         <img src="/static/hash-%%etag%%/img/dart-logo.svg" style="height: 30px; margin-right: 1em;"/>
       </a>
@@ -41,6 +41,12 @@
       <form class="search navbar-right" role="search">
         <input type="text" id="search-box" autocomplete="off" disabled="" class="form-control typeahead" placeholder="Loading search..."/>
       </form>
+      <div class="toggle" id="theme-button">
+        <label for="theme">
+          <input type="checkbox" id="theme" value="light-theme"/>
+          <span class="material-symbols-outlined">brightness_4</span>
+        </label>
+      </div>
     </header>
     <main>
       <div id="dartdoc-main-content" class="main-content">
@@ -52,7 +58,7 @@
         </div>
         <section class="multi-line-signature">
           <span class="returntype">
-            <a href="https://api.dart.dev/stable/2.17.0/dart-core/String-class.html">String</a>
+            <a href="https://api.dart.dev/stable/2.18.0/dart-core/String-class.html">String</a>
           </span>
           <span class="name ">prettyJson</span>
           (

--- a/pkg/_popularity/pubspec.lock
+++ b/pkg/_popularity/pubspec.lock
@@ -7,14 +7,14 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "46.0.0"
+    version: "48.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.6.0"
+    version: "5.0.0"
   args:
     dependency: transitive
     description:
@@ -42,7 +42,7 @@ packages:
       name: build
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.0"
+    version: "2.3.1"
   build_config:
     dependency: transitive
     description:
@@ -63,21 +63,21 @@ packages:
       name: build_resolvers
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.9"
+    version: "2.0.10"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.0"
+    version: "2.2.1"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "7.2.3"
+    version: "7.2.4"
   build_verify:
     dependency: "direct dev"
     description:
@@ -112,7 +112,7 @@ packages:
       name: code_builder
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.2.0"
+    version: "4.3.0"
   collection:
     dependency: transitive
     description:
@@ -133,7 +133,7 @@ packages:
       name: coverage
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.0"
+    version: "1.6.1"
   crypto:
     dependency: transitive
     description:
@@ -147,7 +147,7 @@ packages:
       name: dart_style
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.3"
+    version: "2.2.4"
   file:
     dependency: transitive
     description:
@@ -217,14 +217,14 @@ packages:
       name: json_annotation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.6.0"
+    version: "4.7.0"
   json_serializable:
     dependency: "direct dev"
     description:
       name: json_serializable
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.3.1"
+    version: "6.4.0"
   logging:
     dependency: transitive
     description:
@@ -301,7 +301,7 @@ packages:
       name: shelf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.2"
+    version: "1.4.0"
   shelf_packages_handler:
     dependency: transitive
     description:
@@ -329,14 +329,14 @@ packages:
       name: source_gen
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.2"
+    version: "1.2.5"
   source_helper:
     dependency: transitive
     description:
       name: source_helper
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.2"
+    version: "1.3.3"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -371,7 +371,7 @@ packages:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   stream_transform:
     dependency: transitive
     description:
@@ -399,21 +399,21 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.21.4"
+    version: "1.21.6"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.12"
+    version: "0.4.14"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.16"
+    version: "0.4.18"
   timing:
     dependency: transitive
     description:
@@ -434,7 +434,7 @@ packages:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "9.3.0"
+    version: "9.4.0"
   watcher:
     dependency: transitive
     description:
@@ -455,7 +455,7 @@ packages:
       name: webkit_inspection_protocol
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   yaml:
     dependency: transitive
     description:
@@ -464,4 +464,4 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.17.0 <3.0.0"
+  dart: ">=2.18.0 <3.0.0"

--- a/pkg/_pub_shared/pubspec.lock
+++ b/pkg/_pub_shared/pubspec.lock
@@ -7,14 +7,14 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "46.0.0"
+    version: "48.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.6.0"
+    version: "5.0.0"
   args:
     dependency: transitive
     description:
@@ -42,7 +42,7 @@ packages:
       name: build
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.0"
+    version: "2.3.1"
   build_config:
     dependency: transitive
     description:
@@ -63,21 +63,21 @@ packages:
       name: build_resolvers
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.9"
+    version: "2.0.10"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.0"
+    version: "2.2.1"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "7.2.3"
+    version: "7.2.4"
   build_verify:
     dependency: "direct dev"
     description:
@@ -112,7 +112,7 @@ packages:
       name: code_builder
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.2.0"
+    version: "4.3.0"
   collection:
     dependency: transitive
     description:
@@ -133,7 +133,7 @@ packages:
       name: coverage
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.0"
+    version: "1.6.1"
   crypto:
     dependency: transitive
     description:
@@ -154,7 +154,7 @@ packages:
       name: dart_style
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.3"
+    version: "2.2.4"
   file:
     dependency: transitive
     description:
@@ -231,14 +231,14 @@ packages:
       name: json_annotation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.6.0"
+    version: "4.7.0"
   json_serializable:
     dependency: "direct dev"
     description:
       name: json_serializable
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.3.1"
+    version: "6.4.0"
   logging:
     dependency: transitive
     description:
@@ -315,7 +315,7 @@ packages:
       name: shelf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.2"
+    version: "1.4.0"
   shelf_packages_handler:
     dependency: transitive
     description:
@@ -343,14 +343,14 @@ packages:
       name: source_gen
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.2"
+    version: "1.2.5"
   source_helper:
     dependency: transitive
     description:
       name: source_helper
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.2"
+    version: "1.3.3"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -385,7 +385,7 @@ packages:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   stream_transform:
     dependency: transitive
     description:
@@ -413,21 +413,21 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.21.4"
+    version: "1.21.6"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.12"
+    version: "0.4.14"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.16"
+    version: "0.4.18"
   timing:
     dependency: transitive
     description:
@@ -448,7 +448,7 @@ packages:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "9.3.0"
+    version: "9.4.0"
   watcher:
     dependency: transitive
     description:
@@ -469,7 +469,7 @@ packages:
       name: webkit_inspection_protocol
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   yaml:
     dependency: transitive
     description:
@@ -478,4 +478,4 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.17.0 <3.0.0"
+  dart: ">=2.18.0 <3.0.0"

--- a/pkg/api_builder/pubspec.lock
+++ b/pkg/api_builder/pubspec.lock
@@ -133,7 +133,7 @@ packages:
       name: coverage
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.0"
+    version: "1.6.1"
   crypto:
     dependency: transitive
     description:
@@ -231,7 +231,7 @@ packages:
       name: json_annotation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.6.0"
+    version: "4.7.0"
   logging:
     dependency: "direct main"
     description:
@@ -308,7 +308,7 @@ packages:
       name: shelf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.2"
+    version: "1.4.0"
   shelf_packages_handler:
     dependency: transitive
     description:
@@ -343,7 +343,7 @@ packages:
       name: source_gen
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.3"
+    version: "1.2.5"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -378,7 +378,7 @@ packages:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   stream_transform:
     dependency: transitive
     description:

--- a/pkg/fake_gcloud/pubspec.lock
+++ b/pkg/fake_gcloud/pubspec.lock
@@ -14,14 +14,14 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "46.0.0"
+    version: "48.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.6.0"
+    version: "5.0.0"
   args:
     dependency: transitive
     description:
@@ -63,7 +63,7 @@ packages:
       name: coverage
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.0"
+    version: "1.6.1"
   crypto:
     dependency: transitive
     description:
@@ -84,7 +84,7 @@ packages:
       name: frontend_server_client
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.3"
+    version: "3.0.0"
   gcloud:
     dependency: "direct main"
     description:
@@ -105,7 +105,7 @@ packages:
       name: googleapis
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "9.1.0"
+    version: "9.2.0"
   http:
     dependency: transitive
     description:
@@ -210,7 +210,7 @@ packages:
       name: shelf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.2"
+    version: "1.4.0"
   shelf_packages_handler:
     dependency: transitive
     description:
@@ -266,7 +266,7 @@ packages:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   string_scanner:
     dependency: transitive
     description:
@@ -287,21 +287,21 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.21.4"
+    version: "1.21.6"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.12"
+    version: "0.4.14"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.16"
+    version: "0.4.18"
   typed_data:
     dependency: transitive
     description:
@@ -315,7 +315,7 @@ packages:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "9.3.0"
+    version: "9.4.0"
   watcher:
     dependency: transitive
     description:
@@ -336,7 +336,7 @@ packages:
       name: webkit_inspection_protocol
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   yaml:
     dependency: transitive
     description:
@@ -345,4 +345,4 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.17.0 <3.0.0"
+  dart: ">=2.18.0 <3.0.0"

--- a/pkg/indexed_blob/pubspec.lock
+++ b/pkg/indexed_blob/pubspec.lock
@@ -7,14 +7,14 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "46.0.0"
+    version: "48.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.6.0"
+    version: "5.0.0"
   args:
     dependency: transitive
     description:
@@ -56,7 +56,7 @@ packages:
       name: coverage
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.0"
+    version: "1.6.1"
   crypto:
     dependency: transitive
     description:
@@ -77,7 +77,7 @@ packages:
       name: frontend_server_client
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.3"
+    version: "3.0.0"
   glob:
     dependency: transitive
     description:
@@ -189,7 +189,7 @@ packages:
       name: shelf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.2"
+    version: "1.4.0"
   shelf_packages_handler:
     dependency: transitive
     description:
@@ -245,7 +245,7 @@ packages:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   string_scanner:
     dependency: transitive
     description:
@@ -266,21 +266,21 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.21.4"
+    version: "1.21.6"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.12"
+    version: "0.4.14"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.16"
+    version: "0.4.18"
   typed_data:
     dependency: transitive
     description:
@@ -294,7 +294,7 @@ packages:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "9.3.0"
+    version: "9.4.0"
   watcher:
     dependency: transitive
     description:
@@ -315,7 +315,7 @@ packages:
       name: webkit_inspection_protocol
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   yaml:
     dependency: transitive
     description:
@@ -324,4 +324,4 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.17.0 <3.0.0"
+  dart: ">=2.18.0 <3.0.0"

--- a/pkg/pub_dartdoc/pubspec.lock
+++ b/pkg/pub_dartdoc/pubspec.lock
@@ -7,14 +7,14 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "46.0.0"
+    version: "48.0.0"
   analyzer:
     dependency: "direct main"
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.6.0"
+    version: "5.0.0"
   args:
     dependency: transitive
     description:
@@ -36,13 +36,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
-  charcode:
-    dependency: transitive
-    description:
-      name: charcode
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.1"
   cli_util:
     dependency: transitive
     description:
@@ -70,7 +63,7 @@ packages:
       name: coverage
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.0"
+    version: "1.6.1"
   crypto:
     dependency: transitive
     description:
@@ -91,7 +84,7 @@ packages:
       name: dartdoc
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.1"
+    version: "6.1.1"
   file:
     dependency: transitive
     description:
@@ -105,7 +98,7 @@ packages:
       name: frontend_server_client
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.3"
+    version: "3.0.0"
   glob:
     dependency: transitive
     description:
@@ -161,7 +154,7 @@ packages:
       name: json_annotation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.6.0"
+    version: "4.7.0"
   logging:
     dependency: transitive
     description:
@@ -175,7 +168,7 @@ packages:
       name: markdown
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.0.0"
+    version: "6.0.1"
   matcher:
     dependency: transitive
     description:
@@ -245,7 +238,7 @@ packages:
       name: shelf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.2"
+    version: "1.4.0"
   shelf_packages_handler:
     dependency: transitive
     description:
@@ -301,7 +294,7 @@ packages:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   string_scanner:
     dependency: transitive
     description:
@@ -315,7 +308,7 @@ packages:
       name: tar
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.5.5+1"
+    version: "0.5.6"
   term_glyph:
     dependency: transitive
     description:
@@ -329,21 +322,21 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.21.4"
+    version: "1.21.6"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.12"
+    version: "0.4.14"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.16"
+    version: "0.4.18"
   typed_data:
     dependency: transitive
     description:
@@ -357,7 +350,7 @@ packages:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "9.3.0"
+    version: "9.4.0"
   watcher:
     dependency: transitive
     description:
@@ -378,7 +371,7 @@ packages:
       name: webkit_inspection_protocol
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   yaml:
     dependency: transitive
     description:
@@ -387,4 +380,4 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.17.0 <3.0.0"
+  dart: ">=2.18.0 <3.0.0"

--- a/pkg/pub_dartdoc/pubspec.yaml
+++ b/pkg/pub_dartdoc/pubspec.yaml
@@ -8,7 +8,7 @@ dependencies:
   pub_dartdoc_data:
     path: ../pub_dartdoc_data
   # dartdoc version to be pinned, keep in-sync with app/lib/shared/versions.dart
-  dartdoc: 6.0.1
+  dartdoc: 6.1.1
 
 dev_dependencies:
   coverage: any # test already depends on it

--- a/pkg/pub_dartdoc/test/self_documenting_test.dart
+++ b/pkg/pub_dartdoc/test/self_documenting_test.dart
@@ -80,6 +80,7 @@ void main() {
         'pub_data_generator/PubDataGenerator/toString.html',
         'pub_data_generator/fileName-constant.html',
         'pub_data_generator/pub_data_generator-library.html',
+        'search.html',
         'static-assets/docs.dart.js',
         'static-assets/docs.dart.js.map',
         'static-assets/favicon.png',
@@ -87,6 +88,7 @@ void main() {
         'static-assets/highlight.pack.js',
         'static-assets/play_button.svg',
         'static-assets/readme.md',
+        'static-assets/search.png',
         'static-assets/styles.css',
       ]);
     });

--- a/pkg/pub_dartdoc_data/pubspec.lock
+++ b/pkg/pub_dartdoc_data/pubspec.lock
@@ -7,14 +7,14 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "46.0.0"
+    version: "48.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.6.0"
+    version: "5.0.0"
   args:
     dependency: transitive
     description:
@@ -42,7 +42,7 @@ packages:
       name: build
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.0"
+    version: "2.3.1"
   build_config:
     dependency: transitive
     description:
@@ -63,21 +63,21 @@ packages:
       name: build_resolvers
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.9"
+    version: "2.0.10"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.0"
+    version: "2.2.1"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "7.2.3"
+    version: "7.2.4"
   build_verify:
     dependency: "direct dev"
     description:
@@ -112,7 +112,7 @@ packages:
       name: code_builder
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.2.0"
+    version: "4.3.0"
   collection:
     dependency: transitive
     description:
@@ -133,7 +133,7 @@ packages:
       name: coverage
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.0"
+    version: "1.6.1"
   crypto:
     dependency: transitive
     description:
@@ -147,7 +147,7 @@ packages:
       name: dart_style
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.3"
+    version: "2.2.4"
   file:
     dependency: transitive
     description:
@@ -217,14 +217,14 @@ packages:
       name: json_annotation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.6.0"
+    version: "4.7.0"
   json_serializable:
     dependency: "direct dev"
     description:
       name: json_serializable
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.3.1"
+    version: "6.4.0"
   logging:
     dependency: transitive
     description:
@@ -301,7 +301,7 @@ packages:
       name: shelf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.2"
+    version: "1.4.0"
   shelf_packages_handler:
     dependency: transitive
     description:
@@ -329,14 +329,14 @@ packages:
       name: source_gen
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.2"
+    version: "1.2.5"
   source_helper:
     dependency: transitive
     description:
       name: source_helper
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.2"
+    version: "1.3.3"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -371,7 +371,7 @@ packages:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   stream_transform:
     dependency: transitive
     description:
@@ -399,21 +399,21 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.21.4"
+    version: "1.21.6"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.12"
+    version: "0.4.14"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.16"
+    version: "0.4.18"
   timing:
     dependency: transitive
     description:
@@ -434,7 +434,7 @@ packages:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "9.3.0"
+    version: "9.4.0"
   watcher:
     dependency: transitive
     description:
@@ -455,7 +455,7 @@ packages:
       name: webkit_inspection_protocol
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   yaml:
     dependency: transitive
     description:
@@ -464,4 +464,4 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.17.0 <3.0.0"
+  dart: ">=2.18.0 <3.0.0"

--- a/pkg/pub_integration/pubspec.lock
+++ b/pkg/pub_integration/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "46.0.0"
+    version: "48.0.0"
   _pub_shared:
     dependency: "direct main"
     description:
@@ -21,7 +21,7 @@ packages:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.6.0"
+    version: "5.0.0"
   archive:
     dependency: transitive
     description:
@@ -70,7 +70,7 @@ packages:
       name: coverage
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.0"
+    version: "1.6.1"
   crypto:
     dependency: transitive
     description:
@@ -98,7 +98,7 @@ packages:
       name: frontend_server_client
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.3"
+    version: "3.0.0"
   glob:
     dependency: transitive
     description:
@@ -154,7 +154,7 @@ packages:
       name: json_annotation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.6.0"
+    version: "4.7.0"
   logging:
     dependency: transitive
     description:
@@ -245,7 +245,7 @@ packages:
       name: shelf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.2"
+    version: "1.4.0"
   shelf_packages_handler:
     dependency: transitive
     description:
@@ -301,7 +301,7 @@ packages:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   string_scanner:
     dependency: transitive
     description:
@@ -322,21 +322,21 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.21.4"
+    version: "1.21.6"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.12"
+    version: "0.4.14"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.16"
+    version: "0.4.18"
   typed_data:
     dependency: transitive
     description:
@@ -350,7 +350,7 @@ packages:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "9.3.0"
+    version: "9.4.0"
   watcher:
     dependency: transitive
     description:
@@ -371,7 +371,7 @@ packages:
       name: webkit_inspection_protocol
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   yaml:
     dependency: transitive
     description:
@@ -380,4 +380,4 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.17.0 <3.0.0"
+  dart: ">=2.18.0 <3.0.0"

--- a/pkg/pub_package_reader/pubspec.lock
+++ b/pkg/pub_package_reader/pubspec.lock
@@ -7,14 +7,14 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "46.0.0"
+    version: "48.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.6.0"
+    version: "5.0.0"
   args:
     dependency: transitive
     description:
@@ -70,7 +70,7 @@ packages:
       name: coverage
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.0"
+    version: "1.6.1"
   crypto:
     dependency: transitive
     description:
@@ -91,7 +91,7 @@ packages:
       name: frontend_server_client
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.3"
+    version: "3.0.0"
   glob:
     dependency: transitive
     description:
@@ -140,7 +140,7 @@ packages:
       name: json_annotation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.6.0"
+    version: "4.7.0"
   logging:
     dependency: "direct main"
     description:
@@ -217,7 +217,7 @@ packages:
       name: shelf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.2"
+    version: "1.4.0"
   shelf_packages_handler:
     dependency: transitive
     description:
@@ -273,7 +273,7 @@ packages:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   string_scanner:
     dependency: transitive
     description:
@@ -301,21 +301,21 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.21.4"
+    version: "1.21.6"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.12"
+    version: "0.4.14"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.16"
+    version: "0.4.18"
   typed_data:
     dependency: transitive
     description:
@@ -329,7 +329,7 @@ packages:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "9.3.0"
+    version: "9.4.0"
   watcher:
     dependency: transitive
     description:
@@ -350,7 +350,7 @@ packages:
       name: webkit_inspection_protocol
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   yaml:
     dependency: "direct main"
     description:
@@ -366,4 +366,4 @@ packages:
     source: hosted
     version: "2.0.3"
 sdks:
-  dart: ">=2.17.0 <3.0.0"
+  dart: ">=2.18.0 <3.0.0"

--- a/pkg/pub_worker/pubspec.lock
+++ b/pkg/pub_worker/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "38.0.0"
+    version: "47.0.0"
   _pub_shared:
     dependency: "direct main"
     description:
@@ -21,7 +21,7 @@ packages:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.4.1"
+    version: "4.7.0"
   api_builder:
     dependency: "direct main"
     description:
@@ -35,7 +35,7 @@ packages:
       name: args
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.0"
+    version: "2.3.1"
   async:
     dependency: transitive
     description:
@@ -56,42 +56,42 @@ packages:
       name: build
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.1"
+    version: "2.3.1"
   build_config:
     dependency: transitive
     description:
       name: build_config
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.0"
   build_daemon:
     dependency: transitive
     description:
       name: build_daemon
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.1"
+    version: "3.1.0"
   build_resolvers:
     dependency: transitive
     description:
       name: build_resolvers
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.6"
+    version: "2.0.10"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.8"
+    version: "2.2.1"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "7.2.3"
+    version: "7.2.4"
   built_collection:
     dependency: transitive
     description:
@@ -105,14 +105,7 @@ packages:
       name: built_value
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "8.1.4"
-  charcode:
-    dependency: transitive
-    description:
-      name: charcode
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.1"
+    version: "8.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -133,14 +126,14 @@ packages:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   code_builder:
     dependency: transitive
     description:
       name: code_builder
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.1.0"
+    version: "4.3.0"
   collection:
     dependency: transitive
     description:
@@ -154,63 +147,63 @@ packages:
       name: convert
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   coverage:
     dependency: transitive
     description:
       name: coverage
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.6.1"
   crypto:
     dependency: transitive
     description:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   csslib:
     dependency: transitive
     description:
       name: csslib
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.17.1"
+    version: "0.17.2"
   dart_style:
     dependency: transitive
     description:
       name: dart_style
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.2"
+    version: "2.2.4"
   file:
     dependency: transitive
     description:
       name: file
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.1.2"
+    version: "6.1.4"
   fixnum:
     dependency: transitive
     description:
       name: fixnum
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.1"
   frontend_server_client:
     dependency: transitive
     description:
       name: frontend_server_client
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.3"
   glob:
     dependency: transitive
     description:
       name: glob
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.2"
+    version: "2.1.0"
   graphs:
     dependency: transitive
     description:
@@ -231,7 +224,7 @@ packages:
       name: http
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.4"
+    version: "0.13.5"
   http_methods:
     dependency: transitive
     description:
@@ -245,14 +238,14 @@ packages:
       name: http_multi_server
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.2.0"
+    version: "3.2.1"
   http_parser:
     dependency: "direct main"
     description:
       name: http_parser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.0"
+    version: "4.0.1"
   indexed_blob:
     dependency: "direct main"
     description:
@@ -280,21 +273,21 @@ packages:
       name: json_annotation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.6.0"
+    version: "4.7.0"
   json_serializable:
     dependency: "direct dev"
     description:
       name: json_serializable
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.3.1"
+    version: "6.4.0"
   jsontool:
     dependency: "direct main"
     description:
       name: jsontool
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.2"
   logging:
     dependency: "direct main"
     description:
@@ -308,28 +301,28 @@ packages:
       name: markdown
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.0"
+    version: "6.0.1"
   matcher:
     dependency: transitive
     description:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.11"
+    version: "0.12.12"
   meta:
     dependency: "direct main"
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   mime:
     dependency: transitive
     description:
       name: mime
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "1.0.2"
   node_preamble:
     dependency: transitive
     description:
@@ -343,7 +336,7 @@ packages:
       name: package_config
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.2"
+    version: "2.1.0"
   pana:
     dependency: "direct main"
     description:
@@ -357,14 +350,14 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   pool:
     dependency: transitive
     description:
       name: pool
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.0"
+    version: "1.5.1"
   pub_semver:
     dependency: transitive
     description:
@@ -399,49 +392,49 @@ packages:
       name: shelf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.0"
   shelf_packages_handler:
     dependency: transitive
     description:
       name: shelf_packages_handler
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0"
+    version: "3.0.1"
   shelf_router:
     dependency: "direct dev"
     description:
       name: shelf_router
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.2"
+    version: "1.1.3"
   shelf_static:
     dependency: transitive
     description:
       name: shelf_static
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "1.0.2"
   source_gen:
     dependency: transitive
     description:
       name: source_gen
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.5"
   source_helper:
     dependency: transitive
     description:
       name: source_helper
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.3"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -462,7 +455,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.2"
+    version: "1.9.1"
   stack_trace:
     dependency: transitive
     description:
@@ -476,7 +469,7 @@ packages:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   stream_transform:
     dependency: transitive
     description:
@@ -490,42 +483,42 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   tar:
     dependency: transitive
     description:
       name: tar
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.5.4"
+    version: "0.5.6"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test:
     dependency: "direct dev"
     description:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.20.2"
+    version: "1.21.6"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.9"
+    version: "0.4.14"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.11"
+    version: "0.4.18"
   timing:
     dependency: transitive
     description:
@@ -539,7 +532,7 @@ packages:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.1"
   uuid:
     dependency: transitive
     description:
@@ -553,7 +546,7 @@ packages:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "8.2.2"
+    version: "9.4.0"
   watcher:
     dependency: transitive
     description:
@@ -567,20 +560,20 @@ packages:
       name: web_socket_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.2.0"
   webkit_inspection_protocol:
     dependency: transitive
     description:
       name: webkit_inspection_protocol
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.2.0"
   yaml:
     dependency: transitive
     description:
       name: yaml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.0"
+    version: "3.1.1"
 sdks:
-  dart: ">=2.17.0 <3.0.0"
+  dart: ">=2.18.0 <3.0.0"

--- a/pkg/web_app/pubspec.lock
+++ b/pkg/web_app/pubspec.lock
@@ -56,7 +56,7 @@ packages:
       name: build
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.0"
+    version: "2.3.1"
   build_config:
     dependency: transitive
     description:
@@ -91,7 +91,7 @@ packages:
       name: code_builder
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.2.0"
+    version: "4.3.0"
   collection:
     dependency: transitive
     description:
@@ -112,7 +112,7 @@ packages:
       name: coverage
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.0"
+    version: "1.6.1"
   crypto:
     dependency: transitive
     description:
@@ -133,7 +133,7 @@ packages:
       name: dart_style
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.3"
+    version: "2.2.4"
   file:
     dependency: transitive
     description:
@@ -154,7 +154,7 @@ packages:
       name: frontend_server_client
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.3"
+    version: "3.0.0"
   glob:
     dependency: transitive
     description:
@@ -217,7 +217,7 @@ packages:
       name: json_annotation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.6.0"
+    version: "4.7.0"
   logging:
     dependency: transitive
     description:
@@ -231,7 +231,7 @@ packages:
       name: markdown
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.0"
+    version: "6.0.1"
   matcher:
     dependency: transitive
     description:
@@ -308,7 +308,7 @@ packages:
       name: shelf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.2"
+    version: "1.4.0"
   shelf_packages_handler:
     dependency: transitive
     description:
@@ -343,7 +343,7 @@ packages:
       name: source_gen
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.2"
+    version: "1.2.5"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -378,7 +378,7 @@ packages:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   string_scanner:
     dependency: transitive
     description:
@@ -399,21 +399,21 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.21.4"
+    version: "1.21.6"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.12"
+    version: "0.4.14"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.16"
+    version: "0.4.18"
   typed_data:
     dependency: transitive
     description:
@@ -434,7 +434,7 @@ packages:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "9.3.0"
+    version: "9.4.0"
   watcher:
     dependency: transitive
     description:
@@ -455,7 +455,7 @@ packages:
       name: webkit_inspection_protocol
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   yaml:
     dependency: transitive
     description:
@@ -464,4 +464,4 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.17.0 <3.0.0"
+  dart: ">=2.18.0 <3.0.0"

--- a/pkg/web_app/pubspec.yaml
+++ b/pkg/web_app/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
     path: ../api_builder
   http: ^0.13.0
   js: ^0.6.1
-  markdown: ^6.0.0
+  markdown: ^6.0.1
   mdc_web: ^0.6.0
   meta: ^1.3.0
 

--- a/pkg/web_css/pubspec.lock
+++ b/pkg/web_css/pubspec.lock
@@ -7,14 +7,14 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "46.0.0"
+    version: "48.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.6.0"
+    version: "5.0.0"
   args:
     dependency: transitive
     description:
@@ -49,7 +49,7 @@ packages:
       name: cli_repl
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.2"
+    version: "0.2.3"
   collection:
     dependency: transitive
     description:
@@ -70,7 +70,7 @@ packages:
       name: coverage
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.0"
+    version: "1.6.1"
   crypto:
     dependency: transitive
     description:
@@ -98,7 +98,7 @@ packages:
       name: frontend_server_client
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.3"
+    version: "3.0.0"
   glob:
     dependency: transitive
     description:
@@ -224,14 +224,14 @@ packages:
       name: sass
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.54.5"
+    version: "1.55.0"
   shelf:
     dependency: transitive
     description:
       name: shelf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.2"
+    version: "1.4.0"
   shelf_packages_handler:
     dependency: transitive
     description:
@@ -287,7 +287,7 @@ packages:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   stream_transform:
     dependency: transitive
     description:
@@ -315,21 +315,21 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.21.4"
+    version: "1.21.6"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.12"
+    version: "0.4.14"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.16"
+    version: "0.4.18"
   tuple:
     dependency: transitive
     description:
@@ -350,7 +350,7 @@ packages:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "9.3.0"
+    version: "9.4.0"
   watcher:
     dependency: transitive
     description:
@@ -371,7 +371,7 @@ packages:
       name: webkit_inspection_protocol
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   yaml:
     dependency: transitive
     description:
@@ -380,4 +380,4 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.17.0 <3.0.0"
+  dart: ">=2.18.0 <3.0.0"


### PR DESCRIPTION
- `markdown 6.0.1` contains a fix for github checkbox rendering
- upgraded dartdoc (also upgraded its markdown version)
