### PR TITLE
Rename message -> errorMessage in search service JSON.

### DIFF
--- a/app/lib/frontend/handlers/custom_api.dart
+++ b/app/lib/frontend/handlers/custom_api.dart
@@ -292,7 +292,7 @@ Future<shelf.Response> apiSearchHandler(shelf.Request request) async {
   final hasNextPage = sr.totalCount > searchForm.pageSize! + searchForm.offset;
   final result = <String, dynamic>{
     'packages': packages,
-    if (sr.message != null) 'message': sr.message,
+    if (sr.errorMessage != null) 'message': sr.errorMessage,
   };
   if (hasNextPage) {
     final newParams =

--- a/app/lib/package/search_adapter.dart
+++ b/app/lib/package/search_adapter.dart
@@ -52,7 +52,7 @@ class SearchAdapter {
           .where((v) => v != null)
           .cast<PackageView>()
           .toList(),
-      errorMessage: result.message,
+      errorMessage: result.errorMessage,
       statusCode: result.statusCode,
     );
   }
@@ -92,7 +92,7 @@ class SearchAdapter {
     // Some search queries must not be served with the fallback search.
     if (form.parsedQuery.tagsPredicate.isNotEmpty) {
       return PackageSearchResult.empty(
-          message: 'Search is temporarily unavailable.');
+          errorMessage: 'Search is temporarily unavailable.');
     }
 
     final names = await nameTracker
@@ -118,7 +118,7 @@ class SearchAdapter {
         timestamp: clock.now().toUtc(),
         packageHits: packageHits,
         totalCount: totalCount,
-        message:
+        errorMessage:
             'Search is temporarily impaired, filtering and ranking may be incorrect.');
   }
 

--- a/app/lib/search/search_client.dart
+++ b/app/lib/search/search_client.dart
@@ -53,7 +53,7 @@ class SearchClient {
     final validity = query.evaluateValidity();
     if (validity.isRejected) {
       return PackageSearchResult.empty(
-        message: 'Search query rejected. ${validity.rejectReason}',
+        errorMessage: 'Search query rejected. ${validity.rejectReason}',
         statusCode: 400,
       );
     }
@@ -88,7 +88,7 @@ class SearchClient {
       }
       if (response == null) {
         return PackageSearchResult.empty(
-            message: 'Search is temporarily unavailable.');
+            errorMessage: 'Search is temporarily unavailable.');
       }
       if (response.statusCode == 200) {
         return PackageSearchResult.fromJson(
@@ -98,11 +98,11 @@ class SearchClient {
       // Search request before the service initialization completed.
       if (response.statusCode == searchIndexNotReadyCode) {
         return PackageSearchResult.empty(
-            message: 'Search is temporarily unavailable.');
+            errorMessage: 'Search is temporarily unavailable.');
       }
       // There has been a generic issue with the service.
       return PackageSearchResult.empty(
-          message: 'Service returned status code ${response.statusCode}.');
+          errorMessage: 'Service returned status code ${response.statusCode}.');
     }
 
     if (sourceIp != null) {
@@ -126,7 +126,7 @@ class SearchClient {
       final r = await searchFn();
       await cacheEntry.set(
           r,
-          r.message == null
+          r.errorMessage == null
               ? const Duration(minutes: 3)
               : const Duration(minutes: 1));
       return r;

--- a/app/lib/search/search_service.dart
+++ b/app/lib/search/search_service.dart
@@ -320,8 +320,7 @@ class PackageSearchResult {
 
   /// An optional message from the search service / client library, in case
   /// the query was not processed entirely.
-  /// TODO: migrate to use `errorMessage` name.
-  final String? message;
+  final String? errorMessage;
 
   final int? statusCode;
 
@@ -330,19 +329,24 @@ class PackageSearchResult {
     required this.totalCount,
     List<SdkLibraryHit>? sdkLibraryHits,
     List<PackageHit>? packageHits,
-    this.message,
+    this.errorMessage,
     this.statusCode,
   })  : sdkLibraryHits = sdkLibraryHits ?? <SdkLibraryHit>[],
         packageHits = packageHits ?? <PackageHit>[];
 
-  PackageSearchResult.empty({this.message, this.statusCode})
+  PackageSearchResult.empty({this.errorMessage, this.statusCode})
       : timestamp = clock.now().toUtc(),
         totalCount = 0,
         sdkLibraryHits = <SdkLibraryHit>[],
         packageHits = <PackageHit>[];
 
-  factory PackageSearchResult.fromJson(Map<String, dynamic> json) =>
-      _$PackageSearchResultFromJson(json);
+  factory PackageSearchResult.fromJson(Map<String, dynamic> json) {
+    return _$PackageSearchResultFromJson({
+      // TODO: remove fallback in the next release
+      'errorMessage': json['message'],
+      ...json,
+    });
+  }
 
   Duration get age => clock.now().difference(timestamp!);
 

--- a/app/lib/search/search_service.g.dart
+++ b/app/lib/search/search_service.g.dart
@@ -85,7 +85,7 @@ PackageSearchResult _$PackageSearchResultFromJson(Map<String, dynamic> json) =>
       packageHits: (json['packageHits'] as List<dynamic>?)
           ?.map((e) => PackageHit.fromJson(e as Map<String, dynamic>))
           .toList(),
-      message: json['message'] as String?,
+      errorMessage: json['errorMessage'] as String?,
       statusCode: (json['statusCode'] as num?)?.toInt(),
     );
 
@@ -103,7 +103,7 @@ Map<String, dynamic> _$PackageSearchResultToJson(PackageSearchResult instance) {
   val['sdkLibraryHits'] =
       instance.sdkLibraryHits.map((e) => e.toJson()).toList();
   val['packageHits'] = instance.packageHits.map((e) => e.toJson()).toList();
-  writeNotNull('message', instance.message);
+  writeNotNull('errorMessage', instance.errorMessage);
   writeNotNull('statusCode', instance.statusCode);
   return val;
 }

--- a/app/lib/service/entrypoint/search_index.dart
+++ b/app/lib/service/entrypoint/search_index.dart
@@ -131,6 +131,7 @@ class IsolateSearchIndex implements SearchIndex {
     } catch (e, st) {
       _logger.warning('Failed to search index.', e, st);
     }
-    return PackageSearchResult.empty(message: 'Failed to process request.');
+    return PackageSearchResult.empty(
+        errorMessage: 'Failed to process request.');
   }
 }

--- a/app/test/service/entrypoint/search_index_test.dart
+++ b/app/test/service/entrypoint/search_index_test.dart
@@ -33,7 +33,7 @@ void main() {
       // working search only with SDK results (no packages in the isolate)
       final rs =
           await searchIndex.search(ServiceSearchQuery.parse(query: 'json'));
-      expect(rs.message, isNull);
+      expect(rs.errorMessage, isNull);
       expect(rs.sdkLibraryHits, isNotEmpty);
       expect(rs.packageHits, isEmpty);
     }, timeout: Timeout(Duration(minutes: 5)));


### PR DESCRIPTION
This is a follow-up to https://github.com/dart-lang/pub-dev/pull/7741, handling the rename of the `message` field used when accessing the search service internally. As we use the versioned service endpoints by default, and only use the generic endpoint as a fallback, it is rare to access search using a different version. However, this fallback provides a simple way to use the `message` field from old results.