### PR TITLE
Fix Flutter archive test.

### DIFF
--- a/pkg/_pub_shared/test/utils/flutter_archive_test.dart
+++ b/pkg/_pub_shared/test/utils/flutter_archive_test.dart
@@ -10,7 +10,7 @@ void main() {
     final archive = await fetchFlutterArchive();
     expect(archive!.latestStable, isNotNull);
     expect(archive.latestBeta, isNotNull);
-    // we usually have a new releases in every 3-5 weeks
+    // we usually have new releases every 3-5 weeks
     expect(
       DateTime.now().difference(archive.latestStable!.releaseDate!).inDays,
       lessThan(45),

--- a/pkg/_pub_shared/test/utils/flutter_archive_test.dart
+++ b/pkg/_pub_shared/test/utils/flutter_archive_test.dart
@@ -10,15 +10,14 @@ void main() {
     final archive = await fetchFlutterArchive();
     expect(archive!.latestStable, isNotNull);
     expect(archive.latestBeta, isNotNull);
-    // we usually have a new stable release in every 3-5 weeks
+    // we usually have a new releases in every 3-5 weeks
+    expect(
+      DateTime.now().difference(archive.latestStable!.releaseDate!).inDays,
+      lessThan(45),
+    );
     expect(
       DateTime.now().difference(archive.latestBeta!.releaseDate!).inDays,
       lessThan(45),
-    );
-    // we usually have a new beta release in every 2-3 weeks
-    expect(
-      DateTime.now().difference(archive.latestBeta!.releaseDate!).inDays,
-      lessThan(30),
     );
   });
 }


### PR DESCRIPTION
- Fixes the test to also check stable release date.
- Increased both time range to 45 days.