### PR TITLE
Use only popularity from search snapshot when serving search queries.

### DIFF
--- a/app/lib/service/services.dart
+++ b/app/lib/service/services.dart
@@ -238,9 +238,7 @@ Future<R> _withPubServices<R>(FutureOr<R> Function() fn) async {
     registerFlutterSdkMemIndex(FlutterSdkMemIndex());
     registerLikeBackend(LikeBackend(dbService));
     registerNameTracker(NameTracker(dbService));
-    final inMemoryPackageIndex = InMemoryPackageIndex(
-      popularityValueFn: (p) => popularityStorage.lookup(p),
-    );
+    final inMemoryPackageIndex = InMemoryPackageIndex();
     registerInMemoryPackageIndex(inMemoryPackageIndex);
     registerIndexUpdater(IndexUpdater(dbService, inMemoryPackageIndex));
     registerPopularityStorage(

--- a/app/test/search/mem_index_test.dart
+++ b/app/test/search/mem_index_test.dart
@@ -34,6 +34,7 @@ void main() {
             'runtime:web'
           ],
           likeCount: 10,
+          popularityScore: 0.7,
           grantedPoints: 110,
           maxPoints: 110,
           dependencies: {'async': 'direct', 'test': 'dev', 'foo': 'transitive'},
@@ -62,6 +63,7 @@ The delegating wrapper classes allow users to easily add functionality on top of
           grantedPoints: 10,
           maxPoints: 110,
           dependencies: {'test': 'dev'},
+          popularityScore: 0.8,
         ),
         PackageDocument(
           package: 'chrome_net',
@@ -80,15 +82,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
       ];
       lastPackageUpdated =
           docs.map((p) => p.updated).reduce((a, b) => a!.isAfter(b!) ? a : b)!;
-      index = InMemoryPackageIndex(
-        popularityValueFn: (p) =>
-            const <String, double>{
-              'http': 0.7,
-              'async': 0.8,
-            }[p] ??
-            0.0,
-        documents: docs,
-      );
+      index = InMemoryPackageIndex(documents: docs);
     });
 
     test('popularity scores', () {

--- a/app/test/search/result_combiner_test.dart
+++ b/app/test/search/result_combiner_test.dart
@@ -16,8 +16,6 @@ import 'package:test/test.dart';
 void main() {
   group('ResultCombiner', () {
     final primaryIndex = InMemoryPackageIndex(
-      popularityValueFn: (p) =>
-          const <String, double>{'stringutils': 0.4}[p] ?? 0.0,
       documents: [
         PackageDocument(
           package: 'stringutils',
@@ -26,6 +24,7 @@ void main() {
           readme: 'Many useful string methods like substring.',
           grantedPoints: 110,
           maxPoints: 110,
+          popularityScore: 0.4,
         ),
       ],
     );


### PR DESCRIPTION
As we have started populating the `PackageDocument` fields in the previous runtime version, it is safe to only use them, and remove the fallback.