### PR TITLE
Use gcloud to obtain secrets for chat-from-build

### DIFF
--- a/tool/.deploy.sh
+++ b/tool/.deploy.sh
@@ -12,7 +12,7 @@ message() {
     CHAT_KEY=`gcloud --project=dartlang-pub secrets versions access latest --secret=google-chat-pub-dev-hackers-key`
     CHAT_TOKEN=`gcloud --project=dartlang-pub secrets versions access latest --secret=google-chat-pub-dev-hackers-token`
     CHAT_ID="AAAAkQUOtE8"
-    THREAD_KEY=$TAG_NAME
+    THREAD_KEY="$TAG_NAME"
     curl -H 'Content-Type: application/json' -X POST "https://chat.googleapis.com/v1/spaces/$CHAT_ID/messages?key=$CHAT_KEY&token=$CHAT_TOKEN&threadKey=$THREAD_KEY" --data "{\"text\": \"$1\"}"
   fi
 }

--- a/tool/.deploy.sh
+++ b/tool/.deploy.sh
@@ -8,9 +8,13 @@ set -e
 # Echos The message and sends it to team chat
 message() {
   echo "$1"
-  CHAT_ID="AAAAkQUOtE8"
-  THREAD_KEY=$TAG_NAME
-  curl -H 'Content-Type: application/json' -X POST "https://chat.googleapis.com/v1/spaces/$CHAT_ID/messages?key=$CHAT_KEY\&token=$CHAT_TOKEN\&threadKey=$THREAD_KEY" --data "{\"text\": \"$1\"}"
+  if [ "$PROJECT_ID" = 'dartlang-pub' ]; then
+    CHAT_KEY=`gcloud --project=dartlang-pub secrets versions access latest --secret=google-chat-pub-dev-hackers-key`
+    CHAT_TOKEN=`gcloud --project=dartlang-pub secrets versions access latest --secret=google-chat-pub-dev-hackers-token`
+    CHAT_ID="AAAAkQUOtE8"
+    THREAD_KEY=$TAG_NAME
+    curl -H 'Content-Type: application/json' -X POST "https://chat.googleapis.com/v1/spaces/$CHAT_ID/messages?key=$CHAT_KEY&token=$CHAT_TOKEN&threadKey=$THREAD_KEY" --data "{\"text\": \"$1\"}"
+  fi
 }
 
 # Print an error message, if exiting non-zero

--- a/tool/.deploy.yaml
+++ b/tool/.deploy.yaml
@@ -14,13 +14,4 @@ steps:
       - 'PROJECT_ID=$PROJECT_ID'
       - 'BRANCH_NAME=$BRANCH_NAME'
       - 'TAG_NAME=$TAG_NAME'
-    secretEnv:
-      - 'CHAT_KEY'
-      - 'CHAT_TOKEN'
 timeout: '5400s'
-availableSecrets:
-  secretManager:
-  - versionName: projects/$PROJECT_ID/secrets/google-chat-pub-dev-hackers-key/versions/latest
-    env: 'CHAT_KEY'
-  - versionName: projects/$PROJECT_ID/secrets/google-chat-pub-dev-hackers-token/versions/latest
-    env: 'CHAT_TOKEN'


### PR DESCRIPTION
That should be more flexible than the `secrets-environment`.

Also don't attempt to chat when building for staging.

Also fix syntax in the curl invocation.