### PR TITLE
Increase pub_worker upload limits for blob.

### DIFF
--- a/app/lib/task/backend.dart
+++ b/app/lib/task/backend.dart
@@ -586,15 +586,21 @@ class TaskBackend {
         .substring(0, 32);
 
     final [blobUploadInfo, indexUploadInfo] = await Future.wait([
-      '$blobId.blob',
-      'index.json',
-    ].map(
-      (name) => uploadSigner.buildUpload(
+      uploadSigner.buildUpload(
         _bucket.bucketName,
-        '$runtimeVersion/$package/$version/$name',
+        '$runtimeVersion/$package/$version/$blobId.blob',
         expiration,
+        // Allow up to 300 MB, keep in mind that 1.6GB dartdoc compressed to 92MB.
+        maxUploadSize: 300 * 1024 * 1024,
       ),
-    ));
+      uploadSigner.buildUpload(
+        _bucket.bucketName,
+        '$runtimeVersion/$package/$version/index.json',
+        expiration,
+        // Allow up to 64 MB just a sanity limit!
+        maxUploadSize: 64 * 1024 * 1024,
+      )
+    ]);
 
     return api.UploadTaskResultResponse(
       blobId: '$runtimeVersion/$package/$version/$blobId.blob',


### PR DESCRIPTION
Increase to 300MB, because we store dartdoc content twice:
 * As individually gzipped processed JSON files, and,
 * As a compressed tar.gz file.

For packages like `package:googleapis` the generated dartdoc is about 1.6 GB, this is a bit crazy, but it actually compresses down to 92 MB. So it's not unreasonable to allow 300MB blobs from the pub_worker.

For the index, which pub.dev will load into memory when serving results, we want to set a lower limit. We could tweak this in the future for now we're limiting it to 64MB, just to have some sanity limit.
