### PR TITLE
Upgrade analysis SDKs + cleanup of Dockerfile.app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@ Important changes to data models, configuration, and migrations between each
 AppEngine version, listed here to ease deployment and troubleshooting.
 
 ## Next Release (replace with git tag when deployed)
+ * Bumped runtimeVersion to `2023.09.12`.
+ * Upgraded stable Dart analysis SDK to `3.1.1`.
+ * Upgraded stable Flutter analysis SDK to `3.13.3`.
+ * Upgraded preview Dart analysis SDK to `3.2.0-42.2.beta`.
+ * Upgraded preview Flutter analysis SDK to `3.14.0-0.2.pre`.
  * Note: isolates do not automatically restart after they are closed with uncaught error.
  * Note: no control isolate is used, first isolate is used as the HTTP-serving frontend.
 

--- a/Dockerfile.app
+++ b/Dockerfile.app
@@ -32,14 +32,7 @@ RUN ./build.sh
 WORKDIR /project/app
 RUN dart /project/tool/pub_get_offline.dart /project/app
 
-# Setup analysis Dart SDKs
-RUN /project/tool/setup-dart.sh /tool/stable 3.1.0
-RUN /project/tool/setup-dart.sh /tool/preview 3.2.0-42.1.beta
 RUN /project/tool/setup-webp.sh /usr/local/bin
-
-# Setup analysis Flutter SDKs
-RUN /project/tool/setup-flutter.sh /tool/stable 3.13.0
-RUN /project/tool/setup-flutter.sh /tool/preview 3.13.0
 
 # Clear out any arguments the base images might have set
 CMD []

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -18,16 +18,16 @@ COPY --chown=worker:worker . /home/worker/pub-dev
 WORKDIR /home/worker/pub-dev
 
 # Setup Dart SDK into /home/worker/dart/{stable,preview}/
-RUN tool/setup-dart.sh /home/worker/dart 3.1.0
+RUN tool/setup-dart.sh /home/worker/dart 3.1.1
 RUN mv /home/worker/dart/dart-sdk /home/worker/dart/stable
-RUN tool/setup-dart.sh /home/worker/dart 3.2.0-42.1.beta
+RUN tool/setup-dart.sh /home/worker/dart 3.2.0-42.2.beta
 RUN tool/setup-webp.sh /home/worker/bin
 RUN mv /home/worker/dart/dart-sdk /home/worker/dart/preview
 
 # Setup Flutter SDK into /home/worker/flutter/{stable,preview}/
-RUN tool/setup-flutter.sh /home/worker/flutter 3.13.0
+RUN tool/setup-flutter.sh /home/worker/flutter 3.13.3
 RUN mv /home/worker/flutter/flutter /home/worker/flutter/stable
-RUN tool/setup-flutter.sh /home/worker/flutter 3.13.0
+RUN tool/setup-flutter.sh /home/worker/flutter 3.14.0-0.2.pre
 RUN mv /home/worker/flutter/flutter /home/worker/flutter/preview
 
 # Configure SDKs to be used for analysis

--- a/app/lib/shared/versions.dart
+++ b/app/lib/shared/versions.dart
@@ -24,10 +24,10 @@ final RegExp runtimeVersionPattern = RegExp(r'^\d{4}\.\d{2}\.\d{2}$');
 /// when the version switch happens.
 const _acceptedRuntimeVersions = <String>[
   // The current [runtimeVersion].
-  '2023.09.05',
+  '2023.09.12',
   // Fallback runtime versions.
+  '2023.09.05',
   '2023.08.29',
-  '2023.08.18',
 ];
 
 /// Sets the current runtime versions.
@@ -62,10 +62,10 @@ bool shouldGCVersion(String version) =>
 
 // keep in-sync with SDK version in .mono_repo.yml and Dockerfile
 final String runtimeSdkVersion = '3.1.0';
-final String toolStableDartSdkVersion = '3.1.0';
-final String toolStableFlutterSdkVersion = '3.13.0';
-final String toolPreviewDartSdkVersion = '3.2.0-42.1.beta';
-final String toolPreviewFlutterSdkVersion = '3.13.0';
+final String toolStableDartSdkVersion = '3.1.1';
+final String toolStableFlutterSdkVersion = '3.13.3';
+final String toolPreviewDartSdkVersion = '3.2.0-42.2.beta';
+final String toolPreviewFlutterSdkVersion = '3.14.0-0.2.pre';
 
 final semanticToolStableDartSdkVersion =
     Version.parse(toolStableDartSdkVersion);

--- a/app/test/shared/versions_test.dart
+++ b/app/test/shared/versions_test.dart
@@ -81,30 +81,12 @@ void main() {
     expect(ci.contains('sdk:$runtimeSdkVersion'), isTrue);
   });
 
-  test('Dart SDK versions should match Dockerfile.app', () async {
-    final dockerfileContent = await File('../Dockerfile.app').readAsString();
-    expect(
-        dockerfileContent,
-        contains(
-            'RUN /project/tool/setup-dart.sh /tool/stable $toolStableDartSdkVersion'));
-    expect(
-        dockerfileContent,
-        contains(
-            'RUN /project/tool/setup-dart.sh /tool/preview $toolPreviewDartSdkVersion'));
-  });
-
   test('Dart SDK versions should match Dockerfile.worker', () async {
     final dockerfileContent = await File('../Dockerfile.worker').readAsString();
     expect(
         dockerfileContent,
         contains(
             'RUN tool/setup-dart.sh /home/worker/dart $toolStableDartSdkVersion'));
-  });
-
-  test('Flutter SDK versions should match Dockerfile.app', () async {
-    final String docker = await File('../Dockerfile.app').readAsString();
-    expect(docker.contains('stable $toolStableFlutterSdkVersion'), isTrue);
-    expect(docker.contains('preview $toolPreviewFlutterSdkVersion'), isTrue);
   });
 
   test('Flutter SDK versions should match Dockerfile.worker', () async {


### PR DESCRIPTION
Removing SDK setup from `Dockerfile.app`, as we no longer run the analysis on those instances.