### PR TITLE
Run pana's dartdoc on dartdoc_page_test.

### DIFF
--- a/app/lib/frontend/static_files.dart
+++ b/app/lib/frontend/static_files.dart
@@ -72,12 +72,6 @@ String resolveWebCssDirPath() {
       .resolveSymbolicLinksSync();
 }
 
-/// Returns the path of pkg/pub_dartdoc on the local filesystem.
-String resolvePubDartdocDirPath() {
-  return Directory(path.join(resolveAppDir(), '../pkg/pub_dartdoc'))
-      .resolveSymbolicLinksSync();
-}
-
 /// Returns the path of /doc on the local filesystem.
 String resolveDocDirPath() {
   return path.join(resolveAppDir(), '../doc');


### PR DESCRIPTION
- Removes the dependency on `pkg/pub_dartdoc` (which we don't use for this purpose anyway), allowing a cleanup of it in a subsequent PR.