### PR TITLE
Update search snapshot periodically in a worker isolate.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ AppEngine version, listed here to ease deployment and troubleshooting.
 
 ## Next Release (replace with git tag when deployed)
  * Switch to not use task backend for output.
+ * Note: search snapshot is now updated in a separate isolate.
 
 ## `20230607t103700-all`
  * Switch to use task backend for output.

--- a/app/lib/search/backend.dart
+++ b/app/lib/search/backend.dart
@@ -76,7 +76,7 @@ class SearchBackend {
   ///
   /// When other process has the claim, the loop waits a minute before
   /// attempting to get the claim.
-  Future<void> updateSnapshotInForeverLoop() async {
+  Future<Never> updateSnapshotInForeverLoop() async {
     final lock = GlobalLock.create(
       'update-search-snapshot',
       expiration: Duration(minutes: 20),

--- a/app/lib/search/backend.dart
+++ b/app/lib/search/backend.dart
@@ -81,7 +81,7 @@ class SearchBackend {
       'update-search-snapshot',
       expiration: Duration(minutes: 20),
     );
-    for (;;) {
+    while (true) {
       try {
         await lock.withClaim((claim) async {
           await doCreateAndUpdateSnapshot(claim);

--- a/app/lib/search/backend.dart
+++ b/app/lib/search/backend.dart
@@ -110,9 +110,9 @@ class SearchBackend {
       // Skip if the last document timestamp is before [updated].
       // 1-minute window is kept to reduce clock-skew.
       if (updated != null) {
-        final lastTimestamp = snapshot.documents![package]?.timestamp;
-        if (lastTimestamp != null &&
-            updated.isBefore(lastTimestamp.subtract(Duration(minutes: 1)))) {
+        final lastRefreshed = snapshot.documents![package]?.timestamp;
+        if (lastRefreshed != null &&
+            updated.isBefore(lastRefreshed.subtract(Duration(minutes: 1)))) {
           return;
         }
       }
@@ -129,6 +129,8 @@ class SearchBackend {
     await for (final package in dbService.query<Package>().run()) {
       if (package.isNotVisible) continue;
       if (!claim.valid) break;
+      // This is the first scan, there isn't any existing document that we
+      // can compare to, ignoring the updated field.
       await updatePackage(package.name!, null);
     }
     if (!claim.valid) {

--- a/app/lib/search/search_service.dart
+++ b/app/lib/search/search_service.dart
@@ -86,6 +86,9 @@ class PackageDocument {
   /// The creation timestamp of this document.
   final DateTime timestamp;
 
+  /// The last updated timestamp of the source entities.
+  final DateTime? sourceUpdated;
+
   PackageDocument({
     required this.package,
     this.version,
@@ -100,6 +103,7 @@ class PackageDocument {
     this.dependencies = const {},
     this.apiDocPages = const [],
     DateTime? timestamp,
+    this.sourceUpdated,
   })  : tags = tags ?? const <String>[],
         timestamp = timestamp ?? clock.now();
 

--- a/app/lib/search/search_service.g.dart
+++ b/app/lib/search/search_service.g.dart
@@ -33,6 +33,9 @@ PackageDocument _$PackageDocumentFromJson(Map<String, dynamic> json) =>
       timestamp: json['timestamp'] == null
           ? null
           : DateTime.parse(json['timestamp'] as String),
+      sourceUpdated: json['sourceUpdated'] == null
+          ? null
+          : DateTime.parse(json['sourceUpdated'] as String),
     );
 
 Map<String, dynamic> _$PackageDocumentToJson(PackageDocument instance) =>
@@ -50,6 +53,7 @@ Map<String, dynamic> _$PackageDocumentToJson(PackageDocument instance) =>
       'dependencies': instance.dependencies,
       'apiDocPages': instance.apiDocPages,
       'timestamp': instance.timestamp.toIso8601String(),
+      'sourceUpdated': instance.sourceUpdated?.toIso8601String(),
     };
 
 ApiDocPage _$ApiDocPageFromJson(Map<String, dynamic> json) => ApiDocPage(

--- a/app/lib/search/updater.dart
+++ b/app/lib/search/updater.dart
@@ -52,7 +52,6 @@ class IndexUpdater implements TaskRunner {
       await _packageIndex.markReady();
       _logger.info('Minimum package index loaded with $cnt packages.');
     }
-    snapshotStorage.startTimer();
   }
 
   /// Updates all packages in the index.

--- a/app/lib/service/entrypoint/search.dart
+++ b/app/lib/service/entrypoint/search.dart
@@ -78,6 +78,5 @@ Future _worker(WorkerEntryMessage message) async {
   message.protocolSendPort.send(WorkerProtocolMessage());
   await popularityStorage.start();
   setupSearchPeriodicTasks();
-  unawaited(searchBackend.updateSnapshotInForeverLoop());
-  await Completer().future; // never completes
+  await searchBackend.updateSnapshotInForeverLoop();
 }

--- a/app/lib/service/entrypoint/search.dart
+++ b/app/lib/service/entrypoint/search.dart
@@ -7,6 +7,7 @@ import 'dart:isolate';
 
 import 'package:args/command_runner.dart';
 import 'package:logging/logging.dart';
+import 'package:pub_dev/search/backend.dart';
 
 import '../../search/dart_sdk_mem_index.dart';
 import '../../search/flutter_sdk_mem_index.dart';
@@ -77,5 +78,6 @@ Future _worker(WorkerEntryMessage message) async {
   message.protocolSendPort.send(WorkerProtocolMessage());
   await popularityStorage.start();
   setupSearchPeriodicTasks();
+  unawaited(searchBackend.updateSnapshotInForeverLoop());
   await Completer().future; // never completes
 }

--- a/app/lib/service/services.dart
+++ b/app/lib/service/services.dart
@@ -256,7 +256,8 @@ Future<R> _withPubServices<R>(FutureOr<R> Function() fn) async {
     );
     registerPublisherBackend(PublisherBackend(dbService));
     registerScoreCardBackend(ScoreCardBackend(dbService));
-    registerSearchBackend(SearchBackend(dbService));
+    registerSearchBackend(SearchBackend(dbService,
+        storageService.bucket(activeConfiguration.searchSnapshotBucketName!)));
     registerSearchClient(SearchClient());
     registerSearchAdapter(SearchAdapter());
     registerSecretBackend(SecretBackend(dbService));

--- a/app/lib/tool/neat_task/pub_dev_tasks.dart
+++ b/app/lib/tool/neat_task/pub_dev_tasks.dart
@@ -207,6 +207,12 @@ void setupDartdocPeriodicTasks() {
 
 /// Setup the tasks that we are running in the search service.
 void setupSearchPeriodicTasks() {
+  // Creates a fresh search snapshot.
+  _15mins(
+    name: 'update-search-snapshot',
+    isRuntimeVersioned: true,
+    task: () => searchBackend.createSnapshotAndUploadToStorageBucket(),
+  );
   // Deletes the old search snapshots
   _weekly(
     name: 'delete-old-search-snapshots',

--- a/app/lib/tool/neat_task/pub_dev_tasks.dart
+++ b/app/lib/tool/neat_task/pub_dev_tasks.dart
@@ -207,12 +207,6 @@ void setupDartdocPeriodicTasks() {
 
 /// Setup the tasks that we are running in the search service.
 void setupSearchPeriodicTasks() {
-  // Creates a fresh search snapshot.
-  _15mins(
-    name: 'update-search-snapshot',
-    isRuntimeVersioned: true,
-    task: () => searchBackend.createSnapshotAndUploadToStorageBucket(),
-  );
   // Deletes the old search snapshots
   _weekly(
     name: 'delete-old-search-snapshots',

--- a/app/test/search/backend_test.dart
+++ b/app/test/search/backend_test.dart
@@ -30,7 +30,7 @@ void main() {
       await snapshotStorage.fetch();
       expect(snapshotStorage.documents, isEmpty);
       await searchBackend.doCreateAndUpdateSnapshot(
-        _GlobalLockClaim(clock.now().add(Duration(seconds: 3))),
+        _FakeGlobalLockClaim(clock.now().add(Duration(seconds: 3))),
         sleepDuration: Duration(milliseconds: 300),
       );
       await snapshotStorage.fetch();
@@ -39,11 +39,11 @@ void main() {
   });
 }
 
-class _GlobalLockClaim implements GlobalLockClaim {
+class _FakeGlobalLockClaim implements GlobalLockClaim {
   @override
   DateTime expires;
 
-  _GlobalLockClaim(this.expires);
+  _FakeGlobalLockClaim(this.expires);
 
   @override
   Future<bool> refresh() async {

--- a/app/test/search/handlers_test.dart
+++ b/app/test/search/handlers_test.dart
@@ -10,6 +10,7 @@ import 'package:pub_dev/search/backend.dart';
 import 'package:pub_dev/search/dart_sdk_mem_index.dart';
 import 'package:pub_dev/search/flutter_sdk_mem_index.dart';
 import 'package:pub_dev/search/mem_index.dart';
+import 'package:pub_dev/search/models.dart';
 import 'package:pub_dev/search/search_service.dart';
 import 'package:pub_dev/shared/exceptions.dart';
 import 'package:test/test.dart';
@@ -195,6 +196,11 @@ class MockSearchBackend implements SearchBackend {
 
   @override
   Future<void> close() {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<SearchSnapshot> createSnapshotAndUploadToStorageBucket() {
     throw UnimplementedError();
   }
 }

--- a/app/test/search/handlers_test.dart
+++ b/app/test/search/handlers_test.dart
@@ -13,6 +13,7 @@ import 'package:pub_dev/search/mem_index.dart';
 import 'package:pub_dev/search/models.dart';
 import 'package:pub_dev/search/search_service.dart';
 import 'package:pub_dev/shared/exceptions.dart';
+import 'package:pub_dev/task/global_lock.dart';
 import 'package:test/test.dart';
 
 import '../frontend/handlers/_utils.dart' as _utils;
@@ -200,7 +201,13 @@ class MockSearchBackend implements SearchBackend {
   }
 
   @override
-  Future<SearchSnapshot> createSnapshotAndUploadToStorageBucket() {
+  Future<SearchSnapshot> updateSnapshotInForeverLoop() {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<void> doCreateAndUpdateSnapshot(GlobalLockClaim claim,
+      {Duration sleepDuration = const Duration(minutes: 2)}) {
     throw UnimplementedError();
   }
 }

--- a/app/test/search/handlers_test.dart
+++ b/app/test/search/handlers_test.dart
@@ -10,7 +10,6 @@ import 'package:pub_dev/search/backend.dart';
 import 'package:pub_dev/search/dart_sdk_mem_index.dart';
 import 'package:pub_dev/search/flutter_sdk_mem_index.dart';
 import 'package:pub_dev/search/mem_index.dart';
-import 'package:pub_dev/search/models.dart';
 import 'package:pub_dev/search/search_service.dart';
 import 'package:pub_dev/shared/exceptions.dart';
 import 'package:pub_dev/task/global_lock.dart';
@@ -201,7 +200,7 @@ class MockSearchBackend implements SearchBackend {
   }
 
   @override
-  Future<SearchSnapshot> updateSnapshotInForeverLoop() {
+  Future<Never> updateSnapshotInForeverLoop() {
     throw UnimplementedError();
   }
 


### PR DESCRIPTION
- reduces the load on the frontend isolate by not blocking the CPU when snapshot save happens
- also moves old snapshot GC into the worker isolate
