### PR TITLE
Added User-Agent to pub_worker

### DIFF
--- a/pkg/pub_worker/lib/src/analyze.dart
+++ b/pkg/pub_worker/lib/src/analyze.dart
@@ -55,7 +55,7 @@ Future<void> analyze(Payload payload) async {
   await panaCacheDir.create(recursive: true);
 
   final workerDeadline = clock.now().add(_workerTimeout);
-  final client = Client();
+  final client = Client().withUserAgent(pubWorkerUserAgent);
   try {
     for (final p in payload.versions) {
       final api = PubApiClient(

--- a/pkg/pub_worker/lib/src/bin/dartdoc_wrapper.dart
+++ b/pkg/pub_worker/lib/src/bin/dartdoc_wrapper.dart
@@ -118,6 +118,7 @@ Future<void> _dartdoc({
 
   final pkgDir = p.join(workDir, 'pkg');
   await Directory(pkgDir).create(recursive: true);
+  // TODO: Ensure that we set User-Agent correctly here!
   await downloadPackage(
     package,
     version,

--- a/pkg/pub_worker/lib/src/fetch_pubspec.dart
+++ b/pkg/pub_worker/lib/src/fetch_pubspec.dart
@@ -9,6 +9,7 @@ import 'dart:io' show IOException;
 import 'package:http/http.dart' as http;
 import 'package:pana/pana.dart';
 import 'package:pub_semver/pub_semver.dart' show Version;
+import 'package:pub_worker/src/http.dart';
 import 'package:retry/retry.dart';
 
 /// Fetch pubspec for the given version
@@ -17,7 +18,7 @@ Future<Pubspec> fetchPubspec({
   required String version,
   required String pubHostedUrl,
 }) async {
-  final c = http.Client();
+  final c = http.Client().withUserAgent(pubWorkerUserAgent);
   try {
     final result = await retry(
       () async {

--- a/pkg/pub_worker/lib/src/http.dart
+++ b/pkg/pub_worker/lib/src/http.dart
@@ -1,15 +1,33 @@
 import 'dart:async' show FutureOr;
 import 'package:http/http.dart' as http;
 
-/// Returns an [http.Client] which sends a `Bearer` token as `Authorization`
-/// header for each request.
+const pubWorkerUserAgent =
+    'pub_worker/0.0.0 +(http://github.com/dart-lang/pub-dev)';
+
 extension WithAuthorization on http.Client {
+  /// Returns an [http.Client] which sends a `Bearer` token as `Authorization`
+  /// header for each request.
   http.Client withAuthorization(
     FutureOr<String?> Function() tokenProvider, {
-    bool closeParent = false,
+    bool closeParent = true,
   }) =>
       _AuthenticatedClient(
         tokenProvider,
+        this,
+        closeParent,
+      );
+}
+
+extension WithUserAgent on http.Client {
+  /// Returns an [http.Client] which sends `User-Agent` header for each request.
+  ///
+  /// This will only set `User-Agent`, if the header isn't already present.
+  http.Client withUserAgent(
+    String userAgent, {
+    bool closeParent = true,
+  }) =>
+      _UserAgentClient(
+        userAgent,
         this,
         closeParent,
       );
@@ -33,6 +51,35 @@ class _AuthenticatedClient extends http.BaseClient {
     final token = await _tokenProvider();
     if (token != null) {
       request.headers['Authorization'] = 'Bearer $token';
+    }
+    return await _client.send(request);
+  }
+
+  @override
+  void close() {
+    if (_closeInnerClient) {
+      _client.close();
+    }
+    super.close();
+  }
+}
+
+/// An [http.Client] which sends a `User-Agent` header for each request.
+class _UserAgentClient extends http.BaseClient {
+  final String _userAgent;
+  final http.Client _client;
+  final bool _closeInnerClient;
+
+  _UserAgentClient(
+    this._userAgent,
+    this._client,
+    this._closeInnerClient,
+  );
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) async {
+    if (!request.headers.containsKey('User-Agent')) {
+      request.headers['User-Agent'] = _userAgent;
     }
     return await _client.send(request);
   }

--- a/pkg/pub_worker/lib/src/testing/server.dart
+++ b/pkg/pub_worker/lib/src/testing/server.dart
@@ -170,6 +170,9 @@ class PubWorkerTestServer {
     String package,
     String version,
   ) async {
+    if (!(request.headers['User-Agent'] ?? '').contains('pub_worker')) {
+      return Response.badRequest(body: 'User-Agent must say pub_worker');
+    }
     return Response.ok(json.encode(UploadTaskResultResponse(
       blobId: 'files.blob',
       blob: UploadInfo(


### PR DESCRIPTION
Didn't add it to everything. As we'll still run `pub` inside of `pana` and we still do a download using a method from pana.

But having User-Agent on most requests will help identify them. When we refactor download logic we can add it there too.