### PR TITLE
Disable font ligatures.

### DIFF
--- a/pkg/web_css/lib/src/_base.scss
+++ b/pkg/web_css/lib/src/_base.scss
@@ -17,6 +17,9 @@ body {
   margin: 0;
   padding: 0;
   overflow-wrap: anywhere;
+  // we don't use font ligatures, and Google Sans fonts would otherwise change text in surprising ways
+  font-variant-ligatures: none;
+  font-feature-settings: "liga" 0;
 }
 
 body, input, button {


### PR DESCRIPTION
- Fixes #7000.
- `font-variant-ligatures: none;` seems to be enough on Chrome, but on stackoverflow there were reported that they also needed the `font-feature-settings` for Safari.