### PR TITLE
Allow including Dart 3 in upper constraint

### DIFF
--- a/pkg/pub_package_reader/lib/pub_package_reader.dart
+++ b/pkg/pub_package_reader/lib/pub_package_reader.dart
@@ -439,8 +439,8 @@ Iterable<ArchiveIssue> checkStrictVersions(Pubspec pubspec) sync* {
           'Version value `$v` does not follow strict version pattern.'));
 }
 
-final _preDart3 = VersionConstraint.parse('<3.0.0');
-final _firstDart3Pre = Version.parse('3.0.0').firstPreRelease;
+final _preDart4 = VersionConstraint.parse('<4.0.0');
+final _firstDart4Pre = Version.parse('4.0.0').firstPreRelease;
 
 /// Checks if the version range is acceptable by current SDKs.
 Iterable<ArchiveIssue> checkSdkVersionRange(Pubspec pubspec) sync* {
@@ -458,14 +458,14 @@ Iterable<ArchiveIssue> checkSdkVersionRange(Pubspec pubspec) sync* {
   }
 
   // No known version exists.
-  if (sdk.intersect(_preDart3).isEmpty) {
+  if (sdk.intersect(_preDart4).isEmpty) {
     yield ArchiveIssue('SDK constraint does not allow any known Dart SDK.');
   }
 
   // Dart 3 version accepted with valid upper constraint.
-  if (sdk.allows(_firstDart3Pre)) {
+  if (sdk.allows(_firstDart4Pre)) {
     yield ArchiveIssue(
-        'The SDK constraint allows Dart 3.0.0, this is not allowed because Dart 3 does not exist.');
+        'The SDK constraint allows Dart 4.0.0, this is not allowed because Dart 4 does not exist.');
   }
 }
 

--- a/pkg/pub_package_reader/test/package_archive_test.dart
+++ b/pkg/pub_package_reader/test/package_archive_test.dart
@@ -143,6 +143,8 @@ void main() {
       isAccepted('>=2.0.0 <3.0.0');
       isAccepted('>=2.0.0 <3.0.0-0');
       isAccepted('>=2.2.0 <2.11.0');
+      isAccepted('>=2.12.0 <4.0.0');
+      isAccepted('>=3.0.0 <4.0.0');
     });
 
     test('rejected ranges', () {
@@ -162,14 +164,15 @@ void main() {
       isRejected('>=0.0.0');
       isRejected('>=1.0.0');
       isRejected('>=2.0.0');
-      isRejected('<3.0.0');
-      isRejected('<3.0.0-0');
-      isRejected('>=2.12.0 <3.0.1');
-      isRejected('>=3.0.0');
-      isRejected('>=3.0.0-0');
-      isRejected('>=3.0.0 <4.0.0');
+      isRejected('<4.0.0');
+      isRejected('<4.0.0-0');
+      isRejected('>=2.12.0 <4.0.1');
+      isRejected('>=3.0.0 <4.0.1');
       isRejected('>=4.0.0');
+      isRejected('>=4.0.0-0');
       isRejected('>=4.0.0 <5.0.0');
+      isRejected('>=5.0.0');
+      isRejected('>=5.0.0 <6.0.0');
     });
   });
 


### PR DESCRIPTION
Currently attempting to publishing packages (`dart pub publish`) with an upper constraint of `<4.0.0` gets the following error:

```
The SDK constraint allows Dart 3.0.0, this is not allowed because Dart 3 does not exist.
```

Now that the [Flutter templates use `<4.0.0`](https://github.com/flutter/flutter/commit/91568cc9b746046e86436e0ab96bb7df837c5c3f) and `dart create` [does so now too](https://github.com/dart-lang/sdk/commit/e3ab2fc4bd329c03769c327b41a4391edcf2b5c5), it seems to make sense to remove this limitation.

I'm not super familiar with pub though, so not sure if other changes are needed first related to package analysis. Feel free to close this PR if it isn't sufficient. Thanks!

\cc @mit-mit 