### PR TITLE
Remove AuthSource, use expected audience instead.

### DIFF
--- a/app/lib/account/auth_provider.dart
+++ b/app/lib/account/auth_provider.dart
@@ -2,22 +2,16 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-enum AuthSource {
-  /// `pub` command-line client
-  client,
-
-  /// `pub.dev` user on the web UI
-  website,
-
-  /// administrator account
-  admin,
-}
-
 class AuthResult {
   final String oauthUserId;
   final String email;
+  final String audience;
 
-  AuthResult(this.oauthUserId, this.email);
+  AuthResult({
+    required this.oauthUserId,
+    required this.email,
+    required this.audience,
+  });
 }
 
 class AccountProfile {
@@ -36,7 +30,7 @@ abstract class AuthProvider {
   ///
   /// Returns null on any error, or if the token is expired, or the user is not
   /// verified.
-  Future<AuthResult?> tryAuthenticate(AuthSource source, String token);
+  Future<AuthResult?> tryAuthenticate(String token);
 
   /// Returns the profile information of a given access token.
   Future<AccountProfile?> getAccountProfile(String? accessToken);

--- a/app/lib/admin/backend.dart
+++ b/app/lib/admin/backend.dart
@@ -85,7 +85,8 @@ class AdminBackend {
   Future<User> _requireAdminPermission(AdminPermission permission) async {
     ArgumentError.checkNotNull(permission, 'permission');
 
-    final user = await requireAuthenticatedUser(source: AuthSource.admin);
+    final user = await requireAuthenticatedUser(
+        expectedAudience: activeConfiguration.adminAudience);
     if (!await verifyAdminPermission(user, permission)) {
       _logger.warning(
           'User (${user.userId} / ${user.email}) is trying to access unauthorized admin APIs.');

--- a/app/lib/fake/backend/fake_auth_provider.dart
+++ b/app/lib/fake/backend/fake_auth_provider.dart
@@ -20,8 +20,7 @@ class FakeAuthProvider implements AuthProvider {
   Future<void> close() async {}
 
   @override
-  Future<AuthResult?> tryAuthenticate(
-      AuthSource source, String accessToken) async {
+  Future<AuthResult?> tryAuthenticate(String accessToken) async {
     if (!accessToken.contains('-at-')) {
       return null;
     }
@@ -29,14 +28,14 @@ class FakeAuthProvider implements AuthProvider {
     if (uri == null) {
       return null;
     }
-    final sourceValue = uri.queryParameters['source'];
-    if (sourceValue == null || sourceValue != source.name) {
-      return null;
-    }
 
     final email = uri.path.replaceAll('-at-', '@').replaceAll('-dot-', '.');
     final id = email.replaceAll('@', '-').replaceAll('.', '-');
-    return AuthResult(id, email);
+    return AuthResult(
+      oauthUserId: id,
+      email: email,
+      audience: uri.queryParameters['aud'] ?? '',
+    );
   }
 
   @override
@@ -61,10 +60,9 @@ class FakeAuthProvider implements AuthProvider {
 
 String createFakeAuthTokenForEmail(
   String email, {
-  AuthSource? source,
+  String? audience,
 }) {
-  source ??= AuthSource.website;
   return Uri(
       path: email.replaceAll('.', '-dot-').replaceAll('@', '-at-'),
-      queryParameters: {'source': source.name}).toString();
+      queryParameters: {'aud': audience ?? 'fake-site-audience'}).toString();
 }

--- a/app/lib/frontend/handlers/account.dart
+++ b/app/lib/frontend/handlers/account.dart
@@ -37,8 +37,7 @@ Future<shelf.Response> updateSessionHandler(
   final user = await requireAuthenticatedUser();
 
   InvalidInputException.checkNotNull(body.accessToken, 'accessToken');
-  await accountBackend.verifyAccessTokenOwnership(
-      AuthSource.website, body.accessToken!, user);
+  await accountBackend.verifyAccessTokenOwnership(body.accessToken!, user);
   final t1 = sw.elapsed;
 
   // Only allow creation of sessions on the primary site host.

--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -837,7 +837,7 @@ class PackageBackend {
     // user is authenticated. But we're not validating anything at this point
     // because we don't even know which package or version is going to be
     // uploaded.
-    await requireAuthenticatedAgent(source: AuthSource.client);
+    await requireAuthenticatedClient();
 
     final guid = createUuid();
     final String object = tmpObjectName(guid);
@@ -862,7 +862,7 @@ class PackageBackend {
     if (restriction == UploadRestrictionStatus.noUploads) {
       throw PackageRejectedException.uploadRestricted();
     }
-    final agent = await requireAuthenticatedAgent(source: AuthSource.client);
+    final agent = await requireAuthenticatedClient();
     _logger.info('Finishing async upload (uuid: $guid)');
     _logger.info('Reading tarball from cloud storage.');
 
@@ -1336,14 +1336,10 @@ class PackageBackend {
   // Uploaders support.
 
   Future<account_api.InviteStatus> inviteUploader(
-    String packageName,
-    api.InviteUploaderRequest invite, {
-    AuthSource? authSource,
-  }) async {
-    authSource ??= AuthSource.website;
+      String packageName, api.InviteUploaderRequest invite) async {
     InvalidInputException.checkNotNull(invite.email, 'email');
     final uploaderEmail = invite.email.toLowerCase();
-    final user = await requireAuthenticatedUser(source: authSource);
+    final user = await requireAuthenticatedUser();
     final packageKey = db.emptyKey.append(Package, id: packageName);
     final package = await db.lookupOrNull<Package>(packageKey);
 

--- a/app/lib/publisher/backend.dart
+++ b/app/lib/publisher/backend.dart
@@ -154,8 +154,7 @@ class PublisherBackend {
       minimum: 1,
       maximum: 4096,
     );
-    await accountBackend.verifyAccessTokenOwnership(
-        AuthSource.website, body.accessToken, user);
+    await accountBackend.verifyAccessTokenOwnership(body.accessToken, user);
 
     // Verify ownership of domain.
     final isOwner = await domainVerifier.verifyDomainOwnership(

--- a/app/lib/shared/configuration.dart
+++ b/app/lib/shared/configuration.dart
@@ -33,9 +33,15 @@ void registerActiveConfiguration(Configuration configuration) {
   ss.register(_configurationKey, configuration);
 }
 
+/// Special value to indicate that the client is running in fake mode.
+const _fakeClientAudience = 'fake-client-audience';
+
 /// Special value to indicate that the site is running in fake mode, and the
 /// client side authentication should use the fake authentication tokens.
 const _fakeSiteAudience = 'fake-site-audience';
+
+/// Special value to indicate that the admin client is running in fake mode.
+const _fakeAdminAudience = 'fake-admin-audience';
 
 /// The default audience value we expect when the package is published
 /// via an automatically aquired token.
@@ -325,9 +331,9 @@ class Configuration {
       taskWorkerServiceAccount: '-',
       searchServicePrefix: 'http://localhost:$searchPort',
       storageBaseUrl: storageBaseUrl,
-      pubClientAudience: null,
+      pubClientAudience: _fakeClientAudience,
       pubSiteAudience: _fakeSiteAudience,
-      adminAudience: null,
+      adminAudience: _fakeAdminAudience,
       automatedPublishingAudience: _defaultAutomatedPublishingAudience,
       defaultServiceBaseUrl: 'http://localhost:$frontendPort/',
       gmailRelayServiceAccount: null, // disable email sending
@@ -372,9 +378,9 @@ class Configuration {
       taskWorkerServiceAccount: '-',
       searchServicePrefix: 'http://localhost:0',
       storageBaseUrl: storageBaseUrl ?? 'http://localhost:0',
-      pubClientAudience: null,
-      pubSiteAudience: null,
-      adminAudience: null,
+      pubClientAudience: _fakeClientAudience,
+      pubSiteAudience: _fakeSiteAudience,
+      adminAudience: _fakeAdminAudience,
       automatedPublishingAudience: _defaultAutomatedPublishingAudience,
       defaultServiceBaseUrl: 'http://localhost:0/',
       gmailRelayServiceAccount: null, // disable email sending

--- a/app/lib/tool/test_profile/importer.dart
+++ b/app/lib/tool/test_profile/importer.dart
@@ -7,9 +7,9 @@ import 'package:_pub_shared/data/package_api.dart';
 import 'package:_pub_shared/data/publisher_api.dart';
 import 'package:_pub_shared/search/tags.dart';
 import 'package:meta/meta.dart';
-import 'package:pub_dev/account/auth_provider.dart';
 import 'package:pub_dev/fake/backend/fake_auth_provider.dart';
 import 'package:pub_dev/frontend/handlers/pubapi.client.dart';
+import 'package:pub_dev/shared/configuration.dart';
 
 import '../utils/pub_api_client.dart';
 import 'import_source.dart';
@@ -75,8 +75,8 @@ Future<void> importProfile({
 
     final bytes = await source.getArchiveBytes(rv.package, rv.version);
     await withHttpPubApiClient(
-      bearerToken:
-          createFakeAuthTokenForEmail(uploaderEmail, source: AuthSource.client),
+      bearerToken: createFakeAuthTokenForEmail(uploaderEmail,
+          audience: activeConfiguration.pubClientAudience),
       pubHostedUrl: pubHostedUrl,
       // ignore: invalid_use_of_visible_for_testing_member
       fn: (client) => client.uploadPackageBytes(bytes),
@@ -119,7 +119,7 @@ Future<void> importProfile({
     if (testPackage.isFlutterFavorite ?? false) {
       await withHttpPubApiClient(
         bearerToken: createFakeAuthTokenForEmail(adminUserEmail ?? activeEmail,
-            source: AuthSource.admin),
+            audience: activeConfiguration.adminAudience),
         pubHostedUrl: pubHostedUrl,
         fn: (client) async {
           await client.adminPostAssignedTags(

--- a/app/test/account/consent_backend_test.dart
+++ b/app/test/account/consent_backend_test.dart
@@ -9,6 +9,7 @@ import 'package:pub_dev/account/consent_backend.dart';
 import 'package:pub_dev/account/models.dart';
 import 'package:pub_dev/audit/backend.dart';
 import 'package:pub_dev/audit/models.dart';
+import 'package:pub_dev/shared/configuration.dart';
 import 'package:test/test.dart';
 
 import '../shared/test_models.dart';
@@ -19,7 +20,8 @@ void main() {
     Future<String?> inviteUploader() async {
       await accountBackend.withBearerToken(adminClientToken, () async {
         final status = await consentBackend.invitePackageUploader(
-          activeUser: await requireAuthenticatedUser(source: AuthSource.client),
+          activeUser: await requireAuthenticatedUser(
+              expectedAudience: activeConfiguration.pubClientAudience),
           uploaderEmail: 'user@pub.dev',
           packageName: 'oxygen',
         );

--- a/app/test/admin/api_test.dart
+++ b/app/test/admin/api_test.dart
@@ -33,7 +33,7 @@ void main() {
     group('List users', () {
       setupTestsWithCallerAuthorizationIssues(
         (client) => client.adminListUsers(),
-        authSource: AuthSource.admin,
+        audience: 'fake-admin-audience',
       );
 
       testWithProfile('OK', fn: () async {
@@ -159,7 +159,7 @@ void main() {
     group('Delete package', () {
       setupTestsWithCallerAuthorizationIssues(
         (client) => client.adminRemovePackage('oxygen'),
-        authSource: AuthSource.admin,
+        audience: 'fake-admin-audience',
       );
 
       testWithProfile('OK', fn: () async {
@@ -221,7 +221,7 @@ void main() {
     group('Delete package version', () {
       setupTestsWithCallerAuthorizationIssues(
         (client) => client.adminRemovePackageVersion('oxygen', '1.2.0'),
-        authSource: AuthSource.admin,
+        audience: 'fake-admin-audience',
       );
 
       testWithProfile('OK', fn: () async {
@@ -320,7 +320,7 @@ void main() {
           final user = await accountBackend.lookupUserByEmail('user@pub.dev');
           await client.adminRemoveUser(user.userId);
         },
-        authSource: AuthSource.admin,
+        audience: 'fake-admin-audience',
       );
 
       testWithProfile(
@@ -384,7 +384,7 @@ void main() {
     group('get assignedTags', () {
       setupTestsWithCallerAuthorizationIssues(
         (client) => client.adminGetAssignedTags('oxygen'),
-        authSource: AuthSource.admin,
+        audience: 'fake-admin-audience',
       );
 
       testWithProfile('get assignedTags', fn: () async {
@@ -400,7 +400,7 @@ void main() {
           'oxygen',
           PatchAssignedTags(assignedTagsAdded: ['is:featured']),
         ),
-        authSource: AuthSource.admin,
+        audience: 'fake-admin-audience',
       );
 
       testWithProfile('set assignedTags', fn: () async {
@@ -478,7 +478,7 @@ void main() {
       group('get', () {
         setupTestsWithCallerAuthorizationIssues(
           (client) => client.adminGetPackageUploaders('oxygen'),
-          authSource: AuthSource.admin,
+          audience: 'fake-admin-audience',
         );
         setupTestsWithPackageFailures(
             (client, package) => client.adminGetPackageUploaders(package));
@@ -498,7 +498,7 @@ void main() {
         setupTestsWithCallerAuthorizationIssues(
           (client) =>
               client.adminAddPackageUploader('oxygen', 'someuser@pub.dev'),
-          authSource: AuthSource.admin,
+          audience: 'fake-admin-audience',
         );
         setupTestsWithPackageFailures((client, package) =>
             client.adminAddPackageUploader(package, 'someuser@pub.dev'));
@@ -552,7 +552,7 @@ void main() {
         setupTestsWithCallerAuthorizationIssues(
           (client) =>
               client.adminRemovePackageUploader('oxygen', 'admin@pub.dev'),
-          authSource: AuthSource.admin,
+          audience: 'fake-admin-audience',
         );
 
         setupTestsWithPackageFailures((client, package) =>
@@ -615,7 +615,7 @@ void main() {
           '1.2.0',
           VersionOptions(isRetracted: true),
         ),
-        authSource: AuthSource.admin,
+        audience: 'fake-admin-audience',
       );
 
       testWithProfile('bad retraction value', fn: () async {

--- a/app/test/admin/api_tool_test.dart
+++ b/app/test/admin/api_tool_test.dart
@@ -16,7 +16,7 @@ void main() {
     group('bad tool', () {
       setupTestsWithCallerAuthorizationIssues(
         (client) => client.adminExecuteTool('no-such-tool', ''),
-        authSource: AuthSource.admin,
+        audience: 'fake-admin-audience',
       );
 
       testWithProfile('auth with bad tool', fn: () async {
@@ -30,7 +30,7 @@ void main() {
     group('user merger', () {
       setupTestsWithCallerAuthorizationIssues(
         (client) => client.adminExecuteTool('user-merger', ''),
-        authSource: AuthSource.admin,
+        audience: 'fake-admin-audience',
       );
 
       testWithProfile('help', fn: () async {

--- a/app/test/frontend/golden/authorized_page.html
+++ b/app/test/frontend/golden/authorized_page.html
@@ -26,7 +26,7 @@
     <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/style.css"/>
     <script src="/static/hash-%%etag%%/material/bundle/script.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
-    <meta name="google-signin-client_id" content=""/>
+    <meta name="google-signin-client_id" content="fake-site-audience"/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
     <link rel="preload" href="/static/hash-%%etag%%/highlight/highlight-with-init.js" as="script"/>
   </head>

--- a/app/test/frontend/golden/consent_page.html
+++ b/app/test/frontend/golden/consent_page.html
@@ -26,7 +26,7 @@
     <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/style.css"/>
     <script src="/static/hash-%%etag%%/material/bundle/script.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
-    <meta name="google-signin-client_id" content=""/>
+    <meta name="google-signin-client_id" content="fake-site-audience"/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
     <meta name="pub-page-data" content="eyJjb25zZW50SWQiOiIxMjM0LTU2NzgifQ=="/>
   </head>

--- a/app/test/frontend/golden/create_publisher_page.html
+++ b/app/test/frontend/golden/create_publisher_page.html
@@ -26,7 +26,7 @@
     <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/style.css"/>
     <script src="/static/hash-%%etag%%/material/bundle/script.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
-    <meta name="google-signin-client_id" content=""/>
+    <meta name="google-signin-client_id" content="fake-site-audience"/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
   </head>
   <body class="page-standalone light-theme">

--- a/app/test/frontend/golden/error_page.html
+++ b/app/test/frontend/golden/error_page.html
@@ -26,7 +26,7 @@
     <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/style.css"/>
     <script src="/static/hash-%%etag%%/material/bundle/script.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
-    <meta name="google-signin-client_id" content=""/>
+    <meta name="google-signin-client_id" content="fake-site-audience"/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
   </head>
   <body class="light-theme">

--- a/app/test/frontend/golden/help_page.html
+++ b/app/test/frontend/golden/help_page.html
@@ -27,7 +27,7 @@
     <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/style.css"/>
     <script src="/static/hash-%%etag%%/material/bundle/script.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
-    <meta name="google-signin-client_id" content=""/>
+    <meta name="google-signin-client_id" content="fake-site-audience"/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
   </head>
   <body class="page-standalone light-theme">

--- a/app/test/frontend/golden/landing_page.html
+++ b/app/test/frontend/golden/landing_page.html
@@ -27,7 +27,7 @@
     <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/style.css"/>
     <script src="/static/hash-%%etag%%/material/bundle/script.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
-    <meta name="google-signin-client_id" content=""/>
+    <meta name="google-signin-client_id" content="fake-site-audience"/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
     <link rel="preload" href="/static/hash-%%etag%%/img/hero-bg-static.svg" as="image"/>
     <link rel="preload" href="/static/hash-%%etag%%/img/square-bg-full-2x.webp" as="image"/>

--- a/app/test/frontend/golden/my_activity_log_page.html
+++ b/app/test/frontend/golden/my_activity_log_page.html
@@ -26,7 +26,7 @@
     <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/style.css"/>
     <script src="/static/hash-%%etag%%/material/bundle/script.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
-    <meta name="google-signin-client_id" content=""/>
+    <meta name="google-signin-client_id" content="fake-site-audience"/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
   </head>
   <body class="light-theme">

--- a/app/test/frontend/golden/my_liked_packages.html
+++ b/app/test/frontend/golden/my_liked_packages.html
@@ -26,7 +26,7 @@
     <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/style.css"/>
     <script src="/static/hash-%%etag%%/material/bundle/script.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
-    <meta name="google-signin-client_id" content=""/>
+    <meta name="google-signin-client_id" content="fake-site-audience"/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
   </head>
   <body class="light-theme">

--- a/app/test/frontend/golden/my_packages.html
+++ b/app/test/frontend/golden/my_packages.html
@@ -26,7 +26,7 @@
     <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/style.css"/>
     <script src="/static/hash-%%etag%%/material/bundle/script.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
-    <meta name="google-signin-client_id" content=""/>
+    <meta name="google-signin-client_id" content="fake-site-audience"/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
   </head>
   <body class="light-theme">

--- a/app/test/frontend/golden/my_publishers.html
+++ b/app/test/frontend/golden/my_publishers.html
@@ -26,7 +26,7 @@
     <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/style.css"/>
     <script src="/static/hash-%%etag%%/material/bundle/script.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
-    <meta name="google-signin-client_id" content=""/>
+    <meta name="google-signin-client_id" content="fake-site-audience"/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
   </head>
   <body class="light-theme">

--- a/app/test/frontend/golden/pkg_activity_log_page.html
+++ b/app/test/frontend/golden/pkg_activity_log_page.html
@@ -26,7 +26,7 @@
     <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/style.css"/>
     <script src="/static/hash-%%etag%%/material/bundle/script.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
-    <meta name="google-signin-client_id" content=""/>
+    <meta name="google-signin-client_id" content="fake-site-audience"/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
     <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJveHlnZW4iLCJ2ZXJzaW9uIjoiMS4yLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlfX0="/>
     <link rel="preload" href="/static/hash-%%etag%%/highlight/highlight-with-init.js" as="script"/>

--- a/app/test/frontend/golden/pkg_admin_page.html
+++ b/app/test/frontend/golden/pkg_admin_page.html
@@ -26,7 +26,7 @@
     <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/style.css"/>
     <script src="/static/hash-%%etag%%/material/bundle/script.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
-    <meta name="google-signin-client_id" content=""/>
+    <meta name="google-signin-client_id" content="fake-site-audience"/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
     <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJveHlnZW4iLCJ2ZXJzaW9uIjoiMS4yLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlfX0="/>
     <link rel="preload" href="/static/hash-%%etag%%/highlight/highlight-with-init.js" as="script"/>

--- a/app/test/frontend/golden/pkg_changelog_page.html
+++ b/app/test/frontend/golden/pkg_changelog_page.html
@@ -27,7 +27,7 @@
     <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/style.css"/>
     <script src="/static/hash-%%etag%%/material/bundle/script.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
-    <meta name="google-signin-client_id" content=""/>
+    <meta name="google-signin-client_id" content="fake-site-audience"/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
     <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJveHlnZW4iLCJ2ZXJzaW9uIjoiMS4yLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlfX0="/>
     <link rel="preload" href="/static/hash-%%etag%%/highlight/highlight-with-init.js" as="script"/>

--- a/app/test/frontend/golden/pkg_example_page.html
+++ b/app/test/frontend/golden/pkg_example_page.html
@@ -27,7 +27,7 @@
     <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/style.css"/>
     <script src="/static/hash-%%etag%%/material/bundle/script.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
-    <meta name="google-signin-client_id" content=""/>
+    <meta name="google-signin-client_id" content="fake-site-audience"/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
     <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJveHlnZW4iLCJ2ZXJzaW9uIjoiMS4yLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlfX0="/>
     <link rel="preload" href="/static/hash-%%etag%%/highlight/highlight-with-init.js" as="script"/>

--- a/app/test/frontend/golden/pkg_index_page.html
+++ b/app/test/frontend/golden/pkg_index_page.html
@@ -27,7 +27,7 @@
     <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/style.css"/>
     <script src="/static/hash-%%etag%%/material/bundle/script.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
-    <meta name="google-signin-client_id" content=""/>
+    <meta name="google-signin-client_id" content="fake-site-audience"/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
   </head>
   <body class="light-theme">

--- a/app/test/frontend/golden/pkg_install_page.html
+++ b/app/test/frontend/golden/pkg_install_page.html
@@ -27,7 +27,7 @@
     <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/style.css"/>
     <script src="/static/hash-%%etag%%/material/bundle/script.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
-    <meta name="google-signin-client_id" content=""/>
+    <meta name="google-signin-client_id" content="fake-site-audience"/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
     <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJveHlnZW4iLCJ2ZXJzaW9uIjoiMS4yLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlfX0="/>
     <link rel="preload" href="/static/hash-%%etag%%/highlight/highlight-with-init.js" as="script"/>

--- a/app/test/frontend/golden/pkg_score_page.html
+++ b/app/test/frontend/golden/pkg_score_page.html
@@ -27,7 +27,7 @@
     <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/style.css"/>
     <script src="/static/hash-%%etag%%/material/bundle/script.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
-    <meta name="google-signin-client_id" content=""/>
+    <meta name="google-signin-client_id" content="fake-site-audience"/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
     <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJveHlnZW4iLCJ2ZXJzaW9uIjoiMS4yLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlfX0="/>
     <link rel="preload" href="/static/hash-%%etag%%/highlight/highlight-with-init.js" as="script"/>

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -27,7 +27,7 @@
     <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/style.css"/>
     <script src="/static/hash-%%etag%%/material/bundle/script.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
-    <meta name="google-signin-client_id" content=""/>
+    <meta name="google-signin-client_id" content="fake-site-audience"/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
     <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJveHlnZW4iLCJ2ZXJzaW9uIjoiMS4yLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlfX0="/>
     <link rel="preload" href="/static/hash-%%etag%%/highlight/highlight-with-init.js" as="script"/>

--- a/app/test/frontend/golden/pkg_show_page_discontinued.html
+++ b/app/test/frontend/golden/pkg_show_page_discontinued.html
@@ -27,7 +27,7 @@
     <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/style.css"/>
     <script src="/static/hash-%%etag%%/material/bundle/script.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
-    <meta name="google-signin-client_id" content=""/>
+    <meta name="google-signin-client_id" content="fake-site-audience"/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
     <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJwa2ciLCJ2ZXJzaW9uIjoiMS4wLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOnRydWV9fQ=="/>
     <link rel="preload" href="/static/hash-%%etag%%/highlight/highlight-with-init.js" as="script"/>

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -27,7 +27,7 @@
     <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/style.css"/>
     <script src="/static/hash-%%etag%%/material/bundle/script.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
-    <meta name="google-signin-client_id" content=""/>
+    <meta name="google-signin-client_id" content="fake-site-audience"/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
     <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJmbHV0dGVyX3RpdGFuaXVtIiwidmVyc2lvbiI6IjEuMTAuMCIsImxpa2VzIjowLCJpc0Rpc2NvbnRpbnVlZCI6ZmFsc2V9fQ=="/>
     <link rel="preload" href="/static/hash-%%etag%%/highlight/highlight-with-init.js" as="script"/>

--- a/app/test/frontend/golden/pkg_show_page_legacy.html
+++ b/app/test/frontend/golden/pkg_show_page_legacy.html
@@ -27,7 +27,7 @@
     <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/style.css"/>
     <script src="/static/hash-%%etag%%/material/bundle/script.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
-    <meta name="google-signin-client_id" content=""/>
+    <meta name="google-signin-client_id" content="fake-site-audience"/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
     <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJwa2ciLCJ2ZXJzaW9uIjoiMS4wLjAtbGVnYWN5IiwibGlrZXMiOjAsImlzRGlzY29udGludWVkIjpmYWxzZX19"/>
     <link rel="preload" href="/static/hash-%%etag%%/highlight/highlight-with-init.js" as="script"/>

--- a/app/test/frontend/golden/pkg_show_page_publisher.html
+++ b/app/test/frontend/golden/pkg_show_page_publisher.html
@@ -27,7 +27,7 @@
     <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/style.css"/>
     <script src="/static/hash-%%etag%%/material/bundle/script.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
-    <meta name="google-signin-client_id" content=""/>
+    <meta name="google-signin-client_id" content="fake-site-audience"/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
     <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJuZW9uIiwidmVyc2lvbiI6IjEuMC4wIiwibGlrZXMiOjAsInB1Ymxpc2hlcklkIjoiZXhhbXBsZS5jb20iLCJpc0Rpc2NvbnRpbnVlZCI6ZmFsc2V9fQ=="/>
     <link rel="preload" href="/static/hash-%%etag%%/highlight/highlight-with-init.js" as="script"/>

--- a/app/test/frontend/golden/pkg_show_page_retracted.html
+++ b/app/test/frontend/golden/pkg_show_page_retracted.html
@@ -27,7 +27,7 @@
     <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/style.css"/>
     <script src="/static/hash-%%etag%%/material/bundle/script.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
-    <meta name="google-signin-client_id" content=""/>
+    <meta name="google-signin-client_id" content="fake-site-audience"/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
     <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJwa2ciLCJ2ZXJzaW9uIjoiMS4wLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlfX0="/>
     <link rel="preload" href="/static/hash-%%etag%%/highlight/highlight-with-init.js" as="script"/>

--- a/app/test/frontend/golden/pkg_show_page_retracted_non_retracted_version.html
+++ b/app/test/frontend/golden/pkg_show_page_retracted_non_retracted_version.html
@@ -27,7 +27,7 @@
     <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/style.css"/>
     <script src="/static/hash-%%etag%%/material/bundle/script.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
-    <meta name="google-signin-client_id" content=""/>
+    <meta name="google-signin-client_id" content="fake-site-audience"/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
     <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJwa2ciLCJ2ZXJzaW9uIjoiMi4wLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlfX0="/>
     <link rel="preload" href="/static/hash-%%etag%%/highlight/highlight-with-init.js" as="script"/>

--- a/app/test/frontend/golden/pkg_show_version_page.html
+++ b/app/test/frontend/golden/pkg_show_version_page.html
@@ -27,7 +27,7 @@
     <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/style.css"/>
     <script src="/static/hash-%%etag%%/material/bundle/script.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
-    <meta name="google-signin-client_id" content=""/>
+    <meta name="google-signin-client_id" content="fake-site-audience"/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
     <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJveHlnZW4iLCJ2ZXJzaW9uIjoiMS4yLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlfX0="/>
     <link rel="preload" href="/static/hash-%%etag%%/highlight/highlight-with-init.js" as="script"/>

--- a/app/test/frontend/golden/pkg_versions_page.html
+++ b/app/test/frontend/golden/pkg_versions_page.html
@@ -27,7 +27,7 @@
     <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/style.css"/>
     <script src="/static/hash-%%etag%%/material/bundle/script.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
-    <meta name="google-signin-client_id" content=""/>
+    <meta name="google-signin-client_id" content="fake-site-audience"/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
     <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJveHlnZW4iLCJ2ZXJzaW9uIjoiMS4yLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlfX0="/>
     <link rel="preload" href="/static/hash-%%etag%%/highlight/highlight-with-init.js" as="script"/>

--- a/app/test/frontend/golden/publisher_activity_log_page.html
+++ b/app/test/frontend/golden/publisher_activity_log_page.html
@@ -27,7 +27,7 @@
     <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/style.css"/>
     <script src="/static/hash-%%etag%%/material/bundle/script.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
-    <meta name="google-signin-client_id" content=""/>
+    <meta name="google-signin-client_id" content="fake-site-audience"/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
     <meta name="pub-page-data" content="eyJwdWJsaXNoZXIiOnsicHVibGlzaGVySWQiOiJleGFtcGxlLmNvbSJ9fQ=="/>
   </head>

--- a/app/test/frontend/golden/publisher_admin_page.html
+++ b/app/test/frontend/golden/publisher_admin_page.html
@@ -27,7 +27,7 @@
     <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/style.css"/>
     <script src="/static/hash-%%etag%%/material/bundle/script.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
-    <meta name="google-signin-client_id" content=""/>
+    <meta name="google-signin-client_id" content="fake-site-audience"/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
     <meta name="pub-page-data" content="eyJwdWJsaXNoZXIiOnsicHVibGlzaGVySWQiOiJleGFtcGxlLmNvbSJ9fQ=="/>
   </head>

--- a/app/test/frontend/golden/publisher_list_page.html
+++ b/app/test/frontend/golden/publisher_list_page.html
@@ -27,7 +27,7 @@
     <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/style.css"/>
     <script src="/static/hash-%%etag%%/material/bundle/script.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
-    <meta name="google-signin-client_id" content=""/>
+    <meta name="google-signin-client_id" content="fake-site-audience"/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
   </head>
   <body class="light-theme">

--- a/app/test/frontend/golden/publisher_packages_page.html
+++ b/app/test/frontend/golden/publisher_packages_page.html
@@ -27,7 +27,7 @@
     <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/style.css"/>
     <script src="/static/hash-%%etag%%/material/bundle/script.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
-    <meta name="google-signin-client_id" content=""/>
+    <meta name="google-signin-client_id" content="fake-site-audience"/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
     <meta name="pub-page-data" content="eyJwdWJsaXNoZXIiOnsicHVibGlzaGVySWQiOiJleGFtcGxlLmNvbSJ9fQ=="/>
   </head>

--- a/app/test/frontend/golden/publisher_unlisted_packages_page.html
+++ b/app/test/frontend/golden/publisher_unlisted_packages_page.html
@@ -27,7 +27,7 @@
     <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/style.css"/>
     <script src="/static/hash-%%etag%%/material/bundle/script.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
-    <meta name="google-signin-client_id" content=""/>
+    <meta name="google-signin-client_id" content="fake-site-audience"/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
     <meta name="pub-page-data" content="eyJwdWJsaXNoZXIiOnsicHVibGlzaGVySWQiOiJleGFtcGxlLmNvbSJ9fQ=="/>
   </head>

--- a/app/test/frontend/golden/search_page.html
+++ b/app/test/frontend/golden/search_page.html
@@ -27,7 +27,7 @@
     <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/style.css"/>
     <script src="/static/hash-%%etag%%/material/bundle/script.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
-    <meta name="google-signin-client_id" content=""/>
+    <meta name="google-signin-client_id" content="fake-site-audience"/>
     <script src="https://apis.google.com/js/platform.js?onload=pubAuthInit" defer="defer"></script>
   </head>
   <body class="light-theme">

--- a/app/test/shared/test_models.dart
+++ b/app/test/shared/test_models.dart
@@ -4,7 +4,6 @@
 
 import 'package:gcloud/db.dart';
 
-import 'package:pub_dev/account/auth_provider.dart';
 import 'package:pub_dev/fake/backend/fake_auth_provider.dart';
 import 'package:pub_dev/publisher/models.dart';
 import 'package:pub_dev/tool/test_profile/models.dart';
@@ -49,12 +48,12 @@ final adminAtPubDevAuthToken = createFakeAuthTokenForEmail('admin@pub.dev');
 final userAtPubDevAuthToken = createFakeAuthTokenForEmail('user@pub.dev');
 final unauthorizedAtPubDevAuthToken =
     createFakeAuthTokenForEmail('unauthorized@pub.dev');
-final adminClientToken =
-    createFakeAuthTokenForEmail('admin@pub.dev', source: AuthSource.client);
-final siteAdminToken =
-    createFakeAuthTokenForEmail('admin@pub.dev', source: AuthSource.admin);
-final userClientToken =
-    createFakeAuthTokenForEmail('user@pub.dev', source: AuthSource.client);
+final adminClientToken = createFakeAuthTokenForEmail('admin@pub.dev',
+    audience: 'fake-client-audience');
+final siteAdminToken = createFakeAuthTokenForEmail('admin@pub.dev',
+    audience: 'fake-admin-audience');
+final userClientToken = createFakeAuthTokenForEmail('user@pub.dev',
+    audience: 'fake-client-audience');
 
 final String foobarReadmeContent = '''
 Test Package

--- a/app/test/shared/test_services.dart
+++ b/app/test/shared/test_services.dart
@@ -7,7 +7,6 @@ import 'package:clock/clock.dart';
 import 'package:gcloud/db.dart';
 import 'package:gcloud/service_scope.dart';
 import 'package:logging/logging.dart';
-import 'package:pub_dev/account/auth_provider.dart';
 import 'package:pub_dev/account/models.dart';
 import 'package:pub_dev/fake/backend/fake_auth_provider.dart';
 import 'package:pub_dev/fake/backend/fake_dartdoc_runner.dart';
@@ -207,7 +206,7 @@ void setupLogging() {
 
 void setupTestsWithCallerAuthorizationIssues(
   Future Function(PubApiClient client) fn, {
-  AuthSource? authSource,
+  String? audience,
 }) {
   testWithProfile('No active user', fn: () async {
     final rs = fn(createPubApiClient());
@@ -216,7 +215,7 @@ void setupTestsWithCallerAuthorizationIssues(
 
   testWithProfile('Active user is not authorized', fn: () async {
     final token =
-        createFakeAuthTokenForEmail('unauthorized@pub.dev', source: authSource);
+        createFakeAuthTokenForEmail('unauthorized@pub.dev', audience: audience);
     final rs = fn(createPubApiClient(authToken: token));
     await expectApiException(rs, status: 403, code: 'InsufficientPermissions');
   });
@@ -226,7 +225,7 @@ void setupTestsWithCallerAuthorizationIssues(
     final user = users.firstWhere((u) => u.email == 'admin@pub.dev');
     await dbService.commit(inserts: [user..isBlocked = true]);
     final token =
-        createFakeAuthTokenForEmail('admin@pub.dev', source: authSource);
+        createFakeAuthTokenForEmail('admin@pub.dev', audience: audience);
     final rs = fn(createPubApiClient(authToken: token));
     await expectApiException(rs,
         status: 403,

--- a/pkg/pub_integration/lib/script/publisher.dart
+++ b/pkg/pub_integration/lib/script/publisher.dart
@@ -30,7 +30,7 @@ class PublisherScript {
     required this.inviteCompleterFn,
   }) : _pubHttpClient = PubHttpClient(pubHostedUrl);
 
-  final userWebsiteToken = 'user-at-example-dot-com?source=website';
+  final userWebsiteToken = 'user-at-example-dot-com?aud=fake-site-audience';
 
   /// Verify all integration steps.
   Future<void> verify() async {

--- a/pkg/pub_integration/lib/src/fake_credentials.dart
+++ b/pkg/pub_integration/lib/src/fake_credentials.dart
@@ -7,7 +7,7 @@ import 'dart:convert';
 /// The content of the fake credentials.json that can be used against fake_pub_server.
 String fakeCredentialsFileContent() {
   return json.encode({
-    'accessToken': 'user-at-example-dot-com?source=client',
+    'accessToken': 'user-at-example-dot-com?aud=fake-client-audience',
     'refreshToken': 'refresh-token',
     'tokenEndpoint': 'http://localhost:9999/o/oauth2/token',
     'scopes': ['email', 'openid'],

--- a/pkg/pub_integration/test/pkg_admin_page_test.dart
+++ b/pkg/pub_integration/test/pkg_admin_page_test.dart
@@ -57,7 +57,7 @@ void main() {
           await page.waitForSelector('#-pub-custom-token-input',
               timeout: Duration(seconds: 2));
           await page.focusAndType('#-pub-custom-token-input',
-              'admin-at-pub-dot-dev?source=website');
+              'admin-at-pub-dot-dev?aud=fake-site-audience');
 
           await page.clickOnButtonWithLabel('ok');
           await page.waitForNavigation(timeout: Duration(seconds: 5));

--- a/pkg/pub_integration/test/pub_integration_test.dart
+++ b/pkg/pub_integration/test/pub_integration_test.dart
@@ -39,7 +39,7 @@ void main() {
               'http://localhost:${fakePubServerProcess.port}/api/account/consent/$consentId'),
           headers: {
             'Authorization':
-                'Bearer somebodyelse-at-example-dot-org?source=website',
+                'Bearer somebodyelse-at-example-dot-org?aud=fake-site-audience',
           },
           body: json.encode({'granted': true}),
         );
@@ -52,7 +52,8 @@ void main() {
           Uri.parse(
               'http://localhost:${fakePubServerProcess.port}/api/account/consent/$consentId'),
           headers: {
-            'Authorization': 'Bearer dev-at-example-dot-org?source=website',
+            'Authorization':
+                'Bearer dev-at-example-dot-org?aud=fake-site-audience',
           },
           body: json.encode({'granted': true}),
         );
@@ -64,7 +65,7 @@ void main() {
       await verifyPub(
         pubHostedUrl: 'http://localhost:${fakePubServerProcess.port}',
         credentialsFileContent: fakeCredentialsFileContent(),
-        mainAccessToken: 'user-at-example-dot-com?source=website',
+        mainAccessToken: 'user-at-example-dot-com?aud=fake-site-audience',
         invitedEmail: 'dev@example.org',
         inviteCompleterFn: inviteCompleterFn,
         expectLiveSite: false,

--- a/pkg/pub_integration/test/publisher_test.dart
+++ b/pkg/pub_integration/test/publisher_test.dart
@@ -40,7 +40,7 @@ void main() {
               'http://localhost:${fakePubServerProcess.port}/api/account/consent/$consentId'),
           headers: {
             'Authorization':
-                'Bearer somebodyelse-at-example-dot-org?source=website',
+                'Bearer somebodyelse-at-example-dot-org?aud=fake-site-audience',
           },
           body: json.encode({'granted': true}),
         );
@@ -53,7 +53,8 @@ void main() {
           Uri.parse(
               'http://localhost:${fakePubServerProcess.port}/api/account/consent/$consentId'),
           headers: {
-            'Authorization': 'Bearer dev-at-example-dot-org?source=website',
+            'Authorization':
+                'Bearer dev-at-example-dot-org?aud=fake-site-audience',
           },
           body: json.encode({'granted': true}),
         );


### PR DESCRIPTION
- #6140
- Instead of the `AuthSource` abstraction, callers may do `expectedAudience` checks.
- The auth provider no longer checks for audience, it is pushed one level up (probably not the final place for such checks).
- Audience check cleanup in uploader invites: we no longer allow it from two sources.
- Renamed `requireAuthenticatedAgent` to `requireAuthenticatedClient`, as it is only used in the upload context.