### PR TITLE
Fix sign-out by also calling session invalidation.

### DIFF
--- a/pkg/web_app/lib/src/account.dart
+++ b/pkg/web_app/lib/src/account.dart
@@ -92,7 +92,9 @@ void _initWidgets() {
       .listen((_) => authenticationProxy.trySignIn());
   document.getElementById('-account-logout')?.onClick.listen((_) async {
     await authenticationProxy.signOut();
-    // force-reload page if it was not reloaded after signing out
+    // Force session invalidation in case the signOut() wouldn't trigger it at this point.
+    await api_client.unauthenticatedClient.invalidateSession();
+    // Force page reload if it was not done after signing out.
     if (document.getElementById('-account-logout') != null) {
       window.location.reload();
     }


### PR DESCRIPTION
At the moment sign out may trigger a reload, but it happens earlier than the JS library's flow completes, and the loaded page has still an active user session. By directly invalidating the session we make sure that the reload happens without active session cookies.