### PR TITLE
Configuration for rate limits.

### DIFF
--- a/app/config/dartlang-pub-dev.yaml
+++ b/app/config/dartlang-pub-dev.yaml
@@ -65,3 +65,8 @@ tools:
   previewFlutterSdkPath: '/tool/preview/flutter'
   futureDartSdkPath: '/tool/preview/dart-sdk' # same as preview
   futureFlutterSdkPath: '/tool/future/flutter'
+rateLimits:
+  - operation: package-published
+    scope: package
+    burst: 10
+    daily: 24

--- a/app/config/dartlang-pub.yaml
+++ b/app/config/dartlang-pub.yaml
@@ -73,6 +73,6 @@ rateLimits:
     daily: 24
   - operation: package-published
     scope: user
-    burst: 16
-    hourly: 256
-    daily: 1024
+    burst: 20
+    hourly: 200
+    daily: 250

--- a/app/config/dartlang-pub.yaml
+++ b/app/config/dartlang-pub.yaml
@@ -65,3 +65,14 @@ tools:
   previewFlutterSdkPath: '/tool/preview/flutter'
   futureDartSdkPath: '/tool/preview/dart-sdk' # same as preview
   futureFlutterSdkPath: '/tool/future/flutter'
+rateLimits:
+  - operation: package-published
+    scope: package
+    burst: 1
+    hourly: 12
+    daily: 24
+  - operation: package-published
+    scope: user
+    burst: 16
+    hourly: 256
+    daily: 1024

--- a/app/lib/shared/configuration.dart
+++ b/app/lib/shared/configuration.dart
@@ -229,6 +229,9 @@ class Configuration {
   /// The local command-line tools.
   final ToolsConfiguration? tools;
 
+  /// The rate limits for auditable operations.
+  final List<RateLimit>? rateLimits;
+
   /// Load [Configuration] from YAML file at [path] substituting `{{ENV}}` for
   /// the value of environment variable `ENV`.
   factory Configuration.fromYamlFile(final String path) {
@@ -289,6 +292,7 @@ class Configuration {
     required this.admins,
     required this.defaultServiceBaseUrl,
     required this.tools,
+    required this.rateLimits,
   });
 
   /// Load configuration from `app/config/<projectId>.yaml` where `projectId`
@@ -358,6 +362,7 @@ class Configuration {
         ),
       ],
       tools: null,
+      rateLimits: null,
     );
   }
 
@@ -406,6 +411,7 @@ class Configuration {
         ),
       ],
       tools: null,
+      rateLimits: null,
     );
   }
 
@@ -506,4 +512,47 @@ class ToolsConfiguration {
       _$ToolsConfigurationFromJson(json);
 
   Map<String, dynamic> toJson() => _$ToolsConfigurationToJson(this);
+}
+
+/// Defines the scope and filtering rules of the rate limit rule.
+enum RateLimitScope {
+  /// The rate limit rule is applied on the package scope.
+  package,
+
+  /// The rate limit rule is applied on the user / service account scope.
+  user,
+}
+
+/// Defines a rate limit for auditable operations.
+@JsonSerializable(
+  explicitToJson: true,
+  checked: true,
+  disallowUnrecognizedKeys: true,
+  includeIfNull: false,
+)
+class RateLimit {
+  final String operation;
+  final RateLimitScope scope;
+
+  /// Maximum number of operations in a short burst (2 minutes).
+  final int? burst;
+
+  /// Maximum number of operations in an hour.
+  final int? hourly;
+
+  /// Maximum number of operations in 24 hours.
+  final int? daily;
+
+  RateLimit({
+    required this.operation,
+    required this.scope,
+    this.burst,
+    this.hourly,
+    this.daily,
+  });
+
+  factory RateLimit.fromJson(Map<String, dynamic> json) =>
+      _$RateLimitFromJson(json);
+
+  Map<String, dynamic> toJson() => _$RateLimitToJson(this);
 }

--- a/app/lib/shared/configuration.g.dart
+++ b/app/lib/shared/configuration.g.dart
@@ -44,7 +44,8 @@ Configuration _$ConfigurationFromJson(Map json) => $checkedCreate(
             'primaryApiUri',
             'primarySiteUri',
             'admins',
-            'tools'
+            'tools',
+            'rateLimits'
           ],
         );
         final val = Configuration(
@@ -116,6 +117,12 @@ Configuration _$ConfigurationFromJson(Map json) => $checkedCreate(
                   ? null
                   : ToolsConfiguration.fromJson(
                       Map<String, dynamic>.from(v as Map))),
+          rateLimits: $checkedConvert(
+              'rateLimits',
+              (v) => (v as List<dynamic>?)
+                  ?.map((e) =>
+                      RateLimit.fromJson(Map<String, dynamic>.from(e as Map)))
+                  .toList()),
         );
         return val;
       },
@@ -156,6 +163,7 @@ Map<String, dynamic> _$ConfigurationToJson(Configuration instance) =>
       'primarySiteUri': instance.primarySiteUri.toString(),
       'admins': instance.admins?.map((e) => e.toJson()).toList(),
       'tools': instance.tools?.toJson(),
+      'rateLimits': instance.rateLimits?.map((e) => e.toJson()).toList(),
     };
 
 AdminId _$AdminIdFromJson(Map json) => $checkedCreate(
@@ -239,3 +247,46 @@ Map<String, dynamic> _$ToolsConfigurationToJson(ToolsConfiguration instance) =>
       'futureDartSdkPath': instance.futureDartSdkPath,
       'futureFlutterSdkPath': instance.futureFlutterSdkPath,
     };
+
+RateLimit _$RateLimitFromJson(Map<String, dynamic> json) => $checkedCreate(
+      'RateLimit',
+      json,
+      ($checkedConvert) {
+        $checkKeys(
+          json,
+          allowedKeys: const ['operation', 'scope', 'burst', 'hourly', 'daily'],
+        );
+        final val = RateLimit(
+          operation: $checkedConvert('operation', (v) => v as String),
+          scope: $checkedConvert(
+              'scope', (v) => $enumDecode(_$RateLimitScopeEnumMap, v)),
+          burst: $checkedConvert('burst', (v) => v as int?),
+          hourly: $checkedConvert('hourly', (v) => v as int?),
+          daily: $checkedConvert('daily', (v) => v as int?),
+        );
+        return val;
+      },
+    );
+
+Map<String, dynamic> _$RateLimitToJson(RateLimit instance) {
+  final val = <String, dynamic>{
+    'operation': instance.operation,
+    'scope': _$RateLimitScopeEnumMap[instance.scope]!,
+  };
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('burst', instance.burst);
+  writeNotNull('hourly', instance.hourly);
+  writeNotNull('daily', instance.daily);
+  return val;
+}
+
+const _$RateLimitScopeEnumMap = {
+  RateLimitScope.package: 'package',
+  RateLimitScope.user: 'user',
+};


### PR DESCRIPTION
I've implemented a parsed version along the lines of `X in Y minutes`, but in practice I think we'll end up with short, medium and long-term limits anyway, so I don't think we should have the complexity of parsing here. Keeping just a few integers seems to be enough.