### PR TITLE
On-demand download of preview/beta analysis SDKs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ AppEngine version, listed here to ease deployment and troubleshooting.
 ## Next Release (replace with git tag when deployed)
  * Bumped runtimeVersion to `2024.02.29`.
  * Upgraded dartdoc to `8.0.6`.
+ * Note: preview analysis SDKs are downloaded dynamically.
 
 ## `20240227t140000-all`
  * Bumped runtimeVersion to `2024.02.27`.

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -25,11 +25,9 @@ RUN mkdir -p /home/worker/config/flutter-preview
 
 # Setup Dart SDK into /home/worker/dart/{stable,preview}/
 RUN XDG_CONFIG_HOME=/home/worker/config/dart-stable tool/setup-dart.sh /home/worker/dart/stable 3.3.0
-RUN XDG_CONFIG_HOME=/home/worker/config/dart-preview tool/setup-dart.sh /home/worker/dart/preview 3.4.0-131.0.dev
 
 # Setup Flutter SDK into /home/worker/flutter/{stable,preview}/
 RUN XDG_CONFIG_HOME=/home/worker/config/flutter-stable tool/setup-flutter.sh /home/worker/flutter/stable 3.19.1
-RUN XDG_CONFIG_HOME=/home/worker/config/flutter-preview tool/setup-flutter.sh /home/worker/flutter/preview 3.20.0-1.1.pre
 
 # Setup webp
 RUN tool/setup-webp.sh /home/worker/bin

