### PR TITLE
Cache control on api

### DIFF
--- a/app/lib/frontend/handlers/headers.dart
+++ b/app/lib/frontend/handlers/headers.dart
@@ -13,21 +13,36 @@ class CacheHeaders {
   /// The maximum age while a response may be cached.
   final Duration maxAge;
 
-  /// The cache storage category used for signed-in users.
-  /// `private` by default.
-  final String? signedInStorage;
+  /// Add the `private` directive, indicating that the response must not be
+  /// stored in public cache (such as a CDN).
+  ///
+  /// If neither [private] or [public] is specified, `Cache-Control` will
+  /// set `private` if the request was authenticated.
+  final bool private;
+
+  /// Add the `public` directive, indicating that the response may be
+  /// stored in public cache (such as a CDN).
+  ///
+  /// If neither [private] or [public] is specified, `Cache-Control` will
+  /// set `private` if the request was authenticated.
+  final bool public;
 
   CacheHeaders._(
     this.maxAge, {
-    this.signedInStorage,
-  });
+    bool private = false,
+    bool public = true,
+  })  : public = public,
+        private = private {
+    assert(!private && !public, 'both private and public is not allowed');
+  }
 
   Map<String, String> call() {
     return <String, String>{
       HttpHeaders.cacheControlHeader: <String>[
-        requestContext.isNotAuthenticated
-            ? 'public'
-            : (signedInStorage ?? 'private'),
+        if (private || (!public && requestContext.isNotAuthenticated))
+          'private'
+        else
+          'public',
         if (maxAge >= Duration.zero) 'max-age=${maxAge.inSeconds}',
       ].join(', '),
     };
@@ -39,25 +54,40 @@ class CacheHeaders {
   }
 
   /// Default private-only caching.
-  static final private = CacheHeaders._(Duration.zero);
+  static final defaultPrivate = CacheHeaders._(Duration.zero, private: true);
 
   /// Everything under the /documentation/ endpoint.
   static final dartdocAsset = CacheHeaders._(Duration(minutes: 15));
 
+  /// Version listing API used by `dart pub` client
+  static final versionListingApi = CacheHeaders._(
+    Duration(minutes: 10),
+    public: true,
+  );
+
   /// The package name completion API endpoint serves the cached names
   /// of top packages.
-  static final packageNameCompletion = CacheHeaders._(Duration(hours: 8));
+  static final packageNameCompletion = CacheHeaders._(
+    Duration(hours: 8),
+    public: true,
+  );
 
   /// The package names API endpoint serves the cached names of all packages.
-  static final packageNames = CacheHeaders._(Duration(hours: 2));
+  static final packageNames = CacheHeaders._(
+    Duration(hours: 2),
+    public: true,
+  );
 
   /// The topic name completion API endpoint serves the cached topic names of
   /// all topics.
-  static final topicNameCompletion = CacheHeaders._(Duration(hours: 8));
+  static final topicNameCompletion = CacheHeaders._(
+    Duration(hours: 8),
+    public: true,
+  );
 
   /// Everything under the /static/ endpoint.
   static final staticAsset = CacheHeaders._(
     Duration(days: 7),
-    signedInStorage: 'public',
+    public: true,
   );
 }

--- a/app/lib/frontend/handlers/headers.dart
+++ b/app/lib/frontend/handlers/headers.dart
@@ -30,19 +30,23 @@ class CacheHeaders {
   CacheHeaders._(
     this.maxAge, {
     bool private = false,
-    bool public = true,
+    bool public = false,
   })  : public = public,
         private = private {
-    assert(!private && !public, 'both private and public is not allowed');
+    assert(!private || !public, 'both private and public is not allowed');
   }
 
   Map<String, String> call() {
     return <String, String>{
       HttpHeaders.cacheControlHeader: <String>[
-        if (private || (!public && requestContext.isNotAuthenticated))
+        if (private)
           'private'
+        else if (public)
+          'public'
+        else if (requestContext.isNotAuthenticated)
+          'public'
         else
-          'public',
+          'private',
         if (maxAge >= Duration.zero) 'max-age=${maxAge.inSeconds}',
       ].join(', '),
     };

--- a/app/lib/frontend/handlers/package.dart
+++ b/app/lib/frontend/handlers/package.dart
@@ -10,6 +10,7 @@ import 'package:_pub_shared/data/advisories_api.dart'
 import 'package:_pub_shared/utils/dart_sdk_version.dart';
 import 'package:meta/meta.dart';
 import 'package:neat_cache/neat_cache.dart';
+import 'package:pub_dev/frontend/handlers/headers.dart';
 import 'package:pub_dev/service/security_advisories/backend.dart';
 import 'package:pub_dev/shared/versions.dart';
 import 'package:pub_dev/task/backend.dart';
@@ -494,6 +495,7 @@ Future<shelf.Response> listVersionsHandler(
       if (supportsGzip) 'content-encoding': 'gzip',
       'content-type': 'application/json; charset="utf-8"',
       'x-content-type-options': 'nosniff',
+      ...CacheHeaders.versionListingApi(),
     },
   );
 }

