### PR TITLE
Fixing OutgoingEmail entity, sending and retries.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ AppEngine version, listed here to ease deployment and troubleshooting.
  * Upgraded pana to `0.21.18`.
  * Upgraded dartdoc to `6.1.1`.
  * Upgraded dependencies, including `markdown` to `6.0.1`.
+ * NOTE: Fixed `OutgoingEmail`: all recipients in one entry.
 
 ## `20220922t114500-all`
  * Bumped runtimeVersion to `2022.09.22`.

--- a/app/lib/account/consent_backend.dart
+++ b/app/lib/account/consent_backend.dart
@@ -200,7 +200,7 @@ class ConsentBackend {
       String activeUserEmail, Consent consent) async {
     final invitedEmail = consent.email!;
     final action = _actions[consent.kind]!;
-    final emails = emailBackend.prepareEntities(createInviteEmail(
+    final email = emailBackend.prepareEntity(createInviteEmail(
       invitedEmail: invitedEmail,
       subject: action.renderEmailSubject(consent.args!),
       inviteText: action.renderInviteText(activeUserEmail, consent.args!),
@@ -211,11 +211,11 @@ class ConsentBackend {
       c.notificationCount++;
       c.lastNotified = clock.now().toUtc();
       tx.insert(c);
-      tx.insertAll(emails);
+      tx.insert(email);
       return api.InviteStatus(
           emailSent: true, nextNotification: c.nextNotification);
     });
-    await emailBackend.trySendOutgoingEmails(emails);
+    await emailBackend.trySendOutgoingEmail(email);
     return status;
   }
 

--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -627,7 +627,7 @@ class PackageBackend {
       ...newPublisherAdminEmails.whereType<String>(),
     };
 
-    List<OutgoingEmail>? emails;
+    OutgoingEmail? email;
     String? currentPublisherId;
     final rs = await withRetryTransaction(db, (tx) async {
       final package = await tx.lookupValue<Package>(key);
@@ -648,23 +648,22 @@ class PackageBackend {
         toPublisherId: package.publisherId!,
       ));
 
-      final email = createPackageTransferEmail(
+      email = emailBackend.prepareEntity(createPackageTransferEmail(
         packageName: packageName,
         activeUserEmail: user.email!,
         oldPublisherId: currentPublisherId,
         newPublisherId: package.publisherId!,
         authorizedAdmins:
             allAdminEmails.map((email) => EmailAddress(email)).toList(),
-      );
-      emails = emailBackend.prepareEntities(email);
-      tx.insertAll(emails!);
+      ));
+      tx.insert(email!);
       return _asPackagePublisherInfo(package);
     });
     await purgePublisherCache(publisherId: request.publisherId);
     await purgePackageCache(packageName);
 
-    if (emails != null) {
-      await emailBackend.trySendOutgoingEmails(emails!);
+    if (email != null) {
+      await emailBackend.trySendOutgoingEmail(email!);
     }
     if (currentPublisherId != null) {
       await purgePublisherCache(publisherId: currentPublisherId);
@@ -961,7 +960,7 @@ class PackageBackend {
       authorizedUploaders:
           uploaderEmails.map((email) => EmailAddress(email)).toList(),
     );
-    final emailEntitiesToStore = emailBackend.prepareEntities(email);
+    final emailEntityToStore = emailBackend.prepareEntity(email);
 
     Package? package;
     String? prevLatestStableVersion;
@@ -1043,7 +1042,7 @@ class PackageBackend {
         newVersion,
         entities.packageVersionInfo,
         ...entities.assets,
-        ...emailEntitiesToStore,
+        emailEntityToStore,
         AuditLogRecord.packagePublished(
           uploader: agent,
           package: newVersion.package,
@@ -1065,8 +1064,7 @@ class PackageBackend {
     await purgePackageCache(newVersion.package);
 
     try {
-      final emailFuture =
-          emailBackend.trySendOutgoingEmails(emailEntitiesToStore);
+      final emailFuture = emailBackend.trySendOutgoingEmail(emailEntityToStore);
 
       final latestVersionChanged = prevLatestStableVersion != null &&
           package!.latestVersion != prevLatestStableVersion;

--- a/app/lib/service/email/backend.dart
+++ b/app/lib/service/email/backend.dart
@@ -123,7 +123,14 @@ class EmailBackend {
 
     await withRetryTransaction(_db, (tx) async {
       final o = await tx.lookupOrNull<OutgoingEmail>(key);
-      if (o == null || o.claimId != claimId) {
+      if (o == null) {
+        _logger.shout(
+            'OutgoingEmail was removed while sending emails (claimId="$claimId").');
+        return;
+      }
+      if (o.claimId != claimId) {
+        _logger.shout(
+            'OutgoingEmail `claimId` changed while sending emails (claimId="$claimId").');
         return;
       }
       for (final email in sent) {

--- a/app/lib/service/email/backend.dart
+++ b/app/lib/service/email/backend.dart
@@ -91,7 +91,9 @@ class EmailBackend {
       }
       o.attempts++;
       o.lastAttempted = now;
-      // retry after a random delay in the next 2-6 hours
+      // retry after a random delay in the next 2-6 hours, if and only if,
+      // o.claimId has been cleared. We never retry sending emails if we don't know
+      // if the email was sent or not (because we don't want to send it multiple times)
       o.pendingAt =
           now.add(Duration(hours: 2, minutes: _random.nextInt(4 * 60)));
       o.claimId = claimId;


### PR DESCRIPTION
- Fixes #6082.
- All recipients are stored in the single `OutgoingEmail` entry.
- On a sending attempt, we set a random `claimId`, and clear it when the attempt is completed. A next attempt with an active `claimId` won't proceed, and the GC process will clear it.
