### PR TITLE
Updated GitHub publishing with new event type, admin page + tests.

### DIFF
--- a/app/lib/frontend/templates/views/pkg/admin_page.dart
+++ b/app/lib/frontend/templates/views/pkg/admin_page.dart
@@ -283,6 +283,28 @@ d.Node _automatedPublishing(Package package) {
                 'and for `mypackage-1.2.3` use `mypackage-{{version}}`.'),
           ],
         ),
+        // events
+        d.div(
+          classes: [
+            '-pub-form-checkbox-row',
+          ],
+          child: material.checkbox(
+            id: '-pkg-admin-automated-github-push-events',
+            label: 'Enable push events',
+            checked: github?.isPushEventEnabled ?? true,
+          ),
+        ),
+        d.div(
+          classes: [
+            '-pub-form-checkbox-row',
+          ],
+          child: material.checkbox(
+            id: '-pkg-admin-automated-github-workflowdispatch-events',
+            label: 'Enable workflow_dispatch events',
+            checked: github?.isWorkflowDispatchEventEnabled ?? false,
+          ),
+        ),
+        // enviroment
         d.div(
           classes: [
             '-pub-form-checkbox-row',

--- a/app/lib/frontend/templates/views/pkg/admin_page.dart
+++ b/app/lib/frontend/templates/views/pkg/admin_page.dart
@@ -290,8 +290,13 @@ d.Node _automatedPublishing(Package package) {
           ],
           child: material.checkbox(
             id: '-pkg-admin-automated-github-push-events',
-            label: 'Enable push events',
+            label: 'Enable publishing from `push` events',
             checked: github?.isPushEventEnabled ?? true,
+            labelNodeContent: (_) => d.fragment([
+              d.text('Enable publishing from '),
+              d.code(text: 'push'),
+              d.text(' events'),
+            ]),
           ),
         ),
         d.div(
@@ -300,8 +305,13 @@ d.Node _automatedPublishing(Package package) {
           ],
           child: material.checkbox(
             id: '-pkg-admin-automated-github-workflowdispatch-events',
-            label: 'Enable workflow_dispatch events',
+            label: 'Enable publishing from `workflow_dispatch` events',
             checked: github?.isWorkflowDispatchEventEnabled ?? false,
+            labelNodeContent: (_) => d.fragment([
+              d.text('Enable publishing from '),
+              d.code(text: 'workflow_dispatch'),
+              d.text(' events'),
+            ]),
           ),
         ),
         // enviroment

--- a/app/test/frontend/golden/pkg_admin_page.html
+++ b/app/test/frontend/golden/pkg_admin_page.html
@@ -431,7 +431,11 @@
                           </div>
                           <div class="mdc-checkbox__ripple"></div>
                         </div>
-                        <label for="-pkg-admin-automated-github-push-events">Enable push events</label>
+                        <label for="-pkg-admin-automated-github-push-events">
+                          Enable publishing from
+                          <code>push</code>
+                          events
+                        </label>
                       </div>
                     </div>
                     <div class="-pub-form-checkbox-row">
@@ -446,7 +450,11 @@
                           </div>
                           <div class="mdc-checkbox__ripple"></div>
                         </div>
-                        <label for="-pkg-admin-automated-github-workflowdispatch-events">Enable workflow_dispatch events</label>
+                        <label for="-pkg-admin-automated-github-workflowdispatch-events">
+                          Enable publishing from
+                          <code>workflow_dispatch</code>
+                          events
+                        </label>
                       </div>
                     </div>
                     <div class="-pub-form-checkbox-row -pub-form-checkbox-toggle-next-sibling">

--- a/app/test/frontend/golden/pkg_admin_page.html
+++ b/app/test/frontend/golden/pkg_admin_page.html
@@ -419,6 +419,36 @@
                         .
                       </p>
                     </div>
+                    <div class="-pub-form-checkbox-row">
+                      <div class="mdc-form-field">
+                        <div class="mdc-checkbox">
+                          <input id="-pkg-admin-automated-github-push-events" class="mdc-checkbox__native-control" type="checkbox" checked="checked"/>
+                          <div class="mdc-checkbox__background">
+                            <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
+                              <path class="mdc-checkbox__checkmark-path" fill="none" d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
+                            </svg>
+                            <div class="mdc-checkbox__mixedmark"></div>
+                          </div>
+                          <div class="mdc-checkbox__ripple"></div>
+                        </div>
+                        <label for="-pkg-admin-automated-github-push-events">Enable push events</label>
+                      </div>
+                    </div>
+                    <div class="-pub-form-checkbox-row">
+                      <div class="mdc-form-field">
+                        <div class="mdc-checkbox">
+                          <input id="-pkg-admin-automated-github-workflowdispatch-events" class="mdc-checkbox__native-control" type="checkbox"/>
+                          <div class="mdc-checkbox__background">
+                            <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
+                              <path class="mdc-checkbox__checkmark-path" fill="none" d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
+                            </svg>
+                            <div class="mdc-checkbox__mixedmark"></div>
+                          </div>
+                          <div class="mdc-checkbox__ripple"></div>
+                        </div>
+                        <label for="-pkg-admin-automated-github-workflowdispatch-events">Enable workflow_dispatch events</label>
+                      </div>
+                    </div>
                     <div class="-pub-form-checkbox-row -pub-form-checkbox-toggle-next-sibling">
                       <div class="mdc-form-field">
                         <div class="mdc-checkbox">

--- a/app/test/package/automated_publishing_test.dart
+++ b/app/test/package/automated_publishing_test.dart
@@ -194,6 +194,26 @@ void main() {
       }
     });
 
