### PR TITLE
Fix retrieving secrets with `secret` action

### DIFF
--- a/app/lib/admin/actions/actions.dart
+++ b/app/lib/admin/actions/actions.dart
@@ -46,7 +46,7 @@ final class AdminAction {
   /// [ResponseException].
   /// Any other exception will be considered an internal error.
   final Future<Map<String, Object?>> Function(
-    Map<String, String> arguments,
+    Map<String, String?> arguments,
   ) invoke;
 
   AdminAction({

--- a/app/lib/admin/actions/merge_moderated_package_into_existing.dart
+++ b/app/lib/admin/actions/merge_moderated_package_into_existing.dart
@@ -30,7 +30,8 @@ Fails if that package has no existing Package entity.
         'The name of ModeratedPackage to merge into its existing Package.',
   },
   invoke: (args) async {
-    final packageName = args['package'] as String;
+    final packageName = args['package'] ??
+        (throw InvalidInputException('Missing --package argument.'));
 
     await withRetryTransaction(dbService, (tx) async {
       // check ModeratedPackage existence

--- a/app/lib/admin/actions/publisher_block.dart
+++ b/app/lib/admin/actions/publisher_block.dart
@@ -18,7 +18,8 @@ Get information about publisher and list all members.
     'publisher': 'Publisher to be blocked',
   },
   invoke: (options) async {
-    final publisherId = options['publisher']!;
+    final publisherId = options['publisher'] ??
+        (throw InvalidInputException('Missing --publisher argument.'));
     InvalidInputException.check(
       publisherId.isNotEmpty,
       'publisher must be given',

--- a/app/lib/admin/actions/publisher_members_list.dart
+++ b/app/lib/admin/actions/publisher_members_list.dart
@@ -15,11 +15,8 @@ Get information about a publisher and list all its members.
     'publisher': 'Publisher for which to list members, eg `dart.dev`',
   },
   invoke: (options) async {
-    final publisherId = options['publisher']!;
-    InvalidInputException.check(
-      publisherId.isNotEmpty,
-      'publisher must be given',
-    );
+    final publisherId = options['publisher'] ??
+        (throw InvalidInputException('Missing --publisher argument.'));
 
     final publisher = await publisherBackend.getPublisher(publisherId);
     if (publisher == null) {

--- a/app/lib/admin/actions/secret.dart
+++ b/app/lib/admin/actions/secret.dart
@@ -12,9 +12,7 @@ final setSecret = AdminAction(
 Get, set or remove a "secret" admin value affecting the site.
 
 If a `--value` is given, the secret will be set to that value. An empty value
-will clear the secret.
-
-To just inspect a secret, use the `get-secret` action.
+will set the secret to empty string, effectively clearing it.
 
 Possible secrets are [${SecretKey.values}] or prefixed ${SecretKey.oauthPrefix}.
 
@@ -49,15 +47,22 @@ Valid values for `upload-restriction` are:
       ' ${SecretKey.oauthPrefix}.',
     );
 
-    final value = options['value']!;
+    final value = options['value'];
 
     final currentValue = await secretBackend.lookup(secretId);
 
-    await secretBackend.update(secretId, value);
-    return {
-      'message': 'Value updated.',
-      'previousValue': currentValue,
-      'newValue': value
-    };
+    if (value != null) {
+      await secretBackend.update(secretId, value);
+      return {
+        'message': 'Value updated.',
+        'previousValue': currentValue,
+        'newValue': value
+      };
+    } else {
+      return {
+        'message': 'Value retrieved.',
+        'value': currentValue,
+      };
+    }
   },
 );

--- a/app/lib/admin/actions/tool_execute.dart
+++ b/app/lib/admin/actions/tool_execute.dart
@@ -17,8 +17,11 @@ possible to call them with arguments that contain comma.
     'args': 'comma separated list of arguments',
   },
   invoke: (options) async {
-    final toolName = options['toolName']!;
-    final args = options['args']!.split(',');
+    final toolName = options['tool'] ??
+        (throw InvalidInputException('Missing --tool argument'));
+    final argsOption = options['args'] ??
+        (throw InvalidInputException('Missing --args argument'));
+    final args = argsOption.split(',');
     InvalidInputException.check(toolName.isNotEmpty, 'tool must given');
 
     final tool = availableTools[toolName];

--- a/app/lib/admin/backend.dart
+++ b/app/lib/admin/backend.dart
@@ -707,7 +707,7 @@ class AdminBackend {
     );
 
     final result = await action.invoke({
-      for (final k in action.options.keys) k: args[k] ?? '',
+      for (final k in action.options.keys) k: args[k],
     });
 
     return api.AdminInvokeActionResponse(output: result);

--- a/app/test/admin/api_actions_test.dart
+++ b/app/test/admin/api_actions_test.dart
@@ -155,4 +155,28 @@ void main() {
         .uploadPackageBytes(bytes);
     expect(rs2.success.message, contains('Successfully uploaded'));
   });
+
+  testWithProfile('setting and viewing secrets', fn: () async {
+    // verify that new upload is blocked
+    // merge tombstone
+    final api = createPubApiClient(authToken: siteAdminToken);
+    final result = await api.adminInvokeAction(
+      'secret',
+      AdminInvokeActionArguments(
+          arguments: {'id': 'upload-restriction', 'value': 'no-uploads'}),
+    );
+    expect(result.output, {
+      'message': 'Value updated.',
+      'previousValue': anything,
+      'newValue': 'no-uploads',
+    });
+    final result2 = await api.adminInvokeAction(
+      'secret',
+      AdminInvokeActionArguments(arguments: {'id': 'upload-restriction'}),
+    );
+    expect(result2.output, {
+      'message': 'Value retrieved.',
+      'value': 'no-uploads',
+    });
+  });
 }


### PR DESCRIPTION
Allows options to `actions` to be `null`.

Now passing `null` as the value to the `secret` action will retrieve the secret.
Passing a value will set it

Also fixes the `tool-execute` action. It was looking up an option with the wrong key.

