### PR TITLE
Enable another template test.

### DIFF
--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -563,7 +563,6 @@ void main() {
           'package-created': data.package!.created,
         });
       },
-      skip: true, // skip, until we've fixed fake job data for sandboxing
     );
 
     testWithProfile('publisher list page', fn: () async {


### PR DESCRIPTION
Missed in the previous PR, tested the same way: with and without sandboxing.