### PR TITLE
Set ARIA role and label for header navigation.

### DIFF
--- a/app/lib/frontend/templates/views/shared/site_header.dart
+++ b/app/lib/frontend/templates/views/shared/site_header.dart
@@ -55,6 +55,10 @@ d.Node siteHeaderNode({
           'site-header-nav',
           'scroll-container',
         ],
+        attributes: {
+          'role': 'navigation',
+          'aria-label': 'help and account navigation',
+        },
         children: [
           if (userSession == null || !userSession.isAuthenticated)
             d.div(

--- a/app/test/frontend/golden/authorized_page.html
+++ b/app/test/frontend/golden/authorized_page.html
@@ -44,7 +44,7 @@
           <input class="site-header-search-input" name="q" placeholder="New search..." autocomplete="on" title="Search"/>
         </form>
       </div>
-      <div class="site-header-nav scroll-container">
+      <div class="site-header-nav scroll-container" role="navigation" aria-label="help and account navigation">
         <div class="nav-login-container">
           <button id="-account-login" class="nav-main-button link">Sign in</button>
         </div>

--- a/app/test/frontend/golden/consent_page.html
+++ b/app/test/frontend/golden/consent_page.html
@@ -44,7 +44,7 @@
           <input class="site-header-search-input" name="q" placeholder="New search..." autocomplete="on" title="Search"/>
         </form>
       </div>
-      <div class="site-header-nav scroll-container">
+      <div class="site-header-nav scroll-container" role="navigation" aria-label="help and account navigation">
         <div class="nav-login-container">
           <button id="-account-login" class="nav-main-button link">Sign in</button>
         </div>

--- a/app/test/frontend/golden/create_publisher_page.html
+++ b/app/test/frontend/golden/create_publisher_page.html
@@ -43,7 +43,7 @@
           <input class="site-header-search-input" name="q" placeholder="New search..." autocomplete="on" title="Search"/>
         </form>
       </div>
-      <div class="site-header-nav scroll-container">
+      <div class="site-header-nav scroll-container" role="navigation" aria-label="help and account navigation">
         <div class="nav-login-container">
           <button id="-account-login" class="nav-main-button link">Sign in</button>
         </div>

--- a/app/test/frontend/golden/error_page.html
+++ b/app/test/frontend/golden/error_page.html
@@ -38,7 +38,7 @@
       </a>
       <div class="site-header-space"></div>
       <div class="site-header-mask"></div>
-      <div class="site-header-nav scroll-container">
+      <div class="site-header-nav scroll-container" role="navigation" aria-label="help and account navigation">
         <div class="nav-login-container">
           <button id="-account-login" class="nav-main-button link">Sign in</button>
         </div>

--- a/app/test/frontend/golden/help_page.html
+++ b/app/test/frontend/golden/help_page.html
@@ -44,7 +44,7 @@
           <input class="site-header-search-input" name="q" placeholder="New search..." autocomplete="on" title="Search"/>
         </form>
       </div>
-      <div class="site-header-nav scroll-container">
+      <div class="site-header-nav scroll-container" role="navigation" aria-label="help and account navigation">
         <div class="nav-login-container">
           <button id="-account-login" class="nav-main-button link">Sign in</button>
         </div>

--- a/app/test/frontend/golden/landing_page.html
+++ b/app/test/frontend/golden/landing_page.html
@@ -38,7 +38,7 @@
       <button class="hamburger" aria-label="menu toggle"></button>
       <div class="site-header-space"></div>
       <div class="site-header-mask"></div>
-      <div class="site-header-nav scroll-container">
+      <div class="site-header-nav scroll-container" role="navigation" aria-label="help and account navigation">
         <div class="nav-login-container">
           <button id="-account-login" class="nav-main-button link">Sign in</button>
         </div>

--- a/app/test/frontend/golden/my_activity_log_page.html
+++ b/app/test/frontend/golden/my_activity_log_page.html
@@ -44,7 +44,7 @@
           <input class="site-header-search-input" name="q" placeholder="New search..." autocomplete="on" title="Search"/>
         </form>
       </div>
-      <div class="site-header-nav scroll-container">
+      <div class="site-header-nav scroll-container" role="navigation" aria-label="help and account navigation">
         <div id="-account-profile" class="nav-container nav-my-container hoverable">
           <button class="nav-main-button">My pub.dev</button>
           <div class="nav-hover-popup">

--- a/app/test/frontend/golden/my_liked_packages.html
+++ b/app/test/frontend/golden/my_liked_packages.html
@@ -45,7 +45,7 @@
           <input class="site-header-search-input" name="q" placeholder="New search..." autocomplete="on" title="Search"/>
         </form>
       </div>
-      <div class="site-header-nav scroll-container">
+      <div class="site-header-nav scroll-container" role="navigation" aria-label="help and account navigation">
         <div id="-account-profile" class="nav-container nav-my-container hoverable">
           <button class="nav-main-button">My pub.dev</button>
           <div class="nav-hover-popup">

--- a/app/test/frontend/golden/my_packages.html
+++ b/app/test/frontend/golden/my_packages.html
@@ -44,7 +44,7 @@
           <input class="site-header-search-input" name="q" placeholder="New search..." autocomplete="on" title="Search"/>
         </form>
       </div>
-      <div class="site-header-nav scroll-container">
+      <div class="site-header-nav scroll-container" role="navigation" aria-label="help and account navigation">
         <div id="-account-profile" class="nav-container nav-my-container hoverable">
           <button class="nav-main-button">My pub.dev</button>
           <div class="nav-hover-popup">

--- a/app/test/frontend/golden/my_publishers.html
+++ b/app/test/frontend/golden/my_publishers.html
@@ -44,7 +44,7 @@
           <input class="site-header-search-input" name="q" placeholder="New search..." autocomplete="on" title="Search"/>
         </form>
       </div>
-      <div class="site-header-nav scroll-container">
+      <div class="site-header-nav scroll-container" role="navigation" aria-label="help and account navigation">
         <div id="-account-profile" class="nav-container nav-my-container hoverable">
           <button class="nav-main-button">My pub.dev</button>
           <div class="nav-hover-popup">

--- a/app/test/frontend/golden/pkg_activity_log_page.html
+++ b/app/test/frontend/golden/pkg_activity_log_page.html
@@ -46,7 +46,7 @@
           <input class="site-header-search-input" name="q" placeholder="New search..." autocomplete="on" title="Search"/>
         </form>
       </div>
-      <div class="site-header-nav scroll-container">
+      <div class="site-header-nav scroll-container" role="navigation" aria-label="help and account navigation">
         <div id="-account-profile" class="nav-container nav-my-container hoverable">
           <button class="nav-main-button">My pub.dev</button>
           <div class="nav-hover-popup">

--- a/app/test/frontend/golden/pkg_admin_page.html
+++ b/app/test/frontend/golden/pkg_admin_page.html
@@ -46,7 +46,7 @@
           <input class="site-header-search-input" name="q" placeholder="New search..." autocomplete="on" title="Search"/>
         </form>
       </div>
-      <div class="site-header-nav scroll-container">
+      <div class="site-header-nav scroll-container" role="navigation" aria-label="help and account navigation">
         <div id="-account-profile" class="nav-container nav-my-container hoverable">
           <button class="nav-main-button">My pub.dev</button>
           <div class="nav-hover-popup">

--- a/app/test/frontend/golden/pkg_changelog_page.html
+++ b/app/test/frontend/golden/pkg_changelog_page.html
@@ -46,7 +46,7 @@
           <input class="site-header-search-input" name="q" placeholder="New search..." autocomplete="on" title="Search"/>
         </form>
       </div>
-      <div class="site-header-nav scroll-container">
+      <div class="site-header-nav scroll-container" role="navigation" aria-label="help and account navigation">
         <div class="nav-login-container">
           <button id="-account-login" class="nav-main-button link">Sign in</button>
         </div>

--- a/app/test/frontend/golden/pkg_example_page.html
+++ b/app/test/frontend/golden/pkg_example_page.html
@@ -46,7 +46,7 @@
           <input class="site-header-search-input" name="q" placeholder="New search..." autocomplete="on" title="Search"/>
         </form>
       </div>
-      <div class="site-header-nav scroll-container">
+      <div class="site-header-nav scroll-container" role="navigation" aria-label="help and account navigation">
         <div class="nav-login-container">
           <button id="-account-login" class="nav-main-button link">Sign in</button>
         </div>

--- a/app/test/frontend/golden/pkg_index_page.html
+++ b/app/test/frontend/golden/pkg_index_page.html
@@ -39,7 +39,7 @@
       </a>
       <div class="site-header-space"></div>
       <div class="site-header-mask"></div>
-      <div class="site-header-nav scroll-container">
+      <div class="site-header-nav scroll-container" role="navigation" aria-label="help and account navigation">
         <div class="nav-login-container">
           <button id="-account-login" class="nav-main-button link">Sign in</button>
         </div>

--- a/app/test/frontend/golden/pkg_install_page.html
+++ b/app/test/frontend/golden/pkg_install_page.html
@@ -46,7 +46,7 @@
           <input class="site-header-search-input" name="q" placeholder="New search..." autocomplete="on" title="Search"/>
         </form>
       </div>
-      <div class="site-header-nav scroll-container">
+      <div class="site-header-nav scroll-container" role="navigation" aria-label="help and account navigation">
         <div class="nav-login-container">
           <button id="-account-login" class="nav-main-button link">Sign in</button>
         </div>

--- a/app/test/frontend/golden/pkg_score_page.html
+++ b/app/test/frontend/golden/pkg_score_page.html
@@ -46,7 +46,7 @@
           <input class="site-header-search-input" name="q" placeholder="New search..." autocomplete="on" title="Search"/>
         </form>
       </div>
-      <div class="site-header-nav scroll-container">
+      <div class="site-header-nav scroll-container" role="navigation" aria-label="help and account navigation">
         <div class="nav-login-container">
           <button id="-account-login" class="nav-main-button link">Sign in</button>
         </div>

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -46,7 +46,7 @@
           <input class="site-header-search-input" name="q" placeholder="New search..." autocomplete="on" title="Search"/>
         </form>
       </div>
-      <div class="site-header-nav scroll-container">
+      <div class="site-header-nav scroll-container" role="navigation" aria-label="help and account navigation">
         <div class="nav-login-container">
           <button id="-account-login" class="nav-main-button link">Sign in</button>
         </div>

--- a/app/test/frontend/golden/pkg_show_page_discontinued.html
+++ b/app/test/frontend/golden/pkg_show_page_discontinued.html
@@ -46,7 +46,7 @@
           <input class="site-header-search-input" name="q" placeholder="New search..." autocomplete="on" title="Search"/>
         </form>
       </div>
-      <div class="site-header-nav scroll-container">
+      <div class="site-header-nav scroll-container" role="navigation" aria-label="help and account navigation">
         <div class="nav-login-container">
           <button id="-account-login" class="nav-main-button link">Sign in</button>
         </div>

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -46,7 +46,7 @@
           <input class="site-header-search-input" name="q" placeholder="New search..." autocomplete="on" title="Search"/>
         </form>
       </div>
-      <div class="site-header-nav scroll-container">
+      <div class="site-header-nav scroll-container" role="navigation" aria-label="help and account navigation">
         <div class="nav-login-container">
           <button id="-account-login" class="nav-main-button link">Sign in</button>
         </div>

--- a/app/test/frontend/golden/pkg_show_page_publisher.html
+++ b/app/test/frontend/golden/pkg_show_page_publisher.html
@@ -46,7 +46,7 @@
           <input class="site-header-search-input" name="q" placeholder="New search..." autocomplete="on" title="Search"/>
         </form>
       </div>
-      <div class="site-header-nav scroll-container">
+      <div class="site-header-nav scroll-container" role="navigation" aria-label="help and account navigation">
         <div class="nav-login-container">
           <button id="-account-login" class="nav-main-button link">Sign in</button>
         </div>

--- a/app/test/frontend/golden/pkg_show_page_retracted.html
+++ b/app/test/frontend/golden/pkg_show_page_retracted.html
@@ -46,7 +46,7 @@
           <input class="site-header-search-input" name="q" placeholder="New search..." autocomplete="on" title="Search"/>
         </form>
       </div>
-      <div class="site-header-nav scroll-container">
+      <div class="site-header-nav scroll-container" role="navigation" aria-label="help and account navigation">
         <div class="nav-login-container">
           <button id="-account-login" class="nav-main-button link">Sign in</button>
         </div>

--- a/app/test/frontend/golden/pkg_show_page_retracted_non_retracted_version.html
+++ b/app/test/frontend/golden/pkg_show_page_retracted_non_retracted_version.html
@@ -46,7 +46,7 @@
           <input class="site-header-search-input" name="q" placeholder="New search..." autocomplete="on" title="Search"/>
         </form>
       </div>
-      <div class="site-header-nav scroll-container">
+      <div class="site-header-nav scroll-container" role="navigation" aria-label="help and account navigation">
         <div class="nav-login-container">
           <button id="-account-login" class="nav-main-button link">Sign in</button>
         </div>

--- a/app/test/frontend/golden/pkg_show_version_page.html
+++ b/app/test/frontend/golden/pkg_show_version_page.html
@@ -46,7 +46,7 @@
           <input class="site-header-search-input" name="q" placeholder="New search..." autocomplete="on" title="Search"/>
         </form>
       </div>
-      <div class="site-header-nav scroll-container">
+      <div class="site-header-nav scroll-container" role="navigation" aria-label="help and account navigation">
         <div class="nav-login-container">
           <button id="-account-login" class="nav-main-button link">Sign in</button>
         </div>

--- a/app/test/frontend/golden/pkg_versions_page.html
+++ b/app/test/frontend/golden/pkg_versions_page.html
@@ -46,7 +46,7 @@
           <input class="site-header-search-input" name="q" placeholder="New search..." autocomplete="on" title="Search"/>
         </form>
       </div>
-      <div class="site-header-nav scroll-container">
+      <div class="site-header-nav scroll-container" role="navigation" aria-label="help and account navigation">
         <div class="nav-login-container">
           <button id="-account-login" class="nav-main-button link">Sign in</button>
         </div>

--- a/app/test/frontend/golden/publisher_activity_log_page.html
+++ b/app/test/frontend/golden/publisher_activity_log_page.html
@@ -40,7 +40,7 @@
       </a>
       <div class="site-header-space"></div>
       <div class="site-header-mask"></div>
-      <div class="site-header-nav scroll-container">
+      <div class="site-header-nav scroll-container" role="navigation" aria-label="help and account navigation">
         <div class="nav-login-container">
           <button id="-account-login" class="nav-main-button link">Sign in</button>
         </div>

--- a/app/test/frontend/golden/publisher_admin_page.html
+++ b/app/test/frontend/golden/publisher_admin_page.html
@@ -40,7 +40,7 @@
       </a>
       <div class="site-header-space"></div>
       <div class="site-header-mask"></div>
-      <div class="site-header-nav scroll-container">
+      <div class="site-header-nav scroll-container" role="navigation" aria-label="help and account navigation">
         <div class="nav-login-container">
           <button id="-account-login" class="nav-main-button link">Sign in</button>
         </div>

--- a/app/test/frontend/golden/publisher_list_page.html
+++ b/app/test/frontend/golden/publisher_list_page.html
@@ -39,7 +39,7 @@
       </a>
       <div class="site-header-space"></div>
       <div class="site-header-mask"></div>
-      <div class="site-header-nav scroll-container">
+      <div class="site-header-nav scroll-container" role="navigation" aria-label="help and account navigation">
         <div class="nav-login-container">
           <button id="-account-login" class="nav-main-button link">Sign in</button>
         </div>

--- a/app/test/frontend/golden/publisher_packages_page.html
+++ b/app/test/frontend/golden/publisher_packages_page.html
@@ -40,7 +40,7 @@
       </a>
       <div class="site-header-space"></div>
       <div class="site-header-mask"></div>
-      <div class="site-header-nav scroll-container">
+      <div class="site-header-nav scroll-container" role="navigation" aria-label="help and account navigation">
         <div class="nav-login-container">
           <button id="-account-login" class="nav-main-button link">Sign in</button>
         </div>

--- a/app/test/frontend/golden/publisher_unlisted_packages_page.html
+++ b/app/test/frontend/golden/publisher_unlisted_packages_page.html
@@ -40,7 +40,7 @@
       </a>
       <div class="site-header-space"></div>
       <div class="site-header-mask"></div>
-      <div class="site-header-nav scroll-container">
+      <div class="site-header-nav scroll-container" role="navigation" aria-label="help and account navigation">
         <div class="nav-login-container">
           <button id="-account-login" class="nav-main-button link">Sign in</button>
         </div>

--- a/app/test/frontend/golden/search_page.html
+++ b/app/test/frontend/golden/search_page.html
@@ -39,7 +39,7 @@
       </a>
       <div class="site-header-space"></div>
       <div class="site-header-mask"></div>
-      <div class="site-header-nav scroll-container">
+      <div class="site-header-nav scroll-container" role="navigation" aria-label="help and account navigation">
         <div class="nav-login-container">
           <button id="-account-login" class="nav-main-button link">Sign in</button>
         </div>

--- a/app/test/frontend/golden/topics_page.html
+++ b/app/test/frontend/golden/topics_page.html
@@ -44,7 +44,7 @@
           <input class="site-header-search-input" name="q" placeholder="New search..." autocomplete="on" title="Search"/>
         </form>
       </div>
-      <div class="site-header-nav scroll-container">
+      <div class="site-header-nav scroll-container" role="navigation" aria-label="help and account navigation">
         <div class="nav-login-container">
           <button id="-account-login" class="nav-main-button link">Sign in</button>
         </div>

--- a/app/test/task/testdata/goldens/packages/oxygen.html
+++ b/app/test/task/testdata/goldens/packages/oxygen.html
@@ -46,7 +46,7 @@
           <input class="site-header-search-input" name="q" placeholder="New search..." autocomplete="on" title="Search"/>
         </form>
       </div>
-      <div class="site-header-nav scroll-container">
+      <div class="site-header-nav scroll-container" role="navigation" aria-label="help and account navigation">
         <div class="nav-login-container">
           <button id="-account-login" class="nav-main-button link">Sign in</button>
         </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/changelog.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/changelog.html
@@ -46,7 +46,7 @@
           <input class="site-header-search-input" name="q" placeholder="New search..." autocomplete="on" title="Search"/>
         </form>
       </div>
-      <div class="site-header-nav scroll-container">
+      <div class="site-header-nav scroll-container" role="navigation" aria-label="help and account navigation">
         <div class="nav-login-container">
           <button id="-account-login" class="nav-main-button link">Sign in</button>
         </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/example.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/example.html
@@ -46,7 +46,7 @@
           <input class="site-header-search-input" name="q" placeholder="New search..." autocomplete="on" title="Search"/>
         </form>
       </div>
-      <div class="site-header-nav scroll-container">
+      <div class="site-header-nav scroll-container" role="navigation" aria-label="help and account navigation">
         <div class="nav-login-container">
           <button id="-account-login" class="nav-main-button link">Sign in</button>
         </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/install.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/install.html
@@ -46,7 +46,7 @@
           <input class="site-header-search-input" name="q" placeholder="New search..." autocomplete="on" title="Search"/>
         </form>
       </div>
-      <div class="site-header-nav scroll-container">
+      <div class="site-header-nav scroll-container" role="navigation" aria-label="help and account navigation">
         <div class="nav-login-container">
           <button id="-account-login" class="nav-main-button link">Sign in</button>
         </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/license.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/license.html
@@ -46,7 +46,7 @@
           <input class="site-header-search-input" name="q" placeholder="New search..." autocomplete="on" title="Search"/>
         </form>
       </div>
-      <div class="site-header-nav scroll-container">
+      <div class="site-header-nav scroll-container" role="navigation" aria-label="help and account navigation">
         <div class="nav-login-container">
           <button id="-account-login" class="nav-main-button link">Sign in</button>
         </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/score.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/score.html
@@ -46,7 +46,7 @@
           <input class="site-header-search-input" name="q" placeholder="New search..." autocomplete="on" title="Search"/>
         </form>
       </div>
-      <div class="site-header-nav scroll-container">
+      <div class="site-header-nav scroll-container" role="navigation" aria-label="help and account navigation">
         <div class="nav-login-container">
           <button id="-account-login" class="nav-main-button link">Sign in</button>
         </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions.html
@@ -46,7 +46,7 @@
           <input class="site-header-search-input" name="q" placeholder="New search..." autocomplete="on" title="Search"/>
         </form>
       </div>
-      <div class="site-header-nav scroll-container">
+      <div class="site-header-nav scroll-container" role="navigation" aria-label="help and account navigation">
         <div class="nav-login-container">
           <button id="-account-login" class="nav-main-button link">Sign in</button>
         </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0.html
@@ -46,7 +46,7 @@
           <input class="site-header-search-input" name="q" placeholder="New search..." autocomplete="on" title="Search"/>
         </form>
       </div>
-      <div class="site-header-nav scroll-container">
+      <div class="site-header-nav scroll-container" role="navigation" aria-label="help and account navigation">
         <div class="nav-login-container">
           <button id="-account-login" class="nav-main-button link">Sign in</button>
         </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/changelog.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/changelog.html
@@ -46,7 +46,7 @@
           <input class="site-header-search-input" name="q" placeholder="New search..." autocomplete="on" title="Search"/>
         </form>
       </div>
-      <div class="site-header-nav scroll-container">
+      <div class="site-header-nav scroll-container" role="navigation" aria-label="help and account navigation">
         <div class="nav-login-container">
           <button id="-account-login" class="nav-main-button link">Sign in</button>
         </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/example.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/example.html
@@ -46,7 +46,7 @@
           <input class="site-header-search-input" name="q" placeholder="New search..." autocomplete="on" title="Search"/>
         </form>
       </div>
-      <div class="site-header-nav scroll-container">
+      <div class="site-header-nav scroll-container" role="navigation" aria-label="help and account navigation">
         <div class="nav-login-container">
           <button id="-account-login" class="nav-main-button link">Sign in</button>
         </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/install.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/install.html
@@ -46,7 +46,7 @@
           <input class="site-header-search-input" name="q" placeholder="New search..." autocomplete="on" title="Search"/>
         </form>
       </div>
-      <div class="site-header-nav scroll-container">
+      <div class="site-header-nav scroll-container" role="navigation" aria-label="help and account navigation">
         <div class="nav-login-container">
           <button id="-account-login" class="nav-main-button link">Sign in</button>
         </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/license.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/license.html
@@ -46,7 +46,7 @@
           <input class="site-header-search-input" name="q" placeholder="New search..." autocomplete="on" title="Search"/>
         </form>
       </div>
-      <div class="site-header-nav scroll-container">
+      <div class="site-header-nav scroll-container" role="navigation" aria-label="help and account navigation">
         <div class="nav-login-container">
           <button id="-account-login" class="nav-main-button link">Sign in</button>
         </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/score.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/score.html
@@ -46,7 +46,7 @@
           <input class="site-header-search-input" name="q" placeholder="New search..." autocomplete="on" title="Search"/>
         </form>
       </div>
-      <div class="site-header-nav scroll-container">
+      <div class="site-header-nav scroll-container" role="navigation" aria-label="help and account navigation">
         <div class="nav-login-container">
           <button id="-account-login" class="nav-main-button link">Sign in</button>
         </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/2.0.0.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/2.0.0.html
@@ -46,7 +46,7 @@
           <input class="site-header-search-input" name="q" placeholder="New search..." autocomplete="on" title="Search"/>
         </form>
       </div>
-      <div class="site-header-nav scroll-container">
+      <div class="site-header-nav scroll-container" role="navigation" aria-label="help and account navigation">
         <div class="nav-login-container">
           <button id="-account-login" class="nav-main-button link">Sign in</button>
         </div>

--- a/pkg/_pub_shared/lib/validation/html/html_validation.dart
+++ b/pkg/_pub_shared/lib/validation/html/html_validation.dart
@@ -169,6 +169,12 @@ void validateHtml(Node root) {
     if (allowedForRole.contains(tag)) continue;
     // material components
     if (tag == 'th' && role == 'columnheader') continue;
+    // exception for site header navigation
+    if (tag == 'div' &&
+        role == 'navigation' &&
+        elem.classes.contains('site-header-nav')) {
+      continue;
+    }
     throw AssertionError(
         '<$tag> tag should not have role attribute, found: ${elem.outerHtml}');
   }


### PR DESCRIPTION
Fixes #7415.

Note: we had a HTML validation test that stated: we shouldn't use `role` attribute on non-interactive components, this PR added and exemption for the site header `div`. I see a lot of examples on Mozilla's ARIA documentation pages where the `role` is on a `div`, so it seems to be fine.