### PR TITLE
Do not redirect to /latest/ doc URL and keep the canonical URL in-sync with the URL segment

### DIFF
--- a/app/lib/dartdoc/backend.dart
+++ b/app/lib/dartdoc/backend.dart
@@ -42,18 +42,6 @@ class DartdocBackend {
         );
       }
 
-      // May redirect to /latest/ URL if the version is latest version and it has a finished analysis.
-      final latestVersion = await packageBackend.getLatestVersion(package);
-      if (version == latestVersion) {
-        final latestFinished = await taskBackend.latestFinishedVersion(package);
-        if (version == latestFinished) {
-          return ResolvedDocUrlVersion(
-            version: version,
-            segment: 'latest',
-          );
-        }
-      }
-
       // TODO: check if analysis finished for this version, redirect to closest version if possible
 
       // Default: keep the URL on the version that was provided.

--- a/app/lib/dartdoc/backend.dart
+++ b/app/lib/dartdoc/backend.dart
@@ -33,12 +33,13 @@ class DartdocBackend {
       if (version == 'latest') {
         final latestFinished = await taskBackend.latestFinishedVersion(package);
         if (latestFinished == null) {
-          return ResolvedDocUrlVersion(version: '', segment: '');
+          return ResolvedDocUrlVersion(version: '', urlSegment: '');
         }
         final latestVersion = await packageBackend.getLatestVersion(package);
         return ResolvedDocUrlVersion(
           version: latestFinished,
-          segment: latestFinished == latestVersion ? 'latest' : latestFinished,
+          urlSegment:
+              latestFinished == latestVersion ? 'latest' : latestFinished,
         );
       }
 
@@ -47,7 +48,7 @@ class DartdocBackend {
       // Default: keep the URL on the version that was provided.
       return ResolvedDocUrlVersion(
         version: version,
-        segment: version,
+        urlSegment: version,
       );
     }) as ResolvedDocUrlVersion;
   }

