### PR TITLE
keyboard support for screenshot carrousel

### DIFF
--- a/app/lib/frontend/templates/views/pkg/screenshots.dart
+++ b/app/lib/frontend/templates/views/pkg/screenshots.dart
@@ -27,6 +27,7 @@ d.Node imageCarousel() {
       attributes: {
         'title': 'Next',
         'data-ga-click-event': 'screenshot-carousel-next-click',
+        'tabindex': '0',
       });
 
   final prev = material.floatingActionButton(
@@ -43,6 +44,7 @@ d.Node imageCarousel() {
       attributes: {
         'title': 'Previous',
         'data-ga-click-event': 'screenshot-carousel-prev-click',
+        'tabindex': '0',
       });
 
   final description =

--- a/app/lib/frontend/templates/views/pkg/screenshots.dart
+++ b/app/lib/frontend/templates/views/pkg/screenshots.dart
@@ -81,6 +81,9 @@ d.Node screenshotThumbnailNode({
       image: d.Image(
           alt: 'screenshot', width: null, height: null, src: thumbnailUrl),
       title: 'View screenshots',
+      attributes: {
+        'tabindex': '0',
+      },
     ),
   ]);
 }

--- a/app/test/frontend/golden/my_packages.html
+++ b/app/test/frontend/golden/my_packages.html
@@ -330,12 +330,12 @@
                       </div>
                     </div>
                     <div id="-screenshot-carousel" class="carousel">
-                      <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click">
+                      <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
                         <div class="mdc-fab__ripple"></div>
                         <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
                       </fab>
                       <div id="-image-container" class="image-container"></div>
-                      <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click">
+                      <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
                         <div class="mdc-fab__ripple"></div>
                         <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
                       </fab>

--- a/app/test/frontend/golden/pkg_activity_log_page.html
+++ b/app/test/frontend/golden/pkg_activity_log_page.html
@@ -339,12 +339,12 @@
           </div>
           <aside class="detail-info-box">
             <div id="-screenshot-carousel" class="carousel">
-              <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click">
+              <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
                 <div class="mdc-fab__ripple"></div>
                 <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
               </fab>
               <div id="-image-container" class="image-container"></div>
-              <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click">
+              <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
                 <div class="mdc-fab__ripple"></div>
                 <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
               </fab>
@@ -425,12 +425,12 @@
         </h3>
         <div class="detail-info-box">
           <div id="-screenshot-carousel" class="carousel">
-            <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click">
+            <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
               <div class="mdc-fab__ripple"></div>
               <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
             </fab>
             <div id="-image-container" class="image-container"></div>
-            <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click">
+            <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
               <div class="mdc-fab__ripple"></div>
               <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
             </fab>

--- a/app/test/frontend/golden/pkg_admin_page.html
+++ b/app/test/frontend/golden/pkg_admin_page.html
@@ -557,12 +557,12 @@
           </div>
           <aside class="detail-info-box">
             <div id="-screenshot-carousel" class="carousel">
-              <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click">
+              <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
                 <div class="mdc-fab__ripple"></div>
                 <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
               </fab>
               <div id="-image-container" class="image-container"></div>
-              <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click">
+              <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
                 <div class="mdc-fab__ripple"></div>
                 <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
               </fab>
@@ -643,12 +643,12 @@
         </h3>
         <div class="detail-info-box">
           <div id="-screenshot-carousel" class="carousel">
-            <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click">
+            <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
               <div class="mdc-fab__ripple"></div>
               <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
             </fab>
             <div id="-image-container" class="image-container"></div>
-            <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click">
+            <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
               <div class="mdc-fab__ripple"></div>
               <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
             </fab>

--- a/app/test/frontend/golden/pkg_changelog_page.html
+++ b/app/test/frontend/golden/pkg_changelog_page.html
@@ -225,12 +225,12 @@
           </div>
           <aside class="detail-info-box">
             <div id="-screenshot-carousel" class="carousel">
-              <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click">
+              <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
                 <div class="mdc-fab__ripple"></div>
                 <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
               </fab>
               <div id="-image-container" class="image-container"></div>
-              <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click">
+              <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
                 <div class="mdc-fab__ripple"></div>
                 <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
               </fab>
@@ -312,12 +312,12 @@
         </h3>
         <div class="detail-info-box">
           <div id="-screenshot-carousel" class="carousel">
-            <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click">
+            <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
               <div class="mdc-fab__ripple"></div>
               <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
             </fab>
             <div id="-image-container" class="image-container"></div>
-            <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click">
+            <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
               <div class="mdc-fab__ripple"></div>
               <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
             </fab>

--- a/app/test/frontend/golden/pkg_example_page.html
+++ b/app/test/frontend/golden/pkg_example_page.html
@@ -222,12 +222,12 @@
           </div>
           <aside class="detail-info-box">
             <div id="-screenshot-carousel" class="carousel">
-              <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click">
+              <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
                 <div class="mdc-fab__ripple"></div>
                 <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
               </fab>
               <div id="-image-container" class="image-container"></div>
-              <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click">
+              <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
                 <div class="mdc-fab__ripple"></div>
                 <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
               </fab>
@@ -309,12 +309,12 @@
         </h3>
         <div class="detail-info-box">
           <div id="-screenshot-carousel" class="carousel">
-            <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click">
+            <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
               <div class="mdc-fab__ripple"></div>
               <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
             </fab>
             <div id="-image-container" class="image-container"></div>
-            <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click">
+            <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
               <div class="mdc-fab__ripple"></div>
               <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
             </fab>

--- a/app/test/frontend/golden/pkg_index_page.html
+++ b/app/test/frontend/golden/pkg_index_page.html
@@ -576,12 +576,12 @@
               </div>
             </div>
             <div id="-screenshot-carousel" class="carousel">
-              <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click">
+              <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
                 <div class="mdc-fab__ripple"></div>
                 <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
               </fab>
               <div id="-image-container" class="image-container"></div>
-              <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click">
+              <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
                 <div class="mdc-fab__ripple"></div>
                 <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
               </fab>

--- a/app/test/frontend/golden/pkg_install_page.html
+++ b/app/test/frontend/golden/pkg_install_page.html
@@ -248,12 +248,12 @@
           </div>
           <aside class="detail-info-box">
             <div id="-screenshot-carousel" class="carousel">
-              <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click">
+              <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
                 <div class="mdc-fab__ripple"></div>
                 <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
               </fab>
               <div id="-image-container" class="image-container"></div>
-              <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click">
+              <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
                 <div class="mdc-fab__ripple"></div>
                 <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
               </fab>
@@ -335,12 +335,12 @@
         </h3>
         <div class="detail-info-box">
           <div id="-screenshot-carousel" class="carousel">
-            <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click">
+            <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
               <div class="mdc-fab__ripple"></div>
               <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
             </fab>
             <div id="-image-container" class="image-container"></div>
-            <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click">
+            <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
               <div class="mdc-fab__ripple"></div>
               <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
             </fab>

--- a/app/test/frontend/golden/pkg_score_page.html
+++ b/app/test/frontend/golden/pkg_score_page.html
@@ -317,12 +317,12 @@
           </div>
           <aside class="detail-info-box">
             <div id="-screenshot-carousel" class="carousel">
-              <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click">
+              <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
                 <div class="mdc-fab__ripple"></div>
                 <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
               </fab>
               <div id="-image-container" class="image-container"></div>
-              <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click">
+              <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
                 <div class="mdc-fab__ripple"></div>
                 <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
               </fab>
@@ -404,12 +404,12 @@
         </h3>
         <div class="detail-info-box">
           <div id="-screenshot-carousel" class="carousel">
-            <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click">
+            <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
               <div class="mdc-fab__ripple"></div>
               <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
             </fab>
             <div id="-image-container" class="image-container"></div>
