### PR TITLE
Improve contrast on landing page link.

### DIFF
--- a/pkg/web_css/lib/src/_home.scss
+++ b/pkg/web_css/lib/src/_home.scss
@@ -68,6 +68,11 @@
     margin-bottom: 0;
   }
 
+  a {
+    // To improve contrast, links have the same color as .home-block-title
+    color: #254a76;
+  }
+
   .home-block-context-info {
     font-size: 18px;
     margin-top: 0;
@@ -76,11 +81,6 @@
   &.home-block-ff,
   &.home-block-pow {
     background: #f5f5f7;
-
-    a {
-      // To improve contrast, links have the same color as .home-block-title
-      color: #254a76;
-    }
   }
 
   .home-block-image {

--- a/pkg/web_css/lib/src/_home.scss
+++ b/pkg/web_css/lib/src/_home.scss
@@ -76,6 +76,11 @@
   &.home-block-ff,
   &.home-block-pow {
     background: #f5f5f7;
+
+    a {
+      // To improve contrast, links have the same color as .home-block-title
+      color: #254a76;
+    }
   }
 
   .home-block-image {


### PR DESCRIPTION
Fixes #7228 by using the same link color as the section title (e.g. Flutter Favorites). I did not wanted to introduce yet another color there, and the header contrast was already accepted by lighthouse.