### PR TITLE
Allow long word breaks by default in the base CSS.

### DIFF
--- a/pkg/web_css/lib/src/_base.scss
+++ b/pkg/web_css/lib/src/_base.scss
@@ -16,7 +16,7 @@ body {
   line-height: 1.6;
   margin: 0;
   padding: 0;
-  overflow-wrap: break-word;
+  overflow-wrap: anywhere;
 }
 
 body, input, button {


### PR DESCRIPTION
Fixes #6861.