### PR TITLE
Reenable syncing of security advisories

### DIFF
--- a/app/lib/tool/backfill/backfill_new_fields.dart
+++ b/app/lib/tool/backfill/backfill_new_fields.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:logging/logging.dart';
+import 'package:pub_dev/service/security_advisories/sync_security_advisories.dart';
 
 final _logger = Logger('backfill_new_fields');
 
@@ -12,5 +13,6 @@ final _logger = Logger('backfill_new_fields');
 /// CHANGELOG.md must be updated with the new fields, and the next
 /// release could remove the backfill from here.
 Future<void> backfillNewFields() async {
-  _logger.info('Nothing to do.');
+  _logger.info('Resyncing all security advisories...');
+  await syncSecurityAdvisories(resync: true);
 }


### PR DESCRIPTION
Leaving the syncing for another release to ensure fix of the bug with affected packages.