### PR TITLE
Store pending ModerationCase before sending email on the report page.

### DIFF
--- a/app/lib/admin/models.dart
+++ b/app/lib/admin/models.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:clock/clock.dart';
-import 'package:pub_dev/shared/utils.dart';
 
 import '../shared/datastore.dart' as db;
 
@@ -77,13 +76,26 @@ class ModerationCase extends db.ExpandoModel<String> {
   ModerationCase();
 
   ModerationCase.init({
+    required String caseId,
     required this.reporterUserId,
     required this.reporterEmail,
     required this.detectedBy,
     required this.kind,
     required this.status,
   }) {
-    id = createUuid();
+    id = caseId;
     opened = clock.now().toUtc();
   }
+}
+
+abstract class ModerationDetectedBy {
+  static const externalNotification = 'external-notification';
+}
+
+abstract class ModerationKind {
+  static const notification = 'notification';
+}
+
+abstract class ModerationStatus {
+  static const pending = 'pending';
 }


### PR DESCRIPTION
- #7535
- As the receipt of a report is complete only if we are able to successfully send an email to the reporter, and we want to have immediate feedback upon request, we will have some kind of ambiguity here. The PR chooses that some loose `ModerationCase` entities may be in the Datastore that we may not send emails for, and thus we don't start investigations. However, in such cases the reporter won't get any positive acknowledgement of the report, and they may (and should) retry it later.
- The loose `ModerationCase` entities must be reconciled manually. We could delete them if the mail sending fails, but better to fail safely and let it be a manual review of such entries.