### PR TITLE
Refactor search index API and prepare it for isolate-calls.

### DIFF
--- a/app/lib/search/mem_index.dart
+++ b/app/lib/search/mem_index.dart
@@ -23,7 +23,7 @@ final _textSearchTimeout = Duration(milliseconds: 500);
 typedef PopularityValueFn = double Function(String packageName);
 double _noPopularityScoreFn(String packageName) => 0.0;
 
-class InMemoryPackageIndex implements PackageIndex {
+class InMemoryPackageIndex {
   final PopularityValueFn _popularityValueFn;
   final Map<String, PackageDocument> _packages = <String, PackageDocument>{};
   final _packageNameIndex = PackageNameIndex();
@@ -48,8 +48,7 @@ class InMemoryPackageIndex implements PackageIndex {
   })  : _popularityValueFn = popularityValueFn,
         _alwaysUpdateLikeScores = alwaysUpdateLikeScores;
 
-  @override
-  Future<IndexInfo> indexInfo() async {
+  IndexInfo indexInfo() {
     return IndexInfo(
       isReady: _isReady,
       packageCount: _packages.length,
@@ -147,7 +146,6 @@ class InMemoryPackageIndex implements PackageIndex {
     _invalidateHitCaches();
   }
 
-  @override
   PackageSearchResult search(ServiceSearchQuery query) {
     final packages = Set<String>.of(_packages.keys);
 

--- a/app/lib/search/result_combiner.dart
+++ b/app/lib/search/result_combiner.dart
@@ -5,6 +5,7 @@
 import 'dart:math' as math;
 
 import 'package:_pub_shared/search/tags.dart';
+import 'package:pub_dev/search/mem_index.dart';
 
 import 'dart_sdk_mem_index.dart';
 import 'flutter_sdk_mem_index.dart';
@@ -13,7 +14,7 @@ import 'search_service.dart';
 /// Combines the results from the primary package index and the optional Dart
 /// SDK index.
 class SearchResultCombiner {
-  final PackageIndex primaryIndex;
+  final InMemoryPackageIndex primaryIndex;
   final DartSdkMemIndex dartSdkMemIndex;
   final FlutterSdkMemIndex flutterSdkMemIndex;
 
@@ -24,11 +25,11 @@ class SearchResultCombiner {
   });
 
   PackageSearchResult search(ServiceSearchQuery query) {
+    final primaryResult = primaryIndex.search(query);
     if (!query.includeSdkResults) {
-      return primaryIndex.search(query);
+      return primaryResult;
     }
 
-    final primaryResult = primaryIndex.search(query);
     final queryFlutterSdk = query.tagsPredicate.hasNoTagPrefix('sdk:') ||
         query.tagsPredicate.hasTag(SdkTag.sdkFlutter);
     final sdkLibraryHits = [

--- a/app/lib/search/search_service.dart
+++ b/app/lib/search/search_service.dart
@@ -48,9 +48,9 @@ class IndexInfo {
 }
 
 /// Package search index and lookup.
-abstract class PackageIndex {
-  PackageSearchResult search(ServiceSearchQuery query);
-  Future<IndexInfo> indexInfo();
+abstract class SearchIndex {
+  FutureOr<PackageSearchResult> search(ServiceSearchQuery query);
+  FutureOr<IndexInfo> indexInfo();
 }
 
 /// A summary information about a package that goes into the search index.

--- a/app/lib/service/services.dart
+++ b/app/lib/service/services.dart
@@ -250,7 +250,7 @@ Future<R> _withPubServices<R>(FutureOr<R> Function() fn) async {
     final inMemoryPackageIndex = InMemoryPackageIndex(
       popularityValueFn: (p) => popularityStorage.lookup(p),
     );
-    registerPackageIndex(inMemoryPackageIndex);
+    registerInMemoryPackageIndex(inMemoryPackageIndex);
     registerIndexUpdater(IndexUpdater(dbService, inMemoryPackageIndex));
     registerPopularityStorage(
       PopularityStorage(


### PR DESCRIPTION
- explicit service scope for the in-memory package index
- new service scope for the search combiner, in which place the isolate-based caller would be used later