### PR TITLE
async loading of SessionData inside RequestContext, explicit dependency on rendering

### DIFF
--- a/app/lib/account/backend.dart
+++ b/app/lib/account/backend.dart
@@ -27,15 +27,6 @@ import 'auth_provider.dart';
 import 'models.dart';
 import 'session_cookie.dart' as session_cookie;
 
-/// The name of the session cookie.
-///
-/// Cookies prefixed '__Host-' must:
-///  * be set by a HTTPS response,
-///  * not feature a 'Domain' directive, and,
-///  * have 'Path=/' directive.
-/// Hence, such a cookie cannot have been set by another website or an
-/// HTTP proxy for this website.
-const pubSessionCookieName = '__Host-pub-sid';
 final _logger = Logger('account.backend');
 
 /// The duration or extension of a client session.

--- a/app/lib/account/session_cookie.dart
+++ b/app/lib/account/session_cookie.dart
@@ -40,6 +40,13 @@ String get _userSessionCookieName {
   return '__Host-pub-sid';
 }
 
+/// Returns true if any of the [cookies] is a session-cookie.
+bool hasAnySessionCookie(Map<String, String> cookies) {
+  return cookies.containsKey(_userSessionCookieName) ||
+      cookies.containsKey(clientSessionLaxCookieName) ||
+      cookies.containsKey(clientSessionStrictCookieName);
+}
+
 /// Create a set of HTTP headers that store a session cookie.
 Map<String, String> createUserSessionCookie(
     String sessionId, DateTime expires) {

--- a/app/lib/frontend/handlers/custom_api.dart
+++ b/app/lib/frontend/handlers/custom_api.dart
@@ -109,7 +109,7 @@ Future<shelf.Response> apiPackageNamesHandler(shelf.Request request) async {
   return shelf.Response(200, body: bytes, headers: {
     ...jsonResponseHeaders,
     'Content-Encoding': 'gzip',
-    ...CacheHeaders.packageNames(),
+    ...await CacheHeaders.packageNames(),
   });
 }
 
@@ -141,7 +141,7 @@ Future<shelf.Response> apiPackageNameCompletionDataHandler(
   return shelf.Response(200, body: bytes, headers: {
     ...jsonResponseHeaders,
     'Content-Encoding': 'gzip',
-    ...CacheHeaders.packageNameCompletion(),
+    ...await CacheHeaders.packageNameCompletion(),
   });
 }
 

--- a/app/lib/frontend/handlers/documentation.dart
+++ b/app/lib/frontend/handlers/documentation.dart
@@ -107,10 +107,12 @@ Future<shelf.Response> documentationHandler(shelf.Request request) async {
           version: docFilePath.version, relativePath: 'log.txt');
       final versionsUrl = pkgVersionsUrl(docFilePath.package);
       final content = renderErrorPage(
-          'Documentation missing',
-          'Pub site failed to generate dartdoc for this package.\n\n'
-              '- View [dartdoc log]($logTxtUrl)\n'
-              '- Check [other versions]($versionsUrl) of the same package.\n');
+        'Documentation missing',
+        'Pub site failed to generate dartdoc for this package.\n\n'
+            '- View [dartdoc log]($logTxtUrl)\n'
+            '- Check [other versions]($versionsUrl) of the same package.\n',
+        sessionData: await requestContext.sessionData,
+      );
       return htmlResponse(content, status: 404);
     }
     final info = await dartdocBackend.getFileInfo(entry, docFilePath.path!);
@@ -122,7 +124,7 @@ Future<shelf.Response> documentationHandler(shelf.Request request) async {
     }
     final headers = {
       HttpHeaders.contentTypeHeader: contentType(docFilePath.path!),
-      ...CacheHeaders.dartdocAsset(),
+      ...await CacheHeaders.dartdocAsset(),
       HttpHeaders.lastModifiedHeader: formatHttpDate(info.lastModified),
       HttpHeaders.etagHeader: info.etag,
     };

--- a/app/lib/frontend/handlers/headers.dart
+++ b/app/lib/frontend/handlers/headers.dart
@@ -22,10 +22,10 @@ class CacheHeaders {
     this.signedInStorage,
   });
 
