### PR TITLE
Hack to make integration tests pass

### DIFF
--- a/pkg/pub_integration/lib/script/publishing.dart
+++ b/pkg/pub_integration/lib/script/publishing.dart
@@ -62,13 +62,9 @@ class PublishingScript {
 
       // too large asset files are rejected
       await _createDummyPkg(oversized: true);
-      final knownErrorPrefix = '''Package validation found the following hint:
-* The latest published version is 1.0.0-null-safety.1.
-  Your version $_newDummyVersion is earlier than that.
-''';
 
       await dart.publish(_dummyDir.path,
-          expectedError: knownErrorPrefix +
+          expectedErrorContains:
               '`CHANGELOG.md` exceeds the maximum content length (131072 bytes).');
       await _dummyDir.delete(recursive: true);
 
@@ -83,7 +79,7 @@ class PublishingScript {
 
       // upload the same version again
       await dart.publish(_dummyDir.path,
-          expectedError: knownErrorPrefix +
+          expectedErrorContains:
               'Version $_newDummyVersion of package _dummy_pkg already exists.');
 
       // run example

--- a/pkg/pub_integration/lib/script/publishing.dart
+++ b/pkg/pub_integration/lib/script/publishing.dart
@@ -62,8 +62,13 @@ class PublishingScript {
 
       // too large asset files are rejected
       await _createDummyPkg(oversized: true);
+      final knownErrorPrefix = '''Package validation found the following hint:
+* The latest published version is 1.0.0-null-safety.1.
+  Your version $_newDummyVersion is earlier than that.
+''';
+
       await dart.publish(_dummyDir.path,
-          expectedError:
+          expectedError: knownErrorPrefix +
               '`CHANGELOG.md` exceeds the maximum content length (131072 bytes).');
       await _dummyDir.delete(recursive: true);
 
@@ -78,7 +83,7 @@ class PublishingScript {
 
       // upload the same version again
       await dart.publish(_dummyDir.path,
-          expectedError:
+          expectedError: knownErrorPrefix +
               'Version $_newDummyVersion of package _dummy_pkg already exists.');
 
       // run example

--- a/pkg/pub_integration/lib/src/pub_tool_client.dart
+++ b/pkg/pub_integration/lib/src/pub_tool_client.dart
@@ -110,7 +110,7 @@ class DartToolClient {
     List<String> arguments, {
     String? workingDirectory,
     Map<String, String>? environment,
-    String? expectedError,
+    String? expectedErrorContains,
     String? expectedOutputContains,
   }) async {
     final cmd = 'dart ${arguments.join(' ')}';
@@ -142,7 +142,9 @@ class DartToolClient {
     if (pr.exitCode == 0) {
       return;
     }
-    if (expectedError == pr.stderr.toString().trim()) {
+    if (expectedErrorContains != null &&
+        expectedErrorContains.isNotEmpty &&
+        pr.stderr.toString().contains(expectedErrorContains)) {
       return;
     }
     throw Exception(
@@ -166,13 +168,13 @@ class DartToolClient {
 
   Future<void> publish(
     String pkgDir, {
-    String? expectedError,
+    String? expectedErrorContains,
     String? expectedOutputContains,
   }) async {
     await runDart(
       ['pub', 'publish', '--force'],
       workingDirectory: pkgDir,
-      expectedError: expectedError,
+      expectedErrorContains: expectedErrorContains,
       expectedOutputContains: expectedOutputContains,
     );
   }

--- a/pkg/pub_integration/test/publish_rejection_test.dart
+++ b/pkg/pub_integration/test/publish_rejection_test.dart
@@ -75,7 +75,7 @@ void main() {
         // publish should fail with the description-related error message
         await localDartTool.publish(
           pkgDir,
-          expectedError:
+          expectedErrorContains:
               '`description` contains a generic text fragment coming from package templates (`A sample command-line application`).\n'
               'Please follow the guides to describe your package:\n'
               'https://dart.dev/tools/pub/pubspec#description',


### PR DESCRIPTION
Maybe we should only do `.contains()` testing.

Probably, we should even normalize whitespace and only check contains. Otherwise, new warnings will cause errors.

Better that the tests aren't too fragile.