### PR TITLE
Supporting dart3-compatible badge and checkbox (behind experimental flag).

### DIFF
--- a/app/lib/frontend/handlers/experimental.dart
+++ b/app/lib/frontend/handlers/experimental.dart
@@ -10,6 +10,7 @@ const _publicFlags = <String>{
 
 const _allFlags = <String>{
   ..._publicFlags,
+  'dart3',
   'publishing',
   'signin',
   'sandbox',
@@ -42,6 +43,9 @@ class ExperimentalFlags {
   factory ExperimentalFlags.all() {
     return ExperimentalFlags._(_allFlags);
   }
+
+  /// Whether to show the "Dart 3 ready" badge or the search checkbox.
+  bool get showDart3ReadyOnUI => _enabled.contains('dart3');
 
   /// Whether to show the admin UI for automated publishing admin UI.
   bool get showAdminUIForAutomatedPublishing => _enabled.contains('publishing');

--- a/app/lib/frontend/templates/package_misc.dart
+++ b/app/lib/frontend/templates/package_misc.dart
@@ -37,6 +37,12 @@ d.Node nullSafeBadgeNode({String? title}) {
   );
 }
 
+/// Renders the Dart 3 ready badge.
+final dart3ReadyNode = packageBadgeNode(
+  label: 'Dart 3 ready',
+  title: 'Package is compatible with Dart 3.',
+);
+
 /// Renders the tags using the pkg/tags template.
 d.Node tagsNodeFromPackageView({
   required PackageView package,

--- a/app/lib/frontend/templates/views/pkg/index.dart
+++ b/app/lib/frontend/templates/views/pkg/index.dart
@@ -156,6 +156,16 @@ d.Node _searchFormContainer({
                   searchForm: searchForm,
                   title: 'Show only packages with screenshots.',
                 ),
+              if (requestContext.experimentalFlags.showDart3ReadyOnUI ||
+                  searchForm.parsedQuery.tagsPredicate
+                      .hasTag(PackageVersionTags.isDart3Ready))
+                _tagBasedCheckbox(
+                  tagPrefix: 'is',
+                  tagValue: 'dart3-ready',
+                  label: 'Dart 3 ready',
+                  searchForm: searchForm,
+                  title: 'Show only packages compatible with Dart 3.',
+                ),
             ],
           ),
         ],

--- a/app/lib/frontend/templates/views/pkg/package_list.dart
+++ b/app/lib/frontend/templates/views/pkg/package_list.dart
@@ -74,6 +74,8 @@ d.Node _packageItem(
 }) {
   final isFlutterFavorite = view.tags.contains(PackageTags.isFlutterFavorite);
   final isNullSafe = view.tags.contains(PackageVersionTags.isNullSafe);
+  final isDart3Ready = requestContext.experimentalFlags.showDart3ReadyOnUI &&
+      view.tags.contains(PackageVersionTags.isDart3Ready);
 
   Iterable<d.Node> versionAndTimestamp(
     Release release, {
@@ -128,7 +130,8 @@ d.Node _packageItem(
         child: licenseNode,
       ),
     if (isFlutterFavorite) flutterFavoriteBadgeNode,
-    if (isNullSafe) nullSafeBadgeNode(),
+    if (isNullSafe && !isDart3Ready) nullSafeBadgeNode(),
+    if (isDart3Ready) dart3ReadyNode,
   ]);
 
   final screenshots = view.screenshots;

--- a/pkg/_pub_shared/lib/search/search_form.dart
+++ b/pkg/_pub_shared/lib/search/search_form.dart
@@ -381,7 +381,8 @@ class SearchForm {
       parsedQuery.tagsPredicate.hasTag(PackageTags.isFlutterFavorite) ||
       parsedQuery.tagsPredicate.hasTag(PackageTags.showUnlisted) ||
       parsedQuery.tagsPredicate.hasTag(PackageVersionTags.isNullSafe) ||
-      parsedQuery.tagsPredicate.hasTag(PackageVersionTags.hasScreenshot);
+      parsedQuery.tagsPredicate.hasTag(PackageVersionTags.hasScreenshot) ||
+      parsedQuery.tagsPredicate.hasTag(PackageVersionTags.isDart3Ready);
 
   /// Whether any of the non-query settings are non-default
   /// (e.g. clicking on any platforms, SDKs, or advanced filters).

--- a/pkg/_pub_shared/lib/search/tags.dart
+++ b/pkg/_pub_shared/lib/search/tags.dart
@@ -70,6 +70,9 @@ abstract class PackageVersionTags {
 
   /// Package version has a screenshot that we can display.
   static const String hasScreenshot = 'has:screenshot';
+
+  /// Package version is compatible with Dart 3.
+  static const String isDart3Ready = 'is:dart3-ready';
 }
 
 /// Collection of SDK tags (with prefix and value).


### PR DESCRIPTION
- #6022
- #6023
- only displayed when the experimental flag is on