### PR TITLE
Purge package cache before retrying package analysis.

### DIFF
--- a/app/lib/analyzer/pana_runner.dart
+++ b/app/lib/analyzer/pana_runner.dart
@@ -10,6 +10,7 @@ import 'dart:typed_data';
 import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
 import 'package:pana/pana.dart' hide ReportStatus;
+import 'package:pub_dev/package/backend.dart';
 import 'package:pub_dev/package/screenshots/backend.dart';
 
 import '../job/job.dart';
@@ -164,6 +165,9 @@ class AnalyzerJobProcessor extends JobProcessor {
     Summary? summary = await analyze();
     if (summary?.report == null) {
       _logger.info('Retrying $job...');
+      // Purge package cache in case the latest version hasn't been included in the versions API.
+      await purgePackageCache(job.packageName!);
+      // A short pause to make sure the transient issues go away.
       await Future.delayed(Duration(seconds: 15));
       summary = await analyze();
     }

--- a/pkg/pub_worker/lib/src/bin/pana_wrapper.dart
+++ b/pkg/pub_worker/lib/src/bin/pana_wrapper.dart
@@ -87,6 +87,8 @@ Future<void> main(List<String> args) async {
   final resourcesOutputDir =
       await Directory(p.join(outputFolder, 'resources')).create();
   final pana = PackageAnalyzer(toolEnv);
+  // TODO: add a cache purge + retry if the download would fail
+  //       (e.g. the package version cache wasn't invalidated).
   final summary = await pana.inspectPackage(
     package,
     version: version,


### PR DESCRIPTION
- An alternative workaround for https://github.com/dart-lang/pana/issues/1165 instead of https://github.com/dart-lang/pana/pull/1174. 
- The first pass on the analysis may fail due to version caching, but on retry (and only on retry) we invalidate the package cache, forcing the cached versions list to be repopulated before the 10-minute cache invalidation would happen automatically. 