### PR TITLE
Fix topics text/title and separate CSS styles.

### DIFF
--- a/app/lib/frontend/templates/views/page/topics_list.dart
+++ b/app/lib/frontend/templates/views/page/topics_list.dart
@@ -6,32 +6,26 @@ import '../../../../service/topics/models.dart';
 import '../../../../shared/urls.dart' as urls;
 import '../../../dom/dom.dart' as d;
 
+/// Renders the topics list node of /topics page.
 d.Node renderTopicsList(Map<String, int> topics) {
-  return d.div(children: [
-    d.h1(text: 'Topics '),
-    topicsListNode(topics),
-  ]);
-}
-
-/// Renders the package list node of /topics page.
-d.Node topicsListNode(Map<String, int> topics) {
   final sortedTopics = topics.entries.toList()
     ..sort((a, b) => b.value.compareTo(a.value));
-
-  return d.div(
-    classes: ['packages', '-compact'],
-    children: sortedTopics.map((e) => _topic(e.key, e.value)),
-  );
+  return d.div(classes: [
+    'topics-page'
+  ], children: [
+    d.h1(text: 'Topics '),
+    ...sortedTopics.map((e) => _topic(e.key, e.value)),
+  ]);
 }
 
 d.Node _topic(String name, int count) {
   final ct = canonicalTopics.asMap[name];
   final description = ct?.description;
   return d.div(
-    classes: ['packages-item'],
+    classes: ['topic-item'],
     children: [
       d.h3(
-        classes: ['packages-title'],
+        classes: ['topic-title'],
         children: [
           d.a(
             text: '#$name',
@@ -39,12 +33,12 @@ d.Node _topic(String name, int count) {
             rel: 'nofollow',
           ),
           d.span(
-              classes: ['topics-metadata'],
+              classes: ['topic-metadata'],
               text: '$count ${count == 1 ? 'package' : 'packages'}')
         ],
       ),
       if (description != null)
-        d.p(classes: ['topics-description'], text: description),
+        d.p(classes: ['topic-description'], text: description),
     ],
   );
 }

--- a/app/lib/frontend/templates/views/pkg/info_box.dart
+++ b/app/lib/frontend/templates/views/pkg/info_box.dart
@@ -193,9 +193,11 @@ d.Node? _topicstNode(List<String>? topics) {
     final ct = canonicalTopics.asMap[topic];
     final description = ct?.description;
     final node = d.a(
-        href: urls.searchUrl(q: 'topic:$topic'),
-        text: description ?? '#$topic',
-        rel: 'nofollow');
+      href: urls.searchUrl(q: 'topic:$topic'),
+      text: '#$topic',
+      title: description,
+      rel: 'nofollow',
+    );
     nodes.add(node);
   }
   return d.fragment(nodes);

--- a/app/lib/frontend/templates/views/pkg/package_list.dart
+++ b/app/lib/frontend/templates/views/pkg/package_list.dart
@@ -162,10 +162,12 @@ d.Node _packageItem(
         final ct = canonicalTopics.asMap[topic];
         final description = ct?.description;
         return d.a(
-            classes: ['topics-tag'],
-            href: urls.searchUrl(q: 'topic:$topic'),
-            text: description ?? '#$topic',
-            rel: 'nofollow');
+          classes: ['topics-tag'],
+          href: urls.searchUrl(q: 'topic:$topic'),
+          text: '#$topic',
+          title: description,
+          rel: 'nofollow',
+        );
       },
     ).toList();
   }

--- a/app/test/frontend/golden/topics_page.html
+++ b/app/test/frontend/golden/topics_page.html
@@ -111,34 +111,32 @@
           <img class="standalone-side-image" src="/static/hash-%%etag%%/img/packages-side.webp" alt="" width="400" height="400" role="presentation"/>
         </div>
         <div class="standalone-content">
-          <div>
+          <div class="topics-page">
             <h1>Topics</h1>
