### PR TITLE
Concurrent data loader for package pages.

### DIFF
--- a/app/lib/frontend/handlers/package.dart
+++ b/app/lib/frontend/handlers/package.dart
@@ -334,28 +334,36 @@ Future<PackagePageData> loadPackagePageData(
 
   final latestReleasesFuture = packageBackend.latestReleases(package);
 
-  final isLikedFuture = Future(
-    () async => requestContext.isNotAuthenticated
-        ? false
-        : await likeBackend.getPackageLikeStatus(
-                requestContext.authenticatedUserId!, package.name!) !=
-            null,
-  );
+  final isLikedFuture = Future(() async {
+    if (requestContext.isNotAuthenticated) {
+      return false;
+    }
+    final likeStatus = await likeBackend.getPackageLikeStatus(
+      requestContext.authenticatedUserId!,
+      package.name!,
+    );
+    return likeStatus != null;
+  });
 
   final selectedVersionFuture =
       packageBackend.lookupPackageVersion(packageName, versionName!);
   final versionInfoFuture =
       packageBackend.lookupPackageVersionInfo(packageName, versionName);
 
-  final assetFuture = Future(() async => assetKind == null
-      ? null
+  final assetFuture = assetKind == null
+      ? Future.value(null)
       : packageBackend.lookupPackageVersionAsset(
-          packageName, versionName!, assetKind));
+          packageName,
+          versionName,
+          assetKind,
+        );
 
-  final isAdminFuture = Future(() async => requestContext.isNotAuthenticated
-      ? false
-      : await packageBackend.isPackageAdmin(
-          package, requestContext.authenticatedUserId!));
+  final isAdminFuture = requestContext.isNotAuthenticated
+      ? Future.value(false)
+      : packageBackend.isPackageAdmin(
+          package,
+          requestContext.authenticatedUserId!,
+        );
 
   final scoreCardFuture = scoreCardBackend
       .getScoreCardData(packageName, versionName, package: package);

