### PR TITLE
Rename UserSession-related cookies, introducing ClientSession.

### DIFF
--- a/app/lib/account/models.dart
+++ b/app/lib/account/models.dart
@@ -135,7 +135,7 @@ class ClientSession extends db.ExpandoModel<String> {
   String? email;
 
   /// The name of the user given by the authentication provider.
-  /// May be null, or could contain any arbitrary text.
+  /// May be null, or human readable name (specified by the user, in their profile).
   @db.StringProperty(indexed: false)
   String? name;
 

--- a/app/lib/account/models.g.dart
+++ b/app/lib/account/models.g.dart
@@ -20,8 +20,7 @@ Map<String, dynamic> _$LikeDataToJson(LikeData instance) => <String, dynamic>{
       'created': instance.created?.toIso8601String(),
     };
 
-UserSessionData _$UserSessionDataFromJson(Map<String, dynamic> json) =>
-    UserSessionData(
+SessionData _$SessionDataFromJson(Map<String, dynamic> json) => SessionData(
       sessionId: json['sessionId'] as String,
       userId: json['userId'] as String?,
       email: json['email'] as String?,
@@ -31,7 +30,7 @@ UserSessionData _$UserSessionDataFromJson(Map<String, dynamic> json) =>
       expires: DateTime.parse(json['expires'] as String),
     );
 
-Map<String, dynamic> _$UserSessionDataToJson(UserSessionData instance) =>
+Map<String, dynamic> _$SessionDataToJson(SessionData instance) =>
     <String, dynamic>{
       'sessionId': instance.sessionId,
       'userId': instance.userId,

--- a/app/lib/frontend/handlers/account.dart
+++ b/app/lib/frontend/handlers/account.dart
@@ -54,7 +54,7 @@ Future<shelf.Response> updateSessionHandler(
 
   final cookieString = request.headers[HttpHeaders.cookieHeader];
   final sessionData =
-      await accountBackend.parseAndLookupSessionCookie(cookieString);
+      await accountBackend.parseAndLookupUserSessionCookie(cookieString);
   final t2 = sw.elapsed;
   // check if the session data is the same
   if (sessionData != null &&
@@ -71,7 +71,7 @@ Future<shelf.Response> updateSessionHandler(
 
   final profile = await authProvider.getAccountProfile(body.accessToken);
   final t3 = sw.elapsed;
-  final newSession = await accountBackend.createNewSession(
+  final newSession = await accountBackend.createNewUserSession(
     name: profile!.name!,
     imageUrl: profile.imageUrl!,
   );
@@ -84,7 +84,7 @@ Future<shelf.Response> updateSessionHandler(
       changed: true,
       expires: newSession.expires,
     ).toJson(),
-    headers: session_cookie.createSessionCookie(
+    headers: session_cookie.createUserSessionCookie(
         newSession.sessionId, newSession.expires),
   );
 }
@@ -93,12 +93,12 @@ Future<shelf.Response> updateSessionHandler(
 Future<shelf.Response> invalidateSessionHandler(shelf.Request request) async {
   final cookieString = request.headers[HttpHeaders.cookieHeader];
   final sessionData =
-      await accountBackend.parseAndLookupSessionCookie(cookieString);
+      await accountBackend.parseAndLookupUserSessionCookie(cookieString);
   final hasUserSession = sessionData != null;
   // Invalidate the server-side sessionId, in case the user signed out because
   // the local cookie store was compromised.
   if (hasUserSession) {
-    await accountBackend.invalidateSession(sessionData.sessionId);
+    await accountBackend.invalidateUserSession(sessionData.sessionId);
   }
   return jsonResponse(
     ClientSessionStatus(
@@ -106,7 +106,7 @@ Future<shelf.Response> invalidateSessionHandler(shelf.Request request) async {
       expires: null,
     ).toJson(),
     // Clear cookie, so we don't have to lookup an invalid sessionId.
-    headers: session_cookie.clearSessionCookie(),
+    headers: session_cookie.clearSessionCookies(),
   );
 }
 

--- a/app/lib/frontend/templates/admin.dart
+++ b/app/lib/frontend/templates/admin.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import '../../account/models.dart' show LikeData, User, UserSessionData;
+import '../../account/models.dart' show LikeData, User, SessionData;
 import '../../audit/models.dart';
 import '../../frontend/templates/views/account/activity_log_table.dart';
 import '../../package/models.dart';
@@ -31,7 +31,7 @@ String renderAuthorizedPage() {
 /// Renders the search results on the current user's packages page.
 String renderAccountPackagesPage({
   required User user,
-  required UserSessionData userSessionData,
+  required SessionData userSessionData,
   required List<PackageView> packageHits,
   required String? startPackage,
   required String? nextPackage,
@@ -92,7 +92,7 @@ String renderAccountPackagesPage({
 /// Renders the current user's liked packages page.
 String renderMyLikedPackagesPage({
   required User user,
-  required UserSessionData userSessionData,
+  required SessionData userSessionData,
   required List<LikeData> likes,
 }) {
   final resultCount = likes.isNotEmpty
@@ -131,7 +131,7 @@ String renderMyLikedPackagesPage({
 /// Renders the current user's publishers page.
 String renderAccountPublishersPage({
   required User user,
-  required UserSessionData userSessionData,
+  required SessionData userSessionData,
   required List<PublisherSummary> publishers,
 }) {
   final pln = publisherListNode(publishers: publishers, isGlobal: false);
@@ -162,7 +162,7 @@ String renderAccountPublishersPage({
 /// Renders the current user's activity page.
 String renderAccountMyActivityPage({
   required User user,
-  required UserSessionData userSessionData,
+  required SessionData userSessionData,
   required AuditLogRecordPage activities,
 }) {
   final activityLog = activityLogNode(
@@ -213,7 +213,7 @@ Tab _myActivityLogLink() => Tab.withLink(
     title: myActivityLogTabTitle,
     href: urls.myActivityLogUrl());
 
-d.Node _accountDetailHeader(User user, UserSessionData userSessionData) {
+d.Node _accountDetailHeader(User user, SessionData userSessionData) {
   return renderDetailHeader(
     title: userSessionData.name,
     image: d.Image(

--- a/app/lib/frontend/templates/views/shared/layout.dart
+++ b/app/lib/frontend/templates/views/shared/layout.dart
@@ -4,6 +4,7 @@
 
 import '../../../../shared/urls.dart' as urls;
 import '../../../dom/dom.dart' as d;
+import '../../../request_context.dart';
 import '../../../static_files.dart' show staticUrls;
 
 d.Node pageLayoutNode({
@@ -149,6 +150,8 @@ d.Node pageLayoutNode({
                     .getAssetUrl('/static/highlight/highlight-with-init.js'),
                 as: 'script',
               ),
+            if (requestContext.experimentalFlags.useNewSignIn)
+              d.meta(name: 'pub-experiment-signin', content: '1'),
           ],
         ),
         d.element(

--- a/app/lib/frontend/templates/views/shared/site_header.dart
+++ b/app/lib/frontend/templates/views/shared/site_header.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import '../../../../account/models.dart' show UserSessionData;
+import '../../../../account/models.dart' show SessionData;
 import '../../../../shared/urls.dart' as urls;
 import '../../../dom/dom.dart' as d;
 import '../../../static_files.dart' show staticUrls;
@@ -12,7 +12,7 @@ import '../../layout.dart' show PageType, showSearchBanner;
 /// Creates the site header and navigation node.
 d.Node siteHeaderNode({
   required PageType pageType,
-  UserSessionData? userSession,
+  SessionData? userSession,
 }) {
   return d.div(
     classes: ['site-header'],
@@ -112,7 +112,7 @@ d.Node siteHeaderNode({
   );
 }
 
-d.Node _userBlock(UserSessionData userSession) {
+d.Node _userBlock(SessionData userSession) {
   return d.div(
     classes: ['nav-container', 'nav-profile-container', 'hoverable'],
     children: [

--- a/app/lib/shared/cookie_utils.dart
+++ b/app/lib/shared/cookie_utils.dart
@@ -26,6 +26,7 @@ String buildSetCookieValue({
   required String name,
   required String value,
   required Duration maxAge,
+  bool sameSiteStrict = false,
 }) {
   if (maxAge < Duration.zero) {
     maxAge = Duration.zero;
@@ -43,7 +44,7 @@ String buildSetCookieValue({
     // Do not include the cookie in CORS requests, unless the request is a
     // top-level navigation to the site, as recommended in:
     // https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-02#section-8.8.2
-    'SameSite=Lax',
+    if (sameSiteStrict) 'SameSite=Strict' else 'SameSite=Lax',
     if (!envConfig.isRunningLocally)
       'Secure', // Only allow this cookie to be sent when making HTTPS requests.
     'HttpOnly', // Do not allow Javascript access to this cookie.
@@ -70,7 +71,7 @@ Map<String, String> parseCookieHeader(String? cookieHeader) {
     return r;
   } catch (_) {
     // Ignore broken cookies, we could throw a ResponseException instead, and
-    // send the use a 400 error, this would be more correct. But unfortunately
+    // send the user a 400 error, this would be more correct. But unfortunately
     // it wouldn't help the user if the browser is sending a malformed 'cookie'
     // header. It would only serve to persistently break the site for the user.
     return <String, String>{};

--- a/app/lib/shared/handler_helpers.dart
+++ b/app/lib/shared/handler_helpers.dart
@@ -266,7 +266,7 @@ shelf.Handler _userSessionWrapper(Logger logger, shelf.Handler handler) {
         request.headers.containsKey(HttpHeaders.cookieHeader)) {
       final cookieString = request.headers[HttpHeaders.cookieHeader];
       final sessionData =
-          await accountBackend.parseAndLookupSessionCookie(cookieString);
+          await accountBackend.parseAndLookupUserSessionCookie(cookieString);
       if (sessionData != null) {
         registerUserSessionData(sessionData);
       }

--- a/app/lib/shared/handlers.dart
+++ b/app/lib/shared/handlers.dart
@@ -40,7 +40,7 @@ shelf.Response jsonResponse(
   Map map, {
   int status = 200,
   bool indentJson = false,
-  Map<String, String>? headers,
+  Map<String, Object>? headers,
 }) {
   final body = (indentJson || requestContext.indentJson)
       ? _prettyJson.convert(map)

--- a/app/lib/shared/redis_cache.dart
+++ b/app/lib/shared/redis_cache.dart
@@ -15,7 +15,7 @@ import 'package:neat_cache/cache_provider.dart';
 import 'package:neat_cache/neat_cache.dart';
 import 'package:pub_dev/shared/env_config.dart';
 
-import '../account/models.dart' show LikeData, UserSessionData;
+import '../account/models.dart' show LikeData, SessionData;
 import '../dartdoc/models.dart' show DartdocEntry, FileInfo;
 import '../package/models.dart' show PackageView;
 import '../publisher/models.dart' show PublisherPage;
@@ -41,15 +41,15 @@ class CachePatterns {
   // NOTE: This class should only contain methods that return Entry<T>, as well
   //       configuration options like prefix and TTL.
 
-  /// Cache for [UserSessionData].
-  Entry<UserSessionData> userSessionData(String sessionId) => _cache
+  /// Cache for [SessionData].
+  Entry<SessionData> userSessionData(String sessionId) => _cache
       .withPrefix('account-usersession/')
       .withTTL(Duration(hours: 24))
       .withCodec(utf8)
       .withCodec(json)
       .withCodec(wrapAsCodec(
-        encode: (UserSessionData? data) => data!.toJson(),
-        decode: (d) => UserSessionData.fromJson(d as Map<String, dynamic>),
+        encode: (SessionData? data) => data!.toJson(),
+        decode: (d) => SessionData.fromJson(d as Map<String, dynamic>),
       ))[sessionId];
 
   /// Cache for [DartdocEntry] objects.

--- a/app/lib/tool/neat_task/pub_dev_tasks.dart
+++ b/app/lib/tool/neat_task/pub_dev_tasks.dart
@@ -93,7 +93,7 @@ void _setupGenericPeriodicTasks() {
   _daily(
     name: 'delete-expired-sessions',
     isRuntimeVersioned: false,
-    task: () async => await accountBackend.deleteObsoleteSessions(),
+    task: () async => await accountBackend.deleteExpiredSessions(),
   );
 
   // Updates Package's stable, prerelease and preview version fields in case a

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -435,7 +435,7 @@ void main() {
           () async {
             // update session as package data loading checks that
             final user = await requireAuthenticatedWebUser();
-            registerUserSessionData(UserSessionData(
+            registerUserSessionData(SessionData(
               userId: user.userId,
               created: clock.now(),
               expires: clock.now().add(Duration(days: 1)),
@@ -464,7 +464,7 @@ void main() {
       processJobsWithFakeRunners: true,
       fn: () async {
         await accountBackend.withBearerToken(adminAtPubDevAuthToken, () async {
-          final session = await accountBackend.createNewSession(
+          final session = await accountBackend.createNewUserSession(
             name: 'Pub User',
             imageUrl: 'pub.dev/user-img-url.png',
           );
@@ -722,7 +722,7 @@ void main() {
         await accountBackend.withBearerToken(userAtPubDevAuthToken, () async {
           final authenticatedUser = await requireAuthenticatedWebUser();
           final user = authenticatedUser.user;
-          final session = await accountBackend.createNewSession(
+          final session = await accountBackend.createNewUserSession(
             name: 'Pub User',
             imageUrl: 'pub.dev/user-img-url.png',
           );
@@ -746,7 +746,7 @@ void main() {
       await accountBackend.withBearerToken(userAtPubDevAuthToken, () async {
         final authenticatedUser = await requireAuthenticatedWebUser();
         final user = authenticatedUser.user;
-        final session = await accountBackend.createNewSession(
+        final session = await accountBackend.createNewUserSession(
           name: 'Pub User',
           imageUrl: 'pub.dev/user-img-url.png',
         );
@@ -773,7 +773,7 @@ void main() {
       await accountBackend.withBearerToken(userAtPubDevAuthToken, () async {
         final authenticatedUser = await requireAuthenticatedWebUser();
         final user = authenticatedUser.user;
-        final session = await accountBackend.createNewSession(
+        final session = await accountBackend.createNewUserSession(
           name: 'Pub User',
           imageUrl: 'pub.dev/user-img-url.png',
         );
@@ -800,7 +800,7 @@ void main() {
       await accountBackend.withBearerToken(adminAtPubDevAuthToken, () async {
         final authenticatedUser = await requireAuthenticatedWebUser();
         final user = authenticatedUser.user;
-        final session = await accountBackend.createNewSession(
+        final session = await accountBackend.createNewUserSession(
           name: 'Pub User',
           imageUrl: 'pub.dev/user-img-url.png',
         );

--- a/pkg/web_app/lib/src/account.dart
+++ b/pkg/web_app/lib/src/account.dart
@@ -15,7 +15,21 @@ import 'api_client/api_client.dart' deferred as api_client;
 import 'google_auth_js.dart';
 import 'google_js.dart';
 
+late final _newSigningMetaContent = document
+    .querySelector('meta[name="pub-experiment-signin"]')
+    ?.getAttribute('content');
+late final _useNewSignin = _newSigningMetaContent == '1';
+
 void setupAccount() {
+  if (_useNewSignin) {
+    // TODO: implement client-side sign-in methods.
+    return;
+  } else {
+    _setupOldAccount();
+  }
+}
+
+void _setupOldAccount() {
   final metaElem =
       document.querySelector('meta[name="google-signin-client_id"]');
   final clientId = metaElem == null ? null : metaElem.attributes['content'];


### PR DESCRIPTION
- Renamed `UserSessionData` -> `SessionData` as both Datastore session entities may use it as-is (+ fields can be added).
- Renamed most generic session-related methods to have `UserSession` in it when they are `UserSession`-only.
- Added new `ClientSession` + expired cleanup.
- Added new cookies, setter method (not used yet) + deleting them linked with the current cookie.
- Added `SameSite=Strict` parameter to cookie builder.
- Exposed experimental status via `<meta>` header, returning from `pkg/web_app` authentication setup early when it is on.