### PR TITLE
Use pana-integrated dartdoc instead of pkg/pub_dartdoc.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ Important changes to data models, configuration, and migrations between each
 AppEngine version, listed here to ease deployment and troubleshooting.
 
 ## Next Release (replace with git tag when deployed)
+ * Bumped runtimeVersion to `2023.11.15`.
+ * Upgraded pana to `0.21.42`.
+ * Note: Started running `dartdoc` from `pana`.
 
 ## `20231115t090700-all`
  * Hiding invalid popularity scores.

--- a/app/lib/shared/versions.dart
+++ b/app/lib/shared/versions.dart
@@ -24,10 +24,10 @@ final RegExp runtimeVersionPattern = RegExp(r'^\d{4}\.\d{2}\.\d{2}$');
 /// when the version switch happens.
 const _acceptedRuntimeVersions = <String>[
   // The current [runtimeVersion].
-  '2023.11.02',
+  '2023.11.15',
   // Fallback runtime versions.
+  '2023.11.02',
   '2023.10.18',
-  '2023.10.10',
 ];
 
 /// Sets the current runtime versions.

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -544,10 +544,10 @@ packages:
     dependency: "direct main"
     description:
       name: pana
-      sha256: "0a2546792c71440b69e4dd73d9cd310dab6404c18ce6c0e8ceeb1453249c5d27"
+      sha256: d8c24d31fbf66b9c8c6c5e31c39b094c8535ed5bd152dbce9642049e6e76965d
       url: "https://pub.dev"
     source: hosted
-    version: "0.21.40"
+    version: "0.21.42"
   path:
     dependency: "direct main"
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -53,7 +53,7 @@ dependencies:
   watcher: ^1.0.0
   yaml: '^3.0.0'
   # pana version to be pinned
-  pana: '0.21.40'
+  pana: '0.21.42'
   # 3rd-party packages with pinned versions
   mailer: '6.0.1'
   ulid: '2.0.0'

