### PR TITLE
Refactored isolate runner

### DIFF
--- a/app/lib/service/entrypoint/_isolate.dart
+++ b/app/lib/service/entrypoint/_isolate.dart
@@ -21,267 +21,144 @@ import 'tools.dart';
 
 final _random = Random.secure();
 
-class FrontendEntryMessage {
-  final int frontendIndex;
+class EntryMessage {
   final SendPort protocolSendPort;
   final SendPort aliveSendPort;
+  final SendPort statsSendPort;
 
-  FrontendEntryMessage({
-    required this.frontendIndex,
+  EntryMessage({
     required this.protocolSendPort,
     required this.aliveSendPort,
+    required this.statsSendPort,
   });
 }
 
-class FrontendProtocolMessage {
+/// Message sent from the isolate to indicate that it is ready with the initialization.
+class ReadyMessage {
   final SendPort? statsConsumerPort;
 
-  FrontendProtocolMessage({
+  ReadyMessage({
     this.statsConsumerPort,
   });
 }
 
-class WorkerEntryMessage {
-  final int workerIndex;
-  final SendPort protocolSendPort;
-  final SendPort statsSendPort;
-  final SendPort aliveSendPort;
+/// Message sent from the isolate with arbitrary text.
+class DebugMessage {
+  final String text;
 
-  WorkerEntryMessage({
-    required this.workerIndex,
-    required this.protocolSendPort,
-    required this.statsSendPort,
-    required this.aliveSendPort,
-  });
+  DebugMessage(this.text);
 }
 
-class WorkerProtocolMessage {}
+class IsolateRunner {
+  final Logger logger;
+  var _closing = false;
 
-Future startIsolates({
-  required Logger logger,
-  Future<void> Function(FrontendEntryMessage message)? frontendEntryPoint,
-  Future<void> Function(WorkerEntryMessage message)? workerEntryPoint,
-  Duration? deadWorkerTimeout,
-  required int frontendCount,
-  required int workerCount,
-}) async {
-  await withServices(() async {
-    if (!envConfig.isRunningLocally) {
-      // The existence of this file may indicate an issue with the service health.
-      // Checking it only in AppEngine environment.
-      final stampFile =
-          File(p.join(Directory.systemTemp.path, 'pub-dev-started.stamp'));
-      if (stampFile.existsSync()) {
-        stderr.writeln('[warning-service-restarted]: '
-            '${stampFile.path} already exists, indicating that this process has been restarted.');
-      } else {
-        stampFile.createSync(recursive: true);
-      }
-    }
-    _setupServiceIsolate();
+  /// The duration while errors won't cause frontend isolates to restart.
+  var _restartProtectionOffset = Duration.zero;
+  var _lastStarted = clock.now();
+  final _isolates = <_Isolate>[];
 
-    /// The duration while errors won't cause frontend isolates to restart.
-    var restartProtectionOffset = Duration.zero;
-    var lastStarted = clock.now();
-    int frontendStarted = 0;
-    int workerStarted = 0;
+  IsolateRunner({
+    required this.logger,
+  });
 
-    var closing = false;
-    final isolates = <Isolate>[];
-    final statConsumerPorts = <SendPort>[];
+  Future<void> startIsolates({
+    required String kind,
+    required Future<void> Function(EntryMessage message) entryPoint,
+    required int count,
+    required Duration? deadTimeout,
+  }) async {
+    int started = 0;
 
-    Future<void> startFrontendIsolate() async {
-      if (closing) return;
-      frontendStarted++;
-      final frontendIndex = frontendStarted;
-      logger.info('About to start frontend isolate #$frontendIndex...');
-      final aliveReceivePort = ReceivePort();
-      final errorReceivePort = ReceivePort();
-      final exitReceivePort = ReceivePort();
-      final protocolReceivePort = ReceivePort();
-      final isolate = await Isolate.spawn(
-        _wrapper,
-        [
-          frontendEntryPoint,
-          FrontendEntryMessage(
-            frontendIndex: frontendIndex,
-            protocolSendPort: protocolReceivePort.sendPort,
-            aliveSendPort: aliveReceivePort.sendPort,
-          ),
-        ],
-        onError: errorReceivePort.sendPort,
-        onExit: exitReceivePort.sendPort,
-        errorsAreFatal: true,
-      );
-      isolates.add(isolate);
-      final protocolMessage =
-          (await protocolReceivePort.first) as FrontendProtocolMessage;
-      if (protocolMessage.statsConsumerPort != null) {
-        statConsumerPorts.add(protocolMessage.statsConsumerPort!);
-      }
-      logger.info('Frontend isolate #$frontendIndex started.');
-      lastStarted = clock.now();
-
-      StreamSubscription? errorSubscription;
-      StreamSubscription? exitSubscription;
-
-      final autokillTimerCloseFn = _setupAutokillTimer(
-        isolate: isolate,
-        aliveReceivePort: aliveReceivePort,
-        timeout: Duration(minutes: 1),
+    Future<void> start() async {
+      if (_closing) return;
+      started++;
+      final id = '$kind isolate #$started';
+      logger.info('About to start $id ...');
+      final isolate = _Isolate(
+        runner: this,
         logger: logger,
-        name: 'frontend isolate #$frontendIndex',
+        id: id,
+        entryPoint: entryPoint,
       );
+      _isolates.add(isolate);
+      await isolate.init(deadTimeout: deadTimeout);
+      logger.info('$id started.');
+      _lastStarted = clock.now();
 
-      Future<void> close() async {
-        await autokillTimerCloseFn();
-        if (protocolMessage.statsConsumerPort != null) {
-          statConsumerPorts.remove(protocolMessage.statsConsumerPort);
-        }
-        await errorSubscription?.cancel();
-        await exitSubscription?.cancel();
-        errorReceivePort.close();
-        exitReceivePort.close();
-        protocolReceivePort.close();
-        isolates.remove(isolate);
-      }
-
-      Future<void> restart() async {
-        await close();
+      // automatic restart logic
+      unawaited(isolate.done.then((_) async {
+        _isolates.remove(isolate);
+        if (_closing) return;
         // Restart the isolate after a pause, increasing the pause duration at
         // each restart.
         //
         // NOTE: As this wait period increases, the service may miss /liveness_check
         //       requests, and eventually AppEngine may just kill the instance
         //       marking it unreachable.
-        await Future.delayed(Duration(seconds: 5 + frontendStarted));
-        await startFrontendIsolate();
-      }
-
-      errorSubscription = errorReceivePort.listen((e) async {
-        stderr.writeln('ERROR from frontend isolate #$frontendIndex: $e');
-        logger.severe('ERROR from frontend isolate #$frontendIndex', e);
-
-        final now = clock.now();
-        // If the last isolate was started more than an hour ago, we can reset
-        // the protection.
-        if (now.isAfter(lastStarted.add(Duration(hours: 1)))) {
-          restartProtectionOffset = Duration.zero;
+        var waitSeconds = 5 + started;
+        while (waitSeconds > 0) {
+          if (_closing) return;
+          await Future.delayed(Duration(seconds: 1));
+          waitSeconds--;
         }
-
-        // If we have recently restarted an isolate, let's keep it running.
-        if (now.isBefore(lastStarted.add(restartProtectionOffset))) {
-          return;
-        }
-
-        // Extend restart protection for up to 20 minutes.
-        if (restartProtectionOffset.inMinutes < 20) {
-          restartProtectionOffset += Duration(minutes: 4);
-        }
-
-        await restart();
-      });
-
-      exitSubscription = exitReceivePort.listen((e) async {
-        stderr.writeln(
-            'Frontend isolate #$frontendIndex exited with message: $e');
-        logger.warning('Frontend isolate #$frontendIndex exited.', e);
-        await restart();
-      });
+        await start();
+      }));
     }
 
-    Future<void> startWorkerIsolate() async {
-      if (closing) return;
-      workerStarted++;
-      final workerIndex = workerStarted;
-      logger.info('About to start worker isolate #$workerIndex...');
-      final errorReceivePort = ReceivePort();
-      final protocolReceivePort = ReceivePort();
-      final statsReceivePort = ReceivePort();
-      final aliveReceivePort = ReceivePort();
-      final isolate = await Isolate.spawn(
-        _wrapper,
-        [
-          workerEntryPoint,
-          WorkerEntryMessage(
-            workerIndex: workerIndex,
-            protocolSendPort: protocolReceivePort.sendPort,
-            statsSendPort: statsReceivePort.sendPort,
-            aliveSendPort: aliveReceivePort.sendPort,
-          ),
-        ],
-        onError: errorReceivePort.sendPort,
-        onExit: errorReceivePort.sendPort,
-        errorsAreFatal: true,
-      );
-      isolates.add(isolate);
-      // read WorkerProtocolMessage
-      await protocolReceivePort.first;
-      final statsSubscription =
-          statsReceivePort.cast<Map>().listen((Map stats) {
-        updateLatestStats(stats);
-        for (SendPort sp in statConsumerPorts) {
-          sp.send(stats);
-        }
-      });
-      logger.info('Worker isolate #$workerIndex started.');
-
-      final autokillTimerCloseFn = _setupAutokillTimer(
-        isolate: isolate,
-        aliveReceivePort: aliveReceivePort,
-        timeout: deadWorkerTimeout,
-        logger: logger,
-        name: 'worker isolate #$workerIndex',
-      );
-
-      StreamSubscription? errorSubscription;
-
-      Future<void> close() async {
-        await autokillTimerCloseFn();
-        await statsSubscription.cancel();
-        await errorSubscription?.cancel();
-        errorReceivePort.close();
-        protocolReceivePort.close();
-        statsReceivePort.close();
-        isolates.remove(isolate);
-      }
-
-      errorSubscription = errorReceivePort.listen((e) async {
-        stderr.writeln('ERROR from worker isolate #$workerIndex: $e');
-        logger.severe('ERROR from worker isolate #$workerIndex', e);
-        await close();
-        // restart isolate after a brief pause
-        await Future.delayed(Duration(minutes: 1));
-        await startWorkerIsolate();
-      });
+    for (int i = 0; i < count; i++) {
+      await start();
     }
+  }
 
-    Future<void> closeIsolates() async {
-      while (isolates.isNotEmpty) {
-        final i = isolates.removeLast();
-        // TODO: Implement graceful close.
-        i.kill();
-      }
+  Future<void> _closeIsolates() async {
+    while (_isolates.isNotEmpty) {
+      await _isolates.last.close();
     }
+  }
 
+  Future<void> close() async {
+    _closing = true;
+    await _closeIsolates();
+    // A small wait to allow already pending isolates to be created.
+    await Future.delayed(Duration(seconds: 5));
+    await _closeIsolates();
+  }
+}
+
+Future runIsolates({
+  required Logger logger,
+  Future<void> Function(EntryMessage message)? frontendEntryPoint,
+  Future<void> Function(EntryMessage message)? workerEntryPoint,
+  Duration? deadWorkerTimeout,
+  required int frontendCount,
+  required int workerCount,
+}) async {
+  await withServices(() async {
+    _setupServiceIsolate();
+    _verifyStampFile();
     try {
+      final runner = IsolateRunner(logger: logger);
       if (frontendEntryPoint != null) {
-        for (int i = 0; i < frontendCount; i++) {
-          await startFrontendIsolate();
-        }
+        await runner.startIsolates(
+          kind: 'frontend',
+          entryPoint: frontendEntryPoint,
+          count: frontendCount,
+          deadTimeout: Duration(minutes: 1),
+        );
       }
       if (workerEntryPoint != null) {
-        for (int i = 0; i < workerCount; i++) {
-          await startWorkerIsolate();
-        }
+        await runner.startIsolates(
+          kind: 'worker',
+          entryPoint: workerEntryPoint,
+          count: workerCount,
+          deadTimeout: deadWorkerTimeout,
+        );
       }
+
       await waitForProcessSignalTermination();
 
-      closing = true;
-      await closeIsolates();
-      // A small wait to allow already pending isolates to be created.
-      await Future.delayed(Duration(seconds: 5));
-      await closeIsolates();
+      await runner.close();
     } catch (e, st) {
       logger.shout('Failed to start server.', e, st);
       rethrow;
@@ -289,61 +166,197 @@ Future startIsolates({
   });
 }
 
-/// Resets (and starts) autokill timer on alive messages.
-/// Returns the [Function] that should be called on isolate closing,
-/// cancelling the stream listener and the timer that may be active.
-///
-/// NOTE: The timer will NOT be initialized when [timeout] is not specified or negative.
-Future<void> Function() _setupAutokillTimer({
-  required Isolate isolate,
-  required ReceivePort aliveReceivePort,
-  required Duration? timeout,
-  required Logger logger,
-  required String name,
-}) {
-  Timer? autokillTimer;
-  void resetAutokillTimer() {
-    if (timeout == null || timeout <= Duration.zero) {
-      return;
+void _verifyStampFile() {
+  if (!envConfig.isRunningLocally) {
+    // The existence of this file may indicate an issue with the service health.
+    // Checking it only in AppEngine environment.
+    final stampFile =
+        File(p.join(Directory.systemTemp.path, 'pub-dev-started.stamp'));
+    if (stampFile.existsSync()) {
+      stderr.writeln('[warning-service-restarted]: '
+          '${stampFile.path} already exists, indicating that this process has been restarted.');
+    } else {
+      stampFile.createSync(recursive: true);
     }
-    autokillTimer?.cancel();
+  }
+}
 
-    /// Randomize TTL so that isolate restarts do not happen at the same time.
-    final ttl = timeout + Duration(seconds: _random.nextInt(30));
-    autokillTimer = Timer(ttl, () {
-      logger.shout(
-          'Killing "$name" isolate, because it is not sending alive pings');
-      isolate.kill();
+class _Isolate {
+  final IsolateRunner runner;
+  final Logger logger;
+  final String id;
+  final Future<void> Function(EntryMessage message) entryPoint;
+
+  late Isolate _isolate;
+
+  final _aliveReceivePort = ReceivePort();
+  final _statsReceivePort = ReceivePort();
+  final _errorReceivePort = ReceivePort();
+  final _exitReceivePort = ReceivePort();
+  final _protocolReceivePort = ReceivePort();
+
+  ReadyMessage? _readyMessage;
+  bool get isReady => _readyMessage != null;
+  SendPort? get statsConsumerPort => _readyMessage?.statsConsumerPort;
+
+  StreamSubscription? _protocolSubscription;
+  StreamSubscription? _errorSubscription;
+  StreamSubscription? _exitSubscription;
+  StreamSubscription? _aliveSubscription;
+  StreamSubscription? _statsSubscription;
+  Timer? _autokillTimer;
+
+  final _doneCompleter = Completer();
+  late final done = _doneCompleter.future;
+
+  _Isolate({
+    required this.runner,
+    required this.logger,
+    required this.id,
+    required this.entryPoint,
+  });
+
+  Future<void> init({
+    required Duration? deadTimeout,
+  }) async {
+    _isolate = await Isolate.spawn(
+      _wrapper,
+      [
+        entryPoint,
+        EntryMessage(
+          protocolSendPort: _protocolReceivePort.sendPort,
+          aliveSendPort: _aliveReceivePort.sendPort,
+          statsSendPort: _statsReceivePort.sendPort,
+        ),
+      ],
+      onError: _errorReceivePort.sendPort,
+      onExit: _exitReceivePort.sendPort,
+      errorsAreFatal: true,
+      debugName: id,
+    );
+
+    final ready = Completer();
+    _protocolSubscription = _protocolReceivePort.listen((e) {
+      if (e is ReadyMessage && !ready.isCompleted) {
+        _readyMessage = e;
+        ready.complete();
+      }
+      if (e is DebugMessage) {
+        logger.info('Debug message from $id: ${e.text}');
+      }
+    });
+
+    _errorSubscription = _errorReceivePort.listen((e) async {
+      stderr.writeln('ERROR from $id: $e');
+      logger.severe('ERROR from $id', e);
+
+      final now = clock.now();
+      // If the last isolate was started more than an hour ago, we can reset
+      // the protection.
+      if (now.isAfter(runner._lastStarted.add(Duration(hours: 1)))) {
+        runner._restartProtectionOffset = Duration.zero;
+      }
+
+      // If we have recently restarted an isolate, let's keep it running.
+      if (now
+          .isBefore(runner._lastStarted.add(runner._restartProtectionOffset))) {
+        return;
+      }
+
+      // Extend restart protection for up to 20 minutes.
+      if (runner._restartProtectionOffset.inMinutes < 20) {
+        runner._restartProtectionOffset += Duration(minutes: 4);
+      }
+
+      await close();
+    });
+
+    _exitSubscription = _exitReceivePort.listen((e) async {
+      stderr.writeln('$id exited with message: $e');
+      logger.warning('$id exited.', e);
+      await close();
+    });
+
+    _statsSubscription = _statsReceivePort.cast<Map>().listen((Map stats) {
+      updateLatestStats(stats);
+      for (final i in runner._isolates) {
+        i.statsConsumerPort?.send(stats);
+      }
+    });
+
+    _setupAutokillTimer(deadTimeout);
+
+    await ready.future;
+  }
+
+  /// Resets (and starts) autokill timer on alive messages.
+  /// Returns the [Function] that should be called on isolate closing,
+  /// cancelling the stream listener and the timer that may be active.
+  ///
+  /// NOTE: The timer will NOT be initialized when [timeout] is not specified or negative.
+  void _setupAutokillTimer(Duration? timeout) {
+    void resetAutokillTimer() {
+      if (timeout == null || timeout <= Duration.zero) {
+        return;
+      }
+      _autokillTimer?.cancel();
+
+      /// Randomize TTL so that isolate restarts do not happen at the same time.
+      final ttl = timeout + Duration(seconds: _random.nextInt(30));
+      _autokillTimer = Timer(ttl, () {
+        logger.shout('Killing "$id", because it is not sending alive pings');
+        close();
+      });
+    }
+
+    // We DO NOT initialize `autokillTimer` at this point, allowing the isolate
+    // to do arbitrary-length setup. Once the first message comes in, we can
+    // start the auto-kill timer.
+    _aliveSubscription = _aliveReceivePort.listen((_) {
+      resetAutokillTimer();
     });
   }
 
-  // We DO NOT initialize `autokillTimer` at this point, allowing the isolate
-  // to do arbitrary-length setup. Once the first message comes in, we can
-  // start the auto-kill timer.
-  final aliveSubscription = aliveReceivePort.listen((_) {
-    resetAutokillTimer();
-  });
-
-  return () async {
-    await aliveSubscription.cancel();
-    autokillTimer?.cancel();
-  };
+  Future<void> close() async {
+    try {
+      if (_doneCompleter.isCompleted) return;
+      logger.info('About to close $id ...');
+      _autokillTimer?.cancel();
+      await _protocolSubscription?.cancel();
+      await _statsSubscription?.cancel();
+      await _aliveSubscription?.cancel();
+      await _errorSubscription?.cancel();
+      await _exitSubscription?.cancel();
+      _aliveReceivePort.close();
+      _errorReceivePort.close();
+      _exitReceivePort.close();
+      _protocolReceivePort.close();
+      _isolate.kill();
+      logger.info('$id closed.');
+    } finally {
+      if (!_doneCompleter.isCompleted) {
+        _doneCompleter.complete();
+      }
+    }
+  }
 }
 
 void _setupServiceIsolate() {
-  useLoggingPackageAdaptor();
+  if (envConfig.isRunningInAppengine) {
+    useLoggingPackageAdaptor();
+  }
 }
 
-void _wrapper(List fnAndMessage) {
+Future<void> _wrapper(List fnAndMessage) async {
   final fn = fnAndMessage[0] as Function;
   final message = fnAndMessage[1];
   final logger = Logger('isolate.wrapper');
   // NOTE: This timer triggers active "work" and prevents the VM to run compaction GC.
   //       https://github.com/dart-lang/sdk/issues/52513
-  Timer.periodic(Duration(milliseconds: 250), (_) {});
+  final timer = Timer.periodic(Duration(milliseconds: 250), (_) {});
 
-  withServices(() async {
-    await Chain.capture(
+  Future run() async {
+    return await Chain.capture(
       () async {
         try {
           _setupServiceIsolate();
@@ -366,5 +379,17 @@ void _wrapper(List fnAndMessage) {
         throw Exception('Uncaught exception: $e $st');
       },
     );
-  });
+  }
+
+  try {
+    if (envConfig.isRunningInAppengine) {
+      return await withServices(() async {
+        return await run();
+      });
+    } else {
+      return await run();
+    }
+  } finally {
+    timer.cancel();
+  }
 }

--- a/app/lib/service/entrypoint/_isolate.dart
+++ b/app/lib/service/entrypoint/_isolate.dart
@@ -21,6 +21,7 @@ import 'tools.dart';
 
 final _random = Random.secure();
 
+/// Initializing message send from the controller isolate to the new one.
 class EntryMessage {
   final SendPort protocolSendPort;
   final SendPort aliveSendPort;

--- a/app/lib/service/entrypoint/analyzer.dart
+++ b/app/lib/service/entrypoint/analyzer.dart
@@ -36,7 +36,7 @@ class AnalyzerCommand extends Command {
   @override
   Future<void> run() async {
     envConfig.checkServiceEnvironment(name);
-    await startIsolates(
+    await runIsolates(
       logger: logger,
       frontendEntryPoint: _frontendMain,
       workerEntryPoint: _workerMain,
@@ -47,17 +47,17 @@ class AnalyzerCommand extends Command {
   }
 }
 
-Future _frontendMain(FrontendEntryMessage message) async {
+Future _frontendMain(EntryMessage message) async {
   final statsConsumer = ReceivePort();
   registerSchedulerStatsStream(statsConsumer.cast<Map>());
-  message.protocolSendPort.send(FrontendProtocolMessage(
+  message.protocolSendPort.send(ReadyMessage(
     statsConsumerPort: statsConsumer.sendPort,
   ));
   await runHandler(logger, analyzerServiceHandler);
 }
 
-Future _workerMain(WorkerEntryMessage message) async {
-  message.protocolSendPort.send(WorkerProtocolMessage());
+Future _workerMain(EntryMessage message) async {
+  message.protocolSendPort.send(ReadyMessage());
 
   await taskBackend.start();
 

--- a/app/lib/service/entrypoint/dartdoc.dart
+++ b/app/lib/service/entrypoint/dartdoc.dart
@@ -33,7 +33,7 @@ class DartdocCommand extends Command {
   @override
   Future<void> run() async {
     envConfig.checkServiceEnvironment(name);
-    await startIsolates(
+    await runIsolates(
       logger: logger,
       frontendEntryPoint: _frontendMain,
       workerEntryPoint: _workerMain,
@@ -44,17 +44,17 @@ class DartdocCommand extends Command {
   }
 }
 
-Future _frontendMain(FrontendEntryMessage message) async {
+Future _frontendMain(EntryMessage message) async {
   final statsConsumer = ReceivePort();
   registerSchedulerStatsStream(statsConsumer.cast<Map>());
-  message.protocolSendPort.send(FrontendProtocolMessage(
+  message.protocolSendPort.send(ReadyMessage(
     statsConsumerPort: statsConsumer.sendPort,
   ));
   await runHandler(logger, dartdocServiceHandler);
 }
 
-Future _workerMain(WorkerEntryMessage message) async {
-  message.protocolSendPort.send(WorkerProtocolMessage());
+Future _workerMain(EntryMessage message) async {
+  message.protocolSendPort.send(ReadyMessage());
 
   setupDartdocPeriodicTasks();
   await popularityStorage.start();

--- a/app/lib/service/entrypoint/frontend.dart
+++ b/app/lib/service/entrypoint/frontend.dart
@@ -35,7 +35,7 @@ class DefaultCommand extends Command {
   @override
   Future<void> run() async {
     envConfig.checkServiceEnvironment(name);
-    await startIsolates(
+    await runIsolates(
       logger: _logger,
       frontendEntryPoint: _main,
       frontendCount: envConfig.isRunningInAppengine ? 4 : 1,
@@ -44,9 +44,8 @@ class DefaultCommand extends Command {
   }
 }
 
-Future _main(FrontendEntryMessage message) async {
-  message.protocolSendPort
-      .send(FrontendProtocolMessage(statsConsumerPort: null));
+Future _main(EntryMessage message) async {
+  message.protocolSendPort.send(ReadyMessage());
 
   await updateLocalBuiltFilesIfNeeded();
   final appHandler = createAppHandler();

--- a/app/lib/service/entrypoint/search.dart
+++ b/app/lib/service/entrypoint/search.dart
@@ -33,7 +33,7 @@ class SearchCommand extends Command {
   @override
   Future<void> run() async {
     envConfig.checkServiceEnvironment(name);
-    await startIsolates(
+    await runIsolates(
       logger: _logger,
       frontendEntryPoint: _main,
       workerEntryPoint: _worker,
@@ -43,10 +43,10 @@ class SearchCommand extends Command {
   }
 }
 
-Future _main(FrontendEntryMessage message) async {
+Future _main(EntryMessage message) async {
   final statsConsumer = ReceivePort();
   registerSchedulerStatsStream(statsConsumer.cast<Map>());
-  message.protocolSendPort.send(FrontendProtocolMessage(
+  message.protocolSendPort.send(ReadyMessage(
     statsConsumerPort: statsConsumer.sendPort,
   ));
 
@@ -69,8 +69,8 @@ Future _main(FrontendEntryMessage message) async {
   await runHandler(_logger, searchServiceHandler);
 }
 
-Future _worker(WorkerEntryMessage message) async {
-  message.protocolSendPort.send(WorkerProtocolMessage());
+Future _worker(EntryMessage message) async {
+  message.protocolSendPort.send(ReadyMessage());
   await popularityStorage.start();
   setupSearchPeriodicTasks();
   await searchBackend.updateSnapshotInForeverLoop();

--- a/app/test/service/entrypoint/isolate_runner_test.dart
+++ b/app/test/service/entrypoint/isolate_runner_test.dart
@@ -1,0 +1,155 @@
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:isolate';
+
+import 'package:logging/logging.dart';
+import 'package:pub_dev/service/entrypoint/_isolate.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('IsolateRunner', () {
+    test('create -> wait -> close', () async {
+      final logger = Logger.detached('test');
+      final messages = <String>[];
+      final subs = logger.onRecord.listen((event) {
+        messages.add(event.message);
+      });
+      final runner = IsolateRunner(logger: logger);
+      await runner.startIsolates(
+        kind: 'test',
+        entryPoint: _main1,
+        count: 2,
+        deadTimeout: Duration(minutes: 1),
+      );
+
+      await Future.delayed(Duration(seconds: 2));
+      expect(messages, hasLength(6));
+      expect(
+        messages,
+        containsAll([
+          contains('About to start test isolate #1'),
+          contains('About to start test isolate #2'),
+          contains('test isolate #1 started'),
+          contains('test isolate #2 started'),
+          contains('Debug message from test isolate #1:'),
+          contains('Debug message from test isolate #2:'),
+        ]),
+      );
+
+      await runner.close();
+      await subs.cancel();
+
+      expect(messages, hasLength(10));
+      expect(
+        messages,
+        containsAll([
+          contains('About to close test isolate #1'),
+          contains('About to close test isolate #2'),
+          contains('test isolate #1 closed'),
+          contains('test isolate #2 closed'),
+        ]),
+      );
+    });
+
+    test('start -> end', () async {
+      final logger = Logger.detached('test');
+      final messages = <String>[];
+      final subs = logger.onRecord.listen((event) {
+        messages.add(event.message);
+      });
+      final runner = IsolateRunner(logger: logger);
+      await runner.startIsolates(
+        kind: 'test',
+        entryPoint: _main2,
+        count: 1,
+        deadTimeout: Duration(minutes: 1),
+      );
+
+      await Future.delayed(Duration(seconds: 1));
+      expect(
+        messages,
+        [
+          'About to start test isolate #1 ...',
+          'test isolate #1 started.',
+          'test isolate #1 exited.',
+          'About to close test isolate #1 ...',
+          'test isolate #1 closed.',
+        ],
+      );
+      // second isolate starts after 6 seconds
+      await Future.delayed(Duration(seconds: 7));
+      expect(
+          messages,
+          containsAll([
+            'About to start test isolate #2 ...',
+            'test isolate #2 started.',
+            'test isolate #2 exited.',
+            'About to close test isolate #2 ...',
+            'test isolate #2 closed.',
+          ]));
+
+      await runner.close();
+      await subs.cancel();
+    });
+
+    test('throws', () async {
+      final logger = Logger.detached('test');
+      final messages = <String>[];
+      final subs = logger.onRecord.listen((event) {
+        messages.add(event.message);
+      });
+      final runner = IsolateRunner(logger: logger);
+      await runner.startIsolates(
+        kind: 'test',
+        entryPoint: _main3,
+        count: 1,
+        deadTimeout: Duration(minutes: 1),
+      );
+
+      await Future.delayed(Duration(seconds: 1));
+      expect(
+        messages,
+        [
+          'About to start test isolate #1 ...',
+          'test isolate #1 started.',
+          'ERROR from test isolate #1',
+          'About to close test isolate #1 ...',
+          'test isolate #1 closed.',
+        ],
+      );
+      // second isolate starts after 6 seconds
+      await Future.delayed(Duration(seconds: 7));
+      expect(
+          messages,
+          containsAll([
+            'About to start test isolate #2 ...',
+            'test isolate #2 started.',
+            'ERROR from test isolate #2',
+            'About to close test isolate #2 ...',
+            'test isolate #2 closed.',
+          ]));
+
+      await runner.close();
+      await subs.cancel();
+    });
+  });
+}
+
+Future<void> _main1(EntryMessage message) async {
+  message.protocolSendPort.send(ReadyMessage());
+  final currentIsolate = Isolate.current;
+  message.protocolSendPort.send(DebugMessage('${currentIsolate.debugName}'));
+  await Completer().future;
+}
+
+Future<void> _main2(EntryMessage message) async {
+  message.protocolSendPort.send(ReadyMessage());
+}
+
+Future<void> _main3(EntryMessage message) async {
+  message.protocolSendPort.send(ReadyMessage());
+  throw Exception('ex');
+}


### PR DESCRIPTION
- (hopefully) not much functional change, but log messages may be changing slightly
- refactored message handling into a separate class
- unified entry and ready messages for different kind of isolates
- small side effect of the unification: worker isolates have the same restart delay as the frontend ones (less initial delay the increases over time)
- tests for regular and error-based exits and restarts
- a further goal of this is to prepare the search service for starting a new isolate for each new snapshot in a controlled way (TBD in a subsequent PR)
