### PR TITLE
Tests for uploading with GitHub actions.

### DIFF
--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -1216,7 +1216,7 @@ class PackageBackend {
         repository.isEmpty ||
         repository != agent.payload.repository) {
       throw AuthorizationException.githubActionIssue(
-          'publishing is not enabled for the "${agent.payload.repository}" repository, it may be enabled for another repository.');
+          'publishing is not enabled for the "${agent.payload.repository}" repository, it may be enabled for another repository');
     }
 
     // TODO: consider allowing other events from

--- a/app/lib/service/openid/jwt.dart
+++ b/app/lib/service/openid/jwt.dart
@@ -129,6 +129,10 @@ class JsonWebToken {
     }
     return false;
   }
+
+  @visibleForTesting
+  String asEncodedString() =>
+      '$headerAndPayloadEncoded.${base64Url.encode(signature)}';
 }
 
 Map<String, dynamic> _decodePart(String part) {

--- a/app/lib/tool/test_profile/importer.dart
+++ b/app/lib/tool/test_profile/importer.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
 import 'package:_pub_shared/data/admin_api.dart';
 import 'package:_pub_shared/data/package_api.dart';
 import 'package:_pub_shared/data/publisher_api.dart';
@@ -78,7 +80,6 @@ Future<void> importProfile({
       bearerToken: createFakeAuthTokenForEmail(uploaderEmail,
           audience: activeConfiguration.pubClientAudience),
       pubHostedUrl: pubHostedUrl,
-      // ignore: invalid_use_of_visible_for_testing_member
       fn: (client) => client.uploadPackageBytes(bytes),
     );
   }


### PR DESCRIPTION
- #5769 
- Uses and checks JWT token internals. As a next step we could migrate the service account tokens to also use the JWT format.