### PR TITLE
Foldable widgets: added keyboard navigation, removed (broken) animation.

### DIFF
--- a/app/test/frontend/static_files_test.dart
+++ b/app/test/frontend/static_files_test.dart
@@ -200,7 +200,7 @@ void main() {
     test('script.dart.js and parts size check', () {
       final file = cache.getFile('/static/js/script.dart.js');
       expect(file, isNotNull);
-      expect((file!.bytes.length / 1024).round(), closeTo(313, 1));
+      expect((file!.bytes.length / 1024).round(), closeTo(317, 1));
 
       final parts = cache.paths
           .where((path) =>

--- a/pkg/web_css/lib/src/_base.scss
+++ b/pkg/web_css/lib/src/_base.scss
@@ -380,8 +380,6 @@ pre {
 .foldable {
   .foldable-content {
     display: none;
-    overflow: hidden;
-    transition: max-height 0.6s ease;
   }
 
   &.-active {


### PR DESCRIPTION
- Fixes #7286
- I think the animation was not working for a while now, not sure when it stopped working. Removing it, as it did trigger an unnecessary reflow, and it slightly messes with keyboard navigation. (I've tried `visibility: hidden` and `transform: scaleY` alternatives, but they were not working as expected or were breaking accessibility again).
- Added keyboard focus to the folding icon. It is somewhat larger on the score page, but really small on the search sidebar. It should be a follow-up to review the sizes and the outline area for them.