-            <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click">
+            <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
               <div class="mdc-fab__ripple"></div>
               <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
             </fab>

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -225,12 +225,12 @@
           </div>
           <aside class="detail-info-box">
             <div id="-screenshot-carousel" class="carousel">
-              <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click">
+              <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
                 <div class="mdc-fab__ripple"></div>
                 <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
               </fab>
               <div id="-image-container" class="image-container"></div>
-              <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click">
+              <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
                 <div class="mdc-fab__ripple"></div>
                 <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
               </fab>
@@ -312,12 +312,12 @@
         </h3>
         <div class="detail-info-box">
           <div id="-screenshot-carousel" class="carousel">
-            <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click">
+            <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
               <div class="mdc-fab__ripple"></div>
               <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
             </fab>
             <div id="-image-container" class="image-container"></div>
-            <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click">
+            <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
               <div class="mdc-fab__ripple"></div>
               <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
             </fab>

--- a/app/test/frontend/golden/pkg_show_page_discontinued.html
+++ b/app/test/frontend/golden/pkg_show_page_discontinued.html
@@ -205,12 +205,12 @@
           </div>
           <aside class="detail-info-box">
             <div id="-screenshot-carousel" class="carousel">
-              <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click">
+              <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
                 <div class="mdc-fab__ripple"></div>
                 <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
               </fab>
               <div id="-image-container" class="image-container"></div>
-              <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click">
+              <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
                 <div class="mdc-fab__ripple"></div>
                 <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
               </fab>
@@ -287,12 +287,12 @@
         </h3>
         <div class="detail-info-box">
           <div id="-screenshot-carousel" class="carousel">
-            <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click">
+            <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
               <div class="mdc-fab__ripple"></div>
               <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
             </fab>
             <div id="-image-container" class="image-container"></div>
-            <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click">
+            <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
               <div class="mdc-fab__ripple"></div>
               <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
             </fab>

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -214,12 +214,12 @@
           </div>
           <aside class="detail-info-box">
             <div id="-screenshot-carousel" class="carousel">
-              <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click">
+              <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
                 <div class="mdc-fab__ripple"></div>
                 <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
               </fab>
               <div id="-image-container" class="image-container"></div>
-              <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click">
+              <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
                 <div class="mdc-fab__ripple"></div>
                 <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
               </fab>
@@ -305,12 +305,12 @@
         </h3>
         <div class="detail-info-box">
           <div id="-screenshot-carousel" class="carousel">
-            <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click">
+            <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
               <div class="mdc-fab__ripple"></div>
               <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
             </fab>
             <div id="-image-container" class="image-container"></div>
-            <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click">
+            <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
               <div class="mdc-fab__ripple"></div>
               <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
             </fab>

--- a/app/test/frontend/golden/pkg_show_page_publisher.html
+++ b/app/test/frontend/golden/pkg_show_page_publisher.html
@@ -213,12 +213,12 @@
           </div>
           <aside class="detail-info-box">
             <div id="-screenshot-carousel" class="carousel">
-              <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click">
+              <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
                 <div class="mdc-fab__ripple"></div>
                 <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
               </fab>
               <div id="-image-container" class="image-container"></div>
-              <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click">
+              <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
                 <div class="mdc-fab__ripple"></div>
                 <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
               </fab>
@@ -303,12 +303,12 @@
         </h3>
         <div class="detail-info-box">
           <div id="-screenshot-carousel" class="carousel">
-            <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click">
+            <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
               <div class="mdc-fab__ripple"></div>
               <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
             </fab>
             <div id="-image-container" class="image-container"></div>
-            <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click">
+            <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
               <div class="mdc-fab__ripple"></div>
               <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
             </fab>

--- a/app/test/frontend/golden/pkg_show_page_retracted.html
+++ b/app/test/frontend/golden/pkg_show_page_retracted.html
@@ -201,12 +201,12 @@
           </div>
           <aside class="detail-info-box">
             <div id="-screenshot-carousel" class="carousel">
-              <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click">
+              <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
                 <div class="mdc-fab__ripple"></div>
                 <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
               </fab>
               <div id="-image-container" class="image-container"></div>
-              <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click">
+              <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
                 <div class="mdc-fab__ripple"></div>
                 <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
               </fab>
@@ -283,12 +283,12 @@
         </h3>
         <div class="detail-info-box">
           <div id="-screenshot-carousel" class="carousel">
-            <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click">
+            <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
               <div class="mdc-fab__ripple"></div>
               <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
             </fab>
             <div id="-image-container" class="image-container"></div>
-            <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click">
+            <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
               <div class="mdc-fab__ripple"></div>
               <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
             </fab>

--- a/app/test/frontend/golden/pkg_show_page_retracted_non_retracted_version.html
+++ b/app/test/frontend/golden/pkg_show_page_retracted_non_retracted_version.html
@@ -209,12 +209,12 @@
           </div>
           <aside class="detail-info-box">
             <div id="-screenshot-carousel" class="carousel">
-              <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click">
+              <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
                 <div class="mdc-fab__ripple"></div>
                 <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
               </fab>
               <div id="-image-container" class="image-container"></div>
-              <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click">
+              <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
                 <div class="mdc-fab__ripple"></div>
                 <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
               </fab>
@@ -294,12 +294,12 @@
         </h3>
         <div class="detail-info-box">
           <div id="-screenshot-carousel" class="carousel">
-            <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click">
+            <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
               <div class="mdc-fab__ripple"></div>
               <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
             </fab>
             <div id="-image-container" class="image-container"></div>
-            <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click">
+            <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
               <div class="mdc-fab__ripple"></div>
               <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
             </fab>

--- a/app/test/frontend/golden/pkg_show_version_page.html
+++ b/app/test/frontend/golden/pkg_show_version_page.html
@@ -219,12 +219,12 @@
           </div>
           <aside class="detail-info-box">
             <div id="-screenshot-carousel" class="carousel">
-              <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click">
+              <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
                 <div class="mdc-fab__ripple"></div>
                 <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
               </fab>
               <div id="-image-container" class="image-container"></div>
-              <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click">
+              <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
                 <div class="mdc-fab__ripple"></div>
                 <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
               </fab>
@@ -306,12 +306,12 @@
         </h3>
         <div class="detail-info-box">
           <div id="-screenshot-carousel" class="carousel">
-            <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click">
+            <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
               <div class="mdc-fab__ripple"></div>
               <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
             </fab>
             <div id="-image-container" class="image-container"></div>
-            <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click">
+            <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
               <div class="mdc-fab__ripple"></div>
               <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
             </fab>

--- a/app/test/frontend/golden/pkg_versions_page.html
+++ b/app/test/frontend/golden/pkg_versions_page.html
@@ -328,12 +328,12 @@
           </div>
           <aside class="detail-info-box">
             <div id="-screenshot-carousel" class="carousel">
-              <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click">
+              <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
                 <div class="mdc-fab__ripple"></div>
                 <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
               </fab>
               <div id="-image-container" class="image-container"></div>
-              <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click">
+              <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
                 <div class="mdc-fab__ripple"></div>
                 <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
               </fab>
@@ -415,12 +415,12 @@
         </h3>
         <div class="detail-info-box">
           <div id="-screenshot-carousel" class="carousel">
-            <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click">
+            <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
               <div class="mdc-fab__ripple"></div>
               <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
             </fab>
             <div id="-image-container" class="image-container"></div>
-            <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click">
+            <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
               <div class="mdc-fab__ripple"></div>
               <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
             </fab>

--- a/app/test/frontend/golden/publisher_packages_page.html
+++ b/app/test/frontend/golden/publisher_packages_page.html
@@ -326,12 +326,12 @@
                       </div>
                     </div>
                     <div id="-screenshot-carousel" class="carousel">
