### PR TITLE
Check (cached) package status before attempting to load version blob index.

### DIFF
--- a/app/lib/shared/redis_cache.dart
+++ b/app/lib/shared/redis_cache.dart
@@ -328,16 +328,18 @@ class CachePatterns {
           .withTTL(Duration(hours: 4))['$blobId/$path'];
 
   /// Cache for task status.
-  Entry<PackageStateInfo> taskPackageStatus(String package) => _cache
-      .withPrefix('task-status/')
-      .withTTL(Duration(hours: 3))
-      .withCodec(utf8)
-      .withCodec(json)
-      .withCodec(wrapAsCodec(
-        encode: (PackageStateInfo s) => s.toJson(),
-        decode: (data) =>
-            PackageStateInfo.fromJson(data as Map<String, dynamic>),
-      ))[package];
+  Entry<PackageStateInfo> taskPackageStatus(
+          String package, String runtimeVersion) =>
+      _cache
+          .withPrefix('task-status/')
+          .withTTL(Duration(hours: 3))
+          .withCodec(utf8)
+          .withCodec(json)
+          .withCodec(wrapAsCodec(
+            encode: (PackageStateInfo s) => s.toJson(),
+            decode: (data) =>
+                PackageStateInfo.fromJson(data as Map<String, dynamic>),
+          ))['$package/$runtimeVersion'];
 
   /// Cache for sanitized and re-rendered dartdoc HTML files.
   Entry<List<int>> dartdocHtmlBytes(

--- a/app/lib/task/backend.dart
+++ b/app/lib/task/backend.dart
@@ -738,28 +738,26 @@ class TaskBackend {
   Future<BlobIndex?> _taskResultIndex(String package, String version) async =>
       await cache.taskResultIndex(package, version).get(() async {
         // Try runtimeVersions in order of age
-        var path = '$runtimeVersion/$package/$version/index.json';
-        List<int>? bytes;
         for (final rt in acceptedRuntimeVersions) {
-          path = '$rt/$package/$version/index.json';
-          bytes = await _readFromBucket(path);
-          if (bytes != null) break;
+          final pathPrefix = '$rt/$package/$version';
+          final path = '$pathPrefix/index.json';
+          final bytes = await _readFromBucket(path);
+          if (bytes != null) {
+            final index = BlobIndex.fromBytes(bytes);
+            final blobId = index.blobId;
+            // We must check that the blobId points to a file under:
+            //  `$runtimeVersion/$package/$version/`
+            // Technically, the blob index is produced by the sandbox and we cannot
+            // trust it to not be malformed.
+            if (!_blobIdPattern.hasMatch(blobId) ||
+                !blobId.startsWith('$pathPrefix/')) {
+              _log.warning('invalid blobId: "$blobId" in index in "$path"');
+              return BlobIndex.empty(blobId: '');
+            }
+            return index;
+          }
         }
-        if (bytes == null) {
-          return BlobIndex.empty(blobId: '');
-        }
-        final index = BlobIndex.fromBytes(bytes);
-        final blobId = index.blobId;
-        // We must check that the blobId points to a file under:
-        //  `$runtimeVersion/$package/$version/`
-        // Technically, the blob index is produced by the sandbox and we cannot
-        // trust it to not be malformed.
-        if (!_blobIdPattern.hasMatch(blobId) ||
-            !blobId.startsWith('$runtimeVersion/$package/$version/')) {
-          _log.warning('invalid blobId: "$blobId" in index in "$path"');
-          return BlobIndex.empty(blobId: '');
-        }
-        return index;
+        return BlobIndex.empty(blobId: '');
       });
 
   /// Return gzipped result from task for the given [package]/[version] or

--- a/app/lib/task/scheduler.dart
+++ b/app/lib/task/scheduler.dart
@@ -207,7 +207,7 @@ Future<void> schedule(
         return;
       }
       assert(description != null);
-      await cache.taskPackageStatus(state.package).purge();
+      await cache.taskPackageStatus(state.package, runtimeVersion).purge();
 
       scheduleMicrotask(() async {
         var rollbackPackageState = true;
@@ -281,7 +281,9 @@ Future<void> schedule(
               s.derivePendingAt();
               tx.insert(s);
             });
-            await cache.taskPackageStatus(state.package).purge();
+            await cache
+                .taskPackageStatus(state.package, runtimeVersion)
+                .purge();
           }
         }
       });


### PR DESCRIPTION
- Built on top of #6816.
- using the name `forRuntimeVersion` instead of `runtimeVersion`, because otherwise we would need to prefix the imported library
- purging the cache entries with the older `runtimeVersion` values seems to be something we could do, but doesn't really need to, leaving it out for now
 