### PR TITLE
Explicit/expanded JWT timestamp checks and also iat <= nbf.

### DIFF
--- a/app/lib/service/openid/jwt.dart
+++ b/app/lib/service/openid/jwt.dart
@@ -228,17 +228,38 @@ class JwtPayload extends UnmodifiableMapView<String, dynamic> {
   }) {
     now ??= clock.now();
 
-    bool isABeforeB(String name, DateTime? a, DateTime? b) {
-      if (a == null || b == null) {
-        _logger.info('JWT does not have "$name" field.');
-        return false;
-      }
-      return a.isBefore(b.add(threshold)) || a == b;
+    // JWT must have iat field, and it must be in the past.
+    if (iat == null) {
+      _logger.info('JWT does not have "iat" field.');
+      return false;
+    }
+    if (now.add(threshold).isBefore(iat!)) {
+      _logger.info('JWT "iat" field is in the future.');
+      return false;
     }
 
-    return isABeforeB('iat', iat, now) &&
-        // allows `nbf` to be null
-        (nbf == null || isABeforeB('nbf', nbf, now)) &&
-        isABeforeB('exp', now, exp);
+    // JWT must have and exp field, and it must be in the future.
+    if (exp == null) {
+      _logger.info('JWT does not have "exp" field.');
+      return false;
+    }
+    if (exp!.add(threshold).isBefore(now)) {
+      _logger.info('JWT "exp" field is in the past.');
+      return false;
+    }
+
+    // JWT may have nbf field, and if it has:
+    // - it must be in the past,
+    // - it must be on or after the iat timestamp.
+    if (nbf != null && now.add(threshold).isBefore(nbf!)) {
+      _logger.info('JWT "nbf" field is in the future.');
+      return false;
+    }
+    if (nbf != null && iat!.isAfter(nbf!)) {
+      _logger.info('JWT "nbf" field is before "iat".');
+      return false;
+    }
+
+    return true;
   }
 }

--- a/app/lib/service/openid/jwt.dart
+++ b/app/lib/service/openid/jwt.dart
@@ -248,15 +248,9 @@ class JwtPayload extends UnmodifiableMapView<String, dynamic> {
       return false;
     }
 
-    // JWT may have nbf field, and if it has:
-    // - it must be in the past,
-    // - it must be on or after the iat timestamp.
+    // JWT may have nbf field, and if it has, it must be in the past.
     if (nbf != null && now.add(threshold).isBefore(nbf!)) {
       _logger.info('JWT "nbf" field is in the future.');
-      return false;
-    }
-    if (nbf != null && iat!.isAfter(nbf!)) {
-      _logger.info('JWT "nbf" field is before "iat".');
       return false;
     }
 

--- a/app/test/service/openid/jwt_test.dart
+++ b/app/test/service/openid/jwt_test.dart
@@ -145,17 +145,6 @@ void main() {
       );
     });
 
-    test('nbf before iat', () {
-      expect(
-        createPayload(
-          iat: clock.now().subtract(Duration(hours: 2)),
-          nbf: clock.now().subtract(Duration(hours: 3)),
-          exp: clock.now().add(Duration(hours: 2)),
-        ).isTimely(),
-        false,
-      );
-    });
-
     test('valid (with nbf)', () {
       expect(
         createPayload(

--- a/app/test/service/openid/jwt_test.dart
+++ b/app/test/service/openid/jwt_test.dart
@@ -61,10 +61,6 @@ void main() {
       expect(parsed.signature, hasLength(256));
     });
 
-    test('iat missing', () {
-      expect(JwtPayload({'iat': '1', 'exp': '2'}).isTimely(), isFalse);
-    });
-
     test('verify signature', () async {
       final headerAndPayloadEncoded = jwtIoToken.split('.').take(2).join('.');
       final parsed = JsonWebToken.parse(jwtIoToken);


### PR DESCRIPTION
- Fixes #6233.
- Added `iat <= nbf` verification (when `nbf` exists).
- Added test cases for each check.