### PR TITLE
Emit PackageRejectedException when automated agent is trying to publish first version.

### DIFF
--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -1304,7 +1304,7 @@ class PackageBackend {
     final existingEmails = emails.whereType<String>().toList();
     if (existingEmails.isEmpty) {
       // should not happen
-      throw StateError(
+      throw AssertionError(
           'Package "${package.name}" has no admin email to notify.');
     }
     return existingEmails;

--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -995,7 +995,7 @@ class PackageBackend {
     }
     if (uploaderEmails.isEmpty) {
       // should not happen
-      throw StateError(
+      throw AssertionError(
           'Package "${newVersion.package}" has no admin email to notify.');
     }
 

--- a/app/lib/shared/exceptions.dart
+++ b/app/lib/shared/exceptions.dart
@@ -262,6 +262,12 @@ class PackageRejectedException extends ResponseException {
       : super._(400, 'PackageRejected',
             'Uploads are restricted. Please try again later.');
 
+  /// The upload would create a new package, but the authenticated agent is an automated
+  /// account, not a user.
+  PackageRejectedException.onlyUsersAreAllowedToUploadNewPackages()
+      : super._(400, 'PackageRejected',
+            'Only users are allowed to upload new packages.');
+
   /// Check [condition] and throw [PackageRejectedException] with [message] if
   /// [condition] is `false`.
   static void check(bool condition, String message) {

--- a/app/test/package/upload_test.dart
+++ b/app/test/package/upload_test.dart
@@ -239,13 +239,11 @@ void main() {
         final bytes = await packageArchiveBytes(pubspecContent: pubspecContent);
         final rs =
             createPubApiClient(authToken: token).uploadPackageBytes(bytes);
-        // TODO: refactor upload to return better error message
         await expectApiException(
           rs,
-          status: 403,
-          code: 'InsufficientPermissions',
-          message:
-              'Insufficient permissions to perform administrative actions on package `new_package`.',
+          status: 400,
+          code: 'PackageRejected',
+          message: 'Only users are allowed to upload new packages.',
         );
       });
 
@@ -342,10 +340,9 @@ void main() {
         // TODO: refactor upload to return better error message
         await expectApiException(
           rs,
-          status: 403,
-          code: 'InsufficientPermissions',
-          message:
-              'Insufficient permissions to perform administrative actions on package `new_package`.',
+          status: 400,
+          code: 'PackageRejected',
+          message: 'Only users are allowed to upload new packages.',
         );
       });
 


### PR DESCRIPTION
- #5769
- Refactored `_listAdminNotificationEmailsForPackage`: separate check for package existence, making it explicit when agent is trying to publish a new package.
- Using `StateError` for the use case that shouldn't happen (inside and outside of `_listAdminNotificationEmailsForPackage`.