### PR TITLE
Remove docs report joining from fake analyzer.

### DIFF
--- a/app/lib/fake/backend/fake_pana_runner.dart
+++ b/app/lib/fake/backend/fake_pana_runner.dart
@@ -17,12 +17,14 @@ Future<Summary> fakePanaSummary({
   required String package,
   required String version,
   required PackageStatus packageStatus,
+  required double documentedRatio,
 }) async {
   final pv = await packageBackend.lookupPackageVersion(package, version);
   final pubspec = pv!.pubspec!;
   final hasher = createHasher([package, version].join('/'));
   final layoutPoints = hasher('points/layout', max: 30);
-  final examplePoints = hasher('points/example', max: 30);
+  final examplePoints =
+      hasher('points/example', max: 30) + (documentedRatio >= 0.2 ? 10 : 0);
   final hasSdkDart = hasher('sdk:dart', max: 10) > 0;
   final hasSdkFlutter =
       hasher('sdk:flutter', max: packageStatus.usesFlutter ? 20 : 10) > 0;
@@ -128,12 +130,12 @@ Future<Summary> fakePanaSummary({
           id: ReportSectionId.documentation,
           title: 'Fake documentation',
           grantedPoints: examplePoints,
-          maxPoints: 30,
+          maxPoints: 40,
           summary: renderSimpleSectionSummary(
             title: 'Example',
             description: 'Example score randomly set to $examplePoints...',
             grantedPoints: examplePoints,
-            maxPoints: 30,
+            maxPoints: 40,
           ),
           status:
               examplePoints > 20 ? ReportStatus.passed : ReportStatus.partial,

--- a/app/lib/fake/backend/fake_pub_worker.dart
+++ b/app/lib/fake/backend/fake_pub_worker.dart
@@ -92,25 +92,18 @@ Future<void> _processPayload(Payload payload) async {
           documented: documented,
           total: 20,
         );
-        final docSection = documentationCoverageSection(
-          documented: documented,
-          total: 20,
-        );
 
         late Summary summary;
-        if (packageStatus.isObsolete ||
-            packageStatus.isLegacy ||
-            packageStatus.isDiscontinued) {
+        if (packageStatus.isObsolete || packageStatus.isLegacy) {
           summary = _emptySummary(payload.package, v.version);
           dartdocFiles.clear();
         } else {
-          final s = await fakePanaSummary(
+          summary = await fakePanaSummary(
             package: payload.package,
             version: v.version,
             packageStatus: packageStatus,
+            documentedRatio: documented / 20,
           );
-          final updatedReport = s.report?.joinSection(docSection);
-          summary = s.change(report: updatedReport);
         }
 
         final r = await api.taskUploadResult(payload.package, v.version);

--- a/app/test/frontend/golden/pkg_score_page.html
+++ b/app/test/frontend/golden/pkg_score_page.html
@@ -282,17 +282,10 @@
                           <div class="pkg-report-content-summary markdown-body">
                             <h3>
                               <img class="report-summary-icon" src="/static/hash-%%etag%%/img/report-missing-icon-yellow.svg"/>
-                              26/30 points: Example
+                              36/40 points: Example
                             </h3>
                             <ul>
-                              <li>Example score randomly set to 26...</li>
-                            </ul>
-                            <h3>
-                              <img class="report-summary-icon" src="/static/hash-%%etag%%/img/report-ok-icon-green.svg"/>
-                              10/10 points: 20% or more of the public API has dartdoc comments
-                            </h3>
-                            <ul>
-                              <li>17 out of 20 API elements (85.0 %) have documentation comments.</li>
+                              <li>Example score randomly set to 36...</li>
                             </ul>
                           </div>
                         </div>

--- a/app/test/frontend/golden/pkg_show_page_discontinued.html
+++ b/app/test/frontend/golden/pkg_show_page_discontinued.html
@@ -140,6 +140,19 @@
                         </b>
                       </span>
                     </div>
+                    <div class="-pub-tag-badge">
+                      <span class="tag-badge-main">SDK</span>
+                      <a class="tag-badge-sub" href="/packages?q=sdk%3Adart" rel="nofollow" title="Packages compatible with Dart SDK">Dart</a>
+                      <a class="tag-badge-sub" href="/packages?q=sdk%3Aflutter" rel="nofollow" title="Packages compatible with Flutter SDK">Flutter</a>
+                    </div>
+                    <div class="-pub-tag-badge">
+                      <span class="tag-badge-main">Platform</span>
+                      <a class="tag-badge-sub" href="/packages?q=platform%3Aandroid" rel="nofollow" title="Packages compatible with Android platform">Android</a>
+                      <a class="tag-badge-sub" href="/packages?q=platform%3Alinux" rel="nofollow" title="Packages compatible with Linux platform">Linux</a>
+                      <a class="tag-badge-sub" href="/packages?q=platform%3Amacos" rel="nofollow" title="Packages compatible with macOS platform">macOS</a>
+                      <a class="tag-badge-sub" href="/packages?q=platform%3Aweb" rel="nofollow" title="Packages compatible with Web platform">web</a>
+                      <a class="tag-badge-sub" href="/packages?q=platform%3Awindows" rel="nofollow" title="Packages compatible with Windows platform">Windows</a>
+                    </div>
                   </div>
                   <div class="detail-like">
                     <button id="-pub-like-icon-button" class="mdc-icon-button" data-ga-click-event="toggle-like" aria-pressed="false" title="Like this package">
@@ -226,7 +239,7 @@
               </div>
               <div class="packages-score packages-score-health">
                 <div class="packages-score-value -has-value">
-                  <span class="packages-score-value-number">0</span>
+                  <span class="packages-score-value-number">17</span>
                   <span class="packages-score-value-sign"></span>
                 </div>
                 <div class="packages-score-label">pub points</div>
@@ -246,16 +259,19 @@
             <h3 class="title pkg-infobox-metadata">Metadata</h3>
             <p>pkg is awesome</p>
             <p>
-              <a class="link" href="https://pkg.example.dev/" rel="ugc">Homepage</a>
-              <br/>
               <a class="link" href="https://github.com/example/pkg" rel="ugc">Repository (GitHub)</a>
               <br/>
-              <a class="link" href="https://github.com/example/pkg/issues" rel="ugc">View/report issues</a>
+              <a class="link" href="https://github.com/example/pkg/blob/main/CONTRIBUTING.md" rel="ugc">Contributing</a>
               <br/>
             </p>
             <h3 class="title">Topics</h3>
             <p>
               <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
+            </p>
+            <h3 class="title">Documentation</h3>
+            <p>
+              <a class="link" href="/documentation/pkg/latest/">API reference</a>
+              <br/>
             </p>
             <h3 class="title">Funding</h3>
             <p>
@@ -268,7 +284,7 @@
             <h3 class="title">License</h3>
             <p>
               <img class="inline-icon-img" src="/static/hash-%%etag%%/img/material-icon-balance.svg" alt="" width="14" height="14" role="presentation"/>
-              unknown (
+              BSD-3-Clause (
               <a href="/packages/pkg/license">LICENSE</a>
               )
             </p>
@@ -308,7 +324,7 @@
             </div>
             <div class="packages-score packages-score-health">
               <div class="packages-score-value -has-value">
-                <span class="packages-score-value-number">0</span>
+                <span class="packages-score-value-number">17</span>
                 <span class="packages-score-value-sign"></span>
               </div>
               <div class="packages-score-label">pub points</div>
@@ -328,16 +344,19 @@
           <h3 class="title pkg-infobox-metadata">Metadata</h3>
           <p>pkg is awesome</p>
           <p>
-            <a class="link" href="https://pkg.example.dev/" rel="ugc">Homepage</a>
-            <br/>
             <a class="link" href="https://github.com/example/pkg" rel="ugc">Repository (GitHub)</a>
             <br/>
-            <a class="link" href="https://github.com/example/pkg/issues" rel="ugc">View/report issues</a>
+            <a class="link" href="https://github.com/example/pkg/blob/main/CONTRIBUTING.md" rel="ugc">Contributing</a>
             <br/>
           </p>
           <h3 class="title">Topics</h3>
           <p>
             <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
+          </p>
+          <h3 class="title">Documentation</h3>
+          <p>
+            <a class="link" href="/documentation/pkg/latest/">API reference</a>
+            <br/>
           </p>
           <h3 class="title">Funding</h3>
           <p>
@@ -350,7 +369,7 @@
           <h3 class="title">License</h3>
           <p>
             <img class="inline-icon-img" src="/static/hash-%%etag%%/img/material-icon-balance.svg" alt="" width="14" height="14" role="presentation"/>
-            unknown (
+            BSD-3-Clause (
             <a href="/packages/pkg/license">LICENSE</a>
             )
           </p>


### PR DESCRIPTION
This is an artifact from the past where we had separate pana and dartdoc report and needed to join them. Removing it will also allow removing further methods from the pana API.