+    testWithProfile('GitHub Actions: no events enabled', fn: () async {
+      final client =
+          await createFakeAuthPubApiClient(email: adminAtPubDevEmail);
+      final rs = client.setAutomatedPublishing(
+          'oxygen',
+          AutomatedPublishingConfig(
+            github: GithubPublishingConfig(
+              isEnabled: false,
+              repository: 'abcd/efgh',
+              isPushEventEnabled: false,
+            ),
+          ));
+      await expectApiException(
+        rs,
+        status: 400,
+        code: 'InvalidInput',
+        message: 'one of the events',
+      );
+    });
+
     testWithProfile('Google Cloud: bad service account email', fn: () async {
       final client =
           await createFakeAuthPubApiClient(email: adminAtPubDevEmail);

--- a/pkg/web_app/lib/src/admin_pages.dart
+++ b/pkg/web_app/lib/src/admin_pages.dart
@@ -168,7 +168,8 @@ class _PkgAdminWidget {
                 isEnabled: githubEnabledCheckbox!.checked ?? false,
                 repository: githubRepositoryInput.value,
                 tagPattern: githubTagPatternInput!.value,
-                isPushEventEnabled: githubIsPushEventsCheckbox!.checked ?? true,
+                isPushEventEnabled:
+                    githubIsPushEventsCheckbox!.checked ?? false,
                 isWorkflowDispatchEventEnabled:
                     githubIsWorkflowDispatchEventsCheckbox!.checked ?? false,
                 requireEnvironment:

--- a/pkg/web_app/lib/src/admin_pages.dart
+++ b/pkg/web_app/lib/src/admin_pages.dart
@@ -134,6 +134,11 @@ class _PkgAdminWidget {
     final githubTagPatternInput =
         document.getElementById('-pkg-admin-automated-github-tagpattern')
             as InputElement?;
+    final githubIsPushEventsCheckbox =
+        document.getElementById('-pkg-admin-automated-github-push-events')
+            as InputElement?;
+    final githubIsWorkflowDispatchEventsCheckbox = document.getElementById(
+        '-pkg-admin-automated-github-workflowdispatch-events') as InputElement?;
     final githubRequireEnvironmentCheckbox =
         document.getElementById('-pkg-admin-automated-github-requireenv')
             as InputElement?;
@@ -163,6 +168,9 @@ class _PkgAdminWidget {
                 isEnabled: githubEnabledCheckbox!.checked ?? false,
                 repository: githubRepositoryInput.value,
                 tagPattern: githubTagPatternInput!.value,
+                isPushEventEnabled: githubIsPushEventsCheckbox!.checked ?? true,
+                isWorkflowDispatchEventEnabled:
+                    githubIsWorkflowDispatchEventsCheckbox!.checked ?? false,
                 requireEnvironment:
                     githubRequireEnvironmentCheckbox!.checked ?? false,
                 environment: githubEnvironmentInput!.value,


### PR DESCRIPTION
- Replaces #7462
- Adds two checkboxes on the UI (screenshot below)
- Allows only config updates that enables at least one of the events.
- Verifies that the event is allowed at publishing time.

![image](https://github.com/dart-lang/pub-dev/assets/4778111/63e84b91-69d5-44ef-9d2b-ba4d082d2925)
 