### PR TITLE
Update Dart 3 compatible badge text

### DIFF
--- a/app/lib/frontend/templates/package_misc.dart
+++ b/app/lib/frontend/templates/package_misc.dart
@@ -40,7 +40,7 @@ d.Node nullSafeBadgeNode({String? title}) {
 /// Renders the Dart 3 compatible badge.
 final dart3CompatibleNode = packageBadgeNode(
   label: 'Dart 3 compatible',
-  title: 'Package is expected to be compatible with Dart 3.',
+  title: 'Package is compatible with Dart 3.',
 );
 
 /// Renders the Dart 3 incompatible badge.

--- a/app/test/frontend/golden/pkg_activity_log_page.html
+++ b/app/test/frontend/golden/pkg_activity_log_page.html
@@ -257,7 +257,7 @@
                     <tbody>
                       <tr>
                         <td class="date">
-                          <a class="-x-ago" href="" title="%%published-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
+                          <a class="-x-ago" href="" title="%%activity-0-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
                         </td>
                         <td class="summary">
                           <div class="markdown-body">

--- a/app/test/frontend/golden/pkg_activity_log_page.html
+++ b/app/test/frontend/golden/pkg_activity_log_page.html
@@ -257,7 +257,7 @@
                     <tbody>
                       <tr>
                         <td class="date">
-                          <a class="-x-ago" href="" title="%%activity-0-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
+                          <a class="-x-ago" href="" title="%%published-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
                         </td>
                         <td class="summary">
                           <div class="markdown-body">

--- a/app/test/task/testdata/goldens/packages/oxygen.html
+++ b/app/test/task/testdata/goldens/packages/oxygen.html
@@ -130,7 +130,7 @@
                   <span>
                     <a class="-x-ago" href="" title="%%short-dateformat%%" aria-label="Switch between date and elapsed time." aria-role="button">%%time-ago%%</a>
                   </span>
-                  <span class="package-badge" title="Package is expected to be compatible with Dart 3.">Dart 3 compatible</span>
+                  <span class="package-badge" title="Package is compatible with Dart 3.">Dart 3 compatible</span>
                 </div>
                 <div class="detail-tags-and-like">
                   <div class="detail-tags">

--- a/app/test/task/testdata/goldens/packages/oxygen/changelog.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/changelog.html
@@ -130,7 +130,7 @@
                   <span>
                     <a class="-x-ago" href="" title="%%short-dateformat%%" aria-label="Switch between date and elapsed time." aria-role="button">%%time-ago%%</a>
                   </span>
-                  <span class="package-badge" title="Package is expected to be compatible with Dart 3.">Dart 3 compatible</span>
+                  <span class="package-badge" title="Package is compatible with Dart 3.">Dart 3 compatible</span>
                 </div>
                 <div class="detail-tags-and-like">
                   <div class="detail-tags">

--- a/app/test/task/testdata/goldens/packages/oxygen/example.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/example.html
@@ -130,7 +130,7 @@
                   <span>
                     <a class="-x-ago" href="" title="%%short-dateformat%%" aria-label="Switch between date and elapsed time." aria-role="button">%%time-ago%%</a>
                   </span>
-                  <span class="package-badge" title="Package is expected to be compatible with Dart 3.">Dart 3 compatible</span>
+                  <span class="package-badge" title="Package is compatible with Dart 3.">Dart 3 compatible</span>
                 </div>
                 <div class="detail-tags-and-like">
                   <div class="detail-tags">

--- a/app/test/task/testdata/goldens/packages/oxygen/install.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/install.html
@@ -130,7 +130,7 @@
                   <span>
                     <a class="-x-ago" href="" title="%%short-dateformat%%" aria-label="Switch between date and elapsed time." aria-role="button">%%time-ago%%</a>
                   </span>
-                  <span class="package-badge" title="Package is expected to be compatible with Dart 3.">Dart 3 compatible</span>
+                  <span class="package-badge" title="Package is compatible with Dart 3.">Dart 3 compatible</span>
                 </div>
                 <div class="detail-tags-and-like">
                   <div class="detail-tags">

--- a/app/test/task/testdata/goldens/packages/oxygen/license.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/license.html
@@ -130,7 +130,7 @@
                   <span>
                     <a class="-x-ago" href="" title="%%short-dateformat%%" aria-label="Switch between date and elapsed time." aria-role="button">%%time-ago%%</a>
                   </span>
-                  <span class="package-badge" title="Package is expected to be compatible with Dart 3.">Dart 3 compatible</span>
+                  <span class="package-badge" title="Package is compatible with Dart 3.">Dart 3 compatible</span>
                 </div>
                 <div class="detail-tags-and-like">
                   <div class="detail-tags">

--- a/app/test/task/testdata/goldens/packages/oxygen/score.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/score.html
@@ -130,7 +130,7 @@
                   <span>
                     <a class="-x-ago" href="" title="%%short-dateformat%%" aria-label="Switch between date and elapsed time." aria-role="button">%%time-ago%%</a>
                   </span>
-                  <span class="package-badge" title="Package is expected to be compatible with Dart 3.">Dart 3 compatible</span>
+                  <span class="package-badge" title="Package is compatible with Dart 3.">Dart 3 compatible</span>
                 </div>
                 <div class="detail-tags-and-like">
                   <div class="detail-tags">

--- a/app/test/task/testdata/goldens/packages/oxygen/versions.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions.html
@@ -130,7 +130,7 @@
                   <span>
                     <a class="-x-ago" href="" title="%%short-dateformat%%" aria-label="Switch between date and elapsed time." aria-role="button">%%time-ago%%</a>
                   </span>
-                  <span class="package-badge" title="Package is expected to be compatible with Dart 3.">Dart 3 compatible</span>
+                  <span class="package-badge" title="Package is compatible with Dart 3.">Dart 3 compatible</span>
                 </div>
                 <div class="detail-tags-and-like">
                   <div class="detail-tags">

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0.html
@@ -130,7 +130,7 @@
                   <span>
                     <a class="-x-ago" href="" title="%%short-dateformat%%" aria-label="Switch between date and elapsed time." aria-role="button">%%time-ago%%</a>
                   </span>
-                  <span class="package-badge" title="Package is expected to be compatible with Dart 3.">Dart 3 compatible</span>
+                  <span class="package-badge" title="Package is compatible with Dart 3.">Dart 3 compatible</span>
                   • Latest:
                   <span>
                     <a href="/packages/oxygen">2.0.0</a>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/changelog.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/changelog.html
@@ -130,7 +130,7 @@
                   <span>
                     <a class="-x-ago" href="" title="%%short-dateformat%%" aria-label="Switch between date and elapsed time." aria-role="button">%%time-ago%%</a>
                   </span>
-                  <span class="package-badge" title="Package is expected to be compatible with Dart 3.">Dart 3 compatible</span>
+                  <span class="package-badge" title="Package is compatible with Dart 3.">Dart 3 compatible</span>
                   • Latest:
                   <span>
                     <a href="/packages/oxygen">2.0.0</a>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/example.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/example.html
@@ -130,7 +130,7 @@
                   <span>
                     <a class="-x-ago" href="" title="%%short-dateformat%%" aria-label="Switch between date and elapsed time." aria-role="button">%%time-ago%%</a>
                   </span>
-                  <span class="package-badge" title="Package is expected to be compatible with Dart 3.">Dart 3 compatible</span>
+                  <span class="package-badge" title="Package is compatible with Dart 3.">Dart 3 compatible</span>
                   • Latest:
                   <span>
                     <a href="/packages/oxygen">2.0.0</a>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/install.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/install.html
@@ -130,7 +130,7 @@
                   <span>
                     <a class="-x-ago" href="" title="%%short-dateformat%%" aria-label="Switch between date and elapsed time." aria-role="button">%%time-ago%%</a>
                   </span>
-                  <span class="package-badge" title="Package is expected to be compatible with Dart 3.">Dart 3 compatible</span>
+                  <span class="package-badge" title="Package is compatible with Dart 3.">Dart 3 compatible</span>
                   • Latest:
                   <span>
                     <a href="/packages/oxygen">2.0.0</a>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/license.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/license.html
@@ -130,7 +130,7 @@
                   <span>
                     <a class="-x-ago" href="" title="%%short-dateformat%%" aria-label="Switch between date and elapsed time." aria-role="button">%%time-ago%%</a>
                   </span>
-                  <span class="package-badge" title="Package is expected to be compatible with Dart 3.">Dart 3 compatible</span>
+                  <span class="package-badge" title="Package is compatible with Dart 3.">Dart 3 compatible</span>
                   • Latest:
                   <span>
                     <a href="/packages/oxygen">2.0.0</a>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/score.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/score.html
@@ -130,7 +130,7 @@
                   <span>
                     <a class="-x-ago" href="" title="%%short-dateformat%%" aria-label="Switch between date and elapsed time." aria-role="button">%%time-ago%%</a>
                   </span>
-                  <span class="package-badge" title="Package is expected to be compatible with Dart 3.">Dart 3 compatible</span>
+                  <span class="package-badge" title="Package is compatible with Dart 3.">Dart 3 compatible</span>
                   • Latest:
                   <span>
                     <a href="/packages/oxygen">2.0.0</a>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/2.0.0.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/2.0.0.html
@@ -130,7 +130,7 @@
                   <span>
                     <a class="-x-ago" href="" title="%%short-dateformat%%" aria-label="Switch between date and elapsed time." aria-role="button">%%time-ago%%</a>
                   </span>
-                  <span class="package-badge" title="Package is expected to be compatible with Dart 3.">Dart 3 compatible</span>
+                  <span class="package-badge" title="Package is compatible with Dart 3.">Dart 3 compatible</span>
                 </div>
                 <div class="detail-tags-and-like">
                   <div class="detail-tags">

--- a/pkg/_pub_shared/lib/search/tags.dart
+++ b/pkg/_pub_shared/lib/search/tags.dart
@@ -89,7 +89,7 @@ abstract class PackageVersionTags {
   ///
   /// Other version-specific tags are not included to prevent search
   /// regressions where we would downrank and/or hide the package in
-  /// search results (e.g. a version may have compatibilty errors or
+  /// search results (e.g. a version may have compatibility errors or
   /// get `is:legacy` classification).
   static const _futurePackageVersionTags = {
     PackageVersionTags.isNullSafe,


### PR DESCRIPTION
Now that the release has occurred and analysis is running with a Dart 3+ SDK, the "expected" should no longer be needed.