-  Map<String, String> call() {
+  Future<Map<String, String>> call() async {
     return <String, String>{
       HttpHeaders.cacheControlHeader: <String>[
-        requestContext.isAuthenticated
+        (await requestContext.isAuthenticated)
             ? (signedInStorage ?? 'private')
             : 'public',
         if (maxAge >= Duration.zero) 'max-age=${maxAge.inSeconds}',

--- a/app/lib/frontend/handlers/landing.dart
+++ b/app/lib/frontend/handlers/landing.dart
@@ -44,6 +44,7 @@ Future<shelf.Response> indexLandingHandler(shelf.Request request) async {
       topFlutterPackages: topPackages.topFlutter(),
       topDartPackages: topPackages.topDart(),
       topPoWVideos: youtubeBackend.getTopPackageOfWeekVideos(count: 4),
+      sessionData: await requestContext.sessionData,
     );
   }
 

--- a/app/lib/frontend/handlers/listing.dart
+++ b/app/lib/frontend/handlers/listing.dart
@@ -8,6 +8,7 @@ import 'package:_pub_shared/search/search_form.dart';
 import 'package:_pub_shared/search/tags.dart';
 import 'package:shelf/shelf.dart' as shelf;
 
+import '../../frontend/request_context.dart';
 import '../../package/name_tracker.dart';
 import '../../package/search_adapter.dart';
 import '../../shared/handlers.dart';
@@ -79,6 +80,7 @@ Future<shelf.Response> _packagesHandlerHtmlCore(shelf.Request request) async {
       searchForm: searchForm,
       messageFromBackend: searchResult.message,
       openSections: openSections,
+      sessionData: await requestContext.sessionData,
     ),
   );
   _searchOverallLatencyTracker.add(sw.elapsed);

--- a/app/lib/frontend/handlers/misc.dart
+++ b/app/lib/frontend/handlers/misc.dart
@@ -25,37 +25,51 @@ import 'headers.dart';
 
 /// Handles requests for /help
 Future<shelf.Response> helpPageHandler(shelf.Request request) async {
-  return htmlResponse(renderHelpPage());
+  return htmlResponse(renderHelpPage(
+    sessionData: await requestContext.sessionData,
+  ));
 }
 
 /// Handles requests for /help/api
 Future<shelf.Response> helpApiPageHandler(shelf.Request request) async {
-  return htmlResponse(renderHelpApiPage());
+  return htmlResponse(renderHelpApiPage(
+    sessionData: await requestContext.sessionData,
+  ));
 }
 
 /// Handles requests for /help/scoring
 Future<shelf.Response> helpPageScoringHandler(shelf.Request request) async {
-  return htmlResponse(renderHelpScoringPage());
+  return htmlResponse(renderHelpScoringPage(
+    sessionData: await requestContext.sessionData,
+  ));
 }
 
 /// Handles requests for /help/search
 Future<shelf.Response> helpPageSearchHandler(shelf.Request request) async {
-  return htmlResponse(renderHelpSearchPage());
+  return htmlResponse(renderHelpSearchPage(
+    sessionData: await requestContext.sessionData,
+  ));
 }
 
 /// Handles requests for /help/publishing
 Future<shelf.Response> helpPagePublishingHandler(shelf.Request request) async {
-  return htmlResponse(renderHelpPublishingPage());
+  return htmlResponse(renderHelpPublishingPage(
+    sessionData: await requestContext.sessionData,
+  ));
 }
 
 /// Handles requests for /policy
 Future<shelf.Response> policyPageHandler(shelf.Request request) async {
-  return htmlResponse(renderPolicyPage());
+  return htmlResponse(renderPolicyPage(
+    sessionData: await requestContext.sessionData,
+  ));
 }
 
 /// Handles requests for /security
 Future<shelf.Response> securityPageHandler(shelf.Request request) async {
-  return htmlResponse(renderSecurityPage());
+  return htmlResponse(renderSecurityPage(
+    sessionData: await requestContext.sessionData,
+  ));
 }
 
 /// Handles requests for /readiness_check
@@ -156,7 +170,7 @@ Future<shelf.Response> staticsHandler(shelf.Request request) async {
       HttpHeaders.etagHeader: staticFile.etag,
       if (parsed.urlHash == staticFile.etag ||
           parsed.pathHash == staticFileCache.etag)
-        ...CacheHeaders.staticAsset(),
+        ...await CacheHeaders.staticAsset(),
     };
     return shelf.Response.ok(bytes, headers: headers);
   }
@@ -212,9 +226,13 @@ String _notFoundMessage(Uri requestedUri) {
 }
 
 /// Renders a formatted response when the request points to a missing or invalid path.
-shelf.Response formattedNotFoundHandler(shelf.Request request) {
+Future<shelf.Response> formattedNotFoundHandler(shelf.Request request) async {
   return htmlResponse(
-    renderErrorPage(default404NotFound, _notFoundMessage(request.requestedUri)),
+    renderErrorPage(
+      default404NotFound,
+      _notFoundMessage(request.requestedUri),
+      sessionData: await requestContext.sessionData,
+    ),
     status: 404,
   );
 }

--- a/app/lib/frontend/templates/admin.dart
+++ b/app/lib/frontend/templates/admin.dart
@@ -19,12 +19,15 @@ import 'views/pkg/package_list.dart';
 import 'views/publisher/publisher_list.dart';
 
 /// Renders the response that is displayed after pub client authorizes successfully.
-String renderAuthorizedPage() {
+String renderAuthorizedPage({
+  required SessionData? sessionData,
+}) {
   return renderLayoutPage(
     PageType.package,
     authorizedNode,
     title: 'Pub Authorized Successfully',
     noIndex: true,
+    sessionData: sessionData,
   );
 }
 
@@ -86,6 +89,7 @@ String renderAccountPackagesPage({
     title: title,
     noIndex: true,
     mainClasses: [wideHeaderDetailPageClassName],
+    sessionData: userSessionData,
   );
 }
 
@@ -125,6 +129,7 @@ String renderMyLikedPackagesPage({
     title: 'My liked packages',
     noIndex: true,
     mainClasses: [wideHeaderDetailPageClassName],
+    sessionData: userSessionData,
   );
 }
 
@@ -156,6 +161,7 @@ String renderAccountPublishersPage({
     title: 'My publishers',
     noIndex: true,
     mainClasses: [wideHeaderDetailPageClassName],
+    sessionData: userSessionData,
   );
 }
 
@@ -192,6 +198,7 @@ String renderAccountMyActivityPage({
     title: 'My activity log',
     noIndex: true,
     mainClasses: [wideHeaderDetailPageClassName],
+    sessionData: userSessionData,
   );
 }
 

--- a/app/lib/frontend/templates/consent.dart
+++ b/app/lib/frontend/templates/consent.dart
@@ -4,6 +4,7 @@
 
 import 'package:_pub_shared/data/page_data.dart';
 
+import '../../account/models.dart';
 import '../dom/dom.dart' as d;
 
 import 'layout.dart';
@@ -17,6 +18,7 @@ String renderConsentPage({
   required String consentId,
   required String title,
   required String descriptionHtml,
+  required SessionData? sessionData,
 }) {
   final content = consentPageNode(
     title: title,
@@ -28,6 +30,7 @@ String renderConsentPage({
     title: 'Consent',
     noIndex: true,
     pageData: PageData(consentId: consentId),
+    sessionData: sessionData,
   );
 }
 

--- a/app/lib/frontend/templates/landing.dart
+++ b/app/lib/frontend/templates/landing.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import '../../account/models.dart';
 import '../../package/models.dart' show PackageView;
 import '../../service/youtube/backend.dart' show PkgOfWeekVideo;
 
@@ -15,6 +16,7 @@ String renderLandingPage({
   List<PackageView>? topFlutterPackages,
   List<PackageView>? topDartPackages,
   List<PkgOfWeekVideo>? topPoWVideos,
+  required SessionData? sessionData,
 }) {
   final content = landingPageNode(
     ffPackages: ffPackages,
@@ -29,5 +31,6 @@ String renderLandingPage({
     title: 'Dart packages',
     canonicalUrl: '/',
     mainClasses: ['landing-main'],
+    sessionData: sessionData,
   );
 }

--- a/app/lib/frontend/templates/layout.dart
+++ b/app/lib/frontend/templates/layout.dart
@@ -5,7 +5,7 @@
 import 'package:_pub_shared/data/page_data.dart';
 import 'package:_pub_shared/search/search_form.dart';
 
-import '../../frontend/request_context.dart';
+import '../../account/models.dart';
 import '../../service/announcement/backend.dart';
 import '../../shared/configuration.dart';
 import '../../shared/urls.dart' as urls;
@@ -51,6 +51,7 @@ String renderLayoutPage(
   bool noIndex = false,
   PageData? pageData,
   List<String>? mainClasses,
+  required SessionData? sessionData,
 }) {
   // normalize canonical URL
   if (canonicalUrl != null && canonicalUrl.startsWith('/')) {
@@ -63,7 +64,6 @@ String renderLayoutPage(
     if (type == PageType.landing) 'page-landing',
   ];
   final announcementBannerHtml = announcementBackend.getAnnouncementHtml();
-  final session = requestContext.userSessionData;
   return pageLayoutNode(
     title: title,
     description: pageDescription ?? _defaultPageDescription,
@@ -71,13 +71,13 @@ String renderLayoutPage(
     faviconUrl: faviconUrl ?? staticUrls.smallDartFavicon,
     noIndex: noIndex,
     oauthClientId: activeConfiguration.pubSiteAudience,
-    csrfToken: session?.csrfToken,
+    csrfToken: sessionData?.csrfToken,
     pageDataEncoded:
         pageData == null ? null : pageDataJsonCodec.encode(pageData.toJson()),
     bodyClasses: bodyClasses,
     siteHeader: siteHeaderNode(
       pageType: type,
-      userSession: session,
+      userSession: sessionData,
     ),
     announcementBanner: announcementBannerHtml == null
         ? null

--- a/app/lib/frontend/templates/listing.dart
+++ b/app/lib/frontend/templates/listing.dart
@@ -6,6 +6,7 @@ import 'dart:math';
 
 import 'package:_pub_shared/search/search_form.dart';
 
+import '../../account/models.dart';
 import '../../package/search_adapter.dart';
 import '../../search/search_service.dart';
 import '../dom/dom.dart' as d;
@@ -37,6 +38,7 @@ String renderPkgIndexPage(
   required SearchForm searchForm,
   String? messageFromBackend,
   Set<String>? openSections,
+  required SessionData? sessionData,
 }) {
   final topPackages = getSdkDict(null).topSdkPackages;
   final isSearch = searchForm.hasQuery;
@@ -70,6 +72,7 @@ String renderPkgIndexPage(
     canonicalUrl: searchForm.toSearchLink(),
     noIndex: true,
     mainClasses: [],
+    sessionData: sessionData,
   );
 }
 

--- a/app/lib/frontend/templates/misc.dart
+++ b/app/lib/frontend/templates/misc.dart
@@ -6,6 +6,7 @@ import 'dart:io' as io;
 
 import 'package:path/path.dart' as p;
 
+import '../../account/models.dart';
 import '../dom/dom.dart' as d;
 import '../static_files.dart' as static_files;
 
@@ -40,27 +41,35 @@ late final _sideImage = d.Image(
 );
 
 /// Renders the response where the real content is only provided for logged-in users.
-String renderUnauthenticatedPage() {
+String renderUnauthenticatedPage({
+  required SessionData? sessionData,
+}) {
   return renderLayoutPage(
     PageType.standalone,
     unauthenticatedNode,
     title: 'Authentication required',
     noIndex: true,
+    sessionData: sessionData,
   );
 }
 
 /// Renders the response where the real content is only provided for authorized users.
-String renderUnauthorizedPage() {
+String renderUnauthorizedPage({
+  required SessionData? sessionData,
+}) {
   return renderLayoutPage(
     PageType.standalone,
     unauthorizedNode,
     title: 'Authorization required',
     noIndex: true,
+    sessionData: sessionData,
   );
 }
 
 /// Renders the `doc/api.md`.
-String renderHelpApiPage() {
+String renderHelpApiPage({
+  required SessionData? sessionData,
+}) {
   return renderLayoutPage(
     PageType.standalone,
     standalonePageNode(
@@ -69,11 +78,14 @@ String renderHelpApiPage() {
     ),
     title: 'pub.dev API',
     canonicalUrl: '/help/api',
+    sessionData: sessionData,
   );
 }
 
 /// Renders the `doc/help.md`.
-String renderHelpPage() {
+String renderHelpPage({
+  required SessionData? sessionData,
+}) {
   return renderLayoutPage(
     PageType.standalone,
     standalonePageNode(
@@ -82,11 +94,14 @@ String renderHelpPage() {
     ),
     title: 'Help | Dart packages',
     canonicalUrl: '/help',
+    sessionData: sessionData,
   );
 }
 
 /// Renders the `doc/help-scoring.md`.
-String renderHelpScoringPage() {
+String renderHelpScoringPage({
+  required SessionData? sessionData,
+}) {
   return renderLayoutPage(
     PageType.standalone,
     standalonePageNode(
@@ -95,11 +110,14 @@ String renderHelpScoringPage() {
     ),
     title: 'Scoring | Dart packages',
     canonicalUrl: '/help/scoring',
+    sessionData: sessionData,
   );
 }
 
 /// Renders the `doc/help-search.md`.
-String renderHelpSearchPage() {
+String renderHelpSearchPage({
+  required SessionData? sessionData,
+}) {
   return renderLayoutPage(
     PageType.standalone,
     standalonePageNode(
@@ -108,11 +126,14 @@ String renderHelpSearchPage() {
     ),
     title: 'Search | Dart packages',
     canonicalUrl: '/help/search',
+    sessionData: sessionData,
   );
 }
 
 /// Renders the `doc/help-publishing.md`.
-String renderHelpPublishingPage() {
+String renderHelpPublishingPage({
+  required SessionData? sessionData,
+}) {
   return renderLayoutPage(
     PageType.standalone,
     standalonePageNode(
@@ -121,6 +142,7 @@ String renderHelpPublishingPage() {
     ),
     title: 'Publishing | Dart packages',
     canonicalUrl: '/help/publishing',
+    sessionData: sessionData,
   );
 }
 
@@ -131,31 +153,42 @@ d.Node _readDocContent(String path) {
 }
 
 /// Renders the `/doc/policy.md` document.
-String renderPolicyPage() {
+String renderPolicyPage({
+  required SessionData? sessionData,
+}) {
   return renderLayoutPage(
     PageType.standalone,
     standalonePageNode(_policyMarkdown),
     title: 'Policy | Pub site',
     canonicalUrl: '/policy',
+    sessionData: sessionData,
   );
 }
 
 /// Renders the `doc/security.md` template.
-String renderSecurityPage() {
+String renderSecurityPage({
+  required SessionData? sessionData,
+}) {
   return renderLayoutPage(
     PageType.standalone,
     standalonePageNode(_securityMarkdown),
     title: 'Security | Pub site',
     canonicalUrl: '/security',
+    sessionData: sessionData,
   );
 }
 
 /// Renders the error page template.
-String renderErrorPage(String title, String message) {
+String renderErrorPage(
+  String title,
+  String message, {
+  required SessionData? sessionData,
+}) {
   return renderLayoutPage(
     PageType.error,
     errorPageNode(title: title, content: d.markdown(message)),
     title: title,
     noIndex: true,
+    sessionData: sessionData,
   );
 }

--- a/app/lib/frontend/templates/package.dart
+++ b/app/lib/frontend/templates/package.dart
@@ -6,6 +6,7 @@ import 'package:_pub_shared/data/page_data.dart';
 import 'package:_pub_shared/search/tags.dart';
 import 'package:collection/collection.dart' show IterableExtension;
 
+import '../../account/models.dart';
 import '../../package/models.dart';
 import '../../package/overrides.dart' show devDependencyPackages;
 import '../../shared/handlers.dart';
@@ -146,7 +147,10 @@ d.Node renderPkgHeader(PackagePageData data) {
 }
 
 /// Renders the package detail page.
-String renderPkgShowPage(PackagePageData data) {
+String renderPkgShowPage(
+  PackagePageData data, {
+  required SessionData? sessionData,
+}) {
   return _renderPkgPage(
     data: data,
     tabs: buildPackageTabs(
@@ -154,11 +158,15 @@ String renderPkgShowPage(PackagePageData data) {
       readmeTab: _readmeTab(data),
     ),
     pkgPageTab: urls.PkgPageTab.readme,
+    sessionData: sessionData,
   );
 }
 
 /// Renders the package changelog page.
-String renderPkgChangelogPage(PackagePageData data) {
+String renderPkgChangelogPage(
+  PackagePageData data, {
+  required SessionData? sessionData,
+}) {
   return _renderPkgPage(
     data: data,
     tabs: buildPackageTabs(
@@ -166,11 +174,15 @@ String renderPkgChangelogPage(PackagePageData data) {
       changelogTab: _changelogTab(data),
     ),
     pkgPageTab: urls.PkgPageTab.changelog,
+    sessionData: sessionData,
   );
 }
 
 /// Renders the package example page.
-String renderPkgExamplePage(PackagePageData data) {
+String renderPkgExamplePage(
+  PackagePageData data, {
+  required SessionData? sessionData,
+}) {
   return _renderPkgPage(
     data: data,
     tabs: buildPackageTabs(
@@ -178,11 +190,15 @@ String renderPkgExamplePage(PackagePageData data) {
       exampleTab: _exampleTab(data),
     ),
     pkgPageTab: urls.PkgPageTab.example,
+    sessionData: sessionData,
   );
 }
 
 /// Renders the package install page.
-String renderPkgInstallPage(PackagePageData data) {
+String renderPkgInstallPage(
+  PackagePageData data, {
+  required SessionData? sessionData,
+}) {
   return _renderPkgPage(
     data: data,
     tabs: buildPackageTabs(
@@ -190,11 +206,15 @@ String renderPkgInstallPage(PackagePageData data) {
       installingTab: _installTab(data),
     ),
     pkgPageTab: urls.PkgPageTab.install,
+    sessionData: sessionData,
   );
 }
 
 /// Renders the package license page.
-String renderPkgLicensePage(PackagePageData data) {
+String renderPkgLicensePage(
+  PackagePageData data, {
+  required SessionData? sessionData,
+}) {
   return _renderPkgPage(
     data: data,
     tabs: buildPackageTabs(
@@ -202,11 +222,15 @@ String renderPkgLicensePage(PackagePageData data) {
       licenseTab: _licenseTab(data),
     ),
     pkgPageTab: urls.PkgPageTab.license,
+    sessionData: sessionData,
   );
 }
 
 /// Renders the package pubspec page.
-String renderPkgPubspecPage(PackagePageData data) {
+String renderPkgPubspecPage(
+  PackagePageData data, {
+  required SessionData? sessionData,
+}) {
   return _renderPkgPage(
     data: data,
     tabs: buildPackageTabs(
@@ -214,11 +238,15 @@ String renderPkgPubspecPage(PackagePageData data) {
       pubspecTab: _pubspecTab(data),
     ),
     pkgPageTab: urls.PkgPageTab.pubspec,
+    sessionData: sessionData,
   );
 }
 
 /// Renders the package score page.
-String renderPkgScorePage(PackagePageData data) {
+String renderPkgScorePage(
+  PackagePageData data, {
+  required SessionData? sessionData,
+}) {
   return _renderPkgPage(
     data: data,
     tabs: buildPackageTabs(
@@ -226,6 +254,7 @@ String renderPkgScorePage(PackagePageData data) {
       scoreTab: _scoreTab(data),
     ),
     pkgPageTab: urls.PkgPageTab.score,
+    sessionData: sessionData,
   );
 }
 
@@ -233,6 +262,7 @@ String _renderPkgPage({
   required PackagePageData data,
   required List<Tab> tabs,
   required urls.PkgPageTab pkgPageTab,
+  required SessionData? sessionData,
 }) {
   final card = data.scoreCard;
 
@@ -270,6 +300,7 @@ String _renderPkgPage({
     canonicalUrl: canonicalUrl,
     noIndex: noIndex,
     pageData: pkgPageData(data.package!, data.version!),
+    sessionData: sessionData,
   );
 }
 
@@ -515,7 +546,14 @@ List<Tab> buildPackageTabs({
 }
 
 /// Renders the package page when the package has been moderated.
-String renderModeratedPackagePage(String packageName) {
+String renderModeratedPackagePage(
+  String packageName, {
+  required SessionData? sessionData,
+}) {
   final message = 'The package `$packageName` has been removed.';
-  return renderErrorPage(default404NotFound, message);
+  return renderErrorPage(
+    default404NotFound,
+    message,
+    sessionData: sessionData,
+  );
 }

--- a/app/lib/frontend/templates/package_admin.dart
+++ b/app/lib/frontend/templates/package_admin.dart
@@ -19,8 +19,9 @@ String renderPkgAdminPage(
   List<String> userPublishers,
   List<User> uploaderUsers,
   List<String> retractableVersions,
-  List<String> retractedVersions,
-) {
+  List<String> retractedVersions, {
+  required SessionData? sessionData,
+}) {
   final tabs = buildPackageTabs(
     data: data,
     adminTab: Tab.withContent(
@@ -49,13 +50,15 @@ String renderPkgAdminPage(
     title: '${data.package!.name} package - Admin',
     pageData: pkgPageData(data.package!, data.version!),
     noIndex: true,
+    sessionData: sessionData,
   );
 }
 
 String renderPkgActivityLogPage(
   PackagePageData data,
-  AuditLogRecordPage activities,
-) {
+  AuditLogRecordPage activities, {
+  required SessionData? sessionData,
+}) {
   final activityLog = activityLogNode(
     baseUrl: urls.pkgActivityLogUrl(data.package!.name!),
     activities: activities,
@@ -82,5 +85,6 @@ String renderPkgActivityLogPage(
     title: '${data.package!.name} package - Admin',
     pageData: pkgPageData(data.package!, data.version!),
     noIndex: true,
+    sessionData: sessionData,
   );
 }

--- a/app/lib/frontend/templates/package_versions.dart
+++ b/app/lib/frontend/templates/package_versions.dart
@@ -6,6 +6,7 @@ import 'package:_pub_shared/data/package_api.dart';
 import 'package:collection/collection.dart' show IterableExtension;
 import 'package:pub_semver/pub_semver.dart';
 
+import '../../account/models.dart';
 import '../../package/model_properties.dart';
 import '../../package/models.dart';
 import '../../shared/urls.dart' as urls;
@@ -22,6 +23,7 @@ String renderPkgVersionsPage(
   PackagePageData data,
   List<VersionInfo> versions, {
   required Version dartSdkVersion,
+  required SessionData? sessionData,
 }) {
   final previewVersionRows = <d.Node>[];
   final stableVersionRows = <d.Node>[];
@@ -121,5 +123,6 @@ String renderPkgVersionsPage(
     canonicalUrl: canonicalUrl,
     pageData: pkgPageData(data.package!, data.version!),
     noIndex: data.package!.isDiscontinued,
+    sessionData: sessionData,
   );
 }

--- a/app/lib/frontend/templates/publisher.dart
+++ b/app/lib/frontend/templates/publisher.dart
@@ -6,6 +6,7 @@ import 'package:_pub_shared/data/page_data.dart';
 import 'package:_pub_shared/data/publisher_api.dart' as api;
 import 'package:_pub_shared/search/search_form.dart' show SearchForm;
 
+import '../../account/models.dart';
 import '../../audit/models.dart';
 import '../../frontend/templates/views/account/activity_log_table.dart';
 import '../../package/search_adapter.dart' show SearchResultPage;
@@ -21,23 +22,30 @@ import 'views/publisher/header_metadata.dart';
 import 'views/publisher/publisher_list.dart';
 
 /// Renders the create publisher page.
-String renderCreatePublisherPage() {
+String renderCreatePublisherPage({
+  required SessionData? sessionData,
+}) {
   return renderLayoutPage(
     PageType.standalone,
     createPublisherPageNode,
     title: 'Create publisher',
     noIndex: true, // no need to index, as the page is only for a logged-in user
+    sessionData: sessionData,
   );
 }
 
 /// Renders the global publisher list page.
-String renderPublisherListPage(List<PublisherSummary> publishers) {
+String renderPublisherListPage(
+  List<PublisherSummary> publishers, {
+  required SessionData? sessionData,
+}) {
   final content = publisherListNode(publishers: publishers, isGlobal: true);
   return renderLayoutPage(
     PageType.listing,
     content,
     title: 'Publishers',
     canonicalUrl: '/publishers',
+    sessionData: sessionData,
   );
 }
 
@@ -51,6 +59,7 @@ String renderPublisherPackagesPage({
   required SearchForm searchForm,
   required int totalCount,
   required bool isAdmin,
+  required SessionData? sessionData,
 }) {
   final title = 'Packages of publisher ${publisher.publisherId}';
 
@@ -125,6 +134,7 @@ String renderPublisherPackagesPage({
         searchResultPage.hasNoHit ||
         pageLinks.currentPage! > 1,
     mainClasses: [wideHeaderDetailPageClassName],
+    sessionData: sessionData,
   );
 }
 
@@ -132,6 +142,7 @@ String renderPublisherPackagesPage({
 String renderPublisherAdminPage({
   required Publisher publisher,
   required List<api.PublisherMember> members,
+  required SessionData? sessionData,
 }) {
   final tabs = <Tab>[
     _packagesLinkTab(publisher.publisherId),
@@ -163,6 +174,7 @@ String renderPublisherAdminPage({
     canonicalUrl: urls.publisherAdminUrl(publisher.publisherId),
     noIndex: true,
     mainClasses: [wideHeaderDetailPageClassName],
+    sessionData: sessionData,
   );
 }
 
@@ -170,6 +182,7 @@ String renderPublisherAdminPage({
 String renderPublisherActivityLogPage({
   required Publisher publisher,
   required AuditLogRecordPage activities,
+  required SessionData? sessionData,
 }) {
   final activityLog = activityLogNode(
     baseUrl: urls.publisherActivityLogUrl(publisher.publisherId),
@@ -204,6 +217,7 @@ String renderPublisherActivityLogPage({
     canonicalUrl: urls.publisherActivityLogUrl(publisher.publisherId),
     noIndex: true,
     mainClasses: [wideHeaderDetailPageClassName],
+    sessionData: sessionData,
   );
 }
 

--- a/app/lib/shared/handler_helpers.dart
+++ b/app/lib/shared/handler_helpers.dart
@@ -113,7 +113,7 @@ shelf.Handler _requestContextWrapper(shelf.Handler handler) {
     if (!context.uiCacheEnabled && !CacheHeaders.hasCacheHeader(rs.headers)) {
       // Indicates that the response is intended for a single user and must not
       // be stored by a shared cache. A private cache may store the response.
-      rs = rs.change(headers: CacheHeaders.private());
+      rs = rs.change(headers: await CacheHeaders.private());
     }
     return rs;
   };
@@ -159,6 +159,7 @@ shelf.Handler _logRequestWrapper(Logger logger, shelf.Handler handler) {
           content,
           title: 'Error ${e.code}',
           noIndex: true,
+          sessionData: null,
         ),
         status: e.status,
         headers: e.headers,
@@ -189,6 +190,7 @@ Request ID: ${context.traceId}
         d.markdown(markdownText),
         title: title,
         noIndex: true,
+        sessionData: null,
       );
       return htmlResponse(content, status: 500, headers: debugHeaders);
     } finally {

--- a/app/test/frontend/golden/pkg_admin_page.html
+++ b/app/test/frontend/golden/pkg_admin_page.html
@@ -50,8 +50,17 @@
         </form>
       </div>
       <div class="site-header-nav scroll-container">
-        <div class="nav-login-container">
-          <button id="-account-login" class="nav-main-button link">Sign in</button>
+        <div id="-account-profile" class="nav-container nav-my-container hoverable">
+          <button class="nav-main-button">My pub.dev</button>
+          <div class="nav-hover-popup">
+            <div class="nav-table-column">
+              <a class="nav-link" href="/my-publishers">Publishers</a>
+              <a class="nav-link" href="/my-packages">Packages</a>
+              <a class="nav-link" href="/my-liked-packages">Likes</a>
+              <a class="nav-link" href="/my-activity-log">Activity log</a>
+              <a class="nav-link" href="/create-publisher">Create publisher</a>
+            </div>
+          </div>
         </div>
         <div class="nav-container nav-help-container hoverable">
           <button class="nav-main-button">Help</button>
@@ -105,6 +114,21 @@
           <div class="foldable-content">
             <a class="nav-link" href="https://dart.dev/guides/packages" rel="noopener" target="_blank">Using packages</a>
             <a class="nav-link" href="https://dart.dev/tools/pub/publishing" rel="noopener" target="_blank">Publishing a package</a>
+          </div>
+        </div>
+        <div class="nav-container nav-profile-container hoverable">
+          <input class="nav-profile-img nav-profile-image-desktop" type="image" src="" alt="Profile Image"/>
+          <div class="nav-hover-popup">
+            <div class="nav-table-column">
+              <div class="nav-account-title-mobile">
+                <img class="nav-profile-img nav-profile-img-mobile" src="" alt="Profile Image" width="30" height="30"/>
+                <div class="nav-account-title">
+                  <div class="nav-account-email"></div>
+                </div>
+              </div>
+              <div class="nav-separator"></div>
+              <a id="-account-logout" class="nav-link" href="" aria-role="button">Sign out</a>
+            </div>
           </div>
         </div>
       </div>

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -139,18 +139,23 @@ void main() {
       'landing page',
       processJobsWithFakeRunners: true,
       fn: () async {
-        final html = renderLandingPage(ffPackages: [
-          (await scoreCardBackend.getPackageView('flutter_titanium'))!,
-        ], mostPopularPackages: [
-          (await scoreCardBackend.getPackageView('neon'))!,
-          (await scoreCardBackend.getPackageView('oxygen'))!,
-        ], topPoWVideos: [
-          PkgOfWeekVideo(
-              videoId: 'video-id',
-              title: 'POW Title',
-              description: 'POW description',
-              thumbnailUrl: 'http://youtube.com/image/thumbnail?i=123&s=4'),
-        ]);
+        final html = renderLandingPage(
+          ffPackages: [
+            (await scoreCardBackend.getPackageView('flutter_titanium'))!,
+          ],
+          mostPopularPackages: [
+            (await scoreCardBackend.getPackageView('neon'))!,
+            (await scoreCardBackend.getPackageView('oxygen'))!,
+          ],
+          topPoWVideos: [
+            PkgOfWeekVideo(
+                videoId: 'video-id',
+                title: 'POW Title',
+                description: 'POW description',
+                thumbnailUrl: 'http://youtube.com/image/thumbnail?i=123&s=4'),
+          ],
+          sessionData: null,
+        );
         expectGoldenFile(html, 'landing_page.html');
       },
     );
@@ -163,7 +168,7 @@ void main() {
           adminAtPubDevAuthToken,
           () => loadPackagePageData('oxygen', '1.2.0', AssetKind.readme),
         );
-        final html = renderPkgShowPage(data);
+        final html = renderPkgShowPage(data, sessionData: null);
         expectGoldenFile(html, 'pkg_show_page.html', timestamps: {
           'published': data.package!.created,
           'updated': data.version!.created,
@@ -177,7 +182,7 @@ void main() {
       fn: () async {
         final data =
             await loadPackagePageData('oxygen', '1.2.0', AssetKind.changelog);
-        final html = renderPkgChangelogPage(data);
+        final html = renderPkgChangelogPage(data, sessionData: null);
         expectGoldenFile(html, 'pkg_changelog_page.html', timestamps: {
           'published': data.package!.created,
           'updated': data.version!.created,
@@ -191,7 +196,7 @@ void main() {
       fn: () async {
         final data =
             await loadPackagePageData('oxygen', '1.2.0', AssetKind.example);
-        final html = renderPkgExamplePage(data);
+        final html = renderPkgExamplePage(data, sessionData: null);
         expectGoldenFile(html, 'pkg_example_page.html', timestamps: {
           'published': data.package!.created,
           'updated': data.version!.created,
@@ -204,7 +209,7 @@ void main() {
       processJobsWithFakeRunners: true,
       fn: () async {
         final data = await loadPackagePageData('oxygen', '1.2.0', null);
-        final html = renderPkgInstallPage(data);
+        final html = renderPkgInstallPage(data, sessionData: null);
         expectGoldenFile(html, 'pkg_install_page.html', timestamps: {
           'published': data.package!.created,
           'updated': data.version!.created,
@@ -215,7 +220,7 @@ void main() {
     testWithProfile('package score page', processJobsWithFakeRunners: true,
         fn: () async {
       final data = await loadPackagePageData('oxygen', '1.2.0', null);
-      final html = renderPkgScorePage(data);
+      final html = renderPkgScorePage(data, sessionData: null);
       expectGoldenFile(html, 'pkg_score_page.html', timestamps: {
         'published': data.package!.created,
         'updated': data.version!.created,
@@ -228,7 +233,7 @@ void main() {
       fn: () async {
         final data =
             await loadPackagePageData('oxygen', '1.2.0', AssetKind.readme);
-        final html = renderPkgShowPage(data);
+        final html = renderPkgShowPage(data, sessionData: null);
         expectGoldenFile(html, 'pkg_show_version_page.html', timestamps: {
           'published': data.package!.created,
           'updated': data.version!.created,
@@ -245,7 +250,7 @@ void main() {
           () => loadPackagePageData(
               'flutter_titanium', '1.10.0', AssetKind.readme),
         );
-        final html = renderPkgShowPage(data);
+        final html = renderPkgShowPage(data, sessionData: null);
         expectGoldenFile(html, 'pkg_show_page_flutter_plugin.html',
             timestamps: {
               'published': data.package!.created,
@@ -269,7 +274,7 @@ void main() {
         ),
         processJobsWithFakeRunners: true, fn: () async {
       final data = await loadPackagePageData('pkg', '1.0.0', AssetKind.readme);
-      final html = renderPkgShowPage(data);
+      final html = renderPkgShowPage(data, sessionData: null);
       expectGoldenFile(html, 'pkg_show_page_discontinued.html', timestamps: {
         'published': data.package!.created,
         'updated': data.version!.created,
@@ -292,14 +297,14 @@ void main() {
         ),
         processJobsWithFakeRunners: true, fn: () async {
       final data = await loadPackagePageData('pkg', '1.0.0', AssetKind.readme);
-      final html = renderPkgShowPage(data);
+      final html = renderPkgShowPage(data, sessionData: null);
       expectGoldenFile(html, 'pkg_show_page_retracted.html', timestamps: {
         'published': data.package!.created,
         'updated': data.version!.created,
       });
 
       final data2 = await loadPackagePageData('pkg', '2.0.0', AssetKind.readme);
-      final html2 = renderPkgShowPage(data2);
+      final html2 = renderPkgShowPage(data2, sessionData: null);
       expectGoldenFile(
           html2, 'pkg_show_page_retracted_non_retracted_version.html',
           timestamps: {
@@ -324,7 +329,7 @@ void main() {
         ),
         processJobsWithFakeRunners: true, fn: () async {
       final data2 = await loadPackagePageData('pkg', '2.0.0', AssetKind.readme);
-      final html2 = renderPkgShowPage(data2);
+      final html2 = renderPkgShowPage(data2, sessionData: null);
       expectGoldenFile(
           html2, 'pkg_show_page_retracted_non_retracted_version.html',
           timestamps: {
@@ -345,7 +350,7 @@ void main() {
       processJobsWithFakeRunners: true,
       fn: () async {
         final data = await loadPackagePageData('pkg', '1.0.0-legacy', null);
-        final html = renderPkgScorePage(data);
+        final html = renderPkgScorePage(data, sessionData: null);
         expectGoldenFile(html, 'pkg_show_page_legacy.html', timestamps: {
           'published': data.package!.created,
           'updated': data.version!.created,
@@ -356,7 +361,7 @@ void main() {
     // package analysis was intentionally left out for this template
     testWithProfile('package show page with publisher', fn: () async {
       final data = await loadPackagePageData('neon', '1.0.0', AssetKind.readme);
-      final html = renderPkgShowPage(data);
+      final html = renderPkgShowPage(data, sessionData: null);
       expectGoldenFile(html, 'pkg_show_page_publisher.html', timestamps: {
         'published': data.package!.created,
         'updated': data.package!.lastVersionPublished,
@@ -431,19 +436,21 @@ void main() {
       'package admin page',
       processJobsWithFakeRunners: true,
       fn: () async {
+        late SessionData sessionData;
         final data = await accountBackend.withBearerToken(
           adminAtPubDevAuthToken,
           () async {
             // update session as package data loading checks that
             final user = await requireAuthenticatedWebUser();
+            sessionData = SessionData(
+              userId: user.userId,
+              created: clock.now(),
+              expires: clock.now().add(Duration(days: 1)),
+              sessionId: 'session-1',
+            );
             registerRequestContext(
               RequestContext(
-                userSessionData: SessionData(
-                  userId: user.userId,
-                  created: clock.now(),
-                  expires: clock.now().add(Duration(days: 1)),
-                  sessionId: 'session-1',
-                ),
+                oldSessionDataFuture: Future.value(sessionData),
               ),
             );
             return await loadPackagePageData(
@@ -456,6 +463,7 @@ void main() {
           await accountBackend.lookupUsersByEmail('admin@pub.dev'),
           ['2.0.0'],
           ['1.0.0'],
+          sessionData: sessionData,
         );
         expectGoldenFile(html, 'pkg_admin_page.html', timestamps: {
           'published': data.package!.created,
@@ -475,7 +483,7 @@ void main() {
           );
           registerRequestContext(
             RequestContext(
-              userSessionData: session,
+              oldSessionDataFuture: Future.value(session),
             ),
           );
           final data = await loadPackagePageData('oxygen', '1.2.0', null);
@@ -497,7 +505,8 @@ void main() {
             ..expires = auditLogRecordExpiresInFarFuture
             ..summary = 'old action');
 
-          final html = renderPkgActivityLogPage(data, activities);
+          final html =
+              renderPkgActivityLogPage(data, activities, sessionData: session);
           expectGoldenFile(html, 'pkg_activity_log_page.html', timestamps: {
             'published': data.package!.created,
             'updated': data.version!.created,
@@ -534,6 +543,7 @@ void main() {
           ),
           PageLinks.empty(),
           searchForm: searchForm,
+          sessionData: null,
         );
         expectGoldenFile(html, 'pkg_index_page.html', timestamps: {
           'oxygen-created': oxygen.created,
@@ -566,6 +576,7 @@ void main() {
           ),
           PageLinks(searchForm, 50),
           searchForm: searchForm,
+          sessionData: null,
         );
         expectGoldenFile(html, 'search_page.html', timestamps: {
           'oxygen-created': oxygen.created,
@@ -600,6 +611,7 @@ void main() {
             created: DateTime(2019, 09, 19),
           ),
         ],
+        sessionData: null,
       );
       expectGoldenFile(
         html,
@@ -633,6 +645,7 @@ void main() {
           pageLinks: PageLinks(searchForm, 10),
           isAdmin: true,
           messageFromBackend: null,
+          sessionData: null,
         );
         expectGoldenFile(html, 'publisher_packages_page.html', timestamps: {
           'neon-created': neon.created,
@@ -665,6 +678,7 @@ void main() {
           pageLinks: PageLinks(searchForm, 10),
           isAdmin: true,
           messageFromBackend: null,
+          sessionData: null,
         );
         expectGoldenFile(html, 'publisher_unlisted_packages_page.html',
             timestamps: {
@@ -686,6 +700,7 @@ void main() {
         final html = renderPublisherAdminPage(
           publisher: publisher,
           members: members,
+          sessionData: null,
         );
         expectGoldenFile(
           html,
@@ -713,6 +728,7 @@ void main() {
         final html = renderPublisherActivityLogPage(
           publisher: publisher,
           activities: activities,
+          sessionData: null,
         );
         expectGoldenFile(html, 'publisher_activity_log_page.html', timestamps: {
           'publisher-created': publisher.created,
@@ -734,11 +750,6 @@ void main() {
           final session = await accountBackend.createNewUserSession(
             name: 'Pub User',
             imageUrl: 'pub.dev/user-img-url.png',
-          );
-          registerRequestContext(
-            RequestContext(
-              userSessionData: session,
-            ),
           );
           final html = renderAccountPackagesPage(
             user: user,
@@ -762,11 +773,6 @@ void main() {
         final session = await accountBackend.createNewUserSession(
           name: 'Pub User',
           imageUrl: 'pub.dev/user-img-url.png',
-        );
-        registerRequestContext(
-          RequestContext(
-            userSessionData: session,
-          ),
         );
         final liked1 = DateTime.fromMillisecondsSinceEpoch(1574423824000);
         final liked2 = DateTime.fromMillisecondsSinceEpoch(1574423824000);
@@ -794,11 +800,6 @@ void main() {
           name: 'Pub User',
           imageUrl: 'pub.dev/user-img-url.png',
         );
-        registerRequestContext(
-          RequestContext(
-            userSessionData: session,
-          ),
-        );
         final publisherCreated = DateTime(2021, 07, 01, 16, 05);
         final html = renderAccountPublishersPage(
           user: user,
@@ -825,11 +826,6 @@ void main() {
           name: 'Pub User',
           imageUrl: 'pub.dev/user-img-url.png',
         );
-        registerRequestContext(
-          RequestContext(
-            userSessionData: session,
-          ),
-        );
         final activities = await auditBackend.listRecordsForUserId(user.userId);
         expect(activities.records, isNotEmpty);
         final html = renderAccountMyActivityPage(
@@ -845,7 +841,7 @@ void main() {
     });
 
     scopedTest('create publisher page', () {
-      final html = renderCreatePublisherPage();
+      final html = renderCreatePublisherPage(sessionData: null);
       expectGoldenFile(html, 'create_publisher_page.html');
     });
 
@@ -854,6 +850,7 @@ void main() {
         consentId: '1234-5678',
         title: 'Invite for something',
         descriptionHtml: '<b>Warning!</b> And text...',
+        sessionData: null,
       );
       expectGoldenFile(html, 'consent_page.html');
     });
@@ -910,17 +907,18 @@ void main() {
     });
 
     scopedTest('authorized page', () {
-      final String html = renderAuthorizedPage();
+      final String html = renderAuthorizedPage(sessionData: null);
       expectGoldenFile(html, 'authorized_page.html');
     });
 
     scopedTest('error page', () {
-      final String html = renderErrorPage('error_title', 'error_message');
+      final String html =
+          renderErrorPage('error_title', 'error_message', sessionData: null);
       expectGoldenFile(html, 'error_page.html');
     });
 
     scopedTest('help page', () async {
-      final html = renderHelpPage();
+      final html = renderHelpPage(sessionData: null);
       expectGoldenFile(html, 'help_page.html');
     });
 


### PR DESCRIPTION
- async/lazy loading of `SessionData`
- prepares seamless migration to new session cookies
- makes rendering of pages with `SessionData` explicit (while previously the deepest part referenced the `requestContext` in the scope)
- fixed a template test that lacked session profile