### PR TITLE
Revert logging of missing Accept: header in name completion data API.

### DIFF
--- a/app/lib/frontend/handlers/custom_api.dart
+++ b/app/lib/frontend/handlers/custom_api.dart
@@ -7,7 +7,6 @@ import 'dart:io';
 
 import 'package:_pub_shared/data/package_api.dart';
 import 'package:_pub_shared/search/search_form.dart';
-import 'package:logging/logging.dart';
 import 'package:pub_dev/dartdoc/models.dart';
 import 'package:shelf/shelf.dart' as shelf;
 
@@ -28,8 +27,6 @@ import '../../shared/urls.dart' as urls;
 import '../../shared/utils.dart' show jsonUtf8Encoder;
 
 import 'headers.dart';
-
-final _logger = Logger('pub.custom_api');
 
 /// Handles requests for /api/documentation/<package>
 Future<shelf.Response> apiDocumentationHandler(
@@ -118,15 +115,13 @@ Future<shelf.Response> apiPackageNamesHandler(shelf.Request request) async {
 
 /// Handles requests for
 /// - /api/package-name-completion-data
+///
+/// NOTE: we don't require the `Accept: application/json` header for this request.
 Future<shelf.Response> apiPackageNameCompletionDataHandler(
     shelf.Request request) async {
   // only accept requests which allow gzip content encoding
   if (!request.acceptsGzipEncoding()) {
     throw NotAcceptableException('Client must accept gzip content.');
-  }
-  // log if the request does not accept JSON content
-  if (!request.acceptsJsonContent()) {
-    _logger.warning('[api-no-json-accept-header]');
   }
 
   final bytes = await cache.packageNameCompletitionDataJsonGz().get(() async {


### PR DESCRIPTION
Closes #6640.