### PR TITLE
Fix failing test by marking 'type' as reserved word

### DIFF
--- a/pkg/pub_package_reader/lib/src/names.dart
+++ b/pkg/pub_package_reader/lib/src/names.dart
@@ -65,6 +65,7 @@ const reservedWords = <String>{
   'throw',
   'true',
   'try',
+  'type',
   'typedef',
   'var',
   'void',


### PR DESCRIPTION
It was added in https://github.com/dart-lang/sdk/commit/30201181ceabb22fd734b1bba46673cc9acaa8d9 in preparation for extension types.
