### PR TITLE
Fix on-click on screenshot thumbnail

### DIFF
--- a/pkg/web_app/lib/src/screenshot_carousel.dart
+++ b/pkg/web_app/lib/src/screenshot_carousel.dart
@@ -55,7 +55,7 @@ void _setEventForScreenshot() {
 
   int screenshotIndex = 0;
   for (final thumbnail in thumbnails) {
-    thumbnail.onClick.listen((event) {
+    thumbnail.parent!.onClick.listen((event) {
       showElement(carousel);
       images = thumbnail.dataset['thumbnail']!.split(',');
       showImage(screenshotIndex, event);


### PR DESCRIPTION
Setting the on-click listener on the parent of the screenshot thumbnail so that the image carousel is triggered both when clicking the thumbnail and the collections icon.