### PR TITLE
Expand the fake JWT token timestamp range.

### DIFF
--- a/app/lib/fake/backend/fake_auth_provider.dart
+++ b/app/lib/fake/backend/fake_auth_provider.dart
@@ -325,11 +325,12 @@ String fakeOauthUserIdFromEmail(String email) =>
     email.replaceAll('@', '-').replaceAll('.', '-');
 
 Map<String, dynamic> _jwtPayloadTimestamps() {
-  final now = clock.now();
+  final now = clock.now().toUtc();
+  final iat = now.subtract(Duration(minutes: 1));
   return <String, dynamic>{
-    'iat': now.millisecondsSinceEpoch ~/ 1000,
-    'nbf': now.millisecondsSinceEpoch ~/ 1000,
-    'exp': now.add(Duration(minutes: 1)).millisecondsSinceEpoch ~/ 1000,
+    'iat': iat.millisecondsSinceEpoch ~/ 1000,
+    'nbf': iat.millisecondsSinceEpoch ~/ 1000,
+    'exp': now.add(Duration(minutes: 5)).millisecondsSinceEpoch ~/ 1000,
   };
 }
 


### PR DESCRIPTION
There is a slight chance that the strict validity window may cause test flakes on CI, there is not much drawback to extend it a bit.