### PR TITLE
Using a single URL resolver function in markdown rendering.

### DIFF
--- a/app/lib/frontend/templates/_utils.dart
+++ b/app/lib/frontend/templates/_utils.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:path/path.dart' as p;
-
 import '../../package/models.dart' show PackageVersionAsset;
 import '../../shared/markdown.dart';
 import '../dom/dom.dart' as d;
@@ -12,7 +10,6 @@ import '../dom/dom.dart' as d;
 d.Node renderFile(
   PackageVersionAsset asset, {
   UrlResolverFn? urlResolverFn,
-  String? baseUrl,
   bool isChangelog = false,
 }) {
   final filename = asset.path!;
@@ -22,8 +19,7 @@ d.Node renderFile(
       markdownToHtml(
         content,
         urlResolverFn: urlResolverFn,
-        baseUrl: baseUrl,
-        baseDir: p.dirname(filename),
+        relativeFrom: filename,
         isChangelog: isChangelog,
       ),
     );

--- a/app/lib/frontend/templates/package.dart
+++ b/app/lib/frontend/templates/package.dart
@@ -298,14 +298,12 @@ PageData pkgPageData(
 }
 
 Tab _readmeTab(PackagePageData data) {
-  final baseUrl = data.repositoryBaseUrl;
   final content = data.hasReadme &&
           data.asset != null &&
           data.asset!.kind == AssetKind.readme
       ? renderFile(
           data.asset!,
           urlResolverFn: data.urlResolverFn,
-          baseUrl: baseUrl,
         )
       : d.text('');
   return Tab.withContent(
@@ -322,7 +320,6 @@ Tab? _changelogTab(PackagePageData data) {
   final content = renderFile(
     data.asset!,
     urlResolverFn: data.urlResolverFn,
-    baseUrl: data.repositoryBaseUrl,
     isChangelog: true,
   );
   return Tab.withContent(
@@ -342,7 +339,6 @@ Tab? _exampleTab(PackagePageData data) {
   final renderedExample = renderFile(
     data.asset!,
     urlResolverFn: data.urlResolverFn,
-    baseUrl: baseUrl,
   );
   final url = urls.getRepositoryUrl(baseUrl, exampleFilename!);
 
@@ -388,7 +384,6 @@ Tab _licenseTab(PackagePageData data) {
       ? renderFile(
           data.asset!,
           urlResolverFn: data.urlResolverFn,
-          baseUrl: data.repositoryBaseUrl,
         )
       : d.text('No license file found.');
   return Tab.withContent(
@@ -407,7 +402,6 @@ Tab _pubspecTab(PackagePageData data) {
       ? renderFile(
           data.asset!,
           urlResolverFn: data.urlResolverFn,
-          baseUrl: data.repositoryBaseUrl,
         )
       : d.text('No pubspec file found.');
   return Tab.withContent(

--- a/app/lib/package/models.dart
+++ b/app/lib/package/models.dart
@@ -11,6 +11,7 @@ import 'package:_pub_shared/search/tags.dart';
 import 'package:clock/clock.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'package:pana/models.dart';
+import 'package:pub_dev/shared/markdown.dart';
 import 'package:pub_semver/pub_semver.dart';
 
 import '../package/model_properties.dart';
@@ -1130,7 +1131,8 @@ class PackagePageData {
 
   /// The verified repository (or homepage).
   late final urlResolverFn =
-      scoreCard.panaReport?.result?.repository?.resolveUrl;
+      scoreCard.panaReport?.result?.repository?.resolveUrl ??
+          fallbackUrlResolverFn(packageLinks._baseUrl);
 
   PackageView toPackageView() {
     return _view ??= PackageView.fromModel(

--- a/app/lib/shared/markdown.dart
+++ b/app/lib/shared/markdown.dart
@@ -36,8 +36,7 @@ const _whitelistedClassNames = <String>[
 String markdownToHtml(
   String text, {
   UrlResolverFn? urlResolverFn,
-  String? baseUrl,
-  String? baseDir,
+  String? relativeFrom,
   bool isChangelog = false,
   bool disableHashIds = false,
 }) {
@@ -48,8 +47,7 @@ String markdownToHtml(
     nodes = _rewriteRelativeUrls(
       nodes,
       urlResolverFn: urlResolverFn,
-      baseUrl: baseUrl,
-      baseDir: baseDir,
+      relativeFrom: relativeFrom,
     );
     if (isChangelog) {
       nodes = _groupChangelogNodes(nodes).toList();
@@ -71,16 +69,13 @@ List<m.Node> _parseMarkdownSource(String source) {
   return document.parseLines(lines);
 }
 
-/// Rewrites relative URLs, re-basing them on [baseUrl].
+/// Rewrites relative URLs, re-basing them on [relativeFrom].
 List<m.Node> _rewriteRelativeUrls(
   List<m.Node> nodes, {
   required UrlResolverFn? urlResolverFn,
-  required String? baseUrl,
-  required String? baseDir,
+  required String? relativeFrom,
 }) {
-  final sanitizedBaseUrl = _pruneBaseUrl(baseUrl);
-  final urlRewriter =
-      _RelativeUrlRewriter(urlResolverFn, sanitizedBaseUrl, baseDir);
+  final urlRewriter = _RelativeUrlRewriter(urlResolverFn, relativeFrom);
   nodes.forEach((node) => node.accept(urlRewriter));
   return nodes;
 }
@@ -185,13 +180,12 @@ class _UnsafeUrlFilter implements m.NodeVisitor {
   }
 }
 
-/// Rewrites relative URLs with the provided [baseUrl]
+/// Rewrites relative URLs with the provided [urlResolverFn].
 class _RelativeUrlRewriter implements m.NodeVisitor {
   final UrlResolverFn? urlResolverFn;
-  final String? baseUrl;
-  final String? baseDir;
+  final String? relativeFrom;
   final _elementsToRemove = <m.Element>{};
-  _RelativeUrlRewriter(this.urlResolverFn, this.baseUrl, this.baseDir);
+  _RelativeUrlRewriter(this.urlResolverFn, this.relativeFrom);
 
   @override
   void visitText(m.Text text) {}
@@ -245,64 +239,58 @@ class _RelativeUrlRewriter implements m.NodeVisitor {
       if (urlResolverFn != null) {
         return urlResolverFn!(
           url,
-          // note: pana will call `p.dirname(relativeFrom)` to get the reference to baseDir
-          relativeFrom: baseDir == null ? null : p.join(baseDir!, 'README.md'),
+          relativeFrom: relativeFrom,
           isEmbeddedObject: raw,
         );
       }
-      // TODO: remove the rest of the rewrites after repository verification is launched
-      String newUrl = url;
-      if (baseUrl != null && !_isAbsolute(newUrl)) {
-        newUrl = _rewriteRelativeUrl(newUrl);
-      }
-      if (raw && _isAbsolute(newUrl)) {
-        newUrl = _rewriteAbsoluteUrl(newUrl);
-      }
-      return newUrl;
     } catch (e, st) {
       _logger.warning('Link rewrite failed: $url', e, st);
     }
     return url;
   }
+}
 
-  bool _isAbsolute(String url) => url.contains(':');
+bool _isAbsolute(String url) => url.contains(':');
 
-  String _rewriteAbsoluteUrl(String url) {
-    final uri = Uri.parse(url);
-    if (uri.host == 'github.com') {
-      final segments = uri.pathSegments;
-      if (segments.length > 3 && segments[2] == 'blob') {
-        final newSegments = List<String>.from(segments);
-        newSegments[2] = 'raw';
-        return uri.replace(pathSegments: newSegments).toString();
-      }
+String _rewriteAbsoluteUrl(String url) {
+  final uri = Uri.parse(url);
+  if (uri.host == 'github.com') {
+    final segments = uri.pathSegments;
+    if (segments.length > 3 && segments[2] == 'blob') {
+      final newSegments = List<String>.from(segments);
+      newSegments[2] = 'raw';
+      return uri.replace(pathSegments: newSegments).toString();
     }
+  }
+  return url;
+}
+
+String _rewriteRelativeUrl({
+  required String baseUrl,
+  required String url,
+  required String? baseDir,
+}) {
+  final uri = Uri.parse(url);
+  final linkPath = uri.path;
+  final linkFragment = uri.fragment;
+  if (linkPath.isEmpty) {
     return url;
   }
-
-  String _rewriteRelativeUrl(String url) {
-    final uri = Uri.parse(url);
-    final linkPath = uri.path;
-    final linkFragment = uri.fragment;
-    if (linkPath.isEmpty) {
+  String newUrl;
+  if (linkPath.startsWith('/')) {
+    newUrl = Uri.parse(baseUrl).replace(path: linkPath).toString();
+  } else {
+    final adjustedLinkPath = p.normalize(p.join(baseDir ?? '.', linkPath));
+    final repoUrl = getRepositoryUrl(baseUrl, adjustedLinkPath);
+    if (repoUrl == null) {
       return url;
     }
-    String newUrl;
-    if (linkPath.startsWith('/')) {
-      newUrl = Uri.parse(baseUrl!).replace(path: linkPath).toString();
-    } else {
-      final adjustedLinkPath = p.normalize(p.join(baseDir ?? '.', linkPath));
-      final repoUrl = getRepositoryUrl(baseUrl, adjustedLinkPath);
-      if (repoUrl == null) {
-        return url;
-      }
-      newUrl = repoUrl;
-    }
-    if (linkFragment.isNotEmpty) {
-      newUrl = '$newUrl#$linkFragment';
-    }
-    return newUrl;
+    newUrl = repoUrl;
   }
+  if (linkFragment.isNotEmpty) {
+    newUrl = '$newUrl#$linkFragment';
+  }
+  return newUrl;
 }
 
 /// Returns null if the [url] looks invalid.
@@ -395,4 +383,30 @@ Version? _extractVersion(String? text) {
   } on FormatException catch (_) {
     return null;
   }
+}
+
+// TODO: remove after repository verification is launched
+UrlResolverFn? fallbackUrlResolverFn(String? providedBaseUrl) {
+  final baseUrl = _pruneBaseUrl(providedBaseUrl);
+  if (baseUrl == null) {
+    return null;
+  }
+  return (
+    String url, {
+    bool? isEmbeddedObject,
+    String? relativeFrom,
+  }) {
+    String newUrl = url;
+    if (!_isAbsolute(newUrl)) {
+      newUrl = _rewriteRelativeUrl(
+        url: newUrl,
+        baseUrl: baseUrl,
+        baseDir: relativeFrom == null ? null : p.dirname(relativeFrom),
+      );
+    }
+    if ((isEmbeddedObject ?? false) && _isAbsolute(newUrl)) {
+      newUrl = _rewriteAbsoluteUrl(newUrl);
+    }
+    return newUrl;
+  };
 }

--- a/app/test/shared/markdown_test.dart
+++ b/app/test/shared/markdown_test.dart
@@ -18,24 +18,22 @@ void main() {
   });
 
   group('Valid custom base URL', () {
-    final String baseUrl = 'https://github.com/example/project';
+    final baseUrl = 'https://github.com/example/project';
+    final urlResolverFn = fallbackUrlResolverFn(baseUrl);
 
     test('relative link within page', () {
       expect(markdownToHtml('[text](#relative)'),
           '<p><a href="#relative">text</a></p>\n');
-      expect(markdownToHtml('[text](#relative)', baseUrl: baseUrl),
-          '<p><a href="#relative">text</a></p>\n');
-      expect(markdownToHtml('[text](#relative)', baseUrl: '$baseUrl/'),
+      expect(markdownToHtml('[text](#relative)', urlResolverFn: urlResolverFn),
           '<p><a href="#relative">text</a></p>\n');
     });
 
     test('absolute link URL', () {
       expect(markdownToHtml('[text](http://dartlang.org/)'),
           '<p><a href="http://dartlang.org/" rel="ugc">text</a></p>\n');
-      expect(markdownToHtml('[text](http://dartlang.org/)', baseUrl: baseUrl),
-          '<p><a href="http://dartlang.org/" rel="ugc">text</a></p>\n');
       expect(
-          markdownToHtml('[text](http://dartlang.org/)', baseUrl: '$baseUrl/'),
+          markdownToHtml('[text](http://dartlang.org/)',
+              urlResolverFn: urlResolverFn),
           '<p><a href="http://dartlang.org/" rel="ugc">text</a></p>\n');
     });
 
@@ -44,95 +42,86 @@ void main() {
           '<p><img src="http://dartlang.org/image.png" alt="text" /></p>\n');
       expect(
           markdownToHtml('![text](http://dartlang.org/image.png)',
-              baseUrl: baseUrl),
-          '<p><img src="http://dartlang.org/image.png" alt="text" /></p>\n');
-      expect(
-          markdownToHtml('![text](http://dartlang.org/image.png)',
-              baseUrl: '$baseUrl/'),
+              urlResolverFn: urlResolverFn),
           '<p><img src="http://dartlang.org/image.png" alt="text" /></p>\n');
     });
 
     test('sibling link within site', () {
       expect(markdownToHtml('[text](README.md)'),
           '<p><a href="README.md">text</a></p>\n');
-      expect(markdownToHtml('[text](README.md)', baseUrl: baseUrl),
-          '<p><a href="https://github.com/example/project/blob/master/README.md" rel="ugc">text</a></p>\n');
-      expect(markdownToHtml('[text](README.md)', baseUrl: '$baseUrl/'),
+      expect(markdownToHtml('[text](README.md)', urlResolverFn: urlResolverFn),
           '<p><a href="https://github.com/example/project/blob/master/README.md" rel="ugc">text</a></p>\n');
     });
 
     test('sibling image within site', () {
       expect(markdownToHtml('![text](image.png)'),
           '<p><img src="image.png" alt="text" /></p>\n');
-      expect(markdownToHtml('![text](image.png)', baseUrl: baseUrl),
-          '<p><img src="https://github.com/example/project/raw/master/image.png" alt="text" /></p>\n');
-      expect(markdownToHtml('![text](image.png)', baseUrl: '$baseUrl/'),
+      expect(markdownToHtml('![text](image.png)', urlResolverFn: urlResolverFn),
           '<p><img src="https://github.com/example/project/raw/master/image.png" alt="text" /></p>\n');
     });
 
     test('sibling image inside a relative directory', () {
-      expect(markdownToHtml('![text](image.png)', baseDir: 'example'),
+      expect(
+          markdownToHtml('![text](image.png)',
+              relativeFrom: 'example/README.md'),
           '<p><img src="image.png" alt="text" /></p>\n');
       expect(
           markdownToHtml('![text](image.png)',
-              baseUrl: baseUrl, baseDir: 'example'),
+              urlResolverFn: urlResolverFn, relativeFrom: 'example/README.md'),
           '<p><img src="https://github.com/example/project/raw/master/example/image.png" alt="text" /></p>\n');
-      expect(
-          markdownToHtml('![text](img/image.png)',
-              baseUrl: '$baseUrl/', baseDir: 'example'),
-          '<p><img src="https://github.com/example/project/raw/master/example/img/image.png" alt="text" /></p>\n');
     });
 
     test('sibling link plus relative link', () {
       expect(markdownToHtml('[text](README.md#section)'),
           '<p><a href="README.md#section">text</a></p>\n');
-      expect(markdownToHtml('[text](README.md#section)', baseUrl: baseUrl),
-          '<p><a href="https://github.com/example/project/blob/master/README.md#section" rel="ugc">text</a></p>\n');
-      expect(markdownToHtml('[text](README.md#section)', baseUrl: '$baseUrl/'),
+      expect(
+          markdownToHtml('[text](README.md#section)',
+              urlResolverFn: urlResolverFn),
           '<p><a href="https://github.com/example/project/blob/master/README.md#section" rel="ugc">text</a></p>\n');
     });
 
     test('child link within site', () {
       expect(markdownToHtml('[text](example/README.md)'),
           '<p><a href="example/README.md">text</a></p>\n');
-      expect(markdownToHtml('[text](example/README.md)', baseUrl: baseUrl),
-          '<p><a href="https://github.com/example/project/blob/master/example/README.md" rel="ugc">text</a></p>\n');
-      expect(markdownToHtml('[text](example/README.md)', baseUrl: '$baseUrl/'),
+      expect(
+          markdownToHtml('[text](example/README.md)',
+              urlResolverFn: urlResolverFn),
           '<p><a href="https://github.com/example/project/blob/master/example/README.md" rel="ugc">text</a></p>\n');
     });
 
     test('child image within site', () {
       expect(markdownToHtml('![text](example/image.png)'),
           '<p><img src="example/image.png" alt="text" /></p>\n');
-      expect(markdownToHtml('![text](example/image.png)', baseUrl: baseUrl),
-          '<p><img src="https://github.com/example/project/raw/master/example/image.png" alt="text" /></p>\n');
-      expect(markdownToHtml('![text](example/image.png)', baseUrl: '$baseUrl/'),
+      expect(
+          markdownToHtml('![text](example/image.png)',
+              urlResolverFn: urlResolverFn),
           '<p><img src="https://github.com/example/project/raw/master/example/image.png" alt="text" /></p>\n');
     });
 
     test('root link within site', () {
       expect(markdownToHtml('[text](/README.md)'),
           '<p><a href="/README.md">text</a></p>\n');
-      expect(markdownToHtml('[text](/example/README.md)', baseUrl: baseUrl),
-          '<p><a href="https://github.com/example/README.md" rel="ugc">text</a></p>\n');
-      expect(markdownToHtml('[text](/example/README.md)', baseUrl: '$baseUrl/'),
+      expect(
+          markdownToHtml('[text](/example/README.md)',
+              urlResolverFn: urlResolverFn),
           '<p><a href="https://github.com/example/README.md" rel="ugc">text</a></p>\n');
     });
 
     test('root image within site', () {
       expect(markdownToHtml('![text](/image.png)'),
           '<p><img src="/image.png" alt="text" /></p>\n');
-      expect(markdownToHtml('![text](/example/image.png)', baseUrl: baseUrl),
-          '<p><img src="https://github.com/example/image.png" alt="text" /></p>\n');
       expect(
-          markdownToHtml('![text](/example/image.png)', baseUrl: '$baseUrl/'),
+          markdownToHtml('![text](/example/image.png)',
+              urlResolverFn: urlResolverFn),
           '<p><img src="https://github.com/example/image.png" alt="text" /></p>\n');
     });
 
     test('email', () {
       expect(markdownToHtml('[me](mailto:email@example.com)'),
           '<p><a href="mailto:email@example.com">me</a></p>\n');
-      expect(markdownToHtml('[me](mailto:email@example.com)', baseUrl: baseUrl),
+      expect(
+          markdownToHtml('[me](mailto:email@example.com)',
+              urlResolverFn: urlResolverFn),
           '<p><a href="mailto:email@example.com">me</a></p>\n');
     });
   });
@@ -141,12 +130,14 @@ void main() {
     test('not http(s)', () {
       expect(
           markdownToHtml('[text](README.md)',
-              baseUrl: 'ftp://example.com/blah'),
+              urlResolverFn: fallbackUrlResolverFn('ftp://example.com/blah')),
           '<p><a href="README.md">text</a></p>\n');
     });
 
     test('not valid host', () {
-      expect(markdownToHtml('[text](README.md)', baseUrl: 'http://com/blah'),
+      expect(
+          markdownToHtml('[text](README.md)',
+              urlResolverFn: fallbackUrlResolverFn('http://com/blah')),
           '<p><a href="README.md">text</a></p>\n');
     });
   });
@@ -159,7 +150,9 @@ void main() {
 
   group('Bad markdown', () {
     test('bad link', () {
-      expect(markdownToHtml('[a][b]', baseUrl: 'http://www.example.com/'),
+      expect(
+          markdownToHtml('[a][b]',
+              urlResolverFn: fallbackUrlResolverFn('http://www.example.com/')),
           '<p>[a][b]</p>\n');
     });
 
@@ -256,21 +249,23 @@ void main() {
       expect(
           markdownToHtml(
               '![text](https://github.com/rcpassos/progress_hud/blob/master/progress_hud.gif)'),
-          '<p><img src="https://github.com/rcpassos/progress_hud/raw/master/progress_hud.gif" alt="text" /></p>\n');
+          '<p><img src="https://github.com/rcpassos/progress_hud/blob/master/progress_hud.gif" alt="text" /></p>\n');
     });
 
     test('root path: /[..]/blob/master/[path].gif', () {
       expect(
           markdownToHtml(
               '![text](/rcpassos/progress_hud/blob/master/progress_hud.gif)',
-              baseUrl: 'https://github.com/rcpassos/progress_hud'),
+              urlResolverFn: fallbackUrlResolverFn(
+                  'https://github.com/rcpassos/progress_hud')),
           '<p><img src="https://github.com/rcpassos/progress_hud/raw/master/progress_hud.gif" alt="text" /></p>\n');
     });
 
     test('relative path: [path].gif', () {
       expect(
           markdownToHtml('![text](progress_hud.gif)',
-              baseUrl: 'https://github.com/rcpassos/progress_hud'),
+              urlResolverFn: fallbackUrlResolverFn(
+                  'https://github.com/rcpassos/progress_hud')),
           '<p><img src="https://github.com/rcpassos/progress_hud/raw/master/progress_hud.gif" alt="text" /></p>\n');
     });
   });


### PR DESCRIPTION
- moves the old non-verified URL resolution a bit outside of the core markdown rendering classes and methods
- prepares a way to go ahead with url resolver using only verified repositories (we only need to remove the fallback)
- removed tests that will become obsolete
