### PR TITLE
Simpler payload check + single audience verification in _tryAuthenticateServiceAgent.

### DIFF
--- a/app/lib/account/backend.dart
+++ b/app/lib/account/backend.dart
@@ -173,10 +173,11 @@ Future<AuthenticatedAgent?> _tryAuthenticateServiceAgent(String token) async {
   if (idToken == null) {
     return null;
   }
-  final audiences = idToken.payload.aud;
-  if (audiences.length != 1 ||
-      audiences.single != activeConfiguration.externalServiceAudience) {
-    return null;
+  if (idToken.payload.aud.length != 1 ||
+      idToken.payload.aud.single !=
+          activeConfiguration.externalServiceAudience) {
+    throw AssertionError(
+        'authProvider.tryAuthenticateAsServiceToken should not return a parsed token with audience missmatch.');
   }
 
   if (idToken.payload.iss == GitHubJwtPayload.issuerUrl) {

--- a/app/lib/account/backend.dart
+++ b/app/lib/account/backend.dart
@@ -15,7 +15,6 @@ import 'package:neat_cache/neat_cache.dart';
 
 import '../service/openid/gcp_openid.dart';
 import '../service/openid/github_openid.dart';
-import '../service/openid/jwt.dart';
 import '../shared/configuration.dart';
 import '../shared/datastore.dart';
 import '../shared/exceptions.dart';
@@ -174,31 +173,31 @@ Future<AuthenticatedAgent?> _tryAuthenticateServiceAgent(String token) async {
   if (idToken == null) {
     return null;
   }
-
-  Future<A> parseTokenPayload<A>(
-    A? Function(JwtPayload payload) payloadTryParse,
-  ) async {
-    final payload = payloadTryParse(idToken.payload);
-    if (payload == null) {
-      throw AuthenticationException.tokenInvalid('unable to parse payload');
-    }
-    return payload;
+  final audiences = idToken.payload.aud;
+  if (audiences.length != 1 ||
+      audiences.single != activeConfiguration.externalServiceAudience) {
+    return null;
   }
 
   if (idToken.payload.iss == GitHubJwtPayload.issuerUrl) {
+    final payload = GitHubJwtPayload.tryParse(idToken.payload);
+    if (payload == null) {
+      throw AuthenticationException.tokenInvalid('unable to parse payload');
+    }
     return AuthenticatedGithubAction(
       idToken: idToken,
-      payload: await parseTokenPayload(GitHubJwtPayload.tryParse),
+      payload: payload,
     );
   }
 
-  if (idToken.payload.iss == GcpServiceAccountJwtPayload.issuerUrl &&
-      idToken.payload.aud.length == 1 &&
-      idToken.payload.aud.single ==
-          activeConfiguration.externalServiceAudience) {
+  if (idToken.payload.iss == GcpServiceAccountJwtPayload.issuerUrl) {
+    final payload = GcpServiceAccountJwtPayload.tryParse(idToken.payload);
+    if (payload == null) {
+      throw AuthenticationException.tokenInvalid('unable to parse payload');
+    }
     return AuthenticatedGcpServiceAccount(
       idToken: idToken,
-      payload: await parseTokenPayload(GcpServiceAccountJwtPayload.tryParse),
+      payload: payload,
     );
   }
 

--- a/app/lib/account/default_auth_provider.dart
+++ b/app/lib/account/default_auth_provider.dart
@@ -58,11 +58,10 @@ class DefaultAuthProvider extends AuthProvider {
     }
 
     if (idToken.payload.iss == GcpServiceAccountJwtPayload.issuerUrl) {
-      // As the uploader token's audience and the admin token's issuer and also
-      // their audience is the same, we only parse it as a non-user token, when
-      // the authentication source is from the pub client app (e.g. uploading a
-      // new package).
-      // At this point we don't fall back to authenticating the token as a user.
+      // At this point we have confirmed that the token is a JWT token
+      // issued by GCP with the target audience of external services.
+      // If there is an issue with the token, the authentication should fail
+      // without any fallback (e.g. authenticating the token as a User).
 
       // TODO: use the tokeninfo endpoint instead
       await _verifyToken(idToken, openIdDataFetch: fetchGoogleCloudOpenIdData);

--- a/app/lib/account/default_auth_provider.dart
+++ b/app/lib/account/default_auth_provider.dart
@@ -44,6 +44,11 @@ class DefaultAuthProvider extends AuthProvider {
     if (idToken == null) {
       return null;
     }
+    final audiences = idToken.payload.aud;
+    if (audiences.length != 1 ||
+        audiences.single != activeConfiguration.externalServiceAudience) {
+      return null;
+    }
 
     if (idToken.payload.iss == GitHubJwtPayload.issuerUrl) {
       // At this point we have confirmed that the token is a JWT token
@@ -52,10 +57,7 @@ class DefaultAuthProvider extends AuthProvider {
       await _verifyToken(idToken, openIdDataFetch: fetchGithubOpenIdData);
     }
 
-    if (idToken.payload.iss == GcpServiceAccountJwtPayload.issuerUrl &&
-        idToken.payload.aud.length == 1 &&
-        idToken.payload.aud.single ==
-            activeConfiguration.externalServiceAudience) {
+    if (idToken.payload.iss == GcpServiceAccountJwtPayload.issuerUrl) {
       // As the uploader token's audience and the admin token's issuer and also
       // their audience is the same, we only parse it as a non-user token, when
       // the authentication source is from the pub client app (e.g. uploading a

--- a/app/lib/fake/backend/fake_auth_provider.dart
+++ b/app/lib/fake/backend/fake_auth_provider.dart
@@ -34,6 +34,11 @@ class FakeAuthProvider implements AuthProvider {
       if (parsed == null) {
         return null;
       }
+      final audiences = parsed.payload.aud;
+      if (audiences.length != 1 ||
+          audiences.single != activeConfiguration.externalServiceAudience) {
+        return null;
+      }
       // reject if signature is not 'valid'.
       if (base64.encode(parsed.signature) !=
           base64.encode(utf8.encode('valid'))) {


### PR DESCRIPTION
- removes `parseTokenPayload` as it doesn't add much value
- moves audience check into the auth provider(s) and keeps an assertion check in the caller