### PR TITLE
Rate limit check done at the time of creating the record (except for package publishing).

### DIFF
--- a/app/lib/account/consent_backend.dart
+++ b/app/lib/account/consent_backend.dart
@@ -159,7 +159,7 @@ class ConsentBackend {
       email: uploaderEmail,
       kind: ConsentKind.packageUploader,
       args: [packageName],
-      auditLogRecord: AuditLogRecord.uploaderInvited(
+      auditLogRecord: await AuditLogRecord.uploaderInvited(
         agent: agent,
         package: packageName,
         uploaderEmail: uploaderEmail,
@@ -180,7 +180,7 @@ class ConsentBackend {
       email: contactEmail,
       kind: ConsentKind.publisherContact,
       args: [publisherId, contactEmail],
-      auditLogRecord: AuditLogRecord.publisherContactInvited(
+      auditLogRecord: await AuditLogRecord.publisherContactInvited(
           user: user, publisherId: publisherId, contactEmail: contactEmail),
       createdBySiteAdmin: false,
     );
@@ -199,7 +199,7 @@ class ConsentBackend {
       email: invitedUserEmail,
       kind: ConsentKind.publisherMember,
       args: [publisherId],
-      auditLogRecord: AuditLogRecord.publisherMemberInvited(
+      auditLogRecord: await AuditLogRecord.publisherMemberInvited(
         agent: authenticatedAgent,
         publisherId: publisherId,
         memberEmail: invitedUserEmail,
@@ -345,26 +345,26 @@ class _PackageUploaderAction extends ConsentAction {
   @override
   Future<void> onReject(Consent consent, User? user) async {
     final packageName = consent.args![0];
-    await dbService.commit(inserts: [
-      AuditLogRecord.uploaderInviteRejected(
+    await withRetryTransaction(dbService, (tx) async {
+      tx.insert(await AuditLogRecord.uploaderInviteRejected(
         fromUserId: consent.fromUserId!,
         package: packageName,
         uploaderEmail: user?.email ?? consent.email!,
         userId: user?.userId,
-      ),
-    ]);
+      ));
+    });
   }
 
   @override
   Future<void> onExpire(Consent consent) async {
     final packageName = consent.args![0];
-    await dbService.commit(inserts: [
-      AuditLogRecord.uploaderInviteExpired(
+    await withRetryTransaction(dbService, (tx) async {
+      tx.insert(await AuditLogRecord.uploaderInviteExpired(
         fromUserId: consent.fromUserId!,
         package: packageName,
         uploaderEmail: consent.email!,
-      ),
-    ]);
+      ));
+    });
   }
 
   @override
@@ -411,27 +411,27 @@ class _PublisherContactAction extends ConsentAction {
   @override
   Future<void> onReject(Consent consent, User? user) async {
     final publisherId = consent.args![0];
-    await dbService.commit(inserts: [
-      AuditLogRecord.publisherContactInviteRejected(
+    await withRetryTransaction(dbService, (tx) async {
+      tx.insert(await AuditLogRecord.publisherContactInviteRejected(
         fromUserId: consent.fromUserId!,
         publisherId: publisherId,
         contactEmail: consent.email!,
         userEmail: user?.email,
         userId: user?.userId,
-      ),
-    ]);
+      ));
+    });
   }
 
   @override
   Future<void> onExpire(Consent consent) async {
     final publisherId = consent.args![0];
-    await dbService.commit(inserts: [
-      AuditLogRecord.publisherContactInviteExpired(
+    await withRetryTransaction(dbService, (tx) async {
+      tx.insert(await AuditLogRecord.publisherContactInviteExpired(
         fromUserId: consent.fromUserId!,
         publisherId: publisherId,
         contactEmail: consent.email!,
-      ),
-    ]);
+      ));
+    });
   }
 
   @override
@@ -491,26 +491,26 @@ class _PublisherMemberAction extends ConsentAction {
   @override
   Future<void> onReject(Consent consent, User? user) async {
     final publisherId = consent.args![0];
-    await dbService.commit(inserts: [
-      AuditLogRecord.publisherMemberInviteRejected(
+    await withRetryTransaction(dbService, (tx) async {
+      tx.insert(await AuditLogRecord.publisherMemberInviteRejected(
         fromUserId: consent.fromUserId!,
         publisherId: publisherId,
         memberEmail: user?.email ?? consent.email!,
         userId: user?.userId,
-      ),
-    ]);
+      ));
+    });
   }
 
   @override
   Future<void> onExpire(Consent consent) async {
     final publisherId = consent.args![0];
-    await dbService.commit(inserts: [
-      AuditLogRecord.publisherMemberInviteExpired(
+    await withRetryTransaction(dbService, (tx) async {
+      tx.insert(await AuditLogRecord.publisherMemberInviteExpired(
         fromUserId: consent.fromUserId!,
         publisherId: publisherId,
         memberEmail: consent.email!,
-      ),
-    ]);
+      ));
+    });
   }
 
   @override

--- a/app/lib/admin/actions/create_publisher.dart
+++ b/app/lib/admin/actions/create_publisher.dart
@@ -77,7 +77,7 @@ This should generally only be done with PM approval as it skips actual domain ve
             ..created = now
             ..updated = now
             ..role = PublisherMemberRole.admin,
-          AuditLogRecord.publisherCreated(
+          await AuditLogRecord.publisherCreated(
             user: user,
             publisherId: publisherId,
           ),

--- a/app/lib/admin/actions/remove_package_from_publisher.dart
+++ b/app/lib/admin/actions/remove_package_from_publisher.dart
@@ -53,7 +53,7 @@ If the publisher has no members, the package will end up without uploaders.
         pkg.updated = clock.now().toUtc();
         tx.insert(pkg);
         tx.insert(
-          AuditLogRecord.packageRemovedFromPublisher(
+          await AuditLogRecord.packageRemovedFromPublisher(
             package: packageName,
             fromPublisherId: currentPublisherId,
           ),

--- a/app/lib/admin/backend.dart
+++ b/app/lib/admin/backend.dart
@@ -648,7 +648,7 @@ class AdminBackend {
         final r = p.uploaders!.remove(uploaderUser.userId);
         if (r) {
           removed = true;
-          tx.insert(AuditLogRecord.uploaderRemoved(
+          tx.insert(await AuditLogRecord.uploaderRemoved(
             agent: authenticatedUser,
             package: packageName,
             uploaderUser: uploaderUser,
@@ -658,7 +658,7 @@ class AdminBackend {
       if (removed) {
         if (p.uploaders!.isEmpty) {
           p.isDiscontinued = true;
-          tx.insert(AuditLogRecord.packageOptionsUpdated(
+          tx.insert(await AuditLogRecord.packageOptionsUpdated(
             agent: authenticatedUser,
             package: packageName,
             publisherId: p.publisherId,

--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -437,7 +437,7 @@ class PackageBackend {
           'isDiscontinued: ${p.isDiscontinued} '
           'isUnlisted: ${p.isUnlisted}');
       tx.insert(p);
-      tx.insert(AuditLogRecord.packageOptionsUpdated(
+      tx.insert(await AuditLogRecord.packageOptionsUpdated(
         agent: authenticatedUser,
         package: p.name!,
         publisherId: p.publisherId,
@@ -587,7 +587,7 @@ class PackageBackend {
 
       p.updated = clock.now().toUtc();
       tx.insert(p);
-      tx.insert(AuditLogRecord.packagePublicationAutomationUpdated(
+      tx.insert(await AuditLogRecord.packagePublicationAutomationUpdated(
         package: p.name!,
         publisherId: p.publisherId,
         user: user,
@@ -633,7 +633,7 @@ class PackageBackend {
 
     tx.insert(p);
     tx.insert(pv);
-    tx.insert(AuditLogRecord.packageVersionOptionsUpdated(
+    tx.insert(await AuditLogRecord.packageVersionOptionsUpdated(
       agent: agent,
       package: p.name!,
       version: pv.version!,
@@ -725,7 +725,7 @@ class PackageBackend {
       package.updated = clock.now().toUtc();
 
       tx.insert(package);
-      tx.insert(AuditLogRecord.packageTransferred(
+      tx.insert(await AuditLogRecord.packageTransferred(
         user: user,
         package: package.name!,
         fromPublisherId: currentPublisherId,
@@ -1486,7 +1486,7 @@ class PackageBackend {
       package.updated = clock.now().toUtc();
 
       tx.insert(package);
-      tx.insert(AuditLogRecord.uploaderInviteAccepted(
+      tx.insert(await AuditLogRecord.uploaderInviteAccepted(
         user: uploader,
         package: packageName,
       ));
@@ -1561,7 +1561,7 @@ class PackageBackend {
       package.updated = clock.now().toUtc();
 
       tx.insert(package);
-      tx.insert(AuditLogRecord.uploaderRemoved(
+      tx.insert(await AuditLogRecord.uploaderRemoved(
         agent: authenticatedUser,
         package: packageName,
         uploaderUser: uploader,

--- a/app/lib/publisher/backend.dart
+++ b/app/lib/publisher/backend.dart
@@ -222,7 +222,7 @@ class PublisherBackend {
           ..created = now
           ..updated = now
           ..role = PublisherMemberRole.admin,
-        AuditLogRecord.publisherCreated(
+        await AuditLogRecord.publisherCreated(
           user: user,
           publisherId: publisherId,
         ),
@@ -330,7 +330,7 @@ class PublisherBackend {
       p.updated = clock.now().toUtc();
 
       tx.insert(p);
-      tx.insert(AuditLogRecord.publisherUpdated(
+      tx.insert(await AuditLogRecord.publisherUpdated(
         user: user,
         publisherId: publisherId,
       ));
@@ -363,7 +363,7 @@ class PublisherBackend {
       p.contactEmail = contactEmail;
       p.updated = clock.now().toUtc();
       tx.insert(p);
-      tx.insert(AuditLogRecord.publisherContactInviteAccepted(
+      tx.insert(await AuditLogRecord.publisherContactInviteAccepted(
         user: user,
         publisherId: publisherId,
         contactEmail: contactEmail,
@@ -518,7 +518,7 @@ class PublisherBackend {
     final pm = await _db.lookupOrNull<PublisherMember>(key);
     if (pm != null) {
       final memberUser = await accountBackend.lookupUserById(userId);
-      final auditLogRecord = AuditLogRecord.publisherMemberRemoved(
+      final auditLogRecord = await AuditLogRecord.publisherMemberRemoved(
         publisherId: publisherId,
         activeUser: user,
         memberToRemove: memberUser!,
@@ -557,7 +557,7 @@ class PublisherBackend {
           ..created = now
           ..updated = now
           ..role = PublisherMemberRole.admin,
-        AuditLogRecord.publisherMemberInviteAccepted(
+        await AuditLogRecord.publisherMemberInviteAccepted(
           user: user!,
           publisherId: publisherId,
         ),


### PR DESCRIPTION
Reverts most of the changes in #7570.