### PR TITLE
Updated analysis pending logic

### DIFF
--- a/app/lib/frontend/templates/package.dart
+++ b/app/lib/frontend/templates/package.dart
@@ -275,7 +275,7 @@ String _renderPkgPage({
   );
   final noIndex = pkgPageTab == urls.PkgPageTab.install ||
       pkgPageTab == urls.PkgPageTab.score ||
-      card.isSkipped ||
+      card.hasNoTaskStatus ||
       (card.grantedPubPoints == 0) ||
       data.package.isExcludedInRobots;
   return renderLayoutPage(

--- a/app/lib/frontend/templates/views/pkg/score_tab.dart
+++ b/app/lib/frontend/templates/views/pkg/score_tab.dart
@@ -26,7 +26,8 @@ d.Node scoreTabNode({
 
   final report = card.report;
   final showReport = report != null;
-  final showPending = report == null && (card.isPending || isLatestStable);
+  final showPending = !showReport &&
+      (card.isPending || (card.hasNoTaskStatus && isLatestStable));
   final showNoReport = !showReport && !showPending;
 
   final toolEnvInfo = showReport
@@ -73,19 +74,20 @@ d.Node scoreTabNode({
         ),
         _reportNode(report),
         if (toolEnvInfo != null) toolEnvInfo,
-        d.p(
-          classes: ['analysis-info'],
-          children: [
-            d.text('Check the '),
-            d.a(
-              href: urls.pkgScoreLogTxtUrl(package,
-                  version: isLatestStable ? null : version),
-              text: 'analysis log',
-            ),
-            d.text(' for details.'),
-          ],
-        ),
       ]),
+    if (!showPending)
+      d.p(
+        classes: ['analysis-info'],
+        children: [
+          d.text('Check the '),
+          d.a(
+            href: urls.pkgScoreLogTxtUrl(package,
+                version: isLatestStable ? null : version),
+            text: 'analysis log',
+          ),
+          d.text(' for details.'),
+        ],
+      ),
   ]);
 }
 

--- a/app/lib/scorecard/models.dart
+++ b/app/lib/scorecard/models.dart
@@ -57,8 +57,7 @@ class ScoreCardData {
   /// List of tags computed by `pana` or other analyzer.
   List<String>? get derivedTags => panaReport?.derivedTags;
 
-  bool get isSkipped => taskStatus == null;
-  // TODO: also consider finished status
+  bool get hasNoTaskStatus => taskStatus == null;
   bool get isPending => taskStatus == PackageVersionStatus.pending;
   bool get hasApiDocs => dartdocReport?.reportStatus == ReportStatus.success;
   bool get hasPanaReport => panaReport != null;


### PR DESCRIPTION
- Fixes #7563.
- `isSkipped` renamed to `hasNoTaskStatus` for better clarity.
- `showPending` is updated to also consider `hasNoTaskStatus` when checking for `isLatestStable`.
- The `log.txt` link is shown also when it has failed (or aborted).