### PR TITLE
Do not use 'future' SDK for dart3-compatiblity check.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Important changes to data models, configuration, and migrations between each
 AppEngine version, listed here to ease deployment and troubleshooting.
 
 ## Next Release (replace with git tag when deployed)
+ * Bumped runtimeVersion to `2023.05.31`.
+ * Note: Dart 3 compatiblity check uses the same SDK as the analysis.
 
 ## `20230531t083600-all`
  * Bumped runtimeVersion to `2023.05.30`.

--- a/app/config/dartlang-pub-dev.yaml
+++ b/app/config/dartlang-pub-dev.yaml
@@ -64,8 +64,6 @@ tools:
   stableFlutterSdkPath: '/tool/stable/flutter'
   previewDartSdkPath: '/tool/preview/dart-sdk'
   previewFlutterSdkPath: '/tool/preview/flutter'
-  futureDartSdkPath: '/tool/preview/dart-sdk' # same as preview
-  futureFlutterSdkPath: '/tool/preview/flutter' # same as preview
 rateLimits:
   - operation: package-published
     scope: package

--- a/app/config/dartlang-pub.yaml
+++ b/app/config/dartlang-pub.yaml
@@ -64,8 +64,6 @@ tools:
   stableFlutterSdkPath: '/tool/stable/flutter'
   previewDartSdkPath: '/tool/preview/dart-sdk'
   previewFlutterSdkPath: '/tool/preview/flutter'
-  futureDartSdkPath: '/tool/preview/dart-sdk' # same as preview
-  futureFlutterSdkPath: '/tool/preview/flutter' # same as preview
 rateLimits:
   - operation: package-published
     scope: package

--- a/app/lib/shared/configuration.dart
+++ b/app/lib/shared/configuration.dart
@@ -503,16 +503,12 @@ class ToolsConfiguration {
   final String? stableFlutterSdkPath;
   final String? previewDartSdkPath;
   final String? previewFlutterSdkPath;
-  final String? futureDartSdkPath;
-  final String? futureFlutterSdkPath;
 
   ToolsConfiguration({
     required this.stableDartSdkPath,
     required this.stableFlutterSdkPath,
     required this.previewDartSdkPath,
     required this.previewFlutterSdkPath,
-    required this.futureDartSdkPath,
-    required this.futureFlutterSdkPath,
   });
 
   factory ToolsConfiguration.fromJson(Map<String, dynamic> json) =>

--- a/app/lib/shared/configuration.g.dart
+++ b/app/lib/shared/configuration.g.dart
@@ -219,9 +219,7 @@ ToolsConfiguration _$ToolsConfigurationFromJson(Map<String, dynamic> json) =>
             'stableDartSdkPath',
             'stableFlutterSdkPath',
             'previewDartSdkPath',
-            'previewFlutterSdkPath',
-            'futureDartSdkPath',
-            'futureFlutterSdkPath'
+            'previewFlutterSdkPath'
           ],
         );
         final val = ToolsConfiguration(
@@ -233,10 +231,6 @@ ToolsConfiguration _$ToolsConfigurationFromJson(Map<String, dynamic> json) =>
               $checkedConvert('previewDartSdkPath', (v) => v as String?),
           previewFlutterSdkPath:
               $checkedConvert('previewFlutterSdkPath', (v) => v as String?),
-          futureDartSdkPath:
-              $checkedConvert('futureDartSdkPath', (v) => v as String?),
-          futureFlutterSdkPath:
-              $checkedConvert('futureFlutterSdkPath', (v) => v as String?),
         );
         return val;
       },
@@ -248,8 +242,6 @@ Map<String, dynamic> _$ToolsConfigurationToJson(ToolsConfiguration instance) =>
       'stableFlutterSdkPath': instance.stableFlutterSdkPath,
       'previewDartSdkPath': instance.previewDartSdkPath,
       'previewFlutterSdkPath': instance.previewFlutterSdkPath,
-      'futureDartSdkPath': instance.futureDartSdkPath,
-      'futureFlutterSdkPath': instance.futureFlutterSdkPath,
     };
 
 RateLimit _$RateLimitFromJson(Map<String, dynamic> json) => $checkedCreate(

--- a/app/lib/shared/tool_env.dart
+++ b/app/lib/shared/tool_env.dart
@@ -106,8 +106,8 @@ Future<_ToolEnvRef> _createToolEnvRef() async {
       'CI': 'true',
       'PUB_HOSTED_URL': 'https://pub.dartlang.org',
     },
-    futureDartSdkDir: activeConfiguration.tools?.futureDartSdkPath,
-    futureFlutterSdkDir: activeConfiguration.tools?.futureFlutterSdkPath,
+    futureDartSdkDir: activeConfiguration.tools?.stableDartSdkPath,
+    futureFlutterSdkDir: activeConfiguration.tools?.stableFlutterSdkPath,
   );
   final previewToolEnv = await ToolEnvironment.create(
     dartSdkDir: activeConfiguration.tools?.previewDartSdkPath,
@@ -117,8 +117,8 @@ Future<_ToolEnvRef> _createToolEnvRef() async {
       'CI': 'true',
       'PUB_HOSTED_URL': 'https://pub.dartlang.org',
     },
-    futureDartSdkDir: activeConfiguration.tools?.futureDartSdkPath,
-    futureFlutterSdkDir: activeConfiguration.tools?.futureFlutterSdkPath,
+    futureDartSdkDir: activeConfiguration.tools?.previewDartSdkPath,
+    futureFlutterSdkDir: activeConfiguration.tools?.previewFlutterSdkPath,
   );
   return _ToolEnvRef(cacheDir, stableToolEnv, previewToolEnv);
 }

--- a/app/lib/shared/versions.dart
+++ b/app/lib/shared/versions.dart
@@ -22,10 +22,10 @@ final RegExp runtimeVersionPattern = RegExp(r'^\d{4}\.\d{2}\.\d{2}$');
 /// when the version switch happens.
 const acceptedRuntimeVersions = <String>[
   // The current [runtimeVersion].
-  '2023.05.30',
+  '2023.05.31',
   // Fallback runtime versions.
+  '2023.05.30',
   '2023.05.16',
-  '2023.05.10',
 ];
 
 /// Represents a combined version of the overall toolchain and processing,


### PR DESCRIPTION
- removes future SDK config
- sets the same SDK for analysis and future SDK path for pana
- fixes the immediate issue of #6683, but doesn't address what will happen with 3.1 SDK