### PR TITLE
Refactor: requireAuthenticatedAdmin.

### DIFF
--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -25,7 +25,6 @@ import '../account/agent.dart';
 import '../account/backend.dart';
 import '../account/consent_backend.dart';
 import '../account/models.dart' show User;
-import '../admin/backend.dart';
 import '../audit/models.dart';
 import '../job/backend.dart';
 import '../publisher/backend.dart';
@@ -1430,8 +1429,11 @@ class PackageBackend {
       if (user == null) {
         throw AuthorizationException.userCannotChangeUploaders(package.name!);
       }
-      final isAuthorizedAdmin = await adminBackend.verifyAdminPermission(
-          user, AdminPermission.managePackageOwnership);
+      final isAuthorizedAdmin = await accountBackend.hasAdminPermission(
+        oauthUserId: user.oauthUserId,
+        email: user.email,
+        permission: AdminPermission.managePackageOwnership,
+      );
       if (isAuthorizedAdmin) {
         return;
       } else {


### PR DESCRIPTION
- #6140
- moved `requireAuthenticatedAdmin` into `account/backend.dart` to be alongside the other similar methods
- changed return type to `AuthenticatedUser`
- moved and renamed `verifyAdminPermission` into `accountBackend.hasAdminPermission`, changed signature to use only the required field to match the configuration fields