### PR TITLE
Search topics text as if they were part of the description.

### DIFF
--- a/app/lib/search/backend.dart
+++ b/app/lib/search/backend.dart
@@ -138,11 +138,16 @@ class SearchBackend {
       _logger.severe('Parsing pub-data.json failed.', e, st);
     }
 
+    final descriptionAndTopics = <String>[
+      pv.pubspec!.description ?? '',
+      ...?pv.pubspec!.topics,
+    ].join(' ');
+
     return PackageDocument(
       package: pv.package,
       version: pv.version!,
       tags: tags.toList(),
-      description: compactDescription(pv.pubspec!.description),
+      description: compactDescription(descriptionAndTopics),
       created: p.created,
       updated: p.lastVersionPublished,
       readme: compactReadme(readmeAsset?.textContent),


### PR DESCRIPTION
- As topic values are displayed alongside with the description text anyway, we could just add the text as if they were part of the description.
- We also keep the `topic:*` tag values.
- Long topics (or long description + topics) are truncated in the index.