### PR TITLE
Refactor requiredAuthenticatedUser and other agents.

### DIFF
--- a/app/lib/account/consent_backend.dart
+++ b/app/lib/account/consent_backend.dart
@@ -73,15 +73,16 @@ class ConsentBackend {
 
   /// Returns the consent details for API calls.
   Future<api.Consent> handleGetConsent(String consentId) async {
-    final user = await requireAuthenticatedUser();
-    return getConsent(consentId, user);
+    final authenticatedUser = await requireAuthenticatedUser();
+    return getConsent(consentId, authenticatedUser.user);
   }
 
   /// Resolves the consent.
   Future<api.ConsentResult> resolveConsent(
       String consentId, api.ConsentResult result) async {
     InvalidInputException.checkUlid(consentId, 'consentId');
-    final user = await requireAuthenticatedUser();
+    final authenticatedUser = await requireAuthenticatedUser();
+    final user = authenticatedUser.user;
 
     final c = await _lookupAndCheck(consentId, user);
     InvalidInputException.checkNotNull(result.granted, 'granted');
@@ -170,7 +171,8 @@ class ConsentBackend {
     required String publisherId,
     required String contactEmail,
   }) async {
-    final user = await requireAuthenticatedUser();
+    final authenticatedUser = await requireAuthenticatedUser();
+    final user = authenticatedUser.user;
     return await _invite(
         activeUser: user,
         email: contactEmail,
@@ -185,7 +187,8 @@ class ConsentBackend {
     required String publisherId,
     required String invitedUserEmail,
   }) async {
-    final user = await requireAuthenticatedUser();
+    final authenticatedUser = await requireAuthenticatedUser();
+    final user = authenticatedUser.user;
     return await _invite(
       activeUser: user,
       email: invitedUserEmail,
@@ -326,7 +329,7 @@ class _PackageUploaderAction extends ConsentAction {
       fromUserId,
       fromUserEmail,
       packageName,
-      currentUser,
+      currentUser.user,
       isFromAdminUser: isFromAdminUser,
     );
   }

--- a/app/lib/admin/backend.dart
+++ b/app/lib/admin/backend.dart
@@ -86,9 +86,10 @@ class AdminBackend {
   Future<User> _requireAdminPermission(AdminPermission permission) async {
     ArgumentError.checkNotNull(permission, 'permission');
 
-    final user = await requireAuthenticatedUser(
+    final authenticatedUser = await requireAuthenticatedUser(
         expectedAudience: activeConfiguration.adminAudience);
-    if (!await verifyAdminPermission(user, permission)) {
+    final user = authenticatedUser.user;
+    if (!await verifyAdminPermission(authenticatedUser.user, permission)) {
       _logger.warning(
           'User (${user.userId} / ${user.email}) is trying to access unauthorized admin APIs.');
       throw AuthorizationException.userIsNotAdminForPubSite();

--- a/app/lib/audit/models.dart
+++ b/app/lib/audit/models.dart
@@ -5,7 +5,7 @@
 import 'dart:convert';
 
 import 'package:clock/clock.dart';
-import 'package:pub_dev/account/backend.dart';
+import 'package:pub_dev/account/agent.dart';
 
 import '../account/models.dart';
 import '../shared/datastore.dart' as db;

--- a/app/lib/frontend/handlers/account.dart
+++ b/app/lib/frontend/handlers/account.dart
@@ -35,7 +35,8 @@ shelf.Response authorizedHandler(_) => htmlResponse(renderAuthorizedPage());
 Future<shelf.Response> updateSessionHandler(
     shelf.Request request, ClientSessionRequest body) async {
   final sw = Stopwatch()..start();
-  final user = await requireAuthenticatedUser();
+  final authenticatedUser = await requireAuthenticatedUser();
+  final user = authenticatedUser.user;
 
   InvalidInputException.checkNotNull(body.accessToken, 'accessToken');
   await accountBackend.verifyAccessTokenOwnership(body.accessToken!, user);
@@ -155,7 +156,8 @@ Future<AccountPkgOptions> accountPkgOptionsHandler(
 /// Handles GET /api/account/likes
 Future<LikedPackagesRepsonse> listPackageLikesHandler(
     shelf.Request request) async {
-  final user = await requireAuthenticatedUser();
+  final authenticatedUser = await requireAuthenticatedUser();
+  final user = authenticatedUser.user;
   final packages = await likeBackend.listPackageLikes(user);
   final List<PackageLikeResponse> packageLikes = List.from(packages.map(
       (like) => PackageLikeResponse(
@@ -184,7 +186,8 @@ Future<PackageLikeResponse> getLikePackageHandler(
 /// Handles PUT /api/account/likes/<package>
 Future<PackageLikeResponse> likePackageHandler(
     shelf.Request request, String package) async {
-  final user = await requireAuthenticatedUser();
+  final authenticatedUser = await requireAuthenticatedUser();
+  final user = authenticatedUser.user;
   final l = await likeBackend.likePackage(user, package);
   return PackageLikeResponse(liked: true, package: package, created: l.created);
 }
@@ -192,8 +195,8 @@ Future<PackageLikeResponse> likePackageHandler(
 /// Handles DELETE /api/account/likes/<package>
 Future<shelf.Response> unlikePackageHandler(
     shelf.Request request, String package) async {
-  final user = await requireAuthenticatedUser();
-
+  final authenticatedUser = await requireAuthenticatedUser();
+  final user = authenticatedUser.user;
   await likeBackend.unlikePackage(user, package);
   return shelf.Response(204);
 }

--- a/app/lib/publisher/backend.dart
+++ b/app/lib/publisher/backend.dart
@@ -136,7 +136,8 @@ class PublisherBackend {
     api.CreatePublisherRequest body,
   ) async {
     checkPublisherIdParam(publisherId);
-    final user = await requireAuthenticatedUser();
+    final authenticatedUser = await requireAuthenticatedUser();
+    final user = authenticatedUser.user;
     InvalidInputException.checkMatchPattern(
       publisherId,
       'publisherId',
@@ -251,7 +252,8 @@ class PublisherBackend {
         maximum: 256,
       );
     }
-    final user = await requireAuthenticatedUser();
+    final authenticatedUser = await requireAuthenticatedUser();
+    final user = authenticatedUser.user;
     await requirePublisherAdmin(publisherId, user.userId);
     final p = await withRetryTransaction(_db, (tx) async {
       final key = _db.emptyKey.append(Publisher, id: publisherId);
@@ -320,7 +322,8 @@ class PublisherBackend {
   Future updateContactWithVerifiedEmail(
       String publisherId, String contactEmail) async {
     checkPublisherIdParam(publisherId);
-    final activeUser = await requireAuthenticatedUser();
+    final authenticatedUser = await requireAuthenticatedUser();
+    final user = authenticatedUser.user;
     InvalidInputException.check(
         isValidEmail(contactEmail), 'Invalid email: `$contactEmail`');
 
@@ -331,7 +334,7 @@ class PublisherBackend {
       p.updated = clock.now().toUtc();
       tx.insert(p);
       tx.insert(AuditLogRecord.publisherContactInviteAccepted(
-        user: activeUser,
+        user: user,
         publisherId: publisherId,
         contactEmail: contactEmail,
       ));
@@ -461,7 +464,8 @@ class PublisherBackend {
   /// Deletes a publisher's member.
   Future<void> deletePublisherMember(String publisherId, String userId) async {
     checkPublisherIdParam(publisherId);
-    final user = await requireAuthenticatedUser();
+    final authenticatedUser = await requireAuthenticatedUser();
+    final user = authenticatedUser.user;
     final p = await requirePublisherAdmin(publisherId, user.userId);
     if (userId == user.userId) {
       throw ConflictException.cantUpdateSelf();

--- a/app/test/account/consent_backend_test.dart
+++ b/app/test/account/consent_backend_test.dart
@@ -19,9 +19,10 @@ void main() {
   group('Uploader invite', () {
     Future<String?> inviteUploader() async {
       await accountBackend.withBearerToken(adminClientToken, () async {
+        final authenticatedUser = await requireAuthenticatedUser(
+            expectedAudience: activeConfiguration.pubClientAudience);
         final status = await consentBackend.invitePackageUploader(
-          activeUser: await requireAuthenticatedUser(
-              expectedAudience: activeConfiguration.pubClientAudience),
+          activeUser: authenticatedUser.user,
           uploaderEmail: 'user@pub.dev',
           packageName: 'oxygen',
         );
@@ -30,9 +31,11 @@ void main() {
 
       String? consentId;
       await accountBackend.withBearerToken(userAtPubDevAuthToken, () async {
+        final authenticatedUser = await requireAuthenticatedUser();
+        final user = authenticatedUser.user;
         final consentRow = await dbService.query<Consent>().run().single;
-        final consent = await consentBackend.getConsent(
-            consentRow.consentId, await requireAuthenticatedUser());
+        final consent =
+            await consentBackend.getConsent(consentRow.consentId, user);
         expect(consent.descriptionHtml, contains('/packages/oxygen'));
         expect(consent.descriptionHtml, contains('publish new versions'));
         consentId = consentRow.consentId;
@@ -99,9 +102,11 @@ void main() {
 
       String? consentId;
       await accountBackend.withBearerToken(userAtPubDevAuthToken, () async {
+        final authenticatedUser = await requireAuthenticatedUser();
+        final user = authenticatedUser.user;
         final consentRow = await dbService.query<Consent>().run().single;
-        final consent = await consentBackend.getConsent(
-            consentRow.consentId, await requireAuthenticatedUser());
+        final consent =
+            await consentBackend.getConsent(consentRow.consentId, user);
         expect(consent.descriptionHtml, contains('/publishers/example.com'));
         expect(consent.descriptionHtml, contains('contact email means'));
         consentId = consentRow.consentId;
@@ -169,9 +174,11 @@ void main() {
 
       String? consentId;
       await accountBackend.withBearerToken(userAtPubDevAuthToken, () async {
+        final authenticatedUser = await requireAuthenticatedUser();
+        final user = authenticatedUser.user;
         final consentRow = await dbService.query<Consent>().run().single;
-        final consent = await consentBackend.getConsent(
-            consentRow.consentId, await requireAuthenticatedUser());
+        final consent =
+            await consentBackend.getConsent(consentRow.consentId, user);
         expect(consent.descriptionHtml, contains('/publishers/example.com'));
         expect(consent.descriptionHtml,
             contains('perform administrative actions'));

--- a/app/test/audit/backend_test.dart
+++ b/app/test/audit/backend_test.dart
@@ -4,7 +4,7 @@
 
 import 'package:clock/clock.dart';
 import 'package:fake_gcloud/mem_datastore.dart';
-import 'package:pub_dev/account/backend.dart';
+import 'package:pub_dev/account/agent.dart';
 import 'package:pub_dev/account/models.dart';
 import 'package:pub_dev/audit/backend.dart';
 import 'package:pub_dev/audit/models.dart';
@@ -43,9 +43,12 @@ void main() {
         created: clock.now(),
         package: 'pkg',
         version: '1.0.0',
-        uploader: AuthenticatedUser(User()
-          ..id = 'user-id'
-          ..email = 'user@pub.dev'),
+        uploader: AuthenticatedUser(
+          User()
+            ..id = 'user-id'
+            ..email = 'user@pub.dev',
+          audience: 'fake-client-audience',
+        ),
       );
       expect(r.summary,
           'Package `pkg` version `1.0.0` was published by `user@pub.dev`.');

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -698,7 +698,8 @@ void main() {
         final oxygen = await scoreCardBackend.getPackageView('oxygen');
         final neon = await scoreCardBackend.getPackageView('neon');
         await accountBackend.withBearerToken(userAtPubDevAuthToken, () async {
-          final user = await requireAuthenticatedUser();
+          final authenticatedUser = await requireAuthenticatedUser();
+          final user = authenticatedUser.user;
           final session = await accountBackend.createNewSession(
             name: 'Pub User',
             imageUrl: 'pub.dev/user-img-url.png',
@@ -721,7 +722,8 @@ void main() {
 
     testWithProfile('/my-liked-packages page', fn: () async {
       await accountBackend.withBearerToken(userAtPubDevAuthToken, () async {
-        final user = await requireAuthenticatedUser();
+        final authenticatedUser = await requireAuthenticatedUser();
+        final user = authenticatedUser.user;
         final session = await accountBackend.createNewSession(
           name: 'Pub User',
           imageUrl: 'pub.dev/user-img-url.png',
@@ -747,7 +749,8 @@ void main() {
 
     testWithProfile('/my-publishers page', fn: () async {
       await accountBackend.withBearerToken(userAtPubDevAuthToken, () async {
-        final user = await requireAuthenticatedUser();
+        final authenticatedUser = await requireAuthenticatedUser();
+        final user = authenticatedUser.user;
         final session = await accountBackend.createNewSession(
           name: 'Pub User',
           imageUrl: 'pub.dev/user-img-url.png',
@@ -773,7 +776,8 @@ void main() {
 
     testWithProfile('/my-activity-log page', fn: () async {
       await accountBackend.withBearerToken(adminAtPubDevAuthToken, () async {
-        final user = await requireAuthenticatedUser();
+        final authenticatedUser = await requireAuthenticatedUser();
+        final user = authenticatedUser.user;
         final session = await accountBackend.createNewSession(
           name: 'Pub User',
           imageUrl: 'pub.dev/user-img-url.png',


### PR DESCRIPTION
- #6140
- moved agent models to `agent.dart`
- added `audience` to `AuthenticatedUser`
- changed the return type of `requireAuthenticatedUser` to `AuthenticatedUser` (from `User`)