-            <div class="packages -compact">
-              <div class="packages-item">
-                <h3 class="packages-title">
-                  <a href="/packages?q=topic%3Anetwork" rel="nofollow">#network</a>
-                  <span class="topics-metadata">7 packages</span>
-                </h3>
-              </div>
-              <div class="packages-item">
-                <h3 class="packages-title">
-                  <a href="/packages?q=topic%3Aui" rel="nofollow">#ui</a>
-                  <span class="topics-metadata">5 packages</span>
-                </h3>
-              </div>
-              <div class="packages-item">
-                <h3 class="packages-title">
-                  <a href="/packages?q=topic%3Ahttp" rel="nofollow">#http</a>
-                  <span class="topics-metadata">4 packages</span>
-                </h3>
-              </div>
-              <div class="packages-item">
-                <h3 class="packages-title">
-                  <a href="/packages?q=topic%3Awidget" rel="nofollow">#widget</a>
-                  <span class="topics-metadata">1 package</span>
-                </h3>
-                <p class="topics-description">Packages that contain Flutter widgets.</p>
-              </div>
+            <div class="topic-item">
+              <h3 class="topic-title">
+                <a href="/packages?q=topic%3Anetwork" rel="nofollow">#network</a>
+                <span class="topic-metadata">7 packages</span>
+              </h3>
+            </div>
+            <div class="topic-item">
+              <h3 class="topic-title">
+                <a href="/packages?q=topic%3Aui" rel="nofollow">#ui</a>
+                <span class="topic-metadata">5 packages</span>
+              </h3>
+            </div>
+            <div class="topic-item">
+              <h3 class="topic-title">
+                <a href="/packages?q=topic%3Ahttp" rel="nofollow">#http</a>
+                <span class="topic-metadata">4 packages</span>
+              </h3>
+            </div>
+            <div class="topic-item">
+              <h3 class="topic-title">
+                <a href="/packages?q=topic%3Awidget" rel="nofollow">#widget</a>
+                <span class="topic-metadata">1 package</span>
+              </h3>
+              <p class="topic-description">Packages that contain Flutter widgets.</p>
             </div>
           </div>
         </div>

--- a/pkg/web_css/lib/src/_list.scss
+++ b/pkg/web_css/lib/src/_list.scss
@@ -252,22 +252,6 @@
     }
   }
 
-  .topics-tag {
-    display: inline-block;
-    padding: 4px 4px;
-  }
-
-  .topics-metadata {
-    font-size: 12px;
-    padding-left: 10px;
-  }
-
-  .topics-description {
-    margin: 0px;
-    font-size: 14px;
-  }
-
-
   .packages-description {
     margin: 4px 0px;
   }

--- a/pkg/web_css/lib/src/_topics.scss
+++ b/pkg/web_css/lib/src/_topics.scss
@@ -1,0 +1,33 @@
+/* Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+   for details. All rights reserved. Use of this source code is governed by a
+   BSD-style license that can be found in the LICENSE file. */
+
+.topics-page {
+  .topic-item {
+    padding: 0;
+    margin-bottom: 16px;
+
+    .topic-title {
+      flex-grow: 1;
+      font-size: 22px;
+      font-weight: 500;
+      margin: 0;
+      overflow-wrap: anywhere;
+    }
+
+    .topic-metadata {
+      font-size: 12px;
+      padding-left: 10px;
+    }
+
+    .topic-description {
+      margin: 0px;
+      font-size: 14px;
+    }
+  }
+}
+
+.topics-tag {
+  display: inline-block;
+  padding: 4px 4px;
+}

--- a/pkg/web_css/lib/style.scss
+++ b/pkg/web_css/lib/style.scss
@@ -20,3 +20,4 @@
 @import 'src/_scores';
 @import 'src/_search';
 @import 'src/_tags';
+@import 'src/topics';


### PR DESCRIPTION
- #7263
- Fixes a bug in #7700: the description was displayed as part of the `text` instead of the `title` attribute.
- Fixes #7703 by reducing the extra margin between the title tag and the topic block.
- Separates CSS styles from package listing styles, also simpler styles for `topic-item`.