### PR TITLE
Escape relative path for dartdoc page urls.

### DIFF
--- a/app/lib/shared/urls.dart
+++ b/app/lib/shared/urls.dart
@@ -154,9 +154,15 @@ String pkgDocUrl(
   String? version,
   bool includeHost = false,
   String? relativePath,
-  bool omitTrailingSlash = false,
   bool isLatest = false,
 }) {
+  final parsedRelativePathSegments = relativePath == null
+      ? const <String>[]
+      : Uri.parse(relativePath)
+          .pathSegments
+          .where((e) => e.isNotEmpty)
+          .toList();
+
   if (isLatest || version == null) {
     version = 'latest';
   }
@@ -164,20 +170,16 @@ String pkgDocUrl(
     'documentation',
     package,
     version,
+    ...parsedRelativePathSegments,
   ];
   final baseUri = includeHost ? _siteRootUri : _pathRootUri;
   String url = baseUri.resolveUri(Uri(pathSegments: segments)).toString();
 
-  if (relativePath != null) {
-    url = p.join(url, relativePath);
-  } else if (!omitTrailingSlash) {
-    url = '$url/';
-  }
   if (url.endsWith('/index.html')) {
     url = url.substring(0, url.length - 'index.html'.length);
   }
-  if (omitTrailingSlash && url.endsWith('/')) {
-    url = url.substring(0, url.length - 1);
+  if (parsedRelativePathSegments.isEmpty && !url.endsWith('/')) {
+    url = '$url/';
   }
   return url;
 }

--- a/app/lib/shared/urls.dart
+++ b/app/lib/shared/urls.dart
@@ -156,12 +156,19 @@ String pkgDocUrl(
   String? relativePath,
   bool isLatest = false,
 }) {
-  final parsedRelativePathSegments = relativePath == null
+  final relativePathSegments = relativePath == null
       ? const <String>[]
       : Uri.parse(relativePath)
           .pathSegments
           .where((e) => e.isNotEmpty)
           .toList();
+
+  var forceEndingSlash = relativePathSegments.isEmpty;
+  if (relativePathSegments.isNotEmpty &&
+      relativePathSegments.last == 'index.html') {
+    relativePathSegments.removeLast();
+    forceEndingSlash = true;
+  }
 
   if (isLatest || version == null) {
     version = 'latest';
@@ -170,18 +177,11 @@ String pkgDocUrl(
     'documentation',
     package,
     version,
-    ...parsedRelativePathSegments,
+    ...relativePathSegments,
+    if (forceEndingSlash) '',
   ];
   final baseUri = includeHost ? _siteRootUri : _pathRootUri;
-  String url = baseUri.resolveUri(Uri(pathSegments: segments)).toString();
-
-  if (url.endsWith('/index.html')) {
-    url = url.substring(0, url.length - 'index.html'.length);
-  }
-  if (parsedRelativePathSegments.isEmpty && !url.endsWith('/')) {
-    url = '$url/';
-  }
-  return url;
+  return baseUri.resolveUri(Uri(pathSegments: segments)).toString();
 }
 
 String publisherUrl(String publisherId) => '/publishers/$publisherId';

--- a/app/test/shared/urls_test.dart
+++ b/app/test/shared/urls_test.dart
@@ -26,8 +26,6 @@ void main() {
       expect(pkgDocUrl('foo_bar'), '/documentation/foo_bar/latest/');
       expect(pkgDocUrl('foo_bar', version: '1.0.0'),
           '/documentation/foo_bar/1.0.0/');
-      expect(pkgDocUrl('foo_bar', version: '1.0.0', omitTrailingSlash: true),
-          '/documentation/foo_bar/1.0.0');
     });
 
     test('with host', () {
@@ -35,10 +33,6 @@ void main() {
           'https://pub.dev/documentation/foo_bar/latest/');
       expect(pkgDocUrl('foo_bar', version: '1.0.0', includeHost: true),
           'https://pub.dev/documentation/foo_bar/1.0.0/');
-      expect(
-          pkgDocUrl('foo_bar',
-              version: '1.0.0', includeHost: true, omitTrailingSlash: true),
-          'https://pub.dev/documentation/foo_bar/1.0.0');
     });
   });
 

--- a/app/test/shared/urls_test.dart
+++ b/app/test/shared/urls_test.dart
@@ -34,6 +34,11 @@ void main() {
       expect(pkgDocUrl('foo_bar', version: '1.0.0', includeHost: true),
           'https://pub.dev/documentation/foo_bar/1.0.0/');
     });
+
+    test('escaped segments', () {
+      expect(pkgDocUrl('foo', relativePath: 'árvíztűrő.png'),
+          '/documentation/foo/latest/%C3%A1rv%C3%ADzt%C5%B1r%C5%91.png');
+    });
   });
 
   group('SDK urls', () {


### PR DESCRIPTION
Also removes `omitTrailingSlash` as we are not using it, and its logic is entirely driven by the presence of `relativePath`.