--- a/app/lib/fake/backend/fake_pana_runner.dart
+++ b/app/lib/fake/backend/fake_pana_runner.dart
@@ -95,7 +95,7 @@ Future<Summary> fakePanaSummary({
     packageVersion: Version.parse(version),
     runtimeInfo: PanaRuntimeInfo(
       sdkVersion: packageStatus.usesPreviewAnalysisSdk
-          ? toolPreviewDartSdkVersion
+          ? semanticToolStableDartSdkVersion.nextMinor.toString()
           : toolStableDartSdkVersion,
       panaVersion: panaVersion,
       flutterVersions: {},

--- a/app/lib/shared/handlers.dart
+++ b/app/lib/shared/handlers.dart
@@ -133,10 +133,6 @@ shelf.Response debugResponse([Map<String, dynamic>? data]) {
         'dart': toolStableDartSdkVersion,
         'flutter': toolStableFlutterSdkVersion,
       },
-      'preview': {
-        'dart': toolPreviewDartSdkVersion,
-        'flutter': toolPreviewFlutterSdkVersion,
-      }
     },
   };
   if (data != null) {

--- a/app/lib/shared/versions.dart
+++ b/app/lib/shared/versions.dart
@@ -64,8 +64,6 @@ bool shouldGCVersion(String version) =>
 final String runtimeSdkVersion = '3.3.0';
 final String toolStableDartSdkVersion = '3.3.0';
 final String toolStableFlutterSdkVersion = '3.19.1';
-final String toolPreviewDartSdkVersion = '3.4.0-131.0.dev';
-final String toolPreviewFlutterSdkVersion = '3.20.0-1.1.pre';
 
 final semanticToolStableDartSdkVersion =
     Version.parse(toolStableDartSdkVersion);

--- a/app/test/shared/versions_test.dart
+++ b/app/test/shared/versions_test.dart
@@ -48,10 +48,8 @@ void main() {
     }
 
     check(toolStableDartSdkVersion, 'stable Dart analysis SDK');
-    check(toolPreviewDartSdkVersion, 'preview Dart analysis SDK');
     check(runtimeSdkVersion, 'runtime Dart SDK');
     check(toolStableFlutterSdkVersion, 'stable Flutter');
-    check(toolPreviewFlutterSdkVersion, 'preview Flutter');
     check(panaVersion, 'pana');
     check(dartdocVersion, 'dartdoc');
     check(runtimeVersion, 'runtimeVersion', isRuntimeVersion: true);
@@ -88,10 +86,6 @@ void main() {
             dockerfileContent.contains(
                 'tool/setup-dart.sh /home/worker/dart/stable $toolStableDartSdkVersion'),
         isTrue);
-    expect(
-        dockerfileContent,
-        contains(
-            'tool/setup-dart.sh /home/worker/dart/preview $toolPreviewDartSdkVersion'));
   });
 
   test('Flutter SDK versions should match Dockerfile.worker', () async {
@@ -100,10 +94,6 @@ void main() {
         dockerfileContent,
         contains(
             'tool/setup-flutter.sh /home/worker/flutter/stable $toolStableFlutterSdkVersion'));
-    expect(
-        dockerfileContent,
-        contains(
-            'tool/setup-flutter.sh /home/worker/flutter/preview $toolPreviewFlutterSdkVersion'));
   });
 
   test('analyzer version should match resolved pana version', () async {
@@ -117,10 +107,6 @@ void main() {
     expect(
         flutterArchive.releases!
             .any((fr) => fr.version == toolStableFlutterSdkVersion),
-        isTrue);
-    expect(
-        flutterArchive.releases!
-            .any((fr) => fr.version == toolPreviewFlutterSdkVersion),
         isTrue);
   });
 

--- a/pkg/_pub_shared/lib/utils/flutter_archive.dart
+++ b/pkg/_pub_shared/lib/utils/flutter_archive.dart
@@ -6,6 +6,7 @@ import 'dart:convert';
 
 import 'package:_pub_shared/utils/http.dart';
 import 'package:json_annotation/json_annotation.dart';
+import 'package:pub_semver/pub_semver.dart';
 
 part 'flutter_archive.g.dart';
 
@@ -36,6 +37,14 @@ class FlutterArchive {
       _$FlutterArchiveFromJson(json);
 
   Map<String, dynamic> toJson() => _$FlutterArchiveToJson(this);
+
+  late final _betaVersions =
+      releases?.where((e) => e.channel == 'beta' && e.version != null).toList();
+
+  late final latestBeta = (_betaVersions?.isNotEmpty ?? false)
+      ? _betaVersions!.reduce(
+          (a, b) => a.semanticVersion.compareTo(b.semanticVersion) <= 0 ? b : a)
+      : null;
 }
 
 /// The hashes of the current Flutter releases on the different channels.
@@ -77,4 +86,9 @@ class FlutterRelease {
       _$FlutterReleaseFromJson(json);
 
   Map<String, dynamic> toJson() => _$FlutterReleaseToJson(this);
+
+  late final cleanVersion =
+      version!.startsWith('v') ? version!.substring(1) : version!;
+
+  late final semanticVersion = Version.parse(cleanVersion);
 }

--- a/pkg/_pub_shared/pubspec.lock
+++ b/pkg/_pub_shared/pubspec.lock
@@ -369,7 +369,7 @@ packages:
     source: hosted
     version: "1.5.1"
   pub_semver:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: pub_semver
       sha256: "40d3ab1bbd474c4c2328c91e3a7df8c6dd629b79ece4c4bd04bee496a224fb0c"

--- a/pkg/_pub_shared/pubspec.yaml
+++ b/pkg/_pub_shared/pubspec.yaml
@@ -9,6 +9,7 @@ dependencies:
   html: ^0.15.0
   json_annotation: ^4.3.0
   meta: ^1.3.0
+  pub_semver: ^2.0.0
   sanitize_html: ^2.1.0
   api_builder:
     path: ../api_builder

--- a/pkg/_pub_shared/test/utils/flutter_archive_test.dart
+++ b/pkg/_pub_shared/test/utils/flutter_archive_test.dart
@@ -1,0 +1,18 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:_pub_shared/utils/flutter_archive.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('has beta version', () async {
+    final archive = await fetchFlutterArchive();
+    expect(archive.latestBeta, isNotNull);
+    // we usually have a new beta release in every 2-3 weeks
+    expect(
+      DateTime.now().difference(archive.latestBeta!.releaseDate!).inDays,
+      lessThan(30),
+    );
+  });
+}

