### PR TITLE
Fix search's name index: do not broaden the results on multiple words.

### DIFF
--- a/app/lib/search/token_index.dart
+++ b/app/lib/search/token_index.dart
@@ -32,11 +32,11 @@ class Score {
     if (scores.isEmpty) {
       return Score.empty();
     }
-    if (scores.any((score) => score.isEmpty)) {
-      return Score.empty();
-    }
     if (scores.length == 1) {
       return scores.single;
+    }
+    if (scores.any((score) => score.isEmpty)) {
+      return Score.empty();
     }
     var keys = scores.first.getValues().keys.toSet();
     for (var i = 1; i < scores.length; i++) {

--- a/app/test/search/angular_test.dart
+++ b/app/test/search/angular_test.dart
@@ -38,10 +38,7 @@ void main() {
         'sdkLibraryHits': [],
         'packageHits': [
           {'package': 'angular', 'score': 1.0},
-          {
-            'package': 'angular_ui',
-            'score': closeTo(0.95, 0.01),
-          },
+          {'package': 'angular_ui', 'score': 1.0},
         ],
       });
     });

--- a/app/test/search/flutter_95_test.dart
+++ b/app/test/search/flutter_95_test.dart
@@ -22,6 +22,7 @@ void main() {
         description: compactDescription(
             'Windows95 UI components for Flutter apps. Bring back the nostalgic look and feel of old operating systems with this set of UI components ready to use.'),
       ));
+      await index.addPackage(PackageDocument(package: 'flutter_charts'));
       await index.markReady();
     });
 
@@ -38,6 +39,7 @@ void main() {
             'package': 'flutter95',
             'score': 1.0,
           },
+          // flutter_charts must not show up here
         ],
       });
     });

--- a/app/test/search/flutter_iap_test.dart
+++ b/app/test/search/flutter_iap_test.dart
@@ -54,28 +54,12 @@ void main() {
               query: 'flutter iap', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
         'timestamp': isNotNull,
-        'totalCount': 5,
+        'totalCount': 1,
         'sdkLibraryHits': [],
         'packageHits': [
           {
             'package': 'flutter_iap',
             'score': 1.0,
-          },
-          {
-            'package': 'flutter_blue',
-            'score': closeTo(0.82, 0.01),
-          },
-          {
-            'package': 'flutter_redux',
-            'score': closeTo(0.81, 0.01),
-          },
-          {
-            'package': 'flutter_3d_obj',
-            'score': closeTo(0.81, 0.01),
-          },
-          {
-            'package': 'flutter_web_view',
-            'score': closeTo(0.78, 0.01),
           },
         ],
       });
@@ -87,26 +71,10 @@ void main() {
               query: 'flutter_iap', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
         'timestamp': isNotNull,
-        'totalCount': 5,
+        'totalCount': 1,
         'sdkLibraryHits': [],
         'packageHits': [
           {'package': 'flutter_iap', 'score': 1.0},
-          {
-            'package': 'flutter_blue',
-            'score': closeTo(0.82, 0.01),
-          },
-          {
-            'package': 'flutter_redux',
-            'score': closeTo(0.81, 0.01),
-          },
-          {
-            'package': 'flutter_3d_obj',
-            'score': closeTo(0.81, 0.01),
-          },
-          {
-            'package': 'flutter_web_view',
-            'score': closeTo(0.78, 0.01),
-          },
         ],
       });
     });

