### PR TITLE
More logs

### DIFF
--- a/app/lib/service/entrypoint/_isolate.dart
+++ b/app/lib/service/entrypoint/_isolate.dart
@@ -7,7 +7,6 @@ import 'dart:io';
 import 'dart:isolate';
 import 'dart:math';
 
-import 'package:appengine/appengine.dart';
 import 'package:clock/clock.dart';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
@@ -17,6 +16,7 @@ import '../../shared/env_config.dart';
 import '../../shared/scheduler_stats.dart';
 
 import '../services.dart';
+import 'logging.dart';
 import 'tools.dart';
 
 final _random = Random.secure();
@@ -346,7 +346,7 @@ class _Isolate {
 
 void _setupServiceIsolate() {
   if (envConfig.isRunningInAppengine) {
-    useLoggingPackageAdaptor();
+    setupAppEngineLogging();
   }
 }
 

--- a/app/lib/service/entrypoint/_isolate.dart
+++ b/app/lib/service/entrypoint/_isolate.dart
@@ -16,7 +16,6 @@ import '../../shared/env_config.dart';
 import '../../shared/scheduler_stats.dart';
 
 import '../services.dart';
-import 'logging.dart';
 import 'tools.dart';
 
 final _random = Random.secure();
@@ -139,7 +138,6 @@ Future runIsolates({
   required int workerCount,
 }) async {
   await withServices(() async {
-    _setupServiceIsolate();
     _verifyStampFile();
     try {
       final runner = IsolateRunner(logger: logger);
@@ -344,12 +342,6 @@ class _Isolate {
   }
 }
 
-void _setupServiceIsolate() {
-  if (envConfig.isRunningInAppengine) {
-    setupAppEngineLogging();
-  }
-}
-
 Future<void> _wrapper(List fnAndMessage) async {
   final fn = fnAndMessage[0] as Function;
   final message = fnAndMessage[1];
@@ -362,7 +354,6 @@ Future<void> _wrapper(List fnAndMessage) async {
     return await Chain.capture(
       () async {
         try {
-          _setupServiceIsolate();
           return await fn(message);
         } catch (e, st) {
           print('Uncaught exception in isolate. $e $st');

--- a/app/lib/service/entrypoint/_isolate.dart
+++ b/app/lib/service/entrypoint/_isolate.dart
@@ -350,27 +350,16 @@ Future<void> _wrapper(List fnAndMessage) async {
   //       https://github.com/dart-lang/sdk/issues/52513
   final timer = Timer.periodic(Duration(milliseconds: 250), (_) {});
 
-  Future run() async {
+  Future<void> run() async {
     return await Chain.capture(
       () async {
-        try {
-          return await fn(message);
-        } catch (e, st) {
-          print('Uncaught exception in isolate. $e $st');
-          logger.severe('Uncaught exception in isolate.', e, st);
-          rethrow;
-        }
+        return await fn(message);
       },
       onError: (e, st) {
-        print('Uncaught exception in isolate. $e $st');
-        logger.severe('Uncaught exception in isolate.', e, st);
-        if (e is Exception) {
-          throw e;
-        }
-        if (e is Error) {
-          throw e;
-        }
-        throw Exception('Uncaught exception: $e $st');
+        // TODO: Enable, if we undo the hack for logging:
+        // print('Uncaught exception in isolate. $e $st');
+        logger.severe('Uncaught exception in isolate.', e, st.terse);
+        throw Exception('Crashing isolate due to uncaught exception: $e');
       },
     );
   }

--- a/app/lib/service/entrypoint/logging.dart
+++ b/app/lib/service/entrypoint/logging.dart
@@ -1,6 +1,8 @@
 import 'dart:convert';
 
 import 'package:appengine/appengine.dart';
+// ignore: implementation_imports
+import 'package:appengine/src/logging_impl.dart' show LoggingImpl;
 import 'package:logging/logging.dart';
 
 final Map<Level, LogLevel?> _loggingLevel2AppengineLoggingLevel = {
@@ -51,7 +53,8 @@ void setupAppEngineLogging() {
         addBlock('Stack', '${record.stackTrace}');
       }
 
-      if (logging == null) {
+      // Unless logging a request, we just log directly to stdout
+      if (logging == null || logging is! LoggingImpl) {
         print(jsonEncode({
           'severity': level.name.toUpperCase(),
           'message': message,

--- a/app/lib/service/entrypoint/logging.dart
+++ b/app/lib/service/entrypoint/logging.dart
@@ -28,63 +28,46 @@ void setupAppEngineLogging() {
       try {
         logging = loggingService;
       } on StateError {
-        final level = _loggingLevel2AppengineLoggingLevel[record.level];
-        if (level != null) {
-          var message = record.message;
-
-          if (record.loggerName.isNotEmpty) {
-            message = '${record.loggerName}: $message';
-          }
-
-          void addBlock(String header, String body) {
-            body = body.replaceAll('\n', '\n    ');
-            message = '$message\n\n$header:\n    $body';
-          }
-
-          if (record.error != null) addBlock('Error', '${record.error}');
-          if (record.stackTrace != null) {
-            addBlock('Stack', '${record.stackTrace}');
-          }
-
-          print(jsonEncode({
-            'severity': level.name.toUpperCase(),
-            'message': message,
-            'logging.googleapis.com/labels': {
-              'logger': record.loggerName,
-            },
-            'time': record.time.toUtc().toIso8601String(),
-          }));
-          return;
-        }
+        // pass
       }
 
-      if (logging != null) {
-        final level = _loggingLevel2AppengineLoggingLevel[record.level];
-        if (level != null) {
-          var message = record.message;
+      final level = _loggingLevel2AppengineLoggingLevel[record.level];
+      if (level == null) {
+        return;
+      }
+      var message = record.message;
 
-          if (record.loggerName.isNotEmpty) {
-            message = '${record.loggerName}: $message';
-          }
+      if (record.loggerName.isNotEmpty) {
+        message = '${record.loggerName}: $message';
+      }
 
-          void addBlock(String header, String body) {
-            body = body.replaceAll('\n', '\n    ');
-            message = '$message\n\n$header:\n    $body';
-          }
+      void addBlock(String header, String body) {
+        body = body.replaceAll('\n', '\n    ');
+        message = '$message\n\n$header:\n    $body';
+      }
 
-          if (record.error != null) addBlock('Error', '${record.error}');
-          if (record.stackTrace != null) {
-            addBlock('Stack', '${record.stackTrace}');
-          }
+      if (record.error != null) addBlock('Error', '${record.error}');
+      if (record.stackTrace != null) {
+        addBlock('Stack', '${record.stackTrace}');
+      }
 
-          logging.log(
-            level,
-            message,
-            timestamp: record.time,
-          );
-          if (record.error != null && record.stackTrace != null) {
-            logging.reportError(level, record.error!, record.stackTrace!);
-          }
+      if (logging == null) {
+        print(jsonEncode({
+          'severity': level.name.toUpperCase(),
+          'message': message,
+          'logging.googleapis.com/labels': {
+            'logger': record.loggerName,
+          },
+          'time': record.time.toUtc().toIso8601String(),
+        }));
+      } else {
+        logging.log(
+          level,
+          message,
+          timestamp: record.time,
+        );
+        if (record.error != null && record.stackTrace != null) {
+          logging.reportError(level, record.error!, record.stackTrace!);
         }
       }
     });

--- a/app/lib/service/entrypoint/logging.dart
+++ b/app/lib/service/entrypoint/logging.dart
@@ -1,0 +1,92 @@
+import 'dart:convert';
+
+import 'package:appengine/appengine.dart';
+import 'package:logging/logging.dart';
+
+final Map<Level, LogLevel?> _loggingLevel2AppengineLoggingLevel = {
+  Level.OFF: null,
+  Level.ALL: LogLevel.DEBUG,
+  Level.FINEST: LogLevel.DEBUG,
+  Level.FINER: LogLevel.DEBUG,
+  Level.FINE: LogLevel.DEBUG,
+  Level.CONFIG: LogLevel.INFO,
+  Level.INFO: LogLevel.INFO,
+  Level.WARNING: LogLevel.WARNING,
+  Level.SEVERE: LogLevel.ERROR,
+  Level.SHOUT: LogLevel.CRITICAL,
+};
+
+var _setupAppEngineLogging = false;
+void setupAppEngineLogging() {
+  if (_setupAppEngineLogging) {
+    return;
+  }
+  _setupAppEngineLogging = true;
+  Logger.root.onRecord.listen((LogRecord record) {
+    record.zone!.run(() {
+      Logging? logging;
+      try {
+        logging = loggingService;
+      } on StateError {
+        final level = _loggingLevel2AppengineLoggingLevel[record.level];
+        if (level != null) {
+          var message = record.message;
+
+          if (record.loggerName.isNotEmpty) {
+            message = '${record.loggerName}: $message';
+          }
+
+          void addBlock(String header, String body) {
+            body = body.replaceAll('\n', '\n    ');
+            message = '$message\n\n$header:\n    $body';
+          }
+
+          if (record.error != null) addBlock('Error', '${record.error}');
+          if (record.stackTrace != null) {
+            addBlock('Stack', '${record.stackTrace}');
+          }
+
+          print(jsonEncode({
+            'severity': level.name.toUpperCase(),
+            'message': message,
+            'logging.googleapis.com/labels': {
+              'logger': record.loggerName,
+            },
+            'time': record.time.toUtc().toIso8601String(),
+          }));
+          return;
+        }
+      }
+
+      if (logging != null) {
+        final level = _loggingLevel2AppengineLoggingLevel[record.level];
+        if (level != null) {
+          var message = record.message;
+
+          if (record.loggerName.isNotEmpty) {
+            message = '${record.loggerName}: $message';
+          }
+
+          void addBlock(String header, String body) {
+            body = body.replaceAll('\n', '\n    ');
+            message = '$message\n\n$header:\n    $body';
+          }
+
+          if (record.error != null) addBlock('Error', '${record.error}');
+          if (record.stackTrace != null) {
+            addBlock('Stack', '${record.stackTrace}');
+          }
+
+          logging.log(
+            level,
+            message,
+            timestamp: record.time,
+          );
+          if (record.error != null && record.stackTrace != null) {
+            logging.reportError(level, record.error!, record.stackTrace!);
+          }
+        }
+      }
+    });
+  });
+}

--- a/app/lib/service/entrypoint/logging.dart
+++ b/app/lib/service/entrypoint/logging.dart
@@ -53,6 +53,11 @@ void setupAppEngineLogging() {
         addBlock('Stack', '${record.stackTrace}');
       }
 
+      // Truncated messages over 200kb
+      if (message.length > 200 * 1024) {
+        message = message.substring(0, 200 * 1024) + '\n[truncted due to size]';
+      }
+
       // Unless logging a request, we just log directly to stdout
       if (logging == null || logging is! LoggingImpl) {
         print(jsonEncode({

--- a/app/lib/service/services.dart
+++ b/app/lib/service/services.dart
@@ -62,6 +62,7 @@ import '../task/cloudcompute/fakecloudcompute.dart';
 import '../task/cloudcompute/googlecloudcompute.dart';
 import '../tool/utils/http.dart';
 import 'announcement/backend.dart';
+import 'entrypoint/logging.dart';
 import 'secret/backend.dart';
 
 final _logger = Logger('pub.services');
@@ -77,6 +78,9 @@ Future<void> withServices(FutureOr<void> Function() fn) async {
     throw StateError('Already in withServices scope.');
   }
   return withAppEngineServices(() async {
+    if (envConfig.isRunningInAppengine) {
+      setupAppEngineLogging();
+    }
     return await fork(() async {
       // retrying Datastore client
       final origDbService = dbService;


### PR DESCRIPTION
Cleanup some logging logic, add new hacks :see_no_evil: 

Eventually, we might want to only logging to stdout.

Prior to this change, we seem to drop:
```dart
logger.severe('Uncaught exception in isolate.', e, st);
```
Probably because the isolate crashes before it can successfully send the logs.