### PR TITLE
Restrict default logger.

### DIFF
--- a/app/lib/shared/logging.dart
+++ b/app/lib/shared/logging.dart
@@ -30,6 +30,8 @@ void setupDebugEnvBasedLogging() {
     return;
   }
   _envBasedLoggingSetupDone = true;
+  // The default value here is a hack for integration tests to work.
+  // TODO: change fake services to emit important lines via print or communicate via file or API
   // ignore: invalid_use_of_visible_for_testing_member
   final debugEnv = envConfig.debug ?? 'fake_server pub.email';
   if (debugEnv.isEmpty) {

--- a/app/lib/shared/logging.dart
+++ b/app/lib/shared/logging.dart
@@ -31,7 +31,7 @@ void setupDebugEnvBasedLogging() {
   }
   _envBasedLoggingSetupDone = true;
   // ignore: invalid_use_of_visible_for_testing_member
-  final debugEnv = envConfig.debug ?? '*';
+  final debugEnv = envConfig.debug ?? 'fake_server pub.email';
   if (debugEnv.isEmpty) {
     return;
   }


### PR DESCRIPTION
I've found that local (and CI) logs are way too verbose to deal with them reasonably, let's restrict them to a minimum set.