### PR TITLE
JWT token from user session (behind experimental flag).

### DIFF
--- a/app/lib/account/models.dart
+++ b/app/lib/account/models.dart
@@ -150,6 +150,35 @@ class UserSession extends db.ExpandoModel<String> {
   bool isExpired() => clock.now().isAfter(expires!);
 }
 
+/// Maps the token id (from JWT) to User.id, (cookie) sessionId and signature secret.
+@db.Kind(name: 'UserToken', idType: db.IdType.String)
+class UserToken extends db.ExpandoModel<String> {
+  /// Same as [id].
+  /// This is a v4 (random) UUID String.
+  String get tokenId => id as String;
+
+  @db.StringProperty(required: true)
+  String? userId;
+
+  @db.StringProperty(required: true)
+  String? sessionId;
+
+  @db.DateTimeProperty(required: true, indexed: false)
+  DateTime? created;
+
+  /// The expiry in the Datastore should be more into the future than in the JWT,
+  /// as deleting the entry here invalidates the JWT, regardless of the expiry
+  /// there.
+  @db.DateTimeProperty(required: true)
+  DateTime? expires;
+
+  /// The Base64-encoded secret that we use for signing the JWT signature.
+  @db.StringProperty(indexed: false)
+  String? tokenHmacSecretBase64;
+
+  bool isExpired() => clock.now().isAfter(expires!);
+}
+
 /// Pattern for detecting profile image parameters as specified in [1].
 ///
 /// [1]: https://developers.google.com/people/image-sizing

--- a/app/lib/frontend/handlers/experimental.dart
+++ b/app/lib/frontend/handlers/experimental.dart
@@ -45,7 +45,7 @@ class ExperimentalFlags {
   bool get showSandboxedOutput => _enabled.contains('sandbox');
 
   /// Whether to use the new Google Identity Services library.
-  bool get useGisSignIn => _enabled.contains('signin');
+  bool get useNewSignIn => _enabled.contains('signin');
 
   bool get isEmpty => _enabled.isEmpty;
 

--- a/app/lib/frontend/handlers/pubapi.client.dart
+++ b/app/lib/frontend/handlers/pubapi.client.dart
@@ -217,6 +217,13 @@ class PubApiClient {
     ));
   }
 