-                      <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click">
+                      <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
                         <div class="mdc-fab__ripple"></div>
                         <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
                       </fab>
                       <div id="-image-container" class="image-container"></div>
-                      <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click">
+                      <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
                         <div class="mdc-fab__ripple"></div>
                         <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
                       </fab>

--- a/app/test/frontend/golden/publisher_unlisted_packages_page.html
+++ b/app/test/frontend/golden/publisher_unlisted_packages_page.html
@@ -332,12 +332,12 @@
                       </div>
                     </div>
                     <div id="-screenshot-carousel" class="carousel">
-                      <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click">
+                      <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
                         <div class="mdc-fab__ripple"></div>
                         <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
                       </fab>
                       <div id="-image-container" class="image-container"></div>
-                      <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click">
+                      <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
                         <div class="mdc-fab__ripple"></div>
                         <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
                       </fab>

--- a/app/test/frontend/golden/search_page.html
+++ b/app/test/frontend/golden/search_page.html
@@ -569,12 +569,12 @@
               </div>
             </div>
             <div id="-screenshot-carousel" class="carousel">
-              <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click">
+              <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
                 <div class="mdc-fab__ripple"></div>
                 <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
               </fab>
               <div id="-image-container" class="image-container"></div>
-              <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click">
+              <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
                 <div class="mdc-fab__ripple"></div>
                 <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
               </fab>

