### PR TITLE
Update example code for Github Workflow

### DIFF
--- a/app/lib/frontend/templates/views/pkg/admin_page.dart
+++ b/app/lib/frontend/templates/views/pkg/admin_page.dart
@@ -361,7 +361,7 @@ d.Node _exampleGithubWorkflow(GithubPublishingConfig github) {
     '',
     'jobs:',
     '  publish:',
-    '    uses: dart-lang/setup-dart/.github/workflows/publish.yml',
+    '    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1',
     if (hasWithParameter) ...[
       '    with:',
       '      environment: \'${github.environment}\'',


### PR DESCRIPTION
The page is located here:  `pub.dev/packages/{package-name}/admin`

If the version number is missing, GitHub Actions will throw an error: 

```
Invalid workflow file
invalid value workflow reference: no version specified
```