### PR TITLE
Lenient HTTP retries for integrity check.

### DIFF
--- a/app/lib/shared/integrity.dart
+++ b/app/lib/shared/integrity.dart
@@ -70,7 +70,7 @@ class IntegrityChecker {
 
   /// Runs integrity checks, and returns the list of problems.
   Stream<String> findProblems() async* {
-    _httpClient = httpRetryClient();
+    _httpClient = httpRetryClient(lenient: true);
     try {
       yield* _checkUsers();
       yield* _checkOAuthUserIDs();

--- a/app/lib/tool/utils/http.dart
+++ b/app/lib/tool/utils/http.dart
@@ -13,17 +13,23 @@ final _transientStatusCodes = {
 };
 
 /// Creates a HTTP client that retries transient status codes.
+///
+/// When [lenient] is set, we retry on more errors and status codes.
 http.Client httpRetryClient({
   http.Client? innerClient,
   int? retries,
+  bool lenient = false,
 }) {
   return RetryClient(
     innerClient ?? http.Client(),
-    when: (r) => _transientStatusCodes.contains(r.statusCode),
-    // TOOD: Consider implementing whenError and handle DNS + handshake errors.
+    when: (r) =>
+        (lenient && r.statusCode >= 500) ||
+        _transientStatusCodes.contains(r.statusCode),
+    retries: retries ?? 5,
+    // TOOD: Consider implementing whenError to handle DNS + handshake errors.
     //       These are safe, retrying after partially sending data is more
     //       sketchy, but probably safe in our application.
-    retries: retries ?? 5,
+    whenError: (e, st) => lenient,
   );
 }
 


### PR DESCRIPTION
- Fixes #6081.
- Retries HTTP requests on every exception or when `statusCode >= 500`