### PR TITLE
Dynamic `x-ago` calculation

### DIFF
--- a/app/lib/frontend/dom/dom.dart
+++ b/app/lib/frontend/dom/dom.dart
@@ -109,6 +109,7 @@ Node xAgoTimestamp(DateTime timestamp, {String? datePrefix}) {
     attributes: {
       'aria-label': 'Switch between date and elapsed time.',
       'aria-role': 'button',
+      'data-timestamp': timestamp.toUtc().toIso8601String(),
     },
     text: formatXAgo(clock.now().difference(timestamp)),
   );

--- a/app/lib/frontend/dom/dom.dart
+++ b/app/lib/frontend/dom/dom.dart
@@ -4,10 +4,11 @@
 
 import 'dart:convert';
 
+import 'package:_pub_shared/format/x_ago_format.dart';
 import 'package:clock/clock.dart';
 
 import '../../shared/markdown.dart';
-import '../../shared/utils.dart' show formatXAgo, shortDateFormat;
+import '../../shared/utils.dart' show shortDateFormat;
 
 final _attributeEscape = HtmlEscape(HtmlEscapeMode.attribute);
 final _attributeRegExp = RegExp(r'^[a-z](?:[a-z0-9\-\_]*[a-z0-9]+)?$');

--- a/app/lib/frontend/templates/views/pkg/package_list.dart
+++ b/app/lib/frontend/templates/views/pkg/package_list.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:_pub_shared/format/x_ago_format.dart';
 import 'package:_pub_shared/search/search_form.dart';
 import 'package:_pub_shared/search/tags.dart';
 import 'package:clock/clock.dart';
@@ -11,7 +12,6 @@ import '../../../../package/models.dart';
 import '../../../../package/screenshots/backend.dart';
 import '../../../../search/search_service.dart';
 import '../../../../shared/urls.dart' as urls;
-import '../../../../shared/utils.dart' show formatXAgo;
 import '../../../dom/dom.dart' as d;
 
 import '../../../static_files.dart' show staticUrls;

--- a/app/lib/shared/utils.dart
+++ b/app/lib/shared/utils.dart
@@ -38,28 +38,6 @@ final DateFormat shortDateFormat = DateFormat.yMMMd();
 final jsonUtf8Encoder = JsonUtf8Encoder();
 final utf8JsonDecoder = utf8.decoder.fuse(json.decoder);
 
