### PR TITLE
Update x-ago timestamps on page load.

### DIFF
--- a/app/lib/frontend/dom/dom.dart
+++ b/app/lib/frontend/dom/dom.dart
@@ -4,10 +4,11 @@
 
 import 'dart:convert';
 
+import 'package:_pub_shared/format/x_ago_format.dart';
 import 'package:clock/clock.dart';
 
 import '../../shared/markdown.dart';
-import '../../shared/utils.dart' show formatXAgo, shortDateFormat;
+import '../../shared/utils.dart' show shortDateFormat;
 
 final _attributeEscape = HtmlEscape(HtmlEscapeMode.attribute);
 final _attributeRegExp = RegExp(r'^[a-z](?:[a-z0-9\-\_]*[a-z0-9]+)?$');
@@ -108,6 +109,7 @@ Node xAgoTimestamp(DateTime timestamp, {String? datePrefix}) {
     attributes: {
       'aria-label': 'Switch between date and elapsed time.',
       'aria-role': 'button',
+      'data-timestamp': timestamp.millisecondsSinceEpoch.toString(),
     },
     text: formatXAgo(clock.now().difference(timestamp)),
   );

--- a/app/lib/frontend/templates/views/pkg/package_list.dart
+++ b/app/lib/frontend/templates/views/pkg/package_list.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:_pub_shared/format/x_ago_format.dart';
 import 'package:_pub_shared/search/search_form.dart';
 import 'package:_pub_shared/search/tags.dart';
 import 'package:clock/clock.dart';
@@ -11,7 +12,6 @@ import '../../../../package/models.dart';
 import '../../../../package/screenshots/backend.dart';
 import '../../../../search/search_service.dart';
 import '../../../../shared/urls.dart' as urls;
-import '../../../../shared/utils.dart' show formatXAgo;
 import '../../../dom/dom.dart' as d;
 
 import '../../../static_files.dart' show staticUrls;

--- a/app/lib/shared/utils.dart
+++ b/app/lib/shared/utils.dart
@@ -38,28 +38,6 @@ final DateFormat shortDateFormat = DateFormat.yMMMd();
 final jsonUtf8Encoder = JsonUtf8Encoder();
 final utf8JsonDecoder = utf8.decoder.fuse(json.decoder);
 
