### PR TITLE
Remove page data print

### DIFF
--- a/pkg/web_app/lib/src/page_data.dart
+++ b/pkg/web_app/lib/src/page_data.dart
@@ -6,27 +6,22 @@ import 'dart:html';
 
 import 'package:_pub_shared/data/page_data.dart';
 
-PageData? _data;
-
 /// The server-provided config/data for the current page.
 ///
 /// This is the <meta name="pub-page-data" content="[json-data]"> embedded in
 /// the `head` section of the HTML page.
-PageData get pageData {
-  return _data ??= _extractData() ?? PageData();
-}
+final PageData pageData = _extractData();
 
-PageData? _extractData() {
+PageData _extractData() {
   final meta = document.head?.querySelector('meta[name="pub-page-data"]');
   if (meta != null) {
     try {
       final text = meta.attributes['content']!;
       final map = pageDataJsonCodec.decode(text) as Map<String, dynamic>;
-      print(map);
       return PageData.fromJson(map);
     } catch (_) {
       // ignore exception
     }
   }
-  return null;
+  return PageData();
 }


### PR DESCRIPTION
Perhaps this print is intentional, but it threw me off when navigating pub.dev.

I also simplified the getter to a final top-level field to avoid unnecessary null checks. 