### PR TITLE
Fx pkg_admin_page_test.dart for forks

### DIFF
--- a/pkg/pub_integration/test/pkg_admin_page_test.dart
+++ b/pkg/pub_integration/test/pkg_admin_page_test.dart
@@ -4,6 +4,8 @@
 
 import 'dart:convert';
 
+import 'dart:io' show Platform;
+
 import 'package:http/http.dart' as http;
 import 'package:pub_integration/src/fake_test_context_provider.dart';
 import 'package:pub_integration/src/pub_puppeteer_helpers.dart';
@@ -44,6 +46,9 @@ void main() {
         final user =
             await fakeTestScenario.createTestUser(email: 'admin@pub.dev');
 
+        final githubRepository =
+            Platform.environment['GITHUB_REPOSITORY'] ?? 'dart-lang/pub-dev';
+
         // github publishing
         await user.withBrowserPage((page) async {
           await page.gotoOrigin('/packages/test_pkg/admin');
@@ -54,14 +59,14 @@ void main() {
             '#-pkg-admin-automated-github-tagpattern',
           ]);
           await page.waitFocusAndType(
-              '#-pkg-admin-automated-github-repository', 'dart-lang/pub-dev');
+              '#-pkg-admin-automated-github-repository', githubRepository);
           await page.waitAndClick('#-pkg-admin-automated-button',
               waitForOneResponse: true);
           await page.waitAndClickOnDialogOk();
           await page.reload();
           final value = await page.propertyValue(
               '#-pkg-admin-automated-github-repository', 'value');
-          expect(value, 'dart-lang/pub-dev');
+          expect(value, githubRepository);
         });
       });
     },


### PR DESCRIPTION
My forks of this repository had to have a different name than `dart-lang/pub-dev`, so pkg/pub_integration/test/pkg_admin_page_test.dart would fail.

I don't think that the admin page test needs to assert that the repository has that name, so this changes the code to validate that the repository matches the github environment variable's declared repository (including owner) which seems reasonable.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
