### PR TITLE
Always display pubspec URLs (optionally updated from verified URLs).

### DIFF
--- a/app/lib/package/models.dart
+++ b/app/lib/package/models.dart
@@ -1080,29 +1080,32 @@ class PackagePageData {
   bool get isLatestStable => version.version == package.latestVersion;
 
   late final packageLinks = () {
-    // Trying to use verfied URLs
-    final result = scoreCard.panaReport?.result;
-    if (result != null) {
-      final baseUrl = urls.inferBaseUrl(
-        homepageUrl: result.homepageUrl,
-        repositoryUrl: result.repositoryUrl,
-      );
-      return PackageLinks._(
-        baseUrl,
-        homepageUrl: result.homepageUrl,
-        repositoryUrl: result.repositoryUrl,
-        issueTrackerUrl: result.issueTrackerUrl,
-        documentationUrl: result.documentationUrl,
-        contributingUrl: result.contributingUrl,
-      );
-    }
-    // Falling back to use URLs from pubspec.yaml.
+    // start with the URLs from pubspec.yaml
     final pubspec = version.pubspec!;
-    return PackageLinks.infer(
+    final inferred = PackageLinks.infer(
       homepageUrl: pubspec.homepage,
       documentationUrl: pubspec.documentation,
       repositoryUrl: pubspec.repository,
       issueTrackerUrl: pubspec.issueTracker,
+    );
+
+    // Use verified URLs when they are available.
+    final result = scoreCard.panaReport?.result;
+    if (result == null) {
+      return inferred;
+    }
+
+    final baseUrl = urls.inferBaseUrl(
+      homepageUrl: result.homepageUrl ?? inferred.homepageUrl,
+      repositoryUrl: result.repositoryUrl ?? inferred.repositoryUrl,
+    );
+    return PackageLinks._(
+      baseUrl,
+      homepageUrl: result.homepageUrl ?? inferred.homepageUrl,
+      repositoryUrl: result.repositoryUrl ?? inferred.repositoryUrl,
+      issueTrackerUrl: result.issueTrackerUrl ?? inferred.issueTrackerUrl,
+      documentationUrl: result.documentationUrl ?? inferred.documentationUrl,
+      contributingUrl: result.contributingUrl ?? inferred.contributingUrl,
     );
   }();
 

--- a/app/test/frontend/golden/pkg_activity_log_page.html
+++ b/app/test/frontend/golden/pkg_activity_log_page.html
@@ -388,6 +388,8 @@
               <br/>
               <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
               <br/>
+              <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
+              <br/>
               <a class="link" href="https://github.com/example/oxygen/blob/master/CONTRIBUTING.md" rel="ugc">Contributing</a>
               <br/>
             </p>
@@ -461,6 +463,8 @@
             <a class="link" href="https://oxygen.example.dev/" rel="ugc">Homepage</a>
             <br/>
             <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
+            <br/>
+            <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
             <br/>
             <a class="link" href="https://github.com/example/oxygen/blob/master/CONTRIBUTING.md" rel="ugc">Contributing</a>
             <br/>

--- a/app/test/frontend/golden/pkg_admin_page.html
+++ b/app/test/frontend/golden/pkg_admin_page.html
@@ -591,6 +591,8 @@
               <br/>
               <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
               <br/>
+              <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
+              <br/>
               <a class="link" href="https://github.com/example/oxygen/blob/master/CONTRIBUTING.md" rel="ugc">Contributing</a>
               <br/>
             </p>
@@ -664,6 +666,8 @@
             <a class="link" href="https://oxygen.example.dev/" rel="ugc">Homepage</a>
             <br/>
             <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
+            <br/>
+            <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
             <br/>
             <a class="link" href="https://github.com/example/oxygen/blob/master/CONTRIBUTING.md" rel="ugc">Contributing</a>
             <br/>

--- a/app/test/frontend/golden/pkg_changelog_page.html
+++ b/app/test/frontend/golden/pkg_changelog_page.html
@@ -258,6 +258,8 @@
               <br/>
               <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
               <br/>
+              <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
+              <br/>
               <a class="link" href="https://github.com/example/oxygen/blob/master/CONTRIBUTING.md" rel="ugc">Contributing</a>
               <br/>
             </p>
@@ -332,6 +334,8 @@
             <a class="link" href="https://oxygen.example.dev/" rel="ugc">Homepage</a>
             <br/>
             <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
+            <br/>
+            <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
             <br/>
             <a class="link" href="https://github.com/example/oxygen/blob/master/CONTRIBUTING.md" rel="ugc">Contributing</a>
             <br/>

--- a/app/test/frontend/golden/pkg_example_page.html
+++ b/app/test/frontend/golden/pkg_example_page.html
@@ -255,6 +255,8 @@
               <br/>
               <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
               <br/>
+              <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
+              <br/>
               <a class="link" href="https://github.com/example/oxygen/blob/master/CONTRIBUTING.md" rel="ugc">Contributing</a>
               <br/>
             </p>
@@ -329,6 +331,8 @@
             <a class="link" href="https://oxygen.example.dev/" rel="ugc">Homepage</a>
             <br/>
             <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
+            <br/>
+            <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
             <br/>
             <a class="link" href="https://github.com/example/oxygen/blob/master/CONTRIBUTING.md" rel="ugc">Contributing</a>
             <br/>

--- a/app/test/frontend/golden/pkg_install_page.html
+++ b/app/test/frontend/golden/pkg_install_page.html
@@ -281,6 +281,8 @@
               <br/>
               <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
               <br/>
+              <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
+              <br/>
               <a class="link" href="https://github.com/example/oxygen/blob/master/CONTRIBUTING.md" rel="ugc">Contributing</a>
               <br/>
             </p>
@@ -355,6 +357,8 @@
             <a class="link" href="https://oxygen.example.dev/" rel="ugc">Homepage</a>
             <br/>
             <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
+            <br/>
+            <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
             <br/>
             <a class="link" href="https://github.com/example/oxygen/blob/master/CONTRIBUTING.md" rel="ugc">Contributing</a>
             <br/>

--- a/app/test/frontend/golden/pkg_score_page.html
+++ b/app/test/frontend/golden/pkg_score_page.html
@@ -343,6 +343,8 @@
               <br/>
               <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
               <br/>
+              <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
+              <br/>
               <a class="link" href="https://github.com/example/oxygen/blob/master/CONTRIBUTING.md" rel="ugc">Contributing</a>
               <br/>
             </p>
@@ -417,6 +419,8 @@
             <a class="link" href="https://oxygen.example.dev/" rel="ugc">Homepage</a>
             <br/>
             <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
+            <br/>
+            <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
             <br/>
             <a class="link" href="https://github.com/example/oxygen/blob/master/CONTRIBUTING.md" rel="ugc">Contributing</a>
             <br/>

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -258,6 +258,8 @@
               <br/>
               <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
               <br/>
+              <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
+              <br/>
               <a class="link" href="https://github.com/example/oxygen/blob/master/CONTRIBUTING.md" rel="ugc">Contributing</a>
               <br/>
             </p>
@@ -332,6 +334,8 @@
             <a class="link" href="https://oxygen.example.dev/" rel="ugc">Homepage</a>
             <br/>
             <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
+            <br/>
+            <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
             <br/>
             <a class="link" href="https://github.com/example/oxygen/blob/master/CONTRIBUTING.md" rel="ugc">Contributing</a>
             <br/>

--- a/app/test/frontend/golden/pkg_show_page_discontinued.html
+++ b/app/test/frontend/golden/pkg_show_page_discontinued.html
@@ -247,7 +247,11 @@
             <h3 class="title pkg-infobox-metadata">Metadata</h3>
             <p>pkg is awesome</p>
             <p>
+              <a class="link" href="https://pkg.example.dev/" rel="ugc">Homepage</a>
+              <br/>
               <a class="link" href="https://github.com/example/pkg" rel="ugc">Repository (GitHub)</a>
+              <br/>
+              <a class="link" href="https://github.com/example/pkg/issues" rel="ugc">View/report issues</a>
               <br/>
               <a class="link" href="https://github.com/example/pkg/blob/main/CONTRIBUTING.md" rel="ugc">Contributing</a>
               <br/>
@@ -320,7 +324,11 @@
           <h3 class="title pkg-infobox-metadata">Metadata</h3>
           <p>pkg is awesome</p>
           <p>
+            <a class="link" href="https://pkg.example.dev/" rel="ugc">Homepage</a>
+            <br/>
             <a class="link" href="https://github.com/example/pkg" rel="ugc">Repository (GitHub)</a>
+            <br/>
+            <a class="link" href="https://github.com/example/pkg/issues" rel="ugc">View/report issues</a>
             <br/>
             <a class="link" href="https://github.com/example/pkg/blob/main/CONTRIBUTING.md" rel="ugc">Contributing</a>
             <br/>

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -247,6 +247,8 @@
               <br/>
               <a class="link" href="https://github.com/example/flutter_titanium" rel="ugc">Repository (GitHub)</a>
               <br/>
+              <a class="link" href="https://github.com/example/flutter_titanium/issues" rel="ugc">View/report issues</a>
+              <br/>
               <a class="link" href="https://github.com/example/flutter_titanium/blob/master/CONTRIBUTING.md" rel="ugc">Contributing</a>
               <br/>
             </p>
@@ -325,6 +327,8 @@
             <a class="link" href="https://flutter_titanium.example.dev/" rel="ugc">Homepage</a>
             <br/>
             <a class="link" href="https://github.com/example/flutter_titanium" rel="ugc">Repository (GitHub)</a>
+            <br/>
+            <a class="link" href="https://github.com/example/flutter_titanium/issues" rel="ugc">View/report issues</a>
             <br/>
             <a class="link" href="https://github.com/example/flutter_titanium/blob/master/CONTRIBUTING.md" rel="ugc">Contributing</a>
             <br/>

--- a/app/test/frontend/golden/pkg_show_page_publisher.html
+++ b/app/test/frontend/golden/pkg_show_page_publisher.html
@@ -249,6 +249,8 @@
               <br/>
               <a class="link" href="https://github.com/example/neon" rel="ugc">Repository (GitHub)</a>
               <br/>
+              <a class="link" href="https://github.com/example/neon/issues" rel="ugc">View/report issues</a>
+              <br/>
               <a class="link" href="https://github.com/example/neon/blob/master/CONTRIBUTING.md" rel="ugc">Contributing</a>
               <br/>
             </p>
@@ -326,6 +328,8 @@
             <a class="link" href="https://neon.example.dev/" rel="ugc">Homepage</a>
             <br/>
             <a class="link" href="https://github.com/example/neon" rel="ugc">Repository (GitHub)</a>
+            <br/>
+            <a class="link" href="https://github.com/example/neon/issues" rel="ugc">View/report issues</a>
             <br/>
             <a class="link" href="https://github.com/example/neon/blob/master/CONTRIBUTING.md" rel="ugc">Contributing</a>
             <br/>

--- a/app/test/frontend/golden/pkg_show_page_retracted_non_retracted_version.html
+++ b/app/test/frontend/golden/pkg_show_page_retracted_non_retracted_version.html
@@ -238,7 +238,11 @@
             <h3 class="title pkg-infobox-metadata">Metadata</h3>
             <p>pkg is awesome</p>
             <p>
+              <a class="link" href="https://pkg.example.dev/" rel="ugc">Homepage</a>
+              <br/>
               <a class="link" href="https://github.com/example/pkg" rel="ugc">Repository (GitHub)</a>
+              <br/>
+              <a class="link" href="https://github.com/example/pkg/issues" rel="ugc">View/report issues</a>
               <br/>
               <a class="link" href="https://github.com/example/pkg/blob/main/CONTRIBUTING.md" rel="ugc">Contributing</a>
               <br/>
@@ -311,7 +315,11 @@
           <h3 class="title pkg-infobox-metadata">Metadata</h3>
           <p>pkg is awesome</p>
           <p>
+            <a class="link" href="https://pkg.example.dev/" rel="ugc">Homepage</a>
+            <br/>
             <a class="link" href="https://github.com/example/pkg" rel="ugc">Repository (GitHub)</a>
+            <br/>
+            <a class="link" href="https://github.com/example/pkg/issues" rel="ugc">View/report issues</a>
             <br/>
             <a class="link" href="https://github.com/example/pkg/blob/main/CONTRIBUTING.md" rel="ugc">Contributing</a>
             <br/>

--- a/app/test/frontend/golden/pkg_show_version_page.html
+++ b/app/test/frontend/golden/pkg_show_version_page.html
@@ -252,6 +252,8 @@
               <br/>
               <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
               <br/>
+              <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
+              <br/>
               <a class="link" href="https://github.com/example/oxygen/blob/master/CONTRIBUTING.md" rel="ugc">Contributing</a>
               <br/>
             </p>
@@ -326,6 +328,8 @@
             <a class="link" href="https://oxygen.example.dev/" rel="ugc">Homepage</a>
             <br/>
             <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
+            <br/>
+            <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
             <br/>
             <a class="link" href="https://github.com/example/oxygen/blob/master/CONTRIBUTING.md" rel="ugc">Contributing</a>
             <br/>

--- a/app/test/frontend/golden/pkg_versions_page.html
+++ b/app/test/frontend/golden/pkg_versions_page.html
@@ -361,6 +361,8 @@
               <br/>
               <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
               <br/>
+              <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
+              <br/>
               <a class="link" href="https://github.com/example/oxygen/blob/master/CONTRIBUTING.md" rel="ugc">Contributing</a>
               <br/>
             </p>
@@ -435,6 +437,8 @@
             <a class="link" href="https://oxygen.example.dev/" rel="ugc">Homepage</a>
             <br/>
             <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
+            <br/>
+            <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
             <br/>
             <a class="link" href="https://github.com/example/oxygen/blob/master/CONTRIBUTING.md" rel="ugc">Contributing</a>
             <br/>

--- a/app/test/task/testdata/goldens/packages/oxygen.html
+++ b/app/test/task/testdata/goldens/packages/oxygen.html
@@ -245,7 +245,14 @@
             </p>
             <h3 class="title pkg-infobox-metadata">Metadata</h3>
             <p>oxygen is awesome</p>
-            <p></p>
+            <p>
+              <a class="link" href="https://oxygen.example.dev/" rel="ugc">Homepage</a>
+              <br/>
+              <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
+              <br/>
+              <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
+              <br/>
+            </p>
             <h3 class="title">Topics</h3>
             <p>
               <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
@@ -319,7 +326,14 @@
           </p>
           <h3 class="title pkg-infobox-metadata">Metadata</h3>
           <p>oxygen is awesome</p>
-          <p></p>
+          <p>
+            <a class="link" href="https://oxygen.example.dev/" rel="ugc">Homepage</a>
+            <br/>
+            <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
+            <br/>
+            <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
+            <br/>
+          </p>
           <h3 class="title">Topics</h3>
           <p>
             <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>

--- a/app/test/task/testdata/goldens/packages/oxygen/changelog.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/changelog.html
@@ -251,7 +251,14 @@
             </p>
             <h3 class="title pkg-infobox-metadata">Metadata</h3>
             <p>oxygen is awesome</p>
-            <p></p>
+            <p>
+              <a class="link" href="https://oxygen.example.dev/" rel="ugc">Homepage</a>
+              <br/>
+              <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
+              <br/>
+              <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
+              <br/>
+            </p>
             <h3 class="title">Topics</h3>
             <p>
               <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
@@ -325,7 +332,14 @@
           </p>
           <h3 class="title pkg-infobox-metadata">Metadata</h3>
           <p>oxygen is awesome</p>
-          <p></p>
+          <p>
+            <a class="link" href="https://oxygen.example.dev/" rel="ugc">Homepage</a>
+            <br/>
+            <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
+            <br/>
+            <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
+            <br/>
+          </p>
           <h3 class="title">Topics</h3>
           <p>
             <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>

--- a/app/test/task/testdata/goldens/packages/oxygen/example.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/example.html
@@ -201,7 +201,9 @@
               <div class="detail-tabs-content">
                 <section class="tab-content detail-tab-example-content -active markdown-body">
                   <p style="font-family: monospace">
-                    <b>example/example.dart</b>
+                    <b>
+                      <a href="https://github.com/example/oxygen/blob/master/example/example.dart" rel="noopener noreferrer nofollow" target="_blank">example/example.dart</a>
+                    </b>
                   </p>
                   <pre>
                     <code class="language-dart">main() { print('example'); }</code>
@@ -246,7 +248,14 @@
             </p>
             <h3 class="title pkg-infobox-metadata">Metadata</h3>
             <p>oxygen is awesome</p>
-            <p></p>
+            <p>
+              <a class="link" href="https://oxygen.example.dev/" rel="ugc">Homepage</a>
+              <br/>
+              <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
+              <br/>
+              <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
+              <br/>
+            </p>
             <h3 class="title">Topics</h3>
             <p>
               <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
@@ -320,7 +329,14 @@
           </p>
           <h3 class="title pkg-infobox-metadata">Metadata</h3>
           <p>oxygen is awesome</p>
-          <p></p>
+          <p>
+            <a class="link" href="https://oxygen.example.dev/" rel="ugc">Homepage</a>
+            <br/>
+            <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
+            <br/>
+            <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
+            <br/>
+          </p>
           <h3 class="title">Topics</h3>
           <p>
             <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>

--- a/app/test/task/testdata/goldens/packages/oxygen/install.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/install.html
@@ -274,7 +274,14 @@
             </p>
             <h3 class="title pkg-infobox-metadata">Metadata</h3>
             <p>oxygen is awesome</p>
-            <p></p>
+            <p>
+              <a class="link" href="https://oxygen.example.dev/" rel="ugc">Homepage</a>
+              <br/>
+              <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
+              <br/>
+              <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
+              <br/>
+            </p>
             <h3 class="title">Topics</h3>
             <p>
               <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
@@ -348,7 +355,14 @@
           </p>
           <h3 class="title pkg-infobox-metadata">Metadata</h3>
           <p>oxygen is awesome</p>
-          <p></p>
+          <p>
+            <a class="link" href="https://oxygen.example.dev/" rel="ugc">Homepage</a>
+            <br/>
+            <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
+            <br/>
+            <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
+            <br/>
+          </p>
           <h3 class="title">Topics</h3>
           <p>
             <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>

--- a/app/test/task/testdata/goldens/packages/oxygen/license.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/license.html
@@ -247,7 +247,14 @@
             </p>
             <h3 class="title pkg-infobox-metadata">Metadata</h3>
             <p>oxygen is awesome</p>
-            <p></p>
+            <p>
+              <a class="link" href="https://oxygen.example.dev/" rel="ugc">Homepage</a>
+              <br/>
+              <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
+              <br/>
+              <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
+              <br/>
+            </p>
             <h3 class="title">Topics</h3>
             <p>
               <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
@@ -321,7 +328,14 @@
           </p>
           <h3 class="title pkg-infobox-metadata">Metadata</h3>
           <p>oxygen is awesome</p>
-          <p></p>
+          <p>
+            <a class="link" href="https://oxygen.example.dev/" rel="ugc">Homepage</a>
+            <br/>
+            <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
+            <br/>
+            <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
+            <br/>
+          </p>
           <h3 class="title">Topics</h3>
           <p>
             <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>

--- a/app/test/task/testdata/goldens/packages/oxygen/score.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/score.html
@@ -554,7 +554,14 @@
             </p>
             <h3 class="title pkg-infobox-metadata">Metadata</h3>
             <p>oxygen is awesome</p>
-            <p></p>
+            <p>
+              <a class="link" href="https://oxygen.example.dev/" rel="ugc">Homepage</a>
+              <br/>
+              <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
+              <br/>
+              <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
+              <br/>
+            </p>
             <h3 class="title">Topics</h3>
             <p>
               <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
@@ -628,7 +635,14 @@
           </p>
           <h3 class="title pkg-infobox-metadata">Metadata</h3>
           <p>oxygen is awesome</p>
-          <p></p>
+          <p>
+            <a class="link" href="https://oxygen.example.dev/" rel="ugc">Homepage</a>
+            <br/>
+            <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
+            <br/>
+            <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
+            <br/>
+          </p>
           <h3 class="title">Topics</h3>
           <p>
             <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions.html
@@ -307,7 +307,14 @@
             </p>
             <h3 class="title pkg-infobox-metadata">Metadata</h3>
             <p>oxygen is awesome</p>
-            <p></p>
+            <p>
+              <a class="link" href="https://oxygen.example.dev/" rel="ugc">Homepage</a>
+              <br/>
+              <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
+              <br/>
+              <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
+              <br/>
+            </p>
             <h3 class="title">Topics</h3>
             <p>
               <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
@@ -381,7 +388,14 @@
           </p>
           <h3 class="title pkg-infobox-metadata">Metadata</h3>
           <p>oxygen is awesome</p>
-          <p></p>
+          <p>
+            <a class="link" href="https://oxygen.example.dev/" rel="ugc">Homepage</a>
+            <br/>
+            <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
+            <br/>
+            <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
+            <br/>
+          </p>
           <h3 class="title">Topics</h3>
           <p>
             <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0.html
@@ -249,7 +249,14 @@
             </p>
             <h3 class="title pkg-infobox-metadata">Metadata</h3>
             <p>oxygen is awesome</p>
-            <p></p>
+            <p>
+              <a class="link" href="https://oxygen.example.dev/" rel="ugc">Homepage</a>
+              <br/>
+              <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
+              <br/>
+              <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
+              <br/>
+            </p>
             <h3 class="title">Topics</h3>
             <p>
               <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
@@ -323,7 +330,14 @@
           </p>
           <h3 class="title pkg-infobox-metadata">Metadata</h3>
           <p>oxygen is awesome</p>
-          <p></p>
+          <p>
+            <a class="link" href="https://oxygen.example.dev/" rel="ugc">Homepage</a>
+            <br/>
+            <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
+            <br/>
+            <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
+            <br/>
+          </p>
           <h3 class="title">Topics</h3>
           <p>
             <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/changelog.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/changelog.html
@@ -255,7 +255,14 @@
             </p>
             <h3 class="title pkg-infobox-metadata">Metadata</h3>
             <p>oxygen is awesome</p>
-            <p></p>
+            <p>
+              <a class="link" href="https://oxygen.example.dev/" rel="ugc">Homepage</a>
+              <br/>
+              <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
+              <br/>
+              <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
+              <br/>
+            </p>
             <h3 class="title">Topics</h3>
             <p>
               <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
@@ -329,7 +336,14 @@
           </p>
           <h3 class="title pkg-infobox-metadata">Metadata</h3>
           <p>oxygen is awesome</p>
-          <p></p>
+          <p>
+            <a class="link" href="https://oxygen.example.dev/" rel="ugc">Homepage</a>
+            <br/>
+            <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
+            <br/>
+            <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
+            <br/>
+          </p>
           <h3 class="title">Topics</h3>
           <p>
             <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/example.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/example.html
@@ -205,7 +205,9 @@
               <div class="detail-tabs-content">
                 <section class="tab-content detail-tab-example-content -active markdown-body">
                   <p style="font-family: monospace">
-                    <b>example/example.dart</b>
+                    <b>
+                      <a href="https://github.com/example/oxygen/blob/master/example/example.dart" rel="noopener noreferrer nofollow" target="_blank">example/example.dart</a>
+                    </b>
                   </p>
                   <pre>
                     <code class="language-dart">main() { print('example'); }</code>
@@ -250,7 +252,14 @@
             </p>
             <h3 class="title pkg-infobox-metadata">Metadata</h3>
             <p>oxygen is awesome</p>
-            <p></p>
+            <p>
+              <a class="link" href="https://oxygen.example.dev/" rel="ugc">Homepage</a>
+              <br/>
+              <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
+              <br/>
+              <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
+              <br/>
+            </p>
             <h3 class="title">Topics</h3>
             <p>
               <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
@@ -324,7 +333,14 @@
           </p>
           <h3 class="title pkg-infobox-metadata">Metadata</h3>
           <p>oxygen is awesome</p>
-          <p></p>
+          <p>
+            <a class="link" href="https://oxygen.example.dev/" rel="ugc">Homepage</a>
+            <br/>
+            <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
+            <br/>
+            <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
+            <br/>
+          </p>
           <h3 class="title">Topics</h3>
           <p>
             <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/install.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/install.html
@@ -278,7 +278,14 @@
             </p>
             <h3 class="title pkg-infobox-metadata">Metadata</h3>
             <p>oxygen is awesome</p>
-            <p></p>
+            <p>
+              <a class="link" href="https://oxygen.example.dev/" rel="ugc">Homepage</a>
+              <br/>
+              <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
+              <br/>
+              <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
+              <br/>
+            </p>
             <h3 class="title">Topics</h3>
             <p>
               <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
@@ -352,7 +359,14 @@
           </p>
           <h3 class="title pkg-infobox-metadata">Metadata</h3>
           <p>oxygen is awesome</p>
-          <p></p>
+          <p>
+            <a class="link" href="https://oxygen.example.dev/" rel="ugc">Homepage</a>
+            <br/>
+            <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
+            <br/>
+            <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
+            <br/>
+          </p>
           <h3 class="title">Topics</h3>
           <p>
             <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/license.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/license.html
@@ -251,7 +251,14 @@
             </p>
             <h3 class="title pkg-infobox-metadata">Metadata</h3>
             <p>oxygen is awesome</p>
-            <p></p>
+            <p>
+              <a class="link" href="https://oxygen.example.dev/" rel="ugc">Homepage</a>
+              <br/>
+              <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
+              <br/>
+              <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
+              <br/>
+            </p>
             <h3 class="title">Topics</h3>
             <p>
               <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
@@ -325,7 +332,14 @@
           </p>
           <h3 class="title pkg-infobox-metadata">Metadata</h3>
           <p>oxygen is awesome</p>
-          <p></p>
+          <p>
+            <a class="link" href="https://oxygen.example.dev/" rel="ugc">Homepage</a>
+            <br/>
+            <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
+            <br/>
+            <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
+            <br/>
+          </p>
           <h3 class="title">Topics</h3>
           <p>
             <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/score.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/score.html
@@ -558,7 +558,14 @@
             </p>
             <h3 class="title pkg-infobox-metadata">Metadata</h3>
             <p>oxygen is awesome</p>
-            <p></p>
+            <p>
+              <a class="link" href="https://oxygen.example.dev/" rel="ugc">Homepage</a>
+              <br/>
+              <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
+              <br/>
+              <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
+              <br/>
+            </p>
             <h3 class="title">Topics</h3>
             <p>
               <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
@@ -632,7 +639,14 @@
           </p>
           <h3 class="title pkg-infobox-metadata">Metadata</h3>
           <p>oxygen is awesome</p>
-          <p></p>
+          <p>
+            <a class="link" href="https://oxygen.example.dev/" rel="ugc">Homepage</a>
+            <br/>
+            <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
+            <br/>
+            <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
+            <br/>
+          </p>
           <h3 class="title">Topics</h3>
           <p>
             <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/2.0.0.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/2.0.0.html
@@ -245,7 +245,14 @@
             </p>
             <h3 class="title pkg-infobox-metadata">Metadata</h3>
             <p>oxygen is awesome</p>
-            <p></p>
+            <p>
+              <a class="link" href="https://oxygen.example.dev/" rel="ugc">Homepage</a>
+              <br/>
+              <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
+              <br/>
+              <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
+              <br/>
+            </p>
             <h3 class="title">Topics</h3>
             <p>
               <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
@@ -319,7 +326,14 @@
           </p>
           <h3 class="title pkg-infobox-metadata">Metadata</h3>
           <p>oxygen is awesome</p>
-          <p></p>
+          <p>
+            <a class="link" href="https://oxygen.example.dev/" rel="ugc">Homepage</a>
+            <br/>
+            <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
+            <br/>
+            <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
+            <br/>
+          </p>
           <h3 class="title">Topics</h3>
           <p>
             <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>


### PR DESCRIPTION
- #7388
- Now we may display different links on analyzed and non-analyzed versions (with the same pubspec content), depending on the URL verification status. This will improve the consistency by always displaying the URLs from pubspec, even if the verification failed.