### PR TITLE
Search index in an isolate.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ AppEngine version, listed here to ease deployment and troubleshooting.
  * Bumped runtimeVersion to `2023.08.16`.
  * Note: Upgraded `package:gcloud`.
  * Note: `analyzer` and `dartdoc` processing is turned off.
+ * Note: `search` has now a separate index in an isolate that is renewed every 15 minutes.
 
 ## `20230810t094700-all`
  * Bumped runtimeVersion to `2023.08.08`.

--- a/app/lib/search/backend.dart
+++ b/app/lib/search/backend.dart
@@ -505,6 +505,9 @@ class _CombinedSearchIndex implements SearchIndex {
   const _CombinedSearchIndex();
 
   @override
+  bool isReady() => indexInfo().isReady;
+
+  @override
   IndexInfo indexInfo() => _inMemoryPackageIndex.indexInfo();
 
   @override

--- a/app/lib/search/handlers.dart
+++ b/app/lib/search/handlers.dart
@@ -41,8 +41,7 @@ Future<shelf.Response> _livenessCheckHandler(shelf.Request request) async {
 
 /// Handles /readiness_check requests.
 Future<shelf.Response> _readinessCheckHandler(shelf.Request request) async {
-  final info = await searchIndex.indexInfo();
-  if (info.isReady) {
+  if (await searchIndex.isReady()) {
     return htmlResponse('OK');
   } else {
     return htmlResponse('Service Unavailable', status: 503);

--- a/app/lib/search/search_service.dart
+++ b/app/lib/search/search_service.dart
@@ -37,6 +37,16 @@ class IndexInfo {
     required this.updatedPackages,
   });
 
+  factory IndexInfo.fromJson(Map<String, dynamic> map) {
+    final lastUpdated = map['lastUpdated'] as String?;
+    return IndexInfo(
+      isReady: map['isReady'] == true,
+      packageCount: map['packageCount'] as int,
+      lastUpdated: lastUpdated == null ? null : DateTime.parse(lastUpdated),
+      updatedPackages: (map['updatedPackages'] as List).cast<String>(),
+    );
+  }
+
   Map<String, dynamic> toJson() => <String, dynamic>{
         'isReady': isReady,
         'packageCount': packageCount,
@@ -49,6 +59,7 @@ class IndexInfo {
 
 /// Package search index and lookup.
 abstract class SearchIndex {
+  FutureOr<bool> isReady();
   FutureOr<PackageSearchResult> search(ServiceSearchQuery query);
   FutureOr<IndexInfo> indexInfo();
 }

--- a/app/lib/service/entrypoint/_isolate.dart
+++ b/app/lib/service/entrypoint/_isolate.dart
@@ -405,7 +405,7 @@ class _Isolate {
   }) async {
     final ready = Completer();
     _protocolSubscription = _protocolReceivePort.listen((event) {
-      final e = Message.decode(event);
+      final e = Message.fromObject(event);
       if (e is ReadyMessage && !ready.isCompleted) {
         _readyMessage = e;
         ready.complete();

--- a/app/lib/service/entrypoint/_isolate.dart
+++ b/app/lib/service/entrypoint/_isolate.dart
@@ -405,9 +405,7 @@ class _Isolate {
   }) async {
     final ready = Completer();
     _protocolSubscription = _protocolReceivePort.listen((event) {
-      final e = event is Map<String, dynamic>
-          ? Message.decodeFromMap(event)
-          : event as Message;
+      final e = Message.decode(event);
       if (e is ReadyMessage && !ready.isCompleted) {
         _readyMessage = e;
         ready.complete();

--- a/app/lib/service/entrypoint/_messages.dart
+++ b/app/lib/service/entrypoint/_messages.dart
@@ -1,0 +1,172 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:isolate';
+
+/// Base class for inter-isolate messages.
+sealed class Message {
+  static Message decodeFromMap(Map<String, dynamic> map) {
+    if (map.keys.length != 1) {
+      throw FormatException(
+          'Expected only a single key, got "${map.keys.join(' ')}"');
+    }
+    final key = map.keys.single;
+    final inner = map[key] as Map<String, dynamic>;
+    switch (key) {
+      case 'entry':
+        return EntryMessage(
+          protocolSendPort: inner['protocolSendPort'] as SendPort,
+          aliveSendPort: inner['aliveSendPort'] as SendPort,
+        );
+      case 'ready':
+        return ReadyMessage(
+          requestSendPort: inner['requestSendPort'] as SendPort?,
+        );
+      case 'request':
+        return RequestMessage(
+          inner['kind'] as String,
+          inner['payload'] as Object,
+          inner['replyPort'] as SendPort,
+        );
+      case 'reply':
+        return ReplyMessage._(
+          error: inner['error'] as String?,
+          result: inner['result'],
+        );
+      case 'debug':
+        return DebugMessage(inner['text'] as String);
+    }
+    throw FormatException('Unknown key: "$key".');
+  }
+
+  Map<String, dynamic> encodeAsJson();
+}
+
+/// Initializing message send from the controller isolate to the new one.
+class EntryMessage extends Message {
+  final SendPort protocolSendPort;
+  final SendPort aliveSendPort;
+
+  EntryMessage({
+    required this.protocolSendPort,
+    required this.aliveSendPort,
+  });
+
+  @override
+  Map<String, dynamic> encodeAsJson() {
+    return {
+      'entry': {
+        'protocolSendPort': protocolSendPort,
+        'aliveSendPort': aliveSendPort,
+      },
+    };
+  }
+}
+
+/// Message sent from the isolate to indicate that it is ready with the initialization.
+class ReadyMessage extends Message {
+  final SendPort? requestSendPort;
+
+  ReadyMessage({
+    this.requestSendPort,
+  });
+
+  @override
+  Map<String, dynamic> encodeAsJson() {
+    return {
+      'ready': {
+        'requestSendPort': requestSendPort,
+      },
+    };
+  }
+}
+
+/// Message sent to a different isolate group for processing.
+class RequestMessage extends Message {
+  /// The `kind` of the target isolate group.
+  final String kind;
+
+  /// The payload (request) object.
+  final Object payload;
+
+  /// The port where we expect the respnse.
+  final SendPort replyPort;
+
+  RequestMessage(this.kind, this.payload, this.replyPort);
+
+  @override
+  Map<String, dynamic> encodeAsJson() {
+    return {
+      'request': {
+        'kind': kind,
+        'payload': payload,
+        'replyPort': replyPort,
+      },
+    };
+  }
+}
+
+/// Message sent as a reply to a [RequestMessage].
+class ReplyMessage extends Message {
+  final String? error;
+  final Object? result;
+
+  ReplyMessage._({
+    required this.error,
+    required this.result,
+  });
+  ReplyMessage.error(String message)
+      : error = message,
+        result = null;
+  ReplyMessage.result(Object value)
+      : result = value,
+        error = null;
+
+  bool get isError => error != null;
+
+  @override
+  Map<String, dynamic> encodeAsJson() {
+    return {
+      'reply': {
+        if (error != null) 'error': error,
+        if (result != null) 'result': result,
+      }
+    };
+  }
+}
+
+/// Message sent from the isolate with arbitrary text.
+class DebugMessage extends Message {
+  final String text;
+
+  DebugMessage(this.text);
+
+  @override
+  Map<String, dynamic> encodeAsJson() {
+    return {
+      'debug': {
+        'text': text,
+      },
+    };
+  }
+}
+
+/// Wraps the request/reply message sending logic.
+Future<Object?> handleRequestReply({
+  required SendPort requestSendPort,
+  required String kind,
+  required Object payload,
+  required Duration timeout,
+}) async {
+  final replyRecievePort = ReceivePort();
+  final firstFuture = replyRecievePort.first;
+  requestSendPort.send(
+      RequestMessage(kind, payload, replyRecievePort.sendPort).encodeAsJson());
+  final first = await firstFuture.timeout(timeout) as Map<String, dynamic>;
+  final reply = Message.decodeFromMap(first) as ReplyMessage;
+  if (reply.isError) {
+    throw Exception(reply.error);
+  }
+  return reply.result;
+}

--- a/app/lib/service/entrypoint/_messages.dart
+++ b/app/lib/service/entrypoint/_messages.dart
@@ -63,7 +63,7 @@ sealed class Message {
   ///   }
   /// }
   /// ```
-  static Message decode(value) {
+  static Message fromObject(Object? value) {
     if (value is Message) {
       return value;
     }
@@ -252,7 +252,7 @@ Future<Object?> sendRequest({
     target.send(RequestMessage(kind, payload, replyRecievePort.sendPort)
         .encodeAsJson());
     final first = await firstFuture.timeout(timeout) as Map<String, dynamic>;
-    final reply = Message.decode(first) as ReplyMessage;
+    final reply = Message.fromObject(first) as ReplyMessage;
     if (reply.isError) {
       throw IsolateRequestException(reply.error!, kind);
     }

--- a/app/lib/service/entrypoint/search_index.dart
+++ b/app/lib/service/entrypoint/search_index.dart
@@ -43,11 +43,11 @@ Future<void> main(List<String> args, var message) async {
       await indexUpdater.init();
 
       final requestReceivePort = ReceivePort();
-      final entryMessage = Message.decode(message) as EntryMessage;
+      final entryMessage = Message.fromObject(message) as EntryMessage;
 
       final subs = requestReceivePort.listen((e) async {
         try {
-          final msg = Message.decode(e) as RequestMessage;
+          final msg = Message.fromObject(e) as RequestMessage;
           final payload = msg.payload;
           if (payload is String && payload == 'info') {
             final info = await searchIndex.indexInfo();

--- a/app/lib/service/entrypoint/search_index.dart
+++ b/app/lib/service/entrypoint/search_index.dart
@@ -105,8 +105,8 @@ class IsolateSearchIndex implements SearchIndex {
   @override
   FutureOr<IndexInfo> indexInfo() async {
     try {
-      final info = await handleRequestReply(
-        requestSendPort: _requestSendPort,
+      final info = await sendRequest(
+        target: _requestSendPort,
         kind: 'index',
         payload: 'info',
         timeout: Duration(seconds: 5),
@@ -126,8 +126,8 @@ class IsolateSearchIndex implements SearchIndex {
   @override
   FutureOr<PackageSearchResult> search(ServiceSearchQuery query) async {
     try {
-      final rs = await handleRequestReply(
-        requestSendPort: _requestSendPort,
+      final rs = await sendRequest(
+        target: _requestSendPort,
         kind: 'index',
         payload: Uri(queryParameters: query.toUriQueryParameters()).toString(),
         timeout: Duration(minutes: 1),

--- a/app/lib/service/entrypoint/search_index.dart
+++ b/app/lib/service/entrypoint/search_index.dart
@@ -43,14 +43,11 @@ Future<void> main(List<String> args, var message) async {
       await indexUpdater.init();
 
       final requestReceivePort = ReceivePort();
-      final entryMessage =
-          Message.decodeFromMap(message as Map<String, dynamic>)
-              as EntryMessage;
+      final entryMessage = Message.decode(message) as EntryMessage;
 
       final subs = requestReceivePort.listen((e) async {
         try {
-          final msg = Message.decodeFromMap(e as Map<String, dynamic>)
-              as RequestMessage;
+          final msg = Message.decode(e) as RequestMessage;
           final payload = msg.payload;
           if (payload is String && payload == 'info') {
             final info = await searchIndex.indexInfo();

--- a/app/lib/service/entrypoint/search_index.dart
+++ b/app/lib/service/entrypoint/search_index.dart
@@ -18,6 +18,7 @@ import 'package:pub_dev/service/entrypoint/logging.dart';
 import 'package:pub_dev/service/services.dart';
 import 'package:pub_dev/shared/env_config.dart';
 import 'package:pub_dev/shared/logging.dart';
+import 'package:pub_dev/shared/monitoring.dart';
 import 'package:pub_dev/shared/popularity_storage.dart';
 
 final _logger = Logger('search_index');
@@ -63,12 +64,14 @@ Future<void> main(List<String> args, var message) async {
                 ReplyMessage.result(json.encode(rs.toJson())).encodeAsJson());
             return;
           } else {
-            _logger.severe('Unrecognized payload: $msg');
+            _logger.pubNoticeShout(
+                'unknown-isolate-message', 'Unrecognized payload: $msg');
             msg.replyPort.send(ReplyMessage.error('Unrecognized payload: $msg')
                 .encodeAsJson());
           }
         } catch (e, st) {
-          _logger.warning('Error processing message: $e', e, st);
+          _logger.pubNoticeShout(
+              'isolate-message-error', 'Error processing message: $e', e, st);
         }
       });
       entryMessage.protocolSendPort.send(
@@ -77,6 +80,7 @@ Future<void> main(List<String> args, var message) async {
       );
 
       await Completer().future;
+      requestReceivePort.close();
       await subs.cancel();
     });
   });

--- a/app/lib/service/entrypoint/search_index.dart
+++ b/app/lib/service/entrypoint/search_index.dart
@@ -1,0 +1,142 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:isolate';
+
+import 'package:gcloud/service_scope.dart';
+import 'package:logging/logging.dart';
+import 'package:pub_dev/search/backend.dart';
+import 'package:pub_dev/search/dart_sdk_mem_index.dart';
+import 'package:pub_dev/search/flutter_sdk_mem_index.dart';
+import 'package:pub_dev/search/search_service.dart';
+import 'package:pub_dev/search/updater.dart';
+import 'package:pub_dev/service/entrypoint/_isolate.dart';
+import 'package:pub_dev/service/entrypoint/logging.dart';
+import 'package:pub_dev/service/services.dart';
+import 'package:pub_dev/shared/env_config.dart';
+import 'package:pub_dev/shared/logging.dart';
+import 'package:pub_dev/shared/popularity_storage.dart';
+
+final _logger = Logger('search_index');
+
+/// Entry point for the search index isolate.
+Future<void> main(List<String> args, var message) async {
+  final timer = Timer.periodic(Duration(milliseconds: 250), (_) {});
+
+  late ServicesWrapperFn servicesWrapperFn;
+  if (envConfig.isRunningInAppengine) {
+    servicesWrapperFn = withServices;
+    setupAppEngineLogging();
+  } else {
+    servicesWrapperFn = (fn) => withFakeServices(fn: fn);
+    setupDebugEnvBasedLogging();
+  }
+  await fork(() async {
+    await servicesWrapperFn(() async {
+      await popularityStorage.start();
+      await dartSdkMemIndex.start();
+      await flutterSdkMemIndex.start();
+      await indexUpdater.init();
+
+      final requestReceivePort = ReceivePort();
+      final entryMessage =
+          Message.decodeFromMap(message as Map<String, dynamic>)
+              as EntryMessage;
+
+      final subs = requestReceivePort.listen((e) async {
+        try {
+          final msg = Message.decodeFromMap(e as Map<String, dynamic>)
+              as RequestMessage;
+          final payload = msg.payload;
+          if (payload is String && payload == 'info') {
+            final info = await searchIndex.indexInfo();
+            msg.replyPort
+                .send(ReplyMessage.result(info.toJson()).encodeAsJson());
+            return;
+          } else if (payload is String) {
+            final q = ServiceSearchQuery.fromServiceUrl(Uri.parse(payload));
+            final rs = await searchIndex.search(q);
+            msg.replyPort.send(
+                ReplyMessage.result(json.encode(rs.toJson())).encodeAsJson());
+            return;
+          } else {
+            _logger.severe('Unrecognized payload: $msg');
+            msg.replyPort.send(ReplyMessage.error('Unrecognized payload: $msg')
+                .encodeAsJson());
+          }
+        } catch (e, st) {
+          _logger.warning('Error processing message: $e', e, st);
+        }
+      });
+      entryMessage.protocolSendPort.send(
+        ReadyMessage(requestSendPort: requestReceivePort.sendPort)
+            .encodeAsJson(),
+      );
+
+      await Completer().future;
+      await subs.cancel();
+    });
+  });
+
+  timer.cancel();
+}
+
+/// Implementation of [SearchIndex] that uses [RequestMessage]s to send requests
+/// accross isolate boundaries. The instance should be registered inside the
+/// `frontend` isolate, and it calls the `index` isolate as a delegate.
+class IsolateSearchIndex implements SearchIndex {
+  final SendPort _requestSendPort;
+  IsolateSearchIndex(this._requestSendPort);
+  var _isReady = false;
+
+  @override
+  FutureOr<bool> isReady() async {
+    // Set the ready flag once, and after the first time always return as ready.
+    if (!_isReady) {
+      final info = await indexInfo();
+      _isReady = info.isReady;
+    }
+    return _isReady;
+  }
+
+  @override
+  FutureOr<IndexInfo> indexInfo() async {
+    try {
+      final info = await handleRequestReply(
+        requestSendPort: _requestSendPort,
+        kind: 'index',
+        payload: 'info',
+        timeout: Duration(seconds: 5),
+      );
+      return IndexInfo.fromJson(info as Map<String, dynamic>);
+    } catch (e, st) {
+      _logger.warning('Failed to get index info.', e, st);
+    }
+    return IndexInfo(
+      isReady: false,
+      packageCount: 0,
+      lastUpdated: null,
+      updatedPackages: [],
+    );
+  }
+
+  @override
+  FutureOr<PackageSearchResult> search(ServiceSearchQuery query) async {
+    try {
+      final rs = await handleRequestReply(
+        requestSendPort: _requestSendPort,
+        kind: 'index',
+        payload: Uri(queryParameters: query.toUriQueryParameters()).toString(),
+        timeout: Duration(minutes: 1),
+      );
+      return PackageSearchResult.fromJson(
+          json.decode(rs as String) as Map<String, dynamic>);
+    } catch (e, st) {
+      _logger.warning('Failed to search index.', e, st);
+    }
+    return PackageSearchResult.empty(message: 'Failed to process request.');
+  }
+}

--- a/app/test/service/entrypoint/isolate_runner_test.dart
+++ b/app/test/service/entrypoint/isolate_runner_test.dart
@@ -127,7 +127,7 @@ void main() {
         ],
       );
       // renew isolate
-      await group.renew(count: 1, wait: Duration(seconds: 1));
+      await group.renew(wait: Duration(seconds: 1));
       await Future.delayed(Duration(seconds: 1));
       expect(
           messages,

--- a/app/test/service/entrypoint/search_index_test.dart
+++ b/app/test/service/entrypoint/search_index_test.dart
@@ -1,0 +1,62 @@
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:isolate';
+
+import 'package:logging/logging.dart';
+import 'package:pub_dev/search/search_service.dart';
+import 'package:pub_dev/service/entrypoint/_isolate.dart';
+import 'package:pub_dev/service/entrypoint/search_index.dart';
+import 'package:test/test.dart';
+
+final _logger = Logger('search_index_test');
+
+void main() {
+  group('Search index inside an isolate', () {
+    final collection = IsolateCollection(
+      logger: _logger,
+      servicesWrapperFn: fakeServicesWrapper,
+    );
+    late IsolateGroup indexGroup;
+
+    tearDownAll(() async {
+      await collection.close();
+    });
+
+    test('index isolate started', () async {
+      indexGroup = await collection.startGroup(
+        kind: 'index',
+        count: 1,
+        deadTimeout: null,
+        spawnUri:
+            Uri.parse('package:pub_dev/service/entrypoint/search_index.dart'),
+      );
+    }, timeout: Timeout(Duration(minutes: 5)));
+
+    test('work with the index', () async {
+      // forward port to isolate group
+      final delegatePort = ReceivePort();
+      final subscription = delegatePort.listen((m) {
+        final msg = m is RequestMessage
+            ? m
+            : Message.decodeFromMap(m as Map<String, dynamic>)
+                as RequestMessage;
+        indexGroup.processRequestMessage(msg);
+      });
+
+      // index calling the sendport
+      final searchIndex = IsolateSearchIndex(delegatePort.sendPort);
+      expect(await searchIndex.isReady(), true);
+
+      // working search only with SDK results (no packages in the isolate)
+      final rs =
+          await searchIndex.search(ServiceSearchQuery.parse(query: 'json'));
+      expect(rs.message, isNull);
+      expect(rs.sdkLibraryHits, isNotEmpty);
+      expect(rs.packageHits, isEmpty);
+
+      await subscription.cancel();
+    }, timeout: Timeout(Duration(minutes: 5)));
+  });
+}

--- a/app/test/service/entrypoint/search_index_test.dart
+++ b/app/test/service/entrypoint/search_index_test.dart
@@ -36,7 +36,7 @@ void main() {
       // forward port to isolate group
       final delegatePort = ReceivePort();
       final subscription = delegatePort.listen((m) {
-        final msg = Message.decode(m) as RequestMessage;
+        final msg = Message.fromObject(m) as RequestMessage;
         indexGroup.processRequestMessage(msg);
       });
 

--- a/app/test/service/entrypoint/search_index_test.dart
+++ b/app/test/service/entrypoint/search_index_test.dart
@@ -36,10 +36,7 @@ void main() {
       // forward port to isolate group
       final delegatePort = ReceivePort();
       final subscription = delegatePort.listen((m) {
-        final msg = m is RequestMessage
-            ? m
-            : Message.decodeFromMap(m as Map<String, dynamic>)
-                as RequestMessage;
+        final msg = Message.decode(m) as RequestMessage;
         indexGroup.processRequestMessage(msg);
       });
 

--- a/app/test/service/entrypoint/search_index_test.dart
+++ b/app/test/service/entrypoint/search_index_test.dart
@@ -24,7 +24,7 @@ void main() {
       await collection.close();
     });
 
-    test('index isolate started', () async {
+    test('start and work with index', () async {
       indexGroup = await collection.startGroup(
         kind: 'index',
         count: 1,
@@ -32,9 +32,7 @@ void main() {
         spawnUri:
             Uri.parse('package:pub_dev/service/entrypoint/search_index.dart'),
       );
-    }, timeout: Timeout(Duration(minutes: 5)));
 
-    test('work with the index', () async {
       // forward port to isolate group
       final delegatePort = ReceivePort();
       final subscription = delegatePort.listen((m) {

--- a/app/test/shared/timer_import_test.dart
+++ b/app/test/shared/timer_import_test.dart
@@ -38,6 +38,9 @@ void main() {
     // Uses timer to send heartbeat signal to the master isolate.
     'lib/service/entrypoint/frontend.dart',
 
+    // Uses timer to prevent GC compaction.
+    'lib/service/entrypoint/search_index.dart',
+
     // Uses timer to timeout GlobalLock claim aquisition.
     'lib/tool/neat_task/pub_dev_tasks.dart',
 


### PR DESCRIPTION
- Using `spawnUri` for the index isolate, to reduce memory issues.
- Most messages are sent encoded as JSON, but if they are known to go inside the same heap, they may be sent as objects to keep efficiency.
- Tracks pending request-reply pairs, and isolate renewal waits for pending messages to complete (up to a threshold, where isolate will be killed regardless of the pending messages).
- New behavior: once the `SearchIndex.isReady()` signal turns true, it keeps at that, the index is no longer queried.
