### PR TITLE
Strengthen/consistent consent-approval flow + tests.

### DIFF
--- a/app/lib/account/consent_backend.dart
+++ b/app/lib/account/consent_backend.dart
@@ -192,6 +192,7 @@ class ConsentBackend {
     required User activeUser,
     required String publisherId,
     required String invitedUserEmail,
+    bool createdBySiteAdmin = false,
   }) async {
     return await _invite(
       activeUser: activeUser,
@@ -203,7 +204,7 @@ class ConsentBackend {
         publisherId: publisherId,
         memberEmail: invitedUserEmail,
       ),
-      createdBySiteAdmin: false,
+      createdBySiteAdmin: createdBySiteAdmin,
     );
   }
 
@@ -400,7 +401,11 @@ class _PublisherContactAction extends ConsentAction {
     final publisherId = consent.args![0];
     final contactEmail = consent.args![1];
     await publisherBackend.updateContactWithVerifiedEmail(
-        publisherId, contactEmail);
+      publisherId,
+      contactEmail,
+      consentRequestFromUserId: consent.fromUserId!,
+      consentRequestCreatedBySiteAdmin: consent.createdBySiteAdmin ?? false,
+    );
   }
 
   @override
@@ -476,7 +481,11 @@ class _PublisherMemberAction extends ConsentAction {
       throw NotAcceptableException('Consent is not for the current user.');
     }
     await publisherBackend.inviteConsentGranted(
-        publisherId, currentUser.userId);
+      publisherId,
+      currentUser.userId,
+      consentRequestFromUserId: consent.fromUserId!,
+      consentRequestCreatedBySiteAdmin: consent.createdBySiteAdmin ?? false,
+    );
   }
 
   @override

--- a/app/lib/admin/tools/publisher_member.dart
+++ b/app/lib/admin/tools/publisher_member.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 
 import 'package:_pub_shared/data/publisher_api.dart';
 import 'package:pub_dev/account/backend.dart';
+import 'package:pub_dev/account/consent_backend.dart';
 import 'package:pub_dev/publisher/backend.dart';
 import 'package:pub_dev/shared/configuration.dart';
 
@@ -31,11 +32,15 @@ Future<String> executePublisherInviteMember(List<String> args) async {
 
   final authenticatedAgent =
       await requireAuthenticatedAdmin(AdminPermission.executeTool);
-  await publisherBackend.doInvitePublisherMember(
-    authenticatedAgent,
-    (await accountBackend.userForServiceAccount(authenticatedAgent))!,
-    publisherId,
-    InviteMemberRequest(email: invitedEmail),
+  await publisherBackend.verifyPublisherMemberInvite(
+      publisherId, InviteMemberRequest(email: invitedEmail));
+  await consentBackend.invitePublisherMember(
+    authenticatedAgent: authenticatedAgent,
+    activeUser:
+        (await accountBackend.userForServiceAccount(authenticatedAgent))!,
+    publisherId: publisherId,
+    invitedUserEmail: invitedEmail,
+    createdBySiteAdmin: true,
   );
 
   return '$invitedEmail has been invited.';


### PR DESCRIPTION
- Publisher admin checks (when accepting the invite) for contact and member invites.
- Added further tests.
- Part of the #6187 cleanup.