### PR TITLE
Audience refactor: test+private API

### DIFF
--- a/app/lib/account/backend.dart
+++ b/app/lib/account/backend.dart
@@ -86,7 +86,7 @@ UserSessionData? get userSessionData =>
 /// When no associated User entry exists in Datastore, this method will create
 /// a new one. When the authenticated email of the user changes, the email
 /// field will be updated to the latest one.
-Future<AuthenticatedUser> requireAuthenticatedUser() async {
+Future<AuthenticatedUser> requireAuthenticatedWebUser() async {
   return await _requireAuthenticatedUser(
       expectedAudience: activeConfiguration.pubSiteAudience);
 }
@@ -498,7 +498,7 @@ class AccountBackend {
     required String name,
     required String imageUrl,
   }) async {
-    final user = await requireAuthenticatedUser();
+    final user = await requireAuthenticatedWebUser();
     final now = clock.now().toUtc();
     final session = UserSession()
       ..id = createUuid()

--- a/app/lib/account/backend.dart
+++ b/app/lib/account/backend.dart
@@ -86,7 +86,12 @@ UserSessionData? get userSessionData =>
 /// When no associated User entry exists in Datastore, this method will create
 /// a new one. When the authenticated email of the user changes, the email
 /// field will be updated to the latest one.
-Future<AuthenticatedUser> requireAuthenticatedUser(
+Future<AuthenticatedUser> requireAuthenticatedUser() async {
+  return await _requireAuthenticatedUser(
+      expectedAudience: activeConfiguration.pubSiteAudience);
+}
+
+Future<AuthenticatedUser> _requireAuthenticatedUser(
     {String? expectedAudience}) async {
   final token = _getBearerToken();
   if (token == null || token.isEmpty) {
@@ -96,7 +101,6 @@ Future<AuthenticatedUser> requireAuthenticatedUser(
   if (auth == null) {
     throw AuthenticationException.failed();
   }
-  expectedAudience ??= activeConfiguration.pubSiteAudience;
   if (expectedAudience == null || expectedAudience.isEmpty) {
     _logger.shout(
         'Audience was not configured.', expectedAudience, StackTrace.current);
@@ -133,7 +137,7 @@ Future<AuthenticatedUser> requireAuthenticatedUser(
 /// Throws [AuthorizationException] if it doesn't have the permission.
 Future<AuthenticatedUser> requireAuthenticatedAdmin(
     AdminPermission permission) async {
-  final authenticatedUser = await requireAuthenticatedUser(
+  final authenticatedUser = await _requireAuthenticatedUser(
       expectedAudience: activeConfiguration.adminAudience);
   final user = authenticatedUser.user;
   final isAdmin = await accountBackend.hasAdminPermission(
@@ -161,7 +165,7 @@ Future<AuthenticatedAgent> requireAuthenticatedClient() async {
   if (authenticatedServiceAgent != null) {
     return authenticatedServiceAgent;
   } else {
-    return await requireAuthenticatedUser(
+    return await _requireAuthenticatedUser(
         expectedAudience: activeConfiguration.pubClientAudience);
   }
 }

--- a/app/lib/account/consent_backend.dart
+++ b/app/lib/account/consent_backend.dart
@@ -73,7 +73,7 @@ class ConsentBackend {
 
   /// Returns the consent details for API calls.
   Future<api.Consent> handleGetConsent(String consentId) async {
-    final authenticatedUser = await requireAuthenticatedUser();
+    final authenticatedUser = await requireAuthenticatedWebUser();
     return getConsent(consentId, authenticatedUser.user);
   }
 
@@ -81,7 +81,7 @@ class ConsentBackend {
   Future<api.ConsentResult> resolveConsent(
       String consentId, api.ConsentResult result) async {
     InvalidInputException.checkUlid(consentId, 'consentId');
-    final authenticatedUser = await requireAuthenticatedUser();
+    final authenticatedUser = await requireAuthenticatedWebUser();
     final user = authenticatedUser.user;
 
     final c = await _lookupAndCheck(consentId, user);
@@ -171,7 +171,7 @@ class ConsentBackend {
     required String publisherId,
     required String contactEmail,
   }) async {
-    final authenticatedUser = await requireAuthenticatedUser();
+    final authenticatedUser = await requireAuthenticatedWebUser();
     final user = authenticatedUser.user;
     return await _invite(
         activeUser: user,
@@ -187,7 +187,7 @@ class ConsentBackend {
     required String publisherId,
     required String invitedUserEmail,
   }) async {
-    final authenticatedUser = await requireAuthenticatedUser();
+    final authenticatedUser = await requireAuthenticatedWebUser();
     final user = authenticatedUser.user;
     return await _invite(
       activeUser: user,
@@ -319,7 +319,7 @@ class _PackageUploaderAction extends ConsentAction {
         consent.args!.skip(1).contains('is-from-admin-user');
     final fromUserId = consent.fromUserId!;
     final fromUserEmail = (await accountBackend.getEmailOfUserId(fromUserId))!;
-    final currentUser = await requireAuthenticatedUser();
+    final currentUser = await requireAuthenticatedWebUser();
     if (currentUser.email?.toLowerCase() != consent.email?.toLowerCase()) {
       throw NotAcceptableException(
           'Current user and consent user does not match.');
@@ -464,7 +464,7 @@ class _PublisherMemberAction extends ConsentAction {
   @override
   Future<void> onAccept(Consent consent) async {
     final publisherId = consent.args![0];
-    final currentUser = await requireAuthenticatedUser();
+    final currentUser = await requireAuthenticatedWebUser();
     if (consent.email != currentUser.email) {
       throw NotAcceptableException('Consent is not for the current user.');
     }

--- a/app/lib/frontend/handlers/account.dart
+++ b/app/lib/frontend/handlers/account.dart
@@ -35,7 +35,7 @@ shelf.Response authorizedHandler(_) => htmlResponse(renderAuthorizedPage());
 Future<shelf.Response> updateSessionHandler(
     shelf.Request request, ClientSessionRequest body) async {
   final sw = Stopwatch()..start();
-  final authenticatedUser = await requireAuthenticatedUser();
+  final authenticatedUser = await requireAuthenticatedWebUser();
   final user = authenticatedUser.user;
 
   InvalidInputException.checkNotNull(body.accessToken, 'accessToken');
@@ -144,7 +144,7 @@ Future<shelf.Response> consentPageHandler(
 Future<AccountPkgOptions> accountPkgOptionsHandler(
     shelf.Request request, String package) async {
   checkPackageVersionParams(package);
-  final user = await requireAuthenticatedUser();
+  final user = await requireAuthenticatedWebUser();
   final p = await packageBackend.lookupPackage(package);
   if (p == null) {
     throw NotFoundException.resource(package);
@@ -156,7 +156,7 @@ Future<AccountPkgOptions> accountPkgOptionsHandler(
 /// Handles GET /api/account/likes
 Future<LikedPackagesRepsonse> listPackageLikesHandler(
     shelf.Request request) async {
-  final authenticatedUser = await requireAuthenticatedUser();
+  final authenticatedUser = await requireAuthenticatedWebUser();
   final user = authenticatedUser.user;
   final packages = await likeBackend.listPackageLikes(user);
   final List<PackageLikeResponse> packageLikes = List.from(packages.map(
@@ -169,7 +169,7 @@ Future<LikedPackagesRepsonse> listPackageLikesHandler(
 Future<PackageLikeResponse> getLikePackageHandler(
     shelf.Request request, String package) async {
   checkPackageVersionParams(package);
-  final user = await requireAuthenticatedUser();
+  final user = await requireAuthenticatedWebUser();
   final p = await packageBackend.lookupPackage(package);
   if (p == null) {
     throw NotFoundException.resource(package);
@@ -186,7 +186,7 @@ Future<PackageLikeResponse> getLikePackageHandler(
 /// Handles PUT /api/account/likes/<package>
 Future<PackageLikeResponse> likePackageHandler(
     shelf.Request request, String package) async {
-  final authenticatedUser = await requireAuthenticatedUser();
+  final authenticatedUser = await requireAuthenticatedWebUser();
   final user = authenticatedUser.user;
   final l = await likeBackend.likePackage(user, package);
   return PackageLikeResponse(liked: true, package: package, created: l.created);
@@ -195,7 +195,7 @@ Future<PackageLikeResponse> likePackageHandler(
 /// Handles DELETE /api/account/likes/<package>
 Future<shelf.Response> unlikePackageHandler(
     shelf.Request request, String package) async {
-  final authenticatedUser = await requireAuthenticatedUser();
+  final authenticatedUser = await requireAuthenticatedWebUser();
   final user = authenticatedUser.user;
   await likeBackend.unlikePackage(user, package);
   return shelf.Response(204);
@@ -205,7 +205,7 @@ Future<shelf.Response> unlikePackageHandler(
 Future<AccountPublisherOptions> accountPublisherOptionsHandler(
     shelf.Request request, String publisherId) async {
   checkPublisherIdParam(publisherId);
-  final user = await requireAuthenticatedUser();
+  final user = await requireAuthenticatedWebUser();
   final publisher = await publisherBackend.getPublisher(publisherId);
   if (publisher == null) {
     throw NotFoundException.resource('publisher "$publisherId"');

--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -359,7 +359,7 @@ class PackageBackend {
 
   /// Updates [options] on [package].
   Future<void> updateOptions(String package, api.PkgOptions options) async {
-    final authenticatedUser = await requireAuthenticatedUser();
+    final authenticatedUser = await requireAuthenticatedWebUser();
     final user = authenticatedUser.user;
     // Validate replacedBy parameter
     final replacedBy = options.replacedBy?.trim() ?? '';
@@ -434,7 +434,7 @@ class PackageBackend {
     String version,
     api.VersionOptions options,
   ) async {
-    final authenticatedUser = await requireAuthenticatedUser();
+    final authenticatedUser = await requireAuthenticatedWebUser();
     final user = authenticatedUser.user;
 
     final pkgKey = db.emptyKey.append(Package, id: package);
@@ -471,7 +471,7 @@ class PackageBackend {
   /// updates the Datastore entity if everything is valid.
   Future<api.AutomatedPublishing> setAutomatedPublishing(
       String package, api.AutomatedPublishing body) async {
-    final authenticatedUser = await requireAuthenticatedUser();
+    final authenticatedUser = await requireAuthenticatedWebUser();
     final user = authenticatedUser.user;
     return await withRetryTransaction(db, (tx) async {
       final p = await tx
@@ -660,7 +660,7 @@ class PackageBackend {
   Future<api.PackagePublisherInfo> setPublisher(
       String packageName, api.PackagePublisherInfo request) async {
     InvalidInputException.checkNotNull(request.publisherId, 'publisherId');
-    final authenticatedUser = await requireAuthenticatedUser();
+    final authenticatedUser = await requireAuthenticatedWebUser();
     final user = authenticatedUser.user;
 
     final key = db.emptyKey.append(Package, id: packageName);
@@ -731,7 +731,7 @@ class PackageBackend {
 
   /// Moves the package out of its current publisher.
   Future<api.PackagePublisherInfo> removePublisher(String packageName) async {
-    final user = await requireAuthenticatedUser();
+    final user = await requireAuthenticatedWebUser();
     final package = await requirePackageAdmin(packageName, user.userId);
     if (package.publisherId == null) {
       return _asPackagePublisherInfo(package);
@@ -1342,7 +1342,7 @@ class PackageBackend {
       String packageName, api.InviteUploaderRequest invite) async {
     InvalidInputException.checkNotNull(invite.email, 'email');
     final uploaderEmail = invite.email.toLowerCase();
-    final authenticatedUser = await requireAuthenticatedUser();
+    final authenticatedUser = await requireAuthenticatedWebUser();
     final user = authenticatedUser.user;
     final packageKey = db.emptyKey.append(Package, id: packageName);
     final package = await db.lookupOrNull<Package>(packageKey);
@@ -1451,7 +1451,7 @@ class PackageBackend {
     String uploaderEmail,
   ) async {
     uploaderEmail = uploaderEmail.toLowerCase();
-    final authenticatedUser = await requireAuthenticatedUser();
+    final authenticatedUser = await requireAuthenticatedWebUser();
     final user = authenticatedUser.user;
     await withRetryTransaction(db, (tx) async {
       final packageKey = db.emptyKey.append(Package, id: packageName);

--- a/app/lib/publisher/backend.dart
+++ b/app/lib/publisher/backend.dart
@@ -136,7 +136,7 @@ class PublisherBackend {
     api.CreatePublisherRequest body,
   ) async {
     checkPublisherIdParam(publisherId);
-    final authenticatedUser = await requireAuthenticatedUser();
+    final authenticatedUser = await requireAuthenticatedWebUser();
     final user = authenticatedUser.user;
     InvalidInputException.checkMatchPattern(
       publisherId,
@@ -252,7 +252,7 @@ class PublisherBackend {
         maximum: 256,
       );
     }
-    final authenticatedUser = await requireAuthenticatedUser();
+    final authenticatedUser = await requireAuthenticatedWebUser();
     final user = authenticatedUser.user;
     await requirePublisherAdmin(publisherId, user.userId);
     final p = await withRetryTransaction(_db, (tx) async {
@@ -322,7 +322,7 @@ class PublisherBackend {
   Future updateContactWithVerifiedEmail(
       String publisherId, String contactEmail) async {
     checkPublisherIdParam(publisherId);
-    final authenticatedUser = await requireAuthenticatedUser();
+    final authenticatedUser = await requireAuthenticatedWebUser();
     final user = authenticatedUser.user;
     InvalidInputException.check(
         isValidEmail(contactEmail), 'Invalid email: `$contactEmail`');
@@ -345,7 +345,7 @@ class PublisherBackend {
   Future<account_api.InviteStatus> invitePublisherMember(
       String publisherId, api.InviteMemberRequest invite) async {
     checkPublisherIdParam(publisherId);
-    final activeUser = await requireAuthenticatedUser();
+    final activeUser = await requireAuthenticatedWebUser();
     final p = await requirePublisherAdmin(publisherId, activeUser.userId);
     InvalidInputException.checkNotNull(invite.email, 'email');
     InvalidInputException.checkStringLength(invite.email, 'email',
@@ -394,7 +394,7 @@ class PublisherBackend {
     String publisherId,
   ) async {
     checkPublisherIdParam(publisherId);
-    final user = await requireAuthenticatedUser();
+    final user = await requireAuthenticatedWebUser();
     await requirePublisherAdmin(publisherId, user.userId);
     return api.PublisherMembers(
       members: await listPublisherMembers(publisherId),
@@ -415,7 +415,7 @@ class PublisherBackend {
   Future<api.PublisherMember> publisherMemberInfo(
       String publisherId, String userId) async {
     checkPublisherIdParam(publisherId);
-    final user = await requireAuthenticatedUser();
+    final user = await requireAuthenticatedWebUser();
     final p = await requirePublisherAdmin(publisherId, user.userId);
     final key = p.key.append(PublisherMember, id: userId);
     final pm = await _db.lookupOrNull<PublisherMember>(key);
@@ -432,7 +432,7 @@ class PublisherBackend {
     api.UpdatePublisherMemberRequest update,
   ) async {
     checkPublisherIdParam(publisherId);
-    final user = await requireAuthenticatedUser();
+    final user = await requireAuthenticatedWebUser();
     final p = await requirePublisherAdmin(publisherId, user.userId);
     final key = p.key.append(PublisherMember, id: userId);
     final pm = await _db.lookupOrNull<PublisherMember>(key);
@@ -464,7 +464,7 @@ class PublisherBackend {
   /// Deletes a publisher's member.
   Future<void> deletePublisherMember(String publisherId, String userId) async {
     checkPublisherIdParam(publisherId);
-    final authenticatedUser = await requireAuthenticatedUser();
+    final authenticatedUser = await requireAuthenticatedWebUser();
     final user = authenticatedUser.user;
     final p = await requirePublisherAdmin(publisherId, user.userId);
     if (userId == user.userId) {

--- a/app/test/account/backend_test.dart
+++ b/app/test/account/backend_test.dart
@@ -41,7 +41,7 @@ void main() {
 
       final u = await accountBackend.withBearerToken(
         createFakeAuthTokenForEmail('new-user@pub.dev'),
-        () => requireAuthenticatedUser(),
+        () => requireAuthenticatedWebUser(),
       );
       expect(u.userId, hasLength(36));
       expect(u.oauthUserId, isNotNull);
@@ -56,7 +56,7 @@ void main() {
     testWithProfile('Authenticate: token failure', fn: () async {
       await expectLater(
           () => accountBackend.withBearerToken(
-              '', () => requireAuthenticatedUser()),
+              '', () => requireAuthenticatedWebUser()),
           throwsA(isA<AuthenticationException>()));
     });
 
@@ -71,7 +71,7 @@ void main() {
       String? userId;
       await accountBackend.withBearerToken(
           createFakeAuthTokenForEmail('a@example.com'), () async {
-        final u1 = await requireAuthenticatedUser();
+        final u1 = await requireAuthenticatedWebUser();
         expect(u1.userId, hasLength(36));
         expect(u1.email, 'a@example.com');
         userId = u1.userId;
@@ -99,7 +99,7 @@ void main() {
 
       await accountBackend.withBearerToken(
           createFakeAuthTokenForEmail('c@example.com'), () async {
-        final u1 = await requireAuthenticatedUser();
+        final u1 = await requireAuthenticatedWebUser();
         expect(u1.userId, hasLength(36));
         expect(u1.email, 'c@example.com');
 

--- a/app/test/account/consent_backend_test.dart
+++ b/app/test/account/consent_backend_test.dart
@@ -28,7 +28,7 @@ void main() {
 
       String? consentId;
       await accountBackend.withBearerToken(userAtPubDevAuthToken, () async {
-        final authenticatedUser = await requireAuthenticatedUser();
+        final authenticatedUser = await requireAuthenticatedWebUser();
         final user = authenticatedUser.user;
         final consentRow = await dbService.query<Consent>().run().single;
         final consent =
@@ -99,7 +99,7 @@ void main() {
 
       String? consentId;
       await accountBackend.withBearerToken(userAtPubDevAuthToken, () async {
-        final authenticatedUser = await requireAuthenticatedUser();
+        final authenticatedUser = await requireAuthenticatedWebUser();
         final user = authenticatedUser.user;
         final consentRow = await dbService.query<Consent>().run().single;
         final consent =
@@ -171,7 +171,7 @@ void main() {
 
       String? consentId;
       await accountBackend.withBearerToken(userAtPubDevAuthToken, () async {
-        final authenticatedUser = await requireAuthenticatedUser();
+        final authenticatedUser = await requireAuthenticatedWebUser();
         final user = authenticatedUser.user;
         final consentRow = await dbService.query<Consent>().run().single;
         final consent =

--- a/app/test/account/consent_backend_test.dart
+++ b/app/test/account/consent_backend_test.dart
@@ -18,16 +18,13 @@ import '../shared/test_services.dart';
 void main() {
   group('Uploader invite', () {
     Future<String?> inviteUploader() async {
-      await accountBackend.withBearerToken(adminClientToken, () async {
-        final authenticatedUser = await requireAuthenticatedUser(
-            expectedAudience: activeConfiguration.pubClientAudience);
-        final status = await consentBackend.invitePackageUploader(
-          activeUser: authenticatedUser.user,
-          uploaderEmail: 'user@pub.dev',
-          packageName: 'oxygen',
-        );
-        expect(status.emailSent, isTrue);
-      });
+      await withHttpPubApiClient(
+        bearerToken: siteAdminToken,
+        pubHostedUrl: activeConfiguration.primarySiteUri.toString(),
+        fn: (client) async {
+          await client.adminAddPackageUploader('oxygen', 'user@pub.dev');
+        },
+      );
 
       String? consentId;
       await accountBackend.withBearerToken(userAtPubDevAuthToken, () async {

--- a/app/test/admin/api_test.dart
+++ b/app/test/admin/api_test.dart
@@ -179,7 +179,7 @@ void main() {
 
         late Key likeKey;
         await accountBackend.withBearerToken(userAtPubDevAuthToken, () async {
-          final user = await requireAuthenticatedUser();
+          final user = await requireAuthenticatedWebUser();
           likeKey = dbService.emptyKey
               .append(User, id: user.userId)
               .append(Like, id: 'oxygen');
@@ -243,7 +243,7 @@ void main() {
 
         late Key likeKey;
         await accountBackend.withBearerToken(userAtPubDevAuthToken, () async {
-          final user = await requireAuthenticatedUser();
+          final user = await requireAuthenticatedWebUser();
           likeKey = dbService.emptyKey
               .append(User, id: user.userId)
               .append(Like, id: 'oxygen');
@@ -586,7 +586,7 @@ void main() {
               (await accountBackend.lookupUsersByEmail('user@pub.dev')).single;
           final someUser = await accountBackend.withBearerToken(
             createFakeAuthTokenForEmail('someuser@pub.dev'),
-            () => requireAuthenticatedUser(),
+            () => requireAuthenticatedWebUser(),
           );
 
           final pkg = await packageBackend.lookupPackage('oxygen');

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -434,7 +434,7 @@ void main() {
           adminAtPubDevAuthToken,
           () async {
             // update session as package data loading checks that
-            final user = await requireAuthenticatedUser();
+            final user = await requireAuthenticatedWebUser();
             registerUserSessionData(UserSessionData(
               userId: user.userId,
               created: clock.now(),
@@ -700,7 +700,7 @@ void main() {
         final oxygen = await scoreCardBackend.getPackageView('oxygen');
         final neon = await scoreCardBackend.getPackageView('neon');
         await accountBackend.withBearerToken(userAtPubDevAuthToken, () async {
-          final authenticatedUser = await requireAuthenticatedUser();
+          final authenticatedUser = await requireAuthenticatedWebUser();
           final user = authenticatedUser.user;
           final session = await accountBackend.createNewSession(
             name: 'Pub User',
@@ -724,7 +724,7 @@ void main() {
 
     testWithProfile('/my-liked-packages page', fn: () async {
       await accountBackend.withBearerToken(userAtPubDevAuthToken, () async {
-        final authenticatedUser = await requireAuthenticatedUser();
+        final authenticatedUser = await requireAuthenticatedWebUser();
         final user = authenticatedUser.user;
         final session = await accountBackend.createNewSession(
           name: 'Pub User',
@@ -751,7 +751,7 @@ void main() {
 
     testWithProfile('/my-publishers page', fn: () async {
       await accountBackend.withBearerToken(userAtPubDevAuthToken, () async {
-        final authenticatedUser = await requireAuthenticatedUser();
+        final authenticatedUser = await requireAuthenticatedWebUser();
         final user = authenticatedUser.user;
         final session = await accountBackend.createNewSession(
           name: 'Pub User',
@@ -778,7 +778,7 @@ void main() {
 
     testWithProfile('/my-activity-log page', fn: () async {
       await accountBackend.withBearerToken(adminAtPubDevAuthToken, () async {
-        final authenticatedUser = await requireAuthenticatedUser();
+        final authenticatedUser = await requireAuthenticatedWebUser();
         final user = authenticatedUser.user;
         final session = await accountBackend.createNewSession(
           name: 'Pub User',

--- a/app/test/package/package_publisher_test.dart
+++ b/app/test/package/package_publisher_test.dart
@@ -309,7 +309,7 @@ void _testUserNotAdminOfPublisher({
   testWithProfile('Active user is not admin of publisher',
       testProfile: testProfile, fn: () async {
     await accountBackend.withBearerToken(authToken, () async {
-      final user = await requireAuthenticatedUser();
+      final user = await requireAuthenticatedWebUser();
       final members = await dbService
           .query<PublisherMember>()
           .run()

--- a/app/test/publisher/api_test.dart
+++ b/app/test/publisher/api_test.dart
@@ -274,7 +274,7 @@ void main() {
       testWithProfile('User is not admin', fn: () async {
         final user = await accountBackend.withBearerToken(
           createFakeAuthTokenForEmail('other@pub.dev'),
-          () => requireAuthenticatedUser(),
+          () => requireAuthenticatedWebUser(),
         );
         await dbService.commit(inserts: [
           publisherMember(user.userId, 'example.com', 'not-admin'),
@@ -285,7 +285,7 @@ void main() {
       testWithProfile('OK', fn: () async {
         final user = await accountBackend.withBearerToken(
           createFakeAuthTokenForEmail('other@pub.dev'),
-          () => requireAuthenticatedUser(),
+          () => requireAuthenticatedWebUser(),
         );
         await dbService.commit(inserts: [
           publisherMember(user.userId, 'example.com', 'admin'),
@@ -310,7 +310,7 @@ void main() {
       testWithProfile('OK', fn: () async {
         final user = await accountBackend.withBearerToken(
           createFakeAuthTokenForEmail('other@pub.dev'),
-          () => requireAuthenticatedUser(),
+          () => requireAuthenticatedWebUser(),
         );
         await dbService.commit(inserts: [
           publisherMember(user.userId, 'example.com', 'admin'),
@@ -369,7 +369,7 @@ void main() {
       testWithProfile('User is already a member', fn: () async {
         final user = await accountBackend.withBearerToken(
           createFakeAuthTokenForEmail('other@pub.dev'),
-          () => requireAuthenticatedUser(),
+          () => requireAuthenticatedWebUser(),
         );
         await dbService.commit(inserts: [
           publisherMember(
@@ -389,7 +389,7 @@ void main() {
             await accountBackend.lookupUserByEmail('admin@pub.dev');
         final otherUser = await accountBackend.withBearerToken(
           createFakeAuthTokenForEmail('other@pub.dev'),
-          () => requireAuthenticatedUser(),
+          () => requireAuthenticatedWebUser(),
         );
         final consent = Consent.init(
           fromUserId: adminUser.userId,
@@ -650,7 +650,7 @@ void main() {
       testWithProfile('Role value is not allowed', fn: () async {
         final user = await accountBackend.withBearerToken(
           createFakeAuthTokenForEmail('other@pub.dev'),
-          () => requireAuthenticatedUser(),
+          () => requireAuthenticatedWebUser(),
         );
         await dbService.commit(inserts: [
           publisherMember(
@@ -669,7 +669,7 @@ void main() {
       testWithProfile('OK', fn: () async {
         final user = await accountBackend.withBearerToken(
           createFakeAuthTokenForEmail('other@pub.dev'),
-          () => requireAuthenticatedUser(),
+          () => requireAuthenticatedWebUser(),
         );
         await dbService.commit(inserts: [
           publisherMember(user.userId, 'example.com', 'someotherrole'),
@@ -727,7 +727,7 @@ void main() {
       testWithProfile('OK', fn: () async {
         final user = await accountBackend.withBearerToken(
           createFakeAuthTokenForEmail('other@pub.dev'),
-          () => requireAuthenticatedUser(),
+          () => requireAuthenticatedWebUser(),
         );
         await dbService.commit(inserts: [
           publisherMember(

--- a/app/test/shared/user_merger_test.dart
+++ b/app/test/shared/user_merger_test.dart
@@ -58,7 +58,7 @@ void main() {
     final user = await accountBackend.lookupUserByEmail('user@pub.dev');
     final control = await accountBackend.withBearerToken(
       createFakeAuthTokenForEmail('control@pub.dev'),
-      () => requireAuthenticatedUser(),
+      () => requireAuthenticatedWebUser(),
     );
     await dbService.commit(inserts: [
       UserSession()
@@ -90,7 +90,7 @@ void main() {
     final user = await accountBackend.lookupUserByEmail('user@pub.dev');
     final control = await accountBackend.withBearerToken(
       createFakeAuthTokenForEmail('control@pub.dev'),
-      () => requireAuthenticatedUser(),
+      () => requireAuthenticatedWebUser(),
     );
 
     final target1 = Consent.init(


### PR DESCRIPTION
- #6140
- Fixed admin consent test: we shouldn't use pub client audience on admin-related tests. (The test skipped auth checks.)
- With that, the `requireAuthenticatedUser` doesn't need the `expectedAudience` in its public API, preparing the better integration of the auth flows.