### PR TITLE
Prepare dark-mode experimental flag and top-level style.

### DIFF
--- a/app/lib/frontend/handlers/experimental.dart
+++ b/app/lib/frontend/handlers/experimental.dart
@@ -7,6 +7,7 @@ import 'package:meta/meta.dart';
 import '../../shared/cookie_utils.dart';
 
 const _publicFlags = <String>{
+  'dark',
   'report',
 };
 
@@ -79,6 +80,8 @@ class ExperimentalFlags {
   }
 
   bool get isReportPageEnabled => isEnabled('report');
+
+  bool get isDarkModeEnabled => isEnabled('dark');
 
   String encodedAsCookie() => _enabled.join(':');
 

--- a/app/lib/frontend/templates/views/shared/layout.dart
+++ b/app/lib/frontend/templates/views/shared/layout.dart
@@ -2,11 +2,11 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:pub_dev/admin/models.dart';
-
+import '../../../../admin/models.dart';
 import '../../../../shared/configuration.dart';
 import '../../../../shared/urls.dart' as urls;
 import '../../../dom/dom.dart' as d;
+import '../../../request_context.dart';
 import '../../../static_files.dart' show staticUrls;
 
 d.Node pageLayoutNode({
@@ -159,6 +159,8 @@ d.Node pageLayoutNode({
           'body',
           classes: [
             ...?bodyClasses,
+            if (requestContext.experimentalFlags.isDarkModeEnabled)
+              '-experimental-dark-mode',
             'light-theme',
             if (activeConfiguration.isStaging) 'staging-banner',
           ],

--- a/pkg/web_app/lib/script.dart
+++ b/pkg/web_app/lib/script.dart
@@ -26,6 +26,19 @@ void main() {
   window.onPageShow.listen((_) {
     adjustQueryTextAfterPageShow();
   });
+
+  // For now we are reusing dartdoc's theme switcher and local storage-based
+  // setting to replace the body-level theme classname.
+  window.onLoad.listen((_) {
+    final classes = document.body?.classes;
+    if (classes != null && classes.contains('-experimental-dark-mode')) {
+      final colorTheme = window.localStorage['colorTheme'];
+      if (colorTheme == 'true') {
+        classes.remove('light-theme');
+        classes.add('dark-theme');
+      }
+    }
+  });
 }
 
 void _setupAllEvents() {


### PR DESCRIPTION
- #4416
- Note: this PR does not add a button to switch themes, but relies on the `localStorage` flag that the `dartdoc` pages may set when clicking on the dark/light theme button. It is possible that we may introduce a similar button, or we may rely only on the CSS media selectors that are coming from the OS/browser preferences, maybe even both. But for the time being and to explore what kind of SCSS refactoring we may need, this gives an appropriate style isolation and also an easy trigger mechanism.
