### PR TITLE
Minimal session handling with new sign-in flow.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ AppEngine version, listed here to ease deployment and troubleshooting.
 
 ## Next Release (replace with git tag when deployed)
  * Bumped runtimeVersion to `2023.02.28`.
+ * Removed `required: true` from the `UserSession.email` field.
 
 ## `20230223t105400-all`
  * Bumped runtimeVersion to `2023.02.22`.

--- a/app/lib/account/auth_provider.dart
+++ b/app/lib/account/auth_provider.dart
@@ -47,7 +47,7 @@ abstract class AuthProvider {
 
   /// Returns the URL that the user should visit for authentication.
   Future<Uri> getOauthAuthenticationUrl({
-    required String state,
+    required Map<String, String> state,
     required String nonce,
   });
 

--- a/app/lib/account/default_auth_provider.dart
+++ b/app/lib/account/default_auth_provider.dart
@@ -4,6 +4,7 @@
 
 import 'dart:convert';
 
+import 'package:basics/basics.dart';
 import 'package:clock/clock.dart';
 import 'package:googleapis/oauth2/v2.dart' as oauth2_v2;
 import 'package:googleapis_auth/auth_io.dart' as auth;
@@ -495,7 +496,9 @@ Map<String, String> decodeState(String? state) {
   try {
     final map = _stateCodec.decode(state);
     if (map is Map<String, dynamic>) {
-      return map.map((key, value) => MapEntry(key, value.toString()));
+      return map
+          .whereValue((v) => v != null)
+          .map((key, value) => MapEntry(key, value.toString()));
     } else {
       return const <String, String>{};
     }

--- a/app/lib/account/default_auth_provider.dart
+++ b/app/lib/account/default_auth_provider.dart
@@ -480,9 +480,11 @@ DateTime _parseTimestamp(dynamic timestamp) {
   throw ArgumentError.value(timestamp, 'timestamp', 'must be int or string');
 }
 
+final _stateCodec = json.fuse(utf8).fuse(base64Url);
+
 /// Encode map-based [state] as URL-compatible string.
 String encodeState(Map<String, String> state) {
-  return base64Url.encode(utf8.encode(json.encode(state)));
+  return _stateCodec.encode(state);
 }
 
 /// Decode URL-provided state as Map.
@@ -491,7 +493,7 @@ Map<String, String> decodeState(String? state) {
     return const <String, String>{};
   }
   try {
-    final map = json.decode(utf8.decode(base64Url.decode(state)));
+    final map = _stateCodec.decode(state);
     if (map is Map<String, dynamic>) {
       return map.map((key, value) => MapEntry(key, value.toString()));
     } else {

--- a/app/lib/account/default_auth_provider.dart
+++ b/app/lib/account/default_auth_provider.dart
@@ -98,7 +98,7 @@ class DefaultAuthProvider extends BaseAuthProvider {
 
   @override
   Future<Uri> getOauthAuthenticationUrl({
-    required String state,
+    required Map<String, String> state,
     required String nonce,
   }) async {
     // Using https://developers.google.com/identity/protocols/oauth2/web-server#httprest_1
@@ -112,7 +112,7 @@ class DefaultAuthProvider extends BaseAuthProvider {
           oauth2_v2.Oauth2Api.userinfoEmailScope,
           oauth2_v2.Oauth2Api.userinfoProfileScope,
         ].join(' '),
-        'state': state,
+        'state': Uri(queryParameters: state).toString().substring(1),
         'nonce': nonce,
       },
     );

--- a/app/lib/account/session_cookie.dart
+++ b/app/lib/account/session_cookie.dart
@@ -92,10 +92,10 @@ String? parseUserSessionCookie(Map<String, String> cookies) {
 }
 
 /// Parses the cookie values and returns the status of client session cookies.
-ClientSessionCookieStatus parseClientSessionCookies(String? cookieString) {
-  final values = parseCookieHeader(cookieString);
-  final lax = values[clientSessionLaxCookieName]?.trim() ?? '';
-  final strict = values[clientSessionStrictCookieName]?.trim() ?? '';
+ClientSessionCookieStatus parseClientSessionCookies(
+    Map<String, String> cookies) {
+  final lax = cookies[clientSessionLaxCookieName]?.trim() ?? '';
+  final strict = cookies[clientSessionStrictCookieName]?.trim() ?? '';
   final needsReset = (lax.isEmpty && strict.isNotEmpty) ||
       (lax.isNotEmpty && strict.isNotEmpty && lax != strict);
   if (needsReset) {

--- a/app/lib/fake/backend/fake_auth_provider.dart
+++ b/app/lib/fake/backend/fake_auth_provider.dart
@@ -157,7 +157,7 @@ class FakeAuthProvider extends BaseAuthProvider {
     );
     return Uri.parse(getOauthCallbackUrl()).replace(
       queryParameters: {
-        'state': Uri(queryParameters: state).toString().substring(1),
+        'state': encodeState(state),
         'code': token,
       },
     );

--- a/app/lib/frontend/handlers/account.dart
+++ b/app/lib/frontend/handlers/account.dart
@@ -6,6 +6,7 @@ import 'dart:io';
 
 import 'package:_pub_shared/data/account_api.dart';
 import 'package:logging/logging.dart';
+import 'package:pub_dev/account/default_auth_provider.dart';
 import 'package:shelf/shelf.dart' as shelf;
 
 import '../../account/backend.dart';
@@ -93,8 +94,7 @@ Future<shelf.Response> signInCallbackHandler(shelf.Request request) async {
   if (expectedNonce == null) {
     return notFoundHandler(request, body: 'Missing `nonce` in session.');
   }
-  final state = Uri.tryParse('?${params['state'] ?? ''}')?.queryParameters ??
-      <String, String>{};
+  final state = decodeState(params['state']);
   // TODO: verify state in the response
   // TODO: verify authuser (=0)
   // TODO: verify prompt (=none)

--- a/app/lib/shared/handler_helpers.dart
+++ b/app/lib/shared/handler_helpers.dart
@@ -113,10 +113,7 @@ shelf.Handler _requestContextWrapper(shelf.Handler handler) {
     if (!context.uiCacheEnabled && !CacheHeaders.hasCacheHeader(rs.headers)) {
       // Indicates that the response is intended for a single user and must not
       // be stored by a shared cache. A private cache may store the response.
-      rs = rs.change(headers: {
-        ...rs.headers,
-        ...CacheHeaders.private(),
-      });
+      rs = rs.change(headers: CacheHeaders.private());
     }
     return rs;
   };

--- a/app/lib/shared/handlers.dart
+++ b/app/lib/shared/handlers.dart
@@ -30,7 +30,15 @@ const jsonResponseHeaders = <String, String>{
 final _logger = Logger('pub.shared.handler');
 final _prettyJson = JsonUtf8Encoder('  ');
 
-shelf.Response redirectResponse(String url) => shelf.Response.seeOther(url);
+shelf.Response redirectResponse(
+  String url, {
+  Map<String, Object>? headers,
+}) {
+  return shelf.Response.seeOther(
+    url,
+    headers: headers,
+  );
+}
 
 shelf.Response redirectToSearch(String query) {
   return redirectResponse(urls.searchUrl(q: query));
@@ -71,9 +79,17 @@ shelf.Response htmlResponse(
 shelf.Response badRequestHandler(shelf.Request request) =>
     htmlResponse(default400BadRequest, status: 400);
 
-shelf.Response notFoundHandler(shelf.Request request,
-        {String body = default404NotFound}) =>
-    htmlResponse(body, status: 404);
+shelf.Response notFoundHandler(
+  shelf.Request request, {
+  String body = default404NotFound,
+  Map<String, Object>? headers,
+}) {
+  return htmlResponse(
+    body,
+    status: 404,
+    headers: headers,
+  );
+}
 
 shelf.Response rejectRobotsHandler(shelf.Request request) =>
     shelf.Response.ok('User-agent: *\nDisallow: /\n');

--- a/app/test/account/session_cookie_test.dart
+++ b/app/test/account/session_cookie_test.dart
@@ -11,10 +11,10 @@ import 'package:test/test.dart';
 void main() {
   group('Client session cookie parsing', () {
     ClientSessionCookieStatus parse(String? lax, [String? strict]) {
-      final cookies = [
-        if (lax != null) '$clientSessionLaxCookieName=$lax',
-        if (strict != null) '$clientSessionStrictCookieName=$strict',
-      ].join('; ');
+      final cookies = {
+        if (lax != null) clientSessionLaxCookieName: lax,
+        if (strict != null) clientSessionStrictCookieName: strict,
+      };
       try {
         final status = parseClientSessionCookies(cookies);
         if (!status.isPresent) {

--- a/pkg/pub_integration/lib/src/fake_pub_server_process.dart
+++ b/pkg/pub_integration/lib/src/fake_pub_server_process.dart
@@ -66,7 +66,7 @@ class FakePubServerProcess {
       workingDirectory: pkgDir,
       environment: {
         // Because we read the consent email from stdout.
-        'DEBUG': 'fake_server pub.email',
+        'DEBUG': Platform.environment['DEBUG'] ?? 'fake_server pub.email',
       },
     );
     final instance = FakePubServerProcess._(port, process, coverageConfig);

--- a/pkg/pub_integration/test/fake_sign_in_test.dart
+++ b/pkg/pub_integration/test/fake_sign_in_test.dart
@@ -1,0 +1,60 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:pub_integration/src/fake_pub_server_process.dart';
+import 'package:pub_integration/src/headless_env.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('fake sign in', () {
+    late FakePubServerProcess fakePubServerProcess;
+    late final HeadlessEnv headlessEnv;
+
+    setUpAll(() async {
+      fakePubServerProcess = await FakePubServerProcess.start();
+      await fakePubServerProcess.started;
+    });
+
+    tearDownAll(() async {
+      await headlessEnv.close();
+      await fakePubServerProcess.kill();
+    });
+
+    test('bulk tests', () async {
+      // start browser
+      final origin = 'http://localhost:${fakePubServerProcess.port}';
+      headlessEnv = HeadlessEnv(
+        testName: 'fake_sign_in',
+        origin: origin,
+      );
+      await headlessEnv.startBrowser();
+
+      // sign-in page
+      await headlessEnv.withPage(
+        fn: (page) async {
+          await page.gotoOrigin('/experimental?signin=1');
+          final rs = await page.gotoOrigin('/sign-in?fake-email=user@pub.dev');
+          final cookies = (await page.cookies()).map((e) => e.name).toSet();
+          expect(cookies, contains('PUB_SID_INSECURE'));
+          expect(cookies, contains('PUB_SSID_INSECURE'));
+          expect(page.url, startsWith('$origin/sign-in/callback?'));
+          expect(rs.status, 200);
+          final content = await page.content;
+          expect(content, contains('user@pub.dev'));
+        },
+      );
+
+      // sign-in with redirect
+      await headlessEnv.withPage(
+        fn: (page) async {
+          await page.gotoOrigin('/sign-in?fake-email=user@pub.dev&go=/help');
+          final cookies = (await page.cookies()).map((e) => e.name).toSet();
+          expect(cookies, contains('PUB_SID_INSECURE'));
+          expect(cookies, contains('PUB_SSID_INSECURE'));
+          expect(page.url, '$origin/help');
+        },
+      );
+    });
+  });
+}


### PR DESCRIPTION
- `state` is a `Map` encoded as the query parameters of an URI (after the `?` character)
- `UserSession.email` may also accept null in the future, although both `email` and `userId` is filled with `''` (empty string), and session handling logic also checks for that.
- removed `ClientSession` entity, its extra fields (e.g. expected `nonce`) is merged into `UserSession`
- fake service implements a minimal flow by taking a special `fake-email` parameter (only when running locally)
- implemented a minimal `go` target url and redirect
