### PR TITLE
Refactor: don't mix ModeratedPackage entity with PackagePageData.

### DIFF
--- a/app/lib/frontend/handlers/package.dart
+++ b/app/lib/frontend/handlers/package.dart
@@ -229,11 +229,12 @@ Future<shelf.Response> _handlePackagePage({
   if (cachedPage == null) {
     final serviceSw = Stopwatch()..start();
     if (!await packageBackend.isPackageVisible(packageName)) {
-      return formattedNotFoundHandler(request);
-    }
-    if (await packageBackend.isPackageModerated(packageName)) {
-      final content = renderModeratedPackagePage(packageName);
-      return htmlResponse(content, status: 404);
+      if (await packageBackend.isPackageModerated(packageName)) {
+        final content = renderModeratedPackagePage(packageName);
+        return htmlResponse(content, status: 404);
+      } else {
+        return formattedNotFoundHandler(request);
+      }
     }
     final data = await loadPackagePageData(packageName, versionName, assetKind);
     _packageDataLoadLatencyTracker.add(serviceSw.elapsed);

--- a/app/lib/package/models.dart
+++ b/app/lib/package/models.dart
@@ -1083,7 +1083,6 @@ class PackageLinks {
 class PackagePageData {
   final Package? package;
   final LatestReleases? latestReleases;
-  final ModeratedPackage? moderatedPackage;
   final PackageVersion? version;
   final PackageVersionInfo? versionInfo;
   final PackageVersionAsset? asset;
@@ -1101,13 +1100,11 @@ class PackagePageData {
     required this.scoreCard,
     required this.isAdmin,
     required this.isLiked,
-  })  : latestReleases = latestReleases ?? package!.latestReleases,
-        moderatedPackage = null;
+  }) : latestReleases = latestReleases ?? package!.latestReleases;
 
   PackagePageData.missing({
     required this.package,
     required this.latestReleases,
-    this.moderatedPackage,
   })  : version = null,
         versionInfo = null,
         asset = null,

--- a/app/lib/shared/redis_cache.dart
+++ b/app/lib/shared/redis_cache.dart
@@ -120,6 +120,16 @@ class CachePatterns {
         decode: (d) => d as bool,
       ))[package];
 
+  Entry<bool> packageModerated(String package) => _cache
+      .withPrefix('package-moderated/')
+      .withTTL(Duration(days: 7))
+      .withCodec(utf8)
+      .withCodec(json)
+      .withCodec(wrapAsCodec(
+        encode: (bool value) => value,
+        decode: (d) => d as bool,
+      ))[package];
+
   Entry<List<int>> packageData(String package) => _cache
       .withPrefix('api-package-data-by-uri/')
       .withTTL(Duration(minutes: 10))['$package'];


### PR DESCRIPTION
This will help us to make every part of `PackagePageData` non-nullable (which will simplify the rendering logic).