### PR TITLE
Updated dartdoc search.html rendering: redirects, title and noindex.

### DIFF
--- a/app/lib/fake/backend/fake_pub_worker.dart
+++ b/app/lib/fake/backend/fake_pub_worker.dart
@@ -190,6 +190,18 @@ Map<String, String> _fakeDartdocFiles(
     ).toJson()),
     'index.json': '{}',
     'pub-data.json': json.encode(pubData),
+    'search.html': json.encode(DartDocPage(
+      title: 'search',
+      description: 'search description',
+      breadcrumbs: [],
+      content: 'content',
+      left: 'left',
+      right: 'right',
+      baseHref: null,
+      usingBaseHref: null,
+      aboveSidebarUrl: null,
+      belowSidebarUrl: null,
+    ).toJson()),
   };
 }
 

--- a/app/test/dartdoc/doc_url_test.dart
+++ b/app/test/dartdoc/doc_url_test.dart
@@ -66,6 +66,28 @@ void main() {
     );
 
     testWithProfile(
+      'search.html redirects',
+      fn: () async {
+        await expectRedirectResponse(
+          await issueGet('/documentation/oxygen/latest/search.html'),
+          '/documentation/oxygen/latest/',
+        );
+        await expectRedirectResponse(
+          await issueGet('/documentation/oxygen/latest/search.html?q='),
+          '/documentation/oxygen/latest/',
+        );
+        await expectRedirectResponse(
+          await issueGet('/documentation/oxygen/latest/search.html?q=x&a=b'),
+          '/documentation/oxygen/latest/',
+        );
+        await expectHtmlResponse(
+            await issueGet('/documentation/oxygen/latest/search.html?q=abc'));
+      },
+      testProfile: _testProfile,
+      processJobsWithFakeRunners: true,
+    );
+
+    testWithProfile(
       'doc url missing',
       fn: () async {
         await expectNotFoundResponse(


### PR DESCRIPTION
- Fixes #7406.
- I think redirects are important so that keep the URL index clean. TBD: maybe we should also do it for other pages, e.g. `/documentation/package/latest/library.html?x=1` should redirect to `library.html`.
- As the results are rendered via JS from `dartdoc`, we should always `noindex` the pages.
- Also updated the page title.