### PR TITLE
Expose userSessionData internals to prepare new session integration.

### DIFF
--- a/app/lib/frontend/handlers/account.dart
+++ b/app/lib/frontend/handlers/account.dart
@@ -166,7 +166,7 @@ Future<shelf.Response> invalidateSessionHandler(shelf.Request request) async {
 /// Handles GET /consent?id=<consentId>
 Future<shelf.Response> consentPageHandler(
     shelf.Request request, String? consentId) async {
-  if (requestContext.userSessionData == null) {
+  if (requestContext.isNotAuthenticated) {
     return htmlResponse(renderUnauthenticatedPage());
   }
 
@@ -175,8 +175,8 @@ Future<shelf.Response> consentPageHandler(
     throw NotFoundException('Missing consent id.');
   }
 
-  final user = await accountBackend
-      .lookupUserById(requestContext.userSessionData!.userId!);
+  final user =
+      await accountBackend.lookupUserById(requestContext.authenticatedUserId!);
   final consent = await consentBackend.getConsent(consentId, user!);
   // If consent does not exists (or does not belong to the user), the `getConsent`
   // call above will throw, and the generic error page will be shown.
@@ -272,7 +272,7 @@ Future<AccountPublisherOptions> accountPublisherOptionsHandler(
 
 /// Handles requests for GET /my-packages [?q=...]
 Future<shelf.Response> accountPackagesPageHandler(shelf.Request request) async {
-  if (requestContext.userSessionData == null) {
+  if (requestContext.isNotAuthenticated) {
     return htmlResponse(renderUnauthenticatedPage());
   }
 
@@ -283,12 +283,12 @@ Future<shelf.Response> accountPackagesPageHandler(shelf.Request request) async {
 
   final next = request.requestedUri.queryParameters['next'];
   final page = await packageBackend
-      .listPackagesForUser(requestContext.userSessionData!.userId!, next: next);
+      .listPackagesForUser(requestContext.authenticatedUserId!, next: next);
   final hits = await scoreCardBackend.getPackageViews(page.packages);
 
   final html = renderAccountPackagesPage(
     user: (await accountBackend
-        .lookupUserById(requestContext.userSessionData!.userId!))!,
+        .lookupUserById(requestContext.authenticatedUserId!))!,
     userSessionData: requestContext.userSessionData!,
     startPackage: next,
     packageHits: hits.whereType<PackageView>().toList(),
@@ -300,12 +300,12 @@ Future<shelf.Response> accountPackagesPageHandler(shelf.Request request) async {
 /// Handles requests for GET my-liked-packages
 Future<shelf.Response> accountMyLikedPackagesPageHandler(
     shelf.Request request) async {
-  if (requestContext.userSessionData == null) {
+  if (requestContext.isNotAuthenticated) {
     return htmlResponse(renderUnauthenticatedPage());
   }
 
   final user = (await accountBackend
-      .lookupUserById(requestContext.userSessionData!.userId!))!;
+      .lookupUserById(requestContext.authenticatedUserId!))!;
   final likes = await likeBackend.listPackageLikes(user);
   final html = renderMyLikedPackagesPage(
     user: user,
@@ -318,15 +318,15 @@ Future<shelf.Response> accountMyLikedPackagesPageHandler(
 /// Handles requests for GET /my-publishers
 Future<shelf.Response> accountPublishersPageHandler(
     shelf.Request request) async {
-  if (requestContext.userSessionData == null) {
+  if (requestContext.isNotAuthenticated) {
     return htmlResponse(renderUnauthenticatedPage());
   }
 
   final page = await publisherBackend
-      .listPublishersForUser(requestContext.userSessionData!.userId!);
+      .listPublishersForUser(requestContext.authenticatedUserId!);
   final content = renderAccountPublishersPage(
     user: (await accountBackend
-        .lookupUserById(requestContext.userSessionData!.userId!))!,
+        .lookupUserById(requestContext.authenticatedUserId!))!,
     userSessionData: requestContext.userSessionData!,
     publishers: page.publishers!,
   );
@@ -336,18 +336,18 @@ Future<shelf.Response> accountPublishersPageHandler(
 /// Handles requests for GET /my-activity-log
 Future<shelf.Response> accountMyActivityLogPageHandler(
     shelf.Request request) async {
-  if (requestContext.userSessionData == null) {
+  if (requestContext.isNotAuthenticated) {
     return htmlResponse(renderUnauthenticatedPage());
   }
   final before = auditBackend.parseBeforeQueryParameter(
       request.requestedUri.queryParameters['before']);
   final activities = await auditBackend.listRecordsForUserId(
-    requestContext.userSessionData!.userId!,
+    requestContext.authenticatedUserId!,
     before: before,
   );
   final content = renderAccountMyActivityPage(
     user: (await accountBackend
-        .lookupUserById(requestContext.userSessionData!.userId!))!,
+        .lookupUserById(requestContext.authenticatedUserId!))!,
     userSessionData: requestContext.userSessionData!,
     activities: activities,
   );

--- a/app/lib/frontend/handlers/headers.dart
+++ b/app/lib/frontend/handlers/headers.dart
@@ -23,10 +23,11 @@ class CacheHeaders {
   });
 
   Map<String, String> call() {
-    final isSignedin = requestContext.userSessionData != null;
     return <String, String>{
       HttpHeaders.cacheControlHeader: <String>[
-        isSignedin ? (signedInStorage ?? 'private') : 'public',
+        requestContext.isAuthenticated
+            ? (signedInStorage ?? 'private')
+            : 'public',
         if (maxAge >= Duration.zero) 'max-age=${maxAge.inSeconds}',
       ].join(', '),
     };

--- a/app/lib/frontend/handlers/package.dart
+++ b/app/lib/frontend/handlers/package.dart
@@ -261,14 +261,14 @@ Future<shelf.Response> packageAdminHandler(
     versionName: null,
     assetKind: null,
     renderFn: (data) async {
-      if (requestContext.userSessionData == null) {
+      if (requestContext.isNotAuthenticated) {
         return htmlResponse(renderUnauthenticatedPage());
       }
       if (!data.isAdmin!) {
         return htmlResponse(renderUnauthorizedPage());
       }
       final page = await publisherBackend
-          .listPublishersForUser(requestContext.userSessionData!.userId!);
+          .listPublishersForUser(requestContext.authenticatedUserId!);
       final uploaderEmails = await accountBackend
           .lookupUsersById(data.package!.uploaders ?? <String>[]);
       final retractableVersions =
@@ -295,7 +295,7 @@ Future<shelf.Response> packageActivityLogHandler(
     versionName: null,
     assetKind: null,
     renderFn: (data) async {
-      if (requestContext.userSessionData == null) {
+      if (requestContext.isNotAuthenticated) {
         return htmlResponse(renderUnauthenticatedPage());
       }
       if (!data.isAdmin!) {
@@ -328,10 +328,10 @@ Future<PackagePageData> loadPackagePageData(
     );
   }
 
-  final bool isLiked = (requestContext.userSessionData == null)
+  final bool isLiked = requestContext.isNotAuthenticated
       ? false
       : await likeBackend.getPackageLikeStatus(
-              requestContext.userSessionData!.userId!, package.name!) !=
+              requestContext.authenticatedUserId!, package.name!) !=
           null;
 
   versionName ??= package.latestVersion;
@@ -364,10 +364,10 @@ Future<PackagePageData> loadPackagePageData(
     showSandboxedOutput: requestContext.experimentalFlags.showSandboxedOutput,
   );
 
-  final sessionUserId = requestContext.userSessionData?.userId;
-  final isAdmin = sessionUserId == null
+  final isAdmin = requestContext.isNotAuthenticated
       ? false
-      : await packageBackend.isPackageAdmin(package, sessionUserId);
+      : await packageBackend.isPackageAdmin(
+          package, requestContext.authenticatedUserId!);
 
   return PackagePageData(
     package: package,

--- a/app/lib/frontend/handlers/publisher.dart
+++ b/app/lib/frontend/handlers/publisher.dart
@@ -24,7 +24,7 @@ import 'misc.dart' show formattedNotFoundHandler;
 
 /// Handles requests for GET /create-publisher
 Future<shelf.Response> createPublisherPageHandler(shelf.Request request) async {
-  if (requestContext.userSessionData == null) {
+  if (requestContext.isNotAuthenticated) {
     return htmlResponse(renderUnauthenticatedPage());
   }
   return htmlResponse(renderCreatePublisherPage());
@@ -115,7 +115,7 @@ Future<shelf.Response> publisherPackagesPageHandler(
     searchForm: appliedSearchForm,
     totalCount: totalCount,
     isAdmin: await publisherBackend.isMemberAdmin(
-        publisher, requestContext.userSessionData?.userId),
+        publisher, requestContext.authenticatedUserId),
     messageFromBackend: searchResult.message,
   );
   if (isLanding && requestContext.uiCacheEnabled) {
@@ -134,12 +134,12 @@ Future<shelf.Response> publisherAdminPageHandler(
     return formattedNotFoundHandler(request);
   }
 
-  if (requestContext.userSessionData == null) {
+  if (requestContext.isNotAuthenticated) {
     return htmlResponse(renderUnauthenticatedPage());
   }
   final isAdmin = await publisherBackend.isMemberAdmin(
     publisher,
-    requestContext.userSessionData!.userId,
+    requestContext.authenticatedUserId,
   );
   if (!isAdmin) {
     return htmlResponse(renderUnauthorizedPage());
@@ -161,12 +161,12 @@ Future<shelf.Response> publisherActivityLogPageHandler(
     return formattedNotFoundHandler(request);
   }
 
-  if (requestContext.userSessionData == null) {
+  if (requestContext.isNotAuthenticated) {
     return htmlResponse(renderUnauthenticatedPage());
   }
   final isAdmin = await publisherBackend.isMemberAdmin(
     publisher,
-    requestContext.userSessionData!.userId,
+    requestContext.authenticatedUserId,
   );
   if (!isAdmin) {
     return htmlResponse(renderUnauthorizedPage());

--- a/app/lib/frontend/request_context.dart
+++ b/app/lib/frontend/request_context.dart
@@ -57,6 +57,10 @@ class RequestContext {
     ExperimentalFlags? experimentalFlags,
     this.userSessionData,
   }) : experimentalFlags = experimentalFlags ?? ExperimentalFlags.empty;
+
+  late final isAuthenticated = userSessionData?.userId != null;
+  late final isNotAuthenticated = !isAuthenticated;
+  late final authenticatedUserId = userSessionData?.userId;
 }
 
 Future<RequestContext> buildRequestContext({


### PR DESCRIPTION
These new fields could get their inputs from both old and new session, so guarding conditions around `/my-*` pages and similar access restrictions remain the same during the migration.