### PR TITLE
Controlled renew of an isolate within a group.

### DIFF
--- a/app/lib/service/entrypoint/_isolate.dart
+++ b/app/lib/service/entrypoint/_isolate.dart
@@ -50,13 +50,14 @@ class DebugMessage extends Message {
 /// isolate execute the same code).
 ///
 /// TODO: The runner will handle the cross-group communication of the isolates.
-class IsolateRunner {
+@visibleForTesting
+class IsolateCollection {
   final Logger logger;
   var _closing = false;
 
   final _groups = <IsolateGroup>[];
 
-  IsolateRunner({
+  IsolateCollection({
     required this.logger,
   });
 
@@ -99,7 +100,7 @@ class IsolateRunner {
 /// Once an isolate starts, it is expected to run indefinitely. When it exits,
 /// either by completion or uncaught exception, a new isolate will be started.
 class IsolateGroup {
-  final IsolateRunner runner;
+  final IsolateCollection runner;
   final String kind;
   final Future<void> Function(EntryMessage message) entryPoint;
   final Duration? deadTimeout;
@@ -202,7 +203,7 @@ class IsolateGroup {
   }
 }
 
-/// Starts an [IsolateRunner] with the default isolate configuration
+/// Starts an [IsolateCollection] with the default isolate configuration
 /// (when specified).
 ///
 /// After starting the isolates, the method waits for terminating
@@ -219,7 +220,7 @@ Future runIsolates({
   await withServices(() async {
     _verifyStampFile();
     try {
-      final runner = IsolateRunner(logger: logger);
+      final runner = IsolateCollection(logger: logger);
       if (frontendEntryPoint != null) {
         await runner.startGroup(
           kind: 'frontend',
@@ -274,7 +275,7 @@ void _verifyStampFile() {
 /// autokill timer.
 class _Isolate {
   /// Parent runner that owns this group
-  final IsolateRunner parent;
+  final IsolateCollection parent;
   final IsolateGroup group;
   final Logger logger;
   final String id;

--- a/app/lib/service/entrypoint/_isolate.dart
+++ b/app/lib/service/entrypoint/_isolate.dart
@@ -152,7 +152,7 @@ class IsolateGroup {
     final id = '$kind isolate #$started';
     logger.info('About to start $id ...');
     final isolate = _Isolate(
-      runner: runner,
+      parent: runner,
       group: this,
       logger: logger,
       id: id,
@@ -273,7 +273,8 @@ void _verifyStampFile() {
 /// Represents a running isolate, with its current status, subscriptions and
 /// autokill timer.
 class _Isolate {
-  final IsolateRunner runner;
+  /// Parent runner that owns this group
+  final IsolateRunner parent;
   final IsolateGroup group;
   final Logger logger;
   final String id;
@@ -300,7 +301,7 @@ class _Isolate {
   var shouldRestart = true;
 
   _Isolate({
-    required this.runner,
+    required this.parent,
     required this.group,
     required this.logger,
     required this.id,

--- a/app/test/service/entrypoint/isolate_runner_test.dart
+++ b/app/test/service/entrypoint/isolate_runner_test.dart
@@ -18,7 +18,7 @@ void main() {
         messages.add(event.message);
       });
       final runner = IsolateRunner(logger: logger);
-      await runner.startIsolates(
+      await runner.startGroup(
         kind: 'test',
         entryPoint: _main1,
         count: 2,
@@ -61,7 +61,7 @@ void main() {
         messages.add(event.message);
       });
       final runner = IsolateRunner(logger: logger);
-      await runner.startIsolates(
+      await runner.startGroup(
         kind: 'test',
         entryPoint: _main2,
         count: 1,
@@ -95,6 +95,46 @@ void main() {
       await subs.cancel();
     });
 
+    test('renew', () async {
+      final logger = Logger.detached('test');
+      final messages = <String>[];
+      final subs = logger.onRecord.listen((event) {
+        messages.add(event.message);
+      });
+      final runner = IsolateRunner(logger: logger);
+      final group = await runner.startGroup(
+        kind: 'test',
+        entryPoint: _main4,
+        count: 1,
+        deadTimeout: Duration(minutes: 1),
+      );
+
+      await Future.delayed(Duration(seconds: 1));
+      expect(
+        messages,
+        [
+          'About to start test isolate #1 ...',
+          'test isolate #1 started.',
+        ],
+      );
+      // renew isolate
+      await group.renew(count: 1, wait: Duration(seconds: 1));
+      await Future.delayed(Duration(seconds: 1));
+      expect(
+          messages,
+          containsAll([
+            'About to start test isolate #1 ...',
+            'test isolate #1 started.',
+            'About to start test isolate #2 ...',
+            'test isolate #2 started.',
+            'About to close test isolate #1 ...',
+            'test isolate #1 closed.'
+          ]));
+
+      await runner.close();
+      await subs.cancel();
+    });
+
     test('throws', () async {
       final logger = Logger.detached('test');
       final messages = <String>[];
@@ -102,7 +142,7 @@ void main() {
         messages.add(event.message);
       });
       final runner = IsolateRunner(logger: logger);
-      await runner.startIsolates(
+      await runner.startGroup(
         kind: 'test',
         entryPoint: _main3,
         count: 1,
@@ -152,4 +192,9 @@ Future<void> _main2(EntryMessage message) async {
 Future<void> _main3(EntryMessage message) async {
   message.protocolSendPort.send(ReadyMessage());
   throw Exception('ex');
+}
+
+Future<void> _main4(EntryMessage message) async {
+  message.protocolSendPort.send(ReadyMessage());
+  await Completer().future;
 }

--- a/app/test/service/entrypoint/isolate_runner_test.dart
+++ b/app/test/service/entrypoint/isolate_runner_test.dart
@@ -17,7 +17,7 @@ void main() {
       final subs = logger.onRecord.listen((event) {
         messages.add(event.message);
       });
-      final runner = IsolateRunner(logger: logger);
+      final runner = IsolateCollection(logger: logger);
       await runner.startGroup(
         kind: 'test',
         entryPoint: _main1,
@@ -60,7 +60,7 @@ void main() {
       final subs = logger.onRecord.listen((event) {
         messages.add(event.message);
       });
-      final runner = IsolateRunner(logger: logger);
+      final runner = IsolateCollection(logger: logger);
       await runner.startGroup(
         kind: 'test',
         entryPoint: _main2,
@@ -101,7 +101,7 @@ void main() {
       final subs = logger.onRecord.listen((event) {
         messages.add(event.message);
       });
-      final runner = IsolateRunner(logger: logger);
+      final runner = IsolateCollection(logger: logger);
       final group = await runner.startGroup(
         kind: 'test',
         entryPoint: _main4,
@@ -141,7 +141,7 @@ void main() {
       final subs = logger.onRecord.listen((event) {
         messages.add(event.message);
       });
-      final runner = IsolateRunner(logger: logger);
+      final runner = IsolateCollection(logger: logger);
       await runner.startGroup(
         kind: 'test',
         entryPoint: _main3,


### PR DESCRIPTION
- This will be used by the search service.
- Renewing first creates a new isolate, and then closes the older ones. Right now it only wait for a specific duration, later on it may wait for the pending requests to complete before closing the older isolates.
