### PR TITLE
Extend Consent model to include oauthUserId and email of the inviting User.

### DIFF
--- a/app/lib/account/consent_backend.dart
+++ b/app/lib/account/consent_backend.dart
@@ -388,7 +388,7 @@ class _PackageUploaderAction extends ConsentAction {
     required List<String> args,
   }) {
     final packageName = args[0];
-    return '`$fromEmail` has invited you to be an uploader of the package $packageName.';
+    return '$fromEmail has invited you to be an uploader of the package $packageName.';
   }
 
   @override
@@ -462,7 +462,7 @@ class _PublisherContactAction extends ConsentAction {
   }) {
     final publisherId = args[0];
     final contactEmail = args[1];
-    return '`$fromEmail` has requested to use `$contactEmail` as the '
+    return '$fromEmail has requested to use `$contactEmail` as the '
         'contact email of the verified publisher $publisherId.';
   }
 
@@ -532,7 +532,7 @@ class _PublisherMemberAction extends ConsentAction {
     required List<String> args,
   }) {
     final publisherId = args[0];
-    return '`$fromEmail` has invited you to be a member of the verified publisher $publisherId.';
+    return '$fromEmail has invited you to be a member of the verified publisher $publisherId.';
   }
 
   @override

--- a/app/lib/account/models.dart
+++ b/app/lib/account/models.dart
@@ -270,6 +270,12 @@ class Consent extends db.Model {
   @db.StringProperty()
   String? fromUserId;
 
+  @db.StringProperty()
+  String? fromOAuthUserId;
+
+  @db.StringProperty()
+  String? fromEmail;
+
   @db.DateTimeProperty()
   DateTime? created;
 
@@ -286,6 +292,8 @@ class Consent extends db.Model {
 
   Consent.init({
     required this.fromUserId,
+    required this.fromOAuthUserId,
+    required this.fromEmail,
     required this.email,
     required this.kind,
     required this.args,

--- a/app/test/publisher/api_test.dart
+++ b/app/test/publisher/api_test.dart
@@ -393,6 +393,8 @@ void main() {
         );
         final consent = Consent.init(
           fromUserId: adminUser.userId,
+          fromOAuthUserId: adminUser.oauthUserId,
+          fromEmail: adminUser.email,
           email: 'other@pub.dev',
           kind: 'PublisherMember',
           args: ['example.com'],

--- a/app/test/shared/user_merger_test.dart
+++ b/app/test/shared/user_merger_test.dart
@@ -94,14 +94,29 @@ void main() {
     );
 
     final target1 = Consent.init(
-        email: admin.email, kind: 'k1', args: ['1'], fromUserId: user.userId);
+      email: admin.email,
+      kind: 'k1',
+      args: ['1'],
+      fromUserId: user.userId,
+      fromOAuthUserId: user.oauthUserId,
+      fromEmail: user.email,
+    );
     final target2 = Consent.init(
-        email: user.email, kind: 'k2', args: ['2'], fromUserId: admin.userId);
+      email: user.email,
+      kind: 'k2',
+      args: ['2'],
+      fromUserId: admin.userId,
+      fromOAuthUserId: admin.oauthUserId,
+      fromEmail: admin.email,
+    );
     final controlConsent = Consent.init(
-        email: control.email,
-        kind: 'k3',
-        args: ['3'],
-        fromUserId: control.userId);
+      email: control.email,
+      kind: 'k3',
+      args: ['3'],
+      fromUserId: control.userId,
+      fromOAuthUserId: control.oauthUserId,
+      fromEmail: control.email,
+    );
     await dbService.commit(inserts: [target1, target2, controlConsent]);
 
     await _corruptAndFix();


### PR DESCRIPTION
- #6187
- New fields on the `Consent` model: `fromEmail` to reduce the need to lookup the email, `fromOAuthUserId` to eventually replace the `fromUserId` field.
- updated model rendering methods for better named parameter