### PR TITLE
Cleanup non-canonical topics model property + missing test for the property field.

### DIFF
--- a/app/lib/package/model_properties.dart
+++ b/app/lib/package/model_properties.dart
@@ -80,8 +80,6 @@ class Pubspec {
 
   String? get description => _inner.description;
 
-  List<String>? get topics => _inner.topics;
-
   late final canonicalizedTopics = (_inner.topics ?? const <String>[])
       .map((e) => canonicalTopics.aliasToCanonicalMap[e] ?? e)
       .toSet()

--- a/app/test/service/topics/topics_test.dart
+++ b/app/test/service/topics/topics_test.dart
@@ -4,6 +4,7 @@
 import 'dart:convert';
 
 import 'package:gcloud/storage.dart';
+import 'package:pub_dev/package/model_properties.dart';
 import 'package:pub_dev/service/topics/count_topics.dart';
 import 'package:pub_dev/service/topics/models.dart';
 import 'package:pub_dev/shared/configuration.dart';
@@ -76,6 +77,14 @@ void main() {
         fail('The alias "$alias" is listed in "aliases" for two topics!');
       }
     }
+  });
+
+  test('topics are canonicalized', () {
+    final pubspec = Pubspec.fromJson({
+      'name': 'x',
+      'topics': ['widget', 'widgets', 'x'],
+    });
+    expect(pubspec.canonicalizedTopics, ['widget', 'x']);
   });
 
   test('duplicates', () {


### PR DESCRIPTION
This is a nit test, the other tests check the canonicalization on the higher levels (e.g. redirects), but I noticed that there is no direct test to check whether it is working or not.