--- a/pkg/pub_worker/lib/src/bin/pana_wrapper.dart
+++ b/pkg/pub_worker/lib/src/bin/pana_wrapper.dart
@@ -257,6 +257,7 @@ Future<String?> _installSdk({
   }
   if (!await Directory(sdkPath).exists()) {
     final configHomePath = _configHomePath(sdkKind, configKind);
+    // TODO: setup/download with retries (optionally with CRC/hash checks)
     await runConstrained(
       [
         'tool/setup-$sdkKind.sh',

--- a/pkg/pub_worker/lib/src/bin/pana_wrapper.dart
+++ b/pkg/pub_worker/lib/src/bin/pana_wrapper.dart
@@ -189,10 +189,10 @@ Future<(SdkConfig, SdkConfig)> _detectSdks(Pubspec pubspec) async {
   // Choose stable Dart and Flutter SDKs for analysis
   final installedDartSdk =
       dartSdks.firstWhereOrNull((sdk) => !sdk.version.isPreRelease) ??
-          (dartSdks.isNotEmpty ? dartSdks.first : null);
+          dartSdks.firstOrNull;
   final installedFlutterSdk =
       flutterSdks.firstWhereOrNull((sdk) => !sdk.version.isPreRelease) ??
-          (flutterSdks.isNotEmpty ? flutterSdks.first : null);
+          flutterSdks.firstOrNull;
 
   final needsNewer = needsNewerSdk(
           sdkVersion: installedDartSdk?.version,

--- a/pkg/pub_worker/lib/src/bin/pana_wrapper.dart
+++ b/pkg/pub_worker/lib/src/bin/pana_wrapper.dart
@@ -194,6 +194,11 @@ Future<(SdkConfig, SdkConfig)> _detectSdks(Pubspec pubspec) async {
       flutterSdks.firstWhereOrNull((sdk) => !sdk.version.isPreRelease) ??
           flutterSdks.firstOrNull;
 
+  // NOTE: this is very simple constraint check right now. Instead, we should:
+  //       - try to use the latest SDKs in the docker image, or
+  //       - try to use the latest downloadable SDKs, or
+  //       - try to use the latest beta/preview SDKs, or
+  //       - fall back to the latest dev/master branch.
   final needsNewer = needsNewerSdk(
           sdkVersion: installedDartSdk?.version,
           constraint: pubspec.dartSdkConstraint) ||

--- a/pkg/pub_worker/lib/src/sdks.dart
+++ b/pkg/pub_worker/lib/src/sdks.dart
@@ -22,7 +22,7 @@ class InstalledSdk {
   /// List SDKs installed into [path].
   ///
   /// This looks for sub-folders containing `version` files.
-  static Future<List<InstalledSdk>> fromDirectory({
+  static Future<List<InstalledSdk>> scanDirectory({
     required String kind,
     required Directory path,
   }) async {
@@ -54,8 +54,7 @@ class InstalledSdk {
           }
         }
 
-        final v = await File(p.join(d.path, 'version')).readAsString();
-        sdks.add(InstalledSdk(kind, d.path, Version.parse(v.trim())));
+        sdks.add(await fromDirectory(kind: kind, path: d.path));
       } on FormatException {
         continue;
       } on IOException {
@@ -64,5 +63,13 @@ class InstalledSdk {
     }
     sdks.sortByCompare((s) => s.version, Version.prioritize);
     return sdks;
+  }
+
+  static Future<InstalledSdk> fromDirectory({
+    required String kind,
+    required String path,
+  }) async {
+    final v = await File(p.join(path, 'version')).readAsString();
+    return InstalledSdk(kind, path, Version.parse(v.trim()));
   }
 }

--- a/tool/setup-dart.sh
+++ b/tool/setup-dart.sh
@@ -9,6 +9,7 @@ then
 fi
 
 # Expected version argument formats:
+# - master
 # - stable/raw/hash/<hash>
 # - 3.2.5 (stable/release/<version>)
 # - 3.2.5-beta (beta/release/<version>)
@@ -20,7 +21,10 @@ then
 fi
 
 # Infer the download URL
-if [[ "$2" == */raw/hash/* ]]
+if [[ "$2" == "master" ]]
+then
+  DOWNLOAD_URL="https://storage.googleapis.com/dart-archive/channels/main/raw/latest/sdk/dartsdk-linux-x64-release.zip"
+elif [[ "$2" == */raw/hash/* ]]
 then
   DOWNLOAD_URL="https://storage.googleapis.com/dart-archive/channels/$2/sdk/dartsdk-linux-x64-release.zip"
 elif [[ "$2" == *.* ]]


### PR DESCRIPTION
- We will only use stable SDKs as part of the worker image.
- When the worker detects a need for newer SDK, it can download it dynamically into the `<path>/<sdk>/preview` directory.
- Dart SDK is selected by querying the latest version endpoint for `beta` channel.
- Flutter SDK is selected by downloading the Flutter version archive and selecting the version manually.
- In each case, if there is no such version available, the `master` channel/branch will be used.
- Updated `setup-dart.sh` to also accept `master` as version.