### PR TITLE
Run .start() concurrently

### DIFF
--- a/app/lib/search/top_packages.dart
+++ b/app/lib/search/top_packages.dart
@@ -55,9 +55,7 @@ class TopPackages {
       );
     }
     _running = true;
-    for (final v in _values) {
-      await v.start();
-    }
+    await Future.wait(_values.map((v) => v.start()));
   }
 
   @visibleForTesting


### PR DESCRIPTION
Minor optimization, we should probably do this more places!