### PR TITLE
Link to the report page with the page-specific subject.

### DIFF
--- a/app/lib/admin/models.dart
+++ b/app/lib/admin/models.dart
@@ -124,6 +124,25 @@ class ModerationSubject {
     this.publisherId,
   });
 
+  factory ModerationSubject.package(String package, [String? version]) {
+    return ModerationSubject._(
+      kind: version == null
+          ? ModerationSubjectKind.package
+          : ModerationSubjectKind.packageVersion,
+      localName: [package, if (version != null) version].join('/'),
+      package: package,
+      version: version,
+    );
+  }
+
+  factory ModerationSubject.publisher(String publisherId) {
+    return ModerationSubject._(
+      kind: ModerationSubjectKind.publisher,
+      localName: publisherId,
+      publisherId: publisherId,
+    );
+  }
+
   /// Tries to parse subject [value] and returns a [ModerationSubject]
   /// if it is recognized, or `null` if the format is not recognizable.
   static ModerationSubject? tryParse(String value) {

--- a/app/lib/frontend/templates/layout.dart
+++ b/app/lib/frontend/templates/layout.dart
@@ -4,6 +4,7 @@
 
 import 'package:_pub_shared/data/page_data.dart';
 import 'package:_pub_shared/search/search_form.dart';
+import 'package:pub_dev/admin/models.dart';
 
 import '../../frontend/request_context.dart';
 import '../../service/announcement/backend.dart';
@@ -63,6 +64,24 @@ String renderLayoutPage(
   ];
   final announcementBannerHtml = announcementBackend.getAnnouncementHtml();
   final session = requestContext.sessionData;
+  final moderationSubject = () {
+    if (!requestContext.experimentalFlags.isReportPageEnabled) {
+      return null;
+    }
+    if (pageData == null) {
+      return null;
+    }
+    if (pageData.isPackagePage) {
+      final pkgData = pageData.pkgData!;
+      return ModerationSubject.package(
+        pkgData.package,
+        pkgData.isLatest ? null : pkgData.version,
+      );
+    } else if (pageData.isPublisherPage) {
+      return ModerationSubject.publisher(pageData.publisher!.publisherId);
+    }
+    return null;
+  }();
   return pageLayoutNode(
     title: title,
     description: pageDescription ?? _defaultPageDescription,
@@ -92,6 +111,7 @@ String renderLayoutPage(
     mainContent: contentNode,
     includeHighlightJs: type == PageType.package,
     schemaOrgSearchActionJson: isRoot ? _schemaOrgSearchAction : null,
+    moderationSubject: moderationSubject,
   ).toString();
 }
 

--- a/app/lib/frontend/templates/package.dart
+++ b/app/lib/frontend/templates/package.dart
@@ -306,6 +306,7 @@ PageData pkgPageData(
       publisherId: package.publisherId,
       isDiscontinued: package.isDiscontinued,
       likes: package.likes,
+      isLatest: package.latestVersion == selectedVersion.version,
     ),
     sessionAware: editable,
   );

--- a/app/lib/shared/urls.dart
+++ b/app/lib/shared/urls.dart
@@ -217,6 +217,10 @@ String dartSdkMainUrl(String version) {
   return '$url/';
 }
 
