### PR TITLE
Limit size of pub-data.json loaded in search

### DIFF
--- a/app/lib/search/backend.dart
+++ b/app/lib/search/backend.dart
@@ -125,7 +125,7 @@ class SearchBackend {
 
     final pubDataContent = await dartdocBackend.getTextContent(
         packageName, 'latest', 'pub-data.json',
-        timeout: const Duration(minutes: 1));
+        timeout: const Duration(minutes: 1), maxSize: 10 * 1014);
 
     List<ApiDocPage>? apiDocPages;
     try {


### PR DESCRIPTION
Noting that decompressed the googlapis package has a pub-data.json standing at 17mb, I don't even think we index that much.