### PR TITLE
Optionally restrict public bucket sync to a specific package.

### DIFF
--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -267,11 +267,16 @@ class PackageBackend {
     );
   }
 
-  /// Looks up all versions of a package.
+  /// Looks up all versions of a package and return them as a [List].
   Future<List<PackageVersion>> versionsOfPackage(String packageName) async {
+    return streamVersionsOfPackage(packageName).toList();
+  }
+
+  /// Looks up all versions of a package and return them as a [Stream].
+  Stream<PackageVersion> streamVersionsOfPackage(String packageName) {
     final packageKey = db.emptyKey.append(Package, id: packageName);
     final query = db.query<PackageVersion>(ancestorKey: packageKey);
-    return await query.run().toList();
+    return query.run();
   }
 
   /// List the versions of [package] that are published in the last N [days].
@@ -1845,9 +1850,11 @@ DerivedPackageVersionEntities derivePackageVersionEntities({
 }
 
 /// The GCS object name of a tarball object - excluding leading '/'.
-@visibleForTesting
 String tarballObjectName(String package, String version) =>
-    'packages/$package-$version.tar.gz';
+    '${tarballObjectNamePackagePrefix(package)}$version.tar.gz';
+
+/// The GCS object prefix of a tarball object for a given [package] - excluding leading '/'.
+String tarballObjectNamePackagePrefix(String package) => 'packages/$package-';
 
 /// The GCS object name of an temporary object [guid] - excluding leading '/'.
 @visibleForTesting

--- a/app/test/tool/maintenance/update_public_bucket_test.dart
+++ b/app/test/tool/maintenance/update_public_bucket_test.dart
@@ -14,12 +14,10 @@ void main() {
     testWithProfile('no update', fn: () async {
       final changes =
           await updatePublicArchiveBucket(ageCheckThreshold: Duration.zero);
-      expect(changes.archivesUpdated, 0);
-      expect(changes.archivesToBeDeleted, 0);
-      expect(changes.archivesDeleted, 0);
+      expect(changes.isAllZero, isTrue);
     });
 
-    testWithProfile('missing file', fn: () async {
+    testWithProfile('missing file - without package filter', fn: () async {
       final bucket =
           storageService.bucket(activeConfiguration.publicPackagesBucketName!);
       await bucket.delete('packages/oxygen-1.0.0.tar.gz');
@@ -32,21 +30,68 @@ void main() {
 
       final changes2 =
           await updatePublicArchiveBucket(ageCheckThreshold: Duration.zero);
-      expect(changes2.archivesUpdated, 0);
-      expect(changes.archivesToBeDeleted, 0);
-      expect(changes2.archivesDeleted, 0);
+      expect(changes2.isAllZero, isTrue);
     });
 
-    testWithProfile('extra file', fn: () async {
+    testWithProfile('missing file - with matching package filter',
+        fn: () async {
       final bucket =
           storageService.bucket(activeConfiguration.publicPackagesBucketName!);
-      await bucket.writeBytes('xyz.txt', [1]);
+      await bucket.delete('packages/oxygen-1.0.0.tar.gz');
+
+      final changes = await updatePublicArchiveBucket(
+        package: 'oxygen',
+        ageCheckThreshold: Duration.zero,
+      );
+      expect(changes.archivesUpdated, 1);
+      expect(changes.archivesToBeDeleted, 0);
+      expect(changes.archivesDeleted, 0);
+
+      final changes2 = await updatePublicArchiveBucket(
+        package: 'oxygen',
+        ageCheckThreshold: Duration.zero,
+      );
+      expect(changes2.isAllZero, isTrue);
+
+      final changes3 =
+          await updatePublicArchiveBucket(ageCheckThreshold: Duration.zero);
+      expect(changes3.isAllZero, isTrue);
+    });
+
+    testWithProfile('missing file - with different package filter',
+        fn: () async {
+      final bucket =
+          storageService.bucket(activeConfiguration.publicPackagesBucketName!);
+      await bucket.delete('packages/oxygen-1.0.0.tar.gz');
+
+      final changes = await updatePublicArchiveBucket(
+        package: 'neon',
+        ageCheckThreshold: Duration.zero,
+      );
+      expect(changes.isAllZero, isTrue);
+
+      final changes2 = await updatePublicArchiveBucket(
+        package: 'neon',
+        ageCheckThreshold: Duration.zero,
+      );
+      expect(changes2.isAllZero, isTrue);
+
+      // eventual update
+      final changes3 =
+          await updatePublicArchiveBucket(ageCheckThreshold: Duration.zero);
+      expect(changes3.archivesUpdated, 1);
+      expect(changes3.archivesToBeDeleted, 0);
+      expect(changes3.archivesDeleted, 0);
+    });
+
+    testWithProfile('extra file - without package filter', fn: () async {
+      final bucket =
+          storageService.bucket(activeConfiguration.publicPackagesBucketName!);
+      await bucket.writeBytes('packages/oxygen-0.0.99.tar.gz', [1]);
 
       // recent file gets ignored
       final recent = await updatePublicArchiveBucket();
-      expect(recent.archivesUpdated, 0);
-      expect(recent.archivesToBeDeleted, 0);
-      expect(recent.archivesDeleted, 0);
+      expect(recent.isAllZero, isTrue);
 
       // non-recent file will get deleted
       final changes =
@@ -67,9 +112,81 @@ void main() {
       // second round should report 0 deleted
       final changes3 =
           await updatePublicArchiveBucket(ageCheckThreshold: Duration.zero);
-      expect(changes3.archivesUpdated, 0);
-      expect(changes3.archivesToBeDeleted, 0);
-      expect(changes3.archivesDeleted, 0);
+      expect(changes3.isAllZero, isTrue);
+    });
+
+    testWithProfile('extra file - with matching package filter', fn: () async {
+      final bucket =
+          storageService.bucket(activeConfiguration.publicPackagesBucketName!);
+      await bucket.writeBytes('packages/oxygen-0.0.99.tar.gz', [1]);
+
+      // recent file gets ignored
+      final recent = await updatePublicArchiveBucket(package: 'oxygen');
+      expect(recent.isAllZero, isTrue);
+
+      // non-recent file will get deleted
+      final changes = await updatePublicArchiveBucket(
+        package: 'oxygen',
+        ageCheckThreshold: Duration.zero,
+      );
+      expect(changes.archivesUpdated, 0);
+      expect(changes.archivesToBeDeleted, 1);
+      expect(changes.archivesDeleted, 0);
+
+      // non-recent file is deleted
+      final changes2 = await updatePublicArchiveBucket(
+        package: 'oxygen',
+        ageCheckThreshold: Duration.zero,
+        deleteIfOlder: Duration.zero,
+      );
+      expect(changes2.archivesUpdated, 0);
+      expect(changes2.archivesToBeDeleted, 0);
+      expect(changes2.archivesDeleted, 1);
+
+      // second round should report 0 deleted
+      final changes3 = await updatePublicArchiveBucket(
+        package: 'oxygen',
+        ageCheckThreshold: Duration.zero,
+      );
+      expect(changes3.isAllZero, isTrue);
+
+      // no further changes
+      final changes4 =
+          await updatePublicArchiveBucket(ageCheckThreshold: Duration.zero);
+      expect(changes4.isAllZero, isTrue);
+    });
+
+    testWithProfile('extra file - with different package filter', fn: () async {
+      final bucket =
+          storageService.bucket(activeConfiguration.publicPackagesBucketName!);
+      await bucket.writeBytes('packages/oxygen-0.0.99.tar.gz', [1]);
+
+      // no matching file
+      final recent = await updatePublicArchiveBucket(package: 'neon');
+      expect(recent.isAllZero, isTrue);
+
+      // no matching files
+      final changes = await updatePublicArchiveBucket(
+        package: 'neon',
+        ageCheckThreshold: Duration.zero,
+      );
+      expect(changes.isAllZero, isTrue);
+      final changes2 = await updatePublicArchiveBucket(
+        package: 'neon',
+        ageCheckThreshold: Duration.zero,
+        deleteIfOlder: Duration.zero,
+      );
+      expect(changes2.isAllZero, isTrue);
+      final changes3 = await updatePublicArchiveBucket(
+        package: 'neon',
+        ageCheckThreshold: Duration.zero,
+      );
+      expect(changes3.isAllZero, isTrue);
+
+      // changes will be picked up without filter
+      final changes4 =
+          await updatePublicArchiveBucket(ageCheckThreshold: Duration.zero);
+      expect(changes4.isAllZero, isFalse);
     });
   });
 }


### PR DESCRIPTION
The filter will be used by the package moderation admin action to delete or restore the package's archive files.