### PR TITLE
Restrict minimum version on upload when SDK constraint allows Dart 3.

### DIFF
--- a/pkg/pub_package_reader/lib/pub_package_reader.dart
+++ b/pkg/pub_package_reader/lib/pub_package_reader.dart
@@ -441,6 +441,8 @@ Iterable<ArchiveIssue> checkStrictVersions(Pubspec pubspec) sync* {
 
 final _preDart4 = VersionConstraint.parse('<4.0.0');
 final _firstDart4Pre = Version.parse('4.0.0').firstPreRelease;
+final _preNullSafety = VersionConstraint.parse('<2.12.0');
+final _onlyNullSafety = VersionConstraint.parse('>=3.0.0-0');
 
 /// Checks if the version range is acceptable by current SDKs.
 Iterable<ArchiveIssue> checkSdkVersionRange(Pubspec pubspec) sync* {
@@ -466,6 +468,13 @@ Iterable<ArchiveIssue> checkSdkVersionRange(Pubspec pubspec) sync* {
   if (sdk.allows(_firstDart4Pre)) {
     yield ArchiveIssue(
         'The SDK constraint allows Dart 4.0.0, this is not allowed because Dart 4 does not exist.');
+  }
+
+  // Dart 3 does not support pre-null-safety language version.
+  if (!sdk.intersect(_preNullSafety).isEmpty &&
+      !sdk.intersect(_onlyNullSafety).isEmpty) {
+    yield ArchiveIssue(
+        'When the SDK constraint allows Dart 3, the minimum range should be ">=2.12.0".');
   }
 }
 

--- a/pkg/pub_package_reader/test/package_archive_test.dart
+++ b/pkg/pub_package_reader/test/package_archive_test.dart
@@ -166,6 +166,8 @@ void main() {
       isRejected('>=2.0.0');
       isRejected('<4.0.0');
       isRejected('<4.0.0-0');
+      isRejected('>=2.9.0 <4.0.0');
+      isRejected('>=2.11.0 <=3.2.0');
       isRejected('>=2.12.0 <4.0.1');
       isRejected('>=3.0.0 <4.0.1');
       isRejected('>=4.0.0');


### PR DESCRIPTION
Fixes https://github.com/dart-lang/pub/issues/3730