### PR TITLE
Rename GCP-related automated publishing identifiers, types and fields.

### DIFF
--- a/app/lib/account/agent.dart
+++ b/app/lib/account/agent.dart
@@ -9,11 +9,11 @@ final _uuidRegExp =
 
 abstract class KnownAgents {
   static const githubActions = 'service:github-actions';
-  static const googleCloudServiceAccount = 'service:gcp-service-account';
+  static const gcpServiceAccount = 'service:gcp-service-account';
 
   static const _values = <String>{
     githubActions,
-    googleCloudServiceAccount,
+    gcpServiceAccount,
   };
 }
 

--- a/app/lib/account/backend.dart
+++ b/app/lib/account/backend.dart
@@ -14,8 +14,8 @@ import 'package:neat_cache/neat_cache.dart';
 import 'package:pub_dev/shared/configuration.dart';
 
 import '../package/models.dart';
+import '../service/openid/gcp_openid.dart';
 import '../service/openid/github_openid.dart';
-import '../service/openid/google_cloud_openid.dart';
 import '../service/openid/jwt.dart';
 import '../service/openid/openid_models.dart';
 import '../shared/datastore.dart';
@@ -173,9 +173,9 @@ class AuthenticatedGithubAction implements AuthenticatedAgent {
 }
 
 /// Holds the authenticated Google Cloud Service account information.
