### PR TITLE
Search isolates do not need popularity storage.

### DIFF
--- a/app/lib/service/entrypoint/search.dart
+++ b/app/lib/service/entrypoint/search.dart
@@ -14,7 +14,6 @@ import '../../search/handlers.dart';
 import '../../service/services.dart';
 import '../../shared/env_config.dart';
 import '../../shared/handler_helpers.dart';
-import '../../shared/popularity_storage.dart';
 
 import '_isolate.dart';
 
@@ -38,7 +37,6 @@ class SearchCommand extends Command {
       );
       registerScopeExitCallback(index.close);
 
-      await popularityStorage.start();
       registerSearchIndex(IsolateSearchIndex(index));
 
       final renewTimer = Timer.periodic(Duration(minutes: 15), (_) async {

--- a/app/lib/service/entrypoint/search_index.dart
+++ b/app/lib/service/entrypoint/search_index.dart
@@ -19,7 +19,6 @@ import 'package:pub_dev/service/services.dart';
 import 'package:pub_dev/shared/env_config.dart';
 import 'package:pub_dev/shared/logging.dart';
 import 'package:pub_dev/shared/monitoring.dart';
-import 'package:pub_dev/shared/popularity_storage.dart';
 
 final _logger = Logger('search_index');
 
@@ -37,7 +36,6 @@ Future<void> main(List<String> args, var message) async {
   }
   await fork(() async {
     await servicesWrapperFn(() async {
-      await popularityStorage.start();
       await dartSdkMemIndex.start();
       await flutterSdkMemIndex.start();
       await indexUpdater.init();


### PR DESCRIPTION
The popularity score is added at snapshot building time (in the worker isolate of `analyzer` instance).