### PR TITLE
Fix dartdoc status when loading sandboxed ScoreCard.

### DIFF
--- a/app/lib/fake/backend/fake_pub_worker.dart
+++ b/app/lib/fake/backend/fake_pub_worker.dart
@@ -127,7 +127,7 @@ Future<void> processTasksWithFakePanaAndDartdoc() async {
               }
 
               for (final e in dartdocFiles.entries) {
-                await addFileAsStringGzipped(e.key, e.value);
+                await addFileAsStringGzipped('doc/${e.key}', e.value);
               }
               await addFileAsStringGzipped(
                   'summary.json', json.encode(summary.toJson()));

--- a/app/lib/scorecard/backend.dart
+++ b/app/lib/scorecard/backend.dart
@@ -151,12 +151,9 @@ class ScoreCardBackend {
       final status = PackageStatus.fromModels(package, version);
       final summary =
           await taskBackend.panaSummary(packageName, packageVersion);
-      // TODO: check existence of the dartdoc index.html by loading only the index
-      final dartdocFile = summary == null
-          ? null
-          : await taskBackend.dartdocFile(
-              packageName, packageVersion, 'index.html');
-      final hasDartdocFile = dartdocFile != null;
+      final stateInfo = await taskBackend.packageStatus(packageName);
+      final versionInfo = stateInfo.versions[packageVersion];
+      final hasDartdocFile = versionInfo?.docs ?? false;
 
       final data = ScoreCardData(
         packageName: packageName,

--- a/app/lib/scorecard/backend.dart
+++ b/app/lib/scorecard/backend.dart
@@ -151,6 +151,12 @@ class ScoreCardBackend {
       final status = PackageStatus.fromModels(package, version);
       final summary =
           await taskBackend.panaSummary(packageName, packageVersion);
+      // TODO: check existence of the dartdoc index.html by loading only the index
+      final dartdocFile = summary == null
+          ? null
+          : await taskBackend.dartdocFile(
+              packageName, packageVersion, 'index.html');
+      final hasDartdocFile = dartdocFile != null;
 
       final data = ScoreCardData(
         packageName: packageName,
@@ -162,9 +168,8 @@ class ScoreCardBackend {
         packageVersionCreated: version.created,
         dartdocReport: DartdocReport(
           timestamp: summary?.createdAt ?? version.created,
-          // TODO: Embed dartdoc success status in summary, unclear if we need it
           reportStatus:
-              summary == null ? ReportStatus.failed : ReportStatus.success,
+              hasDartdocFile ? ReportStatus.success : ReportStatus.failed,
           dartdocEntry: null, // unused
           documentationSection: null, // already embedded in summary
         ),

--- a/app/test/frontend/golden/pkg_show_page_discontinued.html
+++ b/app/test/frontend/golden/pkg_show_page_discontinued.html
@@ -259,11 +259,6 @@
             <p>
               <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
             </p>
-            <h3 class="title">Documentation</h3>
-            <p>
-              <a class="link" href="/documentation/pkg/latest/">API reference</a>
-              <br/>
-            </p>
             <h3 class="title">Funding</h3>
             <p>
               Consider supporting this project:
@@ -345,11 +340,6 @@
           <h3 class="title">Topics</h3>
           <p>
             <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
-          </p>
-          <h3 class="title">Documentation</h3>
-          <p>
-            <a class="link" href="/documentation/pkg/latest/">API reference</a>
-            <br/>
           </p>
           <h3 class="title">Funding</h3>
           <p>


### PR DESCRIPTION
- This will fix the display of the API docs link on the package infobar (and hopefully reduce the 404 links we are getting).
- Once #6860 is merged, there is further optimization for both here and when finalizing the upload (added a TODO for it)