### PR TITLE
Await post upload tasks

### DIFF
--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -1161,13 +1161,13 @@ class PackageBackend {
     // Let's not block the upload response on these post-upload tasks.
     // The operations should either be non-critical, or should be retried
     // automatically.
-    unawaited(_postUploadTasks(
+    await _postUploadTasks(
       package,
       newVersion,
       outgoingEmail,
       prevLatestStableVersion: prevLatestStableVersion,
       prevLatestPrereleaseVersion: prevLatestPrereleaseVersion,
-    ));
+    );
 
     _logger.info('Post-upload tasks completed in ${sw.elapsed}.');
     return pv;


### PR DESCRIPTION
I'm not sure this is safe, but after the request handler is done, the service scope that the request lives inside is going to be exited.

I'm guessing this might be the cause of issues like:
```
Bad state: The service scope has already been exited. It is therefore forbidden to use this service scope anymore. Please make sure that your code waits for all asynchronous tasks before the closure passed to fork() completes.
```