### PR TITLE
Reduce markdown parsing.

### DIFF
--- a/app/lib/frontend/templates/_utils.dart
+++ b/app/lib/frontend/templates/_utils.dart
@@ -44,7 +44,7 @@ bool _isMarkdownFile(String filename) {
 bool _isDartFile(String filename) => filename.toLowerCase().endsWith('.dart');
 
 d.Node _renderDartCode(String text) =>
-    d.markdown('````dart\n${text.trim()}\n````\n');
+    d.codeSnippet(language: 'dart', text: text.trim());
 
 d.Node _renderPlainText(String text) =>
     d.div(classes: ['highlight'], child: d.pre(text: text));

--- a/app/lib/frontend/templates/misc.dart
+++ b/app/lib/frontend/templates/misc.dart
@@ -159,3 +159,25 @@ String renderErrorPage(String title, String message) {
     noIndex: true,
   );
 }
+
+d.Node renderFatalError({
+  required String title,
+  required Uri requestedUri,
+  required String? traceId,
+}) {
+  final issueUrl = 'https://github.com/dart-lang/pub-dev/issues/new';
+  final message = d.fragment([
+    d.h1(text: title),
+    d.p(child: d.b(text: 'Fatal package site error.')),
+    d.p(children: [
+      d.text('Please open an issue: '),
+      d.a(href: issueUrl, text: issueUrl),
+      d.p(text: 'Add these details to help us fix the issue:'),
+      d.codeSnippet(
+        language: 'text',
+        text: 'Requested URL: $requestedUri\nRequest ID: $traceId',
+      ),
+    ]),
+  ]);
+  return message;
+}

--- a/app/lib/shared/handler_helpers.dart
+++ b/app/lib/shared/handler_helpers.dart
@@ -8,6 +8,7 @@ import 'dart:io';
 import 'package:appengine/appengine.dart';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as path;
+import 'package:pub_dev/frontend/templates/misc.dart';
 import 'package:shelf/shelf.dart' as shelf;
 import 'package:shelf/shelf_io.dart' as shelf_io;
 import 'package:stack_trace/stack_trace.dart';
@@ -173,25 +174,14 @@ shelf.Handler _logRequestWrapper(Logger logger, shelf.Handler handler) {
       if (context.traceId != null) {
         debugHeaders = {'package-site-request-id': context.traceId!};
       }
-      final issueUrl = 'https://github.com/dart-lang/pub-dev/issues/new';
-      final message = d.fragment([
-        d.h1(text: title),
-        d.p(child: d.b(text: 'Fatal package site error.')),
-        d.p(children: [
-          d.text('Please open an issue: '),
-          d.a(href: issueUrl, text: issueUrl),
-          d.p(text: 'Add these details to help us fix the issue:'),
-          d.codeSnippet(
-            language: 'text',
-            text: 'Requested URL: ${request.requestedUri}\n'
-                'Request ID: ${context.traceId}',
-          ),
-        ]),
-      ]);
 
       final content = renderLayoutPage(
         PageType.package,
-        message,
+        renderFatalError(
+          title: title,
+          requestedUri: request.requestedUri,
+          traceId: context.traceId,
+        ),
         title: title,
         noIndex: true,
       );

--- a/app/lib/shared/utils.dart
+++ b/app/lib/shared/utils.dart
@@ -30,9 +30,6 @@ final Duration twoYears = const Duration(days: 2 * 365);
 /// Appengine.
 const _cloudTraceContextHeader = 'X-Cloud-Trace-Context';
 
-const fileAnIssueContent =
-    'Please open an issue: https://github.com/dart-lang/pub-dev/issues/new';
-
 final Logger _logger = Logger('pub.utils');
 final _random = Random.secure();
 


### PR DESCRIPTION
- Dart code rendering is simple to replace with a pre+code block.
- The error handling in request processing has fewer risk if it uses direct rendering of the content.