### PR TITLE
Better Content-Type handling in API builder.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Important changes to data models, configuration, and migrations between each
 AppEngine version, listed here to ease deployment and troubleshooting.
 
 ## Next Release (replace with git tag when deployed)
+ * NOTE: `api_builder` logs unexpected mime types.
 
 ## `20221103t103200-all`
  * Bumped runtimeVersion to `2022.11.02`.

--- a/pkg/api_builder/lib/api_builder.dart
+++ b/pkg/api_builder/lib/api_builder.dart
@@ -77,6 +77,11 @@ class ApiResponseException implements Exception {
           });
 }
 
+const _expectedMimeTypes = <String>{
+  'application/json',
+  'application/vnd.pub.v2+json',
+};
+
 /// Utility methods exported for use in generated code.
 abstract class $utilities {
   /// Utility method exported for use in generated code.
@@ -88,7 +93,7 @@ abstract class $utilities {
       // TODO: Consider enforcing that requests should have 'Content-Type' set to
       // 'application/json'. Notice that we should be careful as the CLI client,
       // might be sending a different Content-Type.
-      if (request.mimeType != 'application/json') {
+      if (!_expectedMimeTypes.contains(request.mimeType)) {
         _log.info('Unexpected MIME type: ${request.mimeType}', request.mimeType,
             StackTrace.current);
       }

--- a/pkg/api_builder/lib/api_builder.dart
+++ b/pkg/api_builder/lib/api_builder.dart
@@ -84,11 +84,15 @@ abstract class $utilities {
     shelf.Request request,
     T Function(Map<String, dynamic>) fromJson,
   ) async {
-    // TODO: Consider enforcing that requests should have 'Content-Type' set to
-    // 'application/json'. Notice that we should be careful as the CLI client,
-    // might be sending a different Content-Type.
-    final data = await request.readAsString();
     try {
+      // TODO: Consider enforcing that requests should have 'Content-Type' set to
+      // 'application/json'. Notice that we should be careful as the CLI client,
+      // might be sending a different Content-Type.
+      if (request.mimeType != 'application/json') {
+        _log.info('Unexpected MIME type: ${request.mimeType}',
+            request.mimeType, StackTrace.current);
+      }
+      final data = await request.readAsString();
       final value = json.decode(data);
       if (value is Map<String, dynamic>) {
         try {

--- a/pkg/api_builder/lib/api_builder.dart
+++ b/pkg/api_builder/lib/api_builder.dart
@@ -77,7 +77,7 @@ class ApiResponseException implements Exception {
           });
 }
 
-const _expectedMimeTypes = <String>{
+const _expectedJsonMimeTypes = <String>{
   'application/json',
   'application/vnd.pub.v2+json',
 };
@@ -93,7 +93,7 @@ abstract class $utilities {
       // TODO: Consider enforcing that requests should have 'Content-Type' set to
       // 'application/json'. Notice that we should be careful as the CLI client,
       // might be sending a different Content-Type.
-      if (!_expectedMimeTypes.contains(request.mimeType)) {
+      if (!_expectedJsonMimeTypes.contains(request.mimeType)) {
         _log.info('Unexpected MIME type: ${request.mimeType}', request.mimeType,
             StackTrace.current);
       }

--- a/pkg/api_builder/lib/api_builder.dart
+++ b/pkg/api_builder/lib/api_builder.dart
@@ -89,8 +89,8 @@ abstract class $utilities {
       // 'application/json'. Notice that we should be careful as the CLI client,
       // might be sending a different Content-Type.
       if (request.mimeType != 'application/json') {
-        _log.info('Unexpected MIME type: ${request.mimeType}',
-            request.mimeType, StackTrace.current);
+        _log.info('Unexpected MIME type: ${request.mimeType}', request.mimeType,
+            StackTrace.current);
       }
       final data = await request.readAsString();
       final value = json.decode(data);


### PR DESCRIPTION
- Fixes #6129.
- The `Content-Type` header is parsed to get the correct encoding when reading the body content as String. If the header has a parse issue, it throws a `FormatException`, which is now executed inside the try-catch block, handling it gracefully.
- Added logging to check if we have any non-json content type in the requests, and if we are good, we can enforce it in the next release. 