### PR TITLE
Fix token-test for forks in renamed repos

### DIFF
--- a/app/test/service/openid/github_actions_id_token_test.dart
+++ b/app/test/service/openid/github_actions_id_token_test.dart
@@ -18,6 +18,7 @@ void main() {
       Platform.environment['ACTIONS_ID_TOKEN_REQUEST_URL'] ?? '';
   final actionsIdTokenRequestToken =
       Platform.environment['ACTIONS_ID_TOKEN_REQUEST_TOKEN'] ?? '';
+  final githubRepository = Platform.environment['GITHUB_REPOSITORY'] ?? '';
 
   // This test only works when running on Github Actions with `id-token: write` permissions.
   //
@@ -70,8 +71,7 @@ void main() {
       expect(token.payload.isTimely(threshold: Duration(minutes: 1)), isTrue);
       final payload = GitHubJwtPayload(token.payload);
       expect(token.payload.aud, ['https://example.com']);
-      // repository check assumes that clones keep the `pub-dev` name:
-      expect(payload.repository, endsWith('/pub-dev'));
+      expect(payload.repository, githubRepository);
       expect(payload.eventName, anyOf(['pull_request', 'push', 'schedule']));
       expect(payload.refType, anyOf(['branch']));
       // example `ref`: `refs/pull/38/merge`


### PR DESCRIPTION
My forks of this repository weren't named `pub-dev` which meant that the token-test failed.

I don't think that the token test needs to assert that the repository have that name, so this changes the code to validate that the token matches the github environment variable's declared repository (including owner) which seems reasonable.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
