### PR TITLE
Reduce the PackageIndex interface.

### DIFF
--- a/app/lib/search/mem_index.dart
+++ b/app/lib/search/mem_index.dart
@@ -65,13 +65,13 @@ class InMemoryPackageIndex implements PackageIndex {
     _updatedPackages.addLast(package);
   }
 
-  @override
+  /// Returns the source update timestamp of the [package].
   DateTime? getPackageSourceLastUpdated(String package) {
     final doc = _packages[package];
     return doc?.sourceUpdated ?? doc?.timestamp;
   }
 
-  @override
+  /// Returns the map of package names and their versions in the index.
   Map<String, String> getPackageNamesNotRecentlyUpdated(Duration threshold) {
     final now = clock.now();
     return Map.fromEntries(_packages.values
@@ -79,12 +79,14 @@ class InMemoryPackageIndex implements PackageIndex {
         .map((doc) => MapEntry(doc.package, doc.version!)));
   }
 
-  @override
+  /// A package index may be accessed while the initialization phase is still
+  /// running. Once the initialization is done (either via a snapshot or a
+  /// `Package`-scan completes), the updater should call this method to indicate
+  /// to the frontend load-balancer that the instance now accepts requests.
   Future<void> markReady() async {
     _isReady = true;
   }
 
-  @override
   Future<void> addPackage(PackageDocument doc) async {
     _packages[doc.package] = doc;
 
@@ -122,7 +124,6 @@ class InMemoryPackageIndex implements PackageIndex {
     _invalidateHitCaches();
   }
 
-  @override
   Future<void> addPackages(Iterable<PackageDocument> documents) async {
     for (PackageDocument doc in documents) {
       await addPackage(doc);
@@ -130,7 +131,6 @@ class InMemoryPackageIndex implements PackageIndex {
     await _likeTracker._updateScores();
   }
 
-  @override
   Future<void> removePackage(String package) async {
     final doc = _packages.remove(package);
     if (doc == null) return;

--- a/app/lib/search/search_service.dart
+++ b/app/lib/search/search_service.dart
@@ -49,23 +49,8 @@ class IndexInfo {
 
 /// Package search index and lookup.
 abstract class PackageIndex {
-  Future<void> addPackage(PackageDocument doc);
-  Future<void> addPackages(Iterable<PackageDocument> documents);
-  Future<void> removePackage(String package);
   PackageSearchResult search(ServiceSearchQuery query);
-
-  /// A package index may be accessed while the initialization phase is still
-  /// running. Once the initialization is done (either via a snapshot or a
-  /// `Package`-scan completes), the updater should call this method to indicate
-  /// to the frontend load-balancer that the instance now accepts requests.
-  Future<void> markReady();
   Future<IndexInfo> indexInfo();
-
-  /// Returns the source update timestamp of the [package].
-  DateTime? getPackageSourceLastUpdated(String package);
-
-  /// Returns the map of package names and their versions in the index.
-  Map<String, String> getPackageNamesNotRecentlyUpdated(Duration threshold);
 }
 
 /// A summary information about a package that goes into the search index.

--- a/app/lib/service/services.dart
+++ b/app/lib/service/services.dart
@@ -247,10 +247,11 @@ Future<R> _withPubServices<R>(FutureOr<R> Function() fn) async {
     registerJobBackend(JobBackend(dbService));
     registerLikeBackend(LikeBackend(dbService));
     registerNameTracker(NameTracker(dbService));
-    registerPackageIndex(InMemoryPackageIndex(
+    final inMemoryPackageIndex = InMemoryPackageIndex(
       popularityValueFn: (p) => popularityStorage.lookup(p),
-    ));
-    registerIndexUpdater(IndexUpdater(dbService, packageIndex));
+    );
+    registerPackageIndex(inMemoryPackageIndex);
+    registerIndexUpdater(IndexUpdater(dbService, inMemoryPackageIndex));
     registerPopularityStorage(
       PopularityStorage(
           storageService.bucket(activeConfiguration.popularityDumpBucketName!)),


### PR DESCRIPTION
Most operations are required only by the updater or specific to the mem index, we don't need to keep them on the top-level interface. We could probably remove the `IndexInfo` too, but keeping it for now, it may be needed for the isolate-based-search.