### PR TITLE
Bump runtime version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Important changes to data models, configuration, and migrations between each
 AppEngine version, listed here to ease deployment and troubleshooting.
 
 ## Next Release (replace with git tag when deployed)
+ * Bumped runtimeVersion to `2023.05.30`.
 
 ## `20230530t100200-all`
 

--- a/app/lib/shared/versions.dart
+++ b/app/lib/shared/versions.dart
@@ -22,10 +22,10 @@ final RegExp runtimeVersionPattern = RegExp(r'^\d{4}\.\d{2}\.\d{2}$');
 /// when the version switch happens.
 const acceptedRuntimeVersions = <String>[
   // The current [runtimeVersion].
-  '2023.05.16',
+  '2023.05.30',
   // Fallback runtime versions.
+  '2023.05.16',
   '2023.05.10',
-  '2023.05.09', // Dart 3 analysis with beta Flutter
 ];
 
 /// Represents a combined version of the overall toolchain and processing,


### PR DESCRIPTION
Because we changed contents of `PackageState` entitites