### PR TITLE
Enable automated publishing for internal packages.

### DIFF
--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -1321,8 +1321,9 @@ class PackageBackend {
       }
     }
 
-    // Disable publishing for all packages, but exempt one for live testing.
-    if (package.name == '_dummy_pkg') {
+    // Disable publishing for all packages, but exempt the test + internal ones for live testing.
+    if (package.name == '_dummy_pkg' ||
+        isDartDevPublisher(package.publisherId)) {
       return;
     }
     throw PackageRejectedException(
@@ -1368,6 +1369,11 @@ class PackageBackend {
       }
     }
 
+    // Disable publishing for all packages, but exempt the test + internal ones for live testing.
+    if (package.name == '_dummy_pkg' ||
+        isDartDevPublisher(package.publisherId)) {
+      return;
+    }
     throw PackageRejectedException(
         'Google Cloud Service account recognized successful, but publishing is not enabled yet.');
   }


### PR DESCRIPTION
- #5769
- Both GitHub Actions and GCP service account is enabled for the test and the internal packages.
