### PR TITLE
Provide `id-token` to example workflow

### DIFF
--- a/app/lib/frontend/templates/views/pkg/admin_page.dart
+++ b/app/lib/frontend/templates/views/pkg/admin_page.dart
@@ -362,6 +362,8 @@ d.Node _exampleGithubWorkflow(GithubPublishingConfig github) {
     '',
     'jobs:',
     '  publish:',
+    '    permissions:',
+    '      id-token: write # Required for authentication using OIDC',
     '    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1',
     if (hasWithParameter) ...[
       '    with:',


### PR DESCRIPTION
Provide the `permission` configuration with `id-token: write` to the example workflow.

Fixes #7146.
