### PR TITLE
Fix NPE in search backend by skipping doc paths without symbols.

### DIFF
--- a/app/lib/search/backend.dart
+++ b/app/lib/search/backend.dart
@@ -292,7 +292,7 @@ List<ApiDocPage> apiDocPagesFromPubData(PubDartdocData pubData) {
     }
   });
 
-  final results = pathMap.keys.map((key) {
+  final results = pathMap.keys.where(symbolMap.containsKey).map((key) {
     final path = pathMap[key]!;
     final symbols = symbolMap[key]!.toList()..sort();
     return ApiDocPage(


### PR DESCRIPTION
Fixes #6524.