### PR TITLE
Separate experimental flags for different features.

### DIFF
--- a/app/lib/frontend/handlers/experimental.dart
+++ b/app/lib/frontend/handlers/experimental.dart
@@ -1,0 +1,89 @@
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:meta/meta.dart';
+
+const _publicFlags = <String>{
+  'screenshots',
+};
+
+const _allFlags = <String>{
+  ..._publicFlags,
+  'publishing',
+  'signin',
+};
+
+/// Holds the enabled experimental flags.
+///
+/// Experimental flags are encoded in HTTP cookie as a list of strings
+/// separated by colon: `<flag-1>:<flag-2>:<flag-3>`
+class ExperimentalFlags {
+  final Set<String> _enabled;
+
+  ExperimentalFlags._(Set<String> enabled)
+      : _enabled = enabled.intersection(_allFlags);
+
+  static final List<String> publicFlags = _publicFlags.toList()..sort();
+  static final ExperimentalFlags empty = ExperimentalFlags._(const {});
+
+  factory ExperimentalFlags.parseFromCookie(String? value) {
+    final enabled = <String>{};
+    for (final part in (value ?? '').split(':')) {
+      final value = part.trim();
+      if (value.isEmpty) continue;
+      enabled.add(value);
+    }
+    return ExperimentalFlags._(enabled);
+  }
+
+  @visibleForTesting
+  factory ExperimentalFlags.all() {
+    return ExperimentalFlags._(_allFlags);
+  }
+
+  /// Whether to show the admin UI for automated publishing admin UI.
+  bool get showAdminUIForAutomatedPublishing => _enabled.contains('publishing');
+
+  /// Whether to show package screenshots in search listings.
+  bool get showScreenshots => _enabled.contains('screenshots');
+
+  /// Whether to use the new Google Identity Services library.
+  bool get useGisSignIn => _enabled.contains('signin');
+
+  bool get isEmpty => _enabled.isEmpty;
+
+  bool isEnabled(String flag) {
+    return _enabled.contains(flag);
+  }
+
+  ExperimentalFlags combineWithQueryParams(Map<String, String> parameters) {
+    final newEnabled = <String>{..._enabled};
+    for (final p in parameters.entries) {
+      final name = p.key.trim();
+      final change = p.value.trim();
+      if (name.isEmpty || change.isEmpty) {
+        continue;
+      }
+      if (change == '1' || change == 'true' || change == 'enabled') {
+        newEnabled.add(name);
+      } else {
+        newEnabled.remove(name);
+      }
+    }
+    return ExperimentalFlags._(newEnabled);
+  }
+
+  Map<String, String> urlParametersForToggle() {
+    final params = <String, String>{};
+    for (final v in _enabled) {
+      params[v] = '0';
+    }
+    return params;
+  }
+
+  String encodedAsCookie() => _enabled.join(':');
+
+  @override
+  String toString() => isEmpty ? '(none)' : _enabled.join(', ');
+}

--- a/app/lib/frontend/request_context.dart
+++ b/app/lib/frontend/request_context.dart
@@ -4,21 +4,20 @@
 
 import 'package:gcloud/service_scope.dart' as ss;
 
