### PR TITLE
Add `messages` to reserved package names

### DIFF
--- a/app/lib/package/overrides.dart
+++ b/app/lib/package/overrides.dart
@@ -24,6 +24,7 @@ final _reservedPackageNames = <String>[
   'location_background',
   'math',
   'mirrors',
+  'messages',
   'developer',
   'pub',
   'swift_ui',


### PR DESCRIPTION
Similar to #7105, to allow `package:messages` to coexist next to the existing, deprecated `package:message`.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
