### PR TITLE
Fix some Dart 2.19 and Dart 3 analysis issues

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,9 +1,9 @@
-# https://www.dartlang.org/guides/language/analysis-options
+# https://dart.dev/guides/language/analysis-options
 analyzer:
   exclude:
     - pkg/pub_integration/test_data/
-  strong-mode:
-    implicit-casts: false
+  language:
+    strict-casts: true
 
 # http://dart-lang.github.io/linter/lints/options/options.html
 linter:
@@ -33,7 +33,6 @@ linter:
   - empty_statements
   - hash_and_equals
   - implementation_imports
-  - invariant_booleans
   - iterable_contains_unrelated_type
   - library_names
   - library_prefixes

--- a/pkg/pub_package_reader/lib/src/pub_semver_2.1.0_parser.dart
+++ b/pkg/pub_package_reader/lib/src/pub_semver_2.1.0_parser.dart
@@ -99,7 +99,9 @@ VersionConstraint parsePossiblyBrokenVersionConstraint(String text) {
       case '>':
         return VersionRange(min: version, includeMin: false);
     }
-    throw FallThroughError();
+
+    throw FormatException('Expected one of "<=", "<", ">=", or ">" '
+        'as the operator in "$originalText", got "$op".');
   }
 
   // Try to parse the "^" operator followed by a version.

--- a/pkg/pub_worker/lib/src/analyze.dart
+++ b/pkg/pub_worker/lib/src/analyze.dart
@@ -138,13 +138,13 @@ Future<void> _analyzePackage(
       );
       await proc.stdin.close();
 
-      await Future.wait([
+      await Future.wait<void>([
         proc.stderr.forEach(log.add),
         proc.stdout.forEach(log.add),
         proc.exitOrTimeout(_analysisTimeout, () {
           log.writeln('TIMEOUT: dartdoc sending SIGTERM/SIGKILL');
         }),
-      ]).catchError((e) {/* ignore */});
+      ]).catchError((e) => const [/* ignore */]);
       final exitCode = await proc.exitCode;
 
       log.writeln('### Execution of dartdoc exited $exitCode');
@@ -175,13 +175,13 @@ Future<void> _analyzePackage(
       );
       await pana.stdin.close();
 
-      await Future.wait([
+      await Future.wait<void>([
         pana.stderr.forEach(log.add),
         pana.stdout.forEach(log.add),
         pana.exitOrTimeout(_analysisTimeout, () {
           log.writeln('TIMEOUT: pana sending SIGTERM/SIGKILL');
         }),
-      ]).catchError((e) {/* ignore */});
+      ]).catchError((e) => const [/* ignore */]);
       final exitCode = await pana.exitCode;
 
       log.writeln('### Execution of pana exited $exitCode');


### PR DESCRIPTION
- Replace the deprecated strong mode `implicit-casts: false` option with the Dart 2.16+ strict-casts [language option](https://dart.dev/guides/language/analysis-options#enabling-additional-type-checks)
- Remove the deprecated [`invariant_booleans`](https://dart-lang.github.io/linter/lints/invariant_booleans.html) linter rule
- Replace the deprecated in 2.19 and removed in Dart 3 `FallThroughError` usage
- Pass an empty list into `catchError` constructor on `wait` to fix [`body_might_complete_normally_catch_error` hint](https://dart.dev/tools/diagnostic-messages#body_might_complete_normally_catch_error)