### PR TITLE
Reduced bottom margin on topics page.

### DIFF
--- a/app/lib/frontend/templates/views/page/topics_list.dart
+++ b/app/lib/frontend/templates/views/page/topics_list.dart
@@ -13,7 +13,7 @@ d.Node renderTopicsList(Map<String, int> topics) {
   return d.div(classes: [
     'topics-page'
   ], children: [
-    d.h1(text: 'Topics '),
+    d.h1(text: 'Topics'),
     ...sortedTopics.map((e) => _topic(e.key, e.value)),
   ]);
 }

--- a/pkg/web_css/lib/src/_topics.scss
+++ b/pkg/web_css/lib/src/_topics.scss
@@ -3,6 +3,10 @@
    BSD-style license that can be found in the LICENSE file. */
 
 .topics-page {
+  h1 {
+    margin-bottom: 0;
+  }
+
   .topic-item {
     padding: 0;
     margin-bottom: 16px;


### PR DESCRIPTION
This is a follow-up to #7706.

I've considered a generic rule for all `h1` elements on standalone (e.g. non-user-content related) pages, but it feels like it is better to implement this on a case-by-case basis, and keep the rule close to the location it applies.