### PR TITLE
Updated search failure handling.

### DIFF
--- a/app/lib/frontend/handlers/listing.dart
+++ b/app/lib/frontend/handlers/listing.dart
@@ -93,7 +93,9 @@ Future<shelf.Response> _packagesHandlerHtmlCore(shelf.Request request) async {
       messageFromBackend: searchResult.errorMessage,
       openSections: openSections,
     ),
-    status: searchResult.errorMessage == null ? 200 : 500,
+    status: searchResult.errorMessage == null
+        ? 200
+        : (searchResult.statusCode ?? 500),
   );
   _searchOverallLatencyTracker.add(sw.elapsed);
   return result;

--- a/app/lib/frontend/handlers/listing.dart
+++ b/app/lib/frontend/handlers/listing.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 
 import 'package:_pub_shared/search/search_form.dart';
 import 'package:_pub_shared/search/tags.dart';
+import 'package:logging/logging.dart';
 import 'package:shelf/shelf.dart' as shelf;
 
 import '../../package/name_tracker.dart';
@@ -16,6 +17,7 @@ import '../../shared/utils.dart' show DurationTracker;
 
 import '../templates/listing.dart';
 
+final _logger = Logger('listing_page');
 final _searchOverallLatencyTracker = DurationTracker();
 
 Map searchDebugStats() {
@@ -78,6 +80,9 @@ Future<shelf.Response> _packagesHandlerHtmlCore(shelf.Request request) async {
     rateLimitKey: request.sourceIp,
   );
   final int totalCount = searchResult.totalCount;
+  if (searchResult.message != null) {
+    _logger.severe('[pub-search-not-working] ${searchResult.message}');
+  }
 
   final links = PageLinks(searchForm, totalCount);
   final result = htmlResponse(
@@ -88,6 +93,7 @@ Future<shelf.Response> _packagesHandlerHtmlCore(shelf.Request request) async {
       messageFromBackend: searchResult.message,
       openSections: openSections,
     ),
+    status: searchResult.message == null ? 200 : 500,
   );
   _searchOverallLatencyTracker.add(sw.elapsed);
   return result;

--- a/app/lib/frontend/handlers/listing.dart
+++ b/app/lib/frontend/handlers/listing.dart
@@ -80,8 +80,8 @@ Future<shelf.Response> _packagesHandlerHtmlCore(shelf.Request request) async {
     rateLimitKey: request.sourceIp,
   );
   final int totalCount = searchResult.totalCount;
-  if (searchResult.message != null) {
-    _logger.severe('[pub-search-not-working] ${searchResult.message}');
+  if (searchResult.errorMessage != null) {
+    _logger.severe('[pub-search-not-working] ${searchResult.errorMessage}');
   }
 
   final links = PageLinks(searchForm, totalCount);
@@ -90,10 +90,10 @@ Future<shelf.Response> _packagesHandlerHtmlCore(shelf.Request request) async {
       searchResult,
       links,
       searchForm: searchForm,
-      messageFromBackend: searchResult.message,
+      messageFromBackend: searchResult.errorMessage,
       openSections: openSections,
     ),
-    status: searchResult.message == null ? 200 : 500,
+    status: searchResult.errorMessage == null ? 200 : 500,
   );
   _searchOverallLatencyTracker.add(sw.elapsed);
   return result;

--- a/app/lib/frontend/handlers/publisher.dart
+++ b/app/lib/frontend/handlers/publisher.dart
@@ -135,7 +135,7 @@ Future<shelf.Response> publisherPackagesPageHandler(
     totalCount: totalCount,
     isAdmin: await publisherBackend.isMemberAdmin(
         publisher, requestContext.authenticatedUserId),
-    messageFromBackend: searchResult.message,
+    messageFromBackend: searchResult.errorMessage,
   );
   if (isLanding && requestContext.uiCacheEnabled) {
     await cache.uiPublisherPackagesPage(publisherId).set(html);

--- a/app/lib/package/search_adapter.dart
+++ b/app/lib/package/search_adapter.dart
@@ -53,6 +53,7 @@ class SearchAdapter {
           .cast<PackageView>()
           .toList(),
       errorMessage: result.message,
+      statusCode: result.statusCode,
     );
   }
 
@@ -152,16 +153,20 @@ class SearchResultPage {
   /// the query was not processed entirely.
   final String? errorMessage;
 
+  /// The non-200 status code that will be used to render the [errorMessage].
+  final int? statusCode;
+
   SearchResultPage(
     this.form,
     this.totalCount, {
     List<SdkLibraryHit>? sdkLibraryHits,
     List<PackageView>? packageHits,
     this.errorMessage,
+    this.statusCode,
   })  : sdkLibraryHits = sdkLibraryHits ?? <SdkLibraryHit>[],
         packageHits = packageHits ?? <PackageView>[];
 
-  SearchResultPage.empty(this.form, {this.errorMessage})
+  SearchResultPage.empty(this.form, {this.errorMessage, this.statusCode})
       : totalCount = 0,
         sdkLibraryHits = <SdkLibraryHit>[],
         packageHits = [];

--- a/app/lib/package/search_adapter.dart
+++ b/app/lib/package/search_adapter.dart
@@ -52,7 +52,7 @@ class SearchAdapter {
           .where((v) => v != null)
           .cast<PackageView>()
           .toList(),
-      message: result.message,
+      errorMessage: result.message,
     );
   }
 
@@ -150,18 +150,18 @@ class SearchResultPage {
 
   /// An optional message from the search service / client library, in case
   /// the query was not processed entirely.
-  final String? message;
+  final String? errorMessage;
 
   SearchResultPage(
     this.form,
     this.totalCount, {
     List<SdkLibraryHit>? sdkLibraryHits,
     List<PackageView>? packageHits,
-    this.message,
+    this.errorMessage,
   })  : sdkLibraryHits = sdkLibraryHits ?? <SdkLibraryHit>[],
         packageHits = packageHits ?? <PackageView>[];
 
-  SearchResultPage.empty(this.form, {this.message})
+  SearchResultPage.empty(this.form, {this.errorMessage})
       : totalCount = 0,
         sdkLibraryHits = <SdkLibraryHit>[],
         packageHits = [];

--- a/app/lib/search/search_client.dart
+++ b/app/lib/search/search_client.dart
@@ -118,7 +118,17 @@ class SearchClient {
       return await searchFn();
     } else {
       final cacheEntry = cache.packageSearchResult(serviceUrlParams.toString());
-      return (await cacheEntry.get(searchFn))!;
+      final cached = await cacheEntry.get();
+      if (cached != null) {
+        return cached;
+      }
+      final r = await searchFn();
+      await cacheEntry.set(
+          r,
+          r.message == null
+              ? const Duration(minutes: 3)
+              : const Duration(minutes: 1));
+      return r;
     }
   }
 

--- a/app/lib/search/search_client.dart
+++ b/app/lib/search/search_client.dart
@@ -54,6 +54,7 @@ class SearchClient {
     if (validity.isRejected) {
       return PackageSearchResult.empty(
         message: 'Search query rejected. ${validity.rejectReason}',
+        statusCode: 400,
       );
     }
 

--- a/app/lib/search/search_service.dart
+++ b/app/lib/search/search_service.dart
@@ -320,7 +320,10 @@ class PackageSearchResult {
 
   /// An optional message from the search service / client library, in case
   /// the query was not processed entirely.
+  /// TODO: migrate to use `errorMessage` name.
   final String? message;
+
+  final int? statusCode;
 
   PackageSearchResult({
     required this.timestamp,
@@ -328,10 +331,11 @@ class PackageSearchResult {
     List<SdkLibraryHit>? sdkLibraryHits,
     List<PackageHit>? packageHits,
     this.message,
+    this.statusCode,
   })  : sdkLibraryHits = sdkLibraryHits ?? <SdkLibraryHit>[],
         packageHits = packageHits ?? <PackageHit>[];
 
-  PackageSearchResult.empty({this.message})
+  PackageSearchResult.empty({this.message, this.statusCode})
       : timestamp = clock.now().toUtc(),
         totalCount = 0,
         sdkLibraryHits = <SdkLibraryHit>[],

--- a/app/lib/search/search_service.g.dart
+++ b/app/lib/search/search_service.g.dart
@@ -86,6 +86,7 @@ PackageSearchResult _$PackageSearchResultFromJson(Map<String, dynamic> json) =>
           ?.map((e) => PackageHit.fromJson(e as Map<String, dynamic>))
           .toList(),
       message: json['message'] as String?,
+      statusCode: (json['statusCode'] as num?)?.toInt(),
     );
 
 Map<String, dynamic> _$PackageSearchResultToJson(PackageSearchResult instance) {
@@ -103,6 +104,7 @@ Map<String, dynamic> _$PackageSearchResultToJson(PackageSearchResult instance) {
       instance.sdkLibraryHits.map((e) => e.toJson()).toList();
   val['packageHits'] = instance.packageHits.map((e) => e.toJson()).toList();
   writeNotNull('message', instance.message);
+  writeNotNull('statusCode', instance.statusCode);
   return val;
 }
 

--- a/app/lib/shared/redis_cache.dart
+++ b/app/lib/shared/redis_cache.dart
@@ -188,7 +188,7 @@ class CachePatterns {
   Entry<PackageSearchResult> packageSearchResult(String url) {
     return _cache
         .withPrefix('search-result/')
-        .withTTL(const Duration(minutes: 5))
+        .withTTL(const Duration(minutes: 1))
         .withCodec(utf8)
         .withCodec(json)
         .withCodec(wrapAsCodec(

--- a/app/test/frontend/handlers/listing_test.dart
+++ b/app/test/frontend/handlers/listing_test.dart
@@ -76,8 +76,9 @@ void main() {
       registerSearchClient(
           SearchClient(MockClient((_) async => throw Exception())));
       await nameTracker.reloadFromDatastore();
-      final content =
-          await expectHtmlResponse(await issueGet('/packages?q=oxyge'));
+      final content = await expectHtmlResponse(
+          await issueGet('/packages?q=oxyge'),
+          status: 500);
       expect(content, contains('oxygen is awesome'));
     });
 
@@ -153,6 +154,7 @@ void main() {
       await expectHtmlResponse(
         await issueGet('/packages?q=$longString'),
         present: ['Search query rejected. Query too long.'],
+        status: 400,
       );
     });
   });


### PR DESCRIPTION
- Fixes #7740.
- Tags log errors with `[pub-search-not-working]`.
- Returns 500 when search is not working.
- Reduces cached page TTL to 1 minute for failed pages, 3 minutes for working pages.