+  Future<List<int>> getSession() async {
+    return await _client.requestBytes(
+      verb: 'get',
+      path: '/api/account/session',
+    );
+  }
+
   Future<List<int>> updateSession(_i4.ClientSessionRequest payload) async {
     return await _client.requestBytes(
       verb: 'post',

--- a/app/lib/frontend/handlers/pubapi.dart
+++ b/app/lib/frontend/handlers/pubapi.dart
@@ -265,6 +265,10 @@ class PubApi {
           Request request, String consentId, ConsentResult result) =>
       consentBackend.resolveConsent(consentId, result);
 
+  /// Gets the current session information as [ClientSessionStatus].
+  @EndPoint.get('/api/account/session')
+  Future<Response> getSession(Request request) => getSessionHandler(request);
+
   /// Registers (or extends) a user session.
   ///
   /// This endpoint should be called after an explicit login action or when the

--- a/app/lib/frontend/handlers/pubapi.g.dart
+++ b/app/lib/frontend/handlers/pubapi.g.dart
@@ -449,6 +449,22 @@ Router _$PubApiRouter(PubApi service) {
     },
   );
   router.add(
+    'GET',
+    r'/api/account/session',
+    (Request request) async {
+      try {
+        final _$result = await service.getSession(
+          request,
+        );
+        return _$result;
+      } on ApiResponseException catch (e) {
+        return e.asApiResponse();
+      } catch (e, st) {
+        return $utilities.unhandledError(e, st);
+      }
+    },
+  );
+  router.add(
     'POST',
     r'/api/account/session',
     (Request request) async {

--- a/app/lib/frontend/templates/views/shared/layout.dart
+++ b/app/lib/frontend/templates/views/shared/layout.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:pub_dev/frontend/request_context.dart';
-
 import '../../../../shared/urls.dart' as urls;
 import '../../../dom/dom.dart' as d;
 import '../../../static_files.dart' show staticUrls;
@@ -125,19 +123,10 @@ d.Node pageLayoutNode({
             ),
             d.meta(
                 name: 'google-signin-client_id', content: oauthClientId ?? ''),
-            if (requestContext.experimentalFlags.useGisSignIn)
-              d.script(
-                src: 'https://accounts.google.com/gsi/client',
-                async: true,
-                defer: true,
-                onload: 'pubGsiClientInit()',
-              )
-            else
-              d.script(
-                src:
-                    'https://apis.google.com/js/platform.js?onload=pubAuthInit',
-                defer: true,
-              ),
+            d.script(
+              src: 'https://apis.google.com/js/platform.js?onload=pubAuthInit',
+              defer: true,
+            ),
             if (pageDataEncoded != null)
               d.meta(name: 'pub-page-data', content: pageDataEncoded),
             if (isLanding) ...[

--- a/app/lib/service/openid/jwt.dart
+++ b/app/lib/service/openid/jwt.dart
@@ -59,7 +59,6 @@ class JsonWebToken {
     this.signature,
   );
 
-  @visibleForTesting
   factory JsonWebToken({
     required Map<String, dynamic> header,
     required Map<String, dynamic> payload,

--- a/app/lib/tool/neat_task/pub_dev_tasks.dart
+++ b/app/lib/tool/neat_task/pub_dev_tasks.dart
@@ -96,6 +96,13 @@ void _setupGenericPeriodicTasks() {
     task: () async => await accountBackend.deleteObsoleteSessions(),
   );
 
+  // Deletes expired tokens.
+  _daily(
+    name: 'delete-expired-tokens',
+    isRuntimeVersioned: false,
+    task: () async => await accountBackend.deleteObsoleteTokens(),
+  );
+
   // Updates Package's stable, prerelease and preview version fields in case a
   // new Dart SDK got released.
   _daily(

--- a/app/test/frontend/static_files_test.dart
+++ b/app/test/frontend/static_files_test.dart
@@ -216,7 +216,7 @@ void main() {
               path.startsWith('/static/js/script.dart.js') &&
               path.endsWith('part.js'))
           .toList();
-      expect(parts.length, 8);
+      expect(parts.length, 7);
       final partsSize = parts
           .map((p) => cache.getFile(p)!.bytes.length)
           .reduce((a, b) => a + b);

--- a/pkg/_pub_shared/lib/data/account_api.dart
+++ b/pkg/_pub_shared/lib/data/account_api.dart
@@ -30,7 +30,7 @@ class ClientSessionRequest {
 }
 
 /// The server-provided status of the current session.
-@JsonSerializable()
+@JsonSerializable(includeIfNull: false, explicitToJson: true)
 class ClientSessionStatus {
   /// True, if the user session has been updated and the current page should be
   /// reloaded.

--- a/pkg/_pub_shared/lib/data/account_api.g.dart
+++ b/pkg/_pub_shared/lib/data/account_api.g.dart
@@ -26,12 +26,19 @@ ClientSessionStatus _$ClientSessionStatusFromJson(Map<String, dynamic> json) =>
           : DateTime.parse(json['expires'] as String),
     );
 
-Map<String, dynamic> _$ClientSessionStatusToJson(
-        ClientSessionStatus instance) =>
-    <String, dynamic>{
-      'changed': instance.changed,
-      'expires': instance.expires?.toIso8601String(),
-    };
+Map<String, dynamic> _$ClientSessionStatusToJson(ClientSessionStatus instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('changed', instance.changed);
+  writeNotNull('expires', instance.expires?.toIso8601String());
+  return val;
+}
 
 LikedPackagesRepsonse _$LikedPackagesRepsonseFromJson(
         Map<String, dynamic> json) =>

--- a/pkg/web_app/lib/src/api_client/api_client.dart
+++ b/pkg/web_app/lib/src/api_client/api_client.dart
@@ -27,6 +27,21 @@ PubApiClient get unauthenticatedClient =>
 PubApiClient get client {
   return PubApiClient(_baseUrl,
       client: http.createAuthenticatedClient(() async {
+    // Try new pub.dev token first.
+    final rs = await http.get(
+      Uri.parse('/api/account/session'),
+      headers: {
+        'content-type': 'application/json; charset="utf-8"',
+        'x-pub-dev-token-request': '1',
+      },
+    );
+    if (rs.statusCode == 200) {
+      final tokenRs = rs.headers['x-pub-dev-token'];
+      if (tokenRs != null) {
+        return tokenRs;
+      }
+    }
+
     // Wait until we're initialized
     await authProxyReady;
 

--- a/pkg/web_app/lib/src/api_client/pubapi.client.dart
+++ b/pkg/web_app/lib/src/api_client/pubapi.client.dart
@@ -217,6 +217,13 @@ class PubApiClient {
     ));
   }
 
+  Future<List<int>> getSession() async {
+    return await _client.requestBytes(
+      verb: 'get',
+      path: '/api/account/session',
+    );
+  }
+
   Future<List<int>> updateSession(_i4.ClientSessionRequest payload) async {
     return await _client.requestBytes(
       verb: 'post',

--- a/pkg/web_app/lib/src/deferred/http.dart
+++ b/pkg/web_app/lib/src/deferred/http.dart
@@ -5,7 +5,7 @@
 import 'package:http/browser_client.dart';
 import 'package:http/http.dart';
 
-export 'package:http/http.dart' show Client;
+export 'package:http/http.dart' show Client, get;
 
 /// Creates an authenticated [Client] that calls [getToken] to obtain an
 /// bearer-token to use in the `Authorization: Bearer <token>` header.


### PR DESCRIPTION
- JWT token backed by a secret in Datastore entity using `HS256` algorithm
- emitted only when the experimental flag is set
- emitted only when a special header is set and response is a header value (reduces cross-origin attack surface)
- used in web_app (if enabled/available)
