### PR TITLE
Added run_id into audit-log

### DIFF
--- a/app/lib/audit/models.dart
+++ b/app/lib/audit/models.dart
@@ -217,20 +217,19 @@ class AuditLogRecord extends db.ExpandoModel<String> {
     late String summary;
     if (uploader is AuthenticatedGithubAction) {
       final repository = uploader.payload.repository;
-      final actor = uploader.payload.actor;
+      final runId = uploader.payload.runId;
       final sha = uploader.payload.sha;
       fields = <String, dynamic>{
         'repository': repository,
-        if (actor != null) 'actor': actor,
+        if (runId != null) 'run_id': runId,
         if (sha != null) 'sha': sha,
       };
       summary = [
         ...summaryParts,
         ' was published from GitHub Actions',
-        if (actor != null)
-          ' triggered by `$actor` on GitHub who pushed'
-        else
-          ' triggered by pushing',
+        if (runId != null)
+          ' (`run_id`: [`$runId`](https://github.com/$repository/actions/runs/$runId))',
+        ' triggered by pushing',
         if (sha != null) ' revision `$sha`',
         ' to the `$repository` repository.',
       ].join();

--- a/app/lib/service/openid/github_openid.dart
+++ b/app/lib/service/openid/github_openid.dart
@@ -48,6 +48,9 @@ class GitHubJwtPayload {
   /// the commit hash
   final String? sha;
 
+  /// RunId of the Github Action that this token comes from.
+  final String? runId;
+
   /// The URL used as the `iss` property of JWT payloads.
   static const issuerUrl = 'https://token.actions.githubusercontent.com';
 
@@ -64,6 +67,7 @@ class GitHubJwtPayload {
     'event_name',
     'ref',
     'ref_type',
+    'run_id',
   };
 
   GitHubJwtPayload._(Map<String, dynamic> map)
@@ -74,7 +78,8 @@ class GitHubJwtPayload {
         refType = parseAsString(map, 'ref_type'),
         actor = parseAsStringOrNull(map, 'actor'),
         environment = parseAsStringOrNull(map, 'environment'),
-        sha = parseAsStringOrNull(map, 'sha');
+        sha = parseAsStringOrNull(map, 'sha'),
+        runId = parseAsStringOrNull(map, 'run_id');
 
   factory GitHubJwtPayload(JwtPayload payload) {
     final missing = _requiredClaims.difference(payload.keys.toSet()).sorted();


### PR DESCRIPTION
Using runId to link the to Github Action run is probably better, then you can also see who signed off on the run (if environment is present).