### PR TITLE
reserve the _macros package name

### DIFF
--- a/app/lib/package/overrides.dart
+++ b/app/lib/package/overrides.dart
@@ -7,6 +7,7 @@ import 'package:pub_package_reader/pub_package_reader.dart'
 
 /// Package names that are reserved for the Dart or Flutter team.
 final _reservedPackageNames = <String>[
+  '_macros',
   'brick',
   'core',
   'dart',


### PR DESCRIPTION
The hope is this would resolve https://github.com/dart-lang/pub-dev/issues/7596 - but I am not sure how to confirm. It could make the problem worse (if the original error is still there but this is now an additional blocker to publishing `_macros`)