--- a/app/lib/dartdoc/dartdoc_page.dart
+++ b/app/lib/dartdoc/dartdoc_page.dart
@@ -15,7 +15,9 @@ export 'package:pub_dartdoc_data/dartdoc_page.dart';
 final class DartDocPageOptions {
   final String package;
   final String version;
-  final String segment;
+
+  /// The URL segment the version is served under (e.g. `/1.2.5/` or `/latest/`)
+  final String urlSegment;
   final bool isLatestStable;
 
   /// Path of the current file relative to the documentation root.
@@ -24,7 +26,7 @@ final class DartDocPageOptions {
   DartDocPageOptions({
     required this.package,
     required this.version,
-    required this.segment,
+    required this.urlSegment,
     required this.isLatestStable,
     required this.path,
   });
@@ -44,7 +46,7 @@ final class DartDocPageOptions {
       package,
       includeHost: true,
       // keeps the [version] or the "latest" string of the requested URI
-      version: segment,
+      version: urlSegment,
       relativePath: p,
     );
   }

--- a/app/lib/dartdoc/dartdoc_page.dart
+++ b/app/lib/dartdoc/dartdoc_page.dart
@@ -15,6 +15,7 @@ export 'package:pub_dartdoc_data/dartdoc_page.dart';
 final class DartDocPageOptions {
   final String package;
   final String version;
+  final String segment;
   final bool isLatestStable;
 
   /// Path of the current file relative to the documentation root.
@@ -23,6 +24,7 @@ final class DartDocPageOptions {
   DartDocPageOptions({
     required this.package,
     required this.version,
+    required this.segment,
     required this.isLatestStable,
     required this.path,
   });
@@ -38,19 +40,13 @@ final class DartDocPageOptions {
     if (p.endsWith('/index.html')) {
       p = p.substring(0, p.length - 'index.html'.length);
     }
-    return isLatestStable
-        ? pkgDocUrl(
-            package,
-            includeHost: true,
-            isLatest: true,
-            relativePath: p,
-          )
-        : pkgDocUrl(
-            package,
-            includeHost: true,
-            version: version,
-            relativePath: p,
-          );
+    return pkgDocUrl(
+      package,
+      includeHost: true,
+      // keeps the [version] or the "latest" string of the requested URI
+      version: segment,
+      relativePath: p,
+    );
   }
 }
 
@@ -78,7 +74,6 @@ extension DartDocPageRender on DartDocPage {
         d.meta(name: 'generator', content: 'made with love by dartdoc'),
         d.meta(name: 'description', content: description),
         d.element('title', text: title),
-        // HACK: Inject a customized canonical url
         d.link(rel: 'canonical', href: options.canonicalUrl),
         // HACK: Inject alternate link, if not is latest stable version
         if (!options.isLatestStable)

--- a/app/lib/dartdoc/models.dart
+++ b/app/lib/dartdoc/models.dart
@@ -18,11 +18,11 @@ class ResolvedDocUrlVersion {
   /// * `"latest"`,
   /// * `"${version}"`, or,
   /// * `""` (indicating empty response)
-  final String segment;
+  final String urlSegment;
 
   ResolvedDocUrlVersion({
     required this.version,
-    required this.segment,
+    required this.urlSegment,
   });
 
   factory ResolvedDocUrlVersion.fromJson(Map<String, dynamic> json) =>
@@ -30,5 +30,5 @@ class ResolvedDocUrlVersion {
 
   Map<String, dynamic> toJson() => _$ResolvedDocUrlVersionToJson(this);
 
-  bool get isEmpty => version.isEmpty || segment.isEmpty;
+  bool get isEmpty => version.isEmpty || urlSegment.isEmpty;
 }

--- a/app/lib/dartdoc/models.g.dart
+++ b/app/lib/dartdoc/models.g.dart
@@ -10,12 +10,12 @@ ResolvedDocUrlVersion _$ResolvedDocUrlVersionFromJson(
         Map<String, dynamic> json) =>
     ResolvedDocUrlVersion(
       version: json['version'] as String,
-      segment: json['segment'] as String,
+      urlSegment: json['urlSegment'] as String,
     );
 
 Map<String, dynamic> _$ResolvedDocUrlVersionToJson(
         ResolvedDocUrlVersion instance) =>
     <String, dynamic>{
       'version': instance.version,
-      'segment': instance.segment,
+      'urlSegment': instance.urlSegment,
     };

--- a/app/lib/frontend/handlers/documentation.dart
+++ b/app/lib/frontend/handlers/documentation.dart
@@ -57,8 +57,8 @@ Future<shelf.Response> documentationHandler(shelf.Request request) async {
       relativePath: docFilePath.path,
     ));
   } else {
-    return await handleDartDoc(
-        request, package, resolved.version, docFilePath.path!);
+    return await handleDartDoc(request, package, resolved.version,
+        resolved.segment, docFilePath.path!);
   }
 }
 

--- a/app/lib/frontend/handlers/documentation.dart
+++ b/app/lib/frontend/handlers/documentation.dart
@@ -50,15 +50,14 @@ Future<shelf.Response> documentationHandler(shelf.Request request) async {
   if (resolved.isEmpty) {
     return notFoundHandler(request);
   }
-  if (version != resolved.segment) {
+  if (version != resolved.urlSegment) {
     return redirectResponse(pkgDocUrl(
       package,
-      version: resolved.segment,
+      version: resolved.urlSegment,
       relativePath: docFilePath.path,
     ));
   } else {
-    return await handleDartDoc(request, package, resolved.version,
-        resolved.segment, docFilePath.path!);
+    return await handleDartDoc(request, package, resolved, docFilePath.path!);
   }
 }
 

--- a/app/lib/frontend/handlers/routes.dart
+++ b/app/lib/frontend/handlers/routes.dart
@@ -356,11 +356,6 @@ class PubSiteService {
   // **** Experimental task end-points
   // ****
 
-  @Route.get('/experimental/task-documentation/<package>/<version>/<path|[^]*>')
-  Future<Response> taskdocumentation(
-          Request request, String package, String version, String path) =>
-      handleDartDoc(request, package, version, path);
-
   @Route.get('/experimental/task-log/<package>/<version>/')
   Future<Response> taskLog(
       Request request, String package, String version) async {

--- a/app/lib/frontend/handlers/routes.g.dart
+++ b/app/lib/frontend/handlers/routes.g.dart
@@ -340,11 +340,6 @@ Router _$PubSiteServiceRouter(PubSiteService service) {
   );
   router.add(
     'GET',
-    r'/experimental/task-documentation/<package>/<version>/<path|[^]*>',
-    service.taskdocumentation,
-  );
-  router.add(
-    'GET',
     r'/experimental/task-log/<package>/<version>/',
     service.taskLog,
   );

--- a/app/lib/shared/redis_cache.dart
+++ b/app/lib/shared/redis_cache.dart
@@ -313,12 +313,12 @@ class CachePatterns {
   /// Cache for sanitized and re-rendered dartdoc HTML files.
   Entry<List<int>> dartdocHtmlBytes(
     String package,
-    String version,
+    String urlSegment,
     String path,
   ) =>
       _cache
           .withPrefix('dartdoc-html/')
-          .withTTL(Duration(minutes: 10))['$package-$version/$path'];
+          .withTTL(Duration(minutes: 10))['$package/$urlSegment/$path'];
 
   /// Stores the OpenID Data (including the JSON Web Key list).
   ///

--- a/app/lib/task/handlers.dart
+++ b/app/lib/task/handlers.dart
@@ -42,6 +42,7 @@ Future<shelf.Response> handleDartDoc(
   shelf.Request request,
   String package,
   String version,
+  String segment,
   String path,
 ) async {
   InvalidInputException.checkPackageName(package);
@@ -53,7 +54,7 @@ Future<shelf.Response> handleDartDoc(
   final isHtml = ext == 'html';
   if (isHtml) {
     final htmlBytes =
-        await cache.dartdocHtmlBytes(package, version, path).get(() async {
+        await cache.dartdocHtmlBytes(package, segment, path).get(() async {
       try {
         final dataGz = await taskBackend.dartdocFile(package, version, path);
         if (dataGz == null) {
@@ -70,6 +71,7 @@ Future<shelf.Response> handleDartDoc(
         final html = page.render(DartDocPageOptions(
           package: package,
           version: version,
+          segment: segment,
           isLatestStable: version == latestVersion,
           path: path,
         ));

--- a/app/lib/task/handlers.dart
+++ b/app/lib/task/handlers.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:io' show gzip;
 
 import 'package:pub_dev/dartdoc/dartdoc_page.dart';
+import 'package:pub_dev/dartdoc/models.dart';
 import 'package:pub_dev/package/backend.dart';
 import 'package:pub_dev/shared/exceptions.dart';
 import 'package:pub_dev/shared/handlers.dart';
@@ -41,20 +42,21 @@ const _safeMimeTypes = {
 Future<shelf.Response> handleDartDoc(
   shelf.Request request,
   String package,
-  String version,
-  String segment,
+  ResolvedDocUrlVersion resolvedDocUrlVersion,
   String path,
 ) async {
   InvalidInputException.checkPackageName(package);
-  version = InvalidInputException.checkSemanticVersion(version);
+  final version =
+      InvalidInputException.checkSemanticVersion(resolvedDocUrlVersion.version);
 
   final ext = path.split('.').last;
 
   // Handle HTML requests
   final isHtml = ext == 'html';
   if (isHtml) {
-    final htmlBytes =
-        await cache.dartdocHtmlBytes(package, segment, path).get(() async {
+    final htmlBytes = await cache
+        .dartdocHtmlBytes(package, resolvedDocUrlVersion.urlSegment, path)
+        .get(() async {
       try {
         final dataGz = await taskBackend.dartdocFile(package, version, path);
         if (dataGz == null) {
@@ -71,7 +73,7 @@ Future<shelf.Response> handleDartDoc(
         final html = page.render(DartDocPageOptions(
           package: package,
           version: version,
-          segment: segment,
+          urlSegment: resolvedDocUrlVersion.urlSegment,
           isLatestStable: version == latestVersion,
           path: path,
         ));

--- a/app/test/dartdoc/doc_url_test.dart
+++ b/app/test/dartdoc/doc_url_test.dart
@@ -1,0 +1,43 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:pub_dev/tool/test_profile/models.dart';
+import 'package:test/test.dart';
+
+import '../frontend/handlers/_utils.dart';
+import '../shared/test_services.dart';
+
+void main() {
+  group('doc url resolution', () {
+    final _testProfile = TestProfile(
+      defaultUser: 'admin@pub.dev',
+      packages: [
+        TestPackage(
+          name: 'oxygen',
+          versions: [
+            TestVersion(version: '1.0.0'),
+            TestVersion(version: '2.0.0'),
+          ],
+        ),
+      ],
+      users: [TestUser(email: 'admin@pub.dev', likes: [])],
+    );
+
+    testWithProfile(
+      'doc url redirects',
+      fn: () async {
+        final segments = ['1.0.0', '2.0.0', 'latest'];
+        for (final segment in segments) {
+          await expectHtmlResponse(
+              await issueGet('/documentation/oxygen/$segment/'),
+              present: [
+                '<link rel="canonical" href="https://pub.dev/documentation/oxygen/$segment/"/>'
+              ]);
+        }
+      },
+      testProfile: _testProfile,
+      processJobsWithFakeRunners: true,
+    );
+  });
+}

--- a/app/test/task/testdata/goldens/documentation/oxygen/2.0.0/index.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/2.0.0/index.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <script type="text/javascript" src="https://www.googletagmanager.com/gtm.js?id=GTM-MX6DBN9" async="async"></script>
+    <script type="text/javascript" src="/static/hash-%%etag%%/js/gtm.js"></script>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+    <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1, user-scalable=no"/>
+    <meta name="generator" content="made with love by dartdoc"/>
+    <meta name="description" content="oxygen API docs, for the Dart programming language."/>
+    <title>oxygen - Dart API docs</title>
+    <link rel="canonical" href="https://pub.dev/documentation/oxygen/2.0.0/"/>
+    <link rel="preconnect" href="https://fonts.gstatic.com"/>
+    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/github-markdown.css"/>
+    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/dartdoc/resources/github.css"/>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,300;0,400;0,500;0,700;1,400&amp;amp;display=swap"/>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@48,400,0,0"/>
+    <link rel="stylesheet" href="/static/hash-%%etag%%/dartdoc/resources/styles.css"/>
+    <link rel="icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
+  </head>
+  <body data-base-href="" data-using-base-href="false" class="light-theme">
+    <noscript>
+      <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MX6DBN9" height="0" width="0" style="display:none;visibility:hidden"></iframe>
+    </noscript>
+    <div id="overlay-under-drawer"></div>
+    <header id="title">
+      <span id="sidenav-left-toggle" class="material-symbols-outlined" role="button" tabindex="0">menu</span>
+      <a class="hidden-xs" href="/">
+        <img src="/static/hash-%%etag%%/img/dart-logo.svg" alt="Dart" width="30" height="30" style="height: 30px; margin-right: 1em;"/>
+      </a>
+      <ol class="breadcrumbs gt-separated dark hidden-xs">
+        <li>
+          <a href="/packages/oxygen">oxygen package</a>
+        </li>
+        <li class="self-crumb">documentation</li>
+      </ol>
+      <div class="self-name">oxygen package</div>
+      <form class="search navbar-right" role="search">
+        <input id="search-box" class="form-control typeahead" type="text" placeholder="Loading search..." autocomplete="off"/>
+      </form>
+      <div id="theme-button" class="toggle">
+        <label for="theme">
+          <input id="theme" type="checkbox" value="light-theme"/>
+          <span class="material-symbols-outlined">brightness_4</span>
+        </label>
+      </div>
+    </header>
+    <main>
+      <div id="dartdoc-main-content" class="main-content">
+        <div class="desc markdown markdown-body">
+          <h1 id="oxygen">oxygen</h1>
+          <p>Awesome package.</p>
+        </div>
+        <div class="summary">
+          <h2>Libraries</h2>
+          <dl>
+            <dt id="oxygen">
+              <span class="name">
+                <a href="oxygen/oxygen-library.html">oxygen</a>
+              </span>
+            </dt>
+            <dd></dd>
+          </dl>
+        </div>
+      </div>
+      <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
+        <header id="header-search-sidebar" class="hidden-l">
+          <form class="search-sidebar" role="search">
+            <input id="search-sidebar" class="form-control typeahead" type="text" placeholder="Loading search..." autocomplete="off"/>
+          </form>
+        </header>
+        <ol id="sidebar-nav" class="breadcrumbs gt-separated dark hidden-l">
+          <li>
+            <a href="/packages/oxygen">oxygen package</a>
+          </li>
+          <li class="self-crumb">documentation</li>
+        </ol>
+        <h5 class="hidden-xs">
+          <span class="package-name">oxygen</span>
+          <span class="package-kind">package</span>
+        </h5>
+        <ol>
+          <li class="section-title">Libraries</li>
+          <li>
+            <a href="oxygen/oxygen-library.html">oxygen</a>
+          </li>
+        </ol>
+        <div id="dartdoc-sidebar-left-content"></div>
+      </div>
+      <div id="dartdoc-sidebar-right" class="sidebar sidebar-offcanvas-right"></div>
+    </main>
+    <footer>
+      <span class="no-break">oxygen 2.0.0</span>
+    </footer>
+    <script src="/static/hash-%%etag%%/dartdoc/resources/highlight.pack.js"></script>
+    <script src="/static/hash-%%etag%%/dartdoc/resources/docs.dart.js"></script>
+  </body>
+</html>

--- a/app/test/task/testdata/goldens/documentation/oxygen/2.0.0/oxygen/main.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/2.0.0/oxygen/main.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <script type="text/javascript" src="https://www.googletagmanager.com/gtm.js?id=GTM-MX6DBN9" async="async"></script>
+    <script type="text/javascript" src="/static/hash-%%etag%%/js/gtm.js"></script>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+    <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1, user-scalable=no"/>
+    <meta name="generator" content="made with love by dartdoc"/>
+    <meta name="description" content="API docs for the main function from the oxygen library, for the Dart programming language."/>
+    <title>main function - oxygen library - Dart API</title>
+    <link rel="canonical" href="https://pub.dev/documentation/oxygen/2.0.0/oxygen/main.html"/>
+    <link rel="preconnect" href="https://fonts.gstatic.com"/>
+    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/github-markdown.css"/>
+    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/dartdoc/resources/github.css"/>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,300;0,400;0,500;0,700;1,400&amp;amp;display=swap"/>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@48,400,0,0"/>
+    <link rel="stylesheet" href="/static/hash-%%etag%%/dartdoc/resources/styles.css"/>
+    <link rel="icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
+  </head>
+  <body data-base-href="../" data-using-base-href="false" class="light-theme">
+    <noscript>
+      <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MX6DBN9" height="0" width="0" style="display:none;visibility:hidden"></iframe>
+    </noscript>
+    <div id="overlay-under-drawer"></div>
+    <header id="title">
+      <span id="sidenav-left-toggle" class="material-symbols-outlined" role="button" tabindex="0">menu</span>
+      <a class="hidden-xs" href="/">
+        <img src="/static/hash-%%etag%%/img/dart-logo.svg" alt="Dart" width="30" height="30" style="height: 30px; margin-right: 1em;"/>
+      </a>
+      <ol class="breadcrumbs gt-separated dark hidden-xs">
+        <li>
+          <a href="/packages/oxygen">oxygen package</a>
+        </li>
+        <li>
+          <a href="../index.html">documentation</a>
+        </li>
+        <li>
+          <a href="../oxygen/oxygen-library.html">oxygen</a>
+        </li>
+        <li class="self-crumb">main function</li>
+      </ol>
+      <div class="self-name">main function</div>
+      <form class="search navbar-right" role="search">
+        <input id="search-box" class="form-control typeahead" type="text" placeholder="Loading search..." autocomplete="off"/>
+      </form>
+      <div id="theme-button" class="toggle">
+        <label for="theme">
+          <input id="theme" type="checkbox" value="light-theme"/>
+          <span class="material-symbols-outlined">brightness_4</span>
+        </label>
+      </div>
+    </header>
+    <main>
+      <div id="dartdoc-main-content" class="main-content" data-above-sidebar="oxygen/oxygen-library-sidebar.html" data-below-sidebar="">
+        <div>
+          <h1>
+            <span class="kind-function">main</span>
+            function
+          </h1>
+        </div>
+        <div class="multi-line-signature">
+          <span class="returntype">dynamic</span>
+          <span class="name ">main</span>
+          (
+          <wbr/>
+          )
+        </div>
+        <div class="summary source-code" id="source">
+          <h2>
+            <span>Implementation</span>
+          </h2>
+          <pre class="language-dart">
+            <code class="language-dart">main() { print('Hello.'); }</code>
+          </pre>
+        </div>
+      </div>
+      <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
+        <header id="header-search-sidebar" class="hidden-l">
+          <form class="search-sidebar" role="search">
+            <input id="search-sidebar" class="form-control typeahead" type="text" placeholder="Loading search..." autocomplete="off"/>
+          </form>
+        </header>
+        <ol id="sidebar-nav" class="breadcrumbs gt-separated dark hidden-l">
+          <li>
+            <a href="/packages/oxygen">oxygen package</a>
+          </li>
+          <li>
+            <a href="../index.html">documentation</a>
+          </li>
+          <li>
+            <a href="../oxygen/oxygen-library.html">oxygen</a>
+          </li>
+          <li class="self-crumb">main function</li>
+        </ol>
+        <h5>oxygen library</h5>
+        <div id="dartdoc-sidebar-left-content"></div>
+      </div>
+      <div id="dartdoc-sidebar-right" class="sidebar sidebar-offcanvas-right"></div>
+    </main>
+    <footer>
+      <span class="no-break">oxygen 2.0.0</span>
+    </footer>
+    <script src="/static/hash-%%etag%%/dartdoc/resources/highlight.pack.js"></script>
+    <script src="/static/hash-%%etag%%/dartdoc/resources/docs.dart.js"></script>
+  </body>
+</html>

--- a/app/test/task/testdata/goldens/documentation/oxygen/2.0.0/oxygen/oxygen-library.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/2.0.0/oxygen/oxygen-library.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <script type="text/javascript" src="https://www.googletagmanager.com/gtm.js?id=GTM-MX6DBN9" async="async"></script>
+    <script type="text/javascript" src="/static/hash-%%etag%%/js/gtm.js"></script>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+    <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1, user-scalable=no"/>
+    <meta name="generator" content="made with love by dartdoc"/>
+    <meta name="description" content="oxygen library API docs, for the Dart programming language."/>
+    <title>oxygen library - Dart API</title>
+    <link rel="canonical" href="https://pub.dev/documentation/oxygen/2.0.0/oxygen/oxygen-library.html"/>
+    <link rel="preconnect" href="https://fonts.gstatic.com"/>
+    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/github-markdown.css"/>
+    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/dartdoc/resources/github.css"/>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,300;0,400;0,500;0,700;1,400&amp;amp;display=swap"/>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@48,400,0,0"/>
+    <link rel="stylesheet" href="/static/hash-%%etag%%/dartdoc/resources/styles.css"/>
+    <link rel="icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
+  </head>
+  <body data-base-href="../" data-using-base-href="false" class="light-theme">
+    <noscript>
+      <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MX6DBN9" height="0" width="0" style="display:none;visibility:hidden"></iframe>
+    </noscript>
+    <div id="overlay-under-drawer"></div>
+    <header id="title">
+      <span id="sidenav-left-toggle" class="material-symbols-outlined" role="button" tabindex="0">menu</span>
+      <a class="hidden-xs" href="/">
+        <img src="/static/hash-%%etag%%/img/dart-logo.svg" alt="Dart" width="30" height="30" style="height: 30px; margin-right: 1em;"/>
+      </a>
+      <ol class="breadcrumbs gt-separated dark hidden-xs">
+        <li>
+          <a href="/packages/oxygen">oxygen package</a>
+        </li>
+        <li>
+          <a href="../index.html">documentation</a>
+        </li>
+        <li class="self-crumb">oxygen library</li>
+      </ol>
+      <div class="self-name">oxygen library</div>
+      <form class="search navbar-right" role="search">
+        <input id="search-box" class="form-control typeahead" type="text" placeholder="Loading search..." autocomplete="off"/>
+      </form>
+      <div id="theme-button" class="toggle">
+        <label for="theme">
+          <input id="theme" type="checkbox" value="light-theme"/>
+          <span class="material-symbols-outlined">brightness_4</span>
+        </label>
+      </div>
+    </header>
+    <main>
+      <div id="dartdoc-main-content" class="main-content" data-above-sidebar="" data-below-sidebar="oxygen/oxygen-library-sidebar.html">
+        <div>
+          <h1>
+            <span class="kind-library">oxygen</span>
+            library
+          </h1>
+        </div>
+        <div class="summary offset-anchor" id="functions">
+          <h2>Functions</h2>
+          <dl class="callables">
+            <dt id="main" class="callable">
+              <span class="name">
+                <a href="../oxygen/main.html">main</a>
+              </span>
+              <span class="signature">
+                (
+                <wbr/>
+                )
+                <span class="returntype parameter">→ dynamic</span>
+              </span>
+            </dt>
+            <dd></dd>
+          </dl>
+        </div>
+      </div>
+      <div id="dartdoc-sidebar-left" class="sidebar sidebar-offcanvas-left">
+        <header id="header-search-sidebar" class="hidden-l">
+          <form class="search-sidebar" role="search">
+            <input id="search-sidebar" class="form-control typeahead" type="text" placeholder="Loading search..." autocomplete="off"/>
+          </form>
+        </header>
+        <ol id="sidebar-nav" class="breadcrumbs gt-separated dark hidden-l">
+          <li>
+            <a href="/packages/oxygen">oxygen package</a>
+          </li>
+          <li>
+            <a href="../index.html">documentation</a>
+          </li>
+          <li class="self-crumb">oxygen library</li>
+        </ol>
+        <h5>
+          <span class="package-name">oxygen</span>
+          <span class="package-kind">package</span>
+        </h5>
+        <ol>
+          <li class="section-title">Libraries</li>
+          <li>
+            <a href="../oxygen/oxygen-library.html">oxygen</a>
+          </li>
+        </ol>
+        <div id="dartdoc-sidebar-left-content"></div>
+      </div>
+      <div id="dartdoc-sidebar-right" class="sidebar sidebar-offcanvas-right">
+        <h5>oxygen library</h5>
+      </div>
+    </main>
+    <footer>
+      <span class="no-break">oxygen 2.0.0</span>
+    </footer>
+    <script src="/static/hash-%%etag%%/dartdoc/resources/highlight.pack.js"></script>
+    <script src="/static/hash-%%etag%%/dartdoc/resources/docs.dart.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
- follow-up to #6994
- with this change, the canonical URL inside the HTML meta headers will always render the same URL that the page is served on
- we no longer redirect `/d*/<pkg>/<v>/` to `/d*/<pkg>/latest/` if the request was for a specific version (even though it may be the latest version)