### PR TITLE
Merge topics `logging` and `logger`

### DIFF
--- a/doc/topics.yaml
+++ b/doc/topics.yaml
@@ -63,7 +63,7 @@ topics:
   aliases:
   - widgets
 - topic: logging
-  decription: Packages for writing log messages.
+  description: Packages for writing log messages.
   aliases:
   - logger
   - logs

--- a/doc/topics.yaml
+++ b/doc/topics.yaml
@@ -62,3 +62,7 @@ topics:
   description: Packages that contain Flutter widgets.
   aliases:
   - widgets
+- topic: logging
+  decription: Packages for writing log messages.
+  aliases:
+  - logger

--- a/doc/topics.yaml
+++ b/doc/topics.yaml
@@ -66,3 +66,5 @@ topics:
   decription: Packages for writing log messages.
   aliases:
   - logger
+  - logs
+  - log


### PR DESCRIPTION
logging: https://pub.dev/packages?q=topic%3Alogging
logger: https://pub.dev/packages?q=topic%3Alogger

I think `logging` is prettier, I didn't think too much about it.

We can always undo this.
