### PR TITLE
Do not try to use unconfigured search endpoint in local tests.

### DIFF
--- a/app/lib/search/search_client.dart
+++ b/app/lib/search/search_client.dart
@@ -61,6 +61,12 @@ class SearchClient {
     // returns null on timeout (after 5 seconds)
     Future<http.Response?> doCallHttpServiceEndpoint({String? prefix}) async {
       final httpHostPort = prefix ?? activeConfiguration.searchServicePrefix;
+      if (httpHostPort == null) {
+        // Skip calling the HTTP endpoint if no value was configured.
+        // Must happen only in local tests.
+        assert(activeConfiguration.isNotProduction);
+        return null;
+      }
       final serviceUrl = '$httpHostPort/search$serviceUrlParams';
       try {
         return await _httpClient

--- a/app/lib/shared/configuration.dart
+++ b/app/lib/shared/configuration.dart
@@ -89,7 +89,7 @@ class Configuration {
   final String projectId;
 
   /// The scheme://host:port prefix for the search service.
-  final String searchServicePrefix;
+  final String? searchServicePrefix;
 
   /// The scheme://host:port prefix for the search service.
   final String? fallbackSearchServicePrefix;
@@ -384,7 +384,7 @@ class Configuration {
       taskWorkerNetwork: '-',
       cosImage: 'projects/cos-cloud/global/images/family/cos-stable',
       taskWorkerServiceAccount: '-',
-      searchServicePrefix: 'http://localhost:0',
+      searchServicePrefix: null,
       fallbackSearchServicePrefix: null,
       storageBaseUrl: storageBaseUrl ?? 'http://localhost:0',
       pubClientAudience: _fakeClientAudience,

--- a/app/lib/shared/configuration.g.dart
+++ b/app/lib/shared/configuration.g.dart
@@ -84,7 +84,7 @@ Configuration _$ConfigurationFromJson(Map json) => $checkedCreate(
           taskWorkerServiceAccount:
               $checkedConvert('taskWorkerServiceAccount', (v) => v as String?),
           searchServicePrefix:
-              $checkedConvert('searchServicePrefix', (v) => v as String),
+              $checkedConvert('searchServicePrefix', (v) => v as String?),
           fallbackSearchServicePrefix: $checkedConvert(
               'fallbackSearchServicePrefix', (v) => v as String?),
           storageBaseUrl:


### PR DESCRIPTION
- Fixes #7608.
- The attempt to connect to `http://localhost:0` timed out after ~2-2.5 seconds, making most of the test cases run longer than needed.