### PR TITLE
Store popularity on PackageView.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Important changes to data models, configuration, and migrations between each
 AppEngine version, listed here to ease deployment and troubleshooting.
 
 ## Next Release (replace with git tag when deployed)
+ * Bumped runtimeVersion to `2023.10.13`.
 
 ## `20231012t082200-all`
 

--- a/app/lib/package/models.dart
+++ b/app/lib/package/models.dart
@@ -928,6 +928,7 @@ class PackageView {
   final List<ProcessedScreenshot>? screenshots;
 
   final List<String>? topics;
+  final int popularity;
 
   PackageView({
     this.screenshots,
@@ -945,6 +946,7 @@ class PackageView {
     this.spdxIdentifiers,
     this.apiPages,
     this.topics,
+    required this.popularity,
   })  : isPending = isPending ?? false,
         tags = tags ?? <String>[];
 
@@ -957,6 +959,7 @@ class PackageView {
     PackageVersion? version,
     required ScoreCardData scoreCard,
     List<ApiPageRef>? apiPages,
+    required int popularity,
   }) {
     final tags = <String>{
       ...package.getTags(),
@@ -980,6 +983,7 @@ class PackageView {
       apiPages: apiPages,
       screenshots: scoreCard.panaReport?.screenshots,
       topics: version?.pubspec?.topics,
+      popularity: popularity,
     );
   }
 
@@ -1000,6 +1004,7 @@ class PackageView {
       apiPages: apiPages ?? this.apiPages,
       screenshots: screenshots,
       topics: topics,
+      popularity: popularity,
     );
   }
 
@@ -1008,9 +1013,6 @@ class PackageView {
   bool get isDiscontinued => tags.contains(PackageTags.isDiscontinued);
   bool get isLegacy => tags.contains(PackageVersionTags.isLegacy);
   bool get isObsolete => tags.contains(PackageVersionTags.isObsolete);
-
-  // TODO: refactor code to use popularityStorage directly.
-  int get popularity => popularityStorage.lookupAsScore(name);
 }
 
 /// Sorts [versions] according to the semantic versioning specification.
@@ -1111,7 +1113,6 @@ class PackagePageData {
   bool get hasPubspec => versionInfo.assets.contains(AssetKind.pubspec);
 
   bool get isLatestStable => version.version == package.latestVersion;
-  int get popularity => popularityStorage.lookupAsScore(package.name!);
 
   late final packageLinks = () {
     // Trying to use verfied URLs
@@ -1151,6 +1152,7 @@ class PackagePageData {
       releases: latestReleases,
       version: version,
       scoreCard: scoreCard,
+      popularity: popularityStorage.lookupAsScore(package.name!),
     );
   }
 }

--- a/app/lib/package/models.g.dart
+++ b/app/lib/package/models.g.dart
@@ -117,6 +117,7 @@ PackageView _$PackageViewFromJson(Map<String, dynamic> json) => PackageView(
           .toList(),
       topics:
           (json['topics'] as List<dynamic>?)?.map((e) => e as String).toList(),
+      popularity: json['popularity'] as int,
     );
 
 Map<String, dynamic> _$PackageViewToJson(PackageView instance) {
@@ -144,5 +145,6 @@ Map<String, dynamic> _$PackageViewToJson(PackageView instance) {
   writeNotNull('apiPages', instance.apiPages);
   writeNotNull('screenshots', instance.screenshots);
   writeNotNull('topics', instance.topics);
+  val['popularity'] = instance.popularity;
   return val;
 }

--- a/app/lib/scorecard/backend.dart
+++ b/app/lib/scorecard/backend.dart
@@ -10,6 +10,7 @@ import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
 import 'package:pool/pool.dart';
 import 'package:pub_dev/shared/exceptions.dart';
+import 'package:pub_dev/shared/popularity_storage.dart';
 import 'package:pub_dev/task/backend.dart';
 
 import '../package/backend.dart';
@@ -95,6 +96,7 @@ class ScoreCardBackend {
         releases: releases,
         version: pv,
         scoreCard: card,
+        popularity: popularityStorage.lookupAsScore(package),
       );
     });
   }

--- a/app/lib/shared/versions.dart
+++ b/app/lib/shared/versions.dart
@@ -24,10 +24,10 @@ final RegExp runtimeVersionPattern = RegExp(r'^\d{4}\.\d{2}\.\d{2}$');
 /// when the version switch happens.
 const _acceptedRuntimeVersions = <String>[
   // The current [runtimeVersion].
-  '2023.10.10',
+  '2023.10.13',
   // Fallback runtime versions.
+  '2023.10.10',
   '2023.09.26',
-  '2023.09.12',
 ];
 
 /// Sets the current runtime versions.


### PR DESCRIPTION
- `PackageView` is stored in cache only, backward-compatibility is not a concern, we can change its fields, but need to bump runtime version.
- Storing the popularity as a field reduces the indirections while rendering the data.