### PR TITLE
New sign-in flow button events: sign-in / switch account / sign out.

### DIFF
--- a/app/lib/account/auth_provider.dart
+++ b/app/lib/account/auth_provider.dart
@@ -49,7 +49,7 @@ abstract class AuthProvider {
   Future<Uri> getOauthAuthenticationUrl({
     required Map<String, String> state,
     required String nonce,
-    required bool promptConsent,
+    required bool promptSelect,
     required String? loginHint,
   });
 

--- a/app/lib/account/default_auth_provider.dart
+++ b/app/lib/account/default_auth_provider.dart
@@ -101,7 +101,7 @@ class DefaultAuthProvider extends BaseAuthProvider {
   Future<Uri> getOauthAuthenticationUrl({
     required Map<String, String> state,
     required String nonce,
-    required bool promptConsent,
+    required bool promptSelect,
     required String? loginHint,
   }) async {
     // Using https://developers.google.com/identity/protocols/oauth2/web-server#httprest_1
@@ -117,8 +117,9 @@ class DefaultAuthProvider extends BaseAuthProvider {
         ].join(' '),
         'state': encodeState(state),
         'nonce': nonce,
-        if (promptConsent) 'prompt': 'consent',
-        if (loginHint != null && loginHint.isNotEmpty) 'login_hint': loginHint,
+        if (promptSelect) 'prompt': 'select_account',
+        if (!promptSelect && loginHint != null && loginHint.isNotEmpty)
+          'login_hint': loginHint,
       },
     );
   }

