### PR TITLE
Cutoff time check while listing files in dartdoc post-processing.

### DIFF
--- a/pkg/pub_worker/test/list_files_with_timeout_test.dart
+++ b/pkg/pub_worker/test/list_files_with_timeout_test.dart
@@ -1,0 +1,35 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:clock/clock.dart';
+import 'package:pub_worker/src/bin/dartdoc_wrapper.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('list files with timeout', () async {
+    final files = (await Directory.current.list(recursive: true).toList())
+        .whereType<File>()
+        .map((e) => e.path)
+        .toSet();
+
+    final list1 = (await listFilesWithTimeout(
+                path: Directory.current.path,
+                cutoffTimestamp: clock.now().add(Duration(minutes: 1)))
+            .toList())
+        .map((e) => e.path)
+        .toSet();
+    expect(list1, files);
+
+    final list2 = (await listFilesWithTimeout(
+                path: Directory.current.path,
+                cutoffTimestamp: clock.now().add(Duration(milliseconds: 10)))
+            .toList())
+        .map((e) => e.path)
+        .toSet();
+    expect(list2, isNotEmpty);
+    expect(list2, hasLength(lessThan(files.length)));
+  });
+}


### PR DESCRIPTION
- #7430
- It appears that the stream of `Directory.list(recursive: true) does have large lags in it, trying to use a finer-tuned listing check to prevent going over the time budget.