### PR TITLE
Use asyncQueue instead of Timers in CachedValue.

### DIFF
--- a/app/lib/search/top_packages.dart
+++ b/app/lib/search/top_packages.dart
@@ -55,7 +55,7 @@ class TopPackages {
       );
     }
     _running = true;
-    await Future.wait(_values.map((v) => v.start()));
+    await Future.wait(_values.map((v) => v.update()));
   }
 
   @visibleForTesting

--- a/app/lib/service/announcement/backend.dart
+++ b/app/lib/service/announcement/backend.dart
@@ -36,7 +36,7 @@ class AnnouncementBackend {
 
   /// Update announcements regularly.
   Future<void> start() async {
-    await _announcementHtml.start();
+    await _announcementHtml.update();
   }
 
   /// Cancel updates and free resources.

--- a/app/lib/service/youtube/backend.dart
+++ b/app/lib/service/youtube/backend.dart
@@ -43,7 +43,7 @@ class YoutubeBackend {
 
   /// Starts the initial and schedules the periodic updates.
   Future<void> start() async {
-    await _packageOfWeekVideoList.start();
+    await _packageOfWeekVideoList.update();
   }
 
   /// Sets the list of PoW videos to a fixed value.

--- a/app/lib/shared/popularity_storage.dart
+++ b/app/lib/shared/popularity_storage.dart
@@ -56,7 +56,7 @@ class PopularityStorage {
   int lookupAsScore(String package) => (lookup(package) * 100).round();
 
   Future<void> start() async {
-    await _popularity.start();
+    await _popularity.update();
   }
 
   Future<void> close() async {


### PR DESCRIPTION
- Fixes #7002
- The use cases of `CachedValue` are mostly (relatively) low-importance but potentially high-latency values to be included in-page. I don't think we should always hit the redis cache for them, a locally cached value seems to be a good in-between solution.
- The new `AsyncQueue` tracks the zones and logging better than the timers were previously.
