### PR TITLE
Update reserved package name to `data_class`

### DIFF
--- a/app/lib/package/overrides.dart
+++ b/app/lib/package/overrides.dart
@@ -37,7 +37,7 @@ final _reservedPackageNames = <String>[
   'fluttery',
   'fluttery_audio',
   'fluttery_seekbar',
-  'dart_class',
+  'data_class',
 ].map(reducePackageName).toList();
 
 const redirectPackageUrls = <String, String>{


### PR DESCRIPTION
Apologies for the confusion and inconvenience! The desired package name was meant to be `data_class` not `dart_class`.

Related to: https://github.com/dart-lang/pub-dev/pull/7759

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.