### PR TITLE
Allow sdk packages

### DIFF
--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -25,6 +25,7 @@ import 'package:pub_dev/shared/versions.dart';
 import 'package:pub_dev/task/backend.dart';
 import 'package:pub_package_reader/pub_package_reader.dart';
 import 'package:pub_semver/pub_semver.dart';
+import 'package:pubspec_parse/pubspec_parse.dart' as pubspec_parse;
 
 import '../account/agent.dart';
 import '../account/backend.dart';
@@ -938,10 +939,17 @@ class PackageBackend {
       }
 
       // check existences of referenced packages
-      final dependencies = <String>{
-        ...pubspec.dependencies.keys,
-      };
-      for (final name in dependencies) {
+      for (final MapEntry(key: name, :value) in pubspec.dependencies.entries) {
+        if (value is! pubspec_parse.HostedDependency) {
+          // We disallow git/path dependencies elsewhere, but for the purpose
+          // of checking of the dependency exists we can skip them.
+          continue;
+        }
+        if (value.hosted?.url != null) {
+          // we disallow hosted dependencies with a URL elsewhere, but for the
+          // purpose of checking if the dependency exists, we skip them.
+          continue;
+        }
         if (isSoftRemoved(name)) {
           continue;
         }

--- a/app/test/package/upload_test.dart
+++ b/app/test/package/upload_test.dart
@@ -1049,6 +1049,32 @@ void main() {
         );
       });
 
+      testWithProfile('has dependency does not exist', fn: () async {
+        final tarball = await packageArchiveBytes(
+            pubspecContent:
+                generatePubspecYaml('xyz', '1.0.0') + '  abc: ^1.0.0\n');
+        final rs = createPubApiClient(authToken: adminClientToken)
+            .uploadPackageBytes(tarball);
+        await expectApiException(
+          rs,
+          status: 400,
+          code: 'PackageRejected',
+          message: 'Dependency `abc` does not exist.',
+        );
+      });
+
+      testWithProfile('has SDK-dependency', fn: () async {
+        final tarball = await packageArchiveBytes(
+            pubspecContent: generatePubspecYaml('xyz', '1.2.3') +
+                '  my_sdk_dep:\n'
+                    '    sdk: dart\n');
+        final message = await createPubApiClient(authToken: adminClientToken)
+            .uploadPackageBytes(tarball);
+        expect(message.success.message, contains('Successfully uploaded'));
+        expect(message.success.message, contains('xyz'));
+        expect(message.success.message, contains('1.2.3'));
+      });
+
       testWithProfile('has git dependency', fn: () async {
         final tarball = await packageArchiveBytes(
             pubspecContent: generatePubspecYaml('xyz', '1.0.0') +


### PR DESCRIPTION
Fixing the issue where packages with SDK-dependencies can't be published.

CC @jakemac53 (I believe we'll have a workaround for `_macros` out today'ish; this will ship thursday or next week)

--------

Noticed some slow tests and ended up filing:
https://github.com/dart-lang/pub-dev/issues/7608