### PR TITLE
Use the admin support email as agent in consent rejection and expiry audit logs.

### DIFF
--- a/app/lib/account/consent_backend.dart
+++ b/app/lib/account/consent_backend.dart
@@ -347,7 +347,7 @@ class _PackageUploaderAction extends ConsentAction {
     final packageName = consent.args![0];
     await withRetryTransaction(dbService, (tx) async {
       tx.insert(await AuditLogRecord.uploaderInviteRejected(
-        fromUserId: consent.fromUserId!,
+        fromUserId: consent.fromUserId,
         package: packageName,
         uploaderEmail: user?.email ?? consent.email!,
         userId: user?.userId,
@@ -360,7 +360,7 @@ class _PackageUploaderAction extends ConsentAction {
     final packageName = consent.args![0];
     await withRetryTransaction(dbService, (tx) async {
       tx.insert(await AuditLogRecord.uploaderInviteExpired(
-        fromUserId: consent.fromUserId!,
+        fromUserId: consent.fromUserId,
         package: packageName,
         uploaderEmail: consent.email!,
       ));
@@ -413,7 +413,7 @@ class _PublisherContactAction extends ConsentAction {
     final publisherId = consent.args![0];
     await withRetryTransaction(dbService, (tx) async {
       tx.insert(await AuditLogRecord.publisherContactInviteRejected(
-        fromUserId: consent.fromUserId!,
+        fromUserId: consent.fromUserId,
         publisherId: publisherId,
         contactEmail: consent.email!,
         userEmail: user?.email,
@@ -427,7 +427,7 @@ class _PublisherContactAction extends ConsentAction {
     final publisherId = consent.args![0];
     await withRetryTransaction(dbService, (tx) async {
       tx.insert(await AuditLogRecord.publisherContactInviteExpired(
-        fromUserId: consent.fromUserId!,
+        fromUserId: consent.fromUserId,
         publisherId: publisherId,
         contactEmail: consent.email!,
       ));
@@ -493,7 +493,7 @@ class _PublisherMemberAction extends ConsentAction {
     final publisherId = consent.args![0];
     await withRetryTransaction(dbService, (tx) async {
       tx.insert(await AuditLogRecord.publisherMemberInviteRejected(
-        fromUserId: consent.fromUserId!,
+        fromUserId: consent.fromUserId,
         publisherId: publisherId,
         memberEmail: user?.email ?? consent.email!,
         userId: user?.userId,
@@ -506,7 +506,7 @@ class _PublisherMemberAction extends ConsentAction {
     final publisherId = consent.args![0];
     await withRetryTransaction(dbService, (tx) async {
       tx.insert(await AuditLogRecord.publisherMemberInviteExpired(
-        fromUserId: consent.fromUserId!,
+        fromUserId: consent.fromUserId,
         publisherId: publisherId,
         memberEmail: consent.email!,
       ));

--- a/app/lib/audit/models.dart
+++ b/app/lib/audit/models.dart
@@ -464,21 +464,21 @@ class AuditLogRecord extends db.ExpandoModel<String> {
   ///
   /// Throws [RateLimitException] when the configured rate limit is reached.
   static Future<AuditLogRecord> publisherContactInviteExpired({
-    required String fromUserId,
+    required String? fromUserId,
     required String publisherId,
     required String contactEmail,
   }) {
     return _checkRateLimit(AuditLogRecord._init()
       ..kind = AuditLogRecordKind.publisherContactInviteExpired
-      ..agent = fromUserId
+      ..agent = KnownAgents.pubSupport
       ..summary = 'Contact invite for publisher `$publisherId` expired, '
           '`$contactEmail` did not respond.'
       ..data = {
-        'fromUserId': fromUserId,
+        if (fromUserId != null) 'fromUserId': fromUserId,
         'publisherId': publisherId,
         'contactEmail': contactEmail,
       }
-      ..users = [fromUserId]
+      ..users = [if (fromUserId != null) fromUserId]
       ..packages = []
       ..packageVersions = []
       ..publishers = [publisherId]);
@@ -488,7 +488,7 @@ class AuditLogRecord extends db.ExpandoModel<String> {
   ///
   /// Throws [RateLimitException] when the configured rate limit is reached.
   static Future<AuditLogRecord> publisherContactInviteRejected({
-    required String fromUserId,
+    required String? fromUserId,
     required String publisherId,
     required String contactEmail,
 
@@ -501,16 +501,19 @@ class AuditLogRecord extends db.ExpandoModel<String> {
         : '`$userEmail` rejected contact invite of `$contactEmail` for publisher `$publisherId`.';
     return _checkRateLimit(AuditLogRecord._init()
       ..kind = AuditLogRecordKind.publisherContactInviteRejected
-      ..agent = userId ?? fromUserId
+      ..agent = userId ?? KnownAgents.pubSupport
       ..summary = summary
       ..data = {
-        'fromUserId': fromUserId,
+        if (fromUserId != null) 'fromUserId': fromUserId,
         'publisherId': publisherId,
         'contactEmail': contactEmail,
         if (userId != null) 'userId': userId,
         if (userEmail != null) 'userEmail': userEmail,
       }
-      ..users = [fromUserId, if (userId != null) userId]
+      ..users = [
+        if (fromUserId != null) fromUserId,
+        if (userId != null) userId,
+      ]
       ..packages = []
       ..packageVersions = []
       ..publishers = [publisherId]);
@@ -589,21 +592,21 @@ class AuditLogRecord extends db.ExpandoModel<String> {
   ///
   /// Throws [RateLimitException] when the configured rate limit is reached.
   static Future<AuditLogRecord> publisherMemberInviteExpired({
-    required String fromUserId,
+    required String? fromUserId,
     required String publisherId,
     required String memberEmail,
   }) {
     return _checkRateLimit(AuditLogRecord._init()
       ..kind = AuditLogRecordKind.publisherMemberInviteExpired
-      ..agent = fromUserId
+      ..agent = KnownAgents.pubSupport
       ..summary = 'Member invite for publisher `$publisherId` expired, '
           '`$memberEmail` did not respond.'
       ..data = {
-        'fromUserId': fromUserId,
+        if (fromUserId != null) 'fromUserId': fromUserId,
         'publisherId': publisherId,
         'memberEmail': memberEmail,
       }
-      ..users = [fromUserId]
+      ..users = [if (fromUserId != null) fromUserId]
       ..packages = []
       ..packageVersions = []
       ..publishers = [publisherId]);
@@ -613,7 +616,7 @@ class AuditLogRecord extends db.ExpandoModel<String> {
   ///
   /// Throws [RateLimitException] when the configured rate limit is reached.
   static Future<AuditLogRecord> publisherMemberInviteRejected({
-    required String fromUserId,
+    required String? fromUserId,
     required String publisherId,
     required String memberEmail,
 
@@ -622,16 +625,19 @@ class AuditLogRecord extends db.ExpandoModel<String> {
   }) {
     return _checkRateLimit(AuditLogRecord._init()
       ..kind = AuditLogRecordKind.publisherMemberInviteRejected
-      ..agent = userId ?? fromUserId
+      ..agent = userId ?? KnownAgents.pubSupport
       ..summary =
           '`$memberEmail` rejected member invite for publisher `$publisherId`.'
       ..data = {
-        'fromUserId': fromUserId,
+        if (fromUserId != null) 'fromUserId': fromUserId,
         'publisherId': publisherId,
         'memberEmail': memberEmail,
         if (userId != null) 'userId': userId,
       }
-      ..users = [fromUserId, if (userId != null) userId]
+      ..users = [
+        if (fromUserId != null) fromUserId,
+        if (userId != null) userId,
+      ]
       ..packages = []
       ..packageVersions = []
       ..publishers = [publisherId]);
@@ -765,21 +771,21 @@ class AuditLogRecord extends db.ExpandoModel<String> {
   ///
   /// Throws [RateLimitException] when the configured rate limit is reached.
   static Future<AuditLogRecord> uploaderInviteExpired({
-    required String fromUserId,
+    required String? fromUserId,
     required String package,
     required String uploaderEmail,
   }) {
     return _checkRateLimit(AuditLogRecord._init()
       ..kind = AuditLogRecordKind.uploaderInviteExpired
-      ..agent = fromUserId
+      ..agent = KnownAgents.pubSupport
       ..summary = 'Uploader invite for package `$package` expired, '
           '`$uploaderEmail` did not respond.'
       ..data = {
-        'fromUserId': fromUserId,
+        if (fromUserId != null) 'fromUserId': fromUserId,
         'package': package,
         'uploaderEmail': uploaderEmail,
       }
-      ..users = [fromUserId]
+      ..users = [if (fromUserId != null) fromUserId]
       ..packages = [package]
       ..packageVersions = []
       ..publishers = []);
@@ -789,7 +795,7 @@ class AuditLogRecord extends db.ExpandoModel<String> {
   ///
   /// Throws [RateLimitException] when the configured rate limit is reached.
   static Future<AuditLogRecord> uploaderInviteRejected({
-    required String fromUserId,
+    required String? fromUserId,
     required String package,
     required String uploaderEmail,
 
@@ -798,16 +804,16 @@ class AuditLogRecord extends db.ExpandoModel<String> {
   }) {
     return _checkRateLimit(AuditLogRecord._init()
       ..kind = AuditLogRecordKind.uploaderInviteRejected
-      ..agent = userId ?? fromUserId
+      ..agent = userId ?? KnownAgents.pubSupport
       ..summary =
           '`$uploaderEmail` rejected uploader invite for package `$package`.'
       ..data = {
-        'fromUserId': fromUserId,
+        if (fromUserId != null) 'fromUserId': fromUserId,
         'package': package,
         'uploaderEmail': uploaderEmail,
         if (userId != null) 'userId': userId,
       }
-      ..users = [fromUserId, if (userId != null) userId]
+      ..users = [if (fromUserId != null) fromUserId, if (userId != null) userId]
       ..packages = [package]
       ..packageVersions = []
       ..publishers = []);


### PR DESCRIPTION
- Found this during the investigation of #7725. This has very little practical effect, but reduces the importance of using `User.userId` in invites.
- For these we were using the userId of the inviting `User` account as an agent (directly or fallback).
- The expiry happens without any real user interaction, using the `support@pub.dev` as placeholder seems to be better.
- For rejection we were using the signed in account's `userId` as primary agent, but in case we implement rejection without signing in, the fallback should be `support@pub.dev` (or something else) instead of the inviting `userId`.
- Instead of `support@pub.dev` we could use another user-friendly agent alias, but we may as well reuse it.
