### PR TITLE
Redirect missing /documentation/ urls to the closest finished/analyzed version

### DIFF
--- a/app/lib/dartdoc/models.dart
+++ b/app/lib/dartdoc/models.dart
@@ -25,6 +25,10 @@ class ResolvedDocUrlVersion {
     required this.urlSegment,
   });
 
+  ResolvedDocUrlVersion.empty()
+      : version = '',
+        urlSegment = '';
+
   factory ResolvedDocUrlVersion.fromJson(Map<String, dynamic> json) =>
       _$ResolvedDocUrlVersionFromJson(json);
 

--- a/app/lib/shared/redis_cache.dart
+++ b/app/lib/shared/redis_cache.dart
@@ -158,6 +158,11 @@ class CachePatterns {
       .withTTL(Duration(minutes: 10))
       .withCodec(utf8)[package];
 
+  Entry<String> closestFinishedVersion(String package, String version) => _cache
+      .withPrefix('closest-finished-version/')
+      .withTTL(Duration(minutes: 10))
+      .withCodec(utf8)['$package/$version'];
+
   Entry<PackageView> packageView(String package) => _cache
       .withPrefix('package-view/')
       .withTTL(Duration(minutes: 60))

--- a/app/lib/task/backend.dart
+++ b/app/lib/task/backend.dart
@@ -1074,7 +1074,7 @@ class TaskBackend {
       for (final rt in acceptedRuntimeVersions) {
         final key = PackageState.createKey(_db, rt, package);
         final state = await dbService.lookupOrNull<PackageState>(key);
-        // skip states where the entry was created, but no analysis has not finished yet
+        // Skip states where the entry was created, but the analysis has not finished yet.
         if (state == null || state.hasNeverFinished) {
           continue;
         }

--- a/app/lib/task/backend.dart
+++ b/app/lib/task/backend.dart
@@ -1063,7 +1063,7 @@ class TaskBackend {
 
   /// Returns the closest version of the [package] which has a finished analysis.
   ///
-  /// If [version] or new exists with finished analysis, it will be preferred, otherwise
+  /// If [version] or newer exists with finished analysis, it will be preferred, otherwise
   /// older versions may be considered too.
   ///
   /// Returns `null` if no such version exists.

--- a/app/lib/task/backend.dart
+++ b/app/lib/task/backend.dart
@@ -1091,7 +1091,7 @@ class TaskBackend {
         final newerCandidates =
             candidates.where((e) => isNewer(semanticVersion, e)).toList();
         if (newerCandidates.isNotEmpty) {
-          // return the earliest finished that is newer than [version].
+          // Return the earliest finished that is newer than [version].
           return newerCandidates
               .reduce((a, b) => isNewer(a, b) ? a : b)
               .toString();

--- a/app/lib/task/backend.dart
+++ b/app/lib/task/backend.dart
@@ -25,7 +25,7 @@ import 'package:pub_dev/shared/exceptions.dart';
 import 'package:pub_dev/shared/redis_cache.dart';
 import 'package:pub_dev/shared/storage.dart';
 import 'package:pub_dev/shared/utils.dart'
-    show canonicalizeVersion, VersionIterableExt;
+    show canonicalizeVersion, isNewer, VersionIterableExt;
 import 'package:pub_dev/shared/versions.dart'
     show
         runtimeVersion,
@@ -421,10 +421,17 @@ class TaskBackend {
         return false;
       }
 
+      final latestFinishedVersion = state.versions?.entries
+          .where((e) => e.value.finished)
+          .map((e) => Version.parse(e.key))
+          .latestVersion;
+
       // Make changes!
       state.versions!
-        // Remove versions that have been deselected
-        ..removeWhere((v, _) => deselectedVersions.contains(v))
+        // Remove versions that have been deselected - but keep the latest finished one
+        ..removeWhere((v, _) =>
+            deselectedVersions.contains(v) &&
+            v != latestFinishedVersion.toString())
         // Add versions we should be tracking
         ..addAll({
           for (final v in untrackedVersions)
@@ -1048,16 +1055,48 @@ class TaskBackend {
         if (bestVersion != null) {
           return bestVersion.toString();
         }
-        // TODO: remove this fallback after all runtime version has the `finished` field populated
-        if (rt.compareTo('2023.08.29') < 0) {
-          final latestNonPending = state.versions?.entries
-              .where((e) => e.value.status != PackageVersionStatus.pending)
-              .map((e) => Version.parse(e.key))
-              .latestVersion;
-          if (latestNonPending != null) {
-            return latestNonPending.toString();
-          }
+      }
+      return '';
+    });
+    return (cachedValue == null || cachedValue.isEmpty) ? null : cachedValue;
+  }
+
+  /// Returns the closest version of the [package] which has a finished analysis.
+  ///
+  /// If [version] or new exists with finished analysis, it will be preferred, otherwise
+  /// older versions may be considered too.
+  ///
+  /// Returns `null` if no such version exists.
+  Future<String?> closestFinishedVersion(String package, String version) async {
+    final cachedValue =
+        await cache.closestFinishedVersion(package, version).get(() async {
+      final semanticVersion = Version.parse(version);
+      for (final rt in acceptedRuntimeVersions) {
+        final key = PackageState.createKey(_db, rt, package);
+        final state = await dbService.lookupOrNull<PackageState>(key);
+        // skip states where the entry was created, but no analysis has not finished yet
+        if (state == null || state.hasNeverFinished) {
+          continue;
         }
+        final candidates = state.versions?.entries
+            .where((e) => e.value.finished)
+            .map((e) => Version.parse(e.key))
+            .toList();
+        if (candidates == null || candidates.isEmpty) {
+          continue;
+        }
+        if (candidates.contains(semanticVersion)) {
+          return version;
+        }
+        final newerCandidates =
+            candidates.where((e) => isNewer(semanticVersion, e)).toList();
+        if (newerCandidates.isNotEmpty) {
+          // return the earliest finished that is newer than [version].
+          return newerCandidates
+              .reduce((a, b) => isNewer(a, b) ? a : b)
+              .toString();
+        }
+        return candidates.latestVersion!.toString();
       }
       return '';
     });


### PR DESCRIPTION
- redirect happens with best effort:
  - if the requested `version` has finished analysis, it is returned
  - first the earliest newer finished version is looked up `1.0.0 -> 1.0.2` before `1.1.0`.
  - if there is no such version, then the latest (earlier) is selected, e.g. `2.1.0 -> 1.4.0`.
- handling of `latest` urls is unchanged
- task status now keeps the latest finished task version entry, increasing the URL stability when a new version is published
- added test for each version + publishing a new version
- cleaning up TODO in `latestFinishedVersion`
