### PR TITLE
Merging fake server process and headless env in integration tests.

### DIFF
--- a/pkg/pub_integration/lib/src/fake_test_context_provider.dart
+++ b/pkg/pub_integration/lib/src/fake_test_context_provider.dart
@@ -16,15 +16,15 @@ import 'test_scenario.dart';
 /// The timeout factor that should be used in integration tests.
 final testTimeoutFactor = 6;
 
-class FakeTestScenario {
+class TestContextProvider {
   final String pubHostedUrl;
   final FakePubServerProcess _fakePubServerProcess;
   final HeadlessGroup _headlessGroup;
 
-  FakeTestScenario._(
+  TestContextProvider._(
       this.pubHostedUrl, this._fakePubServerProcess, this._headlessGroup);
 
-  static Future<FakeTestScenario> start() async {
+  static Future<TestContextProvider> start() async {
     final fakePubServerProcess = await FakePubServerProcess.start();
     await fakePubServerProcess.started;
     final origin = 'http://localhost:${fakePubServerProcess.port}';
@@ -40,7 +40,7 @@ class FakeTestScenario {
       origin: origin,
       testName: testName,
     );
-    return FakeTestScenario._(origin, fakePubServerProcess, headlessGroup);
+    return TestContextProvider._(origin, fakePubServerProcess, headlessGroup);
   }
 
   Future<void> close() async {

--- a/pkg/pub_integration/lib/src/fake_test_scenario.dart
+++ b/pkg/pub_integration/lib/src/fake_test_scenario.dart
@@ -1,0 +1,75 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+import 'dart:isolate';
+
+import 'package:_pub_shared/pubapi.dart';
+import 'package:puppeteer/puppeteer.dart';
+
+import 'fake_pub_server_process.dart';
+import 'fake_test_user.dart';
+import 'headless_env.dart';
+import 'test_scenario.dart';
+
+/// The timeout factor that should be used in integration tests.
+final testTimeoutFactor = 6;
+
+class FakeTestScenario {
+  final String pubHostedUrl;
+  final FakePubServerProcess _fakePubServerProcess;
+  final HeadlessGroup _headlessGroup;
+
+  FakeTestScenario._(
+      this.pubHostedUrl, this._fakePubServerProcess, this._headlessGroup);
+
+  static Future<FakeTestScenario> start() async {
+    final fakePubServerProcess = await FakePubServerProcess.start();
+    await fakePubServerProcess.started;
+    final origin = 'http://localhost:${fakePubServerProcess.port}';
+
+    // creating a unique test name for coverage reports
+    final testName = [
+      Platform.script.pathSegments.last.replaceAll('.', '-'),
+      DateTime.now().millisecondsSinceEpoch,
+      Isolate.current.hashCode,
+    ].join('-');
+
+    final headlessGroup = HeadlessGroup(
+      origin: origin,
+      testName: testName,
+    );
+    return FakeTestScenario._(origin, fakePubServerProcess, headlessGroup);
+  }
+
+  Future<void> close() async {
+    await _headlessGroup.close();
+    await _fakePubServerProcess.kill();
+  }
+
+  Future<TestUser> createAnonymousTestUser() async {
+    final headlessEnv = await _headlessGroup.createNewProfile();
+    return TestUser(
+      email: '',
+      api: PubApiClient(pubHostedUrl),
+      withBrowserPage: <T>(Future<T> Function(Page) fn) async {
+        return await headlessEnv.withPage<T>(fn: fn);
+      },
+      readLatestEmail: () async => throw UnimplementedError(),
+      createCredentials: () async => throw UnimplementedError(),
+    );
+  }
+
+  Future<TestUser> createTestUser({
+    required String email,
+    List<String>? scopes,
+  }) async {
+    return await createFakeTestUser(
+      email: email,
+      headlessEnv: await _headlessGroup.createNewProfile(),
+      fakeEmailReader: _fakePubServerProcess.fakeEmailReader,
+      scopes: scopes,
+    );
+  }
+}

--- a/pkg/pub_integration/test/browser_test.dart
+++ b/pkg/pub_integration/test/browser_test.dart
@@ -5,7 +5,7 @@
 import 'package:http/http.dart' as http;
 import 'package:pub_integration/script/base_setup_script.dart';
 import 'package:pub_integration/src/fake_credentials.dart';
-import 'package:pub_integration/src/fake_test_scenario.dart';
+import 'package:pub_integration/src/fake_test_context_provider.dart';
 import 'package:pub_integration/src/headless_env.dart';
 import 'package:pub_integration/src/pub_puppeteer_helpers.dart';
 import 'package:puppeteer/puppeteer.dart';
@@ -13,12 +13,12 @@ import 'package:test/test.dart';
 
 void main() {
   group('browser', () {
-    late final FakeTestScenario fakeTestScenario;
+    late final TestContextProvider fakeTestScenario;
     late BaseSetupScript script;
     final httpClient = http.Client();
 
     setUpAll(() async {
-      fakeTestScenario = await FakeTestScenario.start();
+      fakeTestScenario = await TestContextProvider.start();
     });
 
     tearDownAll(() async {

--- a/pkg/pub_integration/test/dev_version_test.dart
+++ b/pkg/pub_integration/test/dev_version_test.dart
@@ -5,27 +5,26 @@
 import 'package:http/http.dart' as http;
 import 'package:pub_integration/script/dev_version.dart';
 import 'package:pub_integration/src/fake_credentials.dart';
-import 'package:pub_integration/src/fake_pub_server_process.dart';
+import 'package:pub_integration/src/fake_test_scenario.dart';
 import 'package:test/test.dart';
 
 void main() {
   group('devVersion - dev first', () {
-    late FakePubServerProcess fakePubServerProcess;
+    late final FakeTestScenario fakeTestScenario;
     final httpClient = http.Client();
 
     setUpAll(() async {
-      fakePubServerProcess = await FakePubServerProcess.start();
-      await fakePubServerProcess.started;
+      fakeTestScenario = await FakeTestScenario.start();
     });
 
     tearDownAll(() async {
-      await fakePubServerProcess.kill();
+      await fakeTestScenario.close();
       httpClient.close();
     });
 
     test('steps', () async {
       final script = DevVersionScript(
-        pubHostedUrl: 'http://localhost:${fakePubServerProcess.port}',
+        pubHostedUrl: fakeTestScenario.pubHostedUrl,
         credentialsFileContent: fakeCredentialsFileContent(),
       );
       await script.verify(false);
@@ -33,22 +32,21 @@ void main() {
   }, timeout: Timeout.factor(testTimeoutFactor));
 
   group('devVersion - stable first', () {
-    late FakePubServerProcess fakePubServerProcess;
+    late final FakeTestScenario fakeTestScenario;
     final httpClient = http.Client();
 
     setUpAll(() async {
-      fakePubServerProcess = await FakePubServerProcess.start();
-      await fakePubServerProcess.started;
+      fakeTestScenario = await FakeTestScenario.start();
     });
 
     tearDownAll(() async {
-      await fakePubServerProcess.kill();
+      await fakeTestScenario.close();
       httpClient.close();
     });
 
     test('steps', () async {
       final script = DevVersionScript(
-        pubHostedUrl: 'http://localhost:${fakePubServerProcess.port}',
+        pubHostedUrl: fakeTestScenario.pubHostedUrl,
         credentialsFileContent: fakeCredentialsFileContent(),
       );
       await script.verify(true);

--- a/pkg/pub_integration/test/dev_version_test.dart
+++ b/pkg/pub_integration/test/dev_version_test.dart
@@ -5,16 +5,16 @@
 import 'package:http/http.dart' as http;
 import 'package:pub_integration/script/dev_version.dart';
 import 'package:pub_integration/src/fake_credentials.dart';
-import 'package:pub_integration/src/fake_test_scenario.dart';
+import 'package:pub_integration/src/fake_test_context_provider.dart';
 import 'package:test/test.dart';
 
 void main() {
   group('devVersion - dev first', () {
-    late final FakeTestScenario fakeTestScenario;
+    late final TestContextProvider fakeTestScenario;
     final httpClient = http.Client();
 
     setUpAll(() async {
-      fakeTestScenario = await FakeTestScenario.start();
+      fakeTestScenario = await TestContextProvider.start();
     });
 
     tearDownAll(() async {
@@ -32,11 +32,11 @@ void main() {
   }, timeout: Timeout.factor(testTimeoutFactor));
 
   group('devVersion - stable first', () {
-    late final FakeTestScenario fakeTestScenario;
+    late final TestContextProvider fakeTestScenario;
     final httpClient = http.Client();
 
     setUpAll(() async {
-      fakeTestScenario = await FakeTestScenario.start();
+      fakeTestScenario = await TestContextProvider.start();
     });
 
     tearDownAll(() async {

--- a/pkg/pub_integration/test/fake_sign_in_test.dart
+++ b/pkg/pub_integration/test/fake_sign_in_test.dart
@@ -5,16 +5,16 @@
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
-import 'package:pub_integration/src/fake_test_scenario.dart';
+import 'package:pub_integration/src/fake_test_context_provider.dart';
 import 'package:pub_integration/src/headless_env.dart';
 import 'package:test/test.dart';
 
 void main() {
   group('fake sign in', () {
-    late final FakeTestScenario fakeTestScenario;
+    late final TestContextProvider fakeTestScenario;
 
     setUpAll(() async {
-      fakeTestScenario = await FakeTestScenario.start();
+      fakeTestScenario = await TestContextProvider.start();
     });
 
     tearDownAll(() async {

--- a/pkg/pub_integration/test/fake_sign_in_test.dart
+++ b/pkg/pub_integration/test/fake_sign_in_test.dart
@@ -5,37 +5,26 @@
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
-import 'package:pub_integration/src/fake_pub_server_process.dart';
+import 'package:pub_integration/src/fake_test_scenario.dart';
 import 'package:pub_integration/src/headless_env.dart';
 import 'package:test/test.dart';
 
 void main() {
   group('fake sign in', () {
-    late FakePubServerProcess fakePubServerProcess;
-    late final HeadlessEnv headlessEnv;
+    late final FakeTestScenario fakeTestScenario;
 
     setUpAll(() async {
-      fakePubServerProcess = await FakePubServerProcess.start();
-      await fakePubServerProcess.started;
+      fakeTestScenario = await FakeTestScenario.start();
     });
 
     tearDownAll(() async {
-      await headlessEnv.close();
-      await fakePubServerProcess.kill();
+      await fakeTestScenario.close();
     });
 
     test('bulk tests', () async {
-      // start browser
-      final origin = 'http://localhost:${fakePubServerProcess.port}';
-      headlessEnv = HeadlessEnv(
-        testName: 'fake_sign_in',
-        origin: origin,
-      );
-      await headlessEnv.startBrowser();
-
       // init server data
       await http.post(
-        Uri.parse('$origin/fake-test-profile'),
+        Uri.parse('${fakeTestScenario.pubHostedUrl}/fake-test-profile'),
         body: json.encode(
           {
             'testProfile': {
@@ -54,10 +43,11 @@ void main() {
         ),
       );
 
+      final browserSession = await fakeTestScenario.createAnonymousTestUser();
       String? firstSessionId;
       // sign-in page
-      await headlessEnv.withPage(
-        fn: (page) async {
+      await browserSession.withBrowserPage(
+        (page) async {
           final rs = await page.gotoOrigin('/sign-in?fake-email=user@pub.dev');
           final cookies = await page.cookies();
           final cookieNames = cookies.map((e) => e.name).toSet();
@@ -73,14 +63,14 @@ void main() {
       );
 
       // same user sign-in with redirect
-      await headlessEnv.withPage(
-        fn: (page) async {
+      await browserSession.withBrowserPage(
+        (page) async {
           await page.gotoOrigin('/sign-in?fake-email=user@pub.dev&go=/help');
           final cookies = await page.cookies();
           final cookieNames = cookies.map((e) => e.name).toSet();
           expect(cookieNames, contains('PUB_SID_INSECURE'));
           expect(cookieNames, contains('PUB_SSID_INSECURE'));
-          expect(page.url, '$origin/help');
+          expect(page.url, '${fakeTestScenario.pubHostedUrl}/help');
 
           expect(
             cookies.firstWhere((c) => c.name == 'PUB_SID_INSECURE').value,
@@ -90,8 +80,8 @@ void main() {
       );
 
       // visiting unauthorized admin page fails
-      await headlessEnv.withPage(
-        fn: (page) async {
+      await browserSession.withBrowserPage(
+        (page) async {
           final rs1 = await page.gotoOrigin('/packages/admin_pkg/admin');
           expect(await rs1.content,
               contains('You have insufficient permissions to view this page.'));
@@ -107,14 +97,14 @@ void main() {
       );
 
       // sign-in with different user selected - session id changes
-      await headlessEnv.withPage(
-        fn: (page) async {
+      await browserSession.withBrowserPage(
+        (page) async {
           await page.gotoOrigin('/sign-in?fake-email=admin@pub.dev&go=/');
           final cookies = await page.cookies();
           final cookieNames = cookies.map((e) => e.name).toSet();
           expect(cookieNames, contains('PUB_SID_INSECURE'));
           expect(cookieNames, contains('PUB_SSID_INSECURE'));
-          expect(page.url, '$origin/');
+          expect(page.url, '${fakeTestScenario.pubHostedUrl}/');
 
           expect(
             cookies.firstWhere((c) => c.name == 'PUB_SID_INSECURE').value,
@@ -124,7 +114,7 @@ void main() {
       );
 
       // sign-out with button
-      await headlessEnv.withPage(fn: (page) async {
+      await browserSession.withBrowserPage((page) async {
         await page.gotoOrigin('/');
         expect(await page.content, contains('admin@pub.dev'));
         await page.hover('.nav-profile-img');
@@ -140,7 +130,7 @@ void main() {
       });
 
       // sign-in with button
-      await headlessEnv.withPage(fn: (page) async {
+      await browserSession.withBrowserPage((page) async {
         await page.gotoOrigin('/help');
         expect(await page.content, isNot(contains('user@pub.dev')));
         final handle = await page.$('#-account-login');

--- a/pkg/pub_integration/test/pkg_admin_page_test.dart
+++ b/pkg/pub_integration/test/pkg_admin_page_test.dart
@@ -5,7 +5,7 @@
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
-import 'package:pub_integration/src/fake_test_scenario.dart';
+import 'package:pub_integration/src/fake_test_context_provider.dart';
 import 'package:pub_integration/src/headless_env.dart';
 import 'package:pub_integration/src/pub_puppeteer_helpers.dart';
 import 'package:test/test.dart';
@@ -14,11 +14,11 @@ void main() {
   group(
     'package admin page',
     () {
-      late final FakeTestScenario fakeTestScenario;
+      late final TestContextProvider fakeTestScenario;
       final httpClient = http.Client();
 
       setUpAll(() async {
-        fakeTestScenario = await FakeTestScenario.start();
+        fakeTestScenario = await TestContextProvider.start();
       });
 
       tearDownAll(() async {

--- a/pkg/pub_integration/test/pub_integration_test.dart
+++ b/pkg/pub_integration/test/pub_integration_test.dart
@@ -4,16 +4,16 @@
 
 import 'package:http/http.dart' as http;
 import 'package:pub_integration/pub_integration.dart';
-import 'package:pub_integration/src/fake_test_scenario.dart';
+import 'package:pub_integration/src/fake_test_context_provider.dart';
 import 'package:test/test.dart';
 
 void main() {
   group('Integration test using pkg/fake_pub_server', () {
-    late final FakeTestScenario fakeTestScenario;
+    late final TestContextProvider fakeTestScenario;
     final httpClient = http.Client();
 
     setUpAll(() async {
-      fakeTestScenario = await FakeTestScenario.start();
+      fakeTestScenario = await TestContextProvider.start();
     });
 
     tearDownAll(() async {

--- a/pkg/pub_integration/test/publish_rejection_test.dart
+++ b/pkg/pub_integration/test/publish_rejection_test.dart
@@ -6,20 +6,20 @@ import 'dart:io';
 
 import 'package:path/path.dart' as p;
 import 'package:pub_integration/src/fake_credentials.dart';
-import 'package:pub_integration/src/fake_test_scenario.dart';
+import 'package:pub_integration/src/fake_test_context_provider.dart';
 import 'package:pub_integration/src/pub_tool_client.dart';
 import 'package:test/test.dart';
 
 void main() {
   group('reject based on description', () {
-    late final FakeTestScenario fakeTestScenario;
+    late final TestContextProvider fakeTestScenario;
     late String pubHostedUrl;
     late DartToolClient globalDartTool;
     late DartToolClient localDartTool;
 
     setUpAll(() async {
       globalDartTool = await DartToolClient.withPubDev();
-      fakeTestScenario = await FakeTestScenario.start();
+      fakeTestScenario = await TestContextProvider.start();
       pubHostedUrl = fakeTestScenario.pubHostedUrl;
       localDartTool = await DartToolClient.withServer(
         pubHostedUrl: pubHostedUrl,

--- a/pkg/pub_integration/test/publish_rejection_test.dart
+++ b/pkg/pub_integration/test/publish_rejection_test.dart
@@ -6,22 +6,21 @@ import 'dart:io';
 
 import 'package:path/path.dart' as p;
 import 'package:pub_integration/src/fake_credentials.dart';
-import 'package:pub_integration/src/fake_pub_server_process.dart';
+import 'package:pub_integration/src/fake_test_scenario.dart';
 import 'package:pub_integration/src/pub_tool_client.dart';
 import 'package:test/test.dart';
 
 void main() {
   group('reject based on description', () {
-    late FakePubServerProcess fakePubServerProcess;
+    late final FakeTestScenario fakeTestScenario;
     late String pubHostedUrl;
     late DartToolClient globalDartTool;
     late DartToolClient localDartTool;
 
     setUpAll(() async {
       globalDartTool = await DartToolClient.withPubDev();
-      fakePubServerProcess = await FakePubServerProcess.start();
-      await fakePubServerProcess.started;
-      pubHostedUrl = 'http://localhost:${fakePubServerProcess.port}';
+      fakeTestScenario = await FakeTestScenario.start();
+      pubHostedUrl = fakeTestScenario.pubHostedUrl;
       localDartTool = await DartToolClient.withServer(
         pubHostedUrl: pubHostedUrl,
         credentialsFileContent: fakeCredentialsFileContent(),
@@ -31,7 +30,7 @@ void main() {
     tearDownAll(() async {
       await globalDartTool.close();
       await localDartTool.close();
-      await fakePubServerProcess.kill();
+      await fakeTestScenario.close();
     });
 
     test('uses a template', () async {

--- a/pkg/pub_integration/test/publisher_test.dart
+++ b/pkg/pub_integration/test/publisher_test.dart
@@ -4,53 +4,36 @@
 
 import 'package:http/http.dart' as http;
 import 'package:pub_integration/script/publisher.dart';
-import 'package:pub_integration/src/fake_pub_server_process.dart';
-import 'package:pub_integration/src/fake_test_user.dart';
-import 'package:pub_integration/src/headless_env.dart';
+import 'package:pub_integration/src/fake_test_scenario.dart';
 import 'package:pub_integration/src/pub_puppeteer_helpers.dart';
 import 'package:test/test.dart';
 
 void main() {
   group('publisher', () {
-    late FakePubServerProcess fakePubServerProcess;
-    late final HeadlessGroup headlessGroup;
+    late final FakeTestScenario fakeTestScenario;
     final httpClient = http.Client();
 
     setUpAll(() async {
-      fakePubServerProcess = await FakePubServerProcess.start();
-      await fakePubServerProcess.started;
+      fakeTestScenario = await FakeTestScenario.start();
     });
 
     tearDownAll(() async {
-      await headlessGroup.close();
-      await fakePubServerProcess.kill();
+      await fakeTestScenario.close();
       httpClient.close();
     });
 
     test('publisher script', () async {
-      // start browser
-      headlessGroup = HeadlessGroup(
-        testName: 'browser',
-        origin: 'http://localhost:${fakePubServerProcess.port}',
-      );
-
       final script = PublisherScript(
-        pubHostedUrl: 'http://localhost:${fakePubServerProcess.port}',
-        adminUser: await createFakeTestUser(
+        pubHostedUrl: fakeTestScenario.pubHostedUrl,
+        adminUser: await fakeTestScenario.createTestUser(
           email: 'user@example.com',
-          headlessEnv: await headlessGroup.createNewProfile(),
-          fakeEmailReader: fakePubServerProcess.fakeEmailReader,
           scopes: [webmastersReadonlyScope],
         ),
-        invitedUser: await createFakeTestUser(
+        invitedUser: await fakeTestScenario.createTestUser(
           email: 'dev@example.com',
-          headlessEnv: await headlessGroup.createNewProfile(),
-          fakeEmailReader: fakePubServerProcess.fakeEmailReader,
         ),
-        unrelatedUser: await createFakeTestUser(
+        unrelatedUser: await fakeTestScenario.createTestUser(
           email: 'somebodyelse@example.com',
-          headlessEnv: await headlessGroup.createNewProfile(),
-          fakeEmailReader: fakePubServerProcess.fakeEmailReader,
         ),
       );
       await script.verify();

--- a/pkg/pub_integration/test/publisher_test.dart
+++ b/pkg/pub_integration/test/publisher_test.dart
@@ -4,17 +4,17 @@
 
 import 'package:http/http.dart' as http;
 import 'package:pub_integration/script/publisher.dart';
-import 'package:pub_integration/src/fake_test_scenario.dart';
+import 'package:pub_integration/src/fake_test_context_provider.dart';
 import 'package:pub_integration/src/pub_puppeteer_helpers.dart';
 import 'package:test/test.dart';
 
 void main() {
   group('publisher', () {
-    late final FakeTestScenario fakeTestScenario;
+    late final TestContextProvider fakeTestScenario;
     final httpClient = http.Client();
 
     setUpAll(() async {
-      fakeTestScenario = await FakeTestScenario.start();
+      fakeTestScenario = await TestContextProvider.start();
     });
 
     tearDownAll(() async {

--- a/pkg/pub_integration/test/search_update_test.dart
+++ b/pkg/pub_integration/test/search_update_test.dart
@@ -5,7 +5,7 @@
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
-import 'package:pub_integration/src/fake_test_scenario.dart';
+import 'package:pub_integration/src/fake_test_context_provider.dart';
 import 'package:pub_integration/src/headless_env.dart';
 import 'package:pub_integration/src/pub_puppeteer_helpers.dart';
 import 'package:puppeteer/puppeteer.dart';
@@ -13,11 +13,11 @@ import 'package:test/test.dart';
 
 void main() {
   group('browser', () {
-    late final FakeTestScenario fakeTestScenario;
+    late final TestContextProvider fakeTestScenario;
     final httpClient = http.Client();
 
     setUpAll(() async {
-      fakeTestScenario = await FakeTestScenario.start();
+      fakeTestScenario = await TestContextProvider.start();
     });
 
     tearDownAll(() async {


### PR DESCRIPTION
- This is one step towards having all integration tests into a somewhat uniform format.
- Note: This still uses a separate browser process for each user session, that change is coming in a follow-up PR.
