### PR TITLE
Fallback to old runtimeVersion in packageStatus

### DIFF
--- a/app/lib/task/backend.dart
+++ b/app/lib/task/backend.dart
@@ -744,17 +744,12 @@ class TaskBackend {
           return BlobIndex.empty(blobId: '');
         }
         final versionStatus = status.versions[version]!.status;
-        // if current version is failed, don't load earlier results
+        // if analysis has failed, don't try to load results
         if (versionStatus == PackageVersionStatus.failed) {
           return BlobIndex.empty(blobId: '');
         }
         // Try runtimeVersions in order of age
         for (final rt in acceptedRuntimeVersions) {
-          // skip old runtime(s) when current status is not pending
-          if (rt != runtimeVersion &&
-              versionStatus != PackageVersionStatus.pending) {
-            continue;
-          }
           final pathPrefix = '$rt/$package/$version';
           final path = '$pathPrefix/index.json';
           final bytes = await _readFromBucket(path);
@@ -906,13 +901,17 @@ class TaskBackend {
   /// Get status information for a package being analyzed.
   Future<PackageStateInfo> packageStatus(String package) async {
     final status = await cache.taskPackageStatus(package).get(() async {
-      final key = PackageState.createKey(_db, runtimeVersion, package);
-      final state = await dbService.lookupOrNull<PackageState>(key);
-
-      return PackageStateInfo(
-        package: package,
-        versions: state?.versions ?? {},
-      );
+      for (final rt in acceptedRuntimeVersions) {
+        final key = PackageState.createKey(_db, rt, package);
+        final state = await dbService.lookupOrNull<PackageState>(key);
+        if (state != null) {
+          return PackageStateInfo(
+            package: package,
+            versions: state.versions ?? {},
+          );
+        }
+      }
+      return PackageStateInfo(package: package, versions: {});
     });
     return status ?? PackageStateInfo(package: package, versions: {});
   }


### PR DESCRIPTION
I think the `skip old runtime(s) when current status is not pending` was largely unnecessary.

But certainly it would be wrong now, since `packageStatus` can be an old runtimeVersion...

Other than that, it seems we use `packageStatus` in `/api/documentation/<package>`, were falling back is fine (indeed correct behavior).

We could make the logic in `_taskResultIndex` smarter if we added runtimeVersion as a property in the result from `packageStatus`. But I'm not sure it'd make things better, just less covered by tests :see_no_evil: 