### PR TITLE
Refactor fake authentication to be much closer to the default authentication.

### DIFF
--- a/app/test/shared/test_models.dart
+++ b/app/test/shared/test_models.dart
@@ -44,14 +44,16 @@ final defaultTestProfile = TestProfile(
   ],
 );
 
-final adminAtPubDevAuthToken = createFakeAuthTokenForEmail('admin@pub.dev');
-final userAtPubDevAuthToken = createFakeAuthTokenForEmail('user@pub.dev');
-final unauthorizedAtPubDevAuthToken =
+String get adminAtPubDevAuthToken =>
+    createFakeAuthTokenForEmail('admin@pub.dev');
+String get userAtPubDevAuthToken => createFakeAuthTokenForEmail('user@pub.dev');
+String get unauthorizedAtPubDevAuthToken =>
     createFakeAuthTokenForEmail('unauthorized@pub.dev');
-final adminClientToken = createFakeAuthTokenForEmail('admin@pub.dev',
+String get adminClientToken => createFakeAuthTokenForEmail('admin@pub.dev',
     audience: 'fake-client-audience');
-final siteAdminToken = createFakeServiceAccountToken(email: 'admin@pub.dev');
-final userClientToken = createFakeAuthTokenForEmail('user@pub.dev',
+String get siteAdminToken =>
+    createFakeServiceAccountToken(email: 'admin@pub.dev');
+String get userClientToken => createFakeAuthTokenForEmail('user@pub.dev',
     audience: 'fake-client-audience');
 
 final String foobarReadmeContent = '''

--- a/app/test/shared/test_services.dart
+++ b/app/test/shared/test_services.dart
@@ -267,8 +267,8 @@ void setupTestsWithAdminTokenIssues(Future Function(PubApiClient client) fn) {
   });
 
   testWithProfile('Non-admin service agent token', fn: () async {
-    final token =
-        'gcp-service-account?email=unauthorized@pub.dev&aud=https://pub.dev';
+    final token = createFakeServiceAccountToken(
+        email: 'unauthorized@pub.dev', audience: 'https://pub.dev');
     final rs = fn(createPubApiClient(authToken: token));
     await expectApiException(rs, status: 403, code: 'InsufficientPermissions');
   });


### PR DESCRIPTION
- `BaseAuthProvider` contains the main logic, without the API calls, HTTP calls or `openssl` executions.
- `DefaultAuthProvider` implements the real calls, `FakeAuthProvider` implements in-memory responses with deterministic IDs.
- kept the `user-at-domain-dot-com?audience=fake-site-audience` pattern for simpler entry in the local fake server, but it is transformed into a GCP-like token inside `FakeAuthProvider`