+import 'handlers/experimental.dart';
+
 /// Sets the active [RequestContext].
 void registerRequestContext(RequestContext value) =>
     ss.register(#_request_context, value);
 
 /// The active [RequestContext].
 RequestContext get requestContext =>
-    ss.lookup(#_request_context) as RequestContext? ?? const RequestContext();
+    ss.lookup(#_request_context) as RequestContext? ?? RequestContext();
 
 /// Holds flags for request context.
 class RequestContext {
   /// Whether the JSON responses should be indented.
   final bool indentJson;
-
-  /// Whether experimental UI features are activated.
-  final bool isExperimental;
 
   /// Whether indexing of the content by robots should be blocked.
   final bool blockRobots;
@@ -27,20 +26,13 @@ class RequestContext {
   /// pollution by visually changing the site).
   final bool uiCacheEnabled;
 
-  /// Whether to use the new Google Identity Services library.
-  final bool useGisSignIn;
+  /// The parsed experimental flags.
+  final ExperimentalFlags experimentalFlags;
 
-  const RequestContext({
+  RequestContext({
     this.indentJson = false,
-    this.isExperimental = false,
     this.blockRobots = true,
     this.uiCacheEnabled = false,
-    this.useGisSignIn = false,
-  });
-
-  /// Whether to show the admin UI for automated publishing admin UI.
-  bool get showAdminUIForAutomatedPublishing => isExperimental;
-
-  /// Whether to show package screenshots in search listings.
-  bool get showScreenshots => isExperimental;
+    ExperimentalFlags? experimentalFlags,
+  }) : experimentalFlags = experimentalFlags ?? ExperimentalFlags.empty;
 }

--- a/app/lib/frontend/templates/views/pkg/admin_page.dart
+++ b/app/lib/frontend/templates/views/pkg/admin_page.dart
@@ -167,7 +167,7 @@ d.Node packageAdminPageNode({
         ),
       ),
     ],
-    if (requestContext.showAdminUIForAutomatedPublishing)
+    if (requestContext.experimentalFlags.showAdminUIForAutomatedPublishing)
       _automatedPublishing(package),
     d.h2(text: 'Package Version Retraction'),
     d.div(children: [

--- a/app/lib/frontend/templates/views/pkg/info_box.dart
+++ b/app/lib/frontend/templates/views/pkg/info_box.dart
@@ -66,7 +66,8 @@ d.Node packageInfoBoxNode({
   return d.fragment([
     imageCarousel(),
     labeledScores,
-    if (thumbnailUrl != null && requestContext.showScreenshots)
+    if (thumbnailUrl != null &&
+        requestContext.experimentalFlags.showScreenshots)
       d.div(classes: [
         'detail-screenshot-thumbnail'
       ], children: [

--- a/app/lib/frontend/templates/views/pkg/package_list.dart
+++ b/app/lib/frontend/templates/views/pkg/package_list.dart
@@ -227,7 +227,8 @@ d.Node _item({
               d.div(classes: ['packages-api'], child: _apiPages(apiPages)),
           ],
         ),
-        if (thumbnailUrl != null && requestContext.showScreenshots)
+        if (thumbnailUrl != null &&
+            requestContext.experimentalFlags.showScreenshots)
           d.div(classes: [
             'packages-screenshot-thumbnail'
           ], children: [

--- a/app/lib/frontend/templates/views/shared/layout.dart
+++ b/app/lib/frontend/templates/views/shared/layout.dart
@@ -121,7 +121,7 @@ d.Node pageLayoutNode({
             ),
             d.meta(
                 name: 'google-signin-client_id', content: oauthClientId ?? ''),
-            if (requestContext.useGisSignIn)
+            if (requestContext.experimentalFlags.useGisSignIn)
               d.script(
                 src: 'https://accounts.google.com/gsi/client',
                 async: true,

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -14,6 +14,7 @@ import 'package:pub_dev/account/backend.dart';
 import 'package:pub_dev/account/models.dart';
 import 'package:pub_dev/audit/backend.dart';
 import 'package:pub_dev/audit/models.dart';
+import 'package:pub_dev/frontend/handlers/experimental.dart';
 import 'package:pub_dev/frontend/handlers/package.dart'
     show loadPackagePageData;
 import 'package:pub_dev/frontend/request_context.dart';
@@ -481,7 +482,8 @@ void main() {
       'package index page',
       processJobsWithFakeRunners: true,
       fn: () async {
-        registerRequestContext(RequestContext(isExperimental: true));
+        registerRequestContext(
+            RequestContext(experimentalFlags: ExperimentalFlags.all()));
         final searchForm = SearchForm(query: 'sdk:dart');
         final oxygen = (await scoreCardBackend.getPackageView('oxygen'))!;
         final titanium =

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -14,10 +14,8 @@ import 'package:pub_dev/account/backend.dart';
 import 'package:pub_dev/account/models.dart';
 import 'package:pub_dev/audit/backend.dart';
 import 'package:pub_dev/audit/models.dart';
-import 'package:pub_dev/frontend/handlers/experimental.dart';
 import 'package:pub_dev/frontend/handlers/package.dart'
     show loadPackagePageData;
-import 'package:pub_dev/frontend/request_context.dart';
 import 'package:pub_dev/frontend/static_files.dart';
 import 'package:pub_dev/frontend/templates/admin.dart';
 import 'package:pub_dev/frontend/templates/consent.dart';
@@ -482,8 +480,6 @@ void main() {
       'package index page',
       processJobsWithFakeRunners: true,
       fn: () async {
-        registerRequestContext(
-            RequestContext(experimentalFlags: ExperimentalFlags.all()));
         final searchForm = SearchForm(query: 'sdk:dart');
         final oxygen = (await scoreCardBackend.getPackageView('oxygen'))!;
         final titanium =

--- a/pkg/pub_integration/test/pkg_admin_page_test.dart
+++ b/pkg/pub_integration/test/pkg_admin_page_test.dart
@@ -50,7 +50,7 @@ void main() {
 
         // github publishing
         await headlessEnv.withPage(fn: (page) async {
-          await page.gotoOrigin('/experimental?enabled=1');
+          await page.gotoOrigin('/experimental?publishing=1');
           await page.gotoOrigin('/');
           await page.click('#-account-login');
           await page.waitForSelector('#-pub-custom-token-input',

--- a/pkg/pub_integration/test/pkg_admin_page_test.dart
+++ b/pkg/pub_integration/test/pkg_admin_page_test.dart
@@ -64,10 +64,13 @@ void main() {
           await Future.delayed(Duration(seconds: 2));
 
           await page.gotoOrigin('/packages/test_pkg/admin');
+          await Future.delayed(Duration(seconds: 1));
 
           await page.click('#-pkg-admin-automated-github-enabled');
+          await Future.delayed(Duration(seconds: 1));
           await page.focusAndType(
               '#-pkg-admin-automated-github-repository', 'dart-lang/pub-dev');
+          await Future.delayed(Duration(seconds: 1));
           await page.click('#-pkg-admin-automated-button');
           await Future.delayed(Duration(seconds: 1));
 

--- a/pkg/pub_integration/test/pkg_admin_page_test.dart
+++ b/pkg/pub_integration/test/pkg_admin_page_test.dart
@@ -51,6 +51,7 @@ void main() {
         // github publishing
         await headlessEnv.withPage(fn: (page) async {
           await page.gotoOrigin('/experimental?publishing=1');
+          await Future.delayed(Duration(seconds: 2));
           await page.gotoOrigin('/');
           await page.click('#-account-login');
           await page.waitForSelector('#-pub-custom-token-input',

--- a/pkg/pub_integration/test/pkg_admin_page_test.dart
+++ b/pkg/pub_integration/test/pkg_admin_page_test.dart
@@ -72,7 +72,9 @@ void main() {
           await Future.delayed(Duration(seconds: 1));
 
           await page.clickOnButtonWithLabel('ok');
+          await Future.delayed(Duration(seconds: 1));
           await page.reload();
+          await Future.delayed(Duration(seconds: 1));
           final value =
               await (await page.$('#-pkg-admin-automated-github-repository'))
                   .propertyValue('value');


### PR DESCRIPTION
- turning on a feature: `/experimental?<flag>=1`, turning off: `/experimental?<flag>=0`
- only the known flags are stored in the cookie
- public flags are listed on the `/experimental` page to be turned on individually, non-public flags need to be triggered by manually writing them in the URL