--- a/app/lib/frontend/handlers/pubapi.dart
+++ b/app/lib/frontend/handlers/pubapi.dart
@@ -126,9 +126,13 @@ class PubApi {
       Request request, String uploadId) async {
     final pv = await packageBackend.publishUploadedBlob(uploadId);
     return SuccessMessage(
-        success: Message(
-            message:
-                'Successfully uploaded ${urls.pkgPageUrl(pv.package, includeHost: true)} version ${pv.version}.'));
+      success: Message(
+        message: 'Successfully uploaded '
+            '${urls.pkgPageUrl(pv.package, includeHost: true)} '
+            'version ${pv.version}, '
+            'it may take up-to 10 minutes before the new version is available.',
+      ),
+    );
   }
 
   /// Adding a new uploader

--- a/app/lib/shared/handler_helpers.dart
+++ b/app/lib/shared/handler_helpers.dart
@@ -136,7 +136,7 @@ shelf.Handler _requestContextWrapper(shelf.Handler handler) {
     if (!context.uiCacheEnabled && !CacheHeaders.hasCacheHeader(rs.headers)) {
       // Indicates that the response is intended for a single user and must not
       // be stored by a shared cache. A private cache may store the response.
-      rs = rs.change(headers: CacheHeaders.private());
+      rs = rs.change(headers: CacheHeaders.defaultPrivate());
     }
     return rs;
   };

--- a/app/lib/task/handlers.dart
+++ b/app/lib/task/handlers.dart
@@ -3,6 +3,7 @@ import 'dart:io' show gzip;
 
 import 'package:pub_dev/dartdoc/dartdoc_page.dart';
 import 'package:pub_dev/dartdoc/models.dart';
+import 'package:pub_dev/frontend/handlers/headers.dart';
 import 'package:pub_dev/package/backend.dart';
 import 'package:pub_dev/shared/exceptions.dart';
 import 'package:pub_dev/shared/handlers.dart';
@@ -138,7 +139,9 @@ Future<shelf.Response> handleDartDoc(
     acceptsGzip ? dataGz : gzip.decode(dataGz),
     headers: {
       'Content-Type': mime,
+      'Vary': 'Accept-Encoding', // body depends on accept-encoding!
       if (acceptsGzip) 'Content-Encoding': 'gzip',
+      ...CacheHeaders.dartdocAsset(),
     },
   );
 }

--- a/app/test/frontend/static_files_test.dart
+++ b/app/test/frontend/static_files_test.dart
@@ -223,7 +223,7 @@ void main() {
       expect(rs.statusCode, 200);
       expect(await rs.readAsString(), contains('<svg'));
       final cache = rs.headers['cache-control'];
-      expect(cache, 'public, max-age=0'); // resets public cache
+      expect(cache, contains('max-age=0')); // no caching
     });
 
     testWithProfile('good path hash', fn: () async {

--- a/app/test/package/upload_test.dart
+++ b/app/test/package/upload_test.dart
@@ -364,8 +364,7 @@ void main() {
         final bytes = await packageArchiveBytes(pubspecContent: pubspecContent);
         final rs = await createPubApiClient(authToken: token)
             .uploadPackageBytes(bytes);
-        expect(rs.success.message,
-            'Successfully uploaded https://pub.dev/packages/oxygen version 2.2.0.');
+        expect(rs.success.message, contains('Successfully uploaded'));
 
         final pkg = await packageBackend.lookupPackage('oxygen');
         expect(pkg!.automatedPublishing!.gcpLock!.toJson(), {
@@ -608,8 +607,7 @@ void main() {
         final bytes = await packageArchiveBytes(pubspecContent: pubspecContent);
         final rs = await createPubApiClient(authToken: token)
             .uploadPackageBytes(bytes);
-        expect(rs.success.message,
-            'Successfully uploaded https://pub.dev/packages/oxygen version 2.2.0.');
+        expect(rs.success.message, contains('Successfully uploaded'));
       });
 
       testWithProfile(
@@ -646,8 +644,7 @@ void main() {
         final bytes = await packageArchiveBytes(pubspecContent: pubspecContent);
         final rs = await createPubApiClient(authToken: token)
             .uploadPackageBytes(bytes);
-        expect(rs.success.message,
-            'Successfully uploaded https://pub.dev/packages/_dummy_pkg version 2.2.0.');
+        expect(rs.success.message, contains('Successfully uploaded'));
 
         final pkg = await packageBackend.lookupPackage('_dummy_pkg');
         expect(pkg!.automatedPublishing!.githubLock!.toJson(), {
@@ -798,8 +795,7 @@ void main() {
         final bytes = await packageArchiveBytes(pubspecContent: pubspecContent);
         final rs = await createPubApiClient(authToken: token)
             .uploadPackageBytes(bytes);
-        expect(rs.success.message,
-            'Successfully uploaded https://pub.dev/packages/oxygen version 2.2.0.');
+        expect(rs.success.message, contains('Successfully uploaded'));
       });
     });
 

--- a/pkg/pub_integration/lib/script/publishing.dart
+++ b/pkg/pub_integration/lib/script/publishing.dart
@@ -72,7 +72,7 @@ class PublishingScript {
       await dart.getDependencies(_dummyDir.path);
       await dart.publish(_dummyDir.path,
           expectedOutputContains:
-              'Successfully uploaded https://pub.dev/packages/_dummy_pkg version $_newDummyVersion.');
+              'Successfully uploaded https://pub.dev/packages/_dummy_pkg version $_newDummyVersion');
       await Future.delayed(Duration(seconds: 1));
       await _verifyDummyPkg();
 


### PR DESCRIPTION
We should probably add more cache-control on other API end-points that are frequently scanned by bots. Or just in general on everything that can reasonably be cached.