### PR TITLE
Increase timeout for ensure_build_test.dart, it sometimes fails

### DIFF
--- a/app/test/ensure_build_test.dart
+++ b/app/test/ensure_build_test.dart
@@ -9,5 +9,9 @@ import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart';
 
 void main() {
-  test('ensure_build', () => expectBuildClean(packageRelativeDirectory: 'app'));
+  test(
+    'ensure_build',
+    () => expectBuildClean(packageRelativeDirectory: 'app'),
+    timeout: Timeout(Duration(minutes: 2)),
+  );
 }


### PR DESCRIPTION
I think I've retried this a few times now -- it's messy because all tests after this fail.