### PR TITLE
Make it clear that listVersionsGzCachedBytes returns gzipped data

### DIFF
--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -775,8 +775,8 @@ class PackageBackend {
   /// Returns the known versions of [package] (via [listVersions]),
   /// getting it from cache if available.
   ///
-  /// The data is converted to JSON and UTF-8 (and stored like that in the cache).
-  Future<List<int>> listVersionsCachedBytes(String package) async {
+  /// This returns gzipped UTF-8 encoded JSON.
+  Future<List<int>> listVersionsGzCachedBytes(String package) async {
     final body = await cache.packageDataGz(package).get(() async {
       final data = await listVersions(package);
       final raw = jsonUtf8Encoder.convert(data.toJson());
@@ -790,7 +790,7 @@ class PackageBackend {
   ///
   ///  The available versions are sorted by their semantic version number (ascending).
   Future<api.PackageData> listVersionsCached(String package) async {
-    final data = await listVersionsCachedBytes(package);
+    final data = await listVersionsGzCachedBytes(package);
     return api.PackageData.fromJson(
         utf8JsonDecoder.convert(gzip.decode(data)) as Map<String, dynamic>);
   }


### PR DESCRIPTION
Cleanup, when I found that `listVersionsCachedBytes` return gzipped data I thought that might be an opportunity for the reader to be confused.

Adding `Gz` to the name and explaining it in the documentation comment might help a bit.
Also did a minor refactor to avoid nested functions when there is no need for it.