### PR TITLE
Refactor: more generic JWT claim tests.

### DIFF
--- a/app/lib/service/openid/gcp_openid.dart
+++ b/app/lib/service/openid/gcp_openid.dart
@@ -4,6 +4,7 @@
 
 import 'package:collection/collection.dart';
 import 'package:logging/logging.dart';
+import 'package:meta/meta.dart';
 import 'package:pub_dev/shared/redis_cache.dart';
 
 import 'jwt.dart';
@@ -33,10 +34,11 @@ class GcpServiceAccountJwtPayload {
   /// The URL used as the `iss` property of JWT payloads.
   static const issuerUrl = 'https://accounts.google.com';
 
-  static const _requiredClaims = <String>{
+  @visibleForTesting
+  static const requiredClaims = <String>{
     // generic claims
     'iat',
-    'nbf',
+    // 'nbf', -- for some reason GCP doesn't provide this claim
     'exp',
     'iss',
     'aud',
@@ -50,7 +52,7 @@ class GcpServiceAccountJwtPayload {
         sub = parseAsString(map, 'sub');
 
   factory GcpServiceAccountJwtPayload(JwtPayload payload) {
-    final missing = _requiredClaims.difference(payload.keys.toSet()).sorted();
+    final missing = requiredClaims.difference(payload.keys.toSet()).sorted();
     if (missing.isNotEmpty) {
       throw FormatException(
           'JWT from Google Cloud is missing following claims: ${missing.map((k) => '`$k`').join(', ')}.');

--- a/app/lib/service/openid/github_openid.dart
+++ b/app/lib/service/openid/github_openid.dart
@@ -4,6 +4,7 @@
 
 import 'package:collection/collection.dart';
 import 'package:logging/logging.dart';
+import 'package:meta/meta.dart';
 import 'package:pub_dev/shared/redis_cache.dart';
 
 import 'jwt.dart';
@@ -54,7 +55,8 @@ class GitHubJwtPayload {
   /// The URL used as the `iss` property of JWT payloads.
   static const issuerUrl = 'https://token.actions.githubusercontent.com';
 
-  static const _requiredClaims = <String>{
+  @visibleForTesting
+  static const requiredClaims = <String>{
     // generic claims
     'iat',
     'nbf',
@@ -82,7 +84,7 @@ class GitHubJwtPayload {
         runId = parseAsStringOrNull(map, 'run_id');
 
   factory GitHubJwtPayload(JwtPayload payload) {
-    final missing = _requiredClaims.difference(payload.keys.toSet()).sorted();
+    final missing = requiredClaims.difference(payload.keys.toSet()).sorted();
     if (missing.isNotEmpty) {
       throw FormatException(
           'JWT from Github is missing following claims: ${missing.map((k) => '`$k`').join(', ')}.');

--- a/app/test/service/openid/gcp_openid_test.dart
+++ b/app/test/service/openid/gcp_openid_test.dart
@@ -11,20 +11,8 @@ void main() {
   testWithProfile('Google Cloud key list', fn: () async {
     final data = await fetchGoogleCloudOpenIdData();
     expect(data.provider.issuer, 'https://accounts.google.com');
-    expect(data.provider.claimsSupported, [
-      'aud',
-      'email',
-      'email_verified',
-      'exp',
-      'family_name',
-      'given_name',
-      'iat',
-      'iss',
-      'locale',
-      'name',
-      'picture',
-      'sub',
-    ]);
+    expect(data.provider.claimsSupported,
+        containsAll(GcpServiceAccountJwtPayload.requiredClaims));
     expect(data.provider.idTokenSigningAlgValuesSupported, [
       'RS256',
     ]);

--- a/app/test/service/openid/github_openid_test.dart
+++ b/app/test/service/openid/github_openid_test.dart
@@ -15,34 +15,8 @@ void main() {
   testWithProfile('GitHub key list', fn: () async {
     final data = await fetchGithubOpenIdData();
     expect(data.provider.issuer, 'https://token.actions.githubusercontent.com');
-    expect(data.provider.claimsSupported, [
-      'sub',
-      'aud',
-      'exp',
-      'iat',
-      'iss',
-      'jti',
-      'nbf',
-      'ref',
-      'repository',
-      'repository_id',
-      'repository_owner',
-      'repository_owner_id',
-      'run_id',
-      'run_number',
-      'run_attempt',
-      'actor',
-      'actor_id',
-      'workflow',
-      'head_ref',
-      'base_ref',
-      'event_name',
-      'ref_type',
-      'environment',
-      'environment_node_id',
-      'job_workflow_ref',
-      'repository_visibility',
-    ]);
+    expect(data.provider.claimsSupported,
+        containsAll(GitHubJwtPayload.requiredClaims));
     expect(data.provider.idTokenSigningAlgValuesSupported, [
       'RS256',
     ]);


### PR DESCRIPTION
Note: the change revealed that GCP doesn't provide the `nbf` claim. We don't fail if it is missing, just surprising that it is not there.