### PR TITLE
Store package-created audit log records + apply rate limit.

### DIFF
--- a/app/config/dartlang-pub.yaml
+++ b/app/config/dartlang-pub.yaml
@@ -68,6 +68,10 @@ tools:
   previewDartSdkPath: '/tool/preview/dart-sdk'
   previewFlutterSdkPath: '/tool/preview/flutter'
 rateLimits:
+  - operation: package-created
+    scope: user
+    burst: 4
+    daily: 12
   - operation: package-published
     scope: package
     burst: 3

--- a/app/lib/audit/models.dart
+++ b/app/lib/audit/models.dart
@@ -218,31 +218,39 @@ class AuditLogRecord extends db.ExpandoModel<String> {
       ..publishers = [if (publisherId != null) publisherId];
   }
 
-  static List<AuditLogRecord> packagePublishedRecords({
+  static Map<String, dynamic> _dataForPublishing({
+    required AuthenticatedAgent uploader,
+  }) {
+    if (uploader is AuthenticatedGithubAction) {
+      final runId = uploader.payload.runId;
+      final sha = uploader.payload.sha;
+      return <String, dynamic>{
+        'repository': uploader.payload.repository,
+        if (runId != null) 'run_id': runId,
+        if (sha != null) 'sha': sha,
+      };
+    } else {
+      return const {};
+    }
+  }
+
+  static String _summaryForPublishing({
     required AuthenticatedAgent uploader,
     required String package,
-    required String version,
-    required DateTime created,
-    required bool isNew,
+    String? version,
     String? publisherId,
   }) {
-    final summaryParts = <String>[
-      'Package `$package` version `$version`',
+    final prefix = <String>[
+      'Package `$package`',
+      if (version != null) ' version `$version`',
       if (publisherId != null) ' owned by publisher `$publisherId`',
     ];
-    var fields = const <String, dynamic>{};
-    late String summary;
     if (uploader is AuthenticatedGithubAction) {
       final repository = uploader.payload.repository;
       final runId = uploader.payload.runId;
       final sha = uploader.payload.sha;
-      fields = <String, dynamic>{
-        'repository': repository,
-        if (runId != null) 'run_id': runId,
-        if (sha != null) 'sha': sha,
-      };
-      summary = [
-        ...summaryParts,
+      return [
+        ...prefix,
         ' was published from GitHub Actions',
         if (runId != null)
           ' (`run_id`: [`$runId`](https://github.com/$repository/actions/runs/$runId))',
@@ -251,52 +259,75 @@ class AuditLogRecord extends db.ExpandoModel<String> {
         ' to the `$repository` repository.',
       ].join();
     } else if (uploader is AuthenticatedGcpServiceAccount) {
-      summary = [
-        ...summaryParts,
+      return [
+        ...prefix,
         ' was published by Google Cloud service account: `${uploader.payload.email}`.'
       ].join();
     } else {
-      summary = [
-        ...summaryParts,
+      return [
+        ...prefix,
         ' was published by `${uploader.displayId}`.',
       ].join();
     }
+  }
 
-    AuditLogRecord createRecord({
-      required String kind,
-      required DateTime expires,
-    }) {
-      return AuditLogRecord()
-        ..id = createUuid()
-        ..created = created
-        ..expires = expires
-        ..kind = kind
-        ..agent = uploader.agentId
-        ..summary = summary
-        ..data = {
-          'package': package,
-          'version': version,
-          if (uploader.email != null) 'email': uploader.email,
-          if (publisherId != null) 'publisherId': publisherId,
-          ...fields,
-        }
-        ..users = [if (uploader is AuthenticatedUser) uploader.user.userId]
-        ..packages = [package]
-        ..packageVersions = ['$package/$version']
-        ..publishers = [if (publisherId != null) publisherId];
-    }
+  factory AuditLogRecord.packageCreated({
+    required AuthenticatedAgent uploader,
+    required String package,
+    required DateTime created,
+    String? publisherId,
+  }) {
+    return AuditLogRecord._init()
+      ..created = created
+      ..kind = AuditLogRecordKind.packageCreated
+      ..agent = uploader.agentId
+      ..summary = _summaryForPublishing(
+        uploader: uploader,
+        package: package,
+        publisherId: publisherId,
+      )
+      ..data = {
+        'package': package,
+        if (uploader.email != null) 'email': uploader.email,
+        if (publisherId != null) 'publisherId': publisherId,
+        ..._dataForPublishing(uploader: uploader),
+      }
+      ..users = [if (uploader is AuthenticatedUser) uploader.user.userId]
+      ..packages = [package]
+      ..packageVersions = []
+      ..publishers = [if (publisherId != null) publisherId];
+  }
 
-    return [
-      if (isNew)
-        createRecord(
-          kind: AuditLogRecordKind.packageCreated,
-          expires: clock.now().toUtc().add(_defaultExpires),
-        ),
-      createRecord(
-        kind: AuditLogRecordKind.packagePublished,
-        expires: auditLogRecordExpiresInFarFuture,
-      ),
-    ];
+  factory AuditLogRecord.packagePublished({
+    required AuthenticatedAgent uploader,
+    required String package,
+    required String version,
+    required DateTime created,
+    String? publisherId,
+  }) {
+    return AuditLogRecord()
+      ..id = createUuid()
+      ..created = created
+      ..expires = auditLogRecordExpiresInFarFuture
+      ..kind = AuditLogRecordKind.packagePublished
+      ..agent = uploader.agentId
+      ..summary = _summaryForPublishing(
+        uploader: uploader,
+        package: package,
+        version: version,
+        publisherId: publisherId,
+      )
+      ..data = {
+        'package': package,
+        'version': version,
+        if (uploader.email != null) 'email': uploader.email,
+        if (publisherId != null) 'publisherId': publisherId,
+        ..._dataForPublishing(uploader: uploader),
+      }
+      ..users = [if (uploader is AuthenticatedUser) uploader.user.userId]
+      ..packages = [package]
+      ..packageVersions = ['$package/$version']
+      ..publishers = [if (publisherId != null) publisherId];
   }
 
   factory AuditLogRecord.packageTransferred({

--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -1130,13 +1130,19 @@ class PackageBackend {
         ...entities.assets,
         if (activeConfiguration.isPublishedEmailNotificationEnabled)
           outgoingEmail,
-        ...AuditLogRecord.packagePublishedRecords(
+        if (isNew)
+          AuditLogRecord.packageCreated(
+            uploader: agent,
+            package: newVersion.package,
+            created: newVersion.created!,
+            publisherId: package!.publisherId,
+          ),
+        AuditLogRecord.packagePublished(
           uploader: agent,
           package: newVersion.package,
           version: newVersion.version!,
           created: newVersion.created!,
           publisherId: package!.publisherId,
-          isNew: isNew,
         ),
       ];
 

--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -1008,6 +1008,7 @@ class PackageBackend {
     final newVersion = entities.packageVersion;
     final currentDartSdk = await getDartSdkVersion();
     final existingPackage = await lookupPackage(newVersion.package);
+    final isNew = existingPackage == null;
 
     // check authorizations before the transaction
     await _requireUploadAuthorization(
@@ -1036,6 +1037,7 @@ class PackageBackend {
     await verifyPackageUploadRateLimit(
       agent: agent,
       package: newVersion.package,
+      isNew: isNew,
     );
 
     final email = createPackageUploadedEmail(
@@ -1128,12 +1130,13 @@ class PackageBackend {
         ...entities.assets,
         if (activeConfiguration.isPublishedEmailNotificationEnabled)
           outgoingEmail,
-        AuditLogRecord.packagePublished(
+        ...AuditLogRecord.packagePublishedRecords(
           uploader: agent,
           package: newVersion.package,
           version: newVersion.version!,
           created: newVersion.created!,
           publisherId: package!.publisherId,
+          isNew: isNew,
         ),
       ];
 

--- a/app/test/audit/backend_test.dart
+++ b/app/test/audit/backend_test.dart
@@ -39,7 +39,7 @@ void main() {
 
   group('message test', () {
     test('user uploads a package', () {
-      final r = AuditLogRecord.packagePublished(
+      final r = AuditLogRecord.packagePublishedRecords(
         created: clock.now(),
         package: 'pkg',
         version: '1.0.0',
@@ -49,7 +49,8 @@ void main() {
             ..email = 'user@pub.dev',
           audience: 'fake-client-audience',
         ),
-      );
+        isNew: true,
+      ).last;
       expect(r.summary,
           'Package `pkg` version `1.0.0` was published by `user@pub.dev`.');
       expect(r.data, {
@@ -81,7 +82,7 @@ void main() {
         },
         signature: [],
       );
-      final r = AuditLogRecord.packagePublished(
+      final r = AuditLogRecord.packagePublishedRecords(
         created: clock.now(),
         package: 'pkg',
         version: '1.2.0',
@@ -89,7 +90,8 @@ void main() {
           idToken: token,
           payload: GitHubJwtPayload(token.payload),
         ),
-      );
+        isNew: false,
+      ).last;
       expect(
         r.summary,
         'Package `pkg` version `1.2.0` was published from GitHub Actions '
@@ -119,7 +121,7 @@ void main() {
         },
         signature: [],
       );
-      final r = AuditLogRecord.packagePublished(
+      final r = AuditLogRecord.packagePublishedRecords(
         created: clock.now(),
         package: 'pkg',
         version: '1.2.0',
@@ -127,7 +129,8 @@ void main() {
           idToken: token,
           payload: GcpServiceAccountJwtPayload(token.payload),
         ),
-      );
+        isNew: false,
+      ).last;
       expect(
           r.summary,
           'Package `pkg` version `1.2.0` was published by '

--- a/app/test/audit/backend_test.dart
+++ b/app/test/audit/backend_test.dart
@@ -39,7 +39,7 @@ void main() {
 
   group('message test', () {
     test('user uploads a package', () {
-      final r = AuditLogRecord.packagePublishedRecords(
+      final r = AuditLogRecord.packagePublished(
         created: clock.now(),
         package: 'pkg',
         version: '1.0.0',
@@ -49,8 +49,7 @@ void main() {
             ..email = 'user@pub.dev',
           audience: 'fake-client-audience',
         ),
-        isNew: true,
-      ).last;
+      );
       expect(r.summary,
           'Package `pkg` version `1.0.0` was published by `user@pub.dev`.');
       expect(r.data, {
@@ -82,7 +81,7 @@ void main() {
         },
         signature: [],
       );
-      final r = AuditLogRecord.packagePublishedRecords(
+      final r = AuditLogRecord.packagePublished(
         created: clock.now(),
         package: 'pkg',
         version: '1.2.0',
@@ -90,8 +89,7 @@ void main() {
           idToken: token,
           payload: GitHubJwtPayload(token.payload),
         ),
-        isNew: false,
-      ).last;
+      );
       expect(
         r.summary,
         'Package `pkg` version `1.2.0` was published from GitHub Actions '
@@ -121,7 +119,7 @@ void main() {
         },
         signature: [],
       );
-      final r = AuditLogRecord.packagePublishedRecords(
+      final r = AuditLogRecord.packagePublished(
         created: clock.now(),
         package: 'pkg',
         version: '1.2.0',
@@ -129,8 +127,7 @@ void main() {
           idToken: token,
           payload: GcpServiceAccountJwtPayload(token.payload),
         ),
-        isNew: false,
-      ).last;
+      );
       expect(
           r.summary,
           'Package `pkg` version `1.2.0` was published by '

--- a/app/test/frontend/golden/my_activity_log_page.html
+++ b/app/test/frontend/golden/my_activity_log_page.html
@@ -245,8 +245,6 @@
                             <p>
                               Package
                               <code>oxygen</code>
-                              version
-                              <code>1.0.0</code>
                               was published by
                               <code>admin@pub.dev</code>
                               .
@@ -299,8 +297,6 @@
                             <p>
                               Package
                               <code>neon</code>
-                              version
-                              <code>1.0.0</code>
                               was published by
                               <code>admin@pub.dev</code>
                               .
@@ -335,8 +331,6 @@
                             <p>
                               Package
                               <code>flutter_titanium</code>
-                              version
-                              <code>1.9.0</code>
                               was published by
                               <code>admin@pub.dev</code>
                               .

--- a/app/test/frontend/golden/my_activity_log_page.html
+++ b/app/test/frontend/golden/my_activity_log_page.html
@@ -262,6 +262,24 @@
                           <div class="markdown-body">
                             <p>
                               Package
+                              <code>oxygen</code>
+                              version
+                              <code>1.0.0</code>
+                              was published by
+                              <code>admin@pub.dev</code>
+                              .
+                            </p>
+                          </div>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td class="date">
+                          <a class="-x-ago" href="" title="%%user-created-date%%" aria-label="%%x-ago%%" aria-role="button" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
+                        </td>
+                        <td class="summary">
+                          <div class="markdown-body">
+                            <p>
+                              Package
                               <code>flutter_titanium</code>
                               version
                               <code>1.10.0</code>
@@ -283,6 +301,42 @@
                               <code>neon</code>
                               version
                               <code>1.0.0</code>
+                              was published by
+                              <code>admin@pub.dev</code>
+                              .
+                            </p>
+                          </div>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td class="date">
+                          <a class="-x-ago" href="" title="%%user-created-date%%" aria-label="%%x-ago%%" aria-role="button" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
+                        </td>
+                        <td class="summary">
+                          <div class="markdown-body">
+                            <p>
+                              Package
+                              <code>neon</code>
+                              version
+                              <code>1.0.0</code>
+                              was published by
+                              <code>admin@pub.dev</code>
+                              .
+                            </p>
+                          </div>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td class="date">
+                          <a class="-x-ago" href="" title="%%user-created-date%%" aria-label="%%x-ago%%" aria-role="button" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
+                        </td>
+                        <td class="summary">
+                          <div class="markdown-body">
+                            <p>
+                              Package
+                              <code>flutter_titanium</code>
+                              version
+                              <code>1.9.0</code>
                               was published by
                               <code>admin@pub.dev</code>
                               .

--- a/app/test/frontend/golden/pkg_activity_log_page.html
+++ b/app/test/frontend/golden/pkg_activity_log_page.html
@@ -264,10 +264,6 @@
                         </td>
                       </tr>
                       <tr>
-                        <td class="date"></td>
-                        <td class="summary">Only package publication events are retained past 2 months.</td>
-                      </tr>
-                      <tr>
                         <td class="date">
                           <a class="-x-ago" href="" title="%%published-date%%" aria-label="%%x-ago%%" aria-role="button" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                         </td>
@@ -322,8 +318,30 @@
                         </td>
                       </tr>
                       <tr>
+                        <td class="date"></td>
+                        <td class="summary">Only package publication events are retained past 2 months.</td>
+                      </tr>
+                      <tr>
                         <td class="date">
-                          <a class="-x-ago" href="" title="%%activity-4-date%%" aria-label="%%x-ago%%" aria-role="button" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
+                          <a class="-x-ago" href="" title="%%published-date%%" aria-label="%%x-ago%%" aria-role="button" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
+                        </td>
+                        <td class="summary">
+                          <div class="markdown-body">
+                            <p>
+                              Package
+                              <code>oxygen</code>
+                              version
+                              <code>1.0.0</code>
+                              was published by
+                              <code>admin@pub.dev</code>
+                              .
+                            </p>
+                          </div>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td class="date">
+                          <a class="-x-ago" href="" title="%%activity-5-date%%" aria-label="%%x-ago%%" aria-role="button" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                         </td>
                         <td class="summary">
                           <div class="markdown-body">

--- a/app/test/frontend/golden/pkg_activity_log_page.html
+++ b/app/test/frontend/golden/pkg_activity_log_page.html
@@ -308,8 +308,6 @@
                             <p>
                               Package
                               <code>oxygen</code>
-                              version
-                              <code>1.0.0</code>
                               was published by
                               <code>admin@pub.dev</code>
                               .

--- a/app/test/package/upload_test.dart
+++ b/app/test/package/upload_test.dart
@@ -131,7 +131,8 @@ void main() {
 
         final audits = await auditBackend.listRecordsForPackageVersion(
             'new_package', '1.2.3');
-        final publishedAudit = audits.records.first;
+        final publishedAudit = audits.records
+            .firstWhere((e) => e.kind == AuditLogRecordKind.packagePublished);
         expect(publishedAudit.kind, AuditLogRecordKind.packagePublished);
         expect(publishedAudit.created, isNotNull);
         expect(publishedAudit.expires!.year, greaterThan(9998));


### PR DESCRIPTION
- The new record is the same as `package-published`, except for the identifier (`kind`) and expiration (expires as default in two months).
