### PR TITLE
Unauthenticated like button: redirect to sign-in.

### DIFF
--- a/app/lib/frontend/templates/views/shared/detail/header.dart
+++ b/app/lib/frontend/templates/views/shared/detail/header.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:_pub_shared/format/number_format.dart';
-import 'package:pub_dev/frontend/request_context.dart';
 
 import '../../../../dom/dom.dart' as d;
 import '../../../../dom/material.dart' as material;
@@ -21,7 +20,6 @@ d.Node detailHeaderNode({
   /// Set true for more whitespace in the header.
   required bool isLoose,
 }) {
-  final isLikeDisabled = requestContext.isNotAuthenticated;
   final hasBanners = isFlutterFavorite;
   return d.fragment([
     if (hasBanners)
@@ -118,10 +116,6 @@ d.Node detailHeaderNode({
                                 'data-ga-click-event': 'toggle-like',
                                 'aria-pressed': isLiked ? 'true' : 'false',
                               },
-                              disabled: isLikeDisabled,
-                              title: isLikeDisabled
-                                  ? 'Sign-in to like the package.'
-                                  : null,
                             ),
                             d.span(
                               classes: ['likes-count'],

--- a/app/test/frontend/golden/pkg_changelog_page.html
+++ b/app/test/frontend/golden/pkg_changelog_page.html
@@ -158,7 +158,7 @@
                     </div>
                   </div>
                   <div class="detail-like">
-                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false" disabled="disabled" title="Sign-in to like the package.">
+                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="icon indicating liked status (inactive)" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="icon indicating liked status (active)" width="18" height="18"/>
                     </button>

--- a/app/test/frontend/golden/pkg_example_page.html
+++ b/app/test/frontend/golden/pkg_example_page.html
@@ -158,7 +158,7 @@
                     </div>
                   </div>
                   <div class="detail-like">
-                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false" disabled="disabled" title="Sign-in to like the package.">
+                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="icon indicating liked status (inactive)" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="icon indicating liked status (active)" width="18" height="18"/>
                     </button>

--- a/app/test/frontend/golden/pkg_install_page.html
+++ b/app/test/frontend/golden/pkg_install_page.html
@@ -158,7 +158,7 @@
                     </div>
                   </div>
                   <div class="detail-like">
-                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false" disabled="disabled" title="Sign-in to like the package.">
+                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="icon indicating liked status (inactive)" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="icon indicating liked status (active)" width="18" height="18"/>
                     </button>

--- a/app/test/frontend/golden/pkg_score_page.html
+++ b/app/test/frontend/golden/pkg_score_page.html
@@ -158,7 +158,7 @@
                     </div>
                   </div>
                   <div class="detail-like">
-                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false" disabled="disabled" title="Sign-in to like the package.">
+                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="icon indicating liked status (inactive)" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="icon indicating liked status (active)" width="18" height="18"/>
                     </button>

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -158,7 +158,7 @@
                     </div>
                   </div>
                   <div class="detail-like">
-                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false" disabled="disabled" title="Sign-in to like the package.">
+                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="icon indicating liked status (inactive)" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="icon indicating liked status (active)" width="18" height="18"/>
                     </button>

--- a/app/test/frontend/golden/pkg_show_page_discontinued.html
+++ b/app/test/frontend/golden/pkg_show_page_discontinued.html
@@ -144,7 +144,7 @@
                     </div>
                   </div>
                   <div class="detail-like">
-                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false" disabled="disabled" title="Sign-in to like the package.">
+                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="icon indicating liked status (inactive)" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="icon indicating liked status (active)" width="18" height="18"/>
                     </button>

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -147,7 +147,7 @@
                     </div>
                   </div>
                   <div class="detail-like">
-                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false" disabled="disabled" title="Sign-in to like the package.">
+                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="icon indicating liked status (inactive)" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="icon indicating liked status (active)" width="18" height="18"/>
                     </button>

--- a/app/test/frontend/golden/pkg_show_page_legacy.html
+++ b/app/test/frontend/golden/pkg_show_page_legacy.html
@@ -136,7 +136,7 @@
                     <span class="package-tag legacy" title="Package does not support Dart 2 or 3.">Dart 1 only</span>
                   </div>
                   <div class="detail-like">
-                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false" disabled="disabled" title="Sign-in to like the package.">
+                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="icon indicating liked status (inactive)" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="icon indicating liked status (active)" width="18" height="18"/>
                     </button>

--- a/app/test/frontend/golden/pkg_show_page_publisher.html
+++ b/app/test/frontend/golden/pkg_show_page_publisher.html
@@ -141,7 +141,7 @@
                     <span class="package-tag missing" title="This version was scheduled for analysis, but it hasn't completed yet.">[pending analysis]</span>
                   </div>
                   <div class="detail-like">
-                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false" disabled="disabled" title="Sign-in to like the package.">
+                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="icon indicating liked status (inactive)" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="icon indicating liked status (active)" width="18" height="18"/>
                     </button>

--- a/app/test/frontend/golden/pkg_show_page_retracted.html
+++ b/app/test/frontend/golden/pkg_show_page_retracted.html
@@ -153,7 +153,7 @@
                     <span class="package-tag retracted" title="This version was retracted.">retracted</span>
                   </div>
                   <div class="detail-like">
-                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false" disabled="disabled" title="Sign-in to like the package.">
+                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="icon indicating liked status (inactive)" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="icon indicating liked status (active)" width="18" height="18"/>
                     </button>

--- a/app/test/frontend/golden/pkg_show_page_retracted_non_retracted_version.html
+++ b/app/test/frontend/golden/pkg_show_page_retracted_non_retracted_version.html
@@ -148,7 +148,7 @@
                     </div>
                   </div>
                   <div class="detail-like">
-                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false" disabled="disabled" title="Sign-in to like the package.">
+                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="icon indicating liked status (inactive)" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="icon indicating liked status (active)" width="18" height="18"/>
                     </button>

--- a/app/test/frontend/golden/pkg_show_version_page.html
+++ b/app/test/frontend/golden/pkg_show_version_page.html
@@ -158,7 +158,7 @@
                     </div>
                   </div>
                   <div class="detail-like">
-                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false" disabled="disabled" title="Sign-in to like the package.">
+                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="icon indicating liked status (inactive)" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="icon indicating liked status (active)" width="18" height="18"/>
                     </button>

--- a/app/test/frontend/golden/pkg_versions_page.html
+++ b/app/test/frontend/golden/pkg_versions_page.html
@@ -158,7 +158,7 @@
                     </div>
                   </div>
                   <div class="detail-like">
-                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false" disabled="disabled" title="Sign-in to like the package.">
+                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="icon indicating liked status (inactive)" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="icon indicating liked status (active)" width="18" height="18"/>
                     </button>

--- a/app/test/frontend/static_files_test.dart
+++ b/app/test/frontend/static_files_test.dart
@@ -199,7 +199,7 @@ void main() {
     test('script.dart.js and parts size check', () {
       final file = cache.getFile('/static/js/script.dart.js');
       expect(file, isNotNull);
-      expect((file!.bytes.length / 1024).round(), closeTo(261, 1));
+      expect((file!.bytes.length / 1024).round(), closeTo(265, 1));
 
       final parts = cache.paths
           .where((path) =>
@@ -210,7 +210,7 @@ void main() {
       final partsSize = parts
           .map((p) => cache.getFile(p)!.bytes.length)
           .reduce((a, b) => a + b);
-      expect((partsSize / 1024).round(), closeTo(232, 1));
+      expect((partsSize / 1024).round(), closeTo(228, 1));
     });
   });
 

--- a/app/test/task/testdata/goldens/packages/oxygen.html
+++ b/app/test/task/testdata/goldens/packages/oxygen.html
@@ -150,7 +150,7 @@
                     </div>
                   </div>
                   <div class="detail-like">
-                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false" disabled="disabled" title="Sign-in to like the package.">
+                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="icon indicating liked status (inactive)" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="icon indicating liked status (active)" width="18" height="18"/>
                     </button>

--- a/app/test/task/testdata/goldens/packages/oxygen/changelog.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/changelog.html
@@ -150,7 +150,7 @@
                     </div>
                   </div>
                   <div class="detail-like">
-                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false" disabled="disabled" title="Sign-in to like the package.">
+                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="icon indicating liked status (inactive)" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="icon indicating liked status (active)" width="18" height="18"/>
                     </button>

--- a/app/test/task/testdata/goldens/packages/oxygen/example.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/example.html
@@ -150,7 +150,7 @@
                     </div>
                   </div>
                   <div class="detail-like">
-                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false" disabled="disabled" title="Sign-in to like the package.">
+                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="icon indicating liked status (inactive)" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="icon indicating liked status (active)" width="18" height="18"/>
                     </button>

--- a/app/test/task/testdata/goldens/packages/oxygen/install.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/install.html
@@ -150,7 +150,7 @@
                     </div>
                   </div>
                   <div class="detail-like">
-                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false" disabled="disabled" title="Sign-in to like the package.">
+                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="icon indicating liked status (inactive)" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="icon indicating liked status (active)" width="18" height="18"/>
                     </button>

--- a/app/test/task/testdata/goldens/packages/oxygen/license.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/license.html
@@ -150,7 +150,7 @@
                     </div>
                   </div>
                   <div class="detail-like">
-                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false" disabled="disabled" title="Sign-in to like the package.">
+                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="icon indicating liked status (inactive)" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="icon indicating liked status (active)" width="18" height="18"/>
                     </button>

--- a/app/test/task/testdata/goldens/packages/oxygen/score.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/score.html
@@ -150,7 +150,7 @@
                     </div>
                   </div>
                   <div class="detail-like">
-                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false" disabled="disabled" title="Sign-in to like the package.">
+                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="icon indicating liked status (inactive)" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="icon indicating liked status (active)" width="18" height="18"/>
                     </button>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions.html
@@ -150,7 +150,7 @@
                     </div>
                   </div>
                   <div class="detail-like">
-                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false" disabled="disabled" title="Sign-in to like the package.">
+                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="icon indicating liked status (inactive)" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="icon indicating liked status (active)" width="18" height="18"/>
                     </button>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0.html
@@ -154,7 +154,7 @@
                     </div>
                   </div>
                   <div class="detail-like">
-                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false" disabled="disabled" title="Sign-in to like the package.">
+                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="icon indicating liked status (inactive)" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="icon indicating liked status (active)" width="18" height="18"/>
                     </button>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/changelog.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/changelog.html
@@ -154,7 +154,7 @@
                     </div>
                   </div>
                   <div class="detail-like">
-                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false" disabled="disabled" title="Sign-in to like the package.">
+                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="icon indicating liked status (inactive)" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="icon indicating liked status (active)" width="18" height="18"/>
                     </button>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/example.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/example.html
@@ -154,7 +154,7 @@
                     </div>
                   </div>
                   <div class="detail-like">
-                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false" disabled="disabled" title="Sign-in to like the package.">
+                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="icon indicating liked status (inactive)" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="icon indicating liked status (active)" width="18" height="18"/>
                     </button>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/install.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/install.html
@@ -154,7 +154,7 @@
                     </div>
                   </div>
                   <div class="detail-like">
-                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false" disabled="disabled" title="Sign-in to like the package.">
+                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="icon indicating liked status (inactive)" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="icon indicating liked status (active)" width="18" height="18"/>
                     </button>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/license.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/license.html
@@ -154,7 +154,7 @@
                     </div>
                   </div>
                   <div class="detail-like">
-                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false" disabled="disabled" title="Sign-in to like the package.">
+                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="icon indicating liked status (inactive)" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="icon indicating liked status (active)" width="18" height="18"/>
                     </button>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/score.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/score.html
@@ -154,7 +154,7 @@
                     </div>
                   </div>
                   <div class="detail-like">
-                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false" disabled="disabled" title="Sign-in to like the package.">
+                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="icon indicating liked status (inactive)" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="icon indicating liked status (active)" width="18" height="18"/>
                     </button>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/2.0.0.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/2.0.0.html
@@ -150,7 +150,7 @@
                     </div>
                   </div>
                   <div class="detail-like">
-                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false" disabled="disabled" title="Sign-in to like the package.">
+                    <button id="-pub-like-icon-button" class="mdc-icon-button" aria-label="Like this package" data-ga-click-event="toggle-like" aria-pressed="false">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="icon indicating liked status (inactive)" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="icon indicating liked status (active)" width="18" height="18"/>
                     </button>

--- a/pkg/web_app/lib/src/account.dart
+++ b/pkg/web_app/lib/src/account.dart
@@ -11,6 +11,7 @@ import 'admin_pages.dart' deferred as admin_pages;
 import 'api_client/api_client.dart' deferred as api_client;
 
 final _signInButton = document.getElementById('-account-login');
+final isNotAuthenticated = _signInButton != null;
 
 void setupAccount() {
   _initSessionMonitor();

--- a/pkg/web_app/lib/src/likes.dart
+++ b/pkg/web_app/lib/src/likes.dart
@@ -7,6 +7,8 @@ import 'dart:html';
 
 import 'package:_pub_shared/format/number_format.dart';
 import 'package:mdc_web/mdc_web.dart' show MDCIconButtonToggle;
+import 'package:web_app/src/_dom_helper.dart';
+import 'package:web_app/src/account.dart';
 
 import 'api_client/api_client.dart' deferred as api_client;
 import 'page_data.dart';
@@ -59,6 +61,17 @@ void setupLikes() {
   }
 
   iconButtonToggle.listen(MDCIconButtonToggle.changeEvent, (Event e) async {
+    if (isNotAuthenticated) {
+      iconButtonToggle.on = false;
+      final content = ParagraphElement()
+        ..text = 'You need to be signed-in to like packages. '
+            'Would you like to visit the authentication page?';
+      final redirect = await modalConfirm(content);
+      if (redirect) {
+        document.getElementById('-account-login')?.click();
+      }
+      return;
+    }
     likeButton.blur();
     await api_client.loadLibrary();
     if (iconButtonToggle.on ?? false) {


### PR DESCRIPTION
- Fixes #6581
- The previous `title` was not displayed in Chrome.
- This will display a modal window with an OK/Cancel button, where the OK button redirects to sign-in (same as if they have clicked the sign-in button)

<img width="446" alt="image" src="https://user-images.githubusercontent.com/4778111/234556165-eb3e1d0f-1aa3-41e3-950d-96883613f152.png">