--- a/app/test/search/in_app_payments_test.dart
+++ b/app/test/search/in_app_payments_test.dart
@@ -53,7 +53,7 @@ Add _In-App Payments_ to your Flutter app with this plugin.''')));
         'packageHits': [
           {
             'package': 'flutter_iap',
-            'score': closeTo(0.41, 0.01),
+            'score': closeTo(0.57, 0.01),
           },
         ],
       });

--- a/app/test/search/json_tool_test.dart
+++ b/app/test/search/json_tool_test.dart
@@ -27,12 +27,10 @@ void main() {
               query: 'json_tool', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
         'timestamp': isNotNull,
-        'totalCount': 3,
+        'totalCount': 1,
         'sdkLibraryHits': [],
         'packageHits': [
           {'package': 'jsontool', 'score': 1.0},
-          {'package': 'json2entity', 'score': closeTo(0.59, 0.01)},
-          {'package': 'json_to_model', 'score': closeTo(0.59, 0.01)},
         ],
       });
     });
@@ -73,8 +71,8 @@ void main() {
         'sdkLibraryHits': [],
         'packageHits': [
           {'package': 'jsontool', 'score': 1.0},
-          {'package': 'json2entity', 'score': closeTo(0.79, 0.01)},
-          {'package': 'json_to_model', 'score': closeTo(0.59, 0.01)},
+          {'package': 'json2entity', 'score': closeTo(0.87, 0.01)},
+          {'package': 'json_to_model', 'score': closeTo(0.73, 0.01)},
         ],
       });
     });

--- a/app/test/search/lombok_test.dart
+++ b/app/test/search/lombok_test.dart
@@ -32,7 +32,7 @@ void main() {
         'packageHits': [
           {
             'package': 'lombok',
-            'score': closeTo(0.64, 0.01),
+            'score': closeTo(0.60, 0.01),
           },
         ],
       });

--- a/app/test/search/mem_index_test.dart
+++ b/app/test/search/mem_index_test.dart
@@ -156,7 +156,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'packageHits': [
           {
             'package': 'chrome_net',
-            'score': closeTo(0.25, 0.01),
+            'score': closeTo(0.33, 0.01),
           },
         ],
       });
@@ -210,7 +210,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'totalCount': 1,
         'sdkLibraryHits': [],
         'packageHits': [
-          {'package': 'async', 'score': closeTo(0.26, 0.01)},
+          {'package': 'async', 'score': closeTo(0.24, 0.01)},
         ],
       });
     });
@@ -236,13 +236,11 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
           ServiceSearchQuery.parse(query: 't', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
         'timestamp': isNotNull,
-        'totalCount': 1,
+        'totalCount': 2,
         'sdkLibraryHits': [],
         'packageHits': [
-          {
-            'package': 'http',
-            'score': closeTo(0.78, 0.01),
-          },
+          {'package': 'http', 'score': 1},
+          {'package': 'chrome_net', 'score': 1},
         ],
       });
     });
@@ -528,7 +526,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'totalCount': 1,
         'sdkLibraryHits': [],
         'packageHits': [
-          {'package': 'http', 'score': closeTo(0.88, 0.01)},
+          {'package': 'http', 'score': closeTo(0.87, 0.01)},
         ],
       });
 
@@ -555,7 +553,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'totalCount': 1,
         'sdkLibraryHits': [],
         'packageHits': [
-          {'package': 'http', 'score': closeTo(0.54, 0.01)},
+          {'package': 'http', 'score': closeTo(0.63, 0.01)},
         ],
       });
     });
@@ -607,13 +605,13 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
           ServiceSearchQuery.parse(query: 'app', order: SearchOrder.text));
       expect(match.packageHits.map((e) => e.toJson()), [
         {'package': 'app', 'score': 1.0},
-        {'package': 'appz', 'score': closeTo(0.95, 0.01)},
+        {'package': 'appz', 'score': 1.0},
       ]);
       final match2 = await index.search(
           ServiceSearchQuery.parse(query: 'appz', order: SearchOrder.text));
       expect(match2.packageHits.map((e) => e.toJson()), [
         {'package': 'appz', 'score': 1.0},
-        {'package': 'app', 'score': closeTo(0.62, 0.01)},
+        {'package': 'app', 'score': closeTo(0.5, 0.01)},
       ]);
     });
 
@@ -705,8 +703,8 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
           'totalCount': 2,
           'sdkLibraryHits': [],
           'packageHits': [
+            {'package': 'flutter_modular', 'score': 1.0},
             {'package': 'serveme', 'score': closeTo(0.87, 0.01)},
-            {'package': 'flutter_modular', 'score': closeTo(0.86, 0.01)},
           ]
         },
       );

--- a/app/test/search/package_name_index_test.dart
+++ b/app/test/search/package_name_index_test.dart
@@ -22,7 +22,7 @@ void main() {
         index.search('fluent').getValues(),
         {
           'fluent': 1.0,
-          'fluent_ui': closeTo(0.95, 0.01),
+          'fluent_ui': 1.0,
         },
       );
     });
@@ -32,14 +32,13 @@ void main() {
         index.search('get').getValues(),
         {
           'get': 1.0,
-          'get_it': closeTo(0.90, 0.01),
+          'get_it': 1.0,
         },
       );
     });
 
     test('get_it', () {
       expect(index.search('get_it').getValues(), {
-        'get': closeTo(0.78, 0.01),
         'get_it': 1.0,
       });
     });
@@ -49,7 +48,7 @@ void main() {
         index.search('modular').getValues(),
         {
           'modular': 1.0,
-          'modular_flutter': closeTo(0.86, 0.01),
+          'modular_flutter': 1.0,
         },
       );
     });
@@ -57,21 +56,14 @@ void main() {
     test('mixed parts: fluent it', () {
       expect(
         index.search('fluent it').getValues(),
-        {
-          'fluent': closeTo(0.88, 0.01),
-          'fluent_ui': closeTo(0.84, 0.01),
-        },
+        {},
       );
     });
 
     test('mixed parts: fluent flutter', () {
       expect(
         index.search('fluent flutter').getValues(),
-        {
-          'fluent': closeTo(0.67, 0.01),
-          'fluent_ui': closeTo(0.65, 0.01),
-          'modular_flutter': closeTo(0.68, 0.01),
-        },
+        {},
       );
     });
 
@@ -79,7 +71,9 @@ void main() {
       expect(
         index.search('f').getValues(),
         {
-          'fluent': closeTo(0.55, 0.01),
+          'fluent': 1.0,
+          'fluent_ui': 1.0,
+          'modular_flutter': 1.0,
         },
       );
     });
@@ -88,8 +82,9 @@ void main() {
       expect(
         index.search('fl').getValues(),
         {
-          'fluent': closeTo(0.75, 0.01),
-          'fluent_ui': closeTo(0.67, 0.01),
+          'fluent': 1.0,
+          'fluent_ui': 1.0,
+          'modular_flutter': 1.0,
         },
       );
     });
@@ -98,9 +93,9 @@ void main() {
       expect(
         index.search('flu').getValues(),
         {
-          'fluent': closeTo(0.86, 0.01),
-          'fluent_ui': closeTo(0.78, 0.01),
-          'modular_flutter': closeTo(0.62, 0.01),
+          'fluent': 1.0,
+          'fluent_ui': 1.0,
+          'modular_flutter': 1.0,
         },
       );
     });
@@ -108,9 +103,7 @@ void main() {
     test('prefix: fluf', () {
       expect(
         index.search('fluf').getValues(),
-        {
-          'fluent': closeTo(0.50, 0.01),
-        },
+        {'fluent': 0.5, 'fluent_ui': 0.5, 'modular_flutter': 0.5},
       );
     });
 

--- a/app/test/search/rest_api_test.dart
+++ b/app/test/search/rest_api_test.dart
@@ -57,11 +57,11 @@ Recent versions (0.3.x and 0.4.x) of this plugin require [extensible codec funct
         'packageHits': [
           {
             'package': 'currency_cloud',
-            'score': closeTo(0.79, 0.01),
+            'score': closeTo(0.77, 0.01),
           },
           {
             'package': 'cloud_firestore', // finds `rest` in name
-            'score': closeTo(0.62, 0.01),
+            'score': closeTo(0.72, 0.01),
           },
         ],
       });


### PR DESCRIPTION
- Fixes the bad search experience where count_of_hits('$a') was less than count_of_hits('$a $b') (e.g. "charts" vs "flutter charts").
- The main change is to evaluate each query term word separately, joining first on a document-level, and then getting the multiply at the query level.
- The name index is rewritten to get an optimized calculation of this method, the regular index is kept as-is for now, there would be a follow-up to also have a similar optimization.