--- a/app/lib/frontend/handlers/package.dart
+++ b/app/lib/frontend/handlers/package.dart
@@ -362,7 +362,6 @@ Future<PackagePageData> loadPackagePageData(
         packageName,
         versionName!,
         package: package,
-        versionFuture: selectedVersionFuture,
       ));
 
   await Future.wait([

--- a/app/lib/frontend/handlers/package.dart
+++ b/app/lib/frontend/handlers/package.dart
@@ -332,8 +332,7 @@ Future<PackagePageData> loadPackagePageData(
   final packageName = package.name!;
   versionName ??= package.latestVersion;
 
-  final latestReleasesFuture =
-      Future(() => packageBackend.latestReleases(package));
+  final latestReleasesFuture = packageBackend.latestReleases(package);
 
   final isLikedFuture = Future(
     () async => requestContext.isNotAuthenticated
@@ -343,10 +342,10 @@ Future<PackagePageData> loadPackagePageData(
             null,
   );
 
-  final selectedVersionFuture = Future(
-      () => packageBackend.lookupPackageVersion(packageName, versionName!));
-  final versionInfoFuture = Future(
-      () => packageBackend.lookupPackageVersionInfo(packageName, versionName!));
+  final selectedVersionFuture =
+      packageBackend.lookupPackageVersion(packageName, versionName!);
+  final versionInfoFuture =
+      packageBackend.lookupPackageVersionInfo(packageName, versionName);
 
   final assetFuture = Future(() async => assetKind == null
       ? null
@@ -358,11 +357,8 @@ Future<PackagePageData> loadPackagePageData(
       : await packageBackend.isPackageAdmin(
           package, requestContext.authenticatedUserId!));
 
-  final scoreCardFuture = Future(() => scoreCardBackend.getScoreCardData(
-        packageName,
-        versionName!,
-        package: package,
-      ));
+  final scoreCardFuture = scoreCardBackend
+      .getScoreCardData(packageName, versionName, package: package);
 
   await Future.wait([
     latestReleasesFuture,

--- a/app/lib/scorecard/backend.dart
+++ b/app/lib/scorecard/backend.dart
@@ -119,7 +119,6 @@ class ScoreCardBackend {
     String packageName,
     String packageVersion, {
     Package? package,
-    Future<PackageVersion?>? versionFuture,
   }) async {
     InvalidInputException.check(
         packageVersion != 'latest', 'latest is no longer supported');
@@ -133,8 +132,8 @@ class ScoreCardBackend {
     if (package == null) {
       throw NotFoundException('Package "$packageName" does not exist.');
     }
-    final version = await (versionFuture ??
-        packageBackend.lookupPackageVersion(packageName, packageVersion));
+    final version =
+        await packageBackend.lookupPackageVersion(packageName, packageVersion);
     if (version == null) {
       throw NotFoundException(
           'Package version "$packageName $packageVersion" does not exist.');

--- a/app/lib/scorecard/backend.dart
+++ b/app/lib/scorecard/backend.dart
@@ -117,8 +117,10 @@ class ScoreCardBackend {
   /// Returns the [ScoreCardData] for the given package and version.
   Future<ScoreCardData> getScoreCardData(
     String packageName,
-    String packageVersion,
-  ) async {
+    String packageVersion, {
+    Package? package,
+    Future<PackageVersion?>? versionFuture,
+  }) async {
     InvalidInputException.check(
         packageVersion != 'latest', 'latest is no longer supported');
     final cacheEntry = cache.scoreCardData(packageName, packageVersion);
@@ -127,12 +129,12 @@ class ScoreCardBackend {
       return cached;
     }
 
-    final package = await packageBackend.lookupPackage(packageName);
+    package ??= await packageBackend.lookupPackage(packageName);
     if (package == null) {
       throw NotFoundException('Package "$packageName" does not exist.');
     }
-    final version =
-        await packageBackend.lookupPackageVersion(packageName, packageVersion);
+    final version = await (versionFuture ??
+        packageBackend.lookupPackageVersion(packageName, packageVersion));
     if (version == null) {
       throw NotFoundException(
           'Package version "$packageName $packageVersion" does not exist.');

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -26,6 +26,7 @@ import 'package:pub_dev/frontend/templates/package.dart';
 import 'package:pub_dev/frontend/templates/package_admin.dart';
 import 'package:pub_dev/frontend/templates/publisher.dart';
 import 'package:pub_dev/frontend/templates/views/pkg/score_tab.dart';
+import 'package:pub_dev/package/backend.dart';
 import 'package:pub_dev/package/models.dart';
 import 'package:pub_dev/package/search_adapter.dart';
 import 'package:pub_dev/publisher/backend.dart';
@@ -50,6 +51,11 @@ final _regenerateGoldens = false;
 
 void main() {
   group('templates', () {
+    Future<PackagePageData> loadPackagePageDataByName(
+            String name, String versionName, String? assetKind) async =>
+        loadPackagePageData((await packageBackend.lookupPackage(name))!,
+            versionName, assetKind);
+
     void expectGoldenFile(
       String content,
       String fileName, {
@@ -144,7 +150,7 @@ void main() {
       fn: () async {
         final data = await withFakeAuthRequestContext(
           adminAtPubDevEmail,
-          () => loadPackagePageData('oxygen', '1.2.0', AssetKind.readme),
+          () => loadPackagePageDataByName('oxygen', '1.2.0', AssetKind.readme),
         );
         final html = renderPkgShowPage(data);
         expectGoldenFile(html, 'pkg_show_page.html', timestamps: {
@@ -158,8 +164,8 @@ void main() {
       'package changelog page',
       processJobsWithFakeRunners: true,
       fn: () async {
-        final data =
-            await loadPackagePageData('oxygen', '1.2.0', AssetKind.changelog);
+        final data = await loadPackagePageDataByName(
+            'oxygen', '1.2.0', AssetKind.changelog);
         final html = renderPkgChangelogPage(data);
         expectGoldenFile(html, 'pkg_changelog_page.html', timestamps: {
           'published': data.package.created,
@@ -172,8 +178,8 @@ void main() {
       'package example page',
       processJobsWithFakeRunners: true,
       fn: () async {
-        final data =
-            await loadPackagePageData('oxygen', '1.2.0', AssetKind.example);
+        final data = await loadPackagePageDataByName(
+            'oxygen', '1.2.0', AssetKind.example);
         final html = renderPkgExamplePage(data);
         expectGoldenFile(html, 'pkg_example_page.html', timestamps: {
           'published': data.package.created,
@@ -186,7 +192,7 @@ void main() {
       'package install page',
       processJobsWithFakeRunners: true,
       fn: () async {
-        final data = await loadPackagePageData('oxygen', '1.2.0', null);
+        final data = await loadPackagePageDataByName('oxygen', '1.2.0', null);
         final html = renderPkgInstallPage(data);
         expectGoldenFile(html, 'pkg_install_page.html', timestamps: {
           'published': data.package.created,
@@ -197,7 +203,7 @@ void main() {
 
     testWithProfile('package score page', processJobsWithFakeRunners: true,
         fn: () async {
-      final data = await loadPackagePageData('oxygen', '1.2.0', null);
+      final data = await loadPackagePageDataByName('oxygen', '1.2.0', null);
       final html = renderPkgScorePage(data);
       expectGoldenFile(html, 'pkg_score_page.html', timestamps: {
         'published': data.package.created,
@@ -209,8 +215,8 @@ void main() {
       'package show page - with version',
       processJobsWithFakeRunners: true,
       fn: () async {
-        final data =
-            await loadPackagePageData('oxygen', '1.2.0', AssetKind.readme);
+        final data = await loadPackagePageDataByName(
+            'oxygen', '1.2.0', AssetKind.readme);
         final html = renderPkgShowPage(data);
         expectGoldenFile(html, 'pkg_show_version_page.html', timestamps: {
           'published': data.package.created,
@@ -225,7 +231,7 @@ void main() {
       fn: () async {
         final data = await withFakeAuthRequestContext(
           adminAtPubDevEmail,
-          () => loadPackagePageData(
+          () => loadPackagePageDataByName(
               'flutter_titanium', '1.10.0', AssetKind.readme),
         );
         final html = renderPkgShowPage(data);
@@ -251,7 +257,8 @@ void main() {
           defaultUser: 'admin@pub.dev',
         ),
         processJobsWithFakeRunners: true, fn: () async {
-      final data = await loadPackagePageData('pkg', '1.0.0', AssetKind.readme);
+      final data =
+          await loadPackagePageDataByName('pkg', '1.0.0', AssetKind.readme);
       final html = renderPkgShowPage(data);
       expectGoldenFile(html, 'pkg_show_page_discontinued.html', timestamps: {
         'published': data.package.created,
@@ -274,14 +281,16 @@ void main() {
           defaultUser: 'admin@pub.dev',
         ),
         processJobsWithFakeRunners: true, fn: () async {
-      final data = await loadPackagePageData('pkg', '1.0.0', AssetKind.readme);
+      final data =
+          await loadPackagePageDataByName('pkg', '1.0.0', AssetKind.readme);
       final html = renderPkgShowPage(data);
       expectGoldenFile(html, 'pkg_show_page_retracted.html', timestamps: {
         'published': data.package.created,
         'updated': data.version.created,
       });
 
-      final data2 = await loadPackagePageData('pkg', '2.0.0', AssetKind.readme);
+      final data2 =
+          await loadPackagePageDataByName('pkg', '2.0.0', AssetKind.readme);
       final html2 = renderPkgShowPage(data2);
       expectGoldenFile(
           html2, 'pkg_show_page_retracted_non_retracted_version.html',
@@ -306,7 +315,8 @@ void main() {
           defaultUser: 'admin@pub.dev',
         ),
         processJobsWithFakeRunners: true, fn: () async {
-      final data2 = await loadPackagePageData('pkg', '2.0.0', AssetKind.readme);
+      final data2 =
+          await loadPackagePageDataByName('pkg', '2.0.0', AssetKind.readme);
       final html2 = renderPkgShowPage(data2);
       expectGoldenFile(
           html2, 'pkg_show_page_retracted_non_retracted_version.html',
@@ -321,7 +331,7 @@ void main() {
       'package show page with publisher',
       fn: () async {
         final data =
-            await loadPackagePageData('neon', '1.0.0', AssetKind.readme);
+            await loadPackagePageDataByName('neon', '1.0.0', AssetKind.readme);
         final html = renderPkgShowPage(data);
         expectGoldenFile(html, 'pkg_show_page_publisher.html', timestamps: {
           'published': data.package.created,
@@ -345,8 +355,8 @@ void main() {
         await withFakeAuthRequestContext(
           adminAtPubDevEmail,
           () async {
-            final data =
-                await loadPackagePageData('oxygen', '1.2.0', AssetKind.readme);
+            final data = await loadPackagePageDataByName(
+                'oxygen', '1.2.0', AssetKind.readme);
             final html = renderPkgAdminPage(
               data,
               ['example.com'],
@@ -368,7 +378,7 @@ void main() {
       processJobsWithFakeRunners: true,
       fn: () async {
         await withFakeAuthRequestContext(adminAtPubDevEmail, () async {
-          final data = await loadPackagePageData('oxygen', '1.2.0', null);
+          final data = await loadPackagePageDataByName('oxygen', '1.2.0', null);
           final activities = await auditBackend.listRecordsForPackage('oxygen');
           expect(activities.records, isNotEmpty);
 
@@ -468,7 +478,7 @@ void main() {
       'package versions page',
       processJobsWithFakeRunners: true,
       fn: () async {
-        final data = await loadPackagePageData('oxygen', '1.2.0', null);
+        final data = await loadPackagePageDataByName('oxygen', '1.2.0', null);
         final rs = await issueGet('/packages/oxygen/versions');
         final html = await rs.readAsString();
         expectGoldenFile(html, 'pkg_versions_page.html', timestamps: {


### PR DESCRIPTION
- loads every entity only a single time
- awaits them concurrently instead of sequentially
- the loaded entities are passed-in into methods that may use them if the cache is empty

Note: current `/debug` endpoint suggests about `90th` percentile to be in the 90-110 ms range, `99th` percentile in the 200-300 ms range.