### PR TITLE
Revert "Fix Flutter index URL"

### DIFF
--- a/app/lib/search/flutter_sdk_mem_index.dart
+++ b/app/lib/search/flutter_sdk_mem_index.dart
@@ -81,7 +81,7 @@ Future<SdkMemIndex?> _createFlutterSdkMemIndex() async {
     final content = DartdocIndex.parseJsonText(
       await searchBackend.fetchSdkIndexContentAsString(
         baseUri: index.baseUri,
-        relativePath: 'flutter/index.json',
+        relativePath: 'index.json',
       ),
     );
     await index.addDartdocIndex(content, allowedLibraries: _allowedLibraries);


### PR DESCRIPTION
Reverts dart-lang/pub-dev#6930

I don't think this fixed the issue, now we have:
```
Exception: Unexpected status code for https://api.flutter.dev/flutter/flutter/index.json: 404
```