### PR TITLE
Run search service behind HTTP server for tests.

### DIFF
--- a/app/lib/fake/backend/fake_auth_provider.dart
+++ b/app/lib/fake/backend/fake_auth_provider.dart
@@ -353,7 +353,7 @@ Future<String> _acquireFakeSessionId({
         path: '/sign-in',
         queryParameters: {
           'fake-email': email,
-          'go': '/',
+          'go': '/help',
           if (scopes != null) 'scope': scopes.join(' '),
         },
       ),

--- a/app/lib/shared/configuration.dart
+++ b/app/lib/shared/configuration.dart
@@ -364,6 +364,7 @@ class Configuration {
     String? storageBaseUrl,
     Uri? primaryApiUri,
     Uri? primarySiteUri,
+    String? searchServicePrefix,
   }) {
     return Configuration(
       canonicalPackagesBucketName: 'fake-canonical-packages',
@@ -384,7 +385,7 @@ class Configuration {
       taskWorkerNetwork: '-',
       cosImage: 'projects/cos-cloud/global/images/family/cos-stable',
       taskWorkerServiceAccount: '-',
-      searchServicePrefix: 'http://localhost:0',
+      searchServicePrefix: searchServicePrefix ?? 'http://localhost:0',
       fallbackSearchServicePrefix: null,
       storageBaseUrl: storageBaseUrl ?? 'http://localhost:0',
       pubClientAudience: _fakeClientAudience,

--- a/app/test/frontend/handlers/landing_test.dart
+++ b/app/test/frontend/handlers/landing_test.dart
@@ -2,9 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:http/testing.dart';
 import 'package:pub_dev/frontend/static_files.dart';
-import 'package:pub_dev/search/search_client.dart';
 import 'package:pub_dev/search/top_packages.dart';
 import 'package:test/test.dart';
 
@@ -49,23 +47,6 @@ void main() {
           '/packages/http',
           '/packages/event_bus',
           'lightweight library for parsing',
-        ],
-      );
-    });
-
-    testWithProfile('/ without a working search service', fn: () async {
-      registerSearchClient(
-          SearchClient(MockClient((_) async => throw Exception())));
-      final rs = await issueGet('/');
-      await expectHtmlResponse(
-        rs,
-        present: [
-          'The official package repository for',
-        ],
-        absent: [
-          '/packages/neon',
-          '/packages/oxygen',
-          'Awesome package',
         ],
       );
     });

--- a/app/test/shared/test_services.dart
+++ b/app/test/shared/test_services.dart
@@ -19,9 +19,11 @@ import 'package:pub_dev/frontend/static_files.dart';
 import 'package:pub_dev/package/name_tracker.dart';
 import 'package:pub_dev/search/handlers.dart';
 import 'package:pub_dev/search/search_client.dart';
+import 'package:pub_dev/search/top_packages.dart';
 import 'package:pub_dev/search/updater.dart';
 import 'package:pub_dev/service/async_queue/async_queue.dart';
 import 'package:pub_dev/service/services.dart';
+import 'package:pub_dev/service/youtube/backend.dart';
 import 'package:pub_dev/shared/configuration.dart';
 import 'package:pub_dev/shared/integrity.dart';
 import 'package:pub_dev/shared/logging.dart';
@@ -109,6 +111,8 @@ class FakeAppengineEnv {
           await nameTracker.reloadFromDatastore();
           await generateFakePopularityValues();
           await indexUpdater.updateAllPackages();
+          await topPackages.start();
+          await youtubeBackend.start();
           await asyncQueue.ongoingProcessing;
           fakeEmailSender.sentMessages.clear();
 


### PR DESCRIPTION
- Fixes #7608.
- Cuts down waiting for search latencies (2+ seconds in each test case).
- Needed to change the fake sign-in redirect to `/help`, as otherwise it would have populated the caches for the landing page, breaking the landing page tests.
- Removed the test using mock search service, as it doesn't add much protection, the internals of search changed and it is no longer that useful.
- Moved topPackages and youtube service initialization to a later point in the service initialization, to prevent early cache population.
