### PR TITLE
Use Set.from(tags) in search tags matching.

### DIFF
--- a/app/lib/search/mem_index.dart
+++ b/app/lib/search/mem_index.dart
@@ -162,8 +162,8 @@ class InMemoryPackageIndex {
     final combinedTagsPredicate =
         query.tagsPredicate.appendPredicate(query.parsedQuery.tagsPredicate);
     if (combinedTagsPredicate.isNotEmpty) {
-      packages.retainWhere(
-          (package) => combinedTagsPredicate.matches(_packages[package]!.tags));
+      packages.retainWhere((package) =>
+          combinedTagsPredicate.matches(_packages[package]!.tagsForLookup));
     }
 
     // filter on dependency

--- a/app/lib/search/search_service.dart
+++ b/app/lib/search/search_service.dart
@@ -113,6 +113,9 @@ class PackageDocument {
       _$PackageDocumentFromJson(json);
 
   Map<String, dynamic> toJson() => _$PackageDocumentToJson(this);
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  late final tagsForLookup = Set<String>.from(tags);
 }
 
 /// A reference to an API doc page

--- a/pkg/_pub_shared/lib/search/search_form.dart
+++ b/pkg/_pub_shared/lib/search/search_form.dart
@@ -137,7 +137,7 @@ class TagsPredicate {
 
   /// Evaluate this predicate against the list of supplied [tags].
   /// Returns true if the predicate matches the [tags], false otherwise.
-  bool matches(List<String> tags) {
+  bool matches(Iterable<String> tags) {
     for (final entry in _values.entries) {
       final tag = entry.key;
       final required = entry.value;


### PR DESCRIPTION
Improves the tag matching latency (overall latency gain on the slow-query benchmark is about 10%).