### PR TITLE
More integration test for report intake + moderation flow.

### DIFF
--- a/app/lib/fake/server/fake_server_entrypoint.dart
+++ b/app/lib/fake/server/fake_server_entrypoint.dart
@@ -6,6 +6,7 @@ import 'dart:convert';
 
 import 'package:args/command_runner.dart';
 import 'package:http/http.dart';
+import 'package:pub_dev/fake/backend/fake_auth_provider.dart';
 import 'package:pub_dev/fake/backend/fake_pub_worker.dart';
 import 'package:pub_dev/fake/server/fake_analyzer_service.dart';
 import 'package:pub_dev/fake/server/fake_default_service.dart';
@@ -14,6 +15,7 @@ import 'package:pub_dev/fake/server/fake_storage_server.dart';
 import 'package:pub_dev/fake/server/local_server_state.dart';
 import 'package:pub_dev/frontend/static_files.dart';
 import 'package:pub_dev/shared/configuration.dart';
+import 'package:pub_dev/shared/handlers.dart';
 import 'package:pub_dev/shared/logging.dart';
 import 'package:pub_dev/task/cloudcompute/fakecloudcompute.dart';
 import 'package:pub_dev/tool/test_profile/import_source.dart';
@@ -123,6 +125,17 @@ class FakeServerCommand extends Command {
       }
       if (rq.requestedUri.path == '/fake-update-search') {
         return await _updateUpstream(searchPort);
+      }
+      if (rq.requestedUri.path == '/fake-gcp-token') {
+        final email = rq.requestedUri.queryParameters['email'];
+        final audience = rq.requestedUri.queryParameters['audience'];
+        return jsonResponse({
+          // ignore: invalid_use_of_visible_for_testing_member
+          'token': createFakeServiceAccountToken(
+            email: email!,
+            audience: audience,
+          ),
+        });
       }
       return shelf.Response.notFound('Not Found.');
     }

--- a/pkg/pub_integration/lib/src/fake_pub_server_process.dart
+++ b/pkg/pub_integration/lib/src/fake_pub_server_process.dart
@@ -212,7 +212,10 @@ class FakeEmailReaderFromOutputDirectory {
   }) async {
     final emails = await readAllEmails();
     return emails.lastWhere((map) {
-      final recipients = (map['recipients'] as List).cast<String>();
+      final recipients = {
+        ...(map['recipients'] as List? ?? <String>[]).cast<String>(),
+        ...(map['ccRecipients'] as List? ?? <String>[]).cast<String>(),
+      };
       return recipients.contains(recipient);
     });
   }

--- a/pkg/pub_integration/lib/src/scenarios/like_package.dart
+++ b/pkg/pub_integration/lib/src/scenarios/like_package.dart
@@ -6,13 +6,13 @@ import 'package:pub_integration/src/test_scenario.dart';
 
 final likePackageScenario = TestScenario('like-package', (ctx) async {
   // Clean up by unliking initially, this should always be safe.
-  await ctx.userA.api.unlikePackage(ctx.testPackage);
+  await ctx.userA.browserApi.unlikePackage(ctx.testPackage);
 
   // Try to like the package
-  await ctx.userA.api.likePackage(ctx.testPackage);
+  await ctx.userA.browserApi.likePackage(ctx.testPackage);
 
   // TODO: grep html in the browser to check if the liked state is updated!
 
   // Try to unlike the package
-  await ctx.userA.api.unlikePackage(ctx.testPackage);
+  await ctx.userA.browserApi.unlikePackage(ctx.testPackage);
 });

--- a/pkg/pub_integration/lib/src/test_scenario.dart
+++ b/pkg/pub_integration/lib/src/test_scenario.dart
@@ -93,9 +93,13 @@ final class TestUser {
   /// The email of the given test user.
   final String email;
 
-  /// An API client for access the API authenticated with a session associated
-  /// with this user.
-  final PubApiClient api;
+  /// A browser-based API client for access the API authenticated with a
+  /// session associated with this user.
+  final PubApiClient browserApi;
+
+  /// A command-line based API client for accessing the API authenticated
+  /// via an auth token (for pub site audience).
+  final PubApiClient serverApi;
 
   /// Executes callback `fn` with the browser page where this test user is
   /// signed-in to their account.
@@ -112,7 +116,8 @@ final class TestUser {
 
   TestUser({
     required this.email,
-    required this.api,
+    required this.browserApi,
+    required this.serverApi,
     required this.withBrowserPage,
     required this.readLatestEmail,
     required this.createCredentials,


### PR DESCRIPTION
- #7535
- Needed to update `TestUser` with a separation of `browserApi` (using session cookies) and `serverApi` (using JWT tokens).
- Created a fake server endpoint to generate a token. An alternative would be to move a lot of code to `pkg/_pub_shared`, but I'd rather keep them together in `app/`, as it is more in focus.
- The test flow revealed that we still need another admin action to close a moderation case, implementing it in a follow-up PR.