### PR TITLE
Refactor InMemorySearchIndex initialization.

### DIFF
--- a/app/test/search/angular_test.dart
+++ b/app/test/search/angular_test.dart
@@ -15,18 +15,18 @@ void main() {
     late InMemoryPackageIndex index;
 
     setUpAll(() async {
-      index = InMemoryPackageIndex();
-      index.addPackage(PackageDocument(
-        package: 'angular',
-        version: '4.0.0',
-        description: compactDescription('Fast and productive web framework.'),
-      ));
-      index.addPackage(PackageDocument(
-        package: 'angular_ui',
-        version: '0.6.5',
-        description: compactDescription('Port of Angular-UI to Dart.'),
-      ));
-      index.markReady();
+      index = InMemoryPackageIndex(documents: [
+        PackageDocument(
+          package: 'angular',
+          version: '4.0.0',
+          description: compactDescription('Fast and productive web framework.'),
+        ),
+        PackageDocument(
+          package: 'angular_ui',
+          version: '0.6.5',
+          description: compactDescription('Port of Angular-UI to Dart.'),
+        ),
+      ]);
     });
 
     test('angular', () async {

--- a/app/test/search/api_doc_page_test.dart
+++ b/app/test/search/api_doc_page_test.dart
@@ -15,36 +15,36 @@ void main() {
     late InMemoryPackageIndex index;
 
     setUpAll(() async {
-      index = InMemoryPackageIndex();
-      index.addPackage(PackageDocument(
-        package: 'foo',
-        version: '1.0.0',
-        description: compactDescription('Yet another web framework.'),
-        apiDocPages: [
-          ApiDocPage(
-            relativePath: 'generator.html',
-            symbols: [
-              'generateWebPage',
-              'WebPageGenerator',
-            ],
-          ),
-        ],
-      ));
-      index.addPackage(PackageDocument(
-        package: 'other_with_api',
-        version: '2.0.0',
-        description: compactDescription('Unrelated package'),
-        apiDocPages: [
-          ApiDocPage(relativePath: 'main.html', symbols: ['foo']),
-          ApiDocPage(relativePath: 'serve.html', symbols: ['serveWebPages']),
-        ],
-      ));
-      index.addPackage(PackageDocument(
-        package: 'other_without_api',
-        version: '2.0.0',
-        description: compactDescription('Unrelated package'),
-      ));
-      index.markReady();
+      index = InMemoryPackageIndex(documents: [
+        PackageDocument(
+          package: 'foo',
+          version: '1.0.0',
+          description: compactDescription('Yet another web framework.'),
+          apiDocPages: [
+            ApiDocPage(
+              relativePath: 'generator.html',
+              symbols: [
+                'generateWebPage',
+                'WebPageGenerator',
+              ],
+            ),
+          ],
+        ),
+        PackageDocument(
+          package: 'other_with_api',
+          version: '2.0.0',
+          description: compactDescription('Unrelated package'),
+          apiDocPages: [
+            ApiDocPage(relativePath: 'main.html', symbols: ['foo']),
+            ApiDocPage(relativePath: 'serve.html', symbols: ['serveWebPages']),
+          ],
+        ),
+        PackageDocument(
+          package: 'other_without_api',
+          version: '2.0.0',
+          description: compactDescription('Unrelated package'),
+        ),
+      ]);
     });
 
     test('foo', () async {

--- a/app/test/search/bluetooth_test.dart
+++ b/app/test/search/bluetooth_test.dart
@@ -15,19 +15,19 @@ void main() {
     late InMemoryPackageIndex index;
 
     setUpAll(() async {
-      index = InMemoryPackageIndex();
-      index.addPackage(PackageDocument(
-        package: 'flutter_blue',
-        version: '0.2.3',
-        description: compactDescription('Bluetooth plugin for Flutter.'),
-      ));
-      index.addPackage(PackageDocument(
-        package: 'smooth_scroll',
-        version: '0.0.3',
-        description: compactDescription(
-            'A Dart library for smooth scroll effect on a web page.'),
-      ));
-      index.markReady();
+      index = InMemoryPackageIndex(documents: [
+        PackageDocument(
+          package: 'flutter_blue',
+          version: '0.2.3',
+          description: compactDescription('Bluetooth plugin for Flutter.'),
+        ),
+        PackageDocument(
+          package: 'smooth_scroll',
+          version: '0.0.3',
+          description: compactDescription(
+              'A Dart library for smooth scroll effect on a web page.'),
+        ),
+      ]);
     });
 
     test('bluetooth', () async {

--- a/app/test/search/flutter_95_test.dart
+++ b/app/test/search/flutter_95_test.dart
@@ -15,15 +15,15 @@ void main() {
     late InMemoryPackageIndex index;
 
     setUpAll(() async {
-      index = InMemoryPackageIndex();
-      index.addPackage(PackageDocument(
-        package: 'flutter95',
-        version: '0.0.7',
-        description: compactDescription(
-            'Windows95 UI components for Flutter apps. Bring back the nostalgic look and feel of old operating systems with this set of UI components ready to use.'),
-      ));
-      index.addPackage(PackageDocument(package: 'flutter_charts'));
-      index.markReady();
+      index = InMemoryPackageIndex(documents: [
+        PackageDocument(
+          package: 'flutter95',
+          version: '0.0.7',
+          description: compactDescription(
+              'Windows95 UI components for Flutter apps. Bring back the nostalgic look and feel of old operating systems with this set of UI components ready to use.'),
+        ),
+        PackageDocument(package: 'flutter_charts'),
+      ]);
     });
 
     test('flutter 95', () async {

--- a/app/test/search/flutter_iap_test.dart
+++ b/app/test/search/flutter_iap_test.dart
@@ -15,37 +15,36 @@ void main() {
     late InMemoryPackageIndex index;
 
     setUpAll(() async {
-      index = InMemoryPackageIndex();
-      index.addPackage(PackageDocument(
-        package: 'flutter_iap',
-        version: '1.0.0',
-        description: compactDescription('in app purchases for flutter'),
-      ));
-      index.addPackage(PackageDocument(
-        package: 'flutter_blue',
-        version: '0.2.3',
-        description: compactDescription('Bluetooth plugin for Flutter.'),
-      ));
-      index.addPackage(PackageDocument(
-        package: 'flutter_redux',
-        version: '0.3.4',
-        description: compactDescription(
-            'A library that connects Widgets to a Redux Store.'),
-      ));
-      index.addPackage(PackageDocument(
-        package: 'flutter_web_view',
-        version: '0.0.2',
-        description: compactDescription(
-            'A native WebView plugin for Flutter with Nav Bar support. Works with iOS and Android'),
-      ));
-      index.addPackage(PackageDocument(
-        package: 'flutter_3d_obj',
-        version: '0.0.3',
-        description: compactDescription(
-            'A new flutter package to render wavefront obj files into a canvas.'),
-      ));
-
-      index.markReady();
+      index = InMemoryPackageIndex(documents: [
+        PackageDocument(
+          package: 'flutter_iap',
+          version: '1.0.0',
+          description: compactDescription('in app purchases for flutter'),
+        ),
+        PackageDocument(
+          package: 'flutter_blue',
+          version: '0.2.3',
+          description: compactDescription('Bluetooth plugin for Flutter.'),
+        ),
+        PackageDocument(
+          package: 'flutter_redux',
+          version: '0.3.4',
+          description: compactDescription(
+              'A library that connects Widgets to a Redux Store.'),
+        ),
+        PackageDocument(
+          package: 'flutter_web_view',
+          version: '0.0.2',
+          description: compactDescription(
+              'A native WebView plugin for Flutter with Nav Bar support. Works with iOS and Android'),
+        ),
+        PackageDocument(
+          package: 'flutter_3d_obj',
+          version: '0.0.3',
+          description: compactDescription(
+              'A new flutter package to render wavefront obj files into a canvas.'),
+        ),
+      ]);
     });
 
     test('flutter iap', () async {

--- a/app/test/search/haversine_test.dart
+++ b/app/test/search/haversine_test.dart
@@ -15,8 +15,7 @@ void main() {
     late InMemoryPackageIndex index;
 
     setUpAll(() async {
-      index = InMemoryPackageIndex();
-      index.addPackages([
+      index = InMemoryPackageIndex(documents: [
         PackageDocument(
           package: 'haversine',
           version: '0.0.2',
@@ -373,7 +372,6 @@ class MyBot implements Bot {
 MIT'''),
         ),
       ]);
-      index.markReady();
     });
 
     test('haversine', () async {

--- a/app/test/search/in_app_payments_test.dart
+++ b/app/test/search/in_app_payments_test.dart
@@ -15,15 +15,15 @@ void main() {
     late InMemoryPackageIndex index;
 
     setUpAll(() async {
-      index = InMemoryPackageIndex();
-      index.addPackage(PackageDocument(
-          package: 'flutter_iap',
-          version: '1.0.1',
-          description: compactDescription('in app purchases for flutter'),
-          readme: compactReadme('''# flutter_iap
+      index = InMemoryPackageIndex(documents: [
+        PackageDocument(
+            package: 'flutter_iap',
+            version: '1.0.1',
+            description: compactDescription('in app purchases for flutter'),
+            readme: compactReadme('''# flutter_iap
 
-Add _In-App Payments_ to your Flutter app with this plugin.''')));
-      index.markReady();
+Add _In-App Payments_ to your Flutter app with this plugin.''')),
+      ]);
     });
 
     test('IAP', () async {

--- a/app/test/search/json_tool_test.dart
+++ b/app/test/search/json_tool_test.dart
@@ -14,11 +14,11 @@ void main() {
     late InMemoryPackageIndex index;
 
     setUpAll(() async {
-      index = InMemoryPackageIndex();
-      index.addPackage(PackageDocument(package: 'jsontool'));
-      index.addPackage(PackageDocument(package: 'json2entity'));
-      index.addPackage(PackageDocument(package: 'json_to_model'));
-      index.markReady();
+      index = InMemoryPackageIndex(documents: [
+        PackageDocument(package: 'jsontool'),
+        PackageDocument(package: 'json2entity'),
+        PackageDocument(package: 'json_to_model'),
+      ]);
     });
 
     test('json_tool', () async {
@@ -39,25 +39,25 @@ void main() {
     late InMemoryPackageIndex index;
 
     setUpAll(() async {
-      index = InMemoryPackageIndex();
-      index.addPackage(PackageDocument(
-        package: 'jsontool',
-        description:
-            'Low-level tools for working with JSON without creating intermediate objects.',
-      ));
-      index.addPackage(PackageDocument(
-        package: 'json2entity',
-        description:
-            'A tool for converting JSON strings into dart entity classes. Support json_serializable.',
-      ));
-      index.addPackage(PackageDocument(
-        package: 'json_to_model',
-        description:
-            'Gernerate model class from Json file. partly inspired by json_model.',
-        readme:
-            'Command line tool for generating Dart models (json_serializable) from Json file.',
-      ));
-      index.markReady();
+      index = InMemoryPackageIndex(documents: [
+        PackageDocument(
+          package: 'jsontool',
+          description:
+              'Low-level tools for working with JSON without creating intermediate objects.',
+        ),
+        PackageDocument(
+          package: 'json2entity',
+          description:
+              'A tool for converting JSON strings into dart entity classes. Support json_serializable.',
+        ),
+        PackageDocument(
+          package: 'json_to_model',
+          description:
+              'Gernerate model class from Json file. partly inspired by json_model.',
+          readme:
+              'Command line tool for generating Dart models (json_serializable) from Json file.',
+        ),
+      ]);
     });
 
     test('json_tool', () async {

--- a/app/test/search/lombok_test.dart
+++ b/app/test/search/lombok_test.dart
@@ -14,12 +14,12 @@ void main() {
     late InMemoryPackageIndex index;
 
     setUpAll(() async {
-      index = InMemoryPackageIndex();
-      index.addPackage(PackageDocument(
-        package: 'lombok',
-        version: '1.0.0',
-      ));
-      index.markReady();
+      index = InMemoryPackageIndex(documents: [
+        PackageDocument(
+          package: 'lombok',
+          version: '1.0.0',
+        ),
+      ]);
     });
 
     test('lombock', () async {

--- a/app/test/search/maps_test.dart
+++ b/app/test/search/maps_test.dart
@@ -14,10 +14,10 @@ void main() {
     late InMemoryPackageIndex index;
 
     setUpAll(() async {
-      index = InMemoryPackageIndex();
-      index.addPackage(PackageDocument(package: 'maps'));
-      index.addPackage(PackageDocument(package: 'map'));
-      index.markReady();
+      index = InMemoryPackageIndex(documents: [
+        PackageDocument(package: 'maps'),
+        PackageDocument(package: 'map'),
+      ]);
     });
 
     test('maps', () async {

--- a/app/test/search/rest_api_test.dart
+++ b/app/test/search/rest_api_test.dart
@@ -15,14 +15,14 @@ void main() {
     late InMemoryPackageIndex index;
 
     setUpAll(() async {
-      index = InMemoryPackageIndex();
-      index.addPackage(PackageDocument(
-        package: 'cloud_firestore',
-        version: '0.7.2',
-        description: compactDescription(
-            'Flutter plugin for Cloud Firestore, a cloud-hosted, noSQL database '
-            'with live synchronization and offline support on Android and iOS.'),
-        readme: compactReadme('''# Cloud Firestore Plugin for Flutter
+      index = InMemoryPackageIndex(documents: [
+        PackageDocument(
+          package: 'cloud_firestore',
+          version: '0.7.2',
+          description: compactDescription(
+              'Flutter plugin for Cloud Firestore, a cloud-hosted, noSQL database '
+              'with live synchronization and offline support on Android and iOS.'),
+          readme: compactReadme('''# Cloud Firestore Plugin for Flutter
 
 A Flutter plugin to use the [Cloud Firestore API](https://firebase.google.com/docs/firestore/).
 
@@ -33,18 +33,18 @@ For Flutter plugins for other Firebase products, see [FlutterFire.md](https://gi
 *Note*: This plugin is still under development, and some APIs might not be available yet. [Feedback](https://github.com/flutter/flutter/issues) and [Pull Requests](https://github.com/flutter/plugins/pulls) are most welcome!
 
 Recent versions (0.3.x and 0.4.x) of this plugin require [extensible codec functionality](https://github.com/flutter/flutter/pull/15414) that is not yet released to the [beta channel](https://github.com/flutter/flutter/wiki/Flutter-build-release-channels) of Flutter. If you're encountering issues using those versions, consider switching to the dev channel.'''),
-      ));
-      index.addPackage(PackageDocument(
-        package: 'currency_cloud',
-        version: '0.2.1',
-        description: compactDescription(
-            'A dart library for the Currency Cloud service. It operates as a '
-            'wrapper for the Currency Cloud REST API.'),
-        readme: compactReadme(
-            'Currency Cloud Dart API A dart library for the Currency Cloud '
-            'service Usage A simple usage example'),
-      ));
-      index.markReady();
+        ),
+        PackageDocument(
+          package: 'currency_cloud',
+          version: '0.2.1',
+          description: compactDescription(
+              'A dart library for the Currency Cloud service. It operates as a '
+              'wrapper for the Currency Cloud REST API.'),
+          readme: compactReadme(
+              'Currency Cloud Dart API A dart library for the Currency Cloud '
+              'service Usage A simple usage example'),
+        ),
+      ]);
     });
 
     test('REST API', () async {

--- a/app/test/search/result_combiner_test.dart
+++ b/app/test/search/result_combiner_test.dart
@@ -18,6 +18,16 @@ void main() {
     final primaryIndex = InMemoryPackageIndex(
       popularityValueFn: (p) =>
           const <String, double>{'stringutils': 0.4}[p] ?? 0.0,
+      documents: [
+        PackageDocument(
+          package: 'stringutils',
+          version: '1.0.0',
+          description: 'many utils utils',
+          readme: 'Many useful string methods like substring.',
+          grantedPoints: 110,
+          maxPoints: 110,
+        ),
+      ],
     );
     final dartSdkMemIndex = DartSdkMemIndex();
     final flutterSdkMemIndex = FlutterSdkMemIndex();
@@ -28,14 +38,6 @@ void main() {
     );
 
     setUpAll(() async {
-      primaryIndex.addPackage(PackageDocument(
-        package: 'stringutils',
-        version: '1.0.0',
-        description: 'many utils utils',
-        readme: 'Many useful string methods like substring.',
-        grantedPoints: 110,
-        maxPoints: 110,
-      ));
       dartSdkMemIndex.setDartdocIndex(
         DartdocIndex.fromJsonList([
           {
@@ -77,7 +79,6 @@ void main() {
         ]),
         version: '2.0.0',
       );
-      primaryIndex.markReady();
     });
 
     test('non-text ranking', () async {

--- a/app/test/search/result_combiner_test.dart
+++ b/app/test/search/result_combiner_test.dart
@@ -102,7 +102,7 @@ void main() {
         'totalCount': 1,
         'sdkLibraryHits': [],
         'packageHits': [
-          {'package': 'stringutils', 'score': closeTo(0.76, 0.01)},
+          {'package': 'stringutils', 'score': closeTo(0.91, 0.01)},
         ],
       });
     });
@@ -131,7 +131,7 @@ void main() {
           },
         ],
         'packageHits': [
-          {'package': 'stringutils', 'score': closeTo(0.56, 0.01)}
+          {'package': 'stringutils', 'score': closeTo(0.67, 0.01)}
         ],
       });
     });

--- a/app/test/search/stack_trace_test.dart
+++ b/app/test/search/stack_trace_test.dart
@@ -15,8 +15,7 @@ void main() {
     late InMemoryPackageIndex index;
 
     setUpAll(() async {
-      index = InMemoryPackageIndex();
-      index.addPackages([
+      index = InMemoryPackageIndex(documents: [
         PackageDocument(
           package: 'stack_trace',
           version: '1.9.3',
@@ -24,7 +23,6 @@ void main() {
               'A package for manipulating stack traces and printing them readably.'),
         ),
       ]);
-      index.markReady();
     });
 
     // should find full word

--- a/app/test/search/tags_test.dart
+++ b/app/test/search/tags_test.dart
@@ -12,9 +12,9 @@ import 'package:test/test.dart';
 void main() {
   group('ServiceSearchQuery.tags', () {
     test('No tags in documents: positive tag match', () async {
-      final index = InMemoryPackageIndex();
-      index.addPackage(PackageDocument(package: 'pkg1'));
-      index.markReady();
+      final index = InMemoryPackageIndex(documents: [
+        PackageDocument(package: 'pkg1'),
+      ]);
 
       final rs = index.search(ServiceSearchQuery.parse(
         tagsPredicate: TagsPredicate(requiredTags: ['is:a']),
@@ -28,9 +28,9 @@ void main() {
     });
 
     test('No tags in documents: negative tag match', () async {
-      final index = InMemoryPackageIndex();
-      index.addPackage(PackageDocument(package: 'pkg1'));
-      index.markReady();
+      final index = InMemoryPackageIndex(documents: [
+        PackageDocument(package: 'pkg1'),
+      ]);
 
       final rs = index.search(ServiceSearchQuery.parse(
         tagsPredicate: TagsPredicate(prohibitedTags: ['is:a']),
@@ -46,10 +46,10 @@ void main() {
     });
 
     test('One tag in documents: negative tag match', () async {
-      final index = InMemoryPackageIndex();
-      index.addPackage(PackageDocument(package: 'pkg1', tags: ['is:a']));
-      index.addPackage(PackageDocument(package: 'pkg2', tags: ['is:b']));
-      index.markReady();
+      final index = InMemoryPackageIndex(documents: [
+        PackageDocument(package: 'pkg1', tags: ['is:a']),
+        PackageDocument(package: 'pkg2', tags: ['is:b']),
+      ]);
 
       final rs = index.search(ServiceSearchQuery.parse(
         tagsPredicate: TagsPredicate(prohibitedTags: ['is:a']),
@@ -65,10 +65,10 @@ void main() {
     });
 
     test('One tag in documents: positive tag match', () async {
-      final index = InMemoryPackageIndex();
-      index.addPackage(PackageDocument(package: 'pkg1', tags: ['is:a']));
-      index.addPackage(PackageDocument(package: 'pkg2', tags: ['is:b']));
-      index.markReady();
+      final index = InMemoryPackageIndex(documents: [
+        PackageDocument(package: 'pkg1', tags: ['is:a']),
+        PackageDocument(package: 'pkg2', tags: ['is:b']),
+      ]);
 
       final rs = index.search(ServiceSearchQuery.parse(
         tagsPredicate: TagsPredicate.parseQueryValues(['is:a']),
@@ -84,12 +84,10 @@ void main() {
     });
 
     test('More tags in documents: multiple results', () async {
-      final index = InMemoryPackageIndex();
-      index.addPackage(
-          PackageDocument(package: 'pkg1', tags: ['is:a', 'is:dart1']));
-      index.addPackage(
-          PackageDocument(package: 'pkg2', tags: ['is:b', 'is:dart1']));
-      index.markReady();
+      final index = InMemoryPackageIndex(documents: [
+        PackageDocument(package: 'pkg1', tags: ['is:a', 'is:dart1']),
+        PackageDocument(package: 'pkg2', tags: ['is:b', 'is:dart1']),
+      ]);
 
       final rs = index.search(ServiceSearchQuery.parse(
         tagsPredicate: TagsPredicate.parseQueryValues(['is:dart1']),
@@ -106,12 +104,10 @@ void main() {
     });
 
     test('More tags in documents: multiple queried tags #1', () async {
-      final index = InMemoryPackageIndex();
-      index.addPackage(
-          PackageDocument(package: 'pkg1', tags: ['is:a', 'is:dart1']));
-      index.addPackage(
-          PackageDocument(package: 'pkg2', tags: ['is:b', 'is:dart1']));
-      index.markReady();
+      final index = InMemoryPackageIndex(documents: [
+        PackageDocument(package: 'pkg1', tags: ['is:a', 'is:dart1']),
+        PackageDocument(package: 'pkg2', tags: ['is:b', 'is:dart1']),
+      ]);
 
       final rs = index.search(ServiceSearchQuery.parse(
         tagsPredicate: TagsPredicate.parseQueryValues(['is:dart1', 'is:b']),
@@ -127,12 +123,10 @@ void main() {
     });
 
     test('More tags in documents: multiple queried tags #2', () async {
-      final index = InMemoryPackageIndex();
-      index.addPackage(
-          PackageDocument(package: 'pkg1', tags: ['is:a', 'is:dart1']));
-      index.addPackage(
-          PackageDocument(package: 'pkg2', tags: ['is:b', 'is:dart1']));
-      index.markReady();
+      final index = InMemoryPackageIndex(documents: [
+        PackageDocument(package: 'pkg1', tags: ['is:a', 'is:dart1']),
+        PackageDocument(package: 'pkg2', tags: ['is:b', 'is:dart1']),
+      ]);
 
       final rs = index.search(ServiceSearchQuery.parse(
         tagsPredicate: TagsPredicate.parseQueryValues(['is:dart1', '-is:b']),
@@ -148,11 +142,10 @@ void main() {
     });
 
     test('User-supplied queried tags #1', () async {
-      final index = InMemoryPackageIndex();
-      index
-          .addPackage(PackageDocument(package: 'pkg1', tags: ['is:a', 'is:b']));
-      index.addPackage(PackageDocument(package: 'pkg2', tags: ['is:b']));
-      index.markReady();
+      final index = InMemoryPackageIndex(documents: [
+        PackageDocument(package: 'pkg1', tags: ['is:a', 'is:b']),
+        PackageDocument(package: 'pkg2', tags: ['is:b']),
+      ]);
 
       final rs = index.search(ServiceSearchQuery.parse(query: 'is:b -is:a'));
       expect(json.decode(json.encode(rs.toJson())), {
@@ -166,11 +159,10 @@ void main() {
     });
 
     test('User-supplied queried tags #2', () async {
-      final index = InMemoryPackageIndex();
-      index
-          .addPackage(PackageDocument(package: 'pkg1', tags: ['is:a', 'is:b']));
-      index.addPackage(PackageDocument(package: 'pkg2', tags: ['is:a']));
-      index.markReady();
+      final index = InMemoryPackageIndex(documents: [
+        PackageDocument(package: 'pkg1', tags: ['is:a', 'is:b']),
+        PackageDocument(package: 'pkg2', tags: ['is:a']),
+      ]);
 
       final rs = index.search(ServiceSearchQuery.parse(
           tagsPredicate: TagsPredicate(prohibitedTags: ['is:b']),

--- a/app/test/search/travis_test.dart
+++ b/app/test/search/travis_test.dart
@@ -15,7 +15,6 @@ void main() {
     late InMemoryPackageIndex index;
 
     setUpAll(() async {
-      index = InMemoryPackageIndex();
       final packageNames = [
         'rainbow_vis',
         'mongo_dart_query',
@@ -24,19 +23,19 @@ void main() {
         'w_transport',
         'sass_transformer',
       ];
-      index.addPackage(PackageDocument(
-        package: 'travis',
-        version: '0.0.1-dev',
-        description: compactDescription(
-            'A starting point for Dart libraries or applications.'),
-      ));
-      for (String packageName in packageNames) {
-        index.addPackage(PackageDocument(
-          package: packageName,
-          version: '1.0.0',
-          description:
-              compactDescription('$packageName a package for $packageName'),
-          readme: compactReadme('''
+      index = InMemoryPackageIndex(documents: [
+        PackageDocument(
+          package: 'travis',
+          version: '0.0.1-dev',
+          description: compactDescription(
+              'A starting point for Dart libraries or applications.'),
+        ),
+        ...packageNames.map((packageName) => PackageDocument(
+              package: packageName,
+              version: '1.0.0',
+              description:
+                  compactDescription('$packageName a package for $packageName'),
+              readme: compactReadme('''
 # $packageName
 
 [![Pub](https://img.shields.io/pub/v/$packageName.svg?maxAge=2592000?style=flat-square)](https://pub.dartlang.org/packages/$packageName)
@@ -46,9 +45,8 @@ void main() {
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
 '''),
-        ));
-      }
-      index.markReady();
+            )),
+      ]);
     });
 
     test('travis', () async {


### PR DESCRIPTION
- Removes the need to call `markReady`.
- Folds most use of `addPackage(s)` methods into the constructor, in preparation to refactor the index to use a single-step initialization.