### PR TITLE
Start using like and popularity score inside the search snapshot.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ AppEngine version, listed here to ease deployment and troubleshooting.
  * Upgraded preview Flutter analysis SDK to `3.15.0-15.2.pre`.
  * Upgraded pana to `0.21.37`.
  * Upgraded `package:tar` and other dependencies.
+ * Note: started to populate `PackageDocument.likeScore` and `popularityScore`.
 
 ## `20230918t113400-all`
  * Fix: search isolate renewal doesn't block ongoing traffic.

--- a/app/lib/search/backend.dart
+++ b/app/lib/search/backend.dart
@@ -165,9 +165,9 @@ class SearchBackend {
     if (!claim.valid) {
       return;
     }
+    snapshot.updateLikeScores();
 
     // first complete snapshot, uploading it
-    snapshot.updateLikeScores();
     await _snapshotStorage.uploadDataAsJsonMap(snapshot.toJson());
     var lastUploadedSnapshotTimestamp = snapshot.updated!;
 

--- a/app/lib/search/backend.dart
+++ b/app/lib/search/backend.dart
@@ -17,6 +17,7 @@ import 'package:meta/meta.dart';
 import 'package:pool/pool.dart';
 
 import 'package:pub_dartdoc_data/pub_dartdoc_data.dart';
+import 'package:pub_dev/shared/popularity_storage.dart';
 
 import '../package/backend.dart';
 import '../package/model_properties.dart';
@@ -166,6 +167,7 @@ class SearchBackend {
     }
 
     // first complete snapshot, uploading it
+    snapshot.updateLikeScores();
     await _snapshotStorage.uploadDataAsJsonMap(snapshot.toJson());
     var lastUploadedSnapshotTimestamp = snapshot.updated!;
 
@@ -192,6 +194,7 @@ class SearchBackend {
       futures.clear();
 
       if (claim.valid && lastUploadedSnapshotTimestamp != snapshot.updated) {
+        snapshot.updateLikeScores();
         await _snapshotStorage.uploadDataAsJsonMap(snapshot.toJson());
         lastUploadedSnapshotTimestamp = snapshot.updated!;
       }
@@ -330,6 +333,7 @@ class SearchBackend {
       updated: p.lastVersionPublished,
       readme: compactReadme(readmeAsset?.textContent),
       likeCount: p.likes,
+      popularityScore: popularityStorage.lookup(packageName),
       grantedPoints: scoreCard.grantedPubPoints,
       maxPoints: scoreCard.maxPubPoints,
       dependencies: _buildDependencies(pv.pubspec!, scoreCard),

--- a/app/lib/search/models.dart
+++ b/app/lib/search/models.dart
@@ -33,6 +33,22 @@ class SearchSnapshot {
     documents!.remove(packageName);
   }
 
+  /// Updates the PackageDocument.likeScore for each package in the snapshot.
+  /// The score is normalized into the range of [0.0 - 1.0] using the
+  /// ordered list of packages by like counts (same like count gets the same score).
+  void updateLikeScores() {
+    final sortedByLikes = documents!.values.toList()
+      ..sort((a, b) => a.likeCount.compareTo(b.likeCount));
+    for (var i = 0; i < sortedByLikes.length; i++) {
+      if (i > 0 &&
+          sortedByLikes[i - 1].likeCount == sortedByLikes[i].likeCount) {
+        sortedByLikes[i].likeScore = sortedByLikes[i - 1].likeScore;
+      } else {
+        sortedByLikes[i].likeScore = (i + 1) / sortedByLikes.length;
+      }
+    }
+  }
+
   Map<String, dynamic> toJson() => _$SearchSnapshotToJson(this);
 }
 

--- a/app/lib/search/search_service.dart
+++ b/app/lib/search/search_service.dart
@@ -72,10 +72,16 @@ class PackageDocument {
 
   final List<String> tags;
 
-  final int? likeCount;
+  final int likeCount;
 
-  final int? grantedPoints;
-  final int? maxPoints;
+  /// The normalized score between [0.0-1.0] (1.0 being the most liked package).
+  double? likeScore;
+
+  /// The normalized score between [0.0-1.0] (1.0 being the most popular package).
+  final double? popularityScore;
+
+  final int grantedPoints;
+  final int maxPoints;
 
   final Map<String, String> dependencies;
 
@@ -95,14 +101,19 @@ class PackageDocument {
     this.updated,
     this.readme = '',
     List<String>? tags,
-    this.likeCount = 0,
-    this.grantedPoints = 0,
-    this.maxPoints = 0,
+    int? likeCount,
+    this.likeScore,
+    this.popularityScore,
+    int? grantedPoints,
+    int? maxPoints,
     this.dependencies = const {},
     this.apiDocPages = const [],
     DateTime? timestamp,
     this.sourceUpdated,
-  })  : tags = tags ?? const <String>[],
+  })  : likeCount = likeCount ?? 0,
+        grantedPoints = grantedPoints ?? 0,
+        maxPoints = maxPoints ?? 0,
+        tags = tags ?? const <String>[],
         timestamp = timestamp ?? clock.now();
 
   factory PackageDocument.fromJson(Map<String, dynamic> json) =>

--- a/app/lib/search/search_service.g.dart
+++ b/app/lib/search/search_service.g.dart
@@ -19,9 +19,11 @@ PackageDocument _$PackageDocumentFromJson(Map<String, dynamic> json) =>
           : DateTime.parse(json['updated'] as String),
       readme: json['readme'] as String? ?? '',
       tags: (json['tags'] as List<dynamic>?)?.map((e) => e as String).toList(),
-      likeCount: json['likeCount'] as int? ?? 0,
-      grantedPoints: json['grantedPoints'] as int? ?? 0,
-      maxPoints: json['maxPoints'] as int? ?? 0,
+      likeCount: json['likeCount'] as int?,
+      likeScore: (json['likeScore'] as num?)?.toDouble(),
+      popularityScore: (json['popularityScore'] as num?)?.toDouble(),
+      grantedPoints: json['grantedPoints'] as int?,
+      maxPoints: json['maxPoints'] as int?,
       dependencies: (json['dependencies'] as Map<String, dynamic>?)?.map(
             (k, e) => MapEntry(k, e as String),
           ) ??
@@ -48,6 +50,8 @@ Map<String, dynamic> _$PackageDocumentToJson(PackageDocument instance) =>
       'readme': instance.readme,
       'tags': instance.tags,
       'likeCount': instance.likeCount,
+      'likeScore': instance.likeScore,
+      'popularityScore': instance.popularityScore,
       'grantedPoints': instance.grantedPoints,
       'maxPoints': instance.maxPoints,
       'dependencies': instance.dependencies,


### PR DESCRIPTION
The search index should not synchronously blocking on the like normalization (in a follow-up PR once we have started using this).
