### PR TITLE
Fix typo in deployment build script

### DIFF
--- a/tool/.deploy.yaml
+++ b/tool/.deploy.yaml
@@ -14,7 +14,7 @@ steps:
       - 'PROJECT_ID=$PROJECT_ID'
       - 'BRANCH_NAME=$BRANCH_NAME'
       - 'TAG_NAME=$TAG_NAME'
-    secretenv:
+    secretEnv:
       - 'CHAT_KEY'
       - 'CHAT_TOKEN'
 timeout: '5400s'


### PR DESCRIPTION
The syntax is documented here: https://cloud.google.com/build/docs/securing-builds/use-secrets