### PR TITLE
Immutable InMemoryPackageIndex

### DIFF
--- a/app/lib/search/updater.dart
+++ b/app/lib/search/updater.dart
@@ -26,9 +26,8 @@ IndexUpdater get indexUpdater => ss.lookup(#_indexUpdater) as IndexUpdater;
 
 class IndexUpdater {
   final DatastoreDB _db;
-  final InMemoryPackageIndex _packageIndex;
 
-  IndexUpdater(this._db, this._packageIndex);
+  IndexUpdater(this._db);
 
   /// Loads the package index snapshot, or if it fails, creates a minimal
   /// package index with only package names and minimal information.
@@ -37,7 +36,7 @@ class IndexUpdater {
     if (!isReady) {
       _logger.info('Loading minimum package index...');
       final documents = await searchBackend.loadMinimumPackageIndex().toList();
-      _packageIndex.addPackages(documents);
+      updatePackageIndex(InMemoryPackageIndex(documents: documents));
       _logger.info(
           'Minimum package index loaded with ${documents.length} packages.');
     }
@@ -53,7 +52,7 @@ class IndexUpdater {
       final doc = await searchBackend.loadDocument(p.name!);
       documents.add(doc);
     }
-    _packageIndex.addPackages(documents);
+    updatePackageIndex(InMemoryPackageIndex(documents: documents));
   }
 
   /// Returns whether the snapshot was initialized and loaded properly.
@@ -64,7 +63,7 @@ class IndexUpdater {
       if (documents == null) {
         return false;
       }
-      _packageIndex.addPackages(documents);
+      updatePackageIndex(InMemoryPackageIndex(documents: documents));
       // Arbitrary sanity check that the snapshot is not entirely bogus.
       // Index merge will enable search.
       if (documents.length > 10) {

--- a/app/lib/service/services.dart
+++ b/app/lib/service/services.dart
@@ -42,7 +42,6 @@ import '../scorecard/backend.dart';
 import '../search/backend.dart';
 import '../search/dart_sdk_mem_index.dart';
 import '../search/flutter_sdk_mem_index.dart';
-import '../search/mem_index.dart';
 import '../search/search_client.dart';
 import '../search/top_packages.dart';
 import '../search/updater.dart';
@@ -238,9 +237,8 @@ Future<R> _withPubServices<R>(FutureOr<R> Function() fn) async {
     registerFlutterSdkMemIndex(FlutterSdkMemIndex());
     registerLikeBackend(LikeBackend(dbService));
     registerNameTracker(NameTracker(dbService));
-    final inMemoryPackageIndex = InMemoryPackageIndex();
-    registerInMemoryPackageIndex(inMemoryPackageIndex);
-    registerIndexUpdater(IndexUpdater(dbService, inMemoryPackageIndex));
+    registerPackageIndexHolder(PackageIndexHolder());
+    registerIndexUpdater(IndexUpdater(dbService));
     registerPopularityStorage(
       PopularityStorage(
           storageService.bucket(activeConfiguration.popularityDumpBucketName!)),


### PR DESCRIPTION
- removes public API to add more packages, allowing more optimization to the index
- removes periodic sort of the updated/created pre-sorted hit results list (also simpler initialization)