### PR TITLE
Use https://pub.dev/ in download URLs (version listing API) and probably other places.

### DIFF
--- a/app/config/dartlang-pub.yaml
+++ b/app/config/dartlang-pub.yaml
@@ -36,7 +36,7 @@ productionHosts:
 - pub.dartlang.org
 - pub.dev
 - api.pub.dev
-primaryApiUri: https://pub.dartlang.org/
+primaryApiUri: https://pub.dev/
 primarySiteUri: https://pub.dev/
 admins:
 - oauthUserId: '106306194842560376600'


### PR DESCRIPTION
Fixes #7561.