### PR TITLE
Use redis cache for announcement and YouTube API response.

### DIFF
--- a/app/lib/search/top_packages.dart
+++ b/app/lib/search/top_packages.dart
@@ -118,6 +118,7 @@ CachedValue<List<PackageView>> _cachedValue(
 }) {
   return CachedValue<List<PackageView>>(
     name: id,
+    // the redis-cached search results have 5 minutes TTL
     interval: Duration(minutes: 15),
     maxAge: Duration(hours: 24),
     updateFn: () async {

--- a/app/lib/search/top_packages.dart
+++ b/app/lib/search/top_packages.dart
@@ -118,7 +118,15 @@ CachedValue<List<PackageView>> _cachedValue(
 }) {
   return CachedValue<List<PackageView>>(
     name: id,
-    // the redis-cached search results have 5 minutes TTL
+    // The search results are cached in redis with a 5 minutes TTL.
+    //
+    // If we have a valid value locally, we don't initiate new search queries
+    // for the top packages for 15 minutes, and after that we have a good chance
+    // that we have a <5 minutes old value in the cache.
+    //
+    // We could reduce the 15 minutes to 5 minutes, but in practice it wouldn't
+    // matter much, as the search index itself won't get updated only at
+    // every 15 minutes.
     interval: Duration(minutes: 15),
     maxAge: Duration(hours: 24),
     updateFn: () async {

--- a/app/lib/service/announcement/backend.dart
+++ b/app/lib/service/announcement/backend.dart
@@ -23,9 +23,10 @@ class AnnouncementBackend {
   final _announcementHtml = CachedValue<String>(
     name: 'announcement-html',
     maxAge: Duration(hours: 12),
-    interval: Duration(minutes: 30),
+    // the redis-cached secret value has 60 minutes TTL
+    interval: Duration(minutes: 1),
     updateFn: () async {
-      final value = await secretBackend.lookup(SecretKey.announcement);
+      final value = await secretBackend.getCachedValue(SecretKey.announcement);
       if (value != null && value.trim().isNotEmpty) {
         return sanitizeHtml(value.trim());
       } else {

--- a/app/lib/service/secret/backend.dart
+++ b/app/lib/service/secret/backend.dart
@@ -62,6 +62,8 @@ class SecretBackend {
   /// WARNING: Do not use this method for sensitive data, as it will be put in
   ///          redis too.
   Future<String?> getCachedValue(String id) async {
-    return await cache.secretValue(id).get(() => lookup(id));
+    final value =
+        await cache.secretValue(id).get(() async => await lookup(id) ?? '');
+    return value == null || value.isEmpty ? null : value;
   }
 }

--- a/app/lib/shared/popularity_storage.dart
+++ b/app/lib/shared/popularity_storage.dart
@@ -36,6 +36,7 @@ class PopularityStorage {
     _loader = _PopularityLoader(bucket);
     _popularity = CachedValue<_PopularityData>(
       name: 'popularity',
+      // note: popularity data is stored in storage bucket, not cached in redis
       interval: Duration(hours: 1),
       maxAge: Duration(days: 14),
       updateFn: () async => _loader.fetch(),

--- a/app/lib/shared/redis_cache.dart
+++ b/app/lib/shared/redis_cache.dart
@@ -8,6 +8,7 @@ import 'dart:math';
 
 import 'package:_pub_shared/data/package_api.dart' show VersionScore;
 import 'package:gcloud/service_scope.dart' as ss;
+import 'package:googleapis/youtube/v3.dart';
 import 'package:indexed_blob/indexed_blob.dart' show BlobIndex;
 import 'package:logging/logging.dart';
 import 'package:neat_cache/cache_provider.dart';
@@ -375,6 +376,17 @@ class CachePatterns {
             decode: (v) =>
                 ResolvedDocUrlVersion.fromJson(v as Map<String, dynamic>),
           ))['$package-$version'];
+
+  Entry<PlaylistItemListResponse> youtubePlaylistItems() => _cache
+      .withPrefix('youtube/playlist-item-list-response/')
+      .withTTL(Duration(hours: 6))
+      .withCodec(utf8)
+      .withCodec(json)
+      .withCodec(wrapAsCodec(
+        encode: (PlaylistItemListResponse v) => v.toJson(),
+        decode: (v) =>
+            PlaylistItemListResponse.fromJson(v as Map<String, dynamic>),
+      ))[''];
 }
 
 /// The active cache.


### PR DESCRIPTION
- part of #7002
- `top_packages.dart` already uses search client's caching of responses
- popularity storage doesn't need redis-based caching
- announcement cache is invalidated on updating the value
- added YouTube redis cache for the API response object