### PR TITLE
Session-based authorization

### DIFF
--- a/app/lib/shared/exceptions.dart
+++ b/app/lib/shared/exceptions.dart
@@ -364,8 +364,12 @@ class AuthenticationException extends ResponseException {
           '`accessToken` does not match current active user.');
 
   /// Signaling that `authorization` header has bad value or is expired.
-  factory AuthenticationException.failed() =>
-      AuthenticationException._('Authentication failed.');
+  factory AuthenticationException.failed([String? message]) {
+    return AuthenticationException._([
+      'Authentication failed.',
+      if (message != null) message,
+    ].join(' '));
+  }
 
   /// Signaling that User lookup (via e-mail) failed.
   factory AuthenticationException.userNotFound() =>

--- a/pkg/pub_integration/lib/src/pub_puppeteer_helpers.dart
+++ b/pkg/pub_integration/lib/src/pub_puppeteer_helpers.dart
@@ -52,8 +52,9 @@ extension PageExt on Page {
       final text = (await button.textContent()).trim();
       if (text.toLowerCase() == label.toLowerCase()) {
         await button.click();
-        break;
+        return;
       }
     }
+    throw Exception('Button with label "$label" is not on the page.');
   }
 }

--- a/pkg/pub_integration/test/pkg_admin_page2_test.dart
+++ b/pkg/pub_integration/test/pkg_admin_page2_test.dart
@@ -1,0 +1,81 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+import 'package:pub_integration/src/fake_pub_server_process.dart';
+import 'package:pub_integration/src/headless_env.dart';
+import 'package:pub_integration/src/pub_puppeteer_helpers.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group(
+    'package admin page',
+    () {
+      late FakePubServerProcess fakePubServerProcess;
+      late final HeadlessEnv headlessEnv;
+      final httpClient = http.Client();
+
+      setUpAll(() async {
+        fakePubServerProcess = await FakePubServerProcess.start();
+        await fakePubServerProcess.started;
+      });
+
+      tearDownAll(() async {
+        await headlessEnv.close();
+        await fakePubServerProcess.kill();
+        httpClient.close();
+      });
+
+      test('bulk tests', () async {
+        final origin = 'http://localhost:${fakePubServerProcess.port}';
+        // init server data
+        await httpClient.post(Uri.parse('$origin/fake-test-profile'),
+            body: json.encode({
+              'testProfile': {
+                'defaultUser': 'admin@pub.dev',
+                'packages': [
+                  {
+                    'name': 'test_pkg',
+                  },
+                ],
+              },
+            }));
+
+        // start browser
+        headlessEnv = HeadlessEnv(testName: 'pkg-admin-page', origin: origin);
+        await headlessEnv.startBrowser();
+
+        // github publishing
+        await headlessEnv.withPage(fn: (page) async {
+          await page.gotoOrigin('/experimental?signin=1');
+          await page.gotoOrigin('/sign-in?fake-email=admin@pub.dev');
+          await Future.delayed(Duration(seconds: 1));
+
+          await page.gotoOrigin('/packages/test_pkg/admin');
+          await Future.delayed(Duration(seconds: 1));
+
+          await page.click('#-pkg-admin-automated-github-enabled');
+          await Future.delayed(Duration(seconds: 1));
+          await page.focusAndType(
+              '#-pkg-admin-automated-github-repository', 'dart-lang/pub-dev');
+          await Future.delayed(Duration(seconds: 1));
+          await page.click('#-pkg-admin-automated-button');
+          await Future.delayed(Duration(seconds: 1));
+
+          await page.clickOnButtonWithLabel('ok');
+          await Future.delayed(Duration(seconds: 1));
+          await page.reload();
+          await Future.delayed(Duration(seconds: 1));
+          final value =
+              await (await page.$('#-pkg-admin-automated-github-repository'))
+                  .propertyValue('value');
+          expect(value, 'dart-lang/pub-dev');
+        });
+      });
+    },
+    timeout: Timeout.factor(testTimeoutFactor),
+  );
+}

--- a/pkg/web_app/lib/src/account.dart
+++ b/pkg/web_app/lib/src/account.dart
@@ -18,11 +18,12 @@ import 'google_js.dart';
 late final _newSigningMetaContent = document
     .querySelector('meta[name="pub-experiment-signin"]')
     ?.getAttribute('content');
-late final _useNewSignin = _newSigningMetaContent == '1';
+late final useNewSignin = _newSigningMetaContent == '1';
 
 void setupAccount() {
-  if (_useNewSignin) {
-    // TODO: implement client-side sign-in methods.
+  if (useNewSignin) {
+    // TODO: review client-side sign-in methods.
+    _initWidgets();
     return;
   } else {
     _setupOldAccount();

--- a/pkg/web_app/lib/src/api_client/api_client.dart
+++ b/pkg/web_app/lib/src/api_client/api_client.dart
@@ -5,6 +5,7 @@
 import 'dart:html';
 
 import '../_authentication_proxy.dart';
+import '../account.dart';
 import '../deferred/http.dart' as http;
 import 'pubapi.client.dart';
 
@@ -27,6 +28,10 @@ PubApiClient get unauthenticatedClient =>
 PubApiClient get client {
   return PubApiClient(_baseUrl,
       client: http.createAuthenticatedClient(() async {
+    if (useNewSignin) {
+      return null;
+    }
+
     // Wait until we're initialized
     await authProxyReady;
 


### PR DESCRIPTION
- `requireAuthenticatedWebUser` accepts session-based authenticated user when the strict session cookie is present AND the CSRF token matches the session
- `pkg/web_app` initializes the admin widgets when the new sign in is enabled (and there is a meta tag for it)
- stricter button click enforcement in browser test