### PR TITLE
Consolidated case check for moderate actions.

### DIFF
--- a/app/lib/admin/backend.dart
+++ b/app/lib/admin/backend.dart
@@ -722,4 +722,31 @@ class AdminBackend {
     return await dbService.lookupOrNull<ModerationCase>(
         dbService.emptyKey.append(ModerationCase, id: caseId));
   }
+
+  /// Returns a valid [ModerationCase] if it exists and [status] is matching.
+  /// Returns `null` if [caseId] is `none`.
+  ///
+  /// Throws exceptions otherwise.
+  Future<ModerationCase?> loadAndVerifyModerationCaseForAdminAction(
+    String? caseId, {
+    required String? status,
+  }) async {
+    InvalidInputException.check(
+      caseId != null && caseId.isNotEmpty,
+      'case must be given',
+    );
+    if (caseId == 'none') {
+      return null;
+    }
+
+    final refCase = await adminBackend.lookupModerationCase(caseId!);
+    if (refCase == null) {
+      throw NotFoundException.resource(caseId);
+    }
+    if (status != null && refCase.status != status) {
+      throw InvalidInputException(
+          'ModerationCase.status ("${refCase.status}") != "$status".');
+    }
+    return refCase;
+  }
 }

--- a/app/test/package/moderate_package_test.dart
+++ b/app/test/package/moderate_package_test.dart
@@ -357,7 +357,7 @@ void main() {
         _moderate('oxygen', state: true, caseId: mc.caseId),
         code: 'InvalidInput',
         status: 400,
-        message: 'ModerationCase is already closed',
+        message: 'ModerationCase.status ("no-action") != "pending".',
       );
     });
   });

--- a/app/test/publisher/moderate_publisher_test.dart
+++ b/app/test/publisher/moderate_publisher_test.dart
@@ -198,7 +198,7 @@ void main() {
         _moderate('example.com', state: true, caseId: mc.caseId),
         code: 'InvalidInput',
         status: 400,
-        message: 'ModerationCase is already closed',
+        message: 'ModerationCase.status ("no-action") != "pending".',
       );
     });
   });


### PR DESCRIPTION
- #7535
- allows `none` as `case` (there won't be a log entry added on any `ModerationCase`)
- but still fails if `case` is missing, non-existent or already closed.