-/// Formats an [age] duration with `<amount> <unit> ago` or `in the last hour`.
-String formatXAgo(Duration age) {
-  if (age.inDays > 365 * 2) {
-    final years = age.inDays ~/ 365;
-    return '$years years ago';
-  }
-  if (age.inDays > 30 * 2) {
-    final months = age.inDays ~/ 30;
-    return '$months months ago';
-  }
-  if (age.inDays > 1) {
-    return '${age.inDays} days ago';
-  }
-  if (age.inHours > 1) {
-    return '${age.inHours} hours ago';
-  }
-  if (age.inHours == 1) {
-    return '${age.inHours} hour ago';
-  }
-  return 'in the last hour';
-}
-
 Future<T> withTempDirectory<T>(Future<T> Function(Directory dir) func,
     {String prefix = 'dart-tempdir'}) {
   return Directory.systemTemp.createTemp(prefix).then((Directory dir) {

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:io';
 
+import 'package:_pub_shared/format/x_ago_format.dart';
 import 'package:_pub_shared/search/search_form.dart';
 import 'package:_pub_shared/search/tags.dart';
 import 'package:_pub_shared/validation/html/html_validation.dart';
@@ -36,7 +37,7 @@ import 'package:pub_dev/scorecard/backend.dart';
 import 'package:pub_dev/scorecard/models.dart';
 import 'package:pub_dev/search/search_service.dart';
 import 'package:pub_dev/service/youtube/backend.dart';
-import 'package:pub_dev/shared/utils.dart' show formatXAgo, shortDateFormat;
+import 'package:pub_dev/shared/utils.dart' show shortDateFormat;
 import 'package:pub_dev/shared/versions.dart';
 import 'package:pub_dev/tool/test_profile/models.dart';
 import 'package:test/test.dart';

--- a/app/test/shared/utils_test.dart
+++ b/app/test/shared/utils_test.dart
@@ -9,23 +9,6 @@ import 'package:pub_dev/shared/utils.dart';
 import 'package:test/test.dart';
 
 void main() {
-  test('formatXAgo', () {
-    expect(formatXAgo(Duration()), 'in the last hour');
-    expect(formatXAgo(Duration(minutes: 59)), 'in the last hour');
-    expect(formatXAgo(Duration(minutes: 60)), '1 hour ago');
-    expect(formatXAgo(Duration(minutes: 119)), '1 hour ago');
-    expect(formatXAgo(Duration(minutes: 120)), '2 hours ago');
-    expect(formatXAgo(Duration(minutes: 179)), '2 hours ago');
-    expect(formatXAgo(Duration(minutes: 180)), '3 hours ago');
-    expect(formatXAgo(Duration(hours: 47)), '47 hours ago');
-    expect(formatXAgo(Duration(hours: 48)), '2 days ago');
-    expect(formatXAgo(Duration(hours: 72)), '3 days ago');
-    expect(formatXAgo(Duration(days: 60)), '60 days ago');
-    expect(formatXAgo(Duration(days: 61)), '2 months ago');
-    expect(formatXAgo(Duration(days: 365 * 2)), '24 months ago');
-    expect(formatXAgo(Duration(days: 365 * 2 + 1)), '2 years ago');
-  });
-
   group('Randomize Stream', () {
     test('Single batch', () async {
       final input = List.generate(10, (i) => i);

--- a/pkg/_pub_shared/lib/format/x_ago_format.dart
+++ b/pkg/_pub_shared/lib/format/x_ago_format.dart
@@ -1,0 +1,21 @@
+/// Formats an [age] duration with `<amount> <unit> ago` or `in the last hour`.
+String formatXAgo(Duration age) {
+  if (age.inDays > 365 * 2) {
+    final years = age.inDays ~/ 365;
+    return '$years years ago';
+  }
+  if (age.inDays > 30 * 2) {
+    final months = age.inDays ~/ 30;
+    return '$months months ago';
+  }
+  if (age.inDays > 1) {
+    return '${age.inDays} days ago';
+  }
+  if (age.inHours > 1) {
+    return '${age.inHours} hours ago';
+  }
+  if (age.inHours == 1) {
+    return '${age.inHours} hour ago';
+  }
+  return 'in the last hour';
+}

--- a/pkg/_pub_shared/test/format/x_ago_format_test.dart
+++ b/pkg/_pub_shared/test/format/x_ago_format_test.dart
@@ -1,0 +1,25 @@
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:_pub_shared/format/x_ago_format.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('formatXAgo', () {
+    expect(formatXAgo(Duration()), 'in the last hour');
+    expect(formatXAgo(Duration(minutes: 59)), 'in the last hour');
+    expect(formatXAgo(Duration(minutes: 60)), '1 hour ago');
+    expect(formatXAgo(Duration(minutes: 119)), '1 hour ago');
+    expect(formatXAgo(Duration(minutes: 120)), '2 hours ago');
+    expect(formatXAgo(Duration(minutes: 179)), '2 hours ago');
+    expect(formatXAgo(Duration(minutes: 180)), '3 hours ago');
+    expect(formatXAgo(Duration(hours: 47)), '47 hours ago');
+    expect(formatXAgo(Duration(hours: 48)), '2 days ago');
+    expect(formatXAgo(Duration(hours: 72)), '3 days ago');
+    expect(formatXAgo(Duration(days: 60)), '60 days ago');
+    expect(formatXAgo(Duration(days: 61)), '2 months ago');
+    expect(formatXAgo(Duration(days: 365 * 2)), '24 months ago');
+    expect(formatXAgo(Duration(days: 365 * 2 + 1)), '2 years ago');
+  });
+}

--- a/pkg/web_app/lib/script.dart
+++ b/pkg/web_app/lib/script.dart
@@ -15,6 +15,7 @@ import 'src/page_updater.dart';
 import 'src/screenshot_carousel.dart';
 import 'src/scroll.dart';
 import 'src/search.dart';
+import 'src/x_ago.dart';
 
 void main() {
   window.onLoad.listen((_) => mdc.autoInit());
@@ -40,4 +41,5 @@ void _setupAllEvents() {
   setupLikes();
   setupLikesList();
   setupScreenshotCarousel();
+  setupXAgo();
 }

--- a/pkg/web_app/lib/src/hoverable.dart
+++ b/pkg/web_app/lib/src/hoverable.dart
@@ -8,7 +8,6 @@ void setupHoverable() {
   _setEventForHoverable();
   _setEventForPackageTitleCopyToClipboard();
   _setEventForPreCodeCopyToClipboard();
-  _setEventForXAgo();
 }
 
 Element? _activeHover;
@@ -112,18 +111,6 @@ void _setEventForPreCodeCopyToClipboard() {
       final text = pre.dataset['textToCopy']?.trim() ?? pre.text!.trim();
       _copyToClipboard(text);
       await _animateCopyFeedback(feedback);
-    });
-  });
-}
-
-void _setEventForXAgo() {
-  document.querySelectorAll('a.-x-ago').forEach((e) {
-    e.onClick.listen((event) {
-      event.preventDefault();
-      event.stopPropagation();
-      final text = e.text;
-      e.text = e.getAttribute('title');
-      e.setAttribute('title', text!);
     });
   });
 }

--- a/pkg/web_app/lib/src/x_ago.dart
+++ b/pkg/web_app/lib/src/x_ago.dart
@@ -1,0 +1,17 @@
+import 'dart:html';
+
+import 'package:_pub_shared/format/x_ago_format.dart';
+
+void setupXAgo() {
+  document.querySelectorAll('a.-x-ago').forEach((e) {
+    final DateTime actual = DateTime.parse(e.getAttribute('data-timestamp')!);
+    e.text = formatXAgo(DateTime.now().toUtc().difference(actual));
+    e.onClick.listen((event) {
+      event.preventDefault();
+      event.stopPropagation();
+      final text = e.text;
+      e.text = e.getAttribute('title');
+      e.setAttribute('title', text!);
+    });
+  });
+}


### PR DESCRIPTION
We recently rolled the new mirror website for pub.dev: https://pub-web.flutter-io.cn.

As a mirror site, it uses a caching mechanism that will cache the whole static page and won't update it until the package gets upgraded (by checking the `/api/packages`). In this case, the published time is fixed and won't follow the regular update as pub.dev does.

To help the caching, and maybe avoid constantly updating pages on pub.dev too (it's not just about the date but also likes, however that's another part of improvement which is not addressed here), the PR adds the ability to write the published date as `data-timestamp` attribute and update the actual `x-ago` text when setup scripts, so the text will always be up-to-date.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
