### PR TITLE
Sync InMemoryPackageIndex API + keeping only additions to the index, no more removals.

### DIFF
--- a/app/test/search/angular_test.dart
+++ b/app/test/search/angular_test.dart
@@ -16,17 +16,17 @@ void main() {
 
     setUpAll(() async {
       index = InMemoryPackageIndex();
-      await index.addPackage(PackageDocument(
+      index.addPackage(PackageDocument(
         package: 'angular',
         version: '4.0.0',
         description: compactDescription('Fast and productive web framework.'),
       ));
-      await index.addPackage(PackageDocument(
+      index.addPackage(PackageDocument(
         package: 'angular_ui',
         version: '0.6.5',
         description: compactDescription('Port of Angular-UI to Dart.'),
       ));
-      await index.markReady();
+      index.markReady();
     });
 
     test('angular', () async {

--- a/app/test/search/api_doc_page_test.dart
+++ b/app/test/search/api_doc_page_test.dart
@@ -16,7 +16,7 @@ void main() {
 
     setUpAll(() async {
       index = InMemoryPackageIndex();
-      await index.addPackage(PackageDocument(
+      index.addPackage(PackageDocument(
         package: 'foo',
         version: '1.0.0',
         description: compactDescription('Yet another web framework.'),
@@ -30,7 +30,7 @@ void main() {
           ),
         ],
       ));
-      await index.addPackage(PackageDocument(
+      index.addPackage(PackageDocument(
         package: 'other_with_api',
         version: '2.0.0',
         description: compactDescription('Unrelated package'),
@@ -39,12 +39,12 @@ void main() {
           ApiDocPage(relativePath: 'serve.html', symbols: ['serveWebPages']),
         ],
       ));
-      await index.addPackage(PackageDocument(
+      index.addPackage(PackageDocument(
         package: 'other_without_api',
         version: '2.0.0',
         description: compactDescription('Unrelated package'),
       ));
-      await index.markReady();
+      index.markReady();
     });
 
     test('foo', () async {

--- a/app/test/search/bluetooth_test.dart
+++ b/app/test/search/bluetooth_test.dart
@@ -16,18 +16,18 @@ void main() {
 
     setUpAll(() async {
       index = InMemoryPackageIndex();
-      await index.addPackage(PackageDocument(
+      index.addPackage(PackageDocument(
         package: 'flutter_blue',
         version: '0.2.3',
         description: compactDescription('Bluetooth plugin for Flutter.'),
       ));
-      await index.addPackage(PackageDocument(
+      index.addPackage(PackageDocument(
         package: 'smooth_scroll',
         version: '0.0.3',
         description: compactDescription(
             'A Dart library for smooth scroll effect on a web page.'),
       ));
-      await index.markReady();
+      index.markReady();
     });
 
     test('bluetooth', () async {

--- a/app/test/search/flutter_95_test.dart
+++ b/app/test/search/flutter_95_test.dart
@@ -16,14 +16,14 @@ void main() {
 
     setUpAll(() async {
       index = InMemoryPackageIndex();
-      await index.addPackage(PackageDocument(
+      index.addPackage(PackageDocument(
         package: 'flutter95',
         version: '0.0.7',
         description: compactDescription(
             'Windows95 UI components for Flutter apps. Bring back the nostalgic look and feel of old operating systems with this set of UI components ready to use.'),
       ));
-      await index.addPackage(PackageDocument(package: 'flutter_charts'));
-      await index.markReady();
+      index.addPackage(PackageDocument(package: 'flutter_charts'));
+      index.markReady();
     });
 
     test('flutter 95', () async {

--- a/app/test/search/flutter_iap_test.dart
+++ b/app/test/search/flutter_iap_test.dart
@@ -16,36 +16,36 @@ void main() {
 
     setUpAll(() async {
       index = InMemoryPackageIndex();
-      await index.addPackage(PackageDocument(
+      index.addPackage(PackageDocument(
         package: 'flutter_iap',
         version: '1.0.0',
         description: compactDescription('in app purchases for flutter'),
       ));
-      await index.addPackage(PackageDocument(
+      index.addPackage(PackageDocument(
         package: 'flutter_blue',
         version: '0.2.3',
         description: compactDescription('Bluetooth plugin for Flutter.'),
       ));
-      await index.addPackage(PackageDocument(
+      index.addPackage(PackageDocument(
         package: 'flutter_redux',
         version: '0.3.4',
         description: compactDescription(
             'A library that connects Widgets to a Redux Store.'),
       ));
-      await index.addPackage(PackageDocument(
+      index.addPackage(PackageDocument(
         package: 'flutter_web_view',
         version: '0.0.2',
         description: compactDescription(
             'A native WebView plugin for Flutter with Nav Bar support. Works with iOS and Android'),
       ));
-      await index.addPackage(PackageDocument(
+      index.addPackage(PackageDocument(
         package: 'flutter_3d_obj',
         version: '0.0.3',
         description: compactDescription(
             'A new flutter package to render wavefront obj files into a canvas.'),
       ));
 
-      await index.markReady();
+      index.markReady();
     });
 
     test('flutter iap', () async {

--- a/app/test/search/haversine_test.dart
+++ b/app/test/search/haversine_test.dart
@@ -16,7 +16,7 @@ void main() {
 
     setUpAll(() async {
       index = InMemoryPackageIndex();
-      await index.addPackages([
+      index.addPackages([
         PackageDocument(
           package: 'haversine',
           version: '0.0.2',
@@ -373,7 +373,7 @@ class MyBot implements Bot {
 MIT'''),
         ),
       ]);
-      await index.markReady();
+      index.markReady();
     });
 
     test('haversine', () async {

--- a/app/test/search/in_app_payments_test.dart
+++ b/app/test/search/in_app_payments_test.dart
@@ -16,14 +16,14 @@ void main() {
 
     setUpAll(() async {
       index = InMemoryPackageIndex();
-      await index.addPackage(PackageDocument(
+      index.addPackage(PackageDocument(
           package: 'flutter_iap',
           version: '1.0.1',
           description: compactDescription('in app purchases for flutter'),
           readme: compactReadme('''# flutter_iap
 
 Add _In-App Payments_ to your Flutter app with this plugin.''')));
-      await index.markReady();
+      index.markReady();
     });
 
     test('IAP', () async {

--- a/app/test/search/json_tool_test.dart
+++ b/app/test/search/json_tool_test.dart
@@ -15,10 +15,10 @@ void main() {
 
     setUpAll(() async {
       index = InMemoryPackageIndex();
-      await index.addPackage(PackageDocument(package: 'jsontool'));
-      await index.addPackage(PackageDocument(package: 'json2entity'));
-      await index.addPackage(PackageDocument(package: 'json_to_model'));
-      await index.markReady();
+      index.addPackage(PackageDocument(package: 'jsontool'));
+      index.addPackage(PackageDocument(package: 'json2entity'));
+      index.addPackage(PackageDocument(package: 'json_to_model'));
+      index.markReady();
     });
 
     test('json_tool', () async {
@@ -40,24 +40,24 @@ void main() {
 
     setUpAll(() async {
       index = InMemoryPackageIndex();
-      await index.addPackage(PackageDocument(
+      index.addPackage(PackageDocument(
         package: 'jsontool',
         description:
             'Low-level tools for working with JSON without creating intermediate objects.',
       ));
-      await index.addPackage(PackageDocument(
+      index.addPackage(PackageDocument(
         package: 'json2entity',
         description:
             'A tool for converting JSON strings into dart entity classes. Support json_serializable.',
       ));
-      await index.addPackage(PackageDocument(
+      index.addPackage(PackageDocument(
         package: 'json_to_model',
         description:
             'Gernerate model class from Json file. partly inspired by json_model.',
         readme:
             'Command line tool for generating Dart models (json_serializable) from Json file.',
       ));
-      await index.markReady();
+      index.markReady();
     });
 
     test('json_tool', () async {

--- a/app/test/search/lombok_test.dart
+++ b/app/test/search/lombok_test.dart
@@ -15,11 +15,11 @@ void main() {
 
     setUpAll(() async {
       index = InMemoryPackageIndex();
-      await index.addPackage(PackageDocument(
+      index.addPackage(PackageDocument(
         package: 'lombok',
         version: '1.0.0',
       ));
-      await index.markReady();
+      index.markReady();
     });
 
     test('lombock', () async {

--- a/app/test/search/maps_test.dart
+++ b/app/test/search/maps_test.dart
@@ -15,9 +15,9 @@ void main() {
 
     setUpAll(() async {
       index = InMemoryPackageIndex();
-      await index.addPackage(PackageDocument(package: 'maps'));
-      await index.addPackage(PackageDocument(package: 'map'));
-      await index.markReady();
+      index.addPackage(PackageDocument(package: 'maps'));
+      index.addPackage(PackageDocument(package: 'map'));
+      index.markReady();
     });
 
     test('maps', () async {

--- a/app/test/search/mem_index_test.dart
+++ b/app/test/search/mem_index_test.dart
@@ -87,8 +87,8 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
           maxPoints: 110,
         ),
       ];
-      await index.addPackages(docs);
-      await index.markReady();
+      index.addPackages(docs);
+      index.markReady();
       lastPackageUpdated =
           docs.map((p) => p.updated).reduce((a, b) => a!.isAfter(b!) ? a : b)!;
     });
@@ -569,10 +569,10 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
   group('special cases', () {
     test('short words: lookup for app(s)', () async {
       final index = InMemoryPackageIndex();
-      await index.addPackage(PackageDocument(
+      index.addPackage(PackageDocument(
         package: 'app',
       ));
-      await index.addPackage(PackageDocument(
+      index.addPackage(PackageDocument(
         package: 'apps',
       ));
       final match = index.search(
@@ -591,10 +591,10 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
 
     test('short words: lookup for app(z)', () async {
       final index = InMemoryPackageIndex();
-      await index.addPackage(PackageDocument(
+      index.addPackage(PackageDocument(
         package: 'app',
       ));
-      await index.addPackage(PackageDocument(
+      index.addPackage(PackageDocument(
         package: 'appz',
       ));
       final match = index.search(
@@ -614,7 +614,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
     group('exact name match', () {
       test('exact match vs description', () async {
         final index = InMemoryPackageIndex();
-        await index.addPackages([
+        index.addPackages([
           PackageDocument(
             package: 'abc',
             description: 'def xyz',
@@ -677,12 +677,12 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
   group('package name weight', () {
     test('modular', () async {
       final index = InMemoryPackageIndex(alwaysUpdateLikeScores: true);
-      await index.addPackage(PackageDocument(
+      index.addPackage(PackageDocument(
         package: 'serveme',
         description:
             'Backend server framework designed for a quick development of modular WebSocket based server applications with MongoDB integration.',
       ));
-      await index.addPackage(PackageDocument(
+      index.addPackage(PackageDocument(
         package: 'flutter_modular',
         description:
             'Smart project structure with dependency injection and route management',

--- a/app/test/search/rest_api_test.dart
+++ b/app/test/search/rest_api_test.dart
@@ -16,7 +16,7 @@ void main() {
 
     setUpAll(() async {
       index = InMemoryPackageIndex();
-      await index.addPackage(PackageDocument(
+      index.addPackage(PackageDocument(
         package: 'cloud_firestore',
         version: '0.7.2',
         description: compactDescription(
@@ -34,7 +34,7 @@ For Flutter plugins for other Firebase products, see [FlutterFire.md](https://gi
 
 Recent versions (0.3.x and 0.4.x) of this plugin require [extensible codec functionality](https://github.com/flutter/flutter/pull/15414) that is not yet released to the [beta channel](https://github.com/flutter/flutter/wiki/Flutter-build-release-channels) of Flutter. If you're encountering issues using those versions, consider switching to the dev channel.'''),
       ));
-      await index.addPackage(PackageDocument(
+      index.addPackage(PackageDocument(
         package: 'currency_cloud',
         version: '0.2.1',
         description: compactDescription(
@@ -44,7 +44,7 @@ Recent versions (0.3.x and 0.4.x) of this plugin require [extensible codec funct
             'Currency Cloud Dart API A dart library for the Currency Cloud '
             'service Usage A simple usage example'),
       ));
-      await index.markReady();
+      index.markReady();
     });
 
     test('REST API', () async {

--- a/app/test/search/result_combiner_test.dart
+++ b/app/test/search/result_combiner_test.dart
@@ -28,7 +28,7 @@ void main() {
     );
 
     setUpAll(() async {
-      await primaryIndex.addPackage(PackageDocument(
+      primaryIndex.addPackage(PackageDocument(
         package: 'stringutils',
         version: '1.0.0',
         description: 'many utils utils',
@@ -77,7 +77,7 @@ void main() {
         ]),
         version: '2.0.0',
       );
-      await primaryIndex.markReady();
+      primaryIndex.markReady();
     });
 
     test('non-text ranking', () async {

--- a/app/test/search/stack_trace_test.dart
+++ b/app/test/search/stack_trace_test.dart
@@ -16,7 +16,7 @@ void main() {
 
     setUpAll(() async {
       index = InMemoryPackageIndex();
-      await index.addPackages([
+      index.addPackages([
         PackageDocument(
           package: 'stack_trace',
           version: '1.9.3',
@@ -24,7 +24,7 @@ void main() {
               'A package for manipulating stack traces and printing them readably.'),
         ),
       ]);
-      await index.markReady();
+      index.markReady();
     });
 
     // should find full word

--- a/app/test/search/tags_test.dart
+++ b/app/test/search/tags_test.dart
@@ -13,8 +13,8 @@ void main() {
   group('ServiceSearchQuery.tags', () {
     test('No tags in documents: positive tag match', () async {
       final index = InMemoryPackageIndex();
-      await index.addPackage(PackageDocument(package: 'pkg1'));
-      await index.markReady();
+      index.addPackage(PackageDocument(package: 'pkg1'));
+      index.markReady();
 
       final rs = index.search(ServiceSearchQuery.parse(
         tagsPredicate: TagsPredicate(requiredTags: ['is:a']),
@@ -29,8 +29,8 @@ void main() {
 
     test('No tags in documents: negative tag match', () async {
       final index = InMemoryPackageIndex();
-      await index.addPackage(PackageDocument(package: 'pkg1'));
-      await index.markReady();
+      index.addPackage(PackageDocument(package: 'pkg1'));
+      index.markReady();
 
       final rs = index.search(ServiceSearchQuery.parse(
         tagsPredicate: TagsPredicate(prohibitedTags: ['is:a']),
@@ -47,9 +47,9 @@ void main() {
 
     test('One tag in documents: negative tag match', () async {
       final index = InMemoryPackageIndex();
-      await index.addPackage(PackageDocument(package: 'pkg1', tags: ['is:a']));
-      await index.addPackage(PackageDocument(package: 'pkg2', tags: ['is:b']));
-      await index.markReady();
+      index.addPackage(PackageDocument(package: 'pkg1', tags: ['is:a']));
+      index.addPackage(PackageDocument(package: 'pkg2', tags: ['is:b']));
+      index.markReady();
 
       final rs = index.search(ServiceSearchQuery.parse(
         tagsPredicate: TagsPredicate(prohibitedTags: ['is:a']),
@@ -66,9 +66,9 @@ void main() {
 
     test('One tag in documents: positive tag match', () async {
       final index = InMemoryPackageIndex();
-      await index.addPackage(PackageDocument(package: 'pkg1', tags: ['is:a']));
-      await index.addPackage(PackageDocument(package: 'pkg2', tags: ['is:b']));
-      await index.markReady();
+      index.addPackage(PackageDocument(package: 'pkg1', tags: ['is:a']));
+      index.addPackage(PackageDocument(package: 'pkg2', tags: ['is:b']));
+      index.markReady();
 
       final rs = index.search(ServiceSearchQuery.parse(
         tagsPredicate: TagsPredicate.parseQueryValues(['is:a']),
@@ -85,11 +85,11 @@ void main() {
 
     test('More tags in documents: multiple results', () async {
       final index = InMemoryPackageIndex();
-      await index.addPackage(
+      index.addPackage(
           PackageDocument(package: 'pkg1', tags: ['is:a', 'is:dart1']));
-      await index.addPackage(
+      index.addPackage(
           PackageDocument(package: 'pkg2', tags: ['is:b', 'is:dart1']));
-      await index.markReady();
+      index.markReady();
 
       final rs = index.search(ServiceSearchQuery.parse(
         tagsPredicate: TagsPredicate.parseQueryValues(['is:dart1']),
@@ -107,11 +107,11 @@ void main() {
 
     test('More tags in documents: multiple queried tags #1', () async {
       final index = InMemoryPackageIndex();
-      await index.addPackage(
+      index.addPackage(
           PackageDocument(package: 'pkg1', tags: ['is:a', 'is:dart1']));
-      await index.addPackage(
+      index.addPackage(
           PackageDocument(package: 'pkg2', tags: ['is:b', 'is:dart1']));
-      await index.markReady();
+      index.markReady();
 
       final rs = index.search(ServiceSearchQuery.parse(
         tagsPredicate: TagsPredicate.parseQueryValues(['is:dart1', 'is:b']),
@@ -128,11 +128,11 @@ void main() {
 
     test('More tags in documents: multiple queried tags #2', () async {
       final index = InMemoryPackageIndex();
-      await index.addPackage(
+      index.addPackage(
           PackageDocument(package: 'pkg1', tags: ['is:a', 'is:dart1']));
-      await index.addPackage(
+      index.addPackage(
           PackageDocument(package: 'pkg2', tags: ['is:b', 'is:dart1']));
-      await index.markReady();
+      index.markReady();
 
       final rs = index.search(ServiceSearchQuery.parse(
         tagsPredicate: TagsPredicate.parseQueryValues(['is:dart1', '-is:b']),
@@ -149,10 +149,10 @@ void main() {
 
     test('User-supplied queried tags #1', () async {
       final index = InMemoryPackageIndex();
-      await index
+      index
           .addPackage(PackageDocument(package: 'pkg1', tags: ['is:a', 'is:b']));
-      await index.addPackage(PackageDocument(package: 'pkg2', tags: ['is:b']));
-      await index.markReady();
+      index.addPackage(PackageDocument(package: 'pkg2', tags: ['is:b']));
+      index.markReady();
 
       final rs = index.search(ServiceSearchQuery.parse(query: 'is:b -is:a'));
       expect(json.decode(json.encode(rs.toJson())), {
@@ -167,10 +167,10 @@ void main() {
 
     test('User-supplied queried tags #2', () async {
       final index = InMemoryPackageIndex();
-      await index
+      index
           .addPackage(PackageDocument(package: 'pkg1', tags: ['is:a', 'is:b']));
-      await index.addPackage(PackageDocument(package: 'pkg2', tags: ['is:a']));
-      await index.markReady();
+      index.addPackage(PackageDocument(package: 'pkg2', tags: ['is:a']));
+      index.markReady();
 
       final rs = index.search(ServiceSearchQuery.parse(
           tagsPredicate: TagsPredicate(prohibitedTags: ['is:b']),

--- a/app/test/search/token_index_test.dart
+++ b/app/test/search/token_index_test.dart
@@ -75,8 +75,6 @@ void main() {
       expect(index.tokenCount, 1);
       index.add('url2', 'another');
       expect(index.tokenCount, 2);
-      index.remove('url2');
-      expect(index.tokenCount, 1);
     });
 
     test('Do not overweight partial matches', () {

--- a/app/test/search/travis_test.dart
+++ b/app/test/search/travis_test.dart
@@ -24,14 +24,14 @@ void main() {
         'w_transport',
         'sass_transformer',
       ];
-      await index.addPackage(PackageDocument(
+      index.addPackage(PackageDocument(
         package: 'travis',
         version: '0.0.1-dev',
         description: compactDescription(
             'A starting point for Dart libraries or applications.'),
       ));
       for (String packageName in packageNames) {
-        await index.addPackage(PackageDocument(
+        index.addPackage(PackageDocument(
           package: packageName,
           version: '1.0.0',
           description:
@@ -48,7 +48,7 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor i
 '''),
         ));
       }
-      await index.markReady();
+      index.markReady();
     });
 
     test('travis', () async {


### PR DESCRIPTION
- Because the index is built only at isolate startup time, we don't need async add methods.
- Because the index is not changing, we don't need remove methods (neither in the package index, nor in the token index), opening up ways to optimize it better.
- No more need to track text hashes in token index, we can drop that.