### PR TITLE
Updated Flutter icon weights for SDK search hits.

### DIFF
--- a/app/lib/search/flutter_sdk_mem_index.dart
+++ b/app/lib/search/flutter_sdk_mem_index.dart
@@ -33,8 +33,8 @@ const _allowedLibraries = <String>{
 };
 
 const _flutterApiPageDirWeights = <String, double>{
-  'cupertino/CupertinoIcons': 0.7,
-  'material/Icons': 0.7,
+  'cupertino/CupertinoIcons': 0.25,
+  'material/Icons': 0.25,
 };
 
 final _logger = Logger('search.flutter_sdk_mem_index');

--- a/app/lib/search/sdk_mem_index.dart
+++ b/app/lib/search/sdk_mem_index.dart
@@ -117,7 +117,10 @@ class SdkMemIndex {
               },
             );
 
-      hits.add(_Hit(library, weightedResults));
+      final hit = _Hit(library, weightedResults);
+      if (hit.score > 0.25) {
+        hits.add(hit);
+      }
     }
     if (hits.isEmpty) return <SdkLibraryHit>[];
 


### PR DESCRIPTION
Fixes #6420 (again). Verified on staging: `flame` does not return icons, but `cupertino flame` does return them.