### PR TITLE
Replace some uses of Consent.fromUserId and use fromAgent instead.

### DIFF
--- a/app/lib/account/consent_backend.dart
+++ b/app/lib/account/consent_backend.dart
@@ -352,7 +352,7 @@ class _PackageUploaderAction extends ConsentAction {
     final packageName = consent.args![0];
     await withRetryTransaction(dbService, (tx) async {
       tx.insert(await AuditLogRecord.uploaderInviteRejected(
-        fromUserId: consent.fromUserId,
+        fromAgent: consent.fromAgent,
         package: packageName,
         uploaderEmail: user?.email ?? consent.email!,
         userId: user?.userId,
@@ -365,7 +365,7 @@ class _PackageUploaderAction extends ConsentAction {
     final packageName = consent.args![0];
     await withRetryTransaction(dbService, (tx) async {
       tx.insert(await AuditLogRecord.uploaderInviteExpired(
-        fromUserId: consent.fromUserId,
+        fromAgent: consent.fromAgent,
         package: packageName,
         uploaderEmail: consent.email!,
       ));
@@ -418,7 +418,7 @@ class _PublisherContactAction extends ConsentAction {
     final publisherId = consent.args![0];
     await withRetryTransaction(dbService, (tx) async {
       tx.insert(await AuditLogRecord.publisherContactInviteRejected(
-        fromUserId: consent.fromUserId,
+        fromAgent: consent.fromAgent,
         publisherId: publisherId,
         contactEmail: consent.email!,
         userEmail: user?.email,
@@ -432,7 +432,7 @@ class _PublisherContactAction extends ConsentAction {
     final publisherId = consent.args![0];
     await withRetryTransaction(dbService, (tx) async {
       tx.insert(await AuditLogRecord.publisherContactInviteExpired(
-        fromUserId: consent.fromUserId,
+        fromAgent: consent.fromAgent,
         publisherId: publisherId,
         contactEmail: consent.email!,
       ));
@@ -498,7 +498,7 @@ class _PublisherMemberAction extends ConsentAction {
     final publisherId = consent.args![0];
     await withRetryTransaction(dbService, (tx) async {
       tx.insert(await AuditLogRecord.publisherMemberInviteRejected(
-        fromUserId: consent.fromUserId,
+        fromAgent: consent.fromAgent,
         publisherId: publisherId,
         memberEmail: user?.email ?? consent.email!,
         userId: user?.userId,
@@ -511,7 +511,7 @@ class _PublisherMemberAction extends ConsentAction {
     final publisherId = consent.args![0];
     await withRetryTransaction(dbService, (tx) async {
       tx.insert(await AuditLogRecord.publisherMemberInviteExpired(
-        fromUserId: consent.fromUserId,
+        fromAgent: consent.fromAgent,
         publisherId: publisherId,
         memberEmail: consent.email!,
       ));

--- a/app/lib/audit/models.dart
+++ b/app/lib/audit/models.dart
@@ -464,10 +464,12 @@ class AuditLogRecord extends db.ExpandoModel<String> {
   ///
   /// Throws [RateLimitException] when the configured rate limit is reached.
   static Future<AuditLogRecord> publisherContactInviteExpired({
-    required String? fromUserId,
+    required String? fromAgent,
     required String publisherId,
     required String contactEmail,
   }) {
+    final fromUserId =
+        fromAgent != null && looksLikeUserId(fromAgent) ? fromAgent : null;
     return _checkRateLimit(AuditLogRecord._init()
       ..kind = AuditLogRecordKind.publisherContactInviteExpired
       ..agent = KnownAgents.pubSupport
@@ -488,7 +490,7 @@ class AuditLogRecord extends db.ExpandoModel<String> {
   ///
   /// Throws [RateLimitException] when the configured rate limit is reached.
   static Future<AuditLogRecord> publisherContactInviteRejected({
-    required String? fromUserId,
+    required String? fromAgent,
     required String publisherId,
     required String contactEmail,
 
@@ -496,6 +498,8 @@ class AuditLogRecord extends db.ExpandoModel<String> {
     required String? userId,
     required String? userEmail,
   }) {
+    final fromUserId =
+        fromAgent != null && looksLikeUserId(fromAgent) ? fromAgent : null;
     final summary = (userEmail == null || userEmail == contactEmail)
         ? '`$contactEmail` rejected contact invite for publisher `$publisherId`.'
         : '`$userEmail` rejected contact invite of `$contactEmail` for publisher `$publisherId`.';
@@ -592,10 +596,12 @@ class AuditLogRecord extends db.ExpandoModel<String> {
   ///
   /// Throws [RateLimitException] when the configured rate limit is reached.
   static Future<AuditLogRecord> publisherMemberInviteExpired({
-    required String? fromUserId,
+    required String? fromAgent,
     required String publisherId,
     required String memberEmail,
   }) {
+    final fromUserId =
+        fromAgent != null && looksLikeUserId(fromAgent) ? fromAgent : null;
     return _checkRateLimit(AuditLogRecord._init()
       ..kind = AuditLogRecordKind.publisherMemberInviteExpired
       ..agent = KnownAgents.pubSupport
@@ -616,13 +622,15 @@ class AuditLogRecord extends db.ExpandoModel<String> {
   ///
   /// Throws [RateLimitException] when the configured rate limit is reached.
   static Future<AuditLogRecord> publisherMemberInviteRejected({
-    required String? fromUserId,
+    required String? fromAgent,
     required String publisherId,
     required String memberEmail,
 
     /// Optional, in the future we may allow invite rejection without sign-in.
     required String? userId,
   }) {
+    final fromUserId =
+        fromAgent != null && looksLikeUserId(fromAgent) ? fromAgent : null;
     return _checkRateLimit(AuditLogRecord._init()
       ..kind = AuditLogRecordKind.publisherMemberInviteRejected
       ..agent = userId ?? KnownAgents.pubSupport
@@ -771,10 +779,12 @@ class AuditLogRecord extends db.ExpandoModel<String> {
   ///
   /// Throws [RateLimitException] when the configured rate limit is reached.
   static Future<AuditLogRecord> uploaderInviteExpired({
-    required String? fromUserId,
+    required String? fromAgent,
     required String package,
     required String uploaderEmail,
   }) {
+    final fromUserId =
+        fromAgent != null && looksLikeUserId(fromAgent) ? fromAgent : null;
     return _checkRateLimit(AuditLogRecord._init()
       ..kind = AuditLogRecordKind.uploaderInviteExpired
       ..agent = KnownAgents.pubSupport
@@ -795,13 +805,15 @@ class AuditLogRecord extends db.ExpandoModel<String> {
   ///
   /// Throws [RateLimitException] when the configured rate limit is reached.
   static Future<AuditLogRecord> uploaderInviteRejected({
-    required String? fromUserId,
+    required String? fromAgent,
     required String package,
     required String uploaderEmail,
 
     /// Optional, in the future we may allow invite rejection without sign-in.
     required String? userId,
   }) {
+    final fromUserId =
+        fromAgent != null && looksLikeUserId(fromAgent) ? fromAgent : null;
     return _checkRateLimit(AuditLogRecord._init()
       ..kind = AuditLogRecordKind.uploaderInviteRejected
       ..agent = userId ?? KnownAgents.pubSupport
@@ -813,7 +825,10 @@ class AuditLogRecord extends db.ExpandoModel<String> {
         'uploaderEmail': uploaderEmail,
         if (userId != null) 'userId': userId,
       }
-      ..users = [if (fromUserId != null) fromUserId, if (userId != null) userId]
+      ..users = [
+        if (fromUserId != null) fromUserId,
+        if (userId != null) userId,
+      ]
       ..packages = [package]
       ..packageVersions = []
       ..publishers = []);


### PR DESCRIPTION
- #7725
- In these cases keeping the `userId` reference is helpful for the inviter to track the status of their invites. Checking the pattern of the `userId` is enough here to decide if it was a user or a different agent.