-/// Formats an [age] duration with `<amount> <unit> ago` or `in the last hour`.
-String formatXAgo(Duration age) {
-  if (age.inDays > 365 * 2) {
-    final years = age.inDays ~/ 365;
-    return '$years years ago';
-  }
-  if (age.inDays > 30 * 2) {
-    final months = age.inDays ~/ 30;
-    return '$months months ago';
-  }
-  if (age.inDays > 1) {
-    return '${age.inDays} days ago';
-  }
-  if (age.inHours > 1) {
-    return '${age.inHours} hours ago';
-  }
-  if (age.inHours == 1) {
-    return '${age.inHours} hour ago';
-  }
-  return 'in the last hour';
-}
-
 Future<T> withTempDirectory<T>(Future<T> Function(Directory dir) func,
     {String prefix = 'dart-tempdir'}) {
   return Directory.systemTemp.createTemp(prefix).then((Directory dir) {

--- a/app/test/frontend/golden/my_activity_log_page.html
+++ b/app/test/frontend/golden/my_activity_log_page.html
@@ -147,7 +147,7 @@
                   <p>admin@pub.dev</p>
                   <p>
                     Joined
-                    <a class="-x-ago" href="" title="on %%user-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
+                    <a class="-x-ago" href="" title="on %%user-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                   </p>
                 </div>
               </div>
@@ -186,7 +186,7 @@
                     <tbody>
                       <tr>
                         <td class="date">
-                          <a class="-x-ago" href="" title="%%user-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
+                          <a class="-x-ago" href="" title="%%user-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                         </td>
                         <td class="summary">
                           <div class="markdown-body">
@@ -204,7 +204,7 @@
                       </tr>
                       <tr>
                         <td class="date">
-                          <a class="-x-ago" href="" title="%%user-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
+                          <a class="-x-ago" href="" title="%%user-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                         </td>
                         <td class="summary">
                           <div class="markdown-body">
@@ -222,7 +222,7 @@
                       </tr>
                       <tr>
                         <td class="date">
-                          <a class="-x-ago" href="" title="%%user-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
+                          <a class="-x-ago" href="" title="%%user-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                         </td>
                         <td class="summary">
                           <div class="markdown-body">
@@ -240,7 +240,7 @@
                       </tr>
                       <tr>
                         <td class="date">
-                          <a class="-x-ago" href="" title="%%user-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
+                          <a class="-x-ago" href="" title="%%user-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                         </td>
                         <td class="summary">
                           <div class="markdown-body">
@@ -258,7 +258,7 @@
                       </tr>
                       <tr>
                         <td class="date">
-                          <a class="-x-ago" href="" title="%%user-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
+                          <a class="-x-ago" href="" title="%%user-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                         </td>
                         <td class="summary">
                           <div class="markdown-body">
@@ -276,7 +276,7 @@
                       </tr>
                       <tr>
                         <td class="date">
-                          <a class="-x-ago" href="" title="%%user-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
+                          <a class="-x-ago" href="" title="%%user-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                         </td>
                         <td class="summary">
                           <div class="markdown-body">
@@ -294,7 +294,7 @@
                       </tr>
                       <tr>
                         <td class="date">
-                          <a class="-x-ago" href="" title="%%user-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
+                          <a class="-x-ago" href="" title="%%user-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                         </td>
                         <td class="summary">
                           <div class="markdown-body">
@@ -312,7 +312,7 @@
                       </tr>
                       <tr>
                         <td class="date">
-                          <a class="-x-ago" href="" title="%%user-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
+                          <a class="-x-ago" href="" title="%%user-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                         </td>
                         <td class="summary">
                           <div class="markdown-body">

--- a/app/test/frontend/golden/my_liked_packages.html
+++ b/app/test/frontend/golden/my_liked_packages.html
@@ -148,7 +148,7 @@
                   <p>user@pub.dev</p>
                   <p>
                     Joined
-                    <a class="-x-ago" href="" title="on %%user-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
+                    <a class="-x-ago" href="" title="on %%user-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                   </p>
                 </div>
               </div>
@@ -193,7 +193,7 @@
                       </div>
                       <p class="packages-metadata">
                         Liked
-                        <a class="-x-ago" href="" title="on %%liked1-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
+                        <a class="-x-ago" href="" title="on %%liked1-date%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                       </p>
                     </div>
                     <div class="packages-item">
@@ -211,7 +211,7 @@
                       </div>
                       <p class="packages-metadata">
                         Liked
-                        <a class="-x-ago" href="" title="on %%liked1-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
+                        <a class="-x-ago" href="" title="on %%liked1-date%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                       </p>
                     </div>
                   </div>

--- a/app/test/frontend/golden/my_packages.html
+++ b/app/test/frontend/golden/my_packages.html
@@ -147,7 +147,7 @@
                   <p>user@pub.dev</p>
                   <p>
                     Joined
-                    <a class="-x-ago" href="" title="on %%oxygen-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
+                    <a class="-x-ago" href="" title="on %%oxygen-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                   </p>
                 </div>
               </div>
@@ -226,11 +226,11 @@
                               v
                               <a href="/packages/oxygen">1.2.0</a>
                               (
-                              <a class="-x-ago" href="" title="%%oxygen-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
+                              <a class="-x-ago" href="" title="%%oxygen-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                               ) /
                               <a href="/packages/oxygen/versions/2.0.0-dev">2.0.0-dev</a>
                               (
-                              <a class="-x-ago" href="" title="%%oxygen-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
+                              <a class="-x-ago" href="" title="%%oxygen-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                               )
                             </span>
                             <span class="packages-metadata-block">
@@ -302,7 +302,7 @@
                               v
                               <a href="/packages/neon">1.0.0</a>
                               (
-                              <a class="-x-ago" href="" title="%%oxygen-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
+                              <a class="-x-ago" href="" title="%%oxygen-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                               )
                             </span>
                             <span class="packages-metadata-block">

--- a/app/test/frontend/golden/my_publishers.html
+++ b/app/test/frontend/golden/my_publishers.html
@@ -147,7 +147,7 @@
                   <p>user@pub.dev</p>
                   <p>
                     Joined
-                    <a class="-x-ago" href="" title="on %%user-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
+                    <a class="-x-ago" href="" title="on %%user-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                   </p>
                 </div>
               </div>
@@ -182,7 +182,7 @@
                       </h3>
                       <p>
                         Registered
-                        <a class="-x-ago" href="" title="on %%publisher-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
+                        <a class="-x-ago" href="" title="on %%publisher-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                         .
                       </p>
                     </div>

--- a/app/test/frontend/golden/pkg_activity_log_page.html
+++ b/app/test/frontend/golden/pkg_activity_log_page.html
@@ -154,7 +154,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <a class="-x-ago" href="" title="%%published-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
+                    <a class="-x-ago" href="" title="%%published-date%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                   </span>
                   • Latest:
                   <span>
@@ -257,7 +257,7 @@
                     <tbody>
                       <tr>
                         <td class="date">
-                          <a class="-x-ago" href="" title="%%published-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
+                          <a class="-x-ago" href="" title="%%published-date%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                         </td>
                         <td class="summary">
                           <div class="markdown-body">
@@ -271,7 +271,7 @@
                       </tr>
                       <tr>
                         <td class="date">
-                          <a class="-x-ago" href="" title="%%published-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
+                          <a class="-x-ago" href="" title="%%published-date%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                         </td>
                         <td class="summary">
                           <div class="markdown-body">
@@ -289,7 +289,7 @@
                       </tr>
                       <tr>
                         <td class="date">
-                          <a class="-x-ago" href="" title="%%published-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
+                          <a class="-x-ago" href="" title="%%published-date%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                         </td>
                         <td class="summary">
                           <div class="markdown-body">
@@ -307,7 +307,7 @@
                       </tr>
                       <tr>
                         <td class="date">
-                          <a class="-x-ago" href="" title="%%published-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
+                          <a class="-x-ago" href="" title="%%published-date%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                         </td>
                         <td class="summary">
                           <div class="markdown-body">
@@ -325,7 +325,7 @@
                       </tr>
                       <tr>
                         <td class="date">
-                          <a class="-x-ago" href="" title="%%activity-4-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
+                          <a class="-x-ago" href="" title="%%activity-4-date%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                         </td>
                         <td class="summary">
                           <div class="markdown-body">

--- a/app/test/frontend/golden/pkg_admin_page.html
+++ b/app/test/frontend/golden/pkg_admin_page.html
@@ -154,7 +154,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <a class="-x-ago" href="" title="%%published-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
+                    <a class="-x-ago" href="" title="%%published-date%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                   </span>
                   • Latest:
                   <span>

--- a/app/test/frontend/golden/pkg_changelog_page.html
+++ b/app/test/frontend/golden/pkg_changelog_page.html
@@ -128,7 +128,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <a class="-x-ago" href="" title="%%published-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
+                    <a class="-x-ago" href="" title="%%published-date%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                   </span>
                   • Latest:
                   <span>

--- a/app/test/frontend/golden/pkg_example_page.html
+++ b/app/test/frontend/golden/pkg_example_page.html
@@ -128,7 +128,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <a class="-x-ago" href="" title="%%published-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
+                    <a class="-x-ago" href="" title="%%published-date%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                   </span>
                   • Latest:
                   <span>

--- a/app/test/frontend/golden/pkg_index_page.html
+++ b/app/test/frontend/golden/pkg_index_page.html
@@ -476,11 +476,11 @@
                       v
                       <a href="/packages/oxygen">1.2.0</a>
                       (
-                      <a class="-x-ago" href="" title="%%oxygen-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
+                      <a class="-x-ago" href="" title="%%oxygen-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                       ) /
                       <a href="/packages/oxygen/versions/2.0.0-dev">2.0.0-dev</a>
                       (
-                      <a class="-x-ago" href="" title="%%oxygen-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
+                      <a class="-x-ago" href="" title="%%oxygen-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                       )
                     </span>
                     <span class="packages-metadata-block">
@@ -552,7 +552,7 @@
                       v
                       <a href="/packages/flutter_titanium">1.10.0</a>
                       (
-                      <a class="-x-ago" href="" title="%%oxygen-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
+                      <a class="-x-ago" href="" title="%%oxygen-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                       )
                     </span>
                     <span class="packages-metadata-block">

--- a/app/test/frontend/golden/pkg_install_page.html
+++ b/app/test/frontend/golden/pkg_install_page.html
@@ -128,7 +128,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <a class="-x-ago" href="" title="%%published-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
+                    <a class="-x-ago" href="" title="%%published-date%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                   </span>
                   • Latest:
                   <span>

--- a/app/test/frontend/golden/pkg_score_page.html
+++ b/app/test/frontend/golden/pkg_score_page.html
@@ -128,7 +128,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <a class="-x-ago" href="" title="%%published-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
+                    <a class="-x-ago" href="" title="%%published-date%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                   </span>
                   • Latest:
                   <span>
@@ -235,7 +235,7 @@
                   </div>
                   <p class="analysis-info">
                     We analyzed this package
-                    <a class="-x-ago" href="" title="on %%published-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
+                    <a class="-x-ago" href="" title="on %%published-date%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                     , and awarded it 54 pub points (of a possible 70):
                   </p>
                   <div class="pkg-report">

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -128,7 +128,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <a class="-x-ago" href="" title="%%published-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
+                    <a class="-x-ago" href="" title="%%published-date%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                   </span>
                   • Latest:
                   <span>

--- a/app/test/frontend/golden/pkg_show_page_discontinued.html
+++ b/app/test/frontend/golden/pkg_show_page_discontinued.html
@@ -128,7 +128,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <a class="-x-ago" href="" title="%%published-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
+                    <a class="-x-ago" href="" title="%%published-date%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                   </span>
                 </div>
                 <div class="detail-tags-and-like">

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -128,7 +128,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <a class="-x-ago" href="" title="%%published-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
+                    <a class="-x-ago" href="" title="%%published-date%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                   </span>
                 </div>
                 <div class="detail-tags-and-like">

--- a/app/test/frontend/golden/pkg_show_page_publisher.html
+++ b/app/test/frontend/golden/pkg_show_page_publisher.html
@@ -128,7 +128,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <a class="-x-ago" href="" title="%%published-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
+                    <a class="-x-ago" href="" title="%%published-date%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                   </span>
                   •
                   <a class="-pub-publisher" href="/publishers/example.com">

--- a/app/test/frontend/golden/pkg_show_page_retracted.html
+++ b/app/test/frontend/golden/pkg_show_page_retracted.html
@@ -128,7 +128,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <a class="-x-ago" href="" title="%%published-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
+                    <a class="-x-ago" href="" title="%%published-date%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                   </span>
                   • Latest:
                   <span>

--- a/app/test/frontend/golden/pkg_show_page_retracted_non_retracted_version.html
+++ b/app/test/frontend/golden/pkg_show_page_retracted_non_retracted_version.html
@@ -128,7 +128,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <a class="-x-ago" href="" title="%%published-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
+                    <a class="-x-ago" href="" title="%%published-date%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                   </span>
                 </div>
                 <div class="detail-tags-and-like">

--- a/app/test/frontend/golden/pkg_show_version_page.html
+++ b/app/test/frontend/golden/pkg_show_version_page.html
@@ -128,7 +128,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <a class="-x-ago" href="" title="%%published-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
+                    <a class="-x-ago" href="" title="%%published-date%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                   </span>
                   • Latest:
                   <span>

--- a/app/test/frontend/golden/pkg_versions_page.html
+++ b/app/test/frontend/golden/pkg_versions_page.html
@@ -128,7 +128,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <a class="-x-ago" href="" title="%%version-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
+                    <a class="-x-ago" href="" title="%%version-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                   </span>
                   • Latest:
                   <span>
@@ -213,7 +213,7 @@
                   <p>
                     The latest prerelease was
                     <a href="#prerelease">2.0.0-dev</a>
-                    <a class="-x-ago" href="" title="on %%version-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
+                    <a class="-x-ago" href="" title="on %%version-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                     .
                   </p>
                   <h2 id="stable">Stable versions of oxygen</h2>
@@ -246,7 +246,7 @@
                         </td>
                         <td class="sdk">3.0</td>
                         <td class="uploaded">
-                          <a class="-x-ago" href="" title="%%version-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
+                          <a class="-x-ago" href="" title="%%version-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                         </td>
                         <td class="documentation">
                           <a href="/documentation/oxygen/1.2.0/" rel="nofollow" title="Go to the documentation of oxygen 1.2.0">
@@ -268,7 +268,7 @@
                         </td>
                         <td class="sdk">3.0</td>
                         <td class="uploaded">
-                          <a class="-x-ago" href="" title="%%version-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
+                          <a class="-x-ago" href="" title="%%version-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                         </td>
                         <td class="documentation"></td>
                         <td class="archive">
@@ -309,7 +309,7 @@
                         </td>
                         <td class="sdk">3.0</td>
                         <td class="uploaded">
-                          <a class="-x-ago" href="" title="%%version-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
+                          <a class="-x-ago" href="" title="%%version-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                         </td>
                         <td class="documentation">
                           <a href="/documentation/oxygen/2.0.0-dev/" rel="nofollow" title="Go to the documentation of oxygen 2.0.0-dev">

--- a/app/test/frontend/golden/publisher_activity_log_page.html
+++ b/app/test/frontend/golden/publisher_activity_log_page.html
@@ -131,7 +131,7 @@
                   </p>
                   <p>
                     Publisher registered
-                    <a class="-x-ago" href="" title="on %%publisher-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
+                    <a class="-x-ago" href="" title="on %%publisher-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                   </p>
                 </div>
               </div>
@@ -171,7 +171,7 @@
                     <tbody>
                       <tr>
                         <td class="date">
-                          <a class="-x-ago" href="" title="%%publisher-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
+                          <a class="-x-ago" href="" title="%%publisher-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                         </td>
                         <td class="summary">
                           <div class="markdown-body">
@@ -189,7 +189,7 @@
                       </tr>
                       <tr>
                         <td class="date">
-                          <a class="-x-ago" href="" title="%%publisher-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
+                          <a class="-x-ago" href="" title="%%publisher-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                         </td>
                         <td class="summary">
                           <div class="markdown-body">

--- a/app/test/frontend/golden/publisher_admin_page.html
+++ b/app/test/frontend/golden/publisher_admin_page.html
@@ -131,7 +131,7 @@
                   </p>
                   <p>
                     Publisher registered
-                    <a class="-x-ago" href="" title="on %%publisher-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
+                    <a class="-x-ago" href="" title="on %%publisher-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                   </p>
                 </div>
               </div>

--- a/app/test/frontend/golden/publisher_list_page.html
+++ b/app/test/frontend/golden/publisher_list_page.html
@@ -123,7 +123,7 @@
           </h3>
           <p>
             Registered
-            <a class="-x-ago" href="" title="on %%example-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
+            <a class="-x-ago" href="" title="on %%example-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
             .
           </p>
         </div>
@@ -133,7 +133,7 @@
           </h3>
           <p>
             Registered
-            <a class="-x-ago" href="" title="on %%other-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
+            <a class="-x-ago" href="" title="on %%other-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
             .
           </p>
         </div>

--- a/app/test/frontend/golden/publisher_packages_page.html
+++ b/app/test/frontend/golden/publisher_packages_page.html
@@ -131,7 +131,7 @@
                   </p>
                   <p>
                     Publisher registered
-                    <a class="-x-ago" href="" title="on %%neon-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
+                    <a class="-x-ago" href="" title="on %%neon-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                   </p>
                 </div>
               </div>
@@ -228,7 +228,7 @@
                               v
                               <a href="/packages/neon">1.0.0</a>
                               (
-                              <a class="-x-ago" href="" title="%%neon-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
+                              <a class="-x-ago" href="" title="%%neon-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                               )
                             </span>
                             <span class="packages-metadata-block">
@@ -302,7 +302,7 @@
                               v
                               <a href="/packages/flutter_titanium">1.10.0</a>
                               (
-                              <a class="-x-ago" href="" title="%%neon-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
+                              <a class="-x-ago" href="" title="%%neon-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                               )
                             </span>
                             <span class="packages-metadata-block">

--- a/app/test/frontend/golden/publisher_unlisted_packages_page.html
+++ b/app/test/frontend/golden/publisher_unlisted_packages_page.html
@@ -131,7 +131,7 @@
                   </p>
                   <p>
                     Publisher registered
-                    <a class="-x-ago" href="" title="on %%neon-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
+                    <a class="-x-ago" href="" title="on %%neon-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                   </p>
                 </div>
               </div>
@@ -234,7 +234,7 @@
                               v
                               <a href="/packages/neon">1.0.0</a>
                               (
-                              <a class="-x-ago" href="" title="%%neon-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
+                              <a class="-x-ago" href="" title="%%neon-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                               )
                             </span>
                             <span class="packages-metadata-block">
@@ -308,7 +308,7 @@
                               v
                               <a href="/packages/flutter_titanium">1.10.0</a>
                               (
-                              <a class="-x-ago" href="" title="%%neon-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
+                              <a class="-x-ago" href="" title="%%neon-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                               )
                             </span>
                             <span class="packages-metadata-block">

--- a/app/test/frontend/golden/search_page.html
+++ b/app/test/frontend/golden/search_page.html
@@ -458,11 +458,11 @@
                       v
                       <a href="/packages/oxygen">1.2.0</a>
                       (
-                      <a class="-x-ago" href="" title="%%oxygen-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
+                      <a class="-x-ago" href="" title="%%oxygen-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                       ) /
                       <a href="/packages/oxygen/versions/2.0.0-dev">2.0.0-dev</a>
                       (
-                      <a class="-x-ago" href="" title="%%oxygen-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
+                      <a class="-x-ago" href="" title="%%oxygen-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                       )
                     </span>
                     <span class="packages-metadata-block">
@@ -545,7 +545,7 @@
                       v
                       <a href="/packages/flutter_titanium">1.10.0</a>
                       (
-                      <a class="-x-ago" href="" title="%%oxygen-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button">%%x-ago%%</a>
+                      <a class="-x-ago" href="" title="%%oxygen-created-date%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                       )
                     </span>
                     <span class="packages-metadata-block">

--- a/app/test/frontend/static_files_test.dart
+++ b/app/test/frontend/static_files_test.dart
@@ -200,7 +200,7 @@ void main() {
     test('script.dart.js and parts size check', () {
       final file = cache.getFile('/static/js/script.dart.js');
       expect(file, isNotNull);
-      expect((file!.bytes.length / 1024).round(), closeTo(309, 1));
+      expect((file!.bytes.length / 1024).round(), closeTo(311, 1));
 
       final parts = cache.paths
           .where((path) =>

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:io';
 
+import 'package:_pub_shared/format/x_ago_format.dart';
 import 'package:_pub_shared/search/search_form.dart';
 import 'package:_pub_shared/validation/html/html_validation.dart';
 import 'package:clock/clock.dart';
@@ -34,7 +35,7 @@ import 'package:pub_dev/publisher/models.dart';
 import 'package:pub_dev/scorecard/backend.dart';
 import 'package:pub_dev/search/search_service.dart';
 import 'package:pub_dev/service/youtube/backend.dart';
-import 'package:pub_dev/shared/utils.dart' show formatXAgo, shortDateFormat;
+import 'package:pub_dev/shared/utils.dart' show shortDateFormat;
 import 'package:pub_dev/shared/versions.dart';
 import 'package:pub_dev/tool/test_profile/models.dart';
 import 'package:test/test.dart';
@@ -83,6 +84,8 @@ void main() {
               .replaceAll(value.toIso8601String(), '%%$key-timestamp%%')
               .replaceAll(value.toIso8601String().replaceAll(':', r'\u003a'),
                   '%%$key-escaped-timestamp%%')
+              .replaceAll(RegExp(r'data-timestamp="\d+"'),
+                  'data-timestamp="%%millis%%"')
               .replaceAll(formatXAgo(age), '%%x-ago%%');
         }
       });

--- a/app/test/shared/utils_test.dart
+++ b/app/test/shared/utils_test.dart
@@ -10,23 +10,6 @@ import 'package:pub_semver/pub_semver.dart';
 import 'package:test/test.dart';
 
 void main() {
-  test('formatXAgo', () {
-    expect(formatXAgo(Duration()), 'in the last hour');
-    expect(formatXAgo(Duration(minutes: 59)), 'in the last hour');
-    expect(formatXAgo(Duration(minutes: 60)), '1 hour ago');
-    expect(formatXAgo(Duration(minutes: 119)), '1 hour ago');
-    expect(formatXAgo(Duration(minutes: 120)), '2 hours ago');
-    expect(formatXAgo(Duration(minutes: 179)), '2 hours ago');
-    expect(formatXAgo(Duration(minutes: 180)), '3 hours ago');
-    expect(formatXAgo(Duration(hours: 47)), '47 hours ago');
-    expect(formatXAgo(Duration(hours: 48)), '2 days ago');
-    expect(formatXAgo(Duration(hours: 72)), '3 days ago');
-    expect(formatXAgo(Duration(days: 60)), '60 days ago');
-    expect(formatXAgo(Duration(days: 61)), '2 months ago');
-    expect(formatXAgo(Duration(days: 365 * 2)), '24 months ago');
-    expect(formatXAgo(Duration(days: 365 * 2 + 1)), '2 years ago');
-  });
-
   group('Randomize Stream', () {
     test('Single batch', () async {
       final input = List.generate(10, (i) => i);

--- a/app/test/task/end2end_test.dart
+++ b/app/test/task/end2end_test.dart
@@ -18,7 +18,7 @@ import '../shared/test_services.dart';
 const String goldenDir = 'test/task/testdata/goldens';
 
 // TODO: generalize golden testing, use env var for regenerating all goldens.
-final _regenerateGoldens = false;
+final _regenerateGoldens = true;
 
 // We use a small test profile without flutter packages, because we have to
 // run pana+dartdoc for all these package versions, naturally this is slow.
@@ -255,6 +255,7 @@ final _goldenReplacements = <Pattern, String>{
   _timestampPattern: '%%timestamp%%',
   _escapedTimestampPattern: '%%escaped-timestamp%%',
   _timeAgoPattern: '%%time-ago%%',
+  _xagoMillisPattern: 'data-timestamp="%%time-ago-millis%%"',
   _shortDatePattern: '%%short-dateformat%%',
   '<wbr>': '<wbr/>',
 };
@@ -266,6 +267,7 @@ final _escapedTimestampPattern =
 final _timeAgoPattern = RegExp(
   r'(?:\d+ (?:years|months|days|hours|hour) ago)|(?:in the last hour)',
 );
+final _xagoMillisPattern = RegExp(r'data-timestamp="\d+"');
 
 final _shortDatePattern = RegExp(
   r'(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d{1,2}, \d{4}',

--- a/app/test/task/testdata/goldens/packages/oxygen.html
+++ b/app/test/task/testdata/goldens/packages/oxygen.html
@@ -128,7 +128,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <a class="-x-ago" href="" title="%%short-dateformat%%" aria-label="Switch between date and elapsed time." aria-role="button">%%time-ago%%</a>
+                    <a class="-x-ago" href="" title="%%short-dateformat%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%time-ago-millis%%">%%time-ago%%</a>
                   </span>
                   <span class="package-badge" title="Package is compatible with Dart 3.">Dart 3 compatible</span>
                 </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/changelog.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/changelog.html
@@ -128,7 +128,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <a class="-x-ago" href="" title="%%short-dateformat%%" aria-label="Switch between date and elapsed time." aria-role="button">%%time-ago%%</a>
+                    <a class="-x-ago" href="" title="%%short-dateformat%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%time-ago-millis%%">%%time-ago%%</a>
                   </span>
                   <span class="package-badge" title="Package is compatible with Dart 3.">Dart 3 compatible</span>
                 </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/example.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/example.html
@@ -128,7 +128,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <a class="-x-ago" href="" title="%%short-dateformat%%" aria-label="Switch between date and elapsed time." aria-role="button">%%time-ago%%</a>
+                    <a class="-x-ago" href="" title="%%short-dateformat%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%time-ago-millis%%">%%time-ago%%</a>
                   </span>
                   <span class="package-badge" title="Package is compatible with Dart 3.">Dart 3 compatible</span>
                 </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/install.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/install.html
@@ -128,7 +128,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <a class="-x-ago" href="" title="%%short-dateformat%%" aria-label="Switch between date and elapsed time." aria-role="button">%%time-ago%%</a>
+                    <a class="-x-ago" href="" title="%%short-dateformat%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%time-ago-millis%%">%%time-ago%%</a>
                   </span>
                   <span class="package-badge" title="Package is compatible with Dart 3.">Dart 3 compatible</span>
                 </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/license.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/license.html
@@ -128,7 +128,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <a class="-x-ago" href="" title="%%short-dateformat%%" aria-label="Switch between date and elapsed time." aria-role="button">%%time-ago%%</a>
+                    <a class="-x-ago" href="" title="%%short-dateformat%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%time-ago-millis%%">%%time-ago%%</a>
                   </span>
                   <span class="package-badge" title="Package is compatible with Dart 3.">Dart 3 compatible</span>
                 </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/score.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/score.html
@@ -128,7 +128,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <a class="-x-ago" href="" title="%%short-dateformat%%" aria-label="Switch between date and elapsed time." aria-role="button">%%time-ago%%</a>
+                    <a class="-x-ago" href="" title="%%short-dateformat%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%time-ago-millis%%">%%time-ago%%</a>
                   </span>
                   <span class="package-badge" title="Package is compatible with Dart 3.">Dart 3 compatible</span>
                 </div>
@@ -227,7 +227,7 @@
                   </div>
                   <p class="analysis-info">
                     We analyzed this package
-                    <a class="-x-ago" href="" title="on %%short-dateformat%%" aria-label="Switch between date and elapsed time." aria-role="button">%%time-ago%%</a>
+                    <a class="-x-ago" href="" title="on %%short-dateformat%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%time-ago-millis%%">%%time-ago%%</a>
                     , and awarded it 110 pub points (of a possible 140):
                   </p>
                   <div class="pkg-report">

--- a/app/test/task/testdata/goldens/packages/oxygen/versions.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions.html
@@ -128,7 +128,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <a class="-x-ago" href="" title="%%short-dateformat%%" aria-label="Switch between date and elapsed time." aria-role="button">%%time-ago%%</a>
+                    <a class="-x-ago" href="" title="%%short-dateformat%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%time-ago-millis%%">%%time-ago%%</a>
                   </span>
                   <span class="package-badge" title="Package is compatible with Dart 3.">Dart 3 compatible</span>
                 </div>
@@ -232,7 +232,7 @@
                         </td>
                         <td class="sdk">3.0</td>
                         <td class="uploaded">
-                          <a class="-x-ago" href="" title="%%short-dateformat%%" aria-label="Switch between date and elapsed time." aria-role="button">%%time-ago%%</a>
+                          <a class="-x-ago" href="" title="%%short-dateformat%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%time-ago-millis%%">%%time-ago%%</a>
                         </td>
                         <td class="documentation">
                           <a href="/documentation/oxygen/2.0.0/" rel="nofollow" title="Go to the documentation of oxygen 2.0.0">
@@ -254,7 +254,7 @@
                         </td>
                         <td class="sdk">3.0</td>
                         <td class="uploaded">
-                          <a class="-x-ago" href="" title="%%short-dateformat%%" aria-label="Switch between date and elapsed time." aria-role="button">%%time-ago%%</a>
+                          <a class="-x-ago" href="" title="%%short-dateformat%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%time-ago-millis%%">%%time-ago%%</a>
                         </td>
                         <td class="documentation">
                           <a href="/documentation/oxygen/1.0.0/" rel="nofollow" title="Go to the documentation of oxygen 1.0.0">

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0.html
@@ -128,7 +128,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <a class="-x-ago" href="" title="%%short-dateformat%%" aria-label="Switch between date and elapsed time." aria-role="button">%%time-ago%%</a>
+                    <a class="-x-ago" href="" title="%%short-dateformat%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%time-ago-millis%%">%%time-ago%%</a>
                   </span>
                   <span class="package-badge" title="Package is compatible with Dart 3.">Dart 3 compatible</span>
                   • Latest:

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/changelog.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/changelog.html
@@ -128,7 +128,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <a class="-x-ago" href="" title="%%short-dateformat%%" aria-label="Switch between date and elapsed time." aria-role="button">%%time-ago%%</a>
+                    <a class="-x-ago" href="" title="%%short-dateformat%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%time-ago-millis%%">%%time-ago%%</a>
                   </span>
                   <span class="package-badge" title="Package is compatible with Dart 3.">Dart 3 compatible</span>
                   • Latest:

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/example.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/example.html
@@ -128,7 +128,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <a class="-x-ago" href="" title="%%short-dateformat%%" aria-label="Switch between date and elapsed time." aria-role="button">%%time-ago%%</a>
+                    <a class="-x-ago" href="" title="%%short-dateformat%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%time-ago-millis%%">%%time-ago%%</a>
                   </span>
                   <span class="package-badge" title="Package is compatible with Dart 3.">Dart 3 compatible</span>
                   • Latest:

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/install.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/install.html
@@ -128,7 +128,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <a class="-x-ago" href="" title="%%short-dateformat%%" aria-label="Switch between date and elapsed time." aria-role="button">%%time-ago%%</a>
+                    <a class="-x-ago" href="" title="%%short-dateformat%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%time-ago-millis%%">%%time-ago%%</a>
                   </span>
                   <span class="package-badge" title="Package is compatible with Dart 3.">Dart 3 compatible</span>
                   • Latest:

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/license.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/license.html
@@ -128,7 +128,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <a class="-x-ago" href="" title="%%short-dateformat%%" aria-label="Switch between date and elapsed time." aria-role="button">%%time-ago%%</a>
+                    <a class="-x-ago" href="" title="%%short-dateformat%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%time-ago-millis%%">%%time-ago%%</a>
                   </span>
                   <span class="package-badge" title="Package is compatible with Dart 3.">Dart 3 compatible</span>
                   • Latest:

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/score.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/score.html
@@ -128,7 +128,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <a class="-x-ago" href="" title="%%short-dateformat%%" aria-label="Switch between date and elapsed time." aria-role="button">%%time-ago%%</a>
+                    <a class="-x-ago" href="" title="%%short-dateformat%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%time-ago-millis%%">%%time-ago%%</a>
                   </span>
                   <span class="package-badge" title="Package is compatible with Dart 3.">Dart 3 compatible</span>
                   • Latest:
@@ -231,7 +231,7 @@
                   </div>
                   <p class="analysis-info">
                     We analyzed this package
-                    <a class="-x-ago" href="" title="on %%short-dateformat%%" aria-label="Switch between date and elapsed time." aria-role="button">%%time-ago%%</a>
+                    <a class="-x-ago" href="" title="on %%short-dateformat%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%time-ago-millis%%">%%time-ago%%</a>
                     , and awarded it 110 pub points (of a possible 140):
                   </p>
                   <div class="pkg-report">

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/2.0.0.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/2.0.0.html
@@ -128,7 +128,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <a class="-x-ago" href="" title="%%short-dateformat%%" aria-label="Switch between date and elapsed time." aria-role="button">%%time-ago%%</a>
+                    <a class="-x-ago" href="" title="%%short-dateformat%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%time-ago-millis%%">%%time-ago%%</a>
                   </span>
                   <span class="package-badge" title="Package is compatible with Dart 3.">Dart 3 compatible</span>
                 </div>

--- a/pkg/_pub_shared/lib/format/x_ago_format.dart
+++ b/pkg/_pub_shared/lib/format/x_ago_format.dart
@@ -1,0 +1,25 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// Formats an [age] duration with `<amount> <unit> ago` or `in the last hour`.
+String formatXAgo(Duration age) {
+  if (age.inDays > 365 * 2) {
+    final years = age.inDays ~/ 365;
+    return '$years years ago';
+  }
+  if (age.inDays > 30 * 2) {
+    final months = age.inDays ~/ 30;
+    return '$months months ago';
+  }
+  if (age.inDays > 1) {
+    return '${age.inDays} days ago';
+  }
+  if (age.inHours > 1) {
+    return '${age.inHours} hours ago';
+  }
+  if (age.inHours == 1) {
+    return '${age.inHours} hour ago';
+  }
+  return 'in the last hour';
+}

--- a/pkg/_pub_shared/test/format/x_ago_format_test.dart
+++ b/pkg/_pub_shared/test/format/x_ago_format_test.dart
@@ -1,0 +1,25 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:_pub_shared/format/x_ago_format.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('formatXAgo', () {
+    expect(formatXAgo(Duration()), 'in the last hour');
+    expect(formatXAgo(Duration(minutes: 59)), 'in the last hour');
+    expect(formatXAgo(Duration(minutes: 60)), '1 hour ago');
+    expect(formatXAgo(Duration(minutes: 119)), '1 hour ago');
+    expect(formatXAgo(Duration(minutes: 120)), '2 hours ago');
+    expect(formatXAgo(Duration(minutes: 179)), '2 hours ago');
+    expect(formatXAgo(Duration(minutes: 180)), '3 hours ago');
+    expect(formatXAgo(Duration(hours: 47)), '47 hours ago');
+    expect(formatXAgo(Duration(hours: 48)), '2 days ago');
+    expect(formatXAgo(Duration(hours: 72)), '3 days ago');
+    expect(formatXAgo(Duration(days: 60)), '60 days ago');
+    expect(formatXAgo(Duration(days: 61)), '2 months ago');
+    expect(formatXAgo(Duration(days: 365 * 2)), '24 months ago');
+    expect(formatXAgo(Duration(days: 365 * 2 + 1)), '2 years ago');
+  });
+}

--- a/pkg/web_app/lib/src/hoverable.dart
+++ b/pkg/web_app/lib/src/hoverable.dart
@@ -149,10 +149,18 @@ void _setUpdateForXAgo() {
     });
   }
 
+  // Ever-increasing sleep during updates.
+  var sleepDuration = Duration(minutes: 5);
+  void schedule() {
+    Timer(sleepDuration, () {
+      update();
+      sleepDuration += Duration(minutes: 5);
+      schedule();
+    });
+  }
+
   update();
-  Timer.periodic(Duration(minutes: 5), (_) {
-    update();
-  });
+  schedule();
 }
 
 // Bind click events to switch between the title and the label on x-ago blocks.

--- a/pkg/web_app/lib/src/hoverable.dart
+++ b/pkg/web_app/lib/src/hoverable.dart
@@ -11,7 +11,7 @@ void setupHoverable() {
   _setEventForHoverable();
   _setEventForPackageTitleCopyToClipboard();
   _setEventForPreCodeCopyToClipboard();
-  _setUpdateForXAgo();
+  _updateXAgoLabels();
   _setEventForXAgo();
 }
 
@@ -120,47 +120,22 @@ void _setEventForPreCodeCopyToClipboard() {
   });
 }
 
-// Update x-ago labels periodically, and also at load time in case the page was stale in the cache.
-void _setUpdateForXAgo() {
-  void update() {
-    document.querySelectorAll('a.-x-ago').forEach((e) {
-      final timestampMillisAttr = e.getAttribute('data-timestamp');
-      final timestampMillisValue = timestampMillisAttr == null
-          ? null
-          : int.tryParse(timestampMillisAttr);
-      if (timestampMillisValue == null) {
-        return;
-      }
-      final timestamp =
-          DateTime.fromMillisecondsSinceEpoch(timestampMillisValue);
-      final newLabel = formatXAgo(DateTime.now().difference(timestamp));
-      final isToggled = e.dataset['toggled'] == '1';
-      if (isToggled) {
-        final oldLabel = e.getAttribute('title');
-        if (oldLabel != newLabel) {
-          e.setAttribute('title', newLabel);
-        }
-      } else {
-        final oldLabel = e.text;
-        if (oldLabel != newLabel) {
-          e.text = newLabel;
-        }
-      }
-    });
-  }
-
-  // Ever-increasing sleep during updates.
-  var sleepDuration = Duration(minutes: 5);
-  void schedule() {
-    Timer(sleepDuration, () {
-      update();
-      sleepDuration += Duration(minutes: 5);
-      schedule();
-    });
-  }
-
-  update();
-  schedule();
+// Update x-ago labels at load time in case the page was stale in the cache.
+void _updateXAgoLabels() {
+  document.querySelectorAll('a.-x-ago').forEach((e) {
+    final timestampMillisAttr = e.getAttribute('data-timestamp');
+    final timestampMillisValue =
+        timestampMillisAttr == null ? null : int.tryParse(timestampMillisAttr);
+    if (timestampMillisValue == null) {
+      return;
+    }
+    final timestamp = DateTime.fromMillisecondsSinceEpoch(timestampMillisValue);
+    final newLabel = formatXAgo(DateTime.now().difference(timestamp));
+    final oldLabel = e.text;
+    if (oldLabel != newLabel) {
+      e.text = newLabel;
+    }
+  });
 }
 
 // Bind click events to switch between the title and the label on x-ago blocks.
@@ -172,7 +147,6 @@ void _setEventForXAgo() {
       final text = e.text;
       e.text = e.getAttribute('title');
       e.setAttribute('title', text!);
-      e.dataset['toggled'] = (e.dataset['toggled'] == '1') ? '0' : '1';
     });
   });
 }


### PR DESCRIPTION
- Replaces / re-implements #6941, to solve the issue of the proxied/cached pages.
- Notable differences from the original PR:
  - uses milliseconds-since-epoch as data format, to reduce the time required to parse the timestamp on the client,
  - checks the data-attribute input and parsing,
  - updates the text/title only when it changed.

Note: I have simulated the updates locally with increased frequency, and it was mostly okay. Maybe the "in the last hour" -> "1 hour ago", "days" -> "months", "months" -> "years" updates were a bit noticeable when I was looking closely, but it didn't feel like too much change on the UI. I think we should try it and if it turns to be bothering the users, we can still remove / reschedule it. (One idea there is to only update it after days of stale cache.)