### PR TITLE
Use role attribute only on interactive or allowlisted components.

### DIFF
--- a/app/lib/frontend/templates/detail_page.dart
+++ b/app/lib/frontend/templates/detail_page.dart
@@ -95,8 +95,13 @@ class Tab {
         if (isPrivate) '-private',
       ];
 
-  d.Node get titleNode =>
-      href == null ? d.text(title) : d.a(href: href, text: title);
+  d.Node get titleNode => href == null
+      ? d.text(title)
+      : d.a(
+          href: href,
+          text: title,
+          attributes: {'role': 'button'},
+        );
 
   bool get hasContent => contentNode != null;
 

--- a/app/lib/frontend/templates/views/shared/detail/tabs.dart
+++ b/app/lib/frontend/templates/views/shared/detail/tabs.dart
@@ -19,7 +19,6 @@ d.Node detailTabsNode({
           children: tabs.map(
             (t) => d.li(
               classes: t.titleClasses,
-              attributes: {'role': 'button'},
               child: t.titleNode,
             ),
           ),

--- a/app/test/frontend/golden/my_activity_log_page.html
+++ b/app/test/frontend/golden/my_activity_log_page.html
@@ -157,16 +157,16 @@
             <div class="detail-tabs-wide-header">
               <div class="detail-container">
                 <ul class="detail-tabs-header">
-                  <li class="detail-tab tab-link detail-tab-my-publishers-title -private" role="button">
-                    <a href="/my-publishers">Publishers</a>
+                  <li class="detail-tab tab-link detail-tab-my-publishers-title -private">
+                    <a href="/my-publishers" role="button">Publishers</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-my-packages-title -private" role="button">
-                    <a href="/my-packages">Packages</a>
+                  <li class="detail-tab tab-link detail-tab-my-packages-title -private">
+                    <a href="/my-packages" role="button">Packages</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-my-liked-packages-title -private" role="button">
-                    <a href="/my-liked-packages">Likes</a>
+                  <li class="detail-tab tab-link detail-tab-my-liked-packages-title -private">
+                    <a href="/my-liked-packages" role="button">Likes</a>
                   </li>
-                  <li class="detail-tab tab-button detail-tab-my-activity-log-title -active -private" role="button">Activity log</li>
+                  <li class="detail-tab tab-button detail-tab-my-activity-log-title -active -private">Activity log</li>
                 </ul>
               </div>
             </div>

--- a/app/test/frontend/golden/my_liked_packages.html
+++ b/app/test/frontend/golden/my_liked_packages.html
@@ -158,15 +158,15 @@
             <div class="detail-tabs-wide-header">
               <div class="detail-container">
                 <ul class="detail-tabs-header">
-                  <li class="detail-tab tab-link detail-tab-my-publishers-title -private" role="button">
-                    <a href="/my-publishers">Publishers</a>
+                  <li class="detail-tab tab-link detail-tab-my-publishers-title -private">
+                    <a href="/my-publishers" role="button">Publishers</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-my-packages-title -private" role="button">
-                    <a href="/my-packages">Packages</a>
+                  <li class="detail-tab tab-link detail-tab-my-packages-title -private">
+                    <a href="/my-packages" role="button">Packages</a>
                   </li>
-                  <li class="detail-tab tab-button detail-tab-my-liked-packages-title -active -private" role="button">Likes</li>
-                  <li class="detail-tab tab-link detail-tab-my-activity-log-title -private" role="button">
-                    <a href="/my-activity-log">Activity log</a>
+                  <li class="detail-tab tab-button detail-tab-my-liked-packages-title -active -private">Likes</li>
+                  <li class="detail-tab tab-link detail-tab-my-activity-log-title -private">
+                    <a href="/my-activity-log" role="button">Activity log</a>
                   </li>
                 </ul>
               </div>

--- a/app/test/frontend/golden/my_packages.html
+++ b/app/test/frontend/golden/my_packages.html
@@ -157,15 +157,15 @@
             <div class="detail-tabs-wide-header">
               <div class="detail-container">
                 <ul class="detail-tabs-header">
-                  <li class="detail-tab tab-link detail-tab-my-publishers-title -private" role="button">
-                    <a href="/my-publishers">Publishers</a>
+                  <li class="detail-tab tab-link detail-tab-my-publishers-title -private">
+                    <a href="/my-publishers" role="button">Publishers</a>
                   </li>
-                  <li class="detail-tab tab-button detail-tab-my-packages-title -active -private" role="button">Packages</li>
-                  <li class="detail-tab tab-link detail-tab-my-liked-packages-title -private" role="button">
-                    <a href="/my-liked-packages">Likes</a>
+                  <li class="detail-tab tab-button detail-tab-my-packages-title -active -private">Packages</li>
+                  <li class="detail-tab tab-link detail-tab-my-liked-packages-title -private">
+                    <a href="/my-liked-packages" role="button">Likes</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-my-activity-log-title -private" role="button">
-                    <a href="/my-activity-log">Activity log</a>
+                  <li class="detail-tab tab-link detail-tab-my-activity-log-title -private">
+                    <a href="/my-activity-log" role="button">Activity log</a>
                   </li>
                 </ul>
               </div>

--- a/app/test/frontend/golden/my_publishers.html
+++ b/app/test/frontend/golden/my_publishers.html
@@ -157,15 +157,15 @@
             <div class="detail-tabs-wide-header">
               <div class="detail-container">
                 <ul class="detail-tabs-header">
-                  <li class="detail-tab tab-button detail-tab-my-publishers-title -active -private" role="button">Publishers</li>
-                  <li class="detail-tab tab-link detail-tab-my-packages-title -private" role="button">
-                    <a href="/my-packages">Packages</a>
+                  <li class="detail-tab tab-button detail-tab-my-publishers-title -active -private">Publishers</li>
+                  <li class="detail-tab tab-link detail-tab-my-packages-title -private">
+                    <a href="/my-packages" role="button">Packages</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-my-liked-packages-title -private" role="button">
-                    <a href="/my-liked-packages">Likes</a>
+                  <li class="detail-tab tab-link detail-tab-my-liked-packages-title -private">
+                    <a href="/my-liked-packages" role="button">Likes</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-my-activity-log-title -private" role="button">
-                    <a href="/my-activity-log">Activity log</a>
+                  <li class="detail-tab tab-link detail-tab-my-activity-log-title -private">
+                    <a href="/my-activity-log" role="button">Activity log</a>
                   </li>
                 </ul>
               </div>

--- a/app/test/frontend/golden/pkg_activity_log_page.html
+++ b/app/test/frontend/golden/pkg_activity_log_page.html
@@ -212,28 +212,28 @@
             <div class="detail-tabs-wide-header">
               <div class="detail-container">
                 <ul class="detail-tabs-header">
-                  <li class="detail-tab tab-link detail-tab-readme-title" role="button">
-                    <a href="/packages/oxygen">Readme</a>
+                  <li class="detail-tab tab-link detail-tab-readme-title">
+                    <a href="/packages/oxygen" role="button">Readme</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-changelog-title" role="button">
-                    <a href="/packages/oxygen/changelog">Changelog</a>
+                  <li class="detail-tab tab-link detail-tab-changelog-title">
+                    <a href="/packages/oxygen/changelog" role="button">Changelog</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-example-title" role="button">
-                    <a href="/packages/oxygen/example">Example</a>
+                  <li class="detail-tab tab-link detail-tab-example-title">
+                    <a href="/packages/oxygen/example" role="button">Example</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-installing-title" role="button">
-                    <a href="/packages/oxygen/install">Installing</a>
+                  <li class="detail-tab tab-link detail-tab-installing-title">
+                    <a href="/packages/oxygen/install" role="button">Installing</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-versions-title" role="button">
-                    <a href="/packages/oxygen/versions">Versions</a>
+                  <li class="detail-tab tab-link detail-tab-versions-title">
+                    <a href="/packages/oxygen/versions" role="button">Versions</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-analysis-title" role="button">
-                    <a href="/packages/oxygen/score">Scores</a>
+                  <li class="detail-tab tab-link detail-tab-analysis-title">
+                    <a href="/packages/oxygen/score" role="button">Scores</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-admin-title -private" role="button">
-                    <a href="/packages/oxygen/admin">Admin</a>
+                  <li class="detail-tab tab-link detail-tab-admin-title -private">
+                    <a href="/packages/oxygen/admin" role="button">Admin</a>
                   </li>
-                  <li class="detail-tab tab-button detail-tab-activity-log-title -active -private" role="button">Activity Log</li>
+                  <li class="detail-tab tab-button detail-tab-activity-log-title -active -private">Activity Log</li>
                 </ul>
               </div>
             </div>

--- a/app/test/frontend/golden/pkg_admin_page.html
+++ b/app/test/frontend/golden/pkg_admin_page.html
@@ -212,27 +212,27 @@
             <div class="detail-tabs-wide-header">
               <div class="detail-container">
                 <ul class="detail-tabs-header">
-                  <li class="detail-tab tab-link detail-tab-readme-title" role="button">
-                    <a href="/packages/oxygen">Readme</a>
+                  <li class="detail-tab tab-link detail-tab-readme-title">
+                    <a href="/packages/oxygen" role="button">Readme</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-changelog-title" role="button">
-                    <a href="/packages/oxygen/changelog">Changelog</a>
+                  <li class="detail-tab tab-link detail-tab-changelog-title">
+                    <a href="/packages/oxygen/changelog" role="button">Changelog</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-example-title" role="button">
-                    <a href="/packages/oxygen/example">Example</a>
+                  <li class="detail-tab tab-link detail-tab-example-title">
+                    <a href="/packages/oxygen/example" role="button">Example</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-installing-title" role="button">
-                    <a href="/packages/oxygen/install">Installing</a>
+                  <li class="detail-tab tab-link detail-tab-installing-title">
+                    <a href="/packages/oxygen/install" role="button">Installing</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-versions-title" role="button">
-                    <a href="/packages/oxygen/versions">Versions</a>
+                  <li class="detail-tab tab-link detail-tab-versions-title">
+                    <a href="/packages/oxygen/versions" role="button">Versions</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-analysis-title" role="button">
-                    <a href="/packages/oxygen/score">Scores</a>
+                  <li class="detail-tab tab-link detail-tab-analysis-title">
+                    <a href="/packages/oxygen/score" role="button">Scores</a>
                   </li>
-                  <li class="detail-tab tab-button detail-tab-admin-title -active -private" role="button">Admin</li>
-                  <li class="detail-tab tab-link detail-tab-activity-log-title -private" role="button">
-                    <a href="/packages/oxygen/activity-log">Activity log</a>
+                  <li class="detail-tab tab-button detail-tab-admin-title -active -private">Admin</li>
+                  <li class="detail-tab tab-link detail-tab-activity-log-title -private">
+                    <a href="/packages/oxygen/activity-log" role="button">Activity log</a>
                   </li>
                 </ul>
               </div>

--- a/app/test/frontend/golden/pkg_changelog_page.html
+++ b/app/test/frontend/golden/pkg_changelog_page.html
@@ -186,21 +186,21 @@
             <div class="detail-tabs-wide-header">
               <div class="detail-container">
                 <ul class="detail-tabs-header">
-                  <li class="detail-tab tab-link detail-tab-readme-title" role="button">
-                    <a href="/packages/oxygen">Readme</a>
+                  <li class="detail-tab tab-link detail-tab-readme-title">
+                    <a href="/packages/oxygen" role="button">Readme</a>
                   </li>
-                  <li class="detail-tab tab-button detail-tab-changelog-title -active" role="button">Changelog</li>
-                  <li class="detail-tab tab-link detail-tab-example-title" role="button">
-                    <a href="/packages/oxygen/example">Example</a>
+                  <li class="detail-tab tab-button detail-tab-changelog-title -active">Changelog</li>
+                  <li class="detail-tab tab-link detail-tab-example-title">
+                    <a href="/packages/oxygen/example" role="button">Example</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-installing-title" role="button">
-                    <a href="/packages/oxygen/install">Installing</a>
+                  <li class="detail-tab tab-link detail-tab-installing-title">
+                    <a href="/packages/oxygen/install" role="button">Installing</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-versions-title" role="button">
-                    <a href="/packages/oxygen/versions">Versions</a>
+                  <li class="detail-tab tab-link detail-tab-versions-title">
+                    <a href="/packages/oxygen/versions" role="button">Versions</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-analysis-title" role="button">
-                    <a href="/packages/oxygen/score">Scores</a>
+                  <li class="detail-tab tab-link detail-tab-analysis-title">
+                    <a href="/packages/oxygen/score" role="button">Scores</a>
                   </li>
                 </ul>
               </div>

--- a/app/test/frontend/golden/pkg_example_page.html
+++ b/app/test/frontend/golden/pkg_example_page.html
@@ -186,21 +186,21 @@
             <div class="detail-tabs-wide-header">
               <div class="detail-container">
                 <ul class="detail-tabs-header">
-                  <li class="detail-tab tab-link detail-tab-readme-title" role="button">
-                    <a href="/packages/oxygen">Readme</a>
+                  <li class="detail-tab tab-link detail-tab-readme-title">
+                    <a href="/packages/oxygen" role="button">Readme</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-changelog-title" role="button">
-                    <a href="/packages/oxygen/changelog">Changelog</a>
+                  <li class="detail-tab tab-link detail-tab-changelog-title">
+                    <a href="/packages/oxygen/changelog" role="button">Changelog</a>
                   </li>
-                  <li class="detail-tab tab-button detail-tab-example-title -active" role="button">Example</li>
-                  <li class="detail-tab tab-link detail-tab-installing-title" role="button">
-                    <a href="/packages/oxygen/install">Installing</a>
+                  <li class="detail-tab tab-button detail-tab-example-title -active">Example</li>
+                  <li class="detail-tab tab-link detail-tab-installing-title">
+                    <a href="/packages/oxygen/install" role="button">Installing</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-versions-title" role="button">
-                    <a href="/packages/oxygen/versions">Versions</a>
+                  <li class="detail-tab tab-link detail-tab-versions-title">
+                    <a href="/packages/oxygen/versions" role="button">Versions</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-analysis-title" role="button">
-                    <a href="/packages/oxygen/score">Scores</a>
+                  <li class="detail-tab tab-link detail-tab-analysis-title">
+                    <a href="/packages/oxygen/score" role="button">Scores</a>
                   </li>
                 </ul>
               </div>

--- a/app/test/frontend/golden/pkg_install_page.html
+++ b/app/test/frontend/golden/pkg_install_page.html
@@ -186,21 +186,21 @@
             <div class="detail-tabs-wide-header">
               <div class="detail-container">
                 <ul class="detail-tabs-header">
-                  <li class="detail-tab tab-link detail-tab-readme-title" role="button">
-                    <a href="/packages/oxygen">Readme</a>
+                  <li class="detail-tab tab-link detail-tab-readme-title">
+                    <a href="/packages/oxygen" role="button">Readme</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-changelog-title" role="button">
-                    <a href="/packages/oxygen/changelog">Changelog</a>
+                  <li class="detail-tab tab-link detail-tab-changelog-title">
+                    <a href="/packages/oxygen/changelog" role="button">Changelog</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-example-title" role="button">
-                    <a href="/packages/oxygen/example">Example</a>
+                  <li class="detail-tab tab-link detail-tab-example-title">
+                    <a href="/packages/oxygen/example" role="button">Example</a>
                   </li>
-                  <li class="detail-tab tab-button detail-tab-installing-title -active" role="button">Installing</li>
-                  <li class="detail-tab tab-link detail-tab-versions-title" role="button">
-                    <a href="/packages/oxygen/versions">Versions</a>
+                  <li class="detail-tab tab-button detail-tab-installing-title -active">Installing</li>
+                  <li class="detail-tab tab-link detail-tab-versions-title">
+                    <a href="/packages/oxygen/versions" role="button">Versions</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-analysis-title" role="button">
-                    <a href="/packages/oxygen/score">Scores</a>
+                  <li class="detail-tab tab-link detail-tab-analysis-title">
+                    <a href="/packages/oxygen/score" role="button">Scores</a>
                   </li>
                 </ul>
               </div>

--- a/app/test/frontend/golden/pkg_score_page.html
+++ b/app/test/frontend/golden/pkg_score_page.html
@@ -186,22 +186,22 @@
             <div class="detail-tabs-wide-header">
               <div class="detail-container">
                 <ul class="detail-tabs-header">
-                  <li class="detail-tab tab-link detail-tab-readme-title" role="button">
-                    <a href="/packages/oxygen">Readme</a>
+                  <li class="detail-tab tab-link detail-tab-readme-title">
+                    <a href="/packages/oxygen" role="button">Readme</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-changelog-title" role="button">
-                    <a href="/packages/oxygen/changelog">Changelog</a>
+                  <li class="detail-tab tab-link detail-tab-changelog-title">
+                    <a href="/packages/oxygen/changelog" role="button">Changelog</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-example-title" role="button">
-                    <a href="/packages/oxygen/example">Example</a>
+                  <li class="detail-tab tab-link detail-tab-example-title">
+                    <a href="/packages/oxygen/example" role="button">Example</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-installing-title" role="button">
-                    <a href="/packages/oxygen/install">Installing</a>
+                  <li class="detail-tab tab-link detail-tab-installing-title">
+                    <a href="/packages/oxygen/install" role="button">Installing</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-versions-title" role="button">
-                    <a href="/packages/oxygen/versions">Versions</a>
+                  <li class="detail-tab tab-link detail-tab-versions-title">
+                    <a href="/packages/oxygen/versions" role="button">Versions</a>
                   </li>
-                  <li class="detail-tab tab-button detail-tab-analysis-title -active" role="button">Scores</li>
+                  <li class="detail-tab tab-button detail-tab-analysis-title -active">Scores</li>
                 </ul>
               </div>
             </div>

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -186,27 +186,27 @@
             <div class="detail-tabs-wide-header">
               <div class="detail-container">
                 <ul class="detail-tabs-header">
-                  <li class="detail-tab tab-button detail-tab-readme-title -active" role="button">Readme</li>
-                  <li class="detail-tab tab-link detail-tab-changelog-title" role="button">
-                    <a href="/packages/oxygen/changelog">Changelog</a>
+                  <li class="detail-tab tab-button detail-tab-readme-title -active">Readme</li>
+                  <li class="detail-tab tab-link detail-tab-changelog-title">
+                    <a href="/packages/oxygen/changelog" role="button">Changelog</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-example-title" role="button">
-                    <a href="/packages/oxygen/example">Example</a>
+                  <li class="detail-tab tab-link detail-tab-example-title">
+                    <a href="/packages/oxygen/example" role="button">Example</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-installing-title" role="button">
-                    <a href="/packages/oxygen/install">Installing</a>
+                  <li class="detail-tab tab-link detail-tab-installing-title">
+                    <a href="/packages/oxygen/install" role="button">Installing</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-versions-title" role="button">
-                    <a href="/packages/oxygen/versions">Versions</a>
+                  <li class="detail-tab tab-link detail-tab-versions-title">
+                    <a href="/packages/oxygen/versions" role="button">Versions</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-analysis-title" role="button">
-                    <a href="/packages/oxygen/score">Scores</a>
+                  <li class="detail-tab tab-link detail-tab-analysis-title">
+                    <a href="/packages/oxygen/score" role="button">Scores</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-admin-title -private" role="button">
-                    <a href="/packages/oxygen/admin">Admin</a>
+                  <li class="detail-tab tab-link detail-tab-admin-title -private">
+                    <a href="/packages/oxygen/admin" role="button">Admin</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-activity-log-title -private" role="button">
-                    <a href="/packages/oxygen/activity-log">Activity log</a>
+                  <li class="detail-tab tab-link detail-tab-activity-log-title -private">
+                    <a href="/packages/oxygen/activity-log" role="button">Activity log</a>
                   </li>
                 </ul>
               </div>

--- a/app/test/frontend/golden/pkg_show_page_discontinued.html
+++ b/app/test/frontend/golden/pkg_show_page_discontinued.html
@@ -172,21 +172,21 @@
             <div class="detail-tabs-wide-header">
               <div class="detail-container">
                 <ul class="detail-tabs-header">
-                  <li class="detail-tab tab-button detail-tab-readme-title -active" role="button">Readme</li>
-                  <li class="detail-tab tab-link detail-tab-changelog-title" role="button">
-                    <a href="/packages/pkg/changelog">Changelog</a>
+                  <li class="detail-tab tab-button detail-tab-readme-title -active">Readme</li>
+                  <li class="detail-tab tab-link detail-tab-changelog-title">
+                    <a href="/packages/pkg/changelog" role="button">Changelog</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-example-title" role="button">
-                    <a href="/packages/pkg/example">Example</a>
+                  <li class="detail-tab tab-link detail-tab-example-title">
+                    <a href="/packages/pkg/example" role="button">Example</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-installing-title" role="button">
-                    <a href="/packages/pkg/install">Installing</a>
+                  <li class="detail-tab tab-link detail-tab-installing-title">
+                    <a href="/packages/pkg/install" role="button">Installing</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-versions-title" role="button">
-                    <a href="/packages/pkg/versions">Versions</a>
+                  <li class="detail-tab tab-link detail-tab-versions-title">
+                    <a href="/packages/pkg/versions" role="button">Versions</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-analysis-title" role="button">
-                    <a href="/packages/pkg/score">Scores</a>
+                  <li class="detail-tab tab-link detail-tab-analysis-title">
+                    <a href="/packages/pkg/score" role="button">Scores</a>
                   </li>
                 </ul>
               </div>

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -175,27 +175,27 @@
             <div class="detail-tabs-wide-header">
               <div class="detail-container">
                 <ul class="detail-tabs-header">
-                  <li class="detail-tab tab-button detail-tab-readme-title -active" role="button">Readme</li>
-                  <li class="detail-tab tab-link detail-tab-changelog-title" role="button">
-                    <a href="/packages/flutter_titanium/changelog">Changelog</a>
+                  <li class="detail-tab tab-button detail-tab-readme-title -active">Readme</li>
+                  <li class="detail-tab tab-link detail-tab-changelog-title">
+                    <a href="/packages/flutter_titanium/changelog" role="button">Changelog</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-example-title" role="button">
-                    <a href="/packages/flutter_titanium/example">Example</a>
+                  <li class="detail-tab tab-link detail-tab-example-title">
+                    <a href="/packages/flutter_titanium/example" role="button">Example</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-installing-title" role="button">
-                    <a href="/packages/flutter_titanium/install">Installing</a>
+                  <li class="detail-tab tab-link detail-tab-installing-title">
+                    <a href="/packages/flutter_titanium/install" role="button">Installing</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-versions-title" role="button">
-                    <a href="/packages/flutter_titanium/versions">Versions</a>
+                  <li class="detail-tab tab-link detail-tab-versions-title">
+                    <a href="/packages/flutter_titanium/versions" role="button">Versions</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-analysis-title" role="button">
-                    <a href="/packages/flutter_titanium/score">Scores</a>
+                  <li class="detail-tab tab-link detail-tab-analysis-title">
+                    <a href="/packages/flutter_titanium/score" role="button">Scores</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-admin-title -private" role="button">
-                    <a href="/packages/flutter_titanium/admin">Admin</a>
+                  <li class="detail-tab tab-link detail-tab-admin-title -private">
+                    <a href="/packages/flutter_titanium/admin" role="button">Admin</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-activity-log-title -private" role="button">
-                    <a href="/packages/flutter_titanium/activity-log">Activity log</a>
+                  <li class="detail-tab tab-link detail-tab-activity-log-title -private">
+                    <a href="/packages/flutter_titanium/activity-log" role="button">Activity log</a>
                   </li>
                 </ul>
               </div>

--- a/app/test/frontend/golden/pkg_show_page_publisher.html
+++ b/app/test/frontend/golden/pkg_show_page_publisher.html
@@ -180,21 +180,21 @@
             <div class="detail-tabs-wide-header">
               <div class="detail-container">
                 <ul class="detail-tabs-header">
-                  <li class="detail-tab tab-button detail-tab-readme-title -active" role="button">Readme</li>
-                  <li class="detail-tab tab-link detail-tab-changelog-title" role="button">
-                    <a href="/packages/neon/changelog">Changelog</a>
+                  <li class="detail-tab tab-button detail-tab-readme-title -active">Readme</li>
+                  <li class="detail-tab tab-link detail-tab-changelog-title">
+                    <a href="/packages/neon/changelog" role="button">Changelog</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-example-title" role="button">
-                    <a href="/packages/neon/example">Example</a>
+                  <li class="detail-tab tab-link detail-tab-example-title">
+                    <a href="/packages/neon/example" role="button">Example</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-installing-title" role="button">
-                    <a href="/packages/neon/install">Installing</a>
+                  <li class="detail-tab tab-link detail-tab-installing-title">
+                    <a href="/packages/neon/install" role="button">Installing</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-versions-title" role="button">
-                    <a href="/packages/neon/versions">Versions</a>
+                  <li class="detail-tab tab-link detail-tab-versions-title">
+                    <a href="/packages/neon/versions" role="button">Versions</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-analysis-title" role="button">
-                    <a href="/packages/neon/score">Scores</a>
+                  <li class="detail-tab tab-link detail-tab-analysis-title">
+                    <a href="/packages/neon/score" role="button">Scores</a>
                   </li>
                 </ul>
               </div>

--- a/app/test/frontend/golden/pkg_show_page_retracted.html
+++ b/app/test/frontend/golden/pkg_show_page_retracted.html
@@ -168,21 +168,21 @@
             <div class="detail-tabs-wide-header">
               <div class="detail-container">
                 <ul class="detail-tabs-header">
-                  <li class="detail-tab tab-button detail-tab-readme-title -active" role="button">Readme</li>
-                  <li class="detail-tab tab-link detail-tab-changelog-title" role="button">
-                    <a href="/packages/pkg/versions/1.0.0/changelog">Changelog</a>
+                  <li class="detail-tab tab-button detail-tab-readme-title -active">Readme</li>
+                  <li class="detail-tab tab-link detail-tab-changelog-title">
+                    <a href="/packages/pkg/versions/1.0.0/changelog" role="button">Changelog</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-example-title" role="button">
-                    <a href="/packages/pkg/versions/1.0.0/example">Example</a>
+                  <li class="detail-tab tab-link detail-tab-example-title">
+                    <a href="/packages/pkg/versions/1.0.0/example" role="button">Example</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-installing-title" role="button">
-                    <a href="/packages/pkg/versions/1.0.0/install">Installing</a>
+                  <li class="detail-tab tab-link detail-tab-installing-title">
+                    <a href="/packages/pkg/versions/1.0.0/install" role="button">Installing</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-versions-title" role="button">
-                    <a href="/packages/pkg/versions">Versions</a>
+                  <li class="detail-tab tab-link detail-tab-versions-title">
+                    <a href="/packages/pkg/versions" role="button">Versions</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-analysis-title" role="button">
-                    <a href="/packages/pkg/versions/1.0.0/score">Scores</a>
+                  <li class="detail-tab tab-link detail-tab-analysis-title">
+                    <a href="/packages/pkg/versions/1.0.0/score" role="button">Scores</a>
                   </li>
                 </ul>
               </div>

--- a/app/test/frontend/golden/pkg_show_page_retracted_non_retracted_version.html
+++ b/app/test/frontend/golden/pkg_show_page_retracted_non_retracted_version.html
@@ -176,21 +176,21 @@
             <div class="detail-tabs-wide-header">
               <div class="detail-container">
                 <ul class="detail-tabs-header">
-                  <li class="detail-tab tab-button detail-tab-readme-title -active" role="button">Readme</li>
-                  <li class="detail-tab tab-link detail-tab-changelog-title" role="button">
-                    <a href="/packages/pkg/changelog">Changelog</a>
+                  <li class="detail-tab tab-button detail-tab-readme-title -active">Readme</li>
+                  <li class="detail-tab tab-link detail-tab-changelog-title">
+                    <a href="/packages/pkg/changelog" role="button">Changelog</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-example-title" role="button">
-                    <a href="/packages/pkg/example">Example</a>
+                  <li class="detail-tab tab-link detail-tab-example-title">
+                    <a href="/packages/pkg/example" role="button">Example</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-installing-title" role="button">
-                    <a href="/packages/pkg/install">Installing</a>
+                  <li class="detail-tab tab-link detail-tab-installing-title">
+                    <a href="/packages/pkg/install" role="button">Installing</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-versions-title" role="button">
-                    <a href="/packages/pkg/versions">Versions</a>
+                  <li class="detail-tab tab-link detail-tab-versions-title">
+                    <a href="/packages/pkg/versions" role="button">Versions</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-analysis-title" role="button">
-                    <a href="/packages/pkg/score">Scores</a>
+                  <li class="detail-tab tab-link detail-tab-analysis-title">
+                    <a href="/packages/pkg/score" role="button">Scores</a>
                   </li>
                 </ul>
               </div>

--- a/app/test/frontend/golden/pkg_show_version_page.html
+++ b/app/test/frontend/golden/pkg_show_version_page.html
@@ -186,21 +186,21 @@
             <div class="detail-tabs-wide-header">
               <div class="detail-container">
                 <ul class="detail-tabs-header">
-                  <li class="detail-tab tab-button detail-tab-readme-title -active" role="button">Readme</li>
-                  <li class="detail-tab tab-link detail-tab-changelog-title" role="button">
-                    <a href="/packages/oxygen/changelog">Changelog</a>
+                  <li class="detail-tab tab-button detail-tab-readme-title -active">Readme</li>
+                  <li class="detail-tab tab-link detail-tab-changelog-title">
+                    <a href="/packages/oxygen/changelog" role="button">Changelog</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-example-title" role="button">
-                    <a href="/packages/oxygen/example">Example</a>
+                  <li class="detail-tab tab-link detail-tab-example-title">
+                    <a href="/packages/oxygen/example" role="button">Example</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-installing-title" role="button">
-                    <a href="/packages/oxygen/install">Installing</a>
+                  <li class="detail-tab tab-link detail-tab-installing-title">
+                    <a href="/packages/oxygen/install" role="button">Installing</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-versions-title" role="button">
-                    <a href="/packages/oxygen/versions">Versions</a>
+                  <li class="detail-tab tab-link detail-tab-versions-title">
+                    <a href="/packages/oxygen/versions" role="button">Versions</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-analysis-title" role="button">
-                    <a href="/packages/oxygen/score">Scores</a>
+                  <li class="detail-tab tab-link detail-tab-analysis-title">
+                    <a href="/packages/oxygen/score" role="button">Scores</a>
                   </li>
                 </ul>
               </div>

--- a/app/test/frontend/golden/pkg_versions_page.html
+++ b/app/test/frontend/golden/pkg_versions_page.html
@@ -186,21 +186,21 @@
             <div class="detail-tabs-wide-header">
               <div class="detail-container">
                 <ul class="detail-tabs-header">
-                  <li class="detail-tab tab-link detail-tab-readme-title" role="button">
-                    <a href="/packages/oxygen">Readme</a>
+                  <li class="detail-tab tab-link detail-tab-readme-title">
+                    <a href="/packages/oxygen" role="button">Readme</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-changelog-title" role="button">
-                    <a href="/packages/oxygen/changelog">Changelog</a>
+                  <li class="detail-tab tab-link detail-tab-changelog-title">
+                    <a href="/packages/oxygen/changelog" role="button">Changelog</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-example-title" role="button">
-                    <a href="/packages/oxygen/example">Example</a>
+                  <li class="detail-tab tab-link detail-tab-example-title">
+                    <a href="/packages/oxygen/example" role="button">Example</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-installing-title" role="button">
-                    <a href="/packages/oxygen/install">Installing</a>
+                  <li class="detail-tab tab-link detail-tab-installing-title">
+                    <a href="/packages/oxygen/install" role="button">Installing</a>
                   </li>
-                  <li class="detail-tab tab-button detail-tab-versions-title -active" role="button">Versions</li>
-                  <li class="detail-tab tab-link detail-tab-analysis-title" role="button">
-                    <a href="/packages/oxygen/score">Scores</a>
+                  <li class="detail-tab tab-button detail-tab-versions-title -active">Versions</li>
+                  <li class="detail-tab tab-link detail-tab-analysis-title">
+                    <a href="/packages/oxygen/score" role="button">Scores</a>
                   </li>
                 </ul>
               </div>

--- a/app/test/frontend/golden/publisher_activity_log_page.html
+++ b/app/test/frontend/golden/publisher_activity_log_page.html
@@ -141,13 +141,13 @@
             <div class="detail-tabs-wide-header">
               <div class="detail-container">
                 <ul class="detail-tabs-header">
-                  <li class="detail-tab tab-link detail-tab-packages-title" role="button">
-                    <a href="/publishers/example.com/packages">Packages</a>
+                  <li class="detail-tab tab-link detail-tab-packages-title">
+                    <a href="/publishers/example.com/packages" role="button">Packages</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-admin-title -private" role="button">
-                    <a href="/publishers/example.com/admin">Admin</a>
+                  <li class="detail-tab tab-link detail-tab-admin-title -private">
+                    <a href="/publishers/example.com/admin" role="button">Admin</a>
                   </li>
-                  <li class="detail-tab tab-button detail-tab-activity-log-title -active -private" role="button">Activity log</li>
+                  <li class="detail-tab tab-button detail-tab-activity-log-title -active -private">Activity log</li>
                 </ul>
               </div>
             </div>

--- a/app/test/frontend/golden/publisher_admin_page.html
+++ b/app/test/frontend/golden/publisher_admin_page.html
@@ -141,12 +141,12 @@
             <div class="detail-tabs-wide-header">
               <div class="detail-container">
                 <ul class="detail-tabs-header">
-                  <li class="detail-tab tab-link detail-tab-packages-title" role="button">
-                    <a href="/publishers/example.com/packages">Packages</a>
+                  <li class="detail-tab tab-link detail-tab-packages-title">
+                    <a href="/publishers/example.com/packages" role="button">Packages</a>
                   </li>
-                  <li class="detail-tab tab-button detail-tab-admin-title -active -private" role="button">Admin</li>
-                  <li class="detail-tab tab-link detail-tab-activity-log-title -private" role="button">
-                    <a href="/publishers/example.com/activity-log">Activity log</a>
+                  <li class="detail-tab tab-button detail-tab-admin-title -active -private">Admin</li>
+                  <li class="detail-tab tab-link detail-tab-activity-log-title -private">
+                    <a href="/publishers/example.com/activity-log" role="button">Activity log</a>
                   </li>
                 </ul>
               </div>

--- a/app/test/frontend/golden/publisher_packages_page.html
+++ b/app/test/frontend/golden/publisher_packages_page.html
@@ -141,15 +141,15 @@
             <div class="detail-tabs-wide-header">
               <div class="detail-container">
                 <ul class="detail-tabs-header">
-                  <li class="detail-tab tab-button detail-tab-packages-title -active" role="button">Packages</li>
-                  <li class="detail-tab tab-link detail-tab-unlisted-packages-title" role="button">
-                    <a href="/publishers/example.com/unlisted-packages">Unlisted packages</a>
+                  <li class="detail-tab tab-button detail-tab-packages-title -active">Packages</li>
+                  <li class="detail-tab tab-link detail-tab-unlisted-packages-title">
+                    <a href="/publishers/example.com/unlisted-packages" role="button">Unlisted packages</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-admin-title -private" role="button">
-                    <a href="/publishers/example.com/admin">Admin</a>
+                  <li class="detail-tab tab-link detail-tab-admin-title -private">
+                    <a href="/publishers/example.com/admin" role="button">Admin</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-activity-log-title -private" role="button">
-                    <a href="/publishers/example.com/activity-log">Activity log</a>
+                  <li class="detail-tab tab-link detail-tab-activity-log-title -private">
+                    <a href="/publishers/example.com/activity-log" role="button">Activity log</a>
                   </li>
                 </ul>
               </div>

--- a/app/test/frontend/golden/publisher_unlisted_packages_page.html
+++ b/app/test/frontend/golden/publisher_unlisted_packages_page.html
@@ -141,15 +141,15 @@
             <div class="detail-tabs-wide-header">
               <div class="detail-container">
                 <ul class="detail-tabs-header">
-                  <li class="detail-tab tab-link detail-tab-packages-title" role="button">
-                    <a href="/publishers/example.com/packages">Packages</a>
+                  <li class="detail-tab tab-link detail-tab-packages-title">
+                    <a href="/publishers/example.com/packages" role="button">Packages</a>
                   </li>
-                  <li class="detail-tab tab-button detail-tab-unlisted-packages-title -active" role="button">Unlisted packages</li>
-                  <li class="detail-tab tab-link detail-tab-admin-title -private" role="button">
-                    <a href="/publishers/example.com/admin">Admin</a>
+                  <li class="detail-tab tab-button detail-tab-unlisted-packages-title -active">Unlisted packages</li>
+                  <li class="detail-tab tab-link detail-tab-admin-title -private">
+                    <a href="/publishers/example.com/admin" role="button">Admin</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-activity-log-title -private" role="button">
-                    <a href="/publishers/example.com/activity-log">Activity log</a>
+                  <li class="detail-tab tab-link detail-tab-activity-log-title -private">
+                    <a href="/publishers/example.com/activity-log" role="button">Activity log</a>
                   </li>
                 </ul>
               </div>

--- a/app/test/task/testdata/goldens/packages/oxygen.html
+++ b/app/test/task/testdata/goldens/packages/oxygen.html
@@ -178,21 +178,21 @@
             <div class="detail-tabs-wide-header">
               <div class="detail-container">
                 <ul class="detail-tabs-header">
-                  <li class="detail-tab tab-button detail-tab-readme-title -active" role="button">Readme</li>
-                  <li class="detail-tab tab-link detail-tab-changelog-title" role="button">
-                    <a href="/packages/oxygen/changelog">Changelog</a>
+                  <li class="detail-tab tab-button detail-tab-readme-title -active">Readme</li>
+                  <li class="detail-tab tab-link detail-tab-changelog-title">
+                    <a href="/packages/oxygen/changelog" role="button">Changelog</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-example-title" role="button">
-                    <a href="/packages/oxygen/example">Example</a>
+                  <li class="detail-tab tab-link detail-tab-example-title">
+                    <a href="/packages/oxygen/example" role="button">Example</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-installing-title" role="button">
-                    <a href="/packages/oxygen/install">Installing</a>
+                  <li class="detail-tab tab-link detail-tab-installing-title">
+                    <a href="/packages/oxygen/install" role="button">Installing</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-versions-title" role="button">
-                    <a href="/packages/oxygen/versions">Versions</a>
+                  <li class="detail-tab tab-link detail-tab-versions-title">
+                    <a href="/packages/oxygen/versions" role="button">Versions</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-analysis-title" role="button">
-                    <a href="/packages/oxygen/score">Scores</a>
+                  <li class="detail-tab tab-link detail-tab-analysis-title">
+                    <a href="/packages/oxygen/score" role="button">Scores</a>
                   </li>
                 </ul>
               </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/changelog.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/changelog.html
@@ -178,21 +178,21 @@
             <div class="detail-tabs-wide-header">
               <div class="detail-container">
                 <ul class="detail-tabs-header">
-                  <li class="detail-tab tab-link detail-tab-readme-title" role="button">
-                    <a href="/packages/oxygen">Readme</a>
+                  <li class="detail-tab tab-link detail-tab-readme-title">
+                    <a href="/packages/oxygen" role="button">Readme</a>
                   </li>
-                  <li class="detail-tab tab-button detail-tab-changelog-title -active" role="button">Changelog</li>
-                  <li class="detail-tab tab-link detail-tab-example-title" role="button">
-                    <a href="/packages/oxygen/example">Example</a>
+                  <li class="detail-tab tab-button detail-tab-changelog-title -active">Changelog</li>
+                  <li class="detail-tab tab-link detail-tab-example-title">
+                    <a href="/packages/oxygen/example" role="button">Example</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-installing-title" role="button">
-                    <a href="/packages/oxygen/install">Installing</a>
+                  <li class="detail-tab tab-link detail-tab-installing-title">
+                    <a href="/packages/oxygen/install" role="button">Installing</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-versions-title" role="button">
-                    <a href="/packages/oxygen/versions">Versions</a>
+                  <li class="detail-tab tab-link detail-tab-versions-title">
+                    <a href="/packages/oxygen/versions" role="button">Versions</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-analysis-title" role="button">
-                    <a href="/packages/oxygen/score">Scores</a>
+                  <li class="detail-tab tab-link detail-tab-analysis-title">
+                    <a href="/packages/oxygen/score" role="button">Scores</a>
                   </li>
                 </ul>
               </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/example.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/example.html
@@ -178,21 +178,21 @@
             <div class="detail-tabs-wide-header">
               <div class="detail-container">
                 <ul class="detail-tabs-header">
-                  <li class="detail-tab tab-link detail-tab-readme-title" role="button">
-                    <a href="/packages/oxygen">Readme</a>
+                  <li class="detail-tab tab-link detail-tab-readme-title">
+                    <a href="/packages/oxygen" role="button">Readme</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-changelog-title" role="button">
-                    <a href="/packages/oxygen/changelog">Changelog</a>
+                  <li class="detail-tab tab-link detail-tab-changelog-title">
+                    <a href="/packages/oxygen/changelog" role="button">Changelog</a>
                   </li>
-                  <li class="detail-tab tab-button detail-tab-example-title -active" role="button">Example</li>
-                  <li class="detail-tab tab-link detail-tab-installing-title" role="button">
-                    <a href="/packages/oxygen/install">Installing</a>
+                  <li class="detail-tab tab-button detail-tab-example-title -active">Example</li>
+                  <li class="detail-tab tab-link detail-tab-installing-title">
+                    <a href="/packages/oxygen/install" role="button">Installing</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-versions-title" role="button">
-                    <a href="/packages/oxygen/versions">Versions</a>
+                  <li class="detail-tab tab-link detail-tab-versions-title">
+                    <a href="/packages/oxygen/versions" role="button">Versions</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-analysis-title" role="button">
-                    <a href="/packages/oxygen/score">Scores</a>
+                  <li class="detail-tab tab-link detail-tab-analysis-title">
+                    <a href="/packages/oxygen/score" role="button">Scores</a>
                   </li>
                 </ul>
               </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/install.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/install.html
@@ -178,21 +178,21 @@
             <div class="detail-tabs-wide-header">
               <div class="detail-container">
                 <ul class="detail-tabs-header">
-                  <li class="detail-tab tab-link detail-tab-readme-title" role="button">
-                    <a href="/packages/oxygen">Readme</a>
+                  <li class="detail-tab tab-link detail-tab-readme-title">
+                    <a href="/packages/oxygen" role="button">Readme</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-changelog-title" role="button">
-                    <a href="/packages/oxygen/changelog">Changelog</a>
+                  <li class="detail-tab tab-link detail-tab-changelog-title">
+                    <a href="/packages/oxygen/changelog" role="button">Changelog</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-example-title" role="button">
-                    <a href="/packages/oxygen/example">Example</a>
+                  <li class="detail-tab tab-link detail-tab-example-title">
+                    <a href="/packages/oxygen/example" role="button">Example</a>
                   </li>
-                  <li class="detail-tab tab-button detail-tab-installing-title -active" role="button">Installing</li>
-                  <li class="detail-tab tab-link detail-tab-versions-title" role="button">
-                    <a href="/packages/oxygen/versions">Versions</a>
+                  <li class="detail-tab tab-button detail-tab-installing-title -active">Installing</li>
+                  <li class="detail-tab tab-link detail-tab-versions-title">
+                    <a href="/packages/oxygen/versions" role="button">Versions</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-analysis-title" role="button">
-                    <a href="/packages/oxygen/score">Scores</a>
+                  <li class="detail-tab tab-link detail-tab-analysis-title">
+                    <a href="/packages/oxygen/score" role="button">Scores</a>
                   </li>
                 </ul>
               </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/license.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/license.html
@@ -178,24 +178,24 @@
             <div class="detail-tabs-wide-header">
               <div class="detail-container">
                 <ul class="detail-tabs-header">
-                  <li class="detail-tab tab-link detail-tab-readme-title" role="button">
-                    <a href="/packages/oxygen">Readme</a>
+                  <li class="detail-tab tab-link detail-tab-readme-title">
+                    <a href="/packages/oxygen" role="button">Readme</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-changelog-title" role="button">
-                    <a href="/packages/oxygen/changelog">Changelog</a>
+                  <li class="detail-tab tab-link detail-tab-changelog-title">
+                    <a href="/packages/oxygen/changelog" role="button">Changelog</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-example-title" role="button">
-                    <a href="/packages/oxygen/example">Example</a>
+                  <li class="detail-tab tab-link detail-tab-example-title">
+                    <a href="/packages/oxygen/example" role="button">Example</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-installing-title" role="button">
-                    <a href="/packages/oxygen/install">Installing</a>
+                  <li class="detail-tab tab-link detail-tab-installing-title">
+                    <a href="/packages/oxygen/install" role="button">Installing</a>
                   </li>
-                  <li class="detail-tab tab-button detail-tab-license-title -active" role="button">License</li>
-                  <li class="detail-tab tab-link detail-tab-versions-title" role="button">
-                    <a href="/packages/oxygen/versions">Versions</a>
+                  <li class="detail-tab tab-button detail-tab-license-title -active">License</li>
+                  <li class="detail-tab tab-link detail-tab-versions-title">
+                    <a href="/packages/oxygen/versions" role="button">Versions</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-analysis-title" role="button">
-                    <a href="/packages/oxygen/score">Scores</a>
+                  <li class="detail-tab tab-link detail-tab-analysis-title">
+                    <a href="/packages/oxygen/score" role="button">Scores</a>
                   </li>
                 </ul>
               </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/score.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/score.html
@@ -178,22 +178,22 @@
             <div class="detail-tabs-wide-header">
               <div class="detail-container">
                 <ul class="detail-tabs-header">
-                  <li class="detail-tab tab-link detail-tab-readme-title" role="button">
-                    <a href="/packages/oxygen">Readme</a>
+                  <li class="detail-tab tab-link detail-tab-readme-title">
+                    <a href="/packages/oxygen" role="button">Readme</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-changelog-title" role="button">
-                    <a href="/packages/oxygen/changelog">Changelog</a>
+                  <li class="detail-tab tab-link detail-tab-changelog-title">
+                    <a href="/packages/oxygen/changelog" role="button">Changelog</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-example-title" role="button">
-                    <a href="/packages/oxygen/example">Example</a>
+                  <li class="detail-tab tab-link detail-tab-example-title">
+                    <a href="/packages/oxygen/example" role="button">Example</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-installing-title" role="button">
-                    <a href="/packages/oxygen/install">Installing</a>
+                  <li class="detail-tab tab-link detail-tab-installing-title">
+                    <a href="/packages/oxygen/install" role="button">Installing</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-versions-title" role="button">
-                    <a href="/packages/oxygen/versions">Versions</a>
+                  <li class="detail-tab tab-link detail-tab-versions-title">
+                    <a href="/packages/oxygen/versions" role="button">Versions</a>
                   </li>
-                  <li class="detail-tab tab-button detail-tab-analysis-title -active" role="button">Scores</li>
+                  <li class="detail-tab tab-button detail-tab-analysis-title -active">Scores</li>
                 </ul>
               </div>
             </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions.html
@@ -178,21 +178,21 @@
             <div class="detail-tabs-wide-header">
               <div class="detail-container">
                 <ul class="detail-tabs-header">
-                  <li class="detail-tab tab-link detail-tab-readme-title" role="button">
-                    <a href="/packages/oxygen">Readme</a>
+                  <li class="detail-tab tab-link detail-tab-readme-title">
+                    <a href="/packages/oxygen" role="button">Readme</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-changelog-title" role="button">
-                    <a href="/packages/oxygen/changelog">Changelog</a>
+                  <li class="detail-tab tab-link detail-tab-changelog-title">
+                    <a href="/packages/oxygen/changelog" role="button">Changelog</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-example-title" role="button">
-                    <a href="/packages/oxygen/example">Example</a>
+                  <li class="detail-tab tab-link detail-tab-example-title">
+                    <a href="/packages/oxygen/example" role="button">Example</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-installing-title" role="button">
-                    <a href="/packages/oxygen/install">Installing</a>
+                  <li class="detail-tab tab-link detail-tab-installing-title">
+                    <a href="/packages/oxygen/install" role="button">Installing</a>
                   </li>
-                  <li class="detail-tab tab-button detail-tab-versions-title -active" role="button">Versions</li>
-                  <li class="detail-tab tab-link detail-tab-analysis-title" role="button">
-                    <a href="/packages/oxygen/score">Scores</a>
+                  <li class="detail-tab tab-button detail-tab-versions-title -active">Versions</li>
+                  <li class="detail-tab tab-link detail-tab-analysis-title">
+                    <a href="/packages/oxygen/score" role="button">Scores</a>
                   </li>
                 </ul>
               </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0.html
@@ -182,21 +182,21 @@
             <div class="detail-tabs-wide-header">
               <div class="detail-container">
                 <ul class="detail-tabs-header">
-                  <li class="detail-tab tab-button detail-tab-readme-title -active" role="button">Readme</li>
-                  <li class="detail-tab tab-link detail-tab-changelog-title" role="button">
-                    <a href="/packages/oxygen/versions/1.0.0/changelog">Changelog</a>
+                  <li class="detail-tab tab-button detail-tab-readme-title -active">Readme</li>
+                  <li class="detail-tab tab-link detail-tab-changelog-title">
+                    <a href="/packages/oxygen/versions/1.0.0/changelog" role="button">Changelog</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-example-title" role="button">
-                    <a href="/packages/oxygen/versions/1.0.0/example">Example</a>
+                  <li class="detail-tab tab-link detail-tab-example-title">
+                    <a href="/packages/oxygen/versions/1.0.0/example" role="button">Example</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-installing-title" role="button">
-                    <a href="/packages/oxygen/versions/1.0.0/install">Installing</a>
+                  <li class="detail-tab tab-link detail-tab-installing-title">
+                    <a href="/packages/oxygen/versions/1.0.0/install" role="button">Installing</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-versions-title" role="button">
-                    <a href="/packages/oxygen/versions">Versions</a>
+                  <li class="detail-tab tab-link detail-tab-versions-title">
+                    <a href="/packages/oxygen/versions" role="button">Versions</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-analysis-title" role="button">
-                    <a href="/packages/oxygen/versions/1.0.0/score">Scores</a>
+                  <li class="detail-tab tab-link detail-tab-analysis-title">
+                    <a href="/packages/oxygen/versions/1.0.0/score" role="button">Scores</a>
                   </li>
                 </ul>
               </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/changelog.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/changelog.html
@@ -182,21 +182,21 @@
             <div class="detail-tabs-wide-header">
               <div class="detail-container">
                 <ul class="detail-tabs-header">
-                  <li class="detail-tab tab-link detail-tab-readme-title" role="button">
-                    <a href="/packages/oxygen/versions/1.0.0">Readme</a>
+                  <li class="detail-tab tab-link detail-tab-readme-title">
+                    <a href="/packages/oxygen/versions/1.0.0" role="button">Readme</a>
                   </li>
-                  <li class="detail-tab tab-button detail-tab-changelog-title -active" role="button">Changelog</li>
-                  <li class="detail-tab tab-link detail-tab-example-title" role="button">
-                    <a href="/packages/oxygen/versions/1.0.0/example">Example</a>
+                  <li class="detail-tab tab-button detail-tab-changelog-title -active">Changelog</li>
+                  <li class="detail-tab tab-link detail-tab-example-title">
+                    <a href="/packages/oxygen/versions/1.0.0/example" role="button">Example</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-installing-title" role="button">
-                    <a href="/packages/oxygen/versions/1.0.0/install">Installing</a>
+                  <li class="detail-tab tab-link detail-tab-installing-title">
+                    <a href="/packages/oxygen/versions/1.0.0/install" role="button">Installing</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-versions-title" role="button">
-                    <a href="/packages/oxygen/versions">Versions</a>
+                  <li class="detail-tab tab-link detail-tab-versions-title">
+                    <a href="/packages/oxygen/versions" role="button">Versions</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-analysis-title" role="button">
-                    <a href="/packages/oxygen/versions/1.0.0/score">Scores</a>
+                  <li class="detail-tab tab-link detail-tab-analysis-title">
+                    <a href="/packages/oxygen/versions/1.0.0/score" role="button">Scores</a>
                   </li>
                 </ul>
               </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/example.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/example.html
@@ -182,21 +182,21 @@
             <div class="detail-tabs-wide-header">
               <div class="detail-container">
                 <ul class="detail-tabs-header">
-                  <li class="detail-tab tab-link detail-tab-readme-title" role="button">
-                    <a href="/packages/oxygen/versions/1.0.0">Readme</a>
+                  <li class="detail-tab tab-link detail-tab-readme-title">
+                    <a href="/packages/oxygen/versions/1.0.0" role="button">Readme</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-changelog-title" role="button">
-                    <a href="/packages/oxygen/versions/1.0.0/changelog">Changelog</a>
+                  <li class="detail-tab tab-link detail-tab-changelog-title">
+                    <a href="/packages/oxygen/versions/1.0.0/changelog" role="button">Changelog</a>
                   </li>
-                  <li class="detail-tab tab-button detail-tab-example-title -active" role="button">Example</li>
-                  <li class="detail-tab tab-link detail-tab-installing-title" role="button">
-                    <a href="/packages/oxygen/versions/1.0.0/install">Installing</a>
+                  <li class="detail-tab tab-button detail-tab-example-title -active">Example</li>
+                  <li class="detail-tab tab-link detail-tab-installing-title">
+                    <a href="/packages/oxygen/versions/1.0.0/install" role="button">Installing</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-versions-title" role="button">
-                    <a href="/packages/oxygen/versions">Versions</a>
+                  <li class="detail-tab tab-link detail-tab-versions-title">
+                    <a href="/packages/oxygen/versions" role="button">Versions</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-analysis-title" role="button">
-                    <a href="/packages/oxygen/versions/1.0.0/score">Scores</a>
+                  <li class="detail-tab tab-link detail-tab-analysis-title">
+                    <a href="/packages/oxygen/versions/1.0.0/score" role="button">Scores</a>
                   </li>
                 </ul>
               </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/install.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/install.html
@@ -182,21 +182,21 @@
             <div class="detail-tabs-wide-header">
               <div class="detail-container">
                 <ul class="detail-tabs-header">
-                  <li class="detail-tab tab-link detail-tab-readme-title" role="button">
-                    <a href="/packages/oxygen/versions/1.0.0">Readme</a>
+                  <li class="detail-tab tab-link detail-tab-readme-title">
+                    <a href="/packages/oxygen/versions/1.0.0" role="button">Readme</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-changelog-title" role="button">
-                    <a href="/packages/oxygen/versions/1.0.0/changelog">Changelog</a>
+                  <li class="detail-tab tab-link detail-tab-changelog-title">
+                    <a href="/packages/oxygen/versions/1.0.0/changelog" role="button">Changelog</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-example-title" role="button">
-                    <a href="/packages/oxygen/versions/1.0.0/example">Example</a>
+                  <li class="detail-tab tab-link detail-tab-example-title">
+                    <a href="/packages/oxygen/versions/1.0.0/example" role="button">Example</a>
                   </li>
-                  <li class="detail-tab tab-button detail-tab-installing-title -active" role="button">Installing</li>
-                  <li class="detail-tab tab-link detail-tab-versions-title" role="button">
-                    <a href="/packages/oxygen/versions">Versions</a>
+                  <li class="detail-tab tab-button detail-tab-installing-title -active">Installing</li>
+                  <li class="detail-tab tab-link detail-tab-versions-title">
+                    <a href="/packages/oxygen/versions" role="button">Versions</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-analysis-title" role="button">
-                    <a href="/packages/oxygen/versions/1.0.0/score">Scores</a>
+                  <li class="detail-tab tab-link detail-tab-analysis-title">
+                    <a href="/packages/oxygen/versions/1.0.0/score" role="button">Scores</a>
                   </li>
                 </ul>
               </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/license.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/license.html
@@ -182,24 +182,24 @@
             <div class="detail-tabs-wide-header">
               <div class="detail-container">
                 <ul class="detail-tabs-header">
-                  <li class="detail-tab tab-link detail-tab-readme-title" role="button">
-                    <a href="/packages/oxygen/versions/1.0.0">Readme</a>
+                  <li class="detail-tab tab-link detail-tab-readme-title">
+                    <a href="/packages/oxygen/versions/1.0.0" role="button">Readme</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-changelog-title" role="button">
-                    <a href="/packages/oxygen/versions/1.0.0/changelog">Changelog</a>
+                  <li class="detail-tab tab-link detail-tab-changelog-title">
+                    <a href="/packages/oxygen/versions/1.0.0/changelog" role="button">Changelog</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-example-title" role="button">
-                    <a href="/packages/oxygen/versions/1.0.0/example">Example</a>
+                  <li class="detail-tab tab-link detail-tab-example-title">
+                    <a href="/packages/oxygen/versions/1.0.0/example" role="button">Example</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-installing-title" role="button">
-                    <a href="/packages/oxygen/versions/1.0.0/install">Installing</a>
+                  <li class="detail-tab tab-link detail-tab-installing-title">
+                    <a href="/packages/oxygen/versions/1.0.0/install" role="button">Installing</a>
                   </li>
-                  <li class="detail-tab tab-button detail-tab-license-title -active" role="button">License</li>
-                  <li class="detail-tab tab-link detail-tab-versions-title" role="button">
-                    <a href="/packages/oxygen/versions">Versions</a>
+                  <li class="detail-tab tab-button detail-tab-license-title -active">License</li>
+                  <li class="detail-tab tab-link detail-tab-versions-title">
+                    <a href="/packages/oxygen/versions" role="button">Versions</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-analysis-title" role="button">
-                    <a href="/packages/oxygen/versions/1.0.0/score">Scores</a>
+                  <li class="detail-tab tab-link detail-tab-analysis-title">
+                    <a href="/packages/oxygen/versions/1.0.0/score" role="button">Scores</a>
                   </li>
                 </ul>
               </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/score.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/score.html
@@ -182,22 +182,22 @@
             <div class="detail-tabs-wide-header">
               <div class="detail-container">
                 <ul class="detail-tabs-header">
-                  <li class="detail-tab tab-link detail-tab-readme-title" role="button">
-                    <a href="/packages/oxygen/versions/1.0.0">Readme</a>
+                  <li class="detail-tab tab-link detail-tab-readme-title">
+                    <a href="/packages/oxygen/versions/1.0.0" role="button">Readme</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-changelog-title" role="button">
-                    <a href="/packages/oxygen/versions/1.0.0/changelog">Changelog</a>
+                  <li class="detail-tab tab-link detail-tab-changelog-title">
+                    <a href="/packages/oxygen/versions/1.0.0/changelog" role="button">Changelog</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-example-title" role="button">
-                    <a href="/packages/oxygen/versions/1.0.0/example">Example</a>
+                  <li class="detail-tab tab-link detail-tab-example-title">
+                    <a href="/packages/oxygen/versions/1.0.0/example" role="button">Example</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-installing-title" role="button">
-                    <a href="/packages/oxygen/versions/1.0.0/install">Installing</a>
+                  <li class="detail-tab tab-link detail-tab-installing-title">
+                    <a href="/packages/oxygen/versions/1.0.0/install" role="button">Installing</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-versions-title" role="button">
-                    <a href="/packages/oxygen/versions">Versions</a>
+                  <li class="detail-tab tab-link detail-tab-versions-title">
+                    <a href="/packages/oxygen/versions" role="button">Versions</a>
                   </li>
-                  <li class="detail-tab tab-button detail-tab-analysis-title -active" role="button">Scores</li>
+                  <li class="detail-tab tab-button detail-tab-analysis-title -active">Scores</li>
                 </ul>
               </div>
             </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/2.0.0.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/2.0.0.html
@@ -178,21 +178,21 @@
             <div class="detail-tabs-wide-header">
               <div class="detail-container">
                 <ul class="detail-tabs-header">
-                  <li class="detail-tab tab-button detail-tab-readme-title -active" role="button">Readme</li>
-                  <li class="detail-tab tab-link detail-tab-changelog-title" role="button">
-                    <a href="/packages/oxygen/changelog">Changelog</a>
+                  <li class="detail-tab tab-button detail-tab-readme-title -active">Readme</li>
+                  <li class="detail-tab tab-link detail-tab-changelog-title">
+                    <a href="/packages/oxygen/changelog" role="button">Changelog</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-example-title" role="button">
-                    <a href="/packages/oxygen/example">Example</a>
+                  <li class="detail-tab tab-link detail-tab-example-title">
+                    <a href="/packages/oxygen/example" role="button">Example</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-installing-title" role="button">
-                    <a href="/packages/oxygen/install">Installing</a>
+                  <li class="detail-tab tab-link detail-tab-installing-title">
+                    <a href="/packages/oxygen/install" role="button">Installing</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-versions-title" role="button">
-                    <a href="/packages/oxygen/versions">Versions</a>
+                  <li class="detail-tab tab-link detail-tab-versions-title">
+                    <a href="/packages/oxygen/versions" role="button">Versions</a>
                   </li>
-                  <li class="detail-tab tab-link detail-tab-analysis-title" role="button">
-                    <a href="/packages/oxygen/score">Scores</a>
+                  <li class="detail-tab tab-link detail-tab-analysis-title">
+                    <a href="/packages/oxygen/score" role="button">Scores</a>
                   </li>
                 </ul>
               </div>

--- a/pkg/_pub_shared/lib/validation/html/html_validation.dart
+++ b/pkg/_pub_shared/lib/validation/html/html_validation.dart
@@ -156,6 +156,22 @@ void validateHtml(Node root) {
           'Element has the same `title` and `aria-label` attribute, keep the `title`: ${elem.outerHtml}');
     }
   }
+
+  // "role"="<role>" attributes should be on interactive components
+  final allowedForRole = {'a', 'form'};
+  for (final elem in querySelectorAll('[role]')) {
+    final tag = elem.localName!;
+    final role = elem.attributes['role'];
+    // image elements may have presentation role
+    if (tag == 'img' && role == 'presentation') continue;
+    // interactive elements
+    if (elem.attributes.containsKey('tabindex')) continue;
+    if (allowedForRole.contains(tag)) continue;
+    // material components
+    if (tag == 'th' && role == 'columnheader') continue;
+    throw AssertionError(
+        '<$tag> tag should not have role attribute, found: ${elem.outerHtml}');
+  }
 }
 
 /// "Google Search result usually points to the canonical page, unless one of


### PR DESCRIPTION
- Added test to check these in the future.
- Fixing tab rendering to move `role` attribute into the link.