### PR TITLE
Upgrade pana and stable analysis SDKs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ Important changes to data models, configuration, and migrations between each
 AppEngine version, listed here to ease deployment and troubleshooting.
 
 ## Next Release (replace with git tag when deployed)
+ * Bumped runtimeVersion to `2023.12.08`.
+ * Upgraded stable Dart analysis SDK to `3.2.3`.
+ * Upgraded stable Flutter analysis SDK to `3.16.3`.
+ * Upgraded pana to `0.21.44`.
 
 ## `20231206t130200-all`
  * Bumped runtimeVersion to `2023.12.06`.

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -22,13 +22,13 @@ WORKDIR /home/worker/pub-dev
 RUN mkdir -p /home/worker/config/preview
 
 # Setup Dart SDK into /home/worker/dart/{stable,preview}/
-RUN tool/setup-dart.sh /home/worker/dart 3.2.2
+RUN tool/setup-dart.sh /home/worker/dart 3.2.3
 RUN mv /home/worker/dart/dart-sdk /home/worker/dart/stable
 RUN XDG_CONFIG_HOME=/home/worker/config/preview tool/setup-dart.sh /home/worker/dart 3.3.0-174.2.beta
 RUN mv /home/worker/dart/dart-sdk /home/worker/dart/preview
 
 # Setup Flutter SDK into /home/worker/flutter/{stable,preview}/
-RUN tool/setup-flutter.sh /home/worker/flutter 3.16.2
+RUN tool/setup-flutter.sh /home/worker/flutter 3.16.3
 RUN mv /home/worker/flutter/flutter /home/worker/flutter/stable
 RUN XDG_CONFIG_HOME=/home/worker/config/preview tool/setup-flutter.sh /home/worker/flutter 3.18.0-0.1.pre
 RUN mv /home/worker/flutter/flutter /home/worker/flutter/preview

--- a/app/lib/shared/versions.dart
+++ b/app/lib/shared/versions.dart
@@ -24,7 +24,7 @@ final RegExp runtimeVersionPattern = RegExp(r'^\d{4}\.\d{2}\.\d{2}$');
 /// when the version switch happens.
 const _acceptedRuntimeVersions = <String>[
   // The current [runtimeVersion].
-  '2023.12.06',
+  '2023.12.08',
   // Fallback runtime versions.
   '2023.11.28',
   '2023.11.21',
@@ -62,8 +62,8 @@ bool shouldGCVersion(String version) =>
 
 // keep in-sync with SDK version in .mono_repo.yml and Dockerfile
 final String runtimeSdkVersion = '3.2.0';
-final String toolStableDartSdkVersion = '3.2.2';
-final String toolStableFlutterSdkVersion = '3.16.2';
+final String toolStableDartSdkVersion = '3.2.3';
+final String toolStableFlutterSdkVersion = '3.16.3';
 final String toolPreviewDartSdkVersion = '3.3.0-174.2.beta';
 final String toolPreviewFlutterSdkVersion = '3.18.0-0.1.pre';
 

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -544,10 +544,10 @@ packages:
     dependency: "direct main"
     description:
       name: pana
-      sha256: "2988751e7571a96cc968533838ddfbeec8d0af084fb075d5759b38f3bd9baaf4"
+      sha256: "40f84eb5ffe06bf27214805e1cf948080f9fd88aecbe678b8df050e05a8edbbf"
       url: "https://pub.dev"
     source: hosted
-    version: "0.21.43"
+    version: "0.21.44"
   path:
     dependency: "direct main"
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -51,7 +51,7 @@ dependencies:
   watcher: ^1.0.0
   yaml: '^3.0.0'
   # pana version to be pinned
-  pana: '0.21.43'
+  pana: '0.21.44'
   # 3rd-party packages with pinned versions
   mailer: '6.0.1'
   ulid: '2.0.0'

--- a/pkg/pub_worker/pubspec.lock
+++ b/pkg/pub_worker/pubspec.lock
@@ -458,10 +458,10 @@ packages:
     dependency: "direct main"
     description:
       name: pana
-      sha256: "2988751e7571a96cc968533838ddfbeec8d0af084fb075d5759b38f3bd9baaf4"
+      sha256: "40f84eb5ffe06bf27214805e1cf948080f9fd88aecbe678b8df050e05a8edbbf"
       url: "https://pub.dev"
     source: hosted
-    version: "0.21.43"
+    version: "0.21.44"
   path:
     dependency: transitive
     description:

--- a/pkg/pub_worker/pubspec.yaml
+++ b/pkg/pub_worker/pubspec.yaml
@@ -9,7 +9,7 @@ dependencies:
   appengine: ^0.13.6
   json_annotation: ^4.3.0
   jsontool: ^1.1.0
-  pana: ^0.21.43
+  pana: ^0.21.44
   lints: ^3.0.0 # required for pana
   meta: ^1.7.0
   api_builder:


### PR DESCRIPTION
Skipping the `2023.12.06` runtime version, as we have bad analysis results in it.