### PR TITLE
Redirect matched mixed-case package names to lowercase names.

### DIFF
--- a/app/lib/frontend/handlers/package.dart
+++ b/app/lib/frontend/handlers/package.dart
@@ -249,6 +249,19 @@ Future<shelf.Response> _handlePackagePage({
   if (redirectPackageUrls.containsKey(packageName)) {
     return redirectResponse(redirectPackageUrls[packageName]!);
   }
+  // May redirect to the lowercased package name, but only if [versionName] and
+  // [assetKind] is unspecified.
+  // NOTE: we have legitimate mixed-case package names that must not be redirected.
+  final lowerCasePackageName = packageName.toLowerCase();
+  if (versionName == null &&
+      packageName != lowerCasePackageName &&
+      assetKind == AssetKind.readme) {
+    if (!await packageBackend.isPackageVisible(packageName) &&
+        await packageBackend.isPackageVisible(lowerCasePackageName)) {
+      return redirectResponse(urls.pkgPageUrl(lowerCasePackageName));
+    }
+  }
+
   final Stopwatch sw = Stopwatch()..start();
   String? cachedPage;
   if (requestContext.uiCacheEnabled && cacheEntry != null) {

--- a/app/test/frontend/handlers/package_test.dart
+++ b/app/test/frontend/handlers/package_test.dart
@@ -28,6 +28,18 @@ void main() {
       );
     });
 
+    testWithProfile(
+      'redirects MixedCase names, but only if it is the main page',
+      fn: () async {
+        await expectRedirectResponse(
+            await issueGet('/packages/OxyGen'), '/packages/oxygen');
+        await expectNotFoundResponse(
+            await issueGet('/packages/OxyGen/versions'));
+        await expectNotFoundResponse(
+            await issueGet('/packages/OxyGen/changelog'));
+      },
+    );
+
     testWithProfile('withheld package - not found', fn: () async {
       final pkg = await dbService.lookupValue<Package>(
           dbService.emptyKey.append(Package, id: 'oxygen'));


### PR DESCRIPTION
Fixes #7455 (99.9% of the cases)