### PR TITLE
Use separate config directory for preview SDKs.

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -17,18 +17,24 @@ USER worker:2000
 COPY --chown=worker:worker . /home/worker/pub-dev
 WORKDIR /home/worker/pub-dev
 
+# A config directory for preview SDKs.
+# TODO(https://github.com/dart-lang/pub-dev/issues/7270): Use per-SDK config directory.
+RUN mkdir -p /home/worker/config/preview
+
 # Setup Dart SDK into /home/worker/dart/{stable,preview}/
 RUN tool/setup-dart.sh /home/worker/dart 3.2.2
 RUN mv /home/worker/dart/dart-sdk /home/worker/dart/stable
-RUN tool/setup-dart.sh /home/worker/dart 3.3.0-174.2.beta
-RUN tool/setup-webp.sh /home/worker/bin
+RUN XDG_CONFIG_HOME=/home/worker/config/preview tool/setup-dart.sh /home/worker/dart 3.3.0-174.2.beta
 RUN mv /home/worker/dart/dart-sdk /home/worker/dart/preview
 
 # Setup Flutter SDK into /home/worker/flutter/{stable,preview}/
 RUN tool/setup-flutter.sh /home/worker/flutter 3.16.2
 RUN mv /home/worker/flutter/flutter /home/worker/flutter/stable
-RUN tool/setup-flutter.sh /home/worker/flutter 3.18.0-0.1.pre
+RUN XDG_CONFIG_HOME=/home/worker/config/preview tool/setup-flutter.sh /home/worker/flutter 3.18.0-0.1.pre
 RUN mv /home/worker/flutter/flutter /home/worker/flutter/preview
+
+# Setup webp
+RUN tool/setup-webp.sh /home/worker/bin
 
 # Configure SDKs to be used for analysis
 ENV DART_SDK="/home/worker/dart/stable"
@@ -36,7 +42,6 @@ ENV FLUTTER_ROOT="/home/worker/flutter/stable"
 
 # Use stable Dart-SDK in PATH
 ENV PATH="/home/worker/bin:/home/worker/dart/stable/bin:${PATH}"
-
 
 # Install dependencies for pub_worker
 WORKDIR /home/worker/pub-dev/pkg/pub_worker

--- a/pkg/pub_worker/lib/src/bin/pana_wrapper.dart
+++ b/pkg/pub_worker/lib/src/bin/pana_wrapper.dart
@@ -95,12 +95,26 @@ Future<void> main(List<String> args) async {
     pubspec.flutterSdkConstraint,
   );
 
+  // NOTE: This is a temporary workaround to use a different config directory for preview SDKs.
+  // TODO(https://github.com/dart-lang/pub-dev/issues/7270): Use per-SDK config directory.
+  final isPreviewSdk = flutterSdk?.version.isPreRelease ??
+      dartSdk?.version.isPreRelease ??
+      false;
+  final workerPreviewConfigDir = Directory('/home/worker/config/preview');
+  String? configDir;
+  if (isPreviewSdk && await workerPreviewConfigDir.exists()) {
+    configDir = workerPreviewConfigDir.path;
+  }
+
   final toolEnv = await ToolEnvironment.create(
     dartSdkDir: dartSdk?.path,
     flutterSdkDir: flutterSdk?.path,
     pubCacheDir: pubCache,
     panaCacheDir: Platform.environment['PANA_CACHE'],
-    environment: {'CI': 'true'},
+    environment: {
+      'CI': 'true',
+      if (configDir != null) 'XDG_CONFIG_HOME': configDir,
+    },
     useGlobalDartdoc: true,
     globalDartdocVersion: '8.0.0',
   );


### PR DESCRIPTION
- Should handle #7270 better.
- This is not the final fix, only a workaround, tracking the proper fix (pana changes) in #7270.