### PR TITLE
Bucket config + initialization for API JSON exporter.

### DIFF
--- a/app/config/dartlang-pub-dev.yaml
+++ b/app/config/dartlang-pub-dev.yaml
@@ -10,6 +10,7 @@ defaultServiceBaseUrl: https://{{GAE_VERSION}}-dot-{{GOOGLE_CLOUD_PROJECT}}.apps
 dartdocStorageBucketName: dartlang-pub-dev--dartdoc-storage
 popularityDumpBucketName: dartlang-pub-dev--popularity
 searchSnapshotBucketName: dartlang-pub-dev--search-snapshot
+exportedApiBucketName: null
 maxTaskInstances: 50
 maxTaskRunHours: 2
 taskResultBucketName: dartlang-pub-dev-task-output

--- a/app/config/dartlang-pub.yaml
+++ b/app/config/dartlang-pub.yaml
@@ -13,6 +13,7 @@ defaultServiceBaseUrl: https://{{GAE_VERSION}}-dot-{{GOOGLE_CLOUD_PROJECT}}.apps
 dartdocStorageBucketName: dartlang-pub--dartdoc-storage
 popularityDumpBucketName: dartlang-pub--popularity
 searchSnapshotBucketName: dartlang-pub--search-snapshot
+exportedApiBucketName: null
 maxTaskInstances: 700
 maxTaskRunHours: 2
 taskResultBucketName: dartlang-pub-task-output

--- a/app/lib/package/export_api_to_bucket.dart
+++ b/app/lib/package/export_api_to_bucket.dart
@@ -7,6 +7,7 @@ import 'dart:io';
 import 'package:basics/basics.dart';
 import 'package:clock/clock.dart';
 import 'package:crypto/crypto.dart';
+import 'package:gcloud/service_scope.dart' as ss;
 import 'package:gcloud/storage.dart';
 import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
@@ -40,6 +41,13 @@ List<String> _apiPkgNameCompletitionDataNames() => [
       '$runtimeVersion/api/package-name-completion-data',
       'current/api/package-name-completion-data',
     ];
