### PR TITLE
StaticFile.contentAsString is only for testing

### DIFF
--- a/app/lib/frontend/static_files.dart
+++ b/app/lib/frontend/static_files.dart
@@ -229,6 +229,7 @@ class StaticFile {
     this.etag,
   );
 
+  @visibleForTesting
   String get contentAsString => utf8.decode(bytes);
 
   late final String _cacheableUrl =


### PR DESCRIPTION
I don't know for sure, but the performance looks bad, and I only see it referenced in tests.

Maybe test should just decode the gzip? But if we have this hack, we certainly should prevent production from using it by accident.