### PR TITLE
Refactored dartdoc post-processing.

### DIFF
--- a/pkg/pub_worker/lib/src/bin/dartdoc_wrapper.dart
+++ b/pkg/pub_worker/lib/src/bin/dartdoc_wrapper.dart
@@ -5,9 +5,9 @@
 import 'dart:async';
 import 'dart:convert' show json, utf8, Utf8Codec;
 import 'dart:io';
+import 'dart:isolate';
 
 import 'package:_pub_shared/dartdoc/dartdoc_page.dart';
-import 'package:clock/clock.dart';
 import 'package:logging/logging.dart' show Logger;
 import 'package:path/path.dart' as p;
 import 'package:stream_transform/stream_transform.dart';
@@ -22,75 +22,76 @@ Future<void> postProcessDartdoc({
   required String package,
   required String version,
   required String docDir,
-  required DateTime cutoffTimestamp,
 }) async {
   _log.info('Running dartdoc post-processing');
   final tmpOutDir = p.join(outputFolder, '_doc');
   await Directory(tmpOutDir).create(recursive: true);
-  final files = Directory(docDir)
-      .list(recursive: true, followLinks: false)
-      .whereType<File>();
-  await for (final file in files) {
-    if (cutoffTimestamp.isBefore(clock.now())) {
-      _log.warning(
-          'Cut-off timestamp reached during dartdoc file post-processing.');
-      return;
+  final processingFuture = Isolate.run(() async {
+    final files = Directory(docDir)
+        .list(recursive: true, followLinks: false)
+        .whereType<File>();
+    await for (final file in files) {
+      final suffix = file.path.substring(docDir.length + 1);
+      final targetFile = File(p.join(tmpOutDir, suffix));
+      await targetFile.parent.create(recursive: true);
+      final isDartDocSidebar =
+          file.path.endsWith('.html') && file.path.endsWith('-sidebar.html');
+      final isDartDocPage = file.path.endsWith('.html') && !isDartDocSidebar;
+      if (isDartDocPage) {
+        final page =
+            DartDocPage.parse(await file.readAsString(encoding: _utf8));
+        await targetFile.writeAsBytes(_jsonUtf8.encode(page.toJson()));
+      } else if (isDartDocSidebar) {
+        final sidebar =
+            DartDocSidebar.parse(await file.readAsString(encoding: _utf8));
+        await targetFile.writeAsBytes(_jsonUtf8.encode(sidebar.toJson()));
+      } else {
+        await file.copy(targetFile.path);
+      }
     }
-    final suffix = file.path.substring(docDir.length + 1);
-    final targetFile = File(p.join(tmpOutDir, suffix));
-    await targetFile.parent.create(recursive: true);
-    final isDartDocSidebar =
-        file.path.endsWith('.html') && file.path.endsWith('-sidebar.html');
-    final isDartDocPage = file.path.endsWith('.html') && !isDartDocSidebar;
-    if (isDartDocPage) {
-      final page = DartDocPage.parse(await file.readAsString(encoding: _utf8));
-      await targetFile.writeAsBytes(_jsonUtf8.encode(page.toJson()));
-    } else if (isDartDocSidebar) {
-      final sidebar =
-          DartDocSidebar.parse(await file.readAsString(encoding: _utf8));
-      await targetFile.writeAsBytes(_jsonUtf8.encode(sidebar.toJson()));
-    } else {
-      await file.copy(targetFile.path);
+  }).whenComplete(() {
+    _log.info('Finished post-processing');
+  });
+
+  _log.info('Creating .tar.gz archive');
+  final tmpTar = File(p.join(outputFolder, '_package.tar.gz'));
+  final archiveFuture = Isolate.run(() async {
+    Stream<TarEntry> _list() async* {
+      final originalDocDir = Directory(docDir);
+      final originalFiles = originalDocDir
+          .list(recursive: true, followLinks: false)
+          .whereType<File>();
+      await for (final file in originalFiles) {
+        // inside the archive prefix the name with <package>/version/
+        final relativePath = p.relative(file.path, from: originalDocDir.path);
+        final tarEntryPath = p.join(package, version, relativePath);
+        final data = await file.readAsBytes();
+        yield TarEntry.data(
+          TarHeader(
+            name: tarEntryPath,
+            size: data.length,
+          ),
+          data,
+        );
+      }
     }
-  }
+
+    await _list()
+        .transform(tarWriter)
+        .transform(gzip.encoder)
+        .pipe(tmpTar.openWrite());
+  }).whenComplete(() {
+    _log.info('Finished .tar.gz archive');
+  });
+
+  await Future.wait([
+    processingFuture,
+    archiveFuture,
+  ]);
+
   // Move from temporary output directory to final one, ensuring that
   // documentation files won't be present unless all files have been processed.
   // This helps if there is a timeout along the way.
   await Directory(tmpOutDir).rename(p.join(outputFolder, 'doc'));
-  _log.info('Finished post-processing');
-
-  _log.info('Creating .tar.gz archive');
-  Stream<TarEntry> _list() async* {
-    final originalDocDir = Directory(docDir);
-    final originalFiles = originalDocDir
-        .list(recursive: true, followLinks: false)
-        .whereType<File>();
-    await for (final file in originalFiles) {
-      if (cutoffTimestamp.isBefore(clock.now())) {
-        _log.warning(
-            'Cut-off timestamp reached during dartdoc archive building.');
-        break;
-      }
-      // inside the archive prefix the name with <package>/version/
-      final relativePath = p.relative(file.path, from: originalDocDir.path);
-      final tarEntryPath = p.join(package, version, relativePath);
-      final data = await file.readAsBytes();
-      yield TarEntry.data(
-        TarHeader(
-          name: tarEntryPath,
-          size: data.length,
-        ),
-        data,
-      );
-    }
-  }
-
-  final tmpTar = File(p.join(outputFolder, '_package.tar.gz'));
-  await _list()
-      .transform(tarWriter)
-      .transform(gzip.encoder)
-      .pipe(tmpTar.openWrite());
   await tmpTar.rename(p.join(outputFolder, 'doc', 'package.tar.gz'));
-
-  _log.info('Finished .tar.gz archive');
 }


### PR DESCRIPTION
- #7430
- decreased dartdoc timeout as even large packages can manage to get it done within 30 minutes
- dart post-processing may be skipped entirely based on the time spent in pana analysis
- processing of files and archive building is in separate isolates, running in parallel