### PR TITLE
Status for API docs

### DIFF
--- a/app/lib/frontend/handlers/custom_api.dart
+++ b/app/lib/frontend/handlers/custom_api.dart
@@ -46,13 +46,13 @@ Future<shelf.Response> apiDocumentationHandler(
     final status = await taskBackend.packageStatus(package);
     return jsonResponse({
       'name': package,
-      'versions': status.versions
-          .map((s) => {
-                'version': s.version,
-                'status': s.status == TaskPackageVersionStatus.pending ||
-                        s.status == TaskPackageVersionStatus.running
+      'versions': status.versions.entries
+          .map((e) => {
+                'version': e.key,
+                'status': e.value == PackageVersionStatus.pending ||
+                        e.value == PackageVersionStatus.running
                     ? 'pending'
-                    : (s.status == TaskPackageVersionStatus.failed
+                    : (e.value == PackageVersionStatus.failed
                         ? 'failed'
                         : 'completed'),
               })

--- a/app/lib/frontend/handlers/custom_api.dart
+++ b/app/lib/frontend/handlers/custom_api.dart
@@ -38,10 +38,11 @@ Future<shelf.Response> apiDocumentationHandler(
     return jsonResponse({}, status: 404);
   }
 
+  if (!await packageBackend.isPackageVisible(package)) {
+    return jsonResponse({}, status: 404);
+  }
+
   if (requestContext.experimentalFlags.showSandboxedOutput) {
-    if (!await packageBackend.isPackageVisible(package)) {
-      return jsonResponse({}, status: 404);
-    }
     final status = await taskBackend.packageStatus(package);
     return jsonResponse({
       'name': package,

--- a/app/lib/scorecard/backend.dart
+++ b/app/lib/scorecard/backend.dart
@@ -159,7 +159,8 @@ class ScoreCardBackend {
         dartdocReport: DartdocReport(
           timestamp: summary?.createdAt,
           // TODO: Embed dartdoc success status in summary, unclear if we need it
-          reportStatus: ReportStatus.success, // assume success
+          reportStatus:
+              summary == null ? ReportStatus.failed : ReportStatus.success,
           dartdocEntry: null, // unused
           documentationSection: null, // already embedded in summary
         ),

--- a/app/lib/shared/redis_cache.dart
+++ b/app/lib/shared/redis_cache.dart
@@ -23,6 +23,7 @@ import '../scorecard/models.dart' show ScoreCardData;
 import '../search/search_service.dart' show PackageSearchResult;
 import '../service/openid/openid_models.dart' show OpenIdData;
 import '../service/secret/backend.dart';
+import '../task/models.dart';
 import 'convert.dart';
 import 'versions.dart';
 
@@ -297,6 +298,17 @@ class CachePatterns {
       _cache
           .withPrefix('task-result/')
           .withTTL(Duration(hours: 4))['$blobId/$path'];
+
+  /// Cache for task status.
+  Entry<PackageStatus> taskPackageStatus(String package) => _cache
+      .withPrefix('task-status/')
+      .withTTL(Duration(hours: 3))
+      .withCodec(utf8)
+      .withCodec(json)
+      .withCodec(wrapAsCodec(
+        encode: (PackageStatus s) => s.toJson(),
+        decode: (data) => PackageStatus.fromJson(data as Map<String, dynamic>),
+      ))[package];
 
   /// Cache for sanitized and re-rendered dartdoc HTML files.
   Entry<String> dartdocHtml(

--- a/app/lib/shared/redis_cache.dart
+++ b/app/lib/shared/redis_cache.dart
@@ -300,14 +300,15 @@ class CachePatterns {
           .withTTL(Duration(hours: 4))['$blobId/$path'];
 
   /// Cache for task status.
-  Entry<PackageStatus> taskPackageStatus(String package) => _cache
+  Entry<PackageStateInfo> taskPackageStatus(String package) => _cache
       .withPrefix('task-status/')
       .withTTL(Duration(hours: 3))
       .withCodec(utf8)
       .withCodec(json)
       .withCodec(wrapAsCodec(
-        encode: (PackageStatus s) => s.toJson(),
-        decode: (data) => PackageStatus.fromJson(data as Map<String, dynamic>),
+        encode: (PackageStateInfo s) => s.toJson(),
+        decode: (data) =>
+            PackageStateInfo.fromJson(data as Map<String, dynamic>),
       ))[package];
 
   /// Cache for sanitized and re-rendered dartdoc HTML files.

--- a/app/lib/task/backend.dart
+++ b/app/lib/task/backend.dart
@@ -918,7 +918,10 @@ class TaskBackend {
           final s = e.value;
 
           var status = TaskPackageVersionStatus.completed;
-          if (s.attempts > 0 && s.attempts < taskRetryLimit) {
+          if (s.attempts == 0 && s.scheduled == initialTimestamp) {
+            // attempts == 0 && scheduled == init         ==> pending
+            status = TaskPackageVersionStatus.pending;
+          } else if (s.attempts > 0 && s.attempts < taskRetryLimit) {
             // attempts > 0 && attempts < taskRetryLimit  ==> pending
             status = TaskPackageVersionStatus.pending;
           } else if (s.scheduled
@@ -926,15 +929,13 @@ class TaskBackend {
               .isBefore(clock.now())) {
             // scheduled + 31 days < now                  ==> pending
             status = TaskPackageVersionStatus.pending;
-          } else if (s.attempts == 0 && s.scheduled == initialTimestamp) {
-            // attempts == 0 && scheduled == init         ==> pending
-            status = TaskPackageVersionStatus.pending;
           } else if (s.attempts >= taskRetryLimit) {
             // attempts >= taskRetryLimit                 ==> failed
             status = TaskPackageVersionStatus.failed;
           } else {
             // attempts == 0                              ==> completed
             assert(s.attempts == 0);
+            assert(status == TaskPackageVersionStatus.completed);
           }
 
           return PackageVersionStatus(version: v, status: status);

--- a/app/lib/task/backend.dart
+++ b/app/lib/task/backend.dart
@@ -38,11 +38,8 @@ import 'package:pub_dev/task/models.dart'
         PackageState,
         PackageStateInfo,
         PackageVersionStateInfo,
-        PackageVersionStatus,
-        PackageVersionStatus,
         initialTimestamp,
-        maxTaskExecutionTime,
-        taskRetryLimit;
+        maxTaskExecutionTime;
 import 'package:pub_dev/task/scheduler.dart';
 import 'package:pub_semver/pub_semver.dart' show Version;
 import 'package:retry/retry.dart' show retry;

--- a/app/lib/task/models.dart
+++ b/app/lib/task/models.dart
@@ -2,10 +2,11 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:convert' show json;
+import 'dart:convert' show Codec, json;
 
 import 'package:clock/clock.dart';
 import 'package:json_annotation/json_annotation.dart';
+import 'package:pub_dev/shared/convert.dart';
 import 'package:pub_dev/shared/datastore.dart' as db;
 
 part 'models.g.dart';
@@ -303,4 +304,57 @@ class PackageVersionStateMapProperty extends db.Property {
   bool validate(db.ModelDB mdb, Object? value) =>
       super.validate(mdb, value) &&
       (value == null || value is Map<String, PackageVersionState>);
+}
+
+/// Status for a package.
+@JsonSerializable()
+class PackageStatus {
+  final String package;
+
+  /// Status for versions.
+  ///
+  /// If a version is not represented by an entry in this list, then it is not
+  /// selected for analysis. Either because, it haven't been discovered yet, or
+  /// because we only analyse a limited number of versions.
+  final List<PackageVersionStatus> versions;
+
+  PackageStatus({
+    required this.package,
+    required this.versions,
+  });
+
+  factory PackageStatus.fromJson(Map<String, dynamic> m) =>
+      _$PackageStatusFromJson(m);
+  Map<String, dynamic> toJson() => _$PackageStatusToJson(this);
+}
+
+@JsonSerializable()
+class PackageVersionStatus {
+  /// Canonical version.
+  final String version;
+
+  final TaskPackageVersionStatus status;
+
+  PackageVersionStatus({
+    required this.version,
+    required this.status,
+  });
+
+  factory PackageVersionStatus.fromJson(Map<String, dynamic> m) =>
+      _$PackageVersionStatusFromJson(m);
+  Map<String, dynamic> toJson() => _$PackageVersionStatusToJson(this);
+}
+
+enum TaskPackageVersionStatus {
+  pending,
+  running,
+
+  /// Analysis have completed, there most likely is a summary, at-least there
+  /// is a task-log.
+  ///
+  /// Analysis may have failed.
+  completed,
+
+  /// Analysis failed to report a result.
+  failed,
 }

--- a/app/lib/task/models.dart
+++ b/app/lib/task/models.dart
@@ -2,11 +2,10 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:convert' show Codec, json;
+import 'dart:convert' show json;
 
 import 'package:clock/clock.dart';
 import 'package:json_annotation/json_annotation.dart';
-import 'package:pub_dev/shared/convert.dart';
 import 'package:pub_dev/shared/datastore.dart' as db;
 
 part 'models.g.dart';

--- a/app/lib/task/models.g.dart
+++ b/app/lib/task/models.g.dart
@@ -24,3 +24,38 @@ Map<String, dynamic> _$PackageVersionStateToJson(
       'instance': instance.instance,
       'secretToken': instance.secretToken,
     };
+
+PackageStatus _$PackageStatusFromJson(Map<String, dynamic> json) =>
+    PackageStatus(
+      package: json['package'] as String,
+      versions: (json['versions'] as List<dynamic>)
+          .map((e) => PackageVersionStatus.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+
+Map<String, dynamic> _$PackageStatusToJson(PackageStatus instance) =>
+    <String, dynamic>{
+      'package': instance.package,
+      'versions': instance.versions,
+    };
+
+PackageVersionStatus _$PackageVersionStatusFromJson(
+        Map<String, dynamic> json) =>
+    PackageVersionStatus(
+      version: json['version'] as String,
+      status: $enumDecode(_$TaskPackageVersionStatusEnumMap, json['status']),
+    );
+
+Map<String, dynamic> _$PackageVersionStatusToJson(
+        PackageVersionStatus instance) =>
+    <String, dynamic>{
+      'version': instance.version,
+      'status': _$TaskPackageVersionStatusEnumMap[instance.status]!,
+    };
+
+const _$TaskPackageVersionStatusEnumMap = {
+  TaskPackageVersionStatus.pending: 'pending',
+  TaskPackageVersionStatus.running: 'running',
+  TaskPackageVersionStatus.completed: 'completed',
+  TaskPackageVersionStatus.failed: 'failed',
+};

--- a/app/lib/task/models.g.dart
+++ b/app/lib/task/models.g.dart
@@ -6,18 +6,23 @@ part of 'models.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-PackageVersionState _$PackageVersionStateFromJson(Map<String, dynamic> json) =>
-    PackageVersionState(
+PackageVersionStateInfo _$PackageVersionStateInfoFromJson(
+        Map<String, dynamic> json) =>
+    PackageVersionStateInfo(
       scheduled: DateTime.parse(json['scheduled'] as String),
       attempts: json['attempts'] as int,
       secretToken: json['secretToken'] as String?,
       zone: json['zone'] as String?,
       instance: json['instance'] as String?,
+      docs: json['docs'] as bool? ?? false,
+      pana: json['pana'] as bool? ?? false,
     );
 
-Map<String, dynamic> _$PackageVersionStateToJson(
-        PackageVersionState instance) =>
+Map<String, dynamic> _$PackageVersionStateInfoToJson(
+        PackageVersionStateInfo instance) =>
     <String, dynamic>{
+      'docs': instance.docs,
+      'pana': instance.pana,
       'scheduled': instance.scheduled.toIso8601String(),
       'attempts': instance.attempts,
       'zone': instance.zone,
@@ -25,37 +30,24 @@ Map<String, dynamic> _$PackageVersionStateToJson(
       'secretToken': instance.secretToken,
     };
 
-PackageStatus _$PackageStatusFromJson(Map<String, dynamic> json) =>
-    PackageStatus(
+PackageStateInfo _$PackageStateInfoFromJson(Map<String, dynamic> json) =>
+    PackageStateInfo(
       package: json['package'] as String,
-      versions: (json['versions'] as List<dynamic>)
-          .map((e) => PackageVersionStatus.fromJson(e as Map<String, dynamic>))
-          .toList(),
+      versions: (json['versions'] as Map<String, dynamic>).map(
+        (k, e) => MapEntry(k, $enumDecode(_$PackageVersionStatusEnumMap, e)),
+      ),
     );
 
-Map<String, dynamic> _$PackageStatusToJson(PackageStatus instance) =>
+Map<String, dynamic> _$PackageStateInfoToJson(PackageStateInfo instance) =>
     <String, dynamic>{
       'package': instance.package,
-      'versions': instance.versions,
+      'versions': instance.versions
+          .map((k, e) => MapEntry(k, _$PackageVersionStatusEnumMap[e]!)),
     };
 
-PackageVersionStatus _$PackageVersionStatusFromJson(
-        Map<String, dynamic> json) =>
-    PackageVersionStatus(
-      version: json['version'] as String,
-      status: $enumDecode(_$TaskPackageVersionStatusEnumMap, json['status']),
-    );
-
-Map<String, dynamic> _$PackageVersionStatusToJson(
-        PackageVersionStatus instance) =>
-    <String, dynamic>{
-      'version': instance.version,
-      'status': _$TaskPackageVersionStatusEnumMap[instance.status]!,
-    };
-
-const _$TaskPackageVersionStatusEnumMap = {
-  TaskPackageVersionStatus.pending: 'pending',
-  TaskPackageVersionStatus.running: 'running',
-  TaskPackageVersionStatus.completed: 'completed',
-  TaskPackageVersionStatus.failed: 'failed',
+const _$PackageVersionStatusEnumMap = {
+  PackageVersionStatus.pending: 'pending',
+  PackageVersionStatus.running: 'running',
+  PackageVersionStatus.completed: 'completed',
+  PackageVersionStatus.failed: 'failed',
 };

--- a/app/lib/task/scheduler.dart
+++ b/app/lib/task/scheduler.dart
@@ -7,6 +7,7 @@ import 'package:clock/clock.dart';
 import 'package:logging/logging.dart' show Logger;
 import 'package:pub_dev/shared/configuration.dart';
 import 'package:pub_dev/shared/datastore.dart';
+import 'package:pub_dev/shared/redis_cache.dart';
 import 'package:pub_dev/shared/utils.dart';
 import 'package:pub_dev/shared/versions.dart' show runtimeVersion;
 import 'package:pub_dev/task/cloudcompute/cloudcompute.dart';
@@ -206,6 +207,7 @@ Future<void> schedule(
         return;
       }
       assert(description != null);
+      await cache.taskPackageStatus(state.package).purge();
 
       scheduleMicrotask(() async {
         var rollbackPackageState = true;
@@ -279,6 +281,7 @@ Future<void> schedule(
               s.derivePendingAt();
               tx.insert(s);
             });
+            await cache.taskPackageStatus(state.package).purge();
           }
         }
       });

--- a/app/lib/task/scheduler.dart
+++ b/app/lib/task/scheduler.dart
@@ -176,7 +176,7 @@ Future<void> schedule(
         // Update PackageState
         s.versions!.addAll({
           for (final v in pendingVersions)
-            v: PackageVersionState(
+            v: PackageVersionStateInfo(
               scheduled: now,
               attempts: s.versions![v]!.attempts + 1,
               zone: zone,


### PR DESCRIPTION
This is not perfect, but once migrated we can put this into the template... no need to fetch it from clientside.

Or maybe we want to load whether docs was successfully generated... I'm open to discussing this.
Perhaps it's something we could include in the pana summary?

Also current UI doesn't have good support for: "we chose not to process this version".