+String reportPage({required String subject}) {
+  return Uri(path: '/report', queryParameters: {'subject': subject}).toString();
+}
+
 /// Parses GitHub and GitLab urls, and returns the root of the repository.
 String? inferRepositoryUrl(String? baseUrl) {
   if (baseUrl == null) {

--- a/app/test/frontend/golden/pkg_activity_log_page.html
+++ b/app/test/frontend/golden/pkg_activity_log_page.html
@@ -29,7 +29,7 @@
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <script src="https://www.gstatic.com/brandstudio/kato/cookie_choice_component/cookie_consent_bar.v3.js" defer="defer" data-autoload-cookie-consent-bar="true"></script>
     <meta name="csrf-token" content="%%csrf-token%%"/>
-    <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJveHlnZW4iLCJ2ZXJzaW9uIjoiMS4yLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlfX0="/>
+    <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJveHlnZW4iLCJ2ZXJzaW9uIjoiMS4yLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlLCJpc0xhdGVzdCI6dHJ1ZX19"/>
     <link rel="preload" href="/static/hash-%%etag%%/highlight/highlight-with-init.js" as="script"/>
   </head>
   <body class="light-theme">

--- a/app/test/frontend/golden/pkg_admin_page.html
+++ b/app/test/frontend/golden/pkg_admin_page.html
@@ -29,7 +29,7 @@
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <script src="https://www.gstatic.com/brandstudio/kato/cookie_choice_component/cookie_consent_bar.v3.js" defer="defer" data-autoload-cookie-consent-bar="true"></script>
     <meta name="csrf-token" content="%%csrf-token%%"/>
-    <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJveHlnZW4iLCJ2ZXJzaW9uIjoiMS4yLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlfSwic2Vzc2lvbkF3YXJlIjp0cnVlfQ=="/>
+    <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJveHlnZW4iLCJ2ZXJzaW9uIjoiMS4yLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlLCJpc0xhdGVzdCI6dHJ1ZX0sInNlc3Npb25Bd2FyZSI6dHJ1ZX0="/>
     <link rel="preload" href="/static/hash-%%etag%%/highlight/highlight-with-init.js" as="script"/>
   </head>
   <body class="light-theme">

--- a/app/test/frontend/golden/pkg_changelog_page.html
+++ b/app/test/frontend/golden/pkg_changelog_page.html
@@ -29,7 +29,7 @@
     <script src="/static/hash-%%etag%%/material/bundle/script.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <script src="https://www.gstatic.com/brandstudio/kato/cookie_choice_component/cookie_consent_bar.v3.js" defer="defer" data-autoload-cookie-consent-bar="true"></script>
-    <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJveHlnZW4iLCJ2ZXJzaW9uIjoiMS4yLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlfSwic2Vzc2lvbkF3YXJlIjpmYWxzZX0="/>
+    <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJveHlnZW4iLCJ2ZXJzaW9uIjoiMS4yLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlLCJpc0xhdGVzdCI6dHJ1ZX0sInNlc3Npb25Bd2FyZSI6ZmFsc2V9"/>
     <link rel="preload" href="/static/hash-%%etag%%/highlight/highlight-with-init.js" as="script"/>
   </head>
   <body class="light-theme">

--- a/app/test/frontend/golden/pkg_example_page.html
+++ b/app/test/frontend/golden/pkg_example_page.html
@@ -29,7 +29,7 @@
     <script src="/static/hash-%%etag%%/material/bundle/script.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <script src="https://www.gstatic.com/brandstudio/kato/cookie_choice_component/cookie_consent_bar.v3.js" defer="defer" data-autoload-cookie-consent-bar="true"></script>
-    <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJveHlnZW4iLCJ2ZXJzaW9uIjoiMS4yLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlfSwic2Vzc2lvbkF3YXJlIjpmYWxzZX0="/>
+    <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJveHlnZW4iLCJ2ZXJzaW9uIjoiMS4yLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlLCJpc0xhdGVzdCI6dHJ1ZX0sInNlc3Npb25Bd2FyZSI6ZmFsc2V9"/>
     <link rel="preload" href="/static/hash-%%etag%%/highlight/highlight-with-init.js" as="script"/>
   </head>
   <body class="light-theme">
@@ -384,7 +384,8 @@
       </div>
     </main>
     <footer class="site-footer">
-      <a class="link" href="https://dart.dev/">Dart language</a>
+      <a class="link" href="/report?subject=package%3Aoxygen">Report package</a>
+      <a class="link sep" href="https://dart.dev/">Dart language</a>
       <a class="link sep" href="/policy">Policy</a>
       <a class="link sep" href="https://www.google.com/intl/en/policies/terms/">Terms</a>
       <a class="link sep" href="https://developers.google.com/terms/">API Terms</a>

--- a/app/test/frontend/golden/pkg_install_page.html
+++ b/app/test/frontend/golden/pkg_install_page.html
@@ -29,7 +29,7 @@
     <script src="/static/hash-%%etag%%/material/bundle/script.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <script src="https://www.gstatic.com/brandstudio/kato/cookie_choice_component/cookie_consent_bar.v3.js" defer="defer" data-autoload-cookie-consent-bar="true"></script>
-    <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJveHlnZW4iLCJ2ZXJzaW9uIjoiMS4yLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlfSwic2Vzc2lvbkF3YXJlIjpmYWxzZX0="/>
+    <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJveHlnZW4iLCJ2ZXJzaW9uIjoiMS4yLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlLCJpc0xhdGVzdCI6dHJ1ZX0sInNlc3Npb25Bd2FyZSI6ZmFsc2V9"/>
     <link rel="preload" href="/static/hash-%%etag%%/highlight/highlight-with-init.js" as="script"/>
   </head>
   <body class="light-theme">

--- a/app/test/frontend/golden/pkg_score_page.html
+++ b/app/test/frontend/golden/pkg_score_page.html
@@ -29,7 +29,7 @@
     <script src="/static/hash-%%etag%%/material/bundle/script.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <script src="https://www.gstatic.com/brandstudio/kato/cookie_choice_component/cookie_consent_bar.v3.js" defer="defer" data-autoload-cookie-consent-bar="true"></script>
-    <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJveHlnZW4iLCJ2ZXJzaW9uIjoiMS4yLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlfSwic2Vzc2lvbkF3YXJlIjpmYWxzZX0="/>
+    <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJveHlnZW4iLCJ2ZXJzaW9uIjoiMS4yLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlLCJpc0xhdGVzdCI6dHJ1ZX0sInNlc3Npb25Bd2FyZSI6ZmFsc2V9"/>
     <link rel="preload" href="/static/hash-%%etag%%/highlight/highlight-with-init.js" as="script"/>
   </head>
   <body class="light-theme">

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -29,7 +29,7 @@
     <script src="/static/hash-%%etag%%/material/bundle/script.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <script src="https://www.gstatic.com/brandstudio/kato/cookie_choice_component/cookie_consent_bar.v3.js" defer="defer" data-autoload-cookie-consent-bar="true"></script>
-    <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJveHlnZW4iLCJ2ZXJzaW9uIjoiMS4yLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlfSwic2Vzc2lvbkF3YXJlIjpmYWxzZX0="/>
+    <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJveHlnZW4iLCJ2ZXJzaW9uIjoiMS4yLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlLCJpc0xhdGVzdCI6dHJ1ZX0sInNlc3Npb25Bd2FyZSI6ZmFsc2V9"/>
     <link rel="preload" href="/static/hash-%%etag%%/highlight/highlight-with-init.js" as="script"/>
   </head>
   <body class="light-theme">
@@ -387,7 +387,8 @@
       </div>
     </main>
     <footer class="site-footer">
-      <a class="link" href="https://dart.dev/">Dart language</a>
+      <a class="link" href="/report?subject=package%3Aoxygen">Report package</a>
+      <a class="link sep" href="https://dart.dev/">Dart language</a>
       <a class="link sep" href="/policy">Policy</a>
       <a class="link sep" href="https://www.google.com/intl/en/policies/terms/">Terms</a>
       <a class="link sep" href="https://developers.google.com/terms/">API Terms</a>

--- a/app/test/frontend/golden/pkg_show_page_discontinued.html
+++ b/app/test/frontend/golden/pkg_show_page_discontinued.html
@@ -29,7 +29,7 @@
     <script src="/static/hash-%%etag%%/material/bundle/script.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <script src="https://www.gstatic.com/brandstudio/kato/cookie_choice_component/cookie_consent_bar.v3.js" defer="defer" data-autoload-cookie-consent-bar="true"></script>
-    <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJwa2ciLCJ2ZXJzaW9uIjoiMS4wLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOnRydWV9LCJzZXNzaW9uQXdhcmUiOmZhbHNlfQ=="/>
+    <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJwa2ciLCJ2ZXJzaW9uIjoiMS4wLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOnRydWUsImlzTGF0ZXN0Ijp0cnVlfSwic2Vzc2lvbkF3YXJlIjpmYWxzZX0="/>
     <link rel="preload" href="/static/hash-%%etag%%/highlight/highlight-with-init.js" as="script"/>
   </head>
   <body class="light-theme">

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -29,7 +29,7 @@
     <script src="/static/hash-%%etag%%/material/bundle/script.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <script src="https://www.gstatic.com/brandstudio/kato/cookie_choice_component/cookie_consent_bar.v3.js" defer="defer" data-autoload-cookie-consent-bar="true"></script>
-    <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJmbHV0dGVyX3RpdGFuaXVtIiwidmVyc2lvbiI6IjEuMTAuMCIsImxpa2VzIjowLCJpc0Rpc2NvbnRpbnVlZCI6ZmFsc2V9LCJzZXNzaW9uQXdhcmUiOmZhbHNlfQ=="/>
+    <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJmbHV0dGVyX3RpdGFuaXVtIiwidmVyc2lvbiI6IjEuMTAuMCIsImxpa2VzIjowLCJpc0Rpc2NvbnRpbnVlZCI6ZmFsc2UsImlzTGF0ZXN0Ijp0cnVlfSwic2Vzc2lvbkF3YXJlIjpmYWxzZX0="/>
     <link rel="preload" href="/static/hash-%%etag%%/highlight/highlight-with-init.js" as="script"/>
   </head>
   <body class="light-theme">

--- a/app/test/frontend/golden/pkg_show_page_publisher.html
+++ b/app/test/frontend/golden/pkg_show_page_publisher.html
@@ -29,7 +29,7 @@
     <script src="/static/hash-%%etag%%/material/bundle/script.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <script src="https://www.gstatic.com/brandstudio/kato/cookie_choice_component/cookie_consent_bar.v3.js" defer="defer" data-autoload-cookie-consent-bar="true"></script>
-    <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJuZW9uIiwidmVyc2lvbiI6IjEuMC4wIiwibGlrZXMiOjAsInB1Ymxpc2hlcklkIjoiZXhhbXBsZS5jb20iLCJpc0Rpc2NvbnRpbnVlZCI6ZmFsc2V9LCJzZXNzaW9uQXdhcmUiOmZhbHNlfQ=="/>
+    <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJuZW9uIiwidmVyc2lvbiI6IjEuMC4wIiwibGlrZXMiOjAsInB1Ymxpc2hlcklkIjoiZXhhbXBsZS5jb20iLCJpc0Rpc2NvbnRpbnVlZCI6ZmFsc2UsImlzTGF0ZXN0Ijp0cnVlfSwic2Vzc2lvbkF3YXJlIjpmYWxzZX0="/>
     <link rel="preload" href="/static/hash-%%etag%%/highlight/highlight-with-init.js" as="script"/>
   </head>
   <body class="light-theme">

--- a/app/test/frontend/golden/pkg_show_page_retracted.html
+++ b/app/test/frontend/golden/pkg_show_page_retracted.html
@@ -29,7 +29,7 @@
     <script src="/static/hash-%%etag%%/material/bundle/script.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <script src="https://www.gstatic.com/brandstudio/kato/cookie_choice_component/cookie_consent_bar.v3.js" defer="defer" data-autoload-cookie-consent-bar="true"></script>
-    <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJwa2ciLCJ2ZXJzaW9uIjoiMS4wLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlfSwic2Vzc2lvbkF3YXJlIjpmYWxzZX0="/>
+    <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJwa2ciLCJ2ZXJzaW9uIjoiMS4wLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlLCJpc0xhdGVzdCI6ZmFsc2V9LCJzZXNzaW9uQXdhcmUiOmZhbHNlfQ=="/>
     <link rel="preload" href="/static/hash-%%etag%%/highlight/highlight-with-init.js" as="script"/>
   </head>
   <body class="light-theme">

--- a/app/test/frontend/golden/pkg_show_page_retracted_non_retracted_version.html
+++ b/app/test/frontend/golden/pkg_show_page_retracted_non_retracted_version.html
@@ -29,7 +29,7 @@
     <script src="/static/hash-%%etag%%/material/bundle/script.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <script src="https://www.gstatic.com/brandstudio/kato/cookie_choice_component/cookie_consent_bar.v3.js" defer="defer" data-autoload-cookie-consent-bar="true"></script>
-    <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJwa2ciLCJ2ZXJzaW9uIjoiMi4wLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlfSwic2Vzc2lvbkF3YXJlIjpmYWxzZX0="/>
+    <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJwa2ciLCJ2ZXJzaW9uIjoiMi4wLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlLCJpc0xhdGVzdCI6dHJ1ZX0sInNlc3Npb25Bd2FyZSI6ZmFsc2V9"/>
     <link rel="preload" href="/static/hash-%%etag%%/highlight/highlight-with-init.js" as="script"/>
   </head>
   <body class="light-theme">

--- a/app/test/frontend/golden/pkg_show_version_page.html
+++ b/app/test/frontend/golden/pkg_show_version_page.html
@@ -29,7 +29,7 @@
     <script src="/static/hash-%%etag%%/material/bundle/script.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <script src="https://www.gstatic.com/brandstudio/kato/cookie_choice_component/cookie_consent_bar.v3.js" defer="defer" data-autoload-cookie-consent-bar="true"></script>
-    <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJveHlnZW4iLCJ2ZXJzaW9uIjoiMS4yLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlfSwic2Vzc2lvbkF3YXJlIjpmYWxzZX0="/>
+    <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJveHlnZW4iLCJ2ZXJzaW9uIjoiMS4yLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlLCJpc0xhdGVzdCI6dHJ1ZX0sInNlc3Npb25Bd2FyZSI6ZmFsc2V9"/>
     <link rel="preload" href="/static/hash-%%etag%%/highlight/highlight-with-init.js" as="script"/>
   </head>
   <body class="light-theme">
@@ -381,7 +381,8 @@
       </div>
     </main>
     <footer class="site-footer">
-      <a class="link" href="https://dart.dev/">Dart language</a>
+      <a class="link" href="/report?subject=package%3Aoxygen">Report package</a>
+      <a class="link sep" href="https://dart.dev/">Dart language</a>
       <a class="link sep" href="/policy">Policy</a>
       <a class="link sep" href="https://www.google.com/intl/en/policies/terms/">Terms</a>
       <a class="link sep" href="https://developers.google.com/terms/">API Terms</a>

--- a/app/test/frontend/golden/pkg_versions_page.html
+++ b/app/test/frontend/golden/pkg_versions_page.html
@@ -29,7 +29,7 @@
     <script src="/static/hash-%%etag%%/material/bundle/script.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <script src="https://www.gstatic.com/brandstudio/kato/cookie_choice_component/cookie_consent_bar.v3.js" defer="defer" data-autoload-cookie-consent-bar="true"></script>
-    <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJveHlnZW4iLCJ2ZXJzaW9uIjoiMS4yLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlfX0="/>
+    <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJveHlnZW4iLCJ2ZXJzaW9uIjoiMS4yLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlLCJpc0xhdGVzdCI6dHJ1ZX19"/>
     <link rel="preload" href="/static/hash-%%etag%%/highlight/highlight-with-init.js" as="script"/>
   </head>
   <body class="light-theme">

--- a/app/test/frontend/golden/publisher_packages_page.html
+++ b/app/test/frontend/golden/publisher_packages_page.html
@@ -375,7 +375,8 @@
       </div>
     </main>
     <footer class="site-footer">
-      <a class="link" href="https://dart.dev/">Dart language</a>
+      <a class="link" href="/report?subject=publisher%3Aexample.com">Report publisher</a>
+      <a class="link sep" href="https://dart.dev/">Dart language</a>
       <a class="link sep" href="/policy">Policy</a>
       <a class="link sep" href="https://www.google.com/intl/en/policies/terms/">Terms</a>
       <a class="link sep" href="https://developers.google.com/terms/">API Terms</a>

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -14,6 +14,7 @@ import 'package:pub_dev/account/models.dart';
 import 'package:pub_dev/audit/backend.dart';
 import 'package:pub_dev/audit/models.dart';
 import 'package:pub_dev/fake/backend/fake_auth_provider.dart';
+import 'package:pub_dev/frontend/handlers/experimental.dart';
 import 'package:pub_dev/frontend/handlers/package.dart'
     show loadPackagePageData;
 import 'package:pub_dev/frontend/request_context.dart';
@@ -138,6 +139,8 @@ void main() {
       'package show page',
       processJobsWithFakeRunners: true,
       fn: () async {
+        registerRequestContext(
+            RequestContext(experimentalFlags: ExperimentalFlags({'report'})));
         final data = await withFakeAuthRequestContext(
           adminAtPubDevEmail,
           () => loadPackagePageDataByName('oxygen', '1.2.0', AssetKind.readme),
@@ -168,6 +171,8 @@ void main() {
       'package example page',
       processJobsWithFakeRunners: true,
       fn: () async {
+        registerRequestContext(
+            RequestContext(experimentalFlags: ExperimentalFlags({'report'})));
         final data = await loadPackagePageDataByName(
             'oxygen', '1.2.0', AssetKind.example);
         final html = renderPkgExamplePage(data);
@@ -205,6 +210,8 @@ void main() {
       'package show page - with version',
       processJobsWithFakeRunners: true,
       fn: () async {
+        registerRequestContext(
+            RequestContext(experimentalFlags: ExperimentalFlags({'report'})));
         final data = await loadPackagePageDataByName(
             'oxygen', '1.2.0', AssetKind.readme);
         final html = renderPkgShowPage(data);
@@ -475,6 +482,8 @@ void main() {
       'package versions page',
       processJobsWithFakeRunners: true,
       fn: () async {
+        registerRequestContext(
+            RequestContext(experimentalFlags: ExperimentalFlags({'report'})));
         final data = await loadPackagePageDataByName('oxygen', '1.2.0', null);
         final rs = await issueGet('/packages/oxygen/versions');
         final html = await rs.readAsString();
@@ -512,6 +521,8 @@ void main() {
       'publisher packages page',
       processJobsWithFakeRunners: true,
       fn: () async {
+        registerRequestContext(
+            RequestContext(experimentalFlags: ExperimentalFlags({'report'})));
         final searchForm = SearchForm();
         final publisher = (await publisherBackend.getPublisher('example.com'))!;
         final neon = (await scoreCardBackend.getPackageView('neon'))!;

--- a/app/test/task/end2end_test.dart
+++ b/app/test/task/end2end_test.dart
@@ -82,7 +82,7 @@ void main() {
 final _headers = {
   'Cookie': Cookie(
     experimentalCookieName,
-    ExperimentalFlags({'sandbox'}).encodedAsCookie(),
+    ExperimentalFlags({'report'}).encodedAsCookie(),
   ).toString(),
 };
 

--- a/app/test/task/testdata/goldens/packages/oxygen.html
+++ b/app/test/task/testdata/goldens/packages/oxygen.html
@@ -29,7 +29,7 @@
     <script src="/static/hash-%%etag%%/material/bundle/script.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <script src="https://www.gstatic.com/brandstudio/kato/cookie_choice_component/cookie_consent_bar.v3.js" defer="defer" data-autoload-cookie-consent-bar="true"></script>
-    <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJveHlnZW4iLCJ2ZXJzaW9uIjoiMi4wLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlfSwic2Vzc2lvbkF3YXJlIjpmYWxzZX0="/>
+    <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJveHlnZW4iLCJ2ZXJzaW9uIjoiMi4wLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlLCJpc0xhdGVzdCI6dHJ1ZX0sInNlc3Npb25Bd2FyZSI6ZmFsc2V9"/>
     <link rel="preload" href="/static/hash-%%etag%%/highlight/highlight-with-init.js" as="script"/>
   </head>
   <body class="light-theme">
@@ -381,7 +381,8 @@
       </div>
     </main>
     <footer class="site-footer">
-      <a class="link" href="https://dart.dev/">Dart language</a>
+      <a class="link" href="/report?subject=package%3Aoxygen">Report package</a>
+      <a class="link sep" href="https://dart.dev/">Dart language</a>
       <a class="link sep" href="/policy">Policy</a>
       <a class="link sep" href="https://www.google.com/intl/en/policies/terms/">Terms</a>
       <a class="link sep" href="https://developers.google.com/terms/">API Terms</a>

--- a/app/test/task/testdata/goldens/packages/oxygen/changelog.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/changelog.html
@@ -29,7 +29,7 @@
     <script src="/static/hash-%%etag%%/material/bundle/script.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <script src="https://www.gstatic.com/brandstudio/kato/cookie_choice_component/cookie_consent_bar.v3.js" defer="defer" data-autoload-cookie-consent-bar="true"></script>
-    <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJveHlnZW4iLCJ2ZXJzaW9uIjoiMi4wLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlfSwic2Vzc2lvbkF3YXJlIjpmYWxzZX0="/>
+    <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJveHlnZW4iLCJ2ZXJzaW9uIjoiMi4wLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlLCJpc0xhdGVzdCI6dHJ1ZX0sInNlc3Npb25Bd2FyZSI6ZmFsc2V9"/>
     <link rel="preload" href="/static/hash-%%etag%%/highlight/highlight-with-init.js" as="script"/>
   </head>
   <body class="light-theme">
@@ -387,7 +387,8 @@
       </div>
     </main>
     <footer class="site-footer">
-      <a class="link" href="https://dart.dev/">Dart language</a>
+      <a class="link" href="/report?subject=package%3Aoxygen">Report package</a>
+      <a class="link sep" href="https://dart.dev/">Dart language</a>
       <a class="link sep" href="/policy">Policy</a>
       <a class="link sep" href="https://www.google.com/intl/en/policies/terms/">Terms</a>
       <a class="link sep" href="https://developers.google.com/terms/">API Terms</a>

--- a/app/test/task/testdata/goldens/packages/oxygen/example.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/example.html
@@ -29,7 +29,7 @@
     <script src="/static/hash-%%etag%%/material/bundle/script.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <script src="https://www.gstatic.com/brandstudio/kato/cookie_choice_component/cookie_consent_bar.v3.js" defer="defer" data-autoload-cookie-consent-bar="true"></script>
-    <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJveHlnZW4iLCJ2ZXJzaW9uIjoiMi4wLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlfSwic2Vzc2lvbkF3YXJlIjpmYWxzZX0="/>
+    <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJveHlnZW4iLCJ2ZXJzaW9uIjoiMi4wLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlLCJpc0xhdGVzdCI6dHJ1ZX0sInNlc3Npb25Bd2FyZSI6ZmFsc2V9"/>
     <link rel="preload" href="/static/hash-%%etag%%/highlight/highlight-with-init.js" as="script"/>
   </head>
   <body class="light-theme">
@@ -384,7 +384,8 @@
       </div>
     </main>
     <footer class="site-footer">
-      <a class="link" href="https://dart.dev/">Dart language</a>
+      <a class="link" href="/report?subject=package%3Aoxygen">Report package</a>
+      <a class="link sep" href="https://dart.dev/">Dart language</a>
       <a class="link sep" href="/policy">Policy</a>
       <a class="link sep" href="https://www.google.com/intl/en/policies/terms/">Terms</a>
       <a class="link sep" href="https://developers.google.com/terms/">API Terms</a>

--- a/app/test/task/testdata/goldens/packages/oxygen/install.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/install.html
@@ -29,7 +29,7 @@
     <script src="/static/hash-%%etag%%/material/bundle/script.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <script src="https://www.gstatic.com/brandstudio/kato/cookie_choice_component/cookie_consent_bar.v3.js" defer="defer" data-autoload-cookie-consent-bar="true"></script>
-    <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJveHlnZW4iLCJ2ZXJzaW9uIjoiMi4wLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlfSwic2Vzc2lvbkF3YXJlIjpmYWxzZX0="/>
+    <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJveHlnZW4iLCJ2ZXJzaW9uIjoiMi4wLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlLCJpc0xhdGVzdCI6dHJ1ZX0sInNlc3Npb25Bd2FyZSI6ZmFsc2V9"/>
     <link rel="preload" href="/static/hash-%%etag%%/highlight/highlight-with-init.js" as="script"/>
   </head>
   <body class="light-theme">
@@ -410,7 +410,8 @@
       </div>
     </main>
     <footer class="site-footer">
-      <a class="link" href="https://dart.dev/">Dart language</a>
+      <a class="link" href="/report?subject=package%3Aoxygen">Report package</a>
+      <a class="link sep" href="https://dart.dev/">Dart language</a>
       <a class="link sep" href="/policy">Policy</a>
       <a class="link sep" href="https://www.google.com/intl/en/policies/terms/">Terms</a>
       <a class="link sep" href="https://developers.google.com/terms/">API Terms</a>

--- a/app/test/task/testdata/goldens/packages/oxygen/license.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/license.html
@@ -29,7 +29,7 @@
     <script src="/static/hash-%%etag%%/material/bundle/script.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <script src="https://www.gstatic.com/brandstudio/kato/cookie_choice_component/cookie_consent_bar.v3.js" defer="defer" data-autoload-cookie-consent-bar="true"></script>
-    <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJveHlnZW4iLCJ2ZXJzaW9uIjoiMi4wLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlfSwic2Vzc2lvbkF3YXJlIjpmYWxzZX0="/>
+    <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJveHlnZW4iLCJ2ZXJzaW9uIjoiMi4wLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlLCJpc0xhdGVzdCI6dHJ1ZX0sInNlc3Npb25Bd2FyZSI6ZmFsc2V9"/>
     <link rel="preload" href="/static/hash-%%etag%%/highlight/highlight-with-init.js" as="script"/>
   </head>
   <body class="light-theme">
@@ -383,7 +383,8 @@
       </div>
     </main>
     <footer class="site-footer">
-      <a class="link" href="https://dart.dev/">Dart language</a>
+      <a class="link" href="/report?subject=package%3Aoxygen">Report package</a>
+      <a class="link sep" href="https://dart.dev/">Dart language</a>
       <a class="link sep" href="/policy">Policy</a>
       <a class="link sep" href="https://www.google.com/intl/en/policies/terms/">Terms</a>
       <a class="link sep" href="https://developers.google.com/terms/">API Terms</a>

--- a/app/test/task/testdata/goldens/packages/oxygen/score.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/score.html
@@ -29,7 +29,7 @@
     <script src="/static/hash-%%etag%%/material/bundle/script.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <script src="https://www.gstatic.com/brandstudio/kato/cookie_choice_component/cookie_consent_bar.v3.js" defer="defer" data-autoload-cookie-consent-bar="true"></script>
-    <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJveHlnZW4iLCJ2ZXJzaW9uIjoiMi4wLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlfSwic2Vzc2lvbkF3YXJlIjpmYWxzZX0="/>
+    <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJveHlnZW4iLCJ2ZXJzaW9uIjoiMi4wLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlLCJpc0xhdGVzdCI6dHJ1ZX0sInNlc3Npb25Bd2FyZSI6ZmFsc2V9"/>
     <link rel="preload" href="/static/hash-%%etag%%/highlight/highlight-with-init.js" as="script"/>
   </head>
   <body class="light-theme">
@@ -690,7 +690,8 @@
       </div>
     </main>
     <footer class="site-footer">
-      <a class="link" href="https://dart.dev/">Dart language</a>
+      <a class="link" href="/report?subject=package%3Aoxygen">Report package</a>
+      <a class="link sep" href="https://dart.dev/">Dart language</a>
       <a class="link sep" href="/policy">Policy</a>
       <a class="link sep" href="https://www.google.com/intl/en/policies/terms/">Terms</a>
       <a class="link sep" href="https://developers.google.com/terms/">API Terms</a>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions.html
@@ -29,7 +29,7 @@
     <script src="/static/hash-%%etag%%/material/bundle/script.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <script src="https://www.gstatic.com/brandstudio/kato/cookie_choice_component/cookie_consent_bar.v3.js" defer="defer" data-autoload-cookie-consent-bar="true"></script>
-    <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJveHlnZW4iLCJ2ZXJzaW9uIjoiMi4wLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlfX0="/>
+    <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJveHlnZW4iLCJ2ZXJzaW9uIjoiMi4wLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlLCJpc0xhdGVzdCI6dHJ1ZX19"/>
     <link rel="preload" href="/static/hash-%%etag%%/highlight/highlight-with-init.js" as="script"/>
   </head>
   <body class="light-theme">
@@ -443,7 +443,8 @@
       </div>
     </main>
     <footer class="site-footer">
-      <a class="link" href="https://dart.dev/">Dart language</a>
+      <a class="link" href="/report?subject=package%3Aoxygen">Report package</a>
+      <a class="link sep" href="https://dart.dev/">Dart language</a>
       <a class="link sep" href="/policy">Policy</a>
       <a class="link sep" href="https://www.google.com/intl/en/policies/terms/">Terms</a>
       <a class="link sep" href="https://developers.google.com/terms/">API Terms</a>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0.html
@@ -29,7 +29,7 @@
     <script src="/static/hash-%%etag%%/material/bundle/script.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <script src="https://www.gstatic.com/brandstudio/kato/cookie_choice_component/cookie_consent_bar.v3.js" defer="defer" data-autoload-cookie-consent-bar="true"></script>
-    <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJveHlnZW4iLCJ2ZXJzaW9uIjoiMS4wLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlfSwic2Vzc2lvbkF3YXJlIjpmYWxzZX0="/>
+    <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJveHlnZW4iLCJ2ZXJzaW9uIjoiMS4wLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlLCJpc0xhdGVzdCI6ZmFsc2V9LCJzZXNzaW9uQXdhcmUiOmZhbHNlfQ=="/>
     <link rel="preload" href="/static/hash-%%etag%%/highlight/highlight-with-init.js" as="script"/>
   </head>
   <body class="light-theme">
@@ -385,7 +385,8 @@
       </div>
     </main>
     <footer class="site-footer">
-      <a class="link" href="https://dart.dev/">Dart language</a>
+      <a class="link" href="/report?subject=package-version%3Aoxygen%2F1.0.0">Report package</a>
+      <a class="link sep" href="https://dart.dev/">Dart language</a>
       <a class="link sep" href="/policy">Policy</a>
       <a class="link sep" href="https://www.google.com/intl/en/policies/terms/">Terms</a>
       <a class="link sep" href="https://developers.google.com/terms/">API Terms</a>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/changelog.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/changelog.html
@@ -29,7 +29,7 @@
     <script src="/static/hash-%%etag%%/material/bundle/script.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <script src="https://www.gstatic.com/brandstudio/kato/cookie_choice_component/cookie_consent_bar.v3.js" defer="defer" data-autoload-cookie-consent-bar="true"></script>
-    <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJveHlnZW4iLCJ2ZXJzaW9uIjoiMS4wLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlfSwic2Vzc2lvbkF3YXJlIjpmYWxzZX0="/>
+    <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJveHlnZW4iLCJ2ZXJzaW9uIjoiMS4wLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlLCJpc0xhdGVzdCI6ZmFsc2V9LCJzZXNzaW9uQXdhcmUiOmZhbHNlfQ=="/>
     <link rel="preload" href="/static/hash-%%etag%%/highlight/highlight-with-init.js" as="script"/>
   </head>
   <body class="light-theme">
@@ -391,7 +391,8 @@
       </div>
     </main>
     <footer class="site-footer">
-      <a class="link" href="https://dart.dev/">Dart language</a>
+      <a class="link" href="/report?subject=package-version%3Aoxygen%2F1.0.0">Report package</a>
+      <a class="link sep" href="https://dart.dev/">Dart language</a>
       <a class="link sep" href="/policy">Policy</a>
       <a class="link sep" href="https://www.google.com/intl/en/policies/terms/">Terms</a>
       <a class="link sep" href="https://developers.google.com/terms/">API Terms</a>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/example.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/example.html
@@ -29,7 +29,7 @@
     <script src="/static/hash-%%etag%%/material/bundle/script.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <script src="https://www.gstatic.com/brandstudio/kato/cookie_choice_component/cookie_consent_bar.v3.js" defer="defer" data-autoload-cookie-consent-bar="true"></script>
-    <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJveHlnZW4iLCJ2ZXJzaW9uIjoiMS4wLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlfSwic2Vzc2lvbkF3YXJlIjpmYWxzZX0="/>
+    <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJveHlnZW4iLCJ2ZXJzaW9uIjoiMS4wLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlLCJpc0xhdGVzdCI6ZmFsc2V9LCJzZXNzaW9uQXdhcmUiOmZhbHNlfQ=="/>
     <link rel="preload" href="/static/hash-%%etag%%/highlight/highlight-with-init.js" as="script"/>
   </head>
   <body class="light-theme">
@@ -388,7 +388,8 @@
       </div>
     </main>
     <footer class="site-footer">
-      <a class="link" href="https://dart.dev/">Dart language</a>
+      <a class="link" href="/report?subject=package-version%3Aoxygen%2F1.0.0">Report package</a>
+      <a class="link sep" href="https://dart.dev/">Dart language</a>
       <a class="link sep" href="/policy">Policy</a>
       <a class="link sep" href="https://www.google.com/intl/en/policies/terms/">Terms</a>
       <a class="link sep" href="https://developers.google.com/terms/">API Terms</a>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/install.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/install.html
@@ -29,7 +29,7 @@
     <script src="/static/hash-%%etag%%/material/bundle/script.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <script src="https://www.gstatic.com/brandstudio/kato/cookie_choice_component/cookie_consent_bar.v3.js" defer="defer" data-autoload-cookie-consent-bar="true"></script>
-    <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJveHlnZW4iLCJ2ZXJzaW9uIjoiMS4wLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlfSwic2Vzc2lvbkF3YXJlIjpmYWxzZX0="/>
+    <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJveHlnZW4iLCJ2ZXJzaW9uIjoiMS4wLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlLCJpc0xhdGVzdCI6ZmFsc2V9LCJzZXNzaW9uQXdhcmUiOmZhbHNlfQ=="/>
     <link rel="preload" href="/static/hash-%%etag%%/highlight/highlight-with-init.js" as="script"/>
   </head>
   <body class="light-theme">
@@ -414,7 +414,8 @@
       </div>
     </main>
     <footer class="site-footer">
-      <a class="link" href="https://dart.dev/">Dart language</a>
+      <a class="link" href="/report?subject=package-version%3Aoxygen%2F1.0.0">Report package</a>
+      <a class="link sep" href="https://dart.dev/">Dart language</a>
       <a class="link sep" href="/policy">Policy</a>
       <a class="link sep" href="https://www.google.com/intl/en/policies/terms/">Terms</a>
       <a class="link sep" href="https://developers.google.com/terms/">API Terms</a>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/license.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/license.html
@@ -29,7 +29,7 @@
     <script src="/static/hash-%%etag%%/material/bundle/script.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <script src="https://www.gstatic.com/brandstudio/kato/cookie_choice_component/cookie_consent_bar.v3.js" defer="defer" data-autoload-cookie-consent-bar="true"></script>
-    <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJveHlnZW4iLCJ2ZXJzaW9uIjoiMS4wLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlfSwic2Vzc2lvbkF3YXJlIjpmYWxzZX0="/>
+    <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJveHlnZW4iLCJ2ZXJzaW9uIjoiMS4wLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlLCJpc0xhdGVzdCI6ZmFsc2V9LCJzZXNzaW9uQXdhcmUiOmZhbHNlfQ=="/>
     <link rel="preload" href="/static/hash-%%etag%%/highlight/highlight-with-init.js" as="script"/>
   </head>
   <body class="light-theme">
@@ -387,7 +387,8 @@
       </div>
     </main>
     <footer class="site-footer">
-      <a class="link" href="https://dart.dev/">Dart language</a>
+      <a class="link" href="/report?subject=package-version%3Aoxygen%2F1.0.0">Report package</a>
+      <a class="link sep" href="https://dart.dev/">Dart language</a>
       <a class="link sep" href="/policy">Policy</a>
       <a class="link sep" href="https://www.google.com/intl/en/policies/terms/">Terms</a>
       <a class="link sep" href="https://developers.google.com/terms/">API Terms</a>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/score.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/score.html
@@ -29,7 +29,7 @@
     <script src="/static/hash-%%etag%%/material/bundle/script.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <script src="https://www.gstatic.com/brandstudio/kato/cookie_choice_component/cookie_consent_bar.v3.js" defer="defer" data-autoload-cookie-consent-bar="true"></script>
-    <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJveHlnZW4iLCJ2ZXJzaW9uIjoiMS4wLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlfSwic2Vzc2lvbkF3YXJlIjpmYWxzZX0="/>
+    <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJveHlnZW4iLCJ2ZXJzaW9uIjoiMS4wLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlLCJpc0xhdGVzdCI6ZmFsc2V9LCJzZXNzaW9uQXdhcmUiOmZhbHNlfQ=="/>
     <link rel="preload" href="/static/hash-%%etag%%/highlight/highlight-with-init.js" as="script"/>
   </head>
   <body class="light-theme">
@@ -694,7 +694,8 @@
       </div>
     </main>
     <footer class="site-footer">
-      <a class="link" href="https://dart.dev/">Dart language</a>
+      <a class="link" href="/report?subject=package-version%3Aoxygen%2F1.0.0">Report package</a>
+      <a class="link sep" href="https://dart.dev/">Dart language</a>
       <a class="link sep" href="/policy">Policy</a>
       <a class="link sep" href="https://www.google.com/intl/en/policies/terms/">Terms</a>
       <a class="link sep" href="https://developers.google.com/terms/">API Terms</a>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/2.0.0.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/2.0.0.html
@@ -29,7 +29,7 @@
     <script src="/static/hash-%%etag%%/material/bundle/script.min.js" defer="defer"></script>
     <script src="/static/hash-%%etag%%/js/script.dart.js" defer="defer"></script>
     <script src="https://www.gstatic.com/brandstudio/kato/cookie_choice_component/cookie_consent_bar.v3.js" defer="defer" data-autoload-cookie-consent-bar="true"></script>
-    <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJveHlnZW4iLCJ2ZXJzaW9uIjoiMi4wLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlfSwic2Vzc2lvbkF3YXJlIjpmYWxzZX0="/>
+    <meta name="pub-page-data" content="eyJwa2dEYXRhIjp7InBhY2thZ2UiOiJveHlnZW4iLCJ2ZXJzaW9uIjoiMi4wLjAiLCJsaWtlcyI6MCwiaXNEaXNjb250aW51ZWQiOmZhbHNlLCJpc0xhdGVzdCI6dHJ1ZX0sInNlc3Npb25Bd2FyZSI6ZmFsc2V9"/>
     <link rel="preload" href="/static/hash-%%etag%%/highlight/highlight-with-init.js" as="script"/>
   </head>
   <body class="light-theme">
@@ -381,7 +381,8 @@
       </div>
     </main>
     <footer class="site-footer">
-      <a class="link" href="https://dart.dev/">Dart language</a>
+      <a class="link" href="/report?subject=package%3Aoxygen">Report package</a>
+      <a class="link sep" href="https://dart.dev/">Dart language</a>
       <a class="link sep" href="/policy">Policy</a>
       <a class="link sep" href="https://www.google.com/intl/en/policies/terms/">Terms</a>
       <a class="link sep" href="https://developers.google.com/terms/">API Terms</a>

--- a/pkg/_pub_shared/lib/data/page_data.dart
+++ b/pkg/_pub_shared/lib/data/page_data.dart
@@ -55,6 +55,7 @@ class PkgData {
   /// isn't owned by a publisher.
   final String? publisherId;
   final bool isDiscontinued;
+  final bool isLatest;
 
   PkgData({
     required this.package,
@@ -62,6 +63,7 @@ class PkgData {
     required this.publisherId,
     required this.isDiscontinued,
     required this.likes,
+    required this.isLatest,
   });
 
   factory PkgData.fromJson(Map<String, dynamic> json) =>

--- a/pkg/_pub_shared/lib/data/page_data.g.dart
+++ b/pkg/_pub_shared/lib/data/page_data.g.dart
@@ -39,6 +39,7 @@ PkgData _$PkgDataFromJson(Map<String, dynamic> json) => PkgData(
       publisherId: json['publisherId'] as String?,
       isDiscontinued: json['isDiscontinued'] as bool,
       likes: json['likes'] as int,
+      isLatest: json['isLatest'] as bool,
     );
 
 Map<String, dynamic> _$PkgDataToJson(PkgData instance) {
@@ -56,6 +57,7 @@ Map<String, dynamic> _$PkgDataToJson(PkgData instance) {
 
   writeNotNull('publisherId', instance.publisherId);
   val['isDiscontinued'] = instance.isDiscontinued;
+  val['isLatest'] = instance.isLatest;
   return val;
 }
 


### PR DESCRIPTION
- #7535
- Reusing `PageData` that is already created during the preparation of the pages to keep the scope simple.