### PR TITLE
Use the latest (version with) finished analysis when displaying generic scorecard, serving /documentation/<pkg>/latest/ or in search.

### DIFF
--- a/app/lib/frontend/handlers/documentation.dart
+++ b/app/lib/frontend/handlers/documentation.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 
 import 'package:path/path.dart' as p;
 import 'package:pub_dev/package/backend.dart';
+import 'package:pub_dev/task/backend.dart';
 import 'package:pub_dev/task/handlers.dart';
 // ignore: implementation_imports
 import 'package:pub_package_reader/src/names.dart';
@@ -59,7 +60,8 @@ Future<shelf.Response> documentationHandler(shelf.Request request) async {
   }
   // Find the latest version
   if (version == 'latest') {
-    final latestVersion = await packageBackend.getLatestVersion(package);
+    final latestVersion = await taskBackend.latestFinishedVersion(package) ??
+        await packageBackend.getLatestVersion(package);
     if (latestVersion == null) {
       return notFoundHandler(request);
     }

--- a/app/lib/scorecard/backend.dart
+++ b/app/lib/scorecard/backend.dart
@@ -88,14 +88,16 @@ class ScoreCardBackend {
         return null;
       }
 
+      // Get the scorecard with the latest version available with finished analysis.
+      final card = await scoreCardBackend.getScoreCardData(package, null);
+
+      // Load the version with the analysis above, or the latest version if no analysis
+      // has been finished yet.
       final releases = await packageBackend.latestReleases(p);
       final version = releases.stable.version;
-      final pvFuture = packageBackend.lookupPackageVersion(package, version);
-      final cardFuture = scoreCardBackend.getScoreCardData(package, version);
-      await Future.wait([pvFuture, cardFuture]);
+      final pv = await packageBackend.lookupPackageVersion(
+          package, card?.packageVersion ?? version);
 
-      final pv = await pvFuture;
-      final card = await cardFuture;
       return PackageView.fromModel(
         package: p,
         releases: releases,
@@ -112,7 +114,8 @@ class ScoreCardBackend {
     bool onlyCurrent = false,
   }) async {
     if (packageVersion == null || packageVersion == 'latest') {
-      packageVersion = await packageBackend.getLatestVersion(packageName);
+      packageVersion = await taskBackend.latestFinishedVersion(packageName) ??
+          await packageBackend.getLatestVersion(packageName);
       if (packageVersion == null) {
         // package does not exists
         return null;

--- a/app/lib/search/backend.dart
+++ b/app/lib/search/backend.dart
@@ -248,18 +248,22 @@ class SearchBackend {
     if (p == null || p.isNotVisible) {
       throw RemovedPackageException();
     }
-    final releases = await packageBackend.latestReleases(p);
+    // Get the scorecard with the latest version available with finished analysis.
+    final scoreCard =
+        await scoreCardBackend.getScoreCardData(packageName, null);
 
+    // Load the version with the analysis above, or the latest version if no analysis
+    // has been finished yet.
+    final releases = await packageBackend.latestReleases(p);
     final pv = await packageBackend.lookupPackageVersion(
-        packageName, releases.stable.version);
+      packageName,
+      scoreCard?.packageVersion ?? releases.stable.version,
+    );
     if (pv == null) {
       throw RemovedPackageException();
     }
     final readmeAsset = await packageBackend.lookupPackageVersionAsset(
         packageName, pv.version!, AssetKind.readme);
-
-    final scoreCard =
-        await scoreCardBackend.getScoreCardData(packageName, pv.version!);
 
     // Find tags from latest prerelease and/or preview (if there one).
     Future<Iterable<String>> loadFutureTags(String version) async {

--- a/app/lib/shared/redis_cache.dart
+++ b/app/lib/shared/redis_cache.dart
@@ -166,6 +166,11 @@ class CachePatterns {
       .withTTL(Duration(minutes: 60))
       .withCodec(utf8)[package];
 
+  Entry<String> latestFinishedVersion(String package) => _cache
+      .withPrefix('latest-finished-version/')
+      .withTTL(Duration(minutes: 10))
+      .withCodec(utf8)[package];
+
   Entry<PackageView> packageView(String package) => _cache
       .withPrefix('package-view/')
       .withTTL(Duration(minutes: 60))

--- a/app/lib/task/backend.dart
+++ b/app/lib/task/backend.dart
@@ -24,7 +24,8 @@ import 'package:pub_dev/shared/datastore.dart';
 import 'package:pub_dev/shared/exceptions.dart';
 import 'package:pub_dev/shared/redis_cache.dart';
 import 'package:pub_dev/shared/storage.dart';
-import 'package:pub_dev/shared/utils.dart' show canonicalizeVersion;
+import 'package:pub_dev/shared/utils.dart'
+    show canonicalizeVersion, compareSemanticVersionsDesc;
 import 'package:pub_dev/shared/versions.dart'
     show
         runtimeVersion,
@@ -687,6 +688,7 @@ class TaskBackend {
         scheduled: versionState.scheduled,
         docs: hasDocIndexHtml,
         pana: summary != null,
+        finished: true,
         attempts: 0,
         instance: null, // version is no-longer running on this instance
         secretToken: null, // TODO: Consider retaining this for idempotency
@@ -758,6 +760,7 @@ class TaskBackend {
   Future<void> _purgeCache(String package, [String? version]) async {
     await Future.wait([
       cache.taskPackageStatus(package).purge(),
+      cache.latestFinishedVersion(package).purge(),
       if (version != null) cache.taskResultIndex(package, version).purge(),
       if (version != null) purgeScorecardData(package, version, isLatest: true),
     ]);
@@ -1021,6 +1024,40 @@ class TaskBackend {
         tx.insert(state);
       }
     });
+  }
+
+  /// Returns the latest version of the [package] which has a finished analysis.
+  ///
+  /// Returns `null` if no such version exists.
+  Future<String?> latestFinishedVersion(String package) async {
+    final cachedValue =
+        await cache.latestFinishedVersion(package).get(() async {
+      for (final rt in acceptedRuntimeVersions) {
+        final key = PackageState.createKey(_db, rt, package);
+        final state = await dbService.lookupOrNull<PackageState>(key);
+        // skip states where the entry was created, but no analysis has not finished yet
+        if (state == null || state.hasNeverFinished) {
+          continue;
+        }
+        final finishedVersions = state.versions?.entries
+            .where((e) => e.value.finished)
+            .map((e) => e.key)
+            .toList();
+        if (finishedVersions == null || finishedVersions.isEmpty) {
+          continue;
+        }
+        if (finishedVersions.length == 1) {
+          return finishedVersions.single;
+        }
+        final bestVersion = finishedVersions
+            .map((e) => Version.parse(e))
+            .reduce((a, b) =>
+                compareSemanticVersionsDesc(a, b, true, true) <= 0 ? a : b);
+        return bestVersion.toString();
+      }
+      return '';
+    });
+    return (cachedValue == null || cachedValue.isEmpty) ? null : cachedValue;
   }
 }
 

--- a/app/lib/task/models.dart
+++ b/app/lib/task/models.dart
@@ -230,6 +230,12 @@ class PackageVersionStateInfo {
   /// True, if pana summary is available.
   final bool pana;
 
+  /// True, if results have been previously reported on this version.
+  ///
+  /// This is true regardless whether pana or dartdoc ran successfully, just
+  /// indicates that the worker reported back a result.
+  final bool finished;
+
   /// [DateTime] this version of the package was last scheduled for analysis.
   ///
   /// This is [initialTimestamp] if never scheduled.
@@ -293,6 +299,7 @@ class PackageVersionStateInfo {
     this.instance,
     this.docs = false,
     this.pana = false,
+    this.finished = false,
   });
 
   factory PackageVersionStateInfo.fromJson(Map<String, dynamic> m) =>

--- a/app/lib/task/models.g.dart
+++ b/app/lib/task/models.g.dart
@@ -16,6 +16,7 @@ PackageVersionStateInfo _$PackageVersionStateInfoFromJson(
       instance: json['instance'] as String?,
       docs: json['docs'] as bool? ?? false,
       pana: json['pana'] as bool? ?? false,
+      finished: json['finished'] as bool? ?? false,
     );
 
 Map<String, dynamic> _$PackageVersionStateInfoToJson(
@@ -23,6 +24,7 @@ Map<String, dynamic> _$PackageVersionStateInfoToJson(
     <String, dynamic>{
       'docs': instance.docs,
       'pana': instance.pana,
+      'finished': instance.finished,
       'scheduled': instance.scheduled.toIso8601String(),
       'attempts': instance.attempts,
       'zone': instance.zone,

--- a/app/lib/task/scheduler.dart
+++ b/app/lib/task/scheduler.dart
@@ -295,6 +295,7 @@ Future<Payload?> updatePackageStateWithPendingVersions(
           zone: zone,
           instance: instanceName,
           secretToken: createUuid(),
+          finished: s.versions![v]!.finished,
         ),
     });
     s.derivePendingAt();

--- a/app/test/task/task_test.dart
+++ b/app/test/task/task_test.dart
@@ -675,6 +675,19 @@ void main() {
           TestUser(email: 'admin@pub.dev', likes: []),
         ],
       ));
+
+  group('latest analyzed version', () {
+    testWithProfile(
+      'without fallback',
+      fn: () async {
+        expect(await taskBackend.latestFinishedVersion('oxygen'), '1.2.0');
+        expect(await taskBackend.latestFinishedVersion('neon'), '1.0.0');
+      },
+      processJobsWithFakeRunners: true,
+    );
+  });
+
+  // TODO: add tests with runtime fallbacks
 }
 
 extension<T> on Stream<T> {


### PR DESCRIPTION
- Should fix #6933 and #6953
- When no version value is specified, instead of loading the latest stable version (and its assets), search, scorecard and `documentation/<pkg>/latest` will first access the latest version with any analysis finished, and use that version to load its assets.
- When the analysis (and dartdoc) completes for a newly uploaded package, the caches will be purged and the new version will be displayed.