-class AuthenticatedGoogleCloudServiceAccount implements AuthenticatedAgent {
+class AuthenticatedGcpServiceAccount implements AuthenticatedAgent {
   @override
-  String get agentId => KnownAgents.googleCloudServiceAccount;
+  String get agentId => KnownAgents.gcpServiceAccount;
 
   @override
   String get displayId => payload.email;
@@ -191,9 +191,9 @@ class AuthenticatedGoogleCloudServiceAccount implements AuthenticatedAgent {
   final JsonWebToken idToken;
 
   /// The parsed, Google Cloud-specific JWT payload.
-  final GoogleCloudServiceAccountJwtPayload payload;
+  final GcpServiceAccountJwtPayload payload;
 
-  AuthenticatedGoogleCloudServiceAccount({
+  AuthenticatedGcpServiceAccount({
     required this.idToken,
     required this.payload,
   });
@@ -258,7 +258,7 @@ Future<AuthenticatedAgent?> _tryAuthenticateServiceAgent(
     );
   }
 
-  if (idToken.payload.iss == GoogleCloudServiceAccountJwtPayload.issuerUrl &&
+  if (idToken.payload.iss == GcpServiceAccountJwtPayload.issuerUrl &&
       source == AuthSource.client &&
       idToken.payload.aud.length == 1 &&
       idToken.payload.aud.single ==
@@ -271,10 +271,10 @@ Future<AuthenticatedAgent?> _tryAuthenticateServiceAgent(
     final payload = await _verifyAndParseToken(
       idToken,
       openIdDataFetch: fetchGoogleCloudOpenIdData,
-      payloadTryParse: GoogleCloudServiceAccountJwtPayload.tryParse,
+      payloadTryParse: GcpServiceAccountJwtPayload.tryParse,
     );
 
-    return AuthenticatedGoogleCloudServiceAccount(
+    return AuthenticatedGcpServiceAccount(
       idToken: idToken,
       payload: payload,
     );

--- a/app/lib/audit/models.dart
+++ b/app/lib/audit/models.dart
@@ -234,7 +234,7 @@ class AuditLogRecord extends db.ExpandoModel<String> {
         if (sha != null) ' revision `$sha`',
         ' to the `$repository` repository.',
       ].join();
-    } else if (uploader is AuthenticatedGoogleCloudServiceAccount) {
+    } else if (uploader is AuthenticatedGcpServiceAccount) {
       fields = {
         'email': uploader.payload.email,
       };

--- a/app/lib/frontend/templates/views/pkg/admin_page.dart
+++ b/app/lib/frontend/templates/views/pkg/admin_page.dart
@@ -233,7 +233,7 @@ d.Node packageAdminPageNode({
 
 d.Node _automatedPublishing(Package package) {
   final github = package.automatedPublishing.github;
-  final googleCloud = package.automatedPublishing.googleCloud;
+  final gcp = package.automatedPublishing.gcp;
   return d.fragment([
     d.h2(text: 'Automated publishing'),
     d.h3(text: 'Publishing from GitHub Actions'),
@@ -314,23 +314,23 @@ d.Node _automatedPublishing(Package package) {
         '-pub-form-checkbox-toggle-next-sibling',
       ],
       child: material.checkbox(
-        id: '-pkg-admin-automated-googlecloud-enabled',
+        id: '-pkg-admin-automated-gcp-enabled',
         label: 'Enable publishing with Google Cloud Service account',
-        checked: googleCloud?.isEnabled ?? false,
+        checked: gcp?.isEnabled ?? false,
       ),
     ),
     d.div(
       classes: [
         '-pub-form-checkbox-indent',
-        if (!(googleCloud?.isEnabled ?? false)) '-pub-form-block-hidden',
+        if (!(gcp?.isEnabled ?? false)) '-pub-form-block-hidden',
       ],
       children: [
         d.div(
           classes: ['-pub-form-textfield-row'],
           child: material.textField(
-            id: '-pkg-admin-automated-googlecloud-serviceaccountemail',
+            id: '-pkg-admin-automated-gcp-serviceaccountemail',
             label: 'Service account email',
-            value: googleCloud?.serviceAccountEmail,
+            value: gcp?.serviceAccountEmail,
           ),
         ),
       ],

--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -480,7 +480,7 @@ class PackageBackend {
       await checkPackageAdmin(p, user.userId);
 
       final github = body.github;
-      final googleCloud = body.googleCloud;
+      final googleCloud = body.gcp;
       if (github != null) {
         final isEnabled = github.isEnabled ?? false;
         // normalize input values
@@ -1183,7 +1183,7 @@ class PackageBackend {
       await _checkGithubActionAllowed(agent, package, newVersion);
       return;
     }
-    if (agent is AuthenticatedGoogleCloudServiceAccount) {
+    if (agent is AuthenticatedGcpServiceAccount) {
       await _checkServiceAccountAllowed(agent, package, newVersion);
       return;
     }
@@ -1263,11 +1263,11 @@ class PackageBackend {
   }
 
   Future<void> _checkServiceAccountAllowed(
-    AuthenticatedGoogleCloudServiceAccount agent,
+    AuthenticatedGcpServiceAccount agent,
     Package package,
     String newVersion,
   ) async {
-    final googleCloudPublishing = package.automatedPublishing.googleCloud;
+    final googleCloudPublishing = package.automatedPublishing.gcp;
     if (googleCloudPublishing == null ||
         (googleCloudPublishing.isEnabled ?? false)) {
       throw AuthorizationException.serviceAccountPublishingIssue(

--- a/app/lib/service/openid/gcp_openid.dart
+++ b/app/lib/service/openid/gcp_openid.dart
@@ -23,7 +23,7 @@ Future<OpenIdData> fetchGoogleCloudOpenIdData() async {
 }
 
 /// Parsed payload values Google Cloud Service account sends with the token.
-class GoogleCloudServiceAccountJwtPayload {
+class GcpServiceAccountJwtPayload {
   /// email of the service account (i.e. <GCP_PROJECT_ID>@cloudbuild.gserviceaccount.com)
   final String email;
 
@@ -45,22 +45,22 @@ class GoogleCloudServiceAccountJwtPayload {
     'sub',
   };
 
-  GoogleCloudServiceAccountJwtPayload._(Map<String, dynamic> map)
+  GcpServiceAccountJwtPayload._(Map<String, dynamic> map)
       : email = parseAsString(map, 'email'),
         sub = parseAsString(map, 'sub');
 
-  factory GoogleCloudServiceAccountJwtPayload(JwtPayload payload) {
+  factory GcpServiceAccountJwtPayload(JwtPayload payload) {
     final missing = _requiredClaims.difference(payload.keys.toSet()).sorted();
     if (missing.isNotEmpty) {
       throw FormatException(
           'JWT from Google Cloud is missing following claims: ${missing.map((k) => '`$k`').join(', ')}.');
     }
-    return GoogleCloudServiceAccountJwtPayload._(payload);
+    return GcpServiceAccountJwtPayload._(payload);
   }
 
-  static GoogleCloudServiceAccountJwtPayload? tryParse(JwtPayload payload) {
+  static GcpServiceAccountJwtPayload? tryParse(JwtPayload payload) {
     try {
-      return GoogleCloudServiceAccountJwtPayload(payload);
+      return GcpServiceAccountJwtPayload(payload);
     } on FormatException {
       return null;
     } catch (e, st) {

--- a/app/test/audit/backend_test.dart
+++ b/app/test/audit/backend_test.dart
@@ -8,8 +8,8 @@ import 'package:pub_dev/account/backend.dart';
 import 'package:pub_dev/account/models.dart';
 import 'package:pub_dev/audit/backend.dart';
 import 'package:pub_dev/audit/models.dart';
+import 'package:pub_dev/service/openid/gcp_openid.dart';
 import 'package:pub_dev/service/openid/github_openid.dart';
-import 'package:pub_dev/service/openid/google_cloud_openid.dart';
 import 'package:pub_dev/service/openid/jwt.dart';
 import 'package:pub_dev/shared/datastore.dart';
 import 'package:test/test.dart';
@@ -116,9 +116,9 @@ void main() {
         created: clock.now(),
         package: 'pkg',
         version: '1.2.0',
-        uploader: AuthenticatedGoogleCloudServiceAccount(
+        uploader: AuthenticatedGcpServiceAccount(
           idToken: token,
-          payload: GoogleCloudServiceAccountJwtPayload(token.payload),
+          payload: GcpServiceAccountJwtPayload(token.payload),
         ),
       );
       expect(

--- a/app/test/package/automated_publishing_test.dart
+++ b/app/test/package/automated_publishing_test.dart
@@ -74,13 +74,13 @@ void main() {
       final rs = await client.setAutomatedPublishing(
           'oxygen',
           AutomatedPublishing(
-            googleCloud: GoogleCloudPublishing(
+            gcp: GcpPublishing(
               isEnabled: true,
               serviceAccountEmail: 'project-id@cloudbuild.gserviceaccount.com',
             ),
           ));
       expect(rs.toJson(), {
-        'googleCloud': {
+        'gcp': {
           'isEnabled': true,
           'serviceAccountEmail': 'project-id@cloudbuild.gserviceaccount.com',
         },
@@ -193,7 +193,7 @@ void main() {
         final rs = client.setAutomatedPublishing(
           'oxygen',
           AutomatedPublishing(
-            googleCloud: GoogleCloudPublishing(
+            gcp: GcpPublishing(
               isEnabled: value.isEmpty,
               serviceAccountEmail: value,
             ),
@@ -215,7 +215,7 @@ void main() {
       final rs = client.setAutomatedPublishing(
         'oxygen',
         AutomatedPublishing(
-          googleCloud: GoogleCloudPublishing(
+          gcp: GcpPublishing(
             isEnabled: true,
             serviceAccountEmail: 'user@pub.dev',
           ),

--- a/app/test/service/openid/gcp_openid_test.dart
+++ b/app/test/service/openid/gcp_openid_test.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:pub_dev/service/openid/google_cloud_openid.dart';
+import 'package:pub_dev/service/openid/gcp_openid.dart';
 import 'package:test/test.dart';
 
 import '../../shared/test_services.dart';

--- a/pkg/_pub_shared/lib/data/package_api.dart
+++ b/pkg/_pub_shared/lib/data/package_api.dart
@@ -52,11 +52,11 @@ class PkgOptions {
 @JsonSerializable(includeIfNull: false, explicitToJson: true)
 class AutomatedPublishing {
   final GithubPublishing? github;
-  final GoogleCloudPublishing? googleCloud;
+  final GcpPublishing? gcp;
 
   AutomatedPublishing({
     this.github,
-    this.googleCloud,
+    this.gcp,
   });
 
   factory AutomatedPublishing.fromJson(Map<String, dynamic> json) =>
@@ -105,19 +105,19 @@ class GithubPublishing {
 }
 
 @JsonSerializable(includeIfNull: false, explicitToJson: true)
-class GoogleCloudPublishing {
+class GcpPublishing {
   final bool? isEnabled;
   String? serviceAccountEmail;
 
-  GoogleCloudPublishing({
+  GcpPublishing({
     this.isEnabled,
     this.serviceAccountEmail,
   });
 
-  factory GoogleCloudPublishing.fromJson(Map<String, dynamic> json) =>
-      _$GoogleCloudPublishingFromJson(json);
+  factory GcpPublishing.fromJson(Map<String, dynamic> json) =>
+      _$GcpPublishingFromJson(json);
 
-  Map<String, dynamic> toJson() => _$GoogleCloudPublishingToJson(this);
+  Map<String, dynamic> toJson() => _$GcpPublishingToJson(this);
 }
 
 @JsonSerializable()

--- a/pkg/_pub_shared/lib/data/package_api.g.dart
+++ b/pkg/_pub_shared/lib/data/package_api.g.dart
@@ -37,10 +37,9 @@ AutomatedPublishing _$AutomatedPublishingFromJson(Map<String, dynamic> json) =>
       github: json['github'] == null
           ? null
           : GithubPublishing.fromJson(json['github'] as Map<String, dynamic>),
-      googleCloud: json['googleCloud'] == null
+      gcp: json['gcp'] == null
           ? null
-          : GoogleCloudPublishing.fromJson(
-              json['googleCloud'] as Map<String, dynamic>),
+          : GcpPublishing.fromJson(json['gcp'] as Map<String, dynamic>),
     );
 
 Map<String, dynamic> _$AutomatedPublishingToJson(AutomatedPublishing instance) {
@@ -53,7 +52,7 @@ Map<String, dynamic> _$AutomatedPublishingToJson(AutomatedPublishing instance) {
   }
 
   writeNotNull('github', instance.github?.toJson());
-  writeNotNull('googleCloud', instance.googleCloud?.toJson());
+  writeNotNull('gcp', instance.gcp?.toJson());
   return val;
 }
 
@@ -83,15 +82,13 @@ Map<String, dynamic> _$GithubPublishingToJson(GithubPublishing instance) {
   return val;
 }
 
-GoogleCloudPublishing _$GoogleCloudPublishingFromJson(
-        Map<String, dynamic> json) =>
-    GoogleCloudPublishing(
+GcpPublishing _$GcpPublishingFromJson(Map<String, dynamic> json) =>
+    GcpPublishing(
       isEnabled: json['isEnabled'] as bool?,
       serviceAccountEmail: json['serviceAccountEmail'] as String?,
     );
 
-Map<String, dynamic> _$GoogleCloudPublishingToJson(
-    GoogleCloudPublishing instance) {
+Map<String, dynamic> _$GcpPublishingToJson(GcpPublishing instance) {
   final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {

--- a/pkg/web_app/lib/src/admin_pages.dart
+++ b/pkg/web_app/lib/src/admin_pages.dart
@@ -105,12 +105,11 @@ class _PkgAdminWidget {
         document.getElementById('-pkg-admin-automated-github-environment')
             as InputElement?;
 
-    final googleCloudEnabledCheckbox =
-        document.getElementById('-pkg-admin-automated-googlecloud-enabled')
+    final gcpEnabledCheckbox = document
+        .getElementById('-pkg-admin-automated-gcp-enabled') as InputElement?;
+    final gcpServiceAccountEmailInput =
+        document.getElementById('-pkg-admin-automated-gcp-serviceaccountemail')
             as InputElement?;
-    final googleCloudServiceAccountEmailInput = document.getElementById(
-            '-pkg-admin-automated-googlecloud-serviceaccountemail')
-        as InputElement?;
 
     final updateButton = document.getElementById('-pkg-admin-automated-button');
     if (updateButton == null || githubRepositoryInput == null) {
@@ -131,9 +130,9 @@ class _PkgAdminWidget {
                 requireEnvironment: githubRequireEnvironmentCheckbox!.checked,
                 environment: githubEnvironmentInput!.value,
               ),
-              googleCloud: GoogleCloudPublishing(
-                isEnabled: googleCloudEnabledCheckbox!.checked,
-                serviceAccountEmail: googleCloudServiceAccountEmailInput!.value,
+              gcp: GcpPublishing(
+                isEnabled: gcpEnabledCheckbox!.checked,
+                serviceAccountEmail: gcpServiceAccountEmailInput!.value,
               ),
             ),
           );


### PR DESCRIPTION
Some naming changes were adopted in later PRs, this changes moves the names to a more consistent state.