### PR TITLE
Unblock search index building after a latest analyzed version got deleted.

### DIFF
--- a/app/lib/admin/backend.dart
+++ b/app/lib/admin/backend.dart
@@ -24,10 +24,12 @@ import '../package/backend.dart'
     show checkPackageVersionParams, packageBackend, purgePackageCache;
 import '../package/models.dart';
 import '../publisher/models.dart';
+import '../scorecard/backend.dart';
 import '../shared/configuration.dart';
 import '../shared/datastore.dart';
 import '../shared/email.dart';
 import '../shared/exceptions.dart';
+import '../task/backend.dart';
 import '../tool/utils/dart_sdk_version.dart';
 import 'actions/actions.dart' show AdminAction;
 import 'tools/delete_all_staging.dart';
@@ -476,6 +478,9 @@ class AdminBackend {
     );
 
     await purgePackageCache(packageName);
+    await purgeScorecardData(packageName, version, isLatest: true);
+    // trigger (eventual) re-analysis
+    await taskBackend.trackPackage(packageName);
   }
 
   /// Handles GET '/api/admin/packages/<package>/assigned-tags'

--- a/app/lib/task/backend.dart
+++ b/app/lib/task/backend.dart
@@ -17,6 +17,7 @@ import 'package:indexed_blob/indexed_blob.dart' show BlobIndex, FileRange;
 import 'package:logging/logging.dart' show Logger;
 import 'package:pana/models.dart' show Summary;
 import 'package:pool/pool.dart' show Pool;
+import 'package:pub_dev/package/backend.dart';
 import 'package:pub_dev/package/models.dart';
 import 'package:pub_dev/package/upload_signer_service.dart';
 import 'package:pub_dev/scorecard/backend.dart';
@@ -1044,7 +1045,12 @@ class TaskBackend {
             .map((e) => Version.parse(e.key))
             .latestVersion;
         if (bestVersion != null) {
-          return bestVersion.toString();
+          // sanity check: the version is not deleted
+          final pv = await packageBackend.lookupPackageVersion(
+              package, bestVersion.toString());
+          if (pv != null) {
+            return bestVersion.toString();
+          }
         }
       }
       return '';


### PR DESCRIPTION
- #7458
- The core issue is a stuck latest analysis marker: the search index builder tried to load the deleted version, and failed to do so.
- The fix (a) reschedules the package for analysis, which will clear the core data, and also (b) updates the cache source with an extra sanity check for reading out the version + (c) clearing the cache after the admin action.
- The test first confirmed the failure and then the fix.