### PR TITLE
Visible focus for like buttons during keyboard navigation.

### DIFF
--- a/pkg/web_css/lib/src/_detail_page.scss
+++ b/pkg/web_css/lib/src/_detail_page.scss
@@ -179,11 +179,17 @@ $detail-tabs-tablet-width: calc(100% - 240px);
     text-transform: uppercase;
     white-space: nowrap;
     display: flex;
-    margin-top: -2px;
+    margin-top: -4px;
+    border: 1px solid transparent;
+    padding: 2px;
 
     .likes-count {
       display: inline-block;
       padding-top: 4px;
+    }
+
+    &:focus-within {
+      border-color: #000;
     }
   }
 }


### PR DESCRIPTION
Fixes #7294.

<img width="611" alt="image" src="https://github.com/dart-lang/pub-dev/assets/4778111/d609eb55-29d1-410e-8f15-996cb51c1ca4">
