### PR TITLE
Extra top padding for like button text.

### DIFF
--- a/pkg/web_css/lib/src/_detail_page.scss
+++ b/pkg/web_css/lib/src/_detail_page.scss
@@ -185,7 +185,7 @@ $detail-tabs-tablet-width: calc(100% - 240px);
 
     .likes-count {
       display: inline-block;
-      padding-top: 4px;
+      padding-top: 6px;
     }
 
     &:focus-within {


### PR DESCRIPTION
Fixes #7423.
![image](https://github.com/dart-lang/pub-dev/assets/4778111/e907f692-f26e-4d48-ad15-7d5c4608bbc5)
