### PR TITLE
Fix tests and CI

### DIFF
--- a/.github/workflows/weekly-tests.yml
+++ b/.github/workflows/weekly-tests.yml
@@ -20,5 +20,5 @@ jobs:
         run: dart pub get
         working-directory: app
       - name: Run test
-        run: dart test -P sanity
+        run: dart test -P sanity -t sanity
         working-directory: app

--- a/app/dart_test.yaml
+++ b/app/dart_test.yaml
@@ -12,5 +12,5 @@ tags:
   sanity:
     skip: 'Run sanity-check tests manually with `pub test -P sanity`.'
     presets:
-      fragile:
+      sanity:
         skip: false # Don't skip these tests.

--- a/app/test/tool/utils/uploader_count_report_test.dart
+++ b/app/test/tool/utils/uploader_count_report_test.dart
@@ -20,15 +20,14 @@ class UserAndTime {
 }
 
 void main() {
-  withClock(Clock.fixed(DateTime(2022, 12, 13)), () {
-    testWithProfile('uploader count report',
-        testProfile: TestProfile.fromJson(
-            {'defaultUser': 'user@domain.com', 'packages': []}), fn: () async {
-      Future<void> uploadAtTime(UserAndTime userAndTime, int cnt) async {
-        await withClock(Clock.fixed(userAndTime.publishingTime), () async {
-          final token = createFakeAuthTokenForEmail(userAndTime.uploaderEmail,
-              audience: 'fake-client-audience');
-          final pubspecContent = '''
+  testWithProfile('uploader count report',
+      testProfile: TestProfile.fromJson(
+          {'defaultUser': 'user@domain.com', 'packages': []}), fn: () async {
+    Future<void> uploadAtTime(UserAndTime userAndTime, int cnt) async {
+      await withClock(Clock.fixed(userAndTime.publishingTime), () async {
+        final token = createFakeAuthTokenForEmail(userAndTime.uploaderEmail,
+            audience: 'fake-client-audience');
+        final pubspecContent = '''
 name: 'new_package_$cnt'
 version: '1.2.$cnt'
 author: 'Hans Juergen <hans@juergen.com>'
@@ -36,28 +35,29 @@ description: 'my package description'
 environment:
   sdk: '>=2.10.0 <3.0.0'
 ''';
-          await createPubApiClient(authToken: token).uploadPackageBytes(
-            await packageArchiveBytes(pubspecContent: pubspecContent),
-          );
-        });
-      }
+        await createPubApiClient(authToken: token).uploadPackageBytes(
+          await packageArchiveBytes(pubspecContent: pubspecContent),
+        );
+      });
+    }
 
-      var i = 0;
-      for (final t in [
-        UserAndTime('user1@pub.dev',
-            DateTime(2021, 12, 2)), // Before range, should not be counted.
-        UserAndTime('user1@pub.dev', DateTime(2022, 1, 5)),
-        UserAndTime('user1@pub.dev',
-            DateTime(2022, 1, 6)), // Same user, should not be counted.
-        UserAndTime('user1@pub.dev', DateTime(2022, 2, 26)),
-        UserAndTime('user2@pub.dev', DateTime(2022, 2, 21)),
-        UserAndTime('user3@pub.dev', DateTime(2022, 2, 22)),
-        UserAndTime('user2@pub.dev', DateTime(2022, 12, 11)),
-      ]) {
-        await uploadAtTime(t, i);
-        i++;
-      }
+    var i = 0;
+    for (final t in [
+      UserAndTime('user1@pub.dev',
+          DateTime(2021, 12, 2)), // Before range, should not be counted.
+      UserAndTime('user1@pub.dev', DateTime(2022, 1, 5)),
+      UserAndTime('user1@pub.dev',
+          DateTime(2022, 1, 6)), // Same user, should not be counted.
+      UserAndTime('user1@pub.dev', DateTime(2022, 2, 26)),
+      UserAndTime('user2@pub.dev', DateTime(2022, 2, 21)),
+      UserAndTime('user3@pub.dev', DateTime(2022, 2, 22)),
+      UserAndTime('user2@pub.dev', DateTime(2022, 12, 11)),
+    ]) {
+      await uploadAtTime(t, i);
+      i++;
+    }
 
+    await withClock(Clock.fixed(DateTime(2022, 12, 13)), () async {
       final s = await executeCountUploaderReport([]);
 
       expect(s, '''


### PR DESCRIPTION
- Weekly CI test should run only sanity tags.
- `sanity` configuration didn't unblock `sanity` tags (copy-paste issue)
- Also fixing uploader count test by applying the timestamp just before the operation being run.