--- a/app/test/shared/versions_test.dart
+++ b/app/test/shared/versions_test.dart
@@ -141,6 +141,13 @@ and do not format to also bump the runtimeVersion.''',
     expect(dependency.version.toString(), dartdocVersion);
   });
 
+  test('dartdoc version should match pkg/pub_worker', () async {
+    final content =
+        await File('../pkg/pub_worker/lib/src/bin/pana_wrapper.dart')
+            .readAsString();
+    expect(content, contains("globalDartdocVersion: '$dartdocVersion'"));
+  });
+
   scopedTest('GC is not deleting currently accepted versions', () {
     for (final version in acceptedRuntimeVersions) {
       expect(shouldGCVersion(version), isFalse);

--- a/app/test/task/testdata/goldens/packages/oxygen.html
+++ b/app/test/task/testdata/goldens/packages/oxygen.html
@@ -234,7 +234,7 @@
               </div>
               <div class="packages-score packages-score-health">
                 <div class="packages-score-value -has-value">
-                  <span class="packages-score-value-number">110</span>
+                  <span class="packages-score-value-number">120</span>
                   <span class="packages-score-value-sign"></span>
                 </div>
                 <div class="packages-score-label">pub points</div>
@@ -320,7 +320,7 @@
             </div>
             <div class="packages-score packages-score-health">
               <div class="packages-score-value -has-value">
-                <span class="packages-score-value-number">110</span>
+                <span class="packages-score-value-number">120</span>
                 <span class="packages-score-value-sign"></span>
               </div>
               <div class="packages-score-label">pub points</div>

--- a/app/test/task/testdata/goldens/packages/oxygen/changelog.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/changelog.html
@@ -240,7 +240,7 @@
               </div>
               <div class="packages-score packages-score-health">
                 <div class="packages-score-value -has-value">
-                  <span class="packages-score-value-number">110</span>
+                  <span class="packages-score-value-number">120</span>
                   <span class="packages-score-value-sign"></span>
                 </div>
                 <div class="packages-score-label">pub points</div>
@@ -326,7 +326,7 @@
             </div>
             <div class="packages-score packages-score-health">
               <div class="packages-score-value -has-value">
-                <span class="packages-score-value-number">110</span>
+                <span class="packages-score-value-number">120</span>
                 <span class="packages-score-value-sign"></span>
               </div>
               <div class="packages-score-label">pub points</div>

--- a/app/test/task/testdata/goldens/packages/oxygen/example.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/example.html
@@ -235,7 +235,7 @@
               </div>
               <div class="packages-score packages-score-health">
                 <div class="packages-score-value -has-value">
-                  <span class="packages-score-value-number">110</span>
+                  <span class="packages-score-value-number">120</span>
                   <span class="packages-score-value-sign"></span>
                 </div>
                 <div class="packages-score-label">pub points</div>
@@ -321,7 +321,7 @@
             </div>
             <div class="packages-score packages-score-health">
               <div class="packages-score-value -has-value">
-                <span class="packages-score-value-number">110</span>
+                <span class="packages-score-value-number">120</span>
                 <span class="packages-score-value-sign"></span>
               </div>
               <div class="packages-score-label">pub points</div>

--- a/app/test/task/testdata/goldens/packages/oxygen/install.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/install.html
@@ -263,7 +263,7 @@
               </div>
               <div class="packages-score packages-score-health">
                 <div class="packages-score-value -has-value">
-                  <span class="packages-score-value-number">110</span>
+                  <span class="packages-score-value-number">120</span>
                   <span class="packages-score-value-sign"></span>
                 </div>
                 <div class="packages-score-label">pub points</div>
@@ -349,7 +349,7 @@
             </div>
             <div class="packages-score packages-score-health">
               <div class="packages-score-value -has-value">
-                <span class="packages-score-value-number">110</span>
+                <span class="packages-score-value-number">120</span>
                 <span class="packages-score-value-sign"></span>
               </div>
               <div class="packages-score-label">pub points</div>

--- a/app/test/task/testdata/goldens/packages/oxygen/license.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/license.html
@@ -236,7 +236,7 @@
               </div>
               <div class="packages-score packages-score-health">
                 <div class="packages-score-value -has-value">
-                  <span class="packages-score-value-number">110</span>
+                  <span class="packages-score-value-number">120</span>
                   <span class="packages-score-value-sign"></span>
                 </div>
                 <div class="packages-score-label">pub points</div>
@@ -322,7 +322,7 @@
             </div>
             <div class="packages-score packages-score-health">
               <div class="packages-score-value -has-value">
-                <span class="packages-score-value-number">110</span>
+                <span class="packages-score-value-number">120</span>
                 <span class="packages-score-value-sign"></span>
               </div>
               <div class="packages-score-label">pub points</div>

--- a/app/test/task/testdata/goldens/packages/oxygen/score.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/score.html
@@ -212,7 +212,7 @@
                     </div>
                     <div class="score-key-figure">
                       <div class="score-key-figure-title">
-                        <span class="score-key-figure-value">110</span>
+                        <span class="score-key-figure-value">120</span>
                         <span class="score-key-figure-supplemental">/ 140</span>
                       </div>
                       <div class="score-key-figure-label">pub points</div>
@@ -228,7 +228,7 @@
                   <p class="analysis-info">
                     We analyzed this package
                     <a class="-x-ago" href="" title="on %%short-dateformat%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%time-ago-millis%%">%%time-ago%%</a>
-                    , and awarded it 110 pub points (of a possible 140):
+                    , and awarded it 120 pub points (of a possible 140):
                   </p>
                   <div class="pkg-report">
                     <div class="pkg-report-section foldable">
@@ -362,11 +362,11 @@
                     <div class="pkg-report-section foldable">
                       <div class="pkg-report-header foldable-button" data-ga-click-event="toggle-report-section-documentation">
                         <div class="pkg-report-header-icon">
-                          <img class="pkg-report-icon" src="/static/hash-%%etag%%/img/report-missing-icon-red.svg" alt="icon indicating section status" width="18" height="18"/>
+                          <img class="pkg-report-icon" src="/static/hash-%%etag%%/img/report-ok-icon-green.svg" alt="icon indicating section status" width="18" height="18"/>
                         </div>
                         <div class="pkg-report-header-title">Provide documentation</div>
-                        <div class="pkg-report-header-score -is-red">
-                          <span class="pkg-report-header-score-granted">10</span>
+                        <div class="pkg-report-header-score">
+                          <span class="pkg-report-header-score-granted">20</span>
                           /
                           <span class="pkg-report-header-score-max">20</span>
                           <img class="foldable-icon" src="/static/hash-%%etag%%/img/report-foldable-icon.svg" alt="icon to trigger folding of the section" width="13" height="6"/>
@@ -377,16 +377,26 @@
                           <div class="pkg-report-content-summary markdown-body">
                             <h3>
                               <img class="report-summary-icon" src="/static/hash-%%etag%%/img/report-ok-icon-green.svg"/>
+                              10/10 points: 20% or more of the public API has dartdoc comments
+                            </h3>
+                            <p>2 out of 9 API elements (22.2 %) have documentation comments.</p>
+                            <p>
+                              Some symbols that are missing documentation:
+                              <code>oxygen</code>
+                              ,
+                              <code>MainClass</code>
+                              ,
+                              <code>MainClass</code>
+                              ,
+                              <code>text</code>
+                              ,
+                              <code>TypeEnum</code>
+                              .
+                            </p>
+                            <h3>
+                              <img class="report-summary-icon" src="/static/hash-%%etag%%/img/report-ok-icon-green.svg"/>
                               10/10 points: Package has an example and has no issues with screenshots
                             </h3>
-                            <h3>
-                              <img class="report-summary-icon" src="/static/hash-%%etag%%/img/report-missing-icon-red.svg"/>
-                              0/10 points: 20% or more of the public API has dartdoc comments
-                            </h3>
-                            <ul>
-                              <li>1 out of 11 API elements (9.1 %) have documentation comments.</li>
-                            </ul>
-                            <p>Providing good documentation for libraries, classes, functions, and other API elements improves code readability and helps developers find and use your API. Document at least 20% of the public API elements.</p>
                           </div>
                         </div>
                       </div>
@@ -533,7 +543,7 @@
               </div>
               <div class="packages-score packages-score-health">
                 <div class="packages-score-value -has-value">
-                  <span class="packages-score-value-number">110</span>
+                  <span class="packages-score-value-number">120</span>
                   <span class="packages-score-value-sign"></span>
                 </div>
                 <div class="packages-score-label">pub points</div>
@@ -619,7 +629,7 @@
             </div>
             <div class="packages-score packages-score-health">
               <div class="packages-score-value -has-value">
-                <span class="packages-score-value-number">110</span>
+                <span class="packages-score-value-number">120</span>
                 <span class="packages-score-value-sign"></span>
               </div>
               <div class="packages-score-label">pub points</div>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions.html
@@ -296,7 +296,7 @@
               </div>
               <div class="packages-score packages-score-health">
                 <div class="packages-score-value -has-value">
-                  <span class="packages-score-value-number">110</span>
+                  <span class="packages-score-value-number">120</span>
                   <span class="packages-score-value-sign"></span>
                 </div>
                 <div class="packages-score-label">pub points</div>
@@ -382,7 +382,7 @@
             </div>
             <div class="packages-score packages-score-health">
               <div class="packages-score-value -has-value">
-                <span class="packages-score-value-number">110</span>
+                <span class="packages-score-value-number">120</span>
                 <span class="packages-score-value-sign"></span>
               </div>
               <div class="packages-score-label">pub points</div>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0.html
@@ -238,7 +238,7 @@
               </div>
               <div class="packages-score packages-score-health">
                 <div class="packages-score-value -has-value">
-                  <span class="packages-score-value-number">110</span>
+                  <span class="packages-score-value-number">120</span>
                   <span class="packages-score-value-sign"></span>
                 </div>
                 <div class="packages-score-label">pub points</div>
@@ -324,7 +324,7 @@
             </div>
             <div class="packages-score packages-score-health">
               <div class="packages-score-value -has-value">
-                <span class="packages-score-value-number">110</span>
+                <span class="packages-score-value-number">120</span>
                 <span class="packages-score-value-sign"></span>
               </div>
               <div class="packages-score-label">pub points</div>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/changelog.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/changelog.html
@@ -244,7 +244,7 @@
               </div>
               <div class="packages-score packages-score-health">
                 <div class="packages-score-value -has-value">
-                  <span class="packages-score-value-number">110</span>
+                  <span class="packages-score-value-number">120</span>
                   <span class="packages-score-value-sign"></span>
                 </div>
                 <div class="packages-score-label">pub points</div>
@@ -330,7 +330,7 @@
             </div>
             <div class="packages-score packages-score-health">
               <div class="packages-score-value -has-value">
-                <span class="packages-score-value-number">110</span>
+                <span class="packages-score-value-number">120</span>
                 <span class="packages-score-value-sign"></span>
               </div>
               <div class="packages-score-label">pub points</div>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/example.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/example.html
@@ -239,7 +239,7 @@
               </div>
               <div class="packages-score packages-score-health">
                 <div class="packages-score-value -has-value">
-                  <span class="packages-score-value-number">110</span>
+                  <span class="packages-score-value-number">120</span>
                   <span class="packages-score-value-sign"></span>
                 </div>
                 <div class="packages-score-label">pub points</div>
@@ -325,7 +325,7 @@
             </div>
             <div class="packages-score packages-score-health">
               <div class="packages-score-value -has-value">
-                <span class="packages-score-value-number">110</span>
+                <span class="packages-score-value-number">120</span>
                 <span class="packages-score-value-sign"></span>
               </div>
               <div class="packages-score-label">pub points</div>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/install.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/install.html
@@ -267,7 +267,7 @@
               </div>
               <div class="packages-score packages-score-health">
                 <div class="packages-score-value -has-value">
-                  <span class="packages-score-value-number">110</span>
+                  <span class="packages-score-value-number">120</span>
                   <span class="packages-score-value-sign"></span>
                 </div>
                 <div class="packages-score-label">pub points</div>
@@ -353,7 +353,7 @@
             </div>
             <div class="packages-score packages-score-health">
               <div class="packages-score-value -has-value">
-                <span class="packages-score-value-number">110</span>
+                <span class="packages-score-value-number">120</span>
                 <span class="packages-score-value-sign"></span>
               </div>
               <div class="packages-score-label">pub points</div>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/license.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/license.html
@@ -240,7 +240,7 @@
               </div>
               <div class="packages-score packages-score-health">
                 <div class="packages-score-value -has-value">
-                  <span class="packages-score-value-number">110</span>
+                  <span class="packages-score-value-number">120</span>
                   <span class="packages-score-value-sign"></span>
                 </div>
                 <div class="packages-score-label">pub points</div>
@@ -326,7 +326,7 @@
             </div>
             <div class="packages-score packages-score-health">
               <div class="packages-score-value -has-value">
-                <span class="packages-score-value-number">110</span>
+                <span class="packages-score-value-number">120</span>
                 <span class="packages-score-value-sign"></span>
               </div>
               <div class="packages-score-label">pub points</div>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/score.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/score.html
@@ -216,7 +216,7 @@
                     </div>
                     <div class="score-key-figure">
                       <div class="score-key-figure-title">
-                        <span class="score-key-figure-value">110</span>
+                        <span class="score-key-figure-value">120</span>
                         <span class="score-key-figure-supplemental">/ 140</span>
                       </div>
                       <div class="score-key-figure-label">pub points</div>
@@ -232,7 +232,7 @@
                   <p class="analysis-info">
                     We analyzed this package
                     <a class="-x-ago" href="" title="on %%short-dateformat%%" aria-label="Switch between date and elapsed time." aria-role="button" data-timestamp="%%time-ago-millis%%">%%time-ago%%</a>
-                    , and awarded it 110 pub points (of a possible 140):
+                    , and awarded it 120 pub points (of a possible 140):
                   </p>
                   <div class="pkg-report">
                     <div class="pkg-report-section foldable">
@@ -366,11 +366,11 @@
                     <div class="pkg-report-section foldable">
                       <div class="pkg-report-header foldable-button" data-ga-click-event="toggle-report-section-documentation">
                         <div class="pkg-report-header-icon">
-                          <img class="pkg-report-icon" src="/static/hash-%%etag%%/img/report-missing-icon-red.svg" alt="icon indicating section status" width="18" height="18"/>
+                          <img class="pkg-report-icon" src="/static/hash-%%etag%%/img/report-ok-icon-green.svg" alt="icon indicating section status" width="18" height="18"/>
                         </div>
                         <div class="pkg-report-header-title">Provide documentation</div>
-                        <div class="pkg-report-header-score -is-red">
-                          <span class="pkg-report-header-score-granted">10</span>
+                        <div class="pkg-report-header-score">
+                          <span class="pkg-report-header-score-granted">20</span>
                           /
                           <span class="pkg-report-header-score-max">20</span>
                           <img class="foldable-icon" src="/static/hash-%%etag%%/img/report-foldable-icon.svg" alt="icon to trigger folding of the section" width="13" height="6"/>
@@ -381,16 +381,26 @@
                           <div class="pkg-report-content-summary markdown-body">
                             <h3>
                               <img class="report-summary-icon" src="/static/hash-%%etag%%/img/report-ok-icon-green.svg"/>
+                              10/10 points: 20% or more of the public API has dartdoc comments
+                            </h3>
+                            <p>2 out of 9 API elements (22.2 %) have documentation comments.</p>
+                            <p>
+                              Some symbols that are missing documentation:
+                              <code>oxygen</code>
+                              ,
+                              <code>MainClass</code>
+                              ,
+                              <code>MainClass</code>
+                              ,
+                              <code>text</code>
+                              ,
+                              <code>TypeEnum</code>
+                              .
+                            </p>
+                            <h3>
+                              <img class="report-summary-icon" src="/static/hash-%%etag%%/img/report-ok-icon-green.svg"/>
                               10/10 points: Package has an example and has no issues with screenshots
                             </h3>
-                            <h3>
-                              <img class="report-summary-icon" src="/static/hash-%%etag%%/img/report-missing-icon-red.svg"/>
-                              0/10 points: 20% or more of the public API has dartdoc comments
-                            </h3>
-                            <ul>
-                              <li>1 out of 11 API elements (9.1 %) have documentation comments.</li>
-                            </ul>
-                            <p>Providing good documentation for libraries, classes, functions, and other API elements improves code readability and helps developers find and use your API. Document at least 20% of the public API elements.</p>
                           </div>
                         </div>
                       </div>
@@ -537,7 +547,7 @@
               </div>
               <div class="packages-score packages-score-health">
                 <div class="packages-score-value -has-value">
-                  <span class="packages-score-value-number">110</span>
+                  <span class="packages-score-value-number">120</span>
                   <span class="packages-score-value-sign"></span>
                 </div>
                 <div class="packages-score-label">pub points</div>
@@ -623,7 +633,7 @@
             </div>
             <div class="packages-score packages-score-health">
               <div class="packages-score-value -has-value">
-                <span class="packages-score-value-number">110</span>
+                <span class="packages-score-value-number">120</span>
                 <span class="packages-score-value-sign"></span>
               </div>
               <div class="packages-score-label">pub points</div>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/2.0.0.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/2.0.0.html
@@ -234,7 +234,7 @@
               </div>
               <div class="packages-score packages-score-health">
                 <div class="packages-score-value -has-value">
-                  <span class="packages-score-value-number">110</span>
+                  <span class="packages-score-value-number">120</span>
                   <span class="packages-score-value-sign"></span>
                 </div>
                 <div class="packages-score-label">pub points</div>
@@ -320,7 +320,7 @@
             </div>
             <div class="packages-score packages-score-health">
               <div class="packages-score-value -has-value">
-                <span class="packages-score-value-number">110</span>
+                <span class="packages-score-value-number">120</span>
                 <span class="packages-score-value-sign"></span>
               </div>
               <div class="packages-score-label">pub points</div>

--- a/pkg/pub_worker/lib/src/bin/dartdoc_wrapper.dart
+++ b/pkg/pub_worker/lib/src/bin/dartdoc_wrapper.dart
@@ -6,13 +6,9 @@ import 'dart:async';
 import 'dart:convert' show json, utf8, Utf8Codec;
 import 'dart:io';
 
-import 'package:logging/logging.dart' show Logger, Level, LogRecord;
-import 'package:pana/pana.dart';
+import 'package:logging/logging.dart' show Logger;
 import 'package:path/path.dart' as p;
-import 'package:pub_dartdoc/pub_dartdoc.dart';
 import 'package:pub_dartdoc_data/dartdoc_page.dart';
-import 'package:pub_worker/src/fetch_pubspec.dart';
-import 'package:pub_worker/src/sdks.dart';
 import 'package:stream_transform/stream_transform.dart';
 import 'package:tar/tar.dart';
 
@@ -20,155 +16,12 @@ final _log = Logger('dartdoc');
 final _utf8 = Utf8Codec(allowMalformed: true);
 final _jsonUtf8 = json.fuse(utf8);
 
-const _defaultMaxFileCount = 10 * 1000 * 1000; // 10 million files
-
-// TODO (sigurdm): reduce this back to 2 GiB when
-// https://github.com/dart-lang/dartdoc/issues/3311 is resolved.
-const _defaultMaxTotalLengthBytes =
-    2 * 1024 * 1024 * 1024 + 300 * 1024 * 1024; // 2 GiB + 300 MiB
-
-/// Program to be used as subprocess for running dartdoc, ensuring that we
-/// capture all the output, and only run dartdoc in a subprocess that can
-/// timeout and be killed.
-Future<void> main(List<String> args) async {
-  if (args.length != 3) {
-    print('Usage: dartdoc_wrapper.dart <output-folder> <package> <version>');
-    exit(1);
-  }
-  final outputFolder = args[0];
-  final package = args[1];
-  final version = args[2];
-  final pubHostedUrl =
-      Platform.environment['PUB_HOSTED_URL'] ?? 'https://pub.dartlang.org';
-  final pubCache = Platform.environment['PUB_CACHE']!;
-
-  // Setup logging
-  Logger.root.level = Level.INFO;
-  Logger.root.onRecord.listen((LogRecord rec) {
-    print('${rec.level.name}: ${rec.time}: ${rec.message}');
-    if (rec.error != null) {
-      print('ERROR: ${rec.error}, ${rec.stackTrace}');
-    }
-  });
-
-  final workDir = await Directory.systemTemp.createTemp('pkg-');
-  try {
-    await _dartdoc(
-      outputFolder: outputFolder,
-      package: package,
-      version: version,
-      pubHostedUrl: pubHostedUrl,
-      pubCache: pubCache,
-      workDir: workDir.path,
-    );
-  } finally {
-    await workDir.delete(recursive: true);
-  }
-}
-
-Future<void> _dartdoc({
+Future<void> postPorcessDartdoc({
   required String outputFolder,
   required String package,
   required String version,
-  required String pubHostedUrl,
-  required String pubCache,
-  required String workDir,
+  required String docDir,
 }) async {
-  // Fetch the pubspec so we detect which SDK to use for analysis
-  // TODO: Download the package, extract and load the pubspec.yaml, that way
-  //       we won't have to list versions again later.
-  final pubspec = await fetchPubspec(
-    package: package,
-    version: version,
-    pubHostedUrl: pubHostedUrl,
-  );
-
-  // Discover installed Dart and Flutter SDKs.
-  // This reads sibling folders to the Dart and Flutter SDK.
-  // TODO: Install Dart / Flutter SDKs into these folders ondemand in the future!
-  final dartSdks = await InstalledSdk.fromDirectory(
-    kind: 'dart',
-    path: Directory(
-      Platform.environment['DART_SDK'] ??
-          Directory(Platform.resolvedExecutable).parent.parent.path,
-    ).parent,
-  );
-  final flutterSdks = await InstalledSdk.fromDirectory(
-    kind: 'flutter',
-    path: Directory(Platform.environment['FLUTTER_ROOT'] ?? '').parent,
-  );
-
-  // Choose Dart and Flutter SDKs for analysis
-  final dartSdk = InstalledSdk.prioritizedSdk(
-    dartSdks,
-    pubspec.dartSdkConstraint,
-  );
-  final flutterSdk = InstalledSdk.prioritizedSdk(
-    flutterSdks,
-    pubspec.flutterSdkConstraint,
-  );
-
-  final toolEnv = await ToolEnvironment.create(
-    dartSdkDir: dartSdk?.path,
-    flutterSdkDir: flutterSdk?.path,
-    pubCacheDir: pubCache,
-    environment: {'CI': 'true'},
-    useGlobalDartdoc: false,
-  );
-
-  final pkgDir = p.join(workDir, 'pkg');
-  await Directory(pkgDir).create(recursive: true);
-  // TODO: Ensure that we set User-Agent correctly here!
-  await downloadPackage(
-    package,
-    version,
-    destination: pkgDir,
-    pubHostedUrl: pubHostedUrl,
-  );
-
-  _log.info('Running pub upgrade');
-  final ret = await toolEnv.runUpgrade(pkgDir, pubspec.usesFlutter);
-  if (ret.exitCode != 0) {
-    _log.shout('Failed to run pub upgrade');
-    return;
-  }
-
-  // Create and/or customize dartdoc_options.yaml
-  final optionsFile = File(p.join(pkgDir, 'dartdoc_options.yaml'));
-  Map<String, dynamic>? originalContent;
-  try {
-    originalContent = yamlToJson(await optionsFile.readAsString());
-  } on IOException {
-    // pass, ignore missing file
-  } on FormatException {
-    // pass, ignore broken file
-  }
-  final updatedContent = _customizeDartdocOptions(originalContent);
-  await optionsFile.writeAsString(json.encode(updatedContent));
-
-  final docDir = p.join(workDir, 'doc');
-  await Directory(docDir).create(recursive: true);
-  await pubDartDoc([
-    '--input',
-    pkgDir,
-    '--output',
-    docDir,
-    '--no-validate-links',
-    '--sanitize-html',
-    '--max-file-count',
-    '$_defaultMaxFileCount',
-    '--max-total-size',
-    '$_defaultMaxTotalLengthBytes',
-    if (pubspec.usesFlutter) ...[
-      '--sdk-dir',
-      p.join(flutterSdk!.path, 'bin', 'cache', 'dart-sdk')
-    ] else ...[
-      '--sdk-dir',
-      dartSdk!.path,
-    ]
-  ]);
-  _log.info('Finished running dartdoc');
-
   _log.info('Running post-processing');
   final tmpOutDir = p.join(outputFolder, '_doc');
   await Directory(tmpOutDir).create(recursive: true);
@@ -229,44 +82,3 @@ Future<void> _dartdoc({
 
   _log.info('Finished .tar.gz archive');
 }
-
-/// Returns a new, pub-specific dartdoc options based on [original].
-///
-/// dartdoc_options.yaml allows to change how doc content is generated.
-/// To provide uniform experience across the pub site, and to reduce the
-/// potential attack surface (HTML-, and code-injections, code executions),
-/// we do not support every option.
-///
-/// https://github.com/dart-lang/dartdoc#dartdoc_optionsyaml
-///
-/// Discussion on the enabled options:
-/// https://github.com/dart-lang/pub-dev/issues/4521#issuecomment-779821098
-Map<String, dynamic> _customizeDartdocOptions(Map<String, dynamic>? original) {
-  final passThroughOptions = <String, dynamic>{};
-  if (original != null &&
-      original.containsKey('dartdoc') &&
-      original['dartdoc'] is Map<String, dynamic>) {
-    final dartdoc = original['dartdoc'] as Map<String, dynamic>;
-    for (final key in _passThroughKeys) {
-      if (dartdoc.containsKey(key)) {
-        passThroughOptions[key] = dartdoc[key];
-      }
-    }
-  }
-  return <String, dynamic>{
-    'dartdoc': <String, dynamic>{
-      ...passThroughOptions,
-      'showUndocumentedCategories': true,
-    },
-  };
-}
-
-final _passThroughKeys = <String>[
-  'categories',
-  'categoryOrder',
-  // TODO: enable after checking that the relative path doesn't escape the package folder
-  // 'examplePathPrefix',
-  'exclude',
-  'include',
-  'nodoc',
-];

--- a/pkg/pub_worker/pubspec.lock
+++ b/pkg/pub_worker/pubspec.lock
@@ -466,10 +466,10 @@ packages:
     dependency: "direct main"
     description:
       name: pana
-      sha256: "0a2546792c71440b69e4dd73d9cd310dab6404c18ce6c0e8ceeb1453249c5d27"
+      sha256: d8c24d31fbf66b9c8c6c5e31c39b094c8535ed5bd152dbce9642049e6e76965d
       url: "https://pub.dev"
     source: hosted
-    version: "0.21.40"
+    version: "0.21.42"
   path:
     dependency: transitive
     description:

--- a/pkg/pub_worker/pubspec.yaml
+++ b/pkg/pub_worker/pubspec.yaml
@@ -9,7 +9,7 @@ dependencies:
   appengine: ^0.13.6
   json_annotation: ^4.3.0
   jsontool: ^1.1.0
-  pana: ^0.21.40
+  pana: ^0.21.42
   lints: ^3.0.0 # required for pana
   meta: ^1.7.0
   api_builder:


### PR DESCRIPTION
- Upgraded to latest pana.
- Main changes are in `pkg/pub_worker`.
- Includes updated tests and golden files from #7167 (see last commit for specific changes).
