### PR TITLE
Slightly simpler scrollTo logic for foldable components.

### DIFF
--- a/pkg/web_app/lib/src/foldable.dart
+++ b/pkg/web_app/lib/src/foldable.dart
@@ -29,7 +29,6 @@ void _setEventForFoldable() {
         return;
       }
 
-      num scrollDiff = 0;
       if (scrollContainer != null) {
         // Wait one animation frame before measurements.
         await window.animationFrame;
@@ -50,18 +49,12 @@ void _setEventForFoldable() {
         final screenLimit = scrollContainerHeight - buttonHeight;
 
         /// Scroll the smaller amount of the two.
-        scrollDiff = max(0, min(screenLimit, outsideViewDiff));
+        final scrollDiff = max(0, min(screenLimit, outsideViewDiff));
 
-        /// Do not scroll if the difference is small, otherwise scroll in small
-        /// steps synchronized to the animation frames.
+        /// Do not scroll if the difference is small.
         if (scrollDiff > 8) {
           final originalScrollTop = scrollContainer.scrollTop;
-          final maxSteps = 20;
-          for (var i = 1; i <= maxSteps; i++) {
-            if (i > 1) await window.animationFrame;
-            final nextPos = originalScrollTop + (scrollDiff * i / maxSteps);
-            scrollContainer.scrollTo(0, nextPos);
-          }
+          scrollContainer.scrollTo(0, originalScrollTop + scrollDiff);
         }
       }
     }


### PR DESCRIPTION
- Follow-up to #7336.
- Closes #7342.
- I was not satisfied with `scrollIntoView`'s behavior, but the multi-step scrolling can be simpler (or we may remove it entirely if we wanted to).