### PR TITLE
Run post-upload tasks outside of the request scope.

### DIFF
--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -1101,6 +1101,10 @@ class PackageBackend {
     return pv;
   }
 
+  /// The post-upload tasks are not critical and could fail without any impact on
+  /// the uploaded package version. Important operations (e.g. email sending) are
+  /// retried periodically, others (e.g. triggering re-analysis of dependent
+  /// packages) are only nice to have.
   Future<void> _postUploadTasks(
     Package? package,
     PackageVersion newVersion,


### PR DESCRIPTION
- run post-upload tasks with a `Timer` that is scheduled with `Duration.zero`
- removed timeout from post-upload tasks (but kept severe log level if there is an issue)