### PR TITLE
Single-step SDK install in docker container.

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -22,16 +22,12 @@ WORKDIR /home/worker/pub-dev
 RUN mkdir -p /home/worker/config/preview
 
 # Setup Dart SDK into /home/worker/dart/{stable,preview}/
-RUN tool/setup-dart.sh /home/worker/dart 3.2.3
-RUN mv /home/worker/dart/dart-sdk /home/worker/dart/stable
-RUN XDG_CONFIG_HOME=/home/worker/config/preview tool/setup-dart.sh /home/worker/dart 3.3.0-174.2.beta
-RUN mv /home/worker/dart/dart-sdk /home/worker/dart/preview
+RUN tool/setup-dart.sh /home/worker/dart/stable 3.2.3
+RUN XDG_CONFIG_HOME=/home/worker/config/preview tool/setup-dart.sh /home/worker/dart/preview 3.3.0-174.2.beta
 
 # Setup Flutter SDK into /home/worker/flutter/{stable,preview}/
-RUN tool/setup-flutter.sh /home/worker/flutter 3.16.4
-RUN mv /home/worker/flutter/flutter /home/worker/flutter/stable
-RUN XDG_CONFIG_HOME=/home/worker/config/preview tool/setup-flutter.sh /home/worker/flutter 3.18.0-0.2.pre
-RUN mv /home/worker/flutter/flutter /home/worker/flutter/preview
+RUN tool/setup-flutter.sh /home/worker/flutter/stable 3.16.4
+RUN XDG_CONFIG_HOME=/home/worker/config/preview tool/setup-flutter.sh /home/worker/flutter/preview 3.18.0-0.2.pre
 
 # Setup webp
 RUN tool/setup-webp.sh /home/worker/bin

--- a/app/test/shared/versions_test.dart
+++ b/app/test/shared/versions_test.dart
@@ -85,7 +85,11 @@ void main() {
     expect(
         dockerfileContent,
         contains(
-            'RUN tool/setup-dart.sh /home/worker/dart $toolStableDartSdkVersion'));
+            'RUN tool/setup-dart.sh /home/worker/dart/stable $toolStableDartSdkVersion'));
+    expect(
+        dockerfileContent,
+        contains(
+            'tool/setup-dart.sh /home/worker/dart/preview $toolPreviewDartSdkVersion'));
   });
 
   test('Flutter SDK versions should match Dockerfile.worker', () async {
@@ -93,7 +97,11 @@ void main() {
     expect(
         dockerfileContent,
         contains(
-            'RUN tool/setup-flutter.sh /home/worker/flutter $toolStableFlutterSdkVersion'));
+            'RUN tool/setup-flutter.sh /home/worker/flutter/stable $toolStableFlutterSdkVersion'));
+    expect(
+        dockerfileContent,
+        contains(
+            'tool/setup-flutter.sh /home/worker/flutter/preview $toolPreviewFlutterSdkVersion'));
   });
 
   test('analyzer version should match resolved pana version', () async {

--- a/tool/setup-dart.sh
+++ b/tool/setup-dart.sh
@@ -26,9 +26,27 @@ then
   CHANNEL="be"
 fi
 
-mkdir -p "$1"
-cd "$1"
+# Create a temporary directory to extract the archive to.
+WORK_DIR=`mktemp -d`
+if [[ ! "$WORK_DIR" || ! -d "$WORK_DIR" ]]; then
+  echo "Could not create temporary directory."
+  exit 1
+fi
+
+# Download and extract Dart SDK
+cd "$WORK_DIR"
 curl -sS "https://storage.googleapis.com/dart-archive/channels/$CHANNEL/raw/$2/sdk/dartsdk-linux-x64-release.zip" >dartsdk.zip
 unzip -q dartsdk.zip
 rm -f dartsdk.zip
-./dart-sdk/bin/dart --disable-analytics
+
+# Move from temp to destination.
+DEST_PARENT=`dirname "$1"`
+mkdir -p "$DEST_PARENT"
+mv "$WORK_DIR/dart-sdk" "$1"
+
+# Initialize and set first run settings
+cd "$1"
+./bin/dart --disable-analytics
+
+# Cleanup
+rm -rf "$WORK_DIR"

--- a/tool/setup-dart.sh
+++ b/tool/setup-dart.sh
@@ -8,22 +8,38 @@ then
   exit 1
 fi
 
+# Expected version argument formats:
+# - stable/raw/hash/<hash>
+# - 3.2.5 (stable/release/<version>)
+# - 3.2.5-beta (beta/release/<version>)
+# - 3.2.5-dev (dev/release/<version>)
 if [[ -z "$2" ]];
 then
   echo "Version argument is missing."
   exit 1
 fi
 
-CHANNEL="stable"
-if [[ "$2" == *beta ]]
+# Infer the download URL
+if [[ "$2" == */raw/hash/* ]]
 then
-  CHANNEL="beta"
-elif [[ "$2" == *dev ]]
+  DOWNLOAD_URL="https://storage.googleapis.com/dart-archive/channels/$2/sdk/dartsdk-linux-x64-release.zip"
+elif [[ "$2" == *.* ]]
 then
-  CHANNEL="dev"
-elif [[ "$2" == "latest" ]]
+  CHANNEL="stable"
+  if [[ "$2" == *beta ]]
+  then
+    CHANNEL="beta"
+  elif [[ "$2" == *dev ]]
+  then
+    CHANNEL="dev"
+  fi
+  DOWNLOAD_URL="https://storage.googleapis.com/dart-archive/channels/$CHANNEL/release/$2/sdk/dartsdk-linux-x64-release.zip"
+fi
+
+if [[ -z "$DOWNLOAD_URL" ]];
 then
-  CHANNEL="be"
+  echo "Unable to infer download URL."
+  exit 1
 fi
 
 # Create a temporary directory to extract the archive to.
@@ -35,7 +51,7 @@ fi
 
 # Download and extract Dart SDK
 cd "$WORK_DIR"
-curl -sS "https://storage.googleapis.com/dart-archive/channels/$CHANNEL/raw/$2/sdk/dartsdk-linux-x64-release.zip" >dartsdk.zip
+curl -sS "$DOWNLOAD_URL" >dartsdk.zip
 unzip -q dartsdk.zip
 rm -f dartsdk.zip
 

--- a/tool/setup-flutter.sh
+++ b/tool/setup-flutter.sh
@@ -14,10 +14,10 @@ then
   exit 1
 fi
 
-mkdir -p "$1"
-cd "$1"
-git clone -b "$2" --single-branch https://github.com/flutter/flutter.git flutter
+# Download and extract Flutter SDK into the target directory.
+git clone -b "$2" --single-branch https://github.com/flutter/flutter.git "$1"
 
 # Downloads the Dart SDK and disables analytics tracking – which we always want.
 # This will add 400 MB.
-./flutter/bin/flutter --no-version-check config --no-analytics
+cd "$1"
+./bin/flutter --no-version-check config --no-analytics


### PR DESCRIPTION
- I think this is much better than the two-step setup approach. It also enables parallelization as we no longer use the shared parent directory for temporary files.
- Also updated `setup-dart.sh` with an option to download SDKs based on hashes (and use the release directory for versioned ones).