### PR TITLE
Improve exact-name match: (if and only if) present, package hit is pushed to the first position.

### DIFF
--- a/app/test/search/package_name_index_test.dart
+++ b/app/test/search/package_name_index_test.dart
@@ -37,6 +37,13 @@ void main() {
       );
     });
 
+    test('get_it', () {
+      expect(index.search('get_it').getValues(), {
+        'get': closeTo(0.78, 0.01),
+        'get_it': 1.0,
+      });
+    });
+
     test('modular vs modular_flutter', () {
       expect(
         index.search('modular').getValues(),


### PR DESCRIPTION
- Fixes #6097
- While the previous highlighted hit concept always included the exact name match package into the result list, this one only pushes it forward when the package is present (matching the search conditions).