+
+/// Sets the API Exporter service.
+void registerApiExporter(ApiExporter value) =>
+    ss.register(#_apiExporter, value);
+
+/// The active API Exporter service or null if it hasn't been initialized.
+ApiExporter? get apiExporter => ss.lookup(#_apiExporter) as ApiExporter?;
 
 class ApiExporter {
   final Bucket _bucket;

--- a/app/lib/service/services.dart
+++ b/app/lib/service/services.dart
@@ -12,6 +12,7 @@ import 'package:gcloud/service_scope.dart';
 import 'package:gcloud/storage.dart';
 import 'package:googleapis_auth/auth_io.dart' as auth;
 import 'package:logging/logging.dart';
+import 'package:pub_dev/package/export_api_to_bucket.dart';
 import 'package:pub_dev/service/async_queue/async_queue.dart';
 import 'package:pub_dev/service/security_advisories/backend.dart';
 import 'package:shelf/shelf.dart' as shelf;
@@ -228,6 +229,11 @@ Future<R> _withPubServices<R>(FutureOr<R> Function() fn) async {
     registerAccountBackend(AccountBackend(dbService));
     registerAdminBackend(AdminBackend(dbService));
     registerAnnouncementBackend(AnnouncementBackend());
+    if (activeConfiguration.exportedApiBucketName != null) {
+      registerApiExporter(ApiExporter(
+          bucket: storageService
+              .bucket(activeConfiguration.exportedApiBucketName!)));
+    }
     registerAsyncQueue(AsyncQueue());
     registerAuditBackend(AuditBackend(dbService));
     registerConsentBackend(ConsentBackend(dbService));

--- a/app/lib/shared/configuration.dart
+++ b/app/lib/shared/configuration.dart
@@ -85,6 +85,9 @@ class Configuration {
   /// The name of the Cloud Storage bucket to use for generated reports.
   final String? reportsBucketName;
 
+  /// The name of the Cloud Storage bucket to use for exporting JSON API responses.
+  final String? exportedApiBucketName;
+
   /// The Cloud project Id. This is only required when using Apiary to access
   /// Datastore and/or Cloud Storage
   final String projectId;
@@ -275,6 +278,7 @@ class Configuration {
     required this.dartdocStorageBucketName,
     required this.popularityDumpBucketName,
     required this.searchSnapshotBucketName,
+    required this.exportedApiBucketName,
     required this.maxTaskInstances,
     required this.maxTaskRunHours,
     required this.taskResultBucketName,
@@ -341,6 +345,7 @@ class Configuration {
       dartdocStorageBucketName: 'fake-bucket-dartdoc',
       popularityDumpBucketName: 'fake-bucket-popularity',
       searchSnapshotBucketName: 'fake-bucket-search',
+      exportedApiBucketName: 'fake-exported-apis',
       maxTaskInstances: 10,
       maxTaskRunHours: 2,
       taskResultBucketName: 'fake-bucket-task-result',
@@ -392,6 +397,7 @@ class Configuration {
       dartdocStorageBucketName: 'fake-bucket-dartdoc',
       popularityDumpBucketName: 'fake-bucket-popularity',
       searchSnapshotBucketName: 'fake-bucket-search',
+      exportedApiBucketName: 'fake-exported-apis',
       taskResultBucketName: 'fake-bucket-task-result',
       maxTaskInstances: 10,
       maxTaskRunHours: 2,
@@ -442,6 +448,7 @@ class Configuration {
     publicPackagesBucketName!,
     searchSnapshotBucketName!,
     taskResultBucketName!,
+    if (exportedApiBucketName != null) exportedApiBucketName!,
   ]);
 
   late final isProduction = projectId == 'dartlang-pub';

--- a/app/lib/shared/configuration.g.dart
+++ b/app/lib/shared/configuration.g.dart
@@ -18,6 +18,7 @@ Configuration _$ConfigurationFromJson(Map json) => $checkedCreate(
             'incomingPackagesBucketName',
             'imageBucketName',
             'reportsBucketName',
+            'exportedApiBucketName',
             'projectId',
             'searchServicePrefix',
             'fallbackSearchServicePrefix',
@@ -68,6 +69,8 @@ Configuration _$ConfigurationFromJson(Map json) => $checkedCreate(
               $checkedConvert('popularityDumpBucketName', (v) => v as String?),
           searchSnapshotBucketName:
               $checkedConvert('searchSnapshotBucketName', (v) => v as String?),
+          exportedApiBucketName:
+              $checkedConvert('exportedApiBucketName', (v) => v as String?),
           maxTaskInstances:
               $checkedConvert('maxTaskInstances', (v) => v as int),
           maxTaskRunHours: $checkedConvert('maxTaskRunHours', (v) => v as int),
@@ -141,6 +144,7 @@ Map<String, dynamic> _$ConfigurationToJson(Configuration instance) =>
       'incomingPackagesBucketName': instance.incomingPackagesBucketName,
       'imageBucketName': instance.imageBucketName,
       'reportsBucketName': instance.reportsBucketName,
+      'exportedApiBucketName': instance.exportedApiBucketName,
       'projectId': instance.projectId,
       'searchServicePrefix': instance.searchServicePrefix,
       'fallbackSearchServicePrefix': instance.fallbackSearchServicePrefix,

--- a/app/lib/tool/neat_task/pub_dev_tasks.dart
+++ b/app/lib/tool/neat_task/pub_dev_tasks.dart
@@ -8,6 +8,7 @@ import 'dart:io';
 import 'package:gcloud/service_scope.dart' as ss;
 import 'package:logging/logging.dart';
 import 'package:neat_periodic_task/neat_periodic_task.dart';
+import 'package:pub_dev/package/export_api_to_bucket.dart';
 
 import '../../account/backend.dart';
 import '../../account/consent_backend.dart';
@@ -114,6 +115,13 @@ void _setupGenericPeriodicTasks() {
     task: updatePublicArchiveBucket,
   );
 
+  // Exports the package name completetion data to a bucket.
+  _daily(
+    name: 'export-package-name-completition-data-to-bucket',
+    isRuntimeVersioned: true,
+    task: () async => await apiExporter?.uploadPkgNameCompletionData(),
+  );
+
   // Deletes task status entities where the status hasn't been updated
   // for more than a month.
   _weekly(
@@ -148,6 +156,13 @@ void _setupGenericPeriodicTasks() {
     name: 'garbage-collect-task-results',
     isRuntimeVersioned: false,
     task: taskBackend.garbageCollect,
+  );
+
+  // Deletes exported API data for old runtime versions
+  _weekly(
+    name: 'garbage-collect-api-exports',
+    isRuntimeVersioned: true,
+    task: () async => apiExporter?.deleteObsoleteRuntimeContent(),
   );
 
   // Delete very old instances that have been abandoned

--- a/app/test/shared/test_data/foo_config.yaml
+++ b/app/test/shared/test_data/foo_config.yaml
@@ -5,6 +5,7 @@ popularityDumpBucketName: foo
 searchSnapshotBucketName: foo
 canonicalPackagesBucketName: foo
 reportsBucketName: foo
+exportedApiBucketName: foo
 maxTaskInstances: 0
 maxTaskRunHours: 2
 searchServicePrefix: 'https://search-dot-dartlang-pub-dev.appspot.com'


### PR DESCRIPTION
- The initialization and use only happens if the bucket is configured, which we are not yet doing for neither staging nor prod.
- The ongoing export runs in one of the analyzer instances as a separate isolate.
- The daily update of name completion and the weekly cleanup runs on the analyzer as part of the other periodic tasks.