### PR TITLE
Refactor PackageLinks: moving contributingUrl and the decision whether to hide the documentationUrl

### DIFF
--- a/app/lib/frontend/templates/package.dart
+++ b/app/lib/frontend/templates/package.dart
@@ -31,10 +31,6 @@ d.Node renderPkgInfoBox(PackagePageData data) {
   final package = data.package;
   final packageLinks = data.packageLinks;
 
-  String? documentationUrl = packageLinks.documentationUrl;
-  if (urls.hideUserProvidedDocUrl(documentationUrl)) {
-    documentationUrl = null;
-  }
   final dartdocsUrl = urls.pkgDocUrl(
     package.name!,
     version: data.version.version,
@@ -83,9 +79,9 @@ d.Node renderPkgInfoBox(PackagePageData data) {
   addLink(packageLinks.repositoryUrl, 'Repository',
       detectServiceProvider: true);
   addLink(packageLinks.issueTrackerUrl, 'View/report issues');
-  addLink(data.contributingUrl, 'Contributing');
+  addLink(packageLinks.contributingUrl, 'Contributing');
 
-  addLink(documentationUrl, 'Documentation', documentation: true);
+  addLink(packageLinks.documentationUrl, 'Documentation', documentation: true);
   if (data.scoreCard.hasApiDocs) {
     addLink(dartdocsUrl, 'API reference', documentation: true);
   }
@@ -333,15 +329,13 @@ Tab? _changelogTab(PackagePageData data) {
 Tab? _exampleTab(PackagePageData data) {
   if (!data.hasExample) return null;
   if (data.asset?.kind != AssetKind.example) return null;
-  final baseUrl = data.repositoryBaseUrl;
 
   final exampleFilename = data.asset!.path;
   final renderedExample = renderFile(
     data.asset!,
     urlResolverFn: data.urlResolverFn,
   );
-  final url = urls.getRepositoryUrl(baseUrl, exampleFilename!);
-
+  final url = data.urlResolverFn?.call(exampleFilename!);
   return Tab.withContent(
     id: 'example',
     title: 'Example',
@@ -350,7 +344,7 @@ Tab? _exampleTab(PackagePageData data) {
         attributes: {'style': 'font-family: monospace'},
         child: d.b(
           child: url == null
-              ? d.text(exampleFilename)
+              ? d.text(exampleFilename!)
               : d.a(
                   href: url,
                   target: '_blank',

--- a/app/lib/package/models.dart
+++ b/app/lib/package/models.dart
@@ -1029,16 +1029,22 @@ class PackageLinks {
   /// inferred URL from [repositoryUrl].
   final String? issueTrackerUrl;
 
+  /// The link to `CONTRIBUTING.md` in the git repository (when the repository is verified).
+  final String? contributingUrl;
+
   /// The inferred base URL that can be used to link files from.
   final String? _baseUrl;
 
   PackageLinks._(
     this._baseUrl, {
     this.homepageUrl,
-    this.documentationUrl,
+    String? documentationUrl,
     this.repositoryUrl,
     this.issueTrackerUrl,
-  });
+    this.contributingUrl,
+  }) : documentationUrl = urls.hideUserProvidedDocUrl(documentationUrl)
+            ? null
+            : documentationUrl;
 
   factory PackageLinks.infer({
     String? homepageUrl,
@@ -1108,10 +1114,10 @@ class PackagePageData {
         repositoryUrl: result.repositoryUrl,
         issueTrackerUrl: result.issueTrackerUrl,
         documentationUrl: result.documentationUrl,
+        contributingUrl: result.contributingUrl,
       );
     }
     // Falling back to use URLs from pubspec.yaml.
-    // TODO: Remove this and return `null` after this release gets stable.
     final pubspec = version.pubspec!;
     return PackageLinks.infer(
       homepageUrl: pubspec.homepage,
@@ -1119,14 +1125,6 @@ class PackagePageData {
       repositoryUrl: pubspec.repository,
       issueTrackerUrl: pubspec.issueTracker,
     );
-  }();
-
-  late final contributingUrl = scoreCard.panaReport?.result?.contributingUrl;
-
-  /// The inferred base URL that can be used to link files from.
-  late final repositoryBaseUrl = () {
-    // TODO: use pana's verified repository instead
-    return packageLinks._baseUrl;
   }();
 
   /// The verified repository (or homepage).


### PR DESCRIPTION
- The `contributingUrl` has a more natural place inside the `PackageLinks` (if/when we want to cache them, we want to cache them together).
- The decision to potentially hide the documentation URL should be at the time we prepare the data and not at the time we render it.