### PR TITLE
Remove period from title of search results page

### DIFF
--- a/app/lib/frontend/templates/listing.dart
+++ b/app/lib/frontend/templates/listing.dart
@@ -56,7 +56,7 @@ String renderPkgIndexPage(
 
   String pageTitle = topPackages;
   if (isSearch) {
-    pageTitle = 'Search results for ${searchForm.query}.';
+    pageTitle = 'Search results for ${searchForm.query}';
   } else {
     if (links.rightmostPage > 1) {
       pageTitle = 'Page ${links.currentPage} | $pageTitle';

--- a/app/test/frontend/golden/pkg_index_page.html
+++ b/app/test/frontend/golden/pkg_index_page.html
@@ -13,10 +13,10 @@
     <meta name="twitter:image" content="https://pub.dev/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <meta property="og:type" content="website"/>
     <meta property="og:site_name" content="Dart packages"/>
-    <meta property="og:title" content="Search results for sdk:dart."/>
+    <meta property="og:title" content="Search results for sdk:dart"/>
     <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <meta property="og:image" content="https://pub.dev/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
-    <title>Search results for sdk:dart.</title>
+    <title>Search results for sdk:dart</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Google+Sans:300,400,500|Google+Sans+Display:400|Roboto:300,400,500,700|Roboto+Mono:300,400,700&amp;display=swap"/>
     <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
     <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/osd.xml"/>

--- a/app/test/frontend/golden/search_page.html
+++ b/app/test/frontend/golden/search_page.html
@@ -13,10 +13,10 @@
     <meta name="twitter:image" content="https://pub.dev/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
     <meta property="og:type" content="website"/>
     <meta property="og:site_name" content="Dart packages"/>
-    <meta property="og:title" content="Search results for foobar."/>
+    <meta property="og:title" content="Search results for foobar"/>
     <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs."/>
     <meta property="og:image" content="https://pub.dev/static/hash-%%etag%%/img/pub-dev-icon-cover-image.png"/>
-    <title>Search results for foobar.</title>
+    <title>Search results for foobar</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Google+Sans:300,400,500|Google+Sans+Display:400|Roboto:300,400,500,700|Roboto+Mono:300,400,700&amp;display=swap"/>
     <link rel="shortcut icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
     <link rel="search" type="application/opensearchdescription+xml" title="Dart packages" href="/osd.xml"/>


### PR DESCRIPTION
[Titles and headings](https://developers.google.com/style/headings) generally shouldn't contain punctuation. 