### PR TITLE
Log admin when creating publisher

### DIFF
--- a/app/lib/admin/tools/create_publisher.dart
+++ b/app/lib/admin/tools/create_publisher.dart
@@ -48,6 +48,7 @@ Future<String> executeCreatePublisher(List<String> args) async {
   if (admins.length > 1) {
     return 'ERROR: more than one user: $adminEmail';
   }
+  final admin = admins.single;
 
   // Create the publisher
   final now = clock.now().toUtc();
@@ -83,7 +84,7 @@ Future<String> executeCreatePublisher(List<String> args) async {
         ..updated = now
         ..role = PublisherMemberRole.admin,
       AuditLogRecord.publisherCreated(
-        user: user,
+        user: admin,
         publisherId: publisherId,
       ),
     ]);


### PR DESCRIPTION
When reviewing the code, I saw that the admin option wasn't used. Shouldn't this be used to log who's creating the publisher?