### PR TITLE
Remove header-based exception in pkg/web_app.

### DIFF
--- a/pkg/web_app/lib/src/deferred/http.dart
+++ b/pkg/web_app/lib/src/deferred/http.dart
@@ -61,14 +61,7 @@ class _BrowserClient extends BrowserClient {
       updateHeaders: headers,
     );
 
-    final response = await _client.send(modifiedRequest);
-    final wwwAuthenticate = response.headers['www-authenticate'];
-    if (wwwAuthenticate != null) {
-      await response.stream.drain();
-      throw Exception(
-          'Access was denied (www-authenticate header was: $wwwAuthenticate).');
-    }
-    return response;
+    return await _client.send(modifiedRequest);
   }
 
   @override


### PR DESCRIPTION
- Fixes #6573.
- We emit www-authenticate header only as part of our normal exceptions with `code` and `message`. It is enough to just display such messages.