### PR TITLE
Remove redis2.connectionString

### DIFF
--- a/app/lib/service/secret/models.dart
+++ b/app/lib/service/secret/models.dart
@@ -15,7 +15,6 @@ class Secret extends db.Model {
 /// Identifiers of the [Secret] keys.
 abstract class SecretKey {
   static const String redisConnectionString = 'redis.connectionString';
-  static const String redis2ConnectionString = 'redis2.connectionString';
 
   /// OAuth audiences have separate secrets for each audience.
   static const String oauthPrefix = 'oauth.secret-';
@@ -39,7 +38,6 @@ abstract class SecretKey {
   /// List of all keys.
   static const values = [
     redisConnectionString,
-    redis2ConnectionString,
     announcement,
     uploadRestriction,
     youtubeApiKey,


### PR DESCRIPTION
We already finished the migration and never used this property.