--- a/app/lib/fake/backend/fake_auth_provider.dart
+++ b/app/lib/fake/backend/fake_auth_provider.dart
@@ -142,7 +142,7 @@ class FakeAuthProvider extends BaseAuthProvider {
   Future<Uri> getOauthAuthenticationUrl({
     required Map<String, String> state,
     required String nonce,
-    required bool promptConsent,
+    required bool promptSelect,
     required String? loginHint,
   }) async {
     final email = state['fake-email'] ?? loginHint;

--- a/app/lib/frontend/handlers/account.dart
+++ b/app/lib/frontend/handlers/account.dart
@@ -55,7 +55,7 @@ Future<shelf.Response> startSignInHandler(shelf.Request request) async {
   final oauth2Url = await authProvider.getOauthAuthenticationUrl(
     state: state,
     nonce: session.openidNonce!,
-    promptConsent: false,
+    promptSelect: params['select'] == '1',
     loginHint: requestContext.sessionData?.email,
   );
   return redirectResponse(

--- a/app/lib/frontend/templates/views/shared/site_header.dart
+++ b/app/lib/frontend/templates/views/shared/site_header.dart
@@ -5,6 +5,7 @@
 import '../../../../account/models.dart' show SessionData;
 import '../../../../shared/urls.dart' as urls;
 import '../../../dom/dom.dart' as d;
+import '../../../request_context.dart';
 import '../../../static_files.dart' show staticUrls;
 import '../../_consts.dart';
 import '../../layout.dart' show PageType, showSearchBanner;
@@ -160,12 +161,16 @@ d.Node _userBlock(SessionData userSession) {
               ],
             ),
             d.div(classes: ['nav-separator']),
-            d.a(
-              classes: ['nav-link'],
+            if (requestContext.experimentalFlags.useNewSignIn)
+              d.button(
+                id: '-account-switch',
+                classes: ['nav-button', 'link'],
+                text: 'Switch account',
+              ),
+            d.button(
+              classes: ['nav-button'],
               id: '-account-logout',
-              href: '',
               text: 'Sign out',
-              attributes: {'aria-role': 'button'},
             ),
           ],
         ),

--- a/app/test/frontend/golden/my_activity_log_page.html
+++ b/app/test/frontend/golden/my_activity_log_page.html
@@ -126,7 +126,7 @@
                 </div>
               </div>
               <div class="nav-separator"></div>
-              <a id="-account-logout" class="nav-link" href="" aria-role="button">Sign out</a>
+              <button id="-account-logout" class="nav-button">Sign out</button>
             </div>
           </div>
         </div>

--- a/app/test/frontend/golden/my_liked_packages.html
+++ b/app/test/frontend/golden/my_liked_packages.html
@@ -126,7 +126,7 @@
                 </div>
               </div>
               <div class="nav-separator"></div>
-              <a id="-account-logout" class="nav-link" href="" aria-role="button">Sign out</a>
+              <button id="-account-logout" class="nav-button">Sign out</button>
             </div>
           </div>
         </div>

--- a/app/test/frontend/golden/my_packages.html
+++ b/app/test/frontend/golden/my_packages.html
@@ -126,7 +126,7 @@
                 </div>
               </div>
               <div class="nav-separator"></div>
-              <a id="-account-logout" class="nav-link" href="" aria-role="button">Sign out</a>
+              <button id="-account-logout" class="nav-button">Sign out</button>
             </div>
           </div>
         </div>

--- a/app/test/frontend/golden/my_publishers.html
+++ b/app/test/frontend/golden/my_publishers.html
@@ -126,7 +126,7 @@
                 </div>
               </div>
               <div class="nav-separator"></div>
-              <a id="-account-logout" class="nav-link" href="" aria-role="button">Sign out</a>
+              <button id="-account-logout" class="nav-button">Sign out</button>
             </div>
           </div>
         </div>

--- a/app/test/frontend/golden/pkg_activity_log_page.html
+++ b/app/test/frontend/golden/pkg_activity_log_page.html
@@ -128,7 +128,7 @@
                 </div>
               </div>
               <div class="nav-separator"></div>
-              <a id="-account-logout" class="nav-link" href="" aria-role="button">Sign out</a>
+              <button id="-account-logout" class="nav-button">Sign out</button>
             </div>
           </div>
         </div>

--- a/app/test/frontend/golden/pkg_admin_page.html
+++ b/app/test/frontend/golden/pkg_admin_page.html
@@ -127,7 +127,7 @@
                 </div>
               </div>
               <div class="nav-separator"></div>
-              <a id="-account-logout" class="nav-link" href="" aria-role="button">Sign out</a>
+              <button id="-account-logout" class="nav-button">Sign out</button>
             </div>
           </div>
         </div>

--- a/pkg/pub_integration/lib/src/headless_env.dart
+++ b/pkg/pub_integration/lib/src/headless_env.dart
@@ -106,7 +106,9 @@ class HeadlessEnv {
       // soft-abort
       if (rq.url.startsWith('https://www.google-analytics.com/') ||
           rq.url.startsWith('https://www.googletagmanager.com/') ||
-          rq.url.startsWith('https://www.google.com/insights')) {
+          rq.url.startsWith('https://www.google.com/insights') ||
+          rq.url.startsWith(
+              'https://www.gstatic.com/brandstudio/kato/cookie_choice_component/')) {
         await rq.abort(error: ErrorReason.failed);
         return;
       }

--- a/pkg/pub_integration/test/fake_sign_in_test.dart
+++ b/pkg/pub_integration/test/fake_sign_in_test.dart
@@ -123,6 +123,36 @@ void main() {
           );
         },
       );
+
+      // sign-out with button
+      await headlessEnv.withPage(fn: (page) async {
+        await page.gotoOrigin('/');
+        expect(await page.content, contains('admin@pub.dev'));
+        await page.hover('.nav-profile-img');
+        await page.click('#-account-logout');
+        await Future.delayed(Duration(seconds: 10));
+        final cookies = await page.cookies();
+        final cookieNames = cookies.map((e) => e.name).toSet();
+        expect(cookieNames, isNot(contains('PUB_SID_INSECURE')));
+        expect(cookieNames, isNot(contains('PUB_SSID_INSECURE')));
+        expect(await page.content, isNot(contains('admin@pub.dev')));
+      });
+
+      // sign-in with button
+      await headlessEnv.withPage(fn: (page) async {
+        await page.gotoOrigin('/help');
+        expect(await page.content, isNot(contains('user@pub.dev')));
+        final handle = await page.$('#-account-login');
+        await handle.evaluate(
+            'node => node.setAttribute("data-fake-email", "user@pub.dev")');
+        await page.click('#-account-login');
+        await Future.delayed(Duration(seconds: 2));
+        final cookies = await page.cookies();
+        final cookieNames = cookies.map((e) => e.name).toSet();
+        expect(cookieNames, contains('PUB_SID_INSECURE'));
+        expect(cookieNames, contains('PUB_SSID_INSECURE'));
+        expect(await page.content, contains('user@pub.dev'));
+      });
     });
   });
 }

--- a/pkg/web_css/lib/src/_site_header.scss
+++ b/pkg/web_css/lib/src/_site_header.scss
@@ -143,6 +143,17 @@
     height: 50px;
   }
 
+  .nav-button {
+    padding: 8px 10px 8px 0px;
+    background-color: transparent;
+    color: inherit;
+    opacity: 1.0;
+
+    &:hover {
+      opacity: 0.8;
+    }
+  }
+
   .nav-link {
     color: $site-header-popup-fg;
     display: block;


### PR DESCRIPTION
- Converted previous `<a>` link to `<button>` (otherwise a fix of `preventDefault()` was missing from the logout event handler, but it is better to use a button anyway).
- Still using a simple bool flag for `prompt`, as we don't really require an explicit consent.
- Included a hack in web_app to pass extra data for fake sign-in flow (if present and set by puppeteer on the DOM).
- Updated headless environment to also block the cookie consent JS, as there is no reason to load it inside the tests.