### PR TITLE
Enable automated publishing behind public experimental flag.

### DIFF
--- a/app/lib/frontend/handlers/experimental.dart
+++ b/app/lib/frontend/handlers/experimental.dart
@@ -5,13 +5,12 @@
 import 'package:meta/meta.dart';
 
 const _publicFlags = <String>{
-  'screenshots',
+  'publishing',
 };
 
 const _allFlags = <String>{
   ..._publicFlags,
   'dart3',
-  'publishing',
   'signin',
   'sandbox',
 };
@@ -50,9 +49,6 @@ class ExperimentalFlags {
 
   /// Whether to show the admin UI for automated publishing admin UI.
   bool get showAdminUIForAutomatedPublishing => _enabled.contains('publishing');
-
-  /// Whether to show package screenshots in search listings.
-  bool get showScreenshots => true;
 
   /// Whether to return dartdoc from sandboxing output.
   bool get showSandboxedOutput => _enabled.contains('sandbox');

--- a/app/lib/frontend/templates/views/pkg/index.dart
+++ b/app/lib/frontend/templates/views/pkg/index.dart
@@ -146,16 +146,13 @@ d.Node _searchFormContainer({
                 searchForm: searchForm,
                 title: 'Show only null-safe packages.',
               ),
-              if (requestContext.experimentalFlags.showScreenshots ||
-                  searchForm.parsedQuery.tagsPredicate
-                      .hasTag(PackageVersionTags.hasScreenshot))
-                _tagBasedCheckbox(
-                  tagPrefix: 'has',
-                  tagValue: 'screenshot',
-                  label: 'Has screenshot',
-                  searchForm: searchForm,
-                  title: 'Show only packages with screenshots.',
-                ),
+              _tagBasedCheckbox(
+                tagPrefix: 'has',
+                tagValue: 'screenshot',
+                label: 'Has screenshot',
+                searchForm: searchForm,
+                title: 'Show only packages with screenshots.',
+              ),
               if (requestContext.experimentalFlags.showDart3ReadyOnUI ||
                   searchForm.parsedQuery.tagsPredicate
                       .hasTag(PackageVersionTags.isDart3Ready))

--- a/app/lib/frontend/templates/views/pkg/info_box.dart
+++ b/app/lib/frontend/templates/views/pkg/info_box.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:pana/pana.dart';
-import 'package:pub_dev/frontend/request_context.dart';
 import 'package:pubspec_parse/pubspec_parse.dart' as pubspek;
 
 import '../../../../package/models.dart';
@@ -66,8 +65,7 @@ d.Node packageInfoBoxNode({
   return d.fragment([
     imageCarousel(),
     labeledScores,
-    if (thumbnailUrl != null &&
-        requestContext.experimentalFlags.showScreenshots)
+    if (thumbnailUrl != null)
       d.div(classes: [
         'detail-screenshot-thumbnail'
       ], children: [

--- a/app/lib/frontend/templates/views/pkg/package_list.dart
+++ b/app/lib/frontend/templates/views/pkg/package_list.dart
@@ -233,8 +233,7 @@ d.Node _item({
               d.div(classes: ['packages-api'], child: _apiPages(apiPages)),
           ],
         ),
-        if (thumbnailUrl != null &&
-            requestContext.experimentalFlags.showScreenshots)
+        if (thumbnailUrl != null)
           d.div(classes: [
             'packages-screenshot-thumbnail'
           ], children: [

--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -1320,15 +1320,6 @@ class PackageBackend {
             'GitHub repository identifiers changed, disabling automated publishing');
       }
     }
-
-    // Disable publishing for all packages, but exempt the test + internal ones for live testing.
-    if (package.name == '_dummy_pkg' ||
-        package.publisherId == 'miksen.dk' ||
-        isDartDevPublisher(package.publisherId)) {
-      return;
-    }
-    throw PackageRejectedException(
-        'GitHub Action recognized successful, but publishing is not enabled yet.');
   }
 
   Future<void> _checkServiceAccountAllowed(
@@ -1369,15 +1360,6 @@ class PackageBackend {
             'Google Cloud Service account identifiers changed, disabling automated publishing');
       }
     }
-
-    // Disable publishing for all packages, but exempt the test + internal ones for live testing.
-    if (package.name == '_dummy_pkg' ||
-        package.publisherId == 'miksen.dk' ||
-        isDartDevPublisher(package.publisherId)) {
-      return;
-    }
-    throw PackageRejectedException(
-        'Google Cloud Service account recognized successful, but publishing is not enabled yet.');
   }
 
   /// List the admin emails that need to be notified when a [package] has a

--- a/app/test/package/upload_test.dart
+++ b/app/test/package/upload_test.dart
@@ -358,17 +358,15 @@ void main() {
             createFakeServiceAccountToken(email: 'admin@x.gserviceaccount.com');
         final pubspecContent = generatePubspecYaml('oxygen', '2.2.0');
         final bytes = await packageArchiveBytes(pubspecContent: pubspecContent);
-        final rs =
-            createPubApiClient(authToken: token).uploadPackageBytes(bytes);
-        await expectApiException(
-          rs,
-          status: 400,
-          code: 'PackageRejected',
-          message:
-              'Google Cloud Service account recognized successful, but publishing is not enabled yet',
-        );
+        final rs = await createPubApiClient(authToken: token)
+            .uploadPackageBytes(bytes);
+        expect(rs.success.message,
+            'Successfully uploaded https://pub.dev/packages/oxygen version 2.2.0.');
 
-        // TODO: once it is enabled, check for automatedPublishingLock
+        final pkg = await packageBackend.lookupPackage('oxygen');
+        expect(pkg!.automatedPublishing!.gcpLock!.toJson(), {
+          'oauthUserId': 'admin-x-gserviceaccount-com',
+        });
       });
     });
 
@@ -604,15 +602,10 @@ void main() {
         );
         final pubspecContent = generatePubspecYaml('oxygen', '2.2.0');
         final bytes = await packageArchiveBytes(pubspecContent: pubspecContent);
-        final rs =
-            createPubApiClient(authToken: token).uploadPackageBytes(bytes);
-        await expectApiException(
-          rs,
-          status: 400,
-          code: 'PackageRejected',
-          message:
-              'GitHub Action recognized successful, but publishing is not enabled yet.',
-        );
+        final rs = await createPubApiClient(authToken: token)
+            .uploadPackageBytes(bytes);
+        expect(rs.success.message,
+            'Successfully uploaded https://pub.dev/packages/oxygen version 2.2.0.');
       });
 
       testWithProfile(
@@ -797,15 +790,10 @@ void main() {
         );
         final pubspecContent = generatePubspecYaml('oxygen', '2.2.0');
         final bytes = await packageArchiveBytes(pubspecContent: pubspecContent);
-        final rs =
-            createPubApiClient(authToken: token).uploadPackageBytes(bytes);
-        await expectApiException(
-          rs,
-          status: 400,
-          code: 'PackageRejected',
-          message:
-              'GitHub Action recognized successful, but publishing is not enabled yet.',
-        );
+        final rs = await createPubApiClient(authToken: token)
+            .uploadPackageBytes(bytes);
+        expect(rs.success.message,
+            'Successfully uploaded https://pub.dev/packages/oxygen version 2.2.0.');
       });
     });
 


### PR DESCRIPTION
- Removes automated publishing exceptions, allows all packages to get published this way.
- Moved `publishing` to public experimental flag (`/experimental` will list it).
- Removed `screenshot` flag.