### PR TITLE
Reject unexpected MIME types in api_builder.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ AppEngine version, listed here to ease deployment and troubleshooting.
  * Bumped runtimeVersion to `2022.11.10`.
  * Upgraded stable Flutter analysis SDK to `3.3.8`.
  * Upgraded dependencies.
+ * NOTE: `api_builder` rejects requests with unexpected mime types.
 
 ## `20221110t093400-all`
  * Bumped runtimeVersion to `2022.11.04`.

--- a/pkg/api_builder/lib/api_builder.dart
+++ b/pkg/api_builder/lib/api_builder.dart
@@ -97,12 +97,13 @@ abstract class $utilities {
     T Function(Map<String, dynamic>) fromJson,
   ) async {
     try {
-      // TODO: Consider enforcing that requests should have 'Content-Type' set to
-      // 'application/json'. Notice that we should be careful as the CLI client,
-      // might be sending a different Content-Type.
-      if (!_expectedJsonMimeTypes.contains(request.mimeType)) {
-        _log.info('Unexpected MIME type: ${request.mimeType}', request.mimeType,
-            StackTrace.current);
+      final mimeType = request.mimeType;
+      if (mimeType != null && !_expectedJsonMimeTypes.contains(mimeType)) {
+        throw ApiResponseException(
+          status: 400,
+          code: 'InvalidInput',
+          message: 'Unexpected `Content-Type` header: "$mimeType".',
+        );
       }
       final data = await request.readAsString();
       final value = json.decode(data);

--- a/pkg/pub_integration/lib/src/pub_http_client.dart
+++ b/pkg/pub_integration/lib/src/pub_http_client.dart
@@ -8,6 +8,10 @@ import 'dart:io';
 import 'package:_pub_shared/validation/html/html_validation.dart';
 import 'package:http/http.dart';
 
+const _jsonRequestHeaders = <String, String>{
+  'content-type': 'application/json; charset="utf-8"',
+};
+
 /// Simple pub client library.
 class PubHttpClient {
   final _http = _HtmlVerifierHttpClient(Client());
@@ -131,6 +135,7 @@ class PubHttpClient {
     final rs = await _http.post(
       _pubHostedUrl.resolve('/api/publishers/$publisherId'),
       headers: {
+        ..._jsonRequestHeaders,
         HttpHeaders.authorizationHeader: 'Bearer $authToken',
       },
       body: json.encode({
@@ -151,6 +156,7 @@ class PubHttpClient {
     final rs = await _http.put(
       _pubHostedUrl.resolve('/api/packages/$package/publisher'),
       headers: {
+        ..._jsonRequestHeaders,
         HttpHeaders.authorizationHeader: 'Bearer $authToken',
       },
       body: json.encode({
@@ -171,6 +177,7 @@ class PubHttpClient {
     final rs = await _http.post(
       _pubHostedUrl.resolve('/api/publishers/$publisherId/invite-member'),
       headers: {
+        ..._jsonRequestHeaders,
         HttpHeaders.authorizationHeader: 'Bearer $authToken',
       },
       body: json.encode({
@@ -190,6 +197,7 @@ class PubHttpClient {
     final rs = await _http.get(
       _pubHostedUrl.resolve('/api/publishers/$publisherId/members'),
       headers: {
+        ..._jsonRequestHeaders,
         HttpHeaders.authorizationHeader: 'Bearer $authToken',
       },
     );
@@ -237,6 +245,7 @@ class PubHttpClient {
     final rs = await _http.post(
       _pubHostedUrl.resolve('/api/packages/$packageName/invite-uploader'),
       headers: {
+        ..._jsonRequestHeaders,
         HttpHeaders.authorizationHeader: 'Bearer $accessToken',
       },
       body: json.encode({
@@ -258,6 +267,7 @@ class PubHttpClient {
     final rs = await _http.post(
       _pubHostedUrl.resolve('/api/packages/$packageName/remove-uploader'),
       headers: {
+        ..._jsonRequestHeaders,
         HttpHeaders.authorizationHeader: 'Bearer $accessToken',
       },
       body: json.encode({

--- a/pkg/pub_integration/test/pub_integration_test.dart
+++ b/pkg/pub_integration/test/pub_integration_test.dart
@@ -40,6 +40,7 @@ void main() {
           headers: {
             'Authorization':
                 'Bearer somebodyelse-at-example-dot-org?aud=fake-site-audience',
+            'content-type': 'application/json; charset="utf-8"',
           },
           body: json.encode({'granted': true}),
         );
@@ -54,6 +55,7 @@ void main() {
           headers: {
             'Authorization':
                 'Bearer dev-at-example-dot-org?aud=fake-site-audience',
+            'content-type': 'application/json; charset="utf-8"',
           },
           body: json.encode({'granted': true}),
         );

--- a/pkg/pub_integration/test/publisher_test.dart
+++ b/pkg/pub_integration/test/publisher_test.dart
@@ -41,6 +41,7 @@ void main() {
           headers: {
             'Authorization':
                 'Bearer somebodyelse-at-example-dot-org?aud=fake-site-audience',
+            'content-type': 'application/json; charset="utf-8"',
           },
           body: json.encode({'granted': true}),
         );
@@ -55,6 +56,7 @@ void main() {
           headers: {
             'Authorization':
                 'Bearer dev-at-example-dot-org?aud=fake-site-audience',
+            'content-type': 'application/json; charset="utf-8"',
           },
           body: json.encode({'granted': true}),
         );


### PR DESCRIPTION
- Fixes #6151.
- No unexpected MIME type has been logged in the past few days.