### PR TITLE
Use AuthenticatedGcpServiceAccount from requireAuthenticatedAdmin + fake token authentication.

### DIFF
--- a/app/lib/account/agent.dart
+++ b/app/lib/account/agent.dart
@@ -135,6 +135,7 @@ class AuthenticatedGcpServiceAccount implements AuthenticatedAgent {
 
   @override
   String get email => payload.email;
+  // TODO: remove from the interface after the consent backend has been migrated
   String get oauthUserId => payload.sub;
   String get audience => idToken.payload.aud.single;
 }

--- a/app/lib/account/agent.dart
+++ b/app/lib/account/agent.dart
@@ -72,6 +72,9 @@ abstract class AuthenticatedAgent {
   ///  * For a service account we display a description.
   ///  * For automated publishing we display the service and the origin trigger.
   String get displayId;
+
+  /// The email address of the agent (if there is any).
+  String? get email;
 }
 
 /// Holds the authenticated Github Action information.
@@ -99,6 +102,9 @@ class AuthenticatedGithubAction implements AuthenticatedAgent {
     required this.idToken,
     required this.payload,
   });
+
+  @override
+  String? get email => null;
 }
 
 /// Holds the authenticated Google Cloud Service account information.
@@ -107,7 +113,7 @@ class AuthenticatedGcpServiceAccount implements AuthenticatedAgent {
   String get agentId => KnownAgents.gcpServiceAccount;
 
   @override
-  String get displayId => payload.email;
+  String get displayId => email;
 
   /// OIDC `id_token` the request was authenticated with.
   ///
@@ -126,6 +132,11 @@ class AuthenticatedGcpServiceAccount implements AuthenticatedAgent {
     required this.idToken,
     required this.payload,
   });
+
+  @override
+  String get email => payload.email;
+  String get oauthUserId => payload.sub;
+  String get audience => idToken.payload.aud.single;
 }
 
 /// Holds the authenticated user information.
@@ -145,6 +156,7 @@ class AuthenticatedUser implements AuthenticatedAgent {
   String get displayId => user.email!;
 
   String get userId => user.userId;
+  @override
   String? get email => user.email;
   String? get oauthUserId => user.oauthUserId;
 }

--- a/app/lib/account/backend.dart
+++ b/app/lib/account/backend.dart
@@ -171,7 +171,7 @@ Future<AuthenticatedGcpServiceAccount> requireAuthenticatedAdmin(
     );
     if (!isAdmin) {
       _logger.warning(
-          'Authenticated user (${agent.oauthUserId} / ${agent.email}) is trying to access unauthorized admin APIs.');
+          'Authenticated user (${agent.displayId}) is trying to access unauthorized admin APIs.');
       throw AuthorizationException.userIsNotAdminForPubSite();
     }
     return agent;

