### PR TITLE
Remove priority package name hit from sort hot path.

### DIFF
--- a/app/lib/search/mem_index.dart
+++ b/app/lib/search/mem_index.dart
@@ -397,18 +397,25 @@ class InMemoryPackageIndex implements PackageIndex {
     Map<String, double> values, {
     String? priorityPackageName,
   }) {
-    final list = values.entries
-        .map((e) => PackageHit(package: e.key, score: e.value))
-        .toList();
+    PackageHit? priorityHit;
+    final list = <PackageHit>[];
+    for (final e in values.entries) {
+      final hit = PackageHit(package: e.key, score: e.value);
+      if (priorityPackageName != null &&
+          priorityHit != null &&
+          hit.package == priorityPackageName) {
+        priorityHit = hit;
+      } else {
+        list.add(hit);
+      }
+    }
     list.sort((a, b) {
-      if (a.package == priorityPackageName) return -1;
-      if (b.package == priorityPackageName) return 1;
-      final int scoreCompare = -a.score!.compareTo(b.score!);
+      final scoreCompare = -a.score!.compareTo(b.score!);
       if (scoreCompare != 0) return scoreCompare;
       // if two packages got the same score, order by last updated
       return _compareUpdated(_packages[a.package]!, _packages[b.package]!);
     });
-    return list;
+    return priorityHit == null ? list : [priorityHit, ...list];
   }
 
   List<PackageHit> _rankWithComparator(Set<String> packages,


### PR DESCRIPTION
- This has only a minor, but consistent effect when the priority hit is in the search result.
- Tried to also implement top-k search with `SplayTreeMap/Set` or keeping a shorter sorted list, and while those also provided some benefits, it made some queries worse.