--- a/app/test/frontend/static_files_test.dart
+++ b/app/test/frontend/static_files_test.dart
@@ -200,7 +200,7 @@ void main() {
     test('script.dart.js and parts size check', () {
       final file = cache.getFile('/static/js/script.dart.js');
       expect(file, isNotNull);
-      expect((file!.bytes.length / 1024).round(), closeTo(311, 1));
+      expect((file!.bytes.length / 1024).round(), closeTo(313, 1));
 
       final parts = cache.paths
           .where((path) =>

--- a/app/test/task/testdata/goldens/packages/oxygen.html
+++ b/app/test/task/testdata/goldens/packages/oxygen.html
@@ -211,12 +211,12 @@
           </div>
           <aside class="detail-info-box">
             <div id="-screenshot-carousel" class="carousel">
-              <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click">
+              <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
                 <div class="mdc-fab__ripple"></div>
                 <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
               </fab>
               <div id="-image-container" class="image-container"></div>
-              <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click">
+              <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
                 <div class="mdc-fab__ripple"></div>
                 <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
               </fab>
@@ -247,7 +247,7 @@
             </a>
             <div class="detail-screenshot-thumbnail">
               <div class="thumbnail-container" data-thumbnail="/packages/oxygen/versions/2.0.0/gen-res/gen/static.webp" data-thumbnail-descriptions-json="[&quot;This is an awesome screenshot&quot;]" data-ga-click-event="screenshot-thumbnail-click">
-                <img class="thumbnail-image" src="/packages/oxygen/versions/2.0.0/gen-res/gen/190x190/static.webp" alt="screenshot" title="View screenshots"/>
+                <img class="thumbnail-image" src="/packages/oxygen/versions/2.0.0/gen-res/gen/190x190/static.webp" alt="screenshot" title="View screenshots" tabindex="0"/>
               </div>
               <img class="collections-icon" src="/static/hash-%%etag%%/img/collections_white_24dp.svg" alt="" width="30" height="30" role="presentation"/>
             </div>
@@ -297,12 +297,12 @@
         </h3>
         <div class="detail-info-box">
           <div id="-screenshot-carousel" class="carousel">
-            <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click">
+            <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
               <div class="mdc-fab__ripple"></div>
               <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
             </fab>
             <div id="-image-container" class="image-container"></div>
-            <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click">
+            <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
               <div class="mdc-fab__ripple"></div>
               <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
             </fab>
@@ -333,7 +333,7 @@
           </a>
           <div class="detail-screenshot-thumbnail">
             <div class="thumbnail-container" data-thumbnail="/packages/oxygen/versions/2.0.0/gen-res/gen/static.webp" data-thumbnail-descriptions-json="[&quot;This is an awesome screenshot&quot;]" data-ga-click-event="screenshot-thumbnail-click">
-              <img class="thumbnail-image" src="/packages/oxygen/versions/2.0.0/gen-res/gen/190x190/static.webp" alt="screenshot" title="View screenshots"/>
+              <img class="thumbnail-image" src="/packages/oxygen/versions/2.0.0/gen-res/gen/190x190/static.webp" alt="screenshot" title="View screenshots" tabindex="0"/>
             </div>
             <img class="collections-icon" src="/static/hash-%%etag%%/img/collections_white_24dp.svg" alt="" width="30" height="30" role="presentation"/>
           </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/changelog.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/changelog.html
@@ -217,12 +217,12 @@
           </div>
           <aside class="detail-info-box">
             <div id="-screenshot-carousel" class="carousel">
-              <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click">
+              <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
                 <div class="mdc-fab__ripple"></div>
                 <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
               </fab>
               <div id="-image-container" class="image-container"></div>
-              <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click">
+              <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
                 <div class="mdc-fab__ripple"></div>
                 <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
               </fab>
@@ -253,7 +253,7 @@
             </a>
             <div class="detail-screenshot-thumbnail">
               <div class="thumbnail-container" data-thumbnail="/packages/oxygen/versions/2.0.0/gen-res/gen/static.webp" data-thumbnail-descriptions-json="[&quot;This is an awesome screenshot&quot;]" data-ga-click-event="screenshot-thumbnail-click">
-                <img class="thumbnail-image" src="/packages/oxygen/versions/2.0.0/gen-res/gen/190x190/static.webp" alt="screenshot" title="View screenshots"/>
+                <img class="thumbnail-image" src="/packages/oxygen/versions/2.0.0/gen-res/gen/190x190/static.webp" alt="screenshot" title="View screenshots" tabindex="0"/>
               </div>
               <img class="collections-icon" src="/static/hash-%%etag%%/img/collections_white_24dp.svg" alt="" width="30" height="30" role="presentation"/>
             </div>
@@ -303,12 +303,12 @@
         </h3>
         <div class="detail-info-box">
           <div id="-screenshot-carousel" class="carousel">
-            <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click">
+            <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
               <div class="mdc-fab__ripple"></div>
               <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
             </fab>
             <div id="-image-container" class="image-container"></div>
-            <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click">
+            <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
               <div class="mdc-fab__ripple"></div>
               <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
             </fab>
@@ -339,7 +339,7 @@
           </a>
           <div class="detail-screenshot-thumbnail">
             <div class="thumbnail-container" data-thumbnail="/packages/oxygen/versions/2.0.0/gen-res/gen/static.webp" data-thumbnail-descriptions-json="[&quot;This is an awesome screenshot&quot;]" data-ga-click-event="screenshot-thumbnail-click">
-              <img class="thumbnail-image" src="/packages/oxygen/versions/2.0.0/gen-res/gen/190x190/static.webp" alt="screenshot" title="View screenshots"/>
+              <img class="thumbnail-image" src="/packages/oxygen/versions/2.0.0/gen-res/gen/190x190/static.webp" alt="screenshot" title="View screenshots" tabindex="0"/>
             </div>
             <img class="collections-icon" src="/static/hash-%%etag%%/img/collections_white_24dp.svg" alt="" width="30" height="30" role="presentation"/>
           </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/example.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/example.html
@@ -212,12 +212,12 @@
           </div>
           <aside class="detail-info-box">
             <div id="-screenshot-carousel" class="carousel">
-              <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click">
+              <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
                 <div class="mdc-fab__ripple"></div>
                 <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
               </fab>
               <div id="-image-container" class="image-container"></div>
-              <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click">
+              <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
                 <div class="mdc-fab__ripple"></div>
                 <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
               </fab>
@@ -248,7 +248,7 @@
             </a>
             <div class="detail-screenshot-thumbnail">
               <div class="thumbnail-container" data-thumbnail="/packages/oxygen/versions/2.0.0/gen-res/gen/static.webp" data-thumbnail-descriptions-json="[&quot;This is an awesome screenshot&quot;]" data-ga-click-event="screenshot-thumbnail-click">
-                <img class="thumbnail-image" src="/packages/oxygen/versions/2.0.0/gen-res/gen/190x190/static.webp" alt="screenshot" title="View screenshots"/>
+                <img class="thumbnail-image" src="/packages/oxygen/versions/2.0.0/gen-res/gen/190x190/static.webp" alt="screenshot" title="View screenshots" tabindex="0"/>
               </div>
               <img class="collections-icon" src="/static/hash-%%etag%%/img/collections_white_24dp.svg" alt="" width="30" height="30" role="presentation"/>
             </div>
@@ -298,12 +298,12 @@
         </h3>
         <div class="detail-info-box">
           <div id="-screenshot-carousel" class="carousel">
-            <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click">
+            <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
               <div class="mdc-fab__ripple"></div>
               <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
             </fab>
             <div id="-image-container" class="image-container"></div>
-            <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click">
+            <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
               <div class="mdc-fab__ripple"></div>
               <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
             </fab>
@@ -334,7 +334,7 @@
           </a>
           <div class="detail-screenshot-thumbnail">
             <div class="thumbnail-container" data-thumbnail="/packages/oxygen/versions/2.0.0/gen-res/gen/static.webp" data-thumbnail-descriptions-json="[&quot;This is an awesome screenshot&quot;]" data-ga-click-event="screenshot-thumbnail-click">
-              <img class="thumbnail-image" src="/packages/oxygen/versions/2.0.0/gen-res/gen/190x190/static.webp" alt="screenshot" title="View screenshots"/>
+              <img class="thumbnail-image" src="/packages/oxygen/versions/2.0.0/gen-res/gen/190x190/static.webp" alt="screenshot" title="View screenshots" tabindex="0"/>
             </div>
             <img class="collections-icon" src="/static/hash-%%etag%%/img/collections_white_24dp.svg" alt="" width="30" height="30" role="presentation"/>
           </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/install.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/install.html
@@ -240,12 +240,12 @@
           </div>
           <aside class="detail-info-box">
             <div id="-screenshot-carousel" class="carousel">
-              <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click">
+              <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
                 <div class="mdc-fab__ripple"></div>
                 <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
               </fab>
               <div id="-image-container" class="image-container"></div>
-              <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click">
+              <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
                 <div class="mdc-fab__ripple"></div>
                 <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
               </fab>
@@ -276,7 +276,7 @@
             </a>
             <div class="detail-screenshot-thumbnail">
               <div class="thumbnail-container" data-thumbnail="/packages/oxygen/versions/2.0.0/gen-res/gen/static.webp" data-thumbnail-descriptions-json="[&quot;This is an awesome screenshot&quot;]" data-ga-click-event="screenshot-thumbnail-click">
-                <img class="thumbnail-image" src="/packages/oxygen/versions/2.0.0/gen-res/gen/190x190/static.webp" alt="screenshot" title="View screenshots"/>
+                <img class="thumbnail-image" src="/packages/oxygen/versions/2.0.0/gen-res/gen/190x190/static.webp" alt="screenshot" title="View screenshots" tabindex="0"/>
               </div>
               <img class="collections-icon" src="/static/hash-%%etag%%/img/collections_white_24dp.svg" alt="" width="30" height="30" role="presentation"/>
             </div>
@@ -326,12 +326,12 @@
         </h3>
         <div class="detail-info-box">
           <div id="-screenshot-carousel" class="carousel">
-            <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click">
+            <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
               <div class="mdc-fab__ripple"></div>
               <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
             </fab>
             <div id="-image-container" class="image-container"></div>
-            <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click">
+            <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
               <div class="mdc-fab__ripple"></div>
               <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
             </fab>
@@ -362,7 +362,7 @@
           </a>
           <div class="detail-screenshot-thumbnail">
             <div class="thumbnail-container" data-thumbnail="/packages/oxygen/versions/2.0.0/gen-res/gen/static.webp" data-thumbnail-descriptions-json="[&quot;This is an awesome screenshot&quot;]" data-ga-click-event="screenshot-thumbnail-click">
-              <img class="thumbnail-image" src="/packages/oxygen/versions/2.0.0/gen-res/gen/190x190/static.webp" alt="screenshot" title="View screenshots"/>
+              <img class="thumbnail-image" src="/packages/oxygen/versions/2.0.0/gen-res/gen/190x190/static.webp" alt="screenshot" title="View screenshots" tabindex="0"/>
             </div>
             <img class="collections-icon" src="/static/hash-%%etag%%/img/collections_white_24dp.svg" alt="" width="30" height="30" role="presentation"/>
           </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/license.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/license.html
@@ -213,12 +213,12 @@
           </div>
           <aside class="detail-info-box">
             <div id="-screenshot-carousel" class="carousel">
-              <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click">
+              <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
                 <div class="mdc-fab__ripple"></div>
                 <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
               </fab>
               <div id="-image-container" class="image-container"></div>
-              <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click">
+              <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
                 <div class="mdc-fab__ripple"></div>
                 <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
               </fab>
@@ -249,7 +249,7 @@
             </a>
             <div class="detail-screenshot-thumbnail">
               <div class="thumbnail-container" data-thumbnail="/packages/oxygen/versions/2.0.0/gen-res/gen/static.webp" data-thumbnail-descriptions-json="[&quot;This is an awesome screenshot&quot;]" data-ga-click-event="screenshot-thumbnail-click">
-                <img class="thumbnail-image" src="/packages/oxygen/versions/2.0.0/gen-res/gen/190x190/static.webp" alt="screenshot" title="View screenshots"/>
+                <img class="thumbnail-image" src="/packages/oxygen/versions/2.0.0/gen-res/gen/190x190/static.webp" alt="screenshot" title="View screenshots" tabindex="0"/>
               </div>
               <img class="collections-icon" src="/static/hash-%%etag%%/img/collections_white_24dp.svg" alt="" width="30" height="30" role="presentation"/>
             </div>
@@ -299,12 +299,12 @@
         </h3>
         <div class="detail-info-box">
           <div id="-screenshot-carousel" class="carousel">
-            <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click">
+            <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
               <div class="mdc-fab__ripple"></div>
               <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
             </fab>
             <div id="-image-container" class="image-container"></div>
-            <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click">
+            <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
               <div class="mdc-fab__ripple"></div>
               <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
             </fab>
@@ -335,7 +335,7 @@
           </a>
           <div class="detail-screenshot-thumbnail">
             <div class="thumbnail-container" data-thumbnail="/packages/oxygen/versions/2.0.0/gen-res/gen/static.webp" data-thumbnail-descriptions-json="[&quot;This is an awesome screenshot&quot;]" data-ga-click-event="screenshot-thumbnail-click">
-              <img class="thumbnail-image" src="/packages/oxygen/versions/2.0.0/gen-res/gen/190x190/static.webp" alt="screenshot" title="View screenshots"/>
+              <img class="thumbnail-image" src="/packages/oxygen/versions/2.0.0/gen-res/gen/190x190/static.webp" alt="screenshot" title="View screenshots" tabindex="0"/>
             </div>
             <img class="collections-icon" src="/static/hash-%%etag%%/img/collections_white_24dp.svg" alt="" width="30" height="30" role="presentation"/>
           </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/score.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/score.html
@@ -520,12 +520,12 @@
           </div>
           <aside class="detail-info-box">
             <div id="-screenshot-carousel" class="carousel">
-              <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click">
+              <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
                 <div class="mdc-fab__ripple"></div>
                 <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
               </fab>
               <div id="-image-container" class="image-container"></div>
-              <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click">
+              <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
                 <div class="mdc-fab__ripple"></div>
                 <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
               </fab>
@@ -556,7 +556,7 @@
             </a>
             <div class="detail-screenshot-thumbnail">
               <div class="thumbnail-container" data-thumbnail="/packages/oxygen/versions/2.0.0/gen-res/gen/static.webp" data-thumbnail-descriptions-json="[&quot;This is an awesome screenshot&quot;]" data-ga-click-event="screenshot-thumbnail-click">
-                <img class="thumbnail-image" src="/packages/oxygen/versions/2.0.0/gen-res/gen/190x190/static.webp" alt="screenshot" title="View screenshots"/>
+                <img class="thumbnail-image" src="/packages/oxygen/versions/2.0.0/gen-res/gen/190x190/static.webp" alt="screenshot" title="View screenshots" tabindex="0"/>
               </div>
               <img class="collections-icon" src="/static/hash-%%etag%%/img/collections_white_24dp.svg" alt="" width="30" height="30" role="presentation"/>
             </div>
@@ -606,12 +606,12 @@
         </h3>
         <div class="detail-info-box">
           <div id="-screenshot-carousel" class="carousel">
-            <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click">
+            <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
               <div class="mdc-fab__ripple"></div>
               <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
             </fab>
             <div id="-image-container" class="image-container"></div>
-            <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click">
+            <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
               <div class="mdc-fab__ripple"></div>
               <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
             </fab>
@@ -642,7 +642,7 @@
           </a>
           <div class="detail-screenshot-thumbnail">
             <div class="thumbnail-container" data-thumbnail="/packages/oxygen/versions/2.0.0/gen-res/gen/static.webp" data-thumbnail-descriptions-json="[&quot;This is an awesome screenshot&quot;]" data-ga-click-event="screenshot-thumbnail-click">
-              <img class="thumbnail-image" src="/packages/oxygen/versions/2.0.0/gen-res/gen/190x190/static.webp" alt="screenshot" title="View screenshots"/>
+              <img class="thumbnail-image" src="/packages/oxygen/versions/2.0.0/gen-res/gen/190x190/static.webp" alt="screenshot" title="View screenshots" tabindex="0"/>
             </div>
             <img class="collections-icon" src="/static/hash-%%etag%%/img/collections_white_24dp.svg" alt="" width="30" height="30" role="presentation"/>
           </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions.html
@@ -273,12 +273,12 @@
           </div>
           <aside class="detail-info-box">
             <div id="-screenshot-carousel" class="carousel">
-              <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click">
+              <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
                 <div class="mdc-fab__ripple"></div>
                 <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
               </fab>
               <div id="-image-container" class="image-container"></div>
-              <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click">
+              <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
                 <div class="mdc-fab__ripple"></div>
                 <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
               </fab>
@@ -309,7 +309,7 @@
             </a>
             <div class="detail-screenshot-thumbnail">
               <div class="thumbnail-container" data-thumbnail="/packages/oxygen/versions/2.0.0/gen-res/gen/static.webp" data-thumbnail-descriptions-json="[&quot;This is an awesome screenshot&quot;]" data-ga-click-event="screenshot-thumbnail-click">
-                <img class="thumbnail-image" src="/packages/oxygen/versions/2.0.0/gen-res/gen/190x190/static.webp" alt="screenshot" title="View screenshots"/>
+                <img class="thumbnail-image" src="/packages/oxygen/versions/2.0.0/gen-res/gen/190x190/static.webp" alt="screenshot" title="View screenshots" tabindex="0"/>
               </div>
               <img class="collections-icon" src="/static/hash-%%etag%%/img/collections_white_24dp.svg" alt="" width="30" height="30" role="presentation"/>
             </div>
@@ -359,12 +359,12 @@
         </h3>
         <div class="detail-info-box">
           <div id="-screenshot-carousel" class="carousel">
-            <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click">
+            <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
               <div class="mdc-fab__ripple"></div>
               <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
             </fab>
             <div id="-image-container" class="image-container"></div>
-            <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click">
+            <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
               <div class="mdc-fab__ripple"></div>
               <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
             </fab>
@@ -395,7 +395,7 @@
           </a>
           <div class="detail-screenshot-thumbnail">
             <div class="thumbnail-container" data-thumbnail="/packages/oxygen/versions/2.0.0/gen-res/gen/static.webp" data-thumbnail-descriptions-json="[&quot;This is an awesome screenshot&quot;]" data-ga-click-event="screenshot-thumbnail-click">
-              <img class="thumbnail-image" src="/packages/oxygen/versions/2.0.0/gen-res/gen/190x190/static.webp" alt="screenshot" title="View screenshots"/>
+              <img class="thumbnail-image" src="/packages/oxygen/versions/2.0.0/gen-res/gen/190x190/static.webp" alt="screenshot" title="View screenshots" tabindex="0"/>
             </div>
             <img class="collections-icon" src="/static/hash-%%etag%%/img/collections_white_24dp.svg" alt="" width="30" height="30" role="presentation"/>
           </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0.html
@@ -215,12 +215,12 @@
           </div>
           <aside class="detail-info-box">
             <div id="-screenshot-carousel" class="carousel">
-              <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click">
+              <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
                 <div class="mdc-fab__ripple"></div>
                 <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
               </fab>
               <div id="-image-container" class="image-container"></div>
-              <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click">
+              <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
                 <div class="mdc-fab__ripple"></div>
                 <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
               </fab>
@@ -251,7 +251,7 @@
             </a>
             <div class="detail-screenshot-thumbnail">
               <div class="thumbnail-container" data-thumbnail="/packages/oxygen/versions/1.0.0/gen-res/gen/static.webp" data-thumbnail-descriptions-json="[&quot;This is an awesome screenshot&quot;]" data-ga-click-event="screenshot-thumbnail-click">
-                <img class="thumbnail-image" src="/packages/oxygen/versions/1.0.0/gen-res/gen/190x190/static.webp" alt="screenshot" title="View screenshots"/>
+                <img class="thumbnail-image" src="/packages/oxygen/versions/1.0.0/gen-res/gen/190x190/static.webp" alt="screenshot" title="View screenshots" tabindex="0"/>
               </div>
               <img class="collections-icon" src="/static/hash-%%etag%%/img/collections_white_24dp.svg" alt="" width="30" height="30" role="presentation"/>
             </div>
@@ -301,12 +301,12 @@
         </h3>
         <div class="detail-info-box">
           <div id="-screenshot-carousel" class="carousel">
-            <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click">
+            <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
               <div class="mdc-fab__ripple"></div>
               <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
             </fab>
             <div id="-image-container" class="image-container"></div>
-            <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click">
+            <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
               <div class="mdc-fab__ripple"></div>
               <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
             </fab>
@@ -337,7 +337,7 @@
           </a>
           <div class="detail-screenshot-thumbnail">
             <div class="thumbnail-container" data-thumbnail="/packages/oxygen/versions/1.0.0/gen-res/gen/static.webp" data-thumbnail-descriptions-json="[&quot;This is an awesome screenshot&quot;]" data-ga-click-event="screenshot-thumbnail-click">
-              <img class="thumbnail-image" src="/packages/oxygen/versions/1.0.0/gen-res/gen/190x190/static.webp" alt="screenshot" title="View screenshots"/>
+              <img class="thumbnail-image" src="/packages/oxygen/versions/1.0.0/gen-res/gen/190x190/static.webp" alt="screenshot" title="View screenshots" tabindex="0"/>
             </div>
             <img class="collections-icon" src="/static/hash-%%etag%%/img/collections_white_24dp.svg" alt="" width="30" height="30" role="presentation"/>
           </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/changelog.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/changelog.html
@@ -221,12 +221,12 @@
           </div>
           <aside class="detail-info-box">
             <div id="-screenshot-carousel" class="carousel">
-              <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click">
+              <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
                 <div class="mdc-fab__ripple"></div>
                 <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
               </fab>
               <div id="-image-container" class="image-container"></div>
-              <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click">
+              <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
                 <div class="mdc-fab__ripple"></div>
                 <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
               </fab>
@@ -257,7 +257,7 @@
             </a>
             <div class="detail-screenshot-thumbnail">
               <div class="thumbnail-container" data-thumbnail="/packages/oxygen/versions/1.0.0/gen-res/gen/static.webp" data-thumbnail-descriptions-json="[&quot;This is an awesome screenshot&quot;]" data-ga-click-event="screenshot-thumbnail-click">
-                <img class="thumbnail-image" src="/packages/oxygen/versions/1.0.0/gen-res/gen/190x190/static.webp" alt="screenshot" title="View screenshots"/>
+                <img class="thumbnail-image" src="/packages/oxygen/versions/1.0.0/gen-res/gen/190x190/static.webp" alt="screenshot" title="View screenshots" tabindex="0"/>
               </div>
               <img class="collections-icon" src="/static/hash-%%etag%%/img/collections_white_24dp.svg" alt="" width="30" height="30" role="presentation"/>
             </div>
@@ -307,12 +307,12 @@
         </h3>
         <div class="detail-info-box">
           <div id="-screenshot-carousel" class="carousel">
-            <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click">
+            <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
               <div class="mdc-fab__ripple"></div>
               <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
             </fab>
             <div id="-image-container" class="image-container"></div>
-            <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click">
+            <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
               <div class="mdc-fab__ripple"></div>
               <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
             </fab>
@@ -343,7 +343,7 @@
           </a>
           <div class="detail-screenshot-thumbnail">
             <div class="thumbnail-container" data-thumbnail="/packages/oxygen/versions/1.0.0/gen-res/gen/static.webp" data-thumbnail-descriptions-json="[&quot;This is an awesome screenshot&quot;]" data-ga-click-event="screenshot-thumbnail-click">
-              <img class="thumbnail-image" src="/packages/oxygen/versions/1.0.0/gen-res/gen/190x190/static.webp" alt="screenshot" title="View screenshots"/>
+              <img class="thumbnail-image" src="/packages/oxygen/versions/1.0.0/gen-res/gen/190x190/static.webp" alt="screenshot" title="View screenshots" tabindex="0"/>
             </div>
             <img class="collections-icon" src="/static/hash-%%etag%%/img/collections_white_24dp.svg" alt="" width="30" height="30" role="presentation"/>
           </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/example.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/example.html
@@ -216,12 +216,12 @@
           </div>
           <aside class="detail-info-box">
             <div id="-screenshot-carousel" class="carousel">
-              <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click">
+              <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
                 <div class="mdc-fab__ripple"></div>
                 <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
               </fab>
               <div id="-image-container" class="image-container"></div>
-              <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click">
+              <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
                 <div class="mdc-fab__ripple"></div>
                 <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
               </fab>
@@ -252,7 +252,7 @@
             </a>
             <div class="detail-screenshot-thumbnail">
               <div class="thumbnail-container" data-thumbnail="/packages/oxygen/versions/1.0.0/gen-res/gen/static.webp" data-thumbnail-descriptions-json="[&quot;This is an awesome screenshot&quot;]" data-ga-click-event="screenshot-thumbnail-click">
-                <img class="thumbnail-image" src="/packages/oxygen/versions/1.0.0/gen-res/gen/190x190/static.webp" alt="screenshot" title="View screenshots"/>
+                <img class="thumbnail-image" src="/packages/oxygen/versions/1.0.0/gen-res/gen/190x190/static.webp" alt="screenshot" title="View screenshots" tabindex="0"/>
               </div>
               <img class="collections-icon" src="/static/hash-%%etag%%/img/collections_white_24dp.svg" alt="" width="30" height="30" role="presentation"/>
             </div>
@@ -302,12 +302,12 @@
         </h3>
         <div class="detail-info-box">
           <div id="-screenshot-carousel" class="carousel">
-            <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click">
+            <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
               <div class="mdc-fab__ripple"></div>
               <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
             </fab>
             <div id="-image-container" class="image-container"></div>
-            <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click">
+            <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
               <div class="mdc-fab__ripple"></div>
               <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
             </fab>
@@ -338,7 +338,7 @@
           </a>
           <div class="detail-screenshot-thumbnail">
             <div class="thumbnail-container" data-thumbnail="/packages/oxygen/versions/1.0.0/gen-res/gen/static.webp" data-thumbnail-descriptions-json="[&quot;This is an awesome screenshot&quot;]" data-ga-click-event="screenshot-thumbnail-click">
-              <img class="thumbnail-image" src="/packages/oxygen/versions/1.0.0/gen-res/gen/190x190/static.webp" alt="screenshot" title="View screenshots"/>
+              <img class="thumbnail-image" src="/packages/oxygen/versions/1.0.0/gen-res/gen/190x190/static.webp" alt="screenshot" title="View screenshots" tabindex="0"/>
             </div>
             <img class="collections-icon" src="/static/hash-%%etag%%/img/collections_white_24dp.svg" alt="" width="30" height="30" role="presentation"/>
           </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/install.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/install.html
@@ -244,12 +244,12 @@
           </div>
           <aside class="detail-info-box">
             <div id="-screenshot-carousel" class="carousel">
-              <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click">
+              <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
                 <div class="mdc-fab__ripple"></div>
                 <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
               </fab>
               <div id="-image-container" class="image-container"></div>
-              <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click">
+              <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
                 <div class="mdc-fab__ripple"></div>
                 <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
               </fab>
@@ -280,7 +280,7 @@
             </a>
             <div class="detail-screenshot-thumbnail">
               <div class="thumbnail-container" data-thumbnail="/packages/oxygen/versions/1.0.0/gen-res/gen/static.webp" data-thumbnail-descriptions-json="[&quot;This is an awesome screenshot&quot;]" data-ga-click-event="screenshot-thumbnail-click">
-                <img class="thumbnail-image" src="/packages/oxygen/versions/1.0.0/gen-res/gen/190x190/static.webp" alt="screenshot" title="View screenshots"/>
+                <img class="thumbnail-image" src="/packages/oxygen/versions/1.0.0/gen-res/gen/190x190/static.webp" alt="screenshot" title="View screenshots" tabindex="0"/>
               </div>
               <img class="collections-icon" src="/static/hash-%%etag%%/img/collections_white_24dp.svg" alt="" width="30" height="30" role="presentation"/>
             </div>
@@ -330,12 +330,12 @@
         </h3>
         <div class="detail-info-box">
           <div id="-screenshot-carousel" class="carousel">
-            <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click">
+            <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
               <div class="mdc-fab__ripple"></div>
               <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
             </fab>
             <div id="-image-container" class="image-container"></div>
-            <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click">
+            <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
               <div class="mdc-fab__ripple"></div>
               <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
             </fab>
@@ -366,7 +366,7 @@
           </a>
           <div class="detail-screenshot-thumbnail">
             <div class="thumbnail-container" data-thumbnail="/packages/oxygen/versions/1.0.0/gen-res/gen/static.webp" data-thumbnail-descriptions-json="[&quot;This is an awesome screenshot&quot;]" data-ga-click-event="screenshot-thumbnail-click">
-              <img class="thumbnail-image" src="/packages/oxygen/versions/1.0.0/gen-res/gen/190x190/static.webp" alt="screenshot" title="View screenshots"/>
+              <img class="thumbnail-image" src="/packages/oxygen/versions/1.0.0/gen-res/gen/190x190/static.webp" alt="screenshot" title="View screenshots" tabindex="0"/>
             </div>
             <img class="collections-icon" src="/static/hash-%%etag%%/img/collections_white_24dp.svg" alt="" width="30" height="30" role="presentation"/>
           </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/license.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/license.html
@@ -217,12 +217,12 @@
           </div>
           <aside class="detail-info-box">
             <div id="-screenshot-carousel" class="carousel">
-              <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click">
+              <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
                 <div class="mdc-fab__ripple"></div>
                 <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
               </fab>
               <div id="-image-container" class="image-container"></div>
-              <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click">
+              <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
                 <div class="mdc-fab__ripple"></div>
                 <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
               </fab>
@@ -253,7 +253,7 @@
             </a>
             <div class="detail-screenshot-thumbnail">
               <div class="thumbnail-container" data-thumbnail="/packages/oxygen/versions/1.0.0/gen-res/gen/static.webp" data-thumbnail-descriptions-json="[&quot;This is an awesome screenshot&quot;]" data-ga-click-event="screenshot-thumbnail-click">
-                <img class="thumbnail-image" src="/packages/oxygen/versions/1.0.0/gen-res/gen/190x190/static.webp" alt="screenshot" title="View screenshots"/>
+                <img class="thumbnail-image" src="/packages/oxygen/versions/1.0.0/gen-res/gen/190x190/static.webp" alt="screenshot" title="View screenshots" tabindex="0"/>
               </div>
               <img class="collections-icon" src="/static/hash-%%etag%%/img/collections_white_24dp.svg" alt="" width="30" height="30" role="presentation"/>
             </div>
@@ -303,12 +303,12 @@
         </h3>
         <div class="detail-info-box">
           <div id="-screenshot-carousel" class="carousel">
-            <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click">
+            <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
               <div class="mdc-fab__ripple"></div>
               <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
             </fab>
             <div id="-image-container" class="image-container"></div>
-            <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click">
+            <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
               <div class="mdc-fab__ripple"></div>
               <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
             </fab>
@@ -339,7 +339,7 @@
           </a>
           <div class="detail-screenshot-thumbnail">
             <div class="thumbnail-container" data-thumbnail="/packages/oxygen/versions/1.0.0/gen-res/gen/static.webp" data-thumbnail-descriptions-json="[&quot;This is an awesome screenshot&quot;]" data-ga-click-event="screenshot-thumbnail-click">
-              <img class="thumbnail-image" src="/packages/oxygen/versions/1.0.0/gen-res/gen/190x190/static.webp" alt="screenshot" title="View screenshots"/>
+              <img class="thumbnail-image" src="/packages/oxygen/versions/1.0.0/gen-res/gen/190x190/static.webp" alt="screenshot" title="View screenshots" tabindex="0"/>
             </div>
             <img class="collections-icon" src="/static/hash-%%etag%%/img/collections_white_24dp.svg" alt="" width="30" height="30" role="presentation"/>
           </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/score.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/score.html
@@ -524,12 +524,12 @@
           </div>
           <aside class="detail-info-box">
             <div id="-screenshot-carousel" class="carousel">
-              <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click">
+              <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
                 <div class="mdc-fab__ripple"></div>
                 <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
               </fab>
               <div id="-image-container" class="image-container"></div>
-              <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click">
+              <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
                 <div class="mdc-fab__ripple"></div>
                 <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
               </fab>
@@ -560,7 +560,7 @@
             </a>
             <div class="detail-screenshot-thumbnail">
               <div class="thumbnail-container" data-thumbnail="/packages/oxygen/versions/1.0.0/gen-res/gen/static.webp" data-thumbnail-descriptions-json="[&quot;This is an awesome screenshot&quot;]" data-ga-click-event="screenshot-thumbnail-click">
-                <img class="thumbnail-image" src="/packages/oxygen/versions/1.0.0/gen-res/gen/190x190/static.webp" alt="screenshot" title="View screenshots"/>
+                <img class="thumbnail-image" src="/packages/oxygen/versions/1.0.0/gen-res/gen/190x190/static.webp" alt="screenshot" title="View screenshots" tabindex="0"/>
               </div>
               <img class="collections-icon" src="/static/hash-%%etag%%/img/collections_white_24dp.svg" alt="" width="30" height="30" role="presentation"/>
             </div>
@@ -610,12 +610,12 @@
         </h3>
         <div class="detail-info-box">
           <div id="-screenshot-carousel" class="carousel">
-            <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click">
+            <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
               <div class="mdc-fab__ripple"></div>
               <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
             </fab>
             <div id="-image-container" class="image-container"></div>
-            <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click">
+            <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
               <div class="mdc-fab__ripple"></div>
               <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
             </fab>
@@ -646,7 +646,7 @@
           </a>
           <div class="detail-screenshot-thumbnail">
             <div class="thumbnail-container" data-thumbnail="/packages/oxygen/versions/1.0.0/gen-res/gen/static.webp" data-thumbnail-descriptions-json="[&quot;This is an awesome screenshot&quot;]" data-ga-click-event="screenshot-thumbnail-click">
-              <img class="thumbnail-image" src="/packages/oxygen/versions/1.0.0/gen-res/gen/190x190/static.webp" alt="screenshot" title="View screenshots"/>
+              <img class="thumbnail-image" src="/packages/oxygen/versions/1.0.0/gen-res/gen/190x190/static.webp" alt="screenshot" title="View screenshots" tabindex="0"/>
             </div>
             <img class="collections-icon" src="/static/hash-%%etag%%/img/collections_white_24dp.svg" alt="" width="30" height="30" role="presentation"/>
           </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/2.0.0.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/2.0.0.html
@@ -211,12 +211,12 @@
           </div>
           <aside class="detail-info-box">
             <div id="-screenshot-carousel" class="carousel">
-              <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click">
+              <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
                 <div class="mdc-fab__ripple"></div>
                 <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
               </fab>
               <div id="-image-container" class="image-container"></div>
-              <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click">
+              <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
                 <div class="mdc-fab__ripple"></div>
                 <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
               </fab>
@@ -247,7 +247,7 @@
             </a>
             <div class="detail-screenshot-thumbnail">
               <div class="thumbnail-container" data-thumbnail="/packages/oxygen/versions/2.0.0/gen-res/gen/static.webp" data-thumbnail-descriptions-json="[&quot;This is an awesome screenshot&quot;]" data-ga-click-event="screenshot-thumbnail-click">
-                <img class="thumbnail-image" src="/packages/oxygen/versions/2.0.0/gen-res/gen/190x190/static.webp" alt="screenshot" title="View screenshots"/>
+                <img class="thumbnail-image" src="/packages/oxygen/versions/2.0.0/gen-res/gen/190x190/static.webp" alt="screenshot" title="View screenshots" tabindex="0"/>
               </div>
               <img class="collections-icon" src="/static/hash-%%etag%%/img/collections_white_24dp.svg" alt="" width="30" height="30" role="presentation"/>
             </div>
@@ -297,12 +297,12 @@
         </h3>
         <div class="detail-info-box">
           <div id="-screenshot-carousel" class="carousel">
-            <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click">
+            <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
               <div class="mdc-fab__ripple"></div>
               <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
             </fab>
             <div id="-image-container" class="image-container"></div>
-            <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click">
+            <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
               <div class="mdc-fab__ripple"></div>
               <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
             </fab>
@@ -333,7 +333,7 @@
           </a>
           <div class="detail-screenshot-thumbnail">
             <div class="thumbnail-container" data-thumbnail="/packages/oxygen/versions/2.0.0/gen-res/gen/static.webp" data-thumbnail-descriptions-json="[&quot;This is an awesome screenshot&quot;]" data-ga-click-event="screenshot-thumbnail-click">
-              <img class="thumbnail-image" src="/packages/oxygen/versions/2.0.0/gen-res/gen/190x190/static.webp" alt="screenshot" title="View screenshots"/>
+              <img class="thumbnail-image" src="/packages/oxygen/versions/2.0.0/gen-res/gen/190x190/static.webp" alt="screenshot" title="View screenshots" tabindex="0"/>
             </div>
             <img class="collections-icon" src="/static/hash-%%etag%%/img/collections_white_24dp.svg" alt="" width="30" height="30" role="presentation"/>
           </div>

--- a/pkg/web_app/lib/src/screenshot_carousel.dart
+++ b/pkg/web_app/lib/src/screenshot_carousel.dart
@@ -5,6 +5,8 @@
 import 'dart:convert';
 import 'dart:html';
 
+import 'package:web_app/src/_dom_helper.dart';
+
 void setupScreenshotCarousel() {
   _setEventForScreenshot();
 }
@@ -30,6 +32,7 @@ void _setEventForScreenshot() {
   }
 
   Element? focusedTriggerSourceElement;
+  Function? restoreFocusabilityFn;
   List<String> images = [];
   List<String> descriptions = [];
 
@@ -69,6 +72,12 @@ void _setEventForScreenshot() {
   int screenshotIndex = 0;
   for (final thumbnail in thumbnails) {
     void setup() {
+      restoreFocusabilityFn = disableAllFocusability(
+        allowedComponents: [
+          prev,
+          next,
+        ],
+      );
       focusedTriggerSourceElement = thumbnail;
       showElement(carousel);
       document.body!.classes.remove('overflow-auto');
@@ -103,16 +112,41 @@ void _setEventForScreenshot() {
     descriptions.clear();
     focusedTriggerSourceElement?.focus();
     focusedTriggerSourceElement = null;
+    if (restoreFocusabilityFn != null) {
+      restoreFocusabilityFn!();
+    }
+  }
+
+  void gotoPrev() {
+    showImage(--screenshotIndex);
+    prev.focus();
+  }
+
+  void gotoNext() {
+    showImage(++screenshotIndex);
+    next.focus();
   }
 
   prev.onClick.listen((event) {
     event.stopPropagation();
-    showImage(--screenshotIndex);
+    gotoPrev();
+  });
+  prev.onKeyDown.listen((event) {
+    if (event.key == 'Enter') {
+      event.stopPropagation();
+      gotoPrev();
+    }
   });
 
   next.onClick.listen((event) {
     event.stopPropagation();
-    showImage(++screenshotIndex);
+    gotoNext();
+  });
+  next.onKeyDown.listen((event) {
+    if (event.key == 'Enter') {
+      event.stopPropagation();
+      gotoNext();
+    }
   });
 
   imageElement.onClick.listen((event) => event.stopPropagation());
@@ -134,13 +168,13 @@ void _setEventForScreenshot() {
     if (event.key == 'ArrowLeft') {
       if (screenshotIndex > 0) {
         event.stopPropagation();
-        showImage(--screenshotIndex);
+        gotoPrev();
       }
     }
     if (event.key == 'ArrowRight') {
       if (screenshotIndex < images.length - 1) {
         event.stopPropagation();
-        showImage(++screenshotIndex);
+        gotoNext();
       }
     }
   });

--- a/pkg/web_app/lib/src/screenshot_carousel.dart
+++ b/pkg/web_app/lib/src/screenshot_carousel.dart
@@ -29,6 +29,7 @@ void _setEventForScreenshot() {
     imageElement.className = 'carousel-image';
   }
 
+  Element? focusedTriggerSourceElement;
   List<String> images = [];
   List<String> descriptions = [];
 
@@ -40,8 +41,7 @@ void _setEventForScreenshot() {
     element.style.display = 'flex';
   }
 
-  void showImage(int index, UIEvent event) {
-    event.stopPropagation();
+  void showImage(int index) {
     hideElement(description);
     hideElement(imageElement!);
     imageElement.src = images[index];
@@ -60,7 +60,7 @@ void _setEventForScreenshot() {
       showElement(next);
     }
 
-    imageElement.onLoad.listen((event) {
+    imageElement.onLoad.listen((_) {
       showElement(imageElement!);
       showElement(description);
     });
@@ -68,19 +68,30 @@ void _setEventForScreenshot() {
 
   int screenshotIndex = 0;
   for (final thumbnail in thumbnails) {
-    thumbnail.parent!.onClick.listen((event) {
+    void setup() {
+      focusedTriggerSourceElement = thumbnail;
       showElement(carousel);
       document.body!.classes.remove('overflow-auto');
       document.body!.classes.add('overflow-hidden');
       images = thumbnail.dataset['thumbnail']!.split(',');
       final raw = jsonDecode(thumbnail.dataset['thumbnail-descriptions-json']!);
       descriptions = (raw as List).cast<String>();
-      showImage(screenshotIndex, event);
+      showImage(screenshotIndex);
+    }
+
+    thumbnail.parent!.onClick.listen((event) {
+      event.stopPropagation();
+      setup();
+    });
+    thumbnail.onKeyDown.listen((event) {
+      if (event.key == 'Enter') {
+        event.stopPropagation();
+        setup();
+      }
     });
   }
 
-  void closeCarousel(UIEvent event) {
-    event.stopPropagation;
+  void closeCarousel() {
     hideElement(carousel);
     hideElement(next);
     hideElement(prev);
@@ -88,15 +99,28 @@ void _setEventForScreenshot() {
     document.body!.classes.remove('overflow-hidden');
     document.body!.classes.add('overflow-auto');
     screenshotIndex = 0;
+    images.clear();
+    descriptions.clear();
+    focusedTriggerSourceElement?.focus();
+    focusedTriggerSourceElement = null;
   }
 
-  prev.onClick.listen((event) => showImage(--screenshotIndex, event));
+  prev.onClick.listen((event) {
+    event.stopPropagation();
+    showImage(--screenshotIndex);
+  });
 
-  next.onClick.listen((event) => showImage(++screenshotIndex, event));
+  next.onClick.listen((event) {
+    event.stopPropagation();
+    showImage(++screenshotIndex);
+  });
 
   imageElement.onClick.listen((event) => event.stopPropagation());
 
-  carousel.onClick.listen((event) => closeCarousel(event));
+  carousel.onClick.listen((event) {
+    event.stopPropagation();
+    closeCarousel();
+  });
 
   document.onKeyDown.listen((event) {
     if (carousel.style.display == 'none') {
@@ -104,16 +128,19 @@ void _setEventForScreenshot() {
     }
 
     if (event.key == 'Escape') {
-      closeCarousel(event);
+      event.stopPropagation;
+      closeCarousel();
     }
     if (event.key == 'ArrowLeft') {
       if (screenshotIndex > 0) {
-        showImage(--screenshotIndex, event);
+        event.stopPropagation();
+        showImage(--screenshotIndex);
       }
     }
     if (event.key == 'ArrowRight') {
       if (screenshotIndex < images.length - 1) {
-        showImage(++screenshotIndex, event);
+        event.stopPropagation();
+        showImage(++screenshotIndex);
       }
     }
   });


### PR DESCRIPTION
- improves accessibility of the screenshot widget, keeps focus on the thumbnail after the carrousel is closed
- disables background widgets (same algorithm is exposed as for modal window components)
- synchronizes click, arrow navigation and focus+enter navigation by keeping the prev/next button focused
- fixes #7284
- fixes #7308