--- a/app/lib/admin/backend.dart
+++ b/app/lib/admin/backend.dart
@@ -149,7 +149,7 @@ class AdminBackend {
     if (user == null) return;
     if (user.isDeleted) return;
 
-    _logger.info('${caller.oauthUserId} (${caller.email}) initiated the delete '
+    _logger.info('${caller.displayId}) initiated the delete '
         'of ${user.userId} (${user.email})');
 
     // Package.uploaders
@@ -301,7 +301,7 @@ class AdminBackend {
     final caller =
         await requireAuthenticatedAdmin(AdminPermission.removePackage);
 
-    _logger.info('${caller.oauthUserId} (${caller.email}) initiated the delete '
+    _logger.info('${caller.displayId}) initiated the delete '
         'of package $packageName');
 
     final packageKey = _db.emptyKey.append(Package, id: packageName);
@@ -403,8 +403,7 @@ class AdminBackend {
 
     if (options.isRetracted != null) {
       final isRetracted = options.isRetracted!;
-      _logger.info(
-          '${caller.oauthUserId} (${caller.email}) initiated the isRetracted status '
+      _logger.info('${caller.displayId}) initiated the isRetracted status '
           'of package $packageName $version to be $isRetracted.');
 
       await withRetryTransaction(_db, (tx) async {
@@ -435,7 +434,7 @@ class AdminBackend {
     final caller =
         await requireAuthenticatedAdmin(AdminPermission.removePackage);
 
-    _logger.info('${caller.oauthUserId} (${caller.email}) initiated the delete '
+    _logger.info('${caller.displayId}) initiated the delete '
         'of package $packageName $version');
 
     final currentDartSdk = await getDartSdkVersion();

--- a/app/lib/fake/backend/fake_auth_provider.dart
+++ b/app/lib/fake/backend/fake_auth_provider.dart
@@ -95,8 +95,8 @@ Future<AuthenticatedAgent?> fakeServiceAgentAuthenticator(String token) async {
     }
 
     final email = uri.queryParameters['email']!;
-    // ignore: invalid_use_of_visible_for_testing_member
     final now = clock.now();
+    // ignore: invalid_use_of_visible_for_testing_member
     final idToken = JsonWebToken(
       header: {},
       payload: {

--- a/app/lib/fake/backend/fake_auth_provider.dart
+++ b/app/lib/fake/backend/fake_auth_provider.dart
@@ -4,6 +4,7 @@
 
 import 'dart:convert';
 
+import 'package:clock/clock.dart';
 import 'package:crypto/crypto.dart';
 
 import '../../account/agent.dart';
@@ -95,16 +96,15 @@ Future<AuthenticatedAgent?> fakeServiceAgentAuthenticator(String token) async {
 
     final email = uri.queryParameters['email']!;
     // ignore: invalid_use_of_visible_for_testing_member
+    final now = clock.now();
     final idToken = JsonWebToken(
       header: {},
       payload: {
         'email': email,
         'sub': _oauthUserIdFromEmail(email),
         'aud': audience,
-        'iat': DateTime.now().millisecondsSinceEpoch ~/ 1000,
-        'exp':
-            DateTime.now().add(Duration(minutes: 1)).millisecondsSinceEpoch ~/
-                1000,
+        'iat': now.millisecondsSinceEpoch ~/ 1000,
+        'exp': now.add(Duration(minutes: 1)).millisecondsSinceEpoch ~/ 1000,
         'iss': GcpServiceAccountJwtPayload.issuerUrl,
       },
       signature: [],

--- a/app/lib/service/services.dart
+++ b/app/lib/service/services.dart
@@ -175,6 +175,7 @@ Future<R> withFakeServices<R>({
     registerScopeExitCallback(authProvider.close);
     registerDomainVerifier(FakeDomainVerifier());
     registerEmailSender(FakeEmailSender());
+    registerServiceAgentAuthenticator(fakeServiceAgentAuthenticator);
     registerUploadSigner(
         FakeUploadSignerService(configuration!.storageBaseUrl!));
 

--- a/app/lib/shared/integrity.dart
+++ b/app/lib/shared/integrity.dart
@@ -654,7 +654,11 @@ class IntegrityChecker {
 
     final users = r.users;
     if (users == null || users.isEmpty) {
-      yield 'AuditLogRecord "${r.id}" has no users.';
+      if (isKnownServiceAgent(r.agent!)) {
+        // agent-initiated log records may not have users
+      } else {
+        yield 'AuditLogRecord "${r.id}" has no users.';
+      }
     } else {
       for (final u in users) {
         yield* _checkUserValid(

--- a/app/lib/tool/test_profile/importer.dart
+++ b/app/lib/tool/test_profile/importer.dart
@@ -118,8 +118,8 @@ Future<void> importProfile({
 
     if (testPackage.isFlutterFavorite ?? false) {
       await withHttpPubApiClient(
-        bearerToken: createFakeAuthTokenForEmail(adminUserEmail ?? activeEmail,
-            audience: activeConfiguration.externalServiceAudience),
+        bearerToken:
+            createFakeServiceAccountToken(email: adminUserEmail ?? activeEmail),
         pubHostedUrl: pubHostedUrl,
         fn: (client) async {
           await client.adminPostAssignedTags(

--- a/app/test/admin/api_test.dart
+++ b/app/test/admin/api_test.dart
@@ -31,10 +31,7 @@ import '../shared/test_services.dart';
 void main() {
   group('Admin API', () {
     group('List users', () {
-      setupTestsWithCallerAuthorizationIssues(
-        (client) => client.adminListUsers(),
-        audience: 'https://pub.dev',
-      );
+      setupTestsWithAdminTokenIssues((client) => client.adminListUsers());
 
       testWithProfile('OK', fn: () async {
         final client = createPubApiClient(authToken: siteAdminToken);
@@ -157,10 +154,8 @@ void main() {
     });
 
     group('Delete package', () {
-      setupTestsWithCallerAuthorizationIssues(
-        (client) => client.adminRemovePackage('oxygen'),
-        audience: 'https://pub.dev',
-      );
+      setupTestsWithAdminTokenIssues(
+          (client) => client.adminRemovePackage('oxygen'));
 
       testWithProfile('OK', fn: () async {
         final client = createPubApiClient(authToken: siteAdminToken);
@@ -219,10 +214,8 @@ void main() {
     });
 
     group('Delete package version', () {
-      setupTestsWithCallerAuthorizationIssues(
-        (client) => client.adminRemovePackageVersion('oxygen', '1.2.0'),
-        audience: 'https://pub.dev',
-      );
+      setupTestsWithAdminTokenIssues(
+          (client) => client.adminRemovePackageVersion('oxygen', '1.2.0'));
 
       testWithProfile('OK', fn: () async {
         final client = createPubApiClient(authToken: siteAdminToken);
@@ -315,12 +308,11 @@ void main() {
     });
 
     group('Delete user', () {
-      setupTestsWithCallerAuthorizationIssues(
+      setupTestsWithAdminTokenIssues(
         (client) async {
           final user = await accountBackend.lookupUserByEmail('user@pub.dev');
           await client.adminRemoveUser(user.userId);
         },
-        audience: 'https://pub.dev',
       );
 
       testWithProfile(
@@ -382,10 +374,8 @@ void main() {
     });
 
     group('get assignedTags', () {
-      setupTestsWithCallerAuthorizationIssues(
-        (client) => client.adminGetAssignedTags('oxygen'),
-        audience: 'https://pub.dev',
-      );
+      setupTestsWithAdminTokenIssues(
+          (client) => client.adminGetAssignedTags('oxygen'));
 
       testWithProfile('get assignedTags', fn: () async {
         final client = createPubApiClient(authToken: siteAdminToken);
@@ -395,12 +385,11 @@ void main() {
     });
 
     group('set assignedTags', () {
-      setupTestsWithCallerAuthorizationIssues(
+      setupTestsWithAdminTokenIssues(
         (client) => client.adminPostAssignedTags(
           'oxygen',
           PatchAssignedTags(assignedTagsAdded: ['is:featured']),
         ),
-        audience: 'https://pub.dev',
       );
 
       testWithProfile('set assignedTags', fn: () async {
@@ -476,10 +465,8 @@ void main() {
       }
 
       group('get', () {
-        setupTestsWithCallerAuthorizationIssues(
-          (client) => client.adminGetPackageUploaders('oxygen'),
-          audience: 'https://pub.dev',
-        );
+        setupTestsWithAdminTokenIssues(
+            (client) => client.adminGetPackageUploaders('oxygen'));
         setupTestsWithPackageFailures(
             (client, package) => client.adminGetPackageUploaders(package));
 
@@ -495,11 +482,8 @@ void main() {
       });
 
       group('add', () {
-        setupTestsWithCallerAuthorizationIssues(
-          (client) =>
-              client.adminAddPackageUploader('oxygen', 'someuser@pub.dev'),
-          audience: 'https://pub.dev',
-        );
+        setupTestsWithAdminTokenIssues((client) =>
+            client.adminAddPackageUploader('oxygen', 'someuser@pub.dev'));
         setupTestsWithPackageFailures((client, package) =>
             client.adminAddPackageUploader(package, 'someuser@pub.dev'));
 
@@ -549,11 +533,8 @@ void main() {
       });
 
       group('remove', () {
-        setupTestsWithCallerAuthorizationIssues(
-          (client) =>
-              client.adminRemovePackageUploader('oxygen', 'admin@pub.dev'),
-          audience: 'https://pub.dev',
-        );
+        setupTestsWithAdminTokenIssues((client) =>
+            client.adminRemovePackageUploader('oxygen', 'admin@pub.dev'));
 
         setupTestsWithPackageFailures((client, package) =>
             client.adminRemovePackageUploader(package, 'admin@pub.dev'));
@@ -609,13 +590,12 @@ void main() {
     });
 
     group('retraction', () {
-      setupTestsWithCallerAuthorizationIssues(
+      setupTestsWithAdminTokenIssues(
         (client) => client.adminUpdateVersionOptions(
           'oxygen',
           '1.2.0',
           VersionOptions(isRetracted: true),
         ),
-        audience: 'https://pub.dev',
       );
 
       testWithProfile('bad retraction value', fn: () async {

--- a/app/test/admin/api_tool_test.dart
+++ b/app/test/admin/api_tool_test.dart
@@ -14,10 +14,8 @@ import '../shared/test_services.dart';
 void main() {
   group('Admin API: tool', () {
     group('bad tool', () {
-      setupTestsWithCallerAuthorizationIssues(
-        (client) => client.adminExecuteTool('no-such-tool', ''),
-        audience: 'https://pub.dev',
-      );
+      setupTestsWithAdminTokenIssues(
+          (client) => client.adminExecuteTool('no-such-tool', ''));
 
       testWithProfile('auth with bad tool', fn: () async {
         final rs = await createPubApiClient(authToken: siteAdminToken)
@@ -28,10 +26,8 @@ void main() {
     });
 
     group('user merger', () {
-      setupTestsWithCallerAuthorizationIssues(
-        (client) => client.adminExecuteTool('user-merger', ''),
-        audience: 'https://pub.dev',
-      );
+      setupTestsWithAdminTokenIssues(
+          (client) => client.adminExecuteTool('user-merger', ''));
 
       testWithProfile('help', fn: () async {
         final rs = await createPubApiClient(authToken: siteAdminToken)

--- a/app/test/shared/test_models.dart
+++ b/app/test/shared/test_models.dart
@@ -50,8 +50,7 @@ final unauthorizedAtPubDevAuthToken =
     createFakeAuthTokenForEmail('unauthorized@pub.dev');
 final adminClientToken = createFakeAuthTokenForEmail('admin@pub.dev',
     audience: 'fake-client-audience');
-final siteAdminToken =
-    createFakeAuthTokenForEmail('admin@pub.dev', audience: 'https://pub.dev');
+final siteAdminToken = createFakeServiceAccountToken(email: 'admin@pub.dev');
 final userClientToken = createFakeAuthTokenForEmail('user@pub.dev',
     audience: 'fake-client-audience');
 

--- a/app/test/shared/test_services.dart
+++ b/app/test/shared/test_services.dart
@@ -231,6 +231,8 @@ void setupTestsWithCallerAuthorizationIssues(
   });
 }
 
+/// Creates generic test cases for admin API operations with failure expectations
+/// (e.g. missing or wrong authentication).
 void setupTestsWithAdminTokenIssues(Future Function(PubApiClient client) fn) {
   testWithProfile('No active user', fn: () async {
     final rs = fn(createPubApiClient());


### PR DESCRIPTION
- #6140
- Updated audit model entities to handle more cases of generic agents, and also adjusted integrity checks for them.
- Consent handling is still User-based, we are still creating `User` entity in Datastore. Filed #6187 to track its migration.
- Added fake token authentication for tests. Registering is restricted for local use only.
- Updated admin tests with new token edge cases.