### PR TITLE
Improve name index: lowercase + trigram forward index.

### DIFF
--- a/app/lib/search/text_utils.dart
+++ b/app/lib/search/text_utils.dart
@@ -133,17 +133,18 @@ final _upperA = 'A'.codeUnits.single;
 final _upperZ = 'Z'.codeUnits.single;
 bool _isLower(int c) => c < _upperA || _upperZ < c;
 
-/// Generates the N-grams of [input], which are continuous character strings of
-/// length between [minLength] and [maxLength] (both inclusive).
-/// Eg. abc -> ab, bc
-Set<String> ngrams(String input, int minLength, int maxLength) {
-  final ngrams = <String>{};
-  for (int length = minLength; length <= maxLength; length++) {
-    if (input.length >= length) {
-      for (int i = 0; i <= input.length - length; i++) {
-        ngrams.add(input.substring(i, i + length));
-      }
+/// Generates the 3-grams of [input], which are continuous character strings of
+/// length 3. Eg. `abcd` -> `abc`, `bcd`.
+List<String> trigrams(String input) {
+  if (input.length < 3) {
+    return const <String>[];
+  } else if (input.length == 3) {
+    return [input];
+  } else {
+    final result = <String>[];
+    for (var i = 0; i < input.length - 2; i++) {
+      result.add(input.substring(i, i + 3));
     }
+    return result;
   }
-  return ngrams;
 }

--- a/app/test/search/in_app_payments_test.dart
+++ b/app/test/search/in_app_payments_test.dart
@@ -36,7 +36,7 @@ Add _In-App Payments_ to your Flutter app with this plugin.''')));
         'packageHits': [
           {
             'package': 'flutter_iap',
-            'score': closeTo(0.73, 0.01),
+            'score': 1.0,
           },
         ],
       });

--- a/app/test/search/text_utils_test.dart
+++ b/app/test/search/text_utils_test.dart
@@ -129,32 +129,20 @@ Other useful methods will be added soon...
     });
   });
 
-  group('ngrams', () {
+  group('trigrams', () {
     test('small input', () {
-      expect(ngrams('', 2, 2), isEmpty);
-      expect(ngrams('a', 2, 2), isEmpty);
-      expect(ngrams('ab', 3, 3), isEmpty);
-      expect(ngrams('ab', 3, 4), isEmpty);
+      expect(trigrams(''), isEmpty);
+      expect(trigrams('a'), isEmpty);
+      expect(trigrams('ab'), isEmpty);
     });
 
-    test('2-grams', () {
-      expect(ngrams('ab', 2, 2), {'ab'});
-      expect(ngrams('abcdef', 2, 2), {'ab', 'bc', 'cd', 'de', 'ef'});
+    test('small inputs', () {
+      expect(trigrams('abc'), ['abc']);
+      expect(trigrams('abcd'), ['abc', 'bcd']);
     });
 
-    test('2-3-grams', () {
-      expect(ngrams('ab', 2, 3), {'ab'});
-      expect(ngrams('abcdef', 2, 3), {
-        'ab',
-        'bc',
-        'cd',
-        'de',
-        'ef',
-        'abc',
-        'bcd',
-        'cde',
-        'def',
-      });
+    test('repeated values', () {
+      expect(trigrams('aaaab'), ['aaa', 'aaa', 'aab']);
     });
   });
 }


### PR DESCRIPTION
- #6692
- simpler trigram parsing method (skips `Set` creation, keeps repeated items, but doesn't really affect the end result)
- trigram forward index with pre-parsed trigram set (created when name is added first time)
- some preprocessing for input and indexed names (lowercase + removing `_`)