### PR TITLE
Use browser's history when displaying/hiding the infobox on mobile view.

### DIFF
--- a/app/test/frontend/static_files_test.dart
+++ b/app/test/frontend/static_files_test.dart
@@ -201,7 +201,7 @@ void main() {
     test('script.dart.js and parts size check', () {
       final file = cache.getFile('/static/js/script.dart.js');
       expect(file, isNotNull);
-      expect((file!.bytes.length / 1024).round(), closeTo(322, 1));
+      expect((file!.bytes.length / 1024).round(), closeTo(324, 1));
 
       final parts = cache.paths
           .where((path) =>

--- a/pkg/web_app/lib/src/mobile_nav.dart
+++ b/pkg/web_app/lib/src/mobile_nav.dart
@@ -35,6 +35,7 @@ void _setEventForDetailMetadataToggle() {
   int? origX, origY;
 
   var isVisible = false;
+  // ignore: cancel_subscriptions
   StreamSubscription? stateSubscription;
   final currentTitle = document.head?.querySelector('title')?.text?.trim();
   final currentUrl = window.location.toString();


### PR DESCRIPTION
- Fixes #7428
- Unfortunately this increased the complexity of the view toggle a bit, but history API is not really friendly in this regard.
