### PR TITLE
Increase CPUs to 4

### DIFF
--- a/analyzer.yaml
+++ b/analyzer.yaml
@@ -7,7 +7,7 @@ env: flex
 service: analyzer
 
 resources:
-  cpu: 2
+  cpu: 4
   memory_gb: 16
   disk_size_gb: 25
 


### PR DESCRIPTION
We can't have 2 CPUs and 16GB memory, we need less memory or more CPUs.

> ERROR: (gcloud.app.deploy) Error Response: [3] App Engine Flexible validation error: Memory GB (8.20) per VCPUs must be between 0.90 and 6.50.
