### PR TITLE
CSS refactoring: dartdoc.scss, separation of third_party and customization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ build/
 *.sum
 
 # Ignore files built when the server is started
+/static/css/dartdoc.css
+/static/css/dartdoc.css.map
 /static/css/style.css
 /static/css/style.css.map
 /static/js/script.dart.js

--- a/app/lib/dartdoc/dartdoc_page.dart
+++ b/app/lib/dartdoc/dartdoc_page.dart
@@ -110,21 +110,6 @@ extension DartDocPageRender on DartDocPage {
         if (!options.isLatestStable)
           d.meta(rel: 'alternate', href: options.latestStableDocumentationUrl),
         d.link(rel: 'preconnect', href: 'https://fonts.gstatic.com'),
-        // HACK: This is not part of dartdoc
-        d.link(
-            rel: 'stylesheet',
-            type: 'text/css',
-            href: staticUrls.githubMarkdownCss),
-        // TODO: Consider using same github.css we use on pub.dev
-        d.link(
-            rel: 'stylesheet',
-            type: 'text/css',
-            href: staticUrls.dartdocGithubCss),
-        if (activeConfiguration.isStaging)
-          d.link(
-              rel: 'stylesheet',
-              type: 'text/css',
-              href: staticUrls.getAssetUrl('/static/css/staging-ribbon.css')),
         d.link(
           rel: 'stylesheet',
           href:
@@ -136,7 +121,7 @@ extension DartDocPageRender on DartDocPage {
               'https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0',
         ),
 
-        d.link(rel: 'stylesheet', href: staticUrls.dartdocStylesCss),
+        d.link(rel: 'stylesheet', href: staticUrls.dartdocCss),
         d.link(rel: 'icon', href: staticUrls.smallDartFavicon),
       ]);
 

--- a/app/lib/frontend/static_files.dart
+++ b/app/lib/frontend/static_files.dart
@@ -240,11 +240,7 @@ class StaticUrls {
   late final pubDevLogoSvg = getAssetUrl('/static/img/pub-dev-logo.svg');
   late final defaultProfilePng = getAssetUrl(
       '/static/img/material-icon-twotone-account-circle-white-24dp.png');
-  late final githubMarkdownCss = getAssetUrl('/static/css/github-markdown.css');
-  late final dartdocGithubCss =
-      getAssetUrl('/static/dartdoc/resources/github.css');
-  late final dartdocStylesCss =
-      getAssetUrl('/static/dartdoc/resources/styles.css');
+  late final dartdocCss = getAssetUrl('/static/css/dartdoc.css');
   late final dartdocScriptJs =
       getAssetUrl('/static/dartdoc/resources/docs.dart.js');
   late final dartdochighlightJs =
@@ -331,11 +327,19 @@ Future updateLocalBuiltFilesIfNeeded() async {
 
   final webCssDir = Directory(resolveWebCssDirPath());
   final webCssLastModified = await _detectLastModified(webCssDir);
-  final styleCss = File(path.join(staticDir.path, 'css', 'style.css'));
-  final styleCssExists = await styleCss.exists();
-  final styleCssLastModified =
-      styleCssExists ? await styleCss.lastModified() : null;
-  if (!styleCssExists || (styleCssLastModified!.isBefore(webCssLastModified))) {
+
+  Future<bool> cssNeedsUpdate(String filename) async {
+    final styleCss = File(path.join(staticDir.path, 'css', filename));
+    final styleCssExists = await styleCss.exists();
+    final styleCssLastModified =
+        styleCssExists ? await styleCss.lastModified() : null;
+    return !styleCssExists ||
+        (styleCssLastModified!.isBefore(webCssLastModified));
+  }
+
+  final needsCssBuild = (await cssNeedsUpdate('style.css')) ||
+      (await cssNeedsUpdate('dartdoc.css'));
+  if (needsCssBuild) {
     _logger.info('Building pkg/web_css');
     await updateWebCssBuild();
   }

--- a/app/lib/frontend/static_files.dart
+++ b/app/lib/frontend/static_files.dart
@@ -118,6 +118,7 @@ class StaticFileCache {
       // deployment process. Normally page rendering checks their existence,
       // and fails when they are missing. By listing these here, the build
       // is no longer a strict requirement, and tests can be run without it.
+      '/static/css/dartdoc.css',
       '/static/css/style.css',
       '/static/js/script.dart.js',
     };

--- a/app/test/dartdoc/dartdoc_page_test.dart
+++ b/app/test/dartdoc/dartdoc_page_test.dart
@@ -134,7 +134,7 @@ void main() {
             _removeSharedXmlNodes(fileXmlRoot, renderedXmlDoc);
 
             // cleanup <head> differences
-            for (final link in ['/styles.css', '/favicon.png']) {
+            for (final link in ['/styles.css', '/github.css', '/favicon.png']) {
               fileXmlRoot.descendantElements
                   .firstWhere((e) =>
                       e.localName == 'link' &&
@@ -149,7 +149,7 @@ void main() {
             renderedHead.childElements
                 .firstWhereOrNull((e) => e.getAttribute('content') == 'noindex')
                 ?.remove();
-            expect(renderedHead.children, hasLength(7));
+            expect(renderedHead.children, hasLength(6));
             for (final c in [...renderedHead.childElements]) {
               c.remove();
             }

--- a/app/test/dartdoc/dartdoc_page_test.dart
+++ b/app/test/dartdoc/dartdoc_page_test.dart
@@ -62,6 +62,7 @@ void main() {
     scopedTest(
       'run dartdoc',
       () async {
+        registerStaticFileCacheForTest(StaticFileCache.forTests());
         final pr = await toolEnv.dartdoc(pkgDir, docDir, usesFlutter: false);
         expect(pr.exitCode, 0);
 

--- a/app/test/frontend/static_files_test.dart
+++ b/app/test/frontend/static_files_test.dart
@@ -130,6 +130,7 @@ void main() {
         ..remove('/static/js/survey-helper.js')
         // debug-helper files are served, but not referenced
         ..removeAll([
+          '/static/css/dartdoc.css.map',
           '/static/css/style.css.map',
           '/static/js/script.dart.js.deps',
           '/static/js/script.dart.js.info.json',
@@ -160,6 +161,11 @@ void main() {
           '/static/css/dartdoc-github-alert.css',
           '/static/css/github-markdown.css',
           '/static/highlight/github.css',
+        ])
+        // dartdoc files included through dartdoc.scss
+        ..removeAll([
+          '/static/dartdoc/resources/github.css',
+          '/static/dartdoc/resources/styles.css',
         ])
         // dartdoc files not used, or included through javascript
         ..removeAll([

--- a/app/test/task/testdata/goldens/documentation/oxygen/1.0.0/index.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/1.0.0/index.html
@@ -13,11 +13,9 @@
     <link rel="canonical" href="https://pub.dev/documentation/oxygen/1.0.0/"/>
     <meta rel="alternate" href="/documentation/oxygen/latest/"/>
     <link rel="preconnect" href="https://fonts.gstatic.com"/>
-    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/github-markdown.css"/>
-    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/dartdoc/resources/github.css"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,300;0,400;0,500;0,700;1,400&amp;display=swap"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0"/>
-    <link rel="stylesheet" href="/static/hash-%%etag%%/dartdoc/resources/styles.css"/>
+    <link rel="stylesheet" href="/static/hash-%%etag%%/css/dartdoc.css"/>
     <link rel="icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
   </head>
   <body class="light-theme" data-base-href="" data-using-base-href="false">

--- a/app/test/task/testdata/goldens/documentation/oxygen/1.0.0/oxygen/MainClass-class.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/1.0.0/oxygen/MainClass-class.html
@@ -13,11 +13,9 @@
     <link rel="canonical" href="https://pub.dev/documentation/oxygen/1.0.0/oxygen/MainClass-class.html"/>
     <meta rel="alternate" href="/documentation/oxygen/latest/"/>
     <link rel="preconnect" href="https://fonts.gstatic.com"/>
-    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/github-markdown.css"/>
-    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/dartdoc/resources/github.css"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,300;0,400;0,500;0,700;1,400&amp;display=swap"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0"/>
-    <link rel="stylesheet" href="/static/hash-%%etag%%/dartdoc/resources/styles.css"/>
+    <link rel="stylesheet" href="/static/hash-%%etag%%/css/dartdoc.css"/>
     <link rel="icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
   </head>
   <body class="light-theme" data-base-href="../" data-using-base-href="false">

--- a/app/test/task/testdata/goldens/documentation/oxygen/1.0.0/oxygen/MainClass/MainClass.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/1.0.0/oxygen/MainClass/MainClass.html
@@ -13,11 +13,9 @@
     <link rel="canonical" href="https://pub.dev/documentation/oxygen/1.0.0/oxygen/MainClass/MainClass.html"/>
     <meta rel="alternate" href="/documentation/oxygen/latest/"/>
     <link rel="preconnect" href="https://fonts.gstatic.com"/>
-    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/github-markdown.css"/>
-    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/dartdoc/resources/github.css"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,300;0,400;0,500;0,700;1,400&amp;display=swap"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0"/>
-    <link rel="stylesheet" href="/static/hash-%%etag%%/dartdoc/resources/styles.css"/>
+    <link rel="stylesheet" href="/static/hash-%%etag%%/css/dartdoc.css"/>
     <link rel="icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
   </head>
   <body class="light-theme" data-base-href="../../" data-using-base-href="false">

--- a/app/test/task/testdata/goldens/documentation/oxygen/1.0.0/oxygen/MainClass/text.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/1.0.0/oxygen/MainClass/text.html
@@ -13,11 +13,9 @@
     <link rel="canonical" href="https://pub.dev/documentation/oxygen/1.0.0/oxygen/MainClass/text.html"/>
     <meta rel="alternate" href="/documentation/oxygen/latest/"/>
     <link rel="preconnect" href="https://fonts.gstatic.com"/>
-    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/github-markdown.css"/>
-    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/dartdoc/resources/github.css"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,300;0,400;0,500;0,700;1,400&amp;display=swap"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0"/>
-    <link rel="stylesheet" href="/static/hash-%%etag%%/dartdoc/resources/styles.css"/>
+    <link rel="stylesheet" href="/static/hash-%%etag%%/css/dartdoc.css"/>
     <link rel="icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
   </head>
   <body class="light-theme" data-base-href="../../" data-using-base-href="false">

--- a/app/test/task/testdata/goldens/documentation/oxygen/1.0.0/oxygen/MainClass/toLowerCase.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/1.0.0/oxygen/MainClass/toLowerCase.html
@@ -13,11 +13,9 @@
     <link rel="canonical" href="https://pub.dev/documentation/oxygen/1.0.0/oxygen/MainClass/toLowerCase.html"/>
     <meta rel="alternate" href="/documentation/oxygen/latest/"/>
     <link rel="preconnect" href="https://fonts.gstatic.com"/>
-    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/github-markdown.css"/>
-    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/dartdoc/resources/github.css"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,300;0,400;0,500;0,700;1,400&amp;display=swap"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0"/>
-    <link rel="stylesheet" href="/static/hash-%%etag%%/dartdoc/resources/styles.css"/>
+    <link rel="stylesheet" href="/static/hash-%%etag%%/css/dartdoc.css"/>
     <link rel="icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
   </head>
   <body class="light-theme" data-base-href="../../" data-using-base-href="false">

--- a/app/test/task/testdata/goldens/documentation/oxygen/1.0.0/oxygen/MainClass/toString.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/1.0.0/oxygen/MainClass/toString.html
@@ -13,11 +13,9 @@
     <link rel="canonical" href="https://pub.dev/documentation/oxygen/1.0.0/oxygen/MainClass/toString.html"/>
     <meta rel="alternate" href="/documentation/oxygen/latest/"/>
     <link rel="preconnect" href="https://fonts.gstatic.com"/>
-    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/github-markdown.css"/>
-    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/dartdoc/resources/github.css"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,300;0,400;0,500;0,700;1,400&amp;display=swap"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0"/>
-    <link rel="stylesheet" href="/static/hash-%%etag%%/dartdoc/resources/styles.css"/>
+    <link rel="stylesheet" href="/static/hash-%%etag%%/css/dartdoc.css"/>
     <link rel="icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
   </head>
   <body class="light-theme" data-base-href="../../" data-using-base-href="false">

--- a/app/test/task/testdata/goldens/documentation/oxygen/1.0.0/oxygen/TypeEnum.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/1.0.0/oxygen/TypeEnum.html
@@ -13,11 +13,9 @@
     <link rel="canonical" href="https://pub.dev/documentation/oxygen/1.0.0/oxygen/TypeEnum.html"/>
     <meta rel="alternate" href="/documentation/oxygen/latest/"/>
     <link rel="preconnect" href="https://fonts.gstatic.com"/>
-    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/github-markdown.css"/>
-    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/dartdoc/resources/github.css"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,300;0,400;0,500;0,700;1,400&amp;display=swap"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0"/>
-    <link rel="stylesheet" href="/static/hash-%%etag%%/dartdoc/resources/styles.css"/>
+    <link rel="stylesheet" href="/static/hash-%%etag%%/css/dartdoc.css"/>
     <link rel="icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
   </head>
   <body class="light-theme" data-base-href="../" data-using-base-href="false">

--- a/app/test/task/testdata/goldens/documentation/oxygen/1.0.0/oxygen/TypeEnum/TypeEnum.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/1.0.0/oxygen/TypeEnum/TypeEnum.html
@@ -13,11 +13,9 @@
     <link rel="canonical" href="https://pub.dev/documentation/oxygen/1.0.0/oxygen/TypeEnum/TypeEnum.html"/>
     <meta rel="alternate" href="/documentation/oxygen/latest/"/>
     <link rel="preconnect" href="https://fonts.gstatic.com"/>
-    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/github-markdown.css"/>
-    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/dartdoc/resources/github.css"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,300;0,400;0,500;0,700;1,400&amp;display=swap"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0"/>
-    <link rel="stylesheet" href="/static/hash-%%etag%%/dartdoc/resources/styles.css"/>
+    <link rel="stylesheet" href="/static/hash-%%etag%%/css/dartdoc.css"/>
     <link rel="icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
   </head>
   <body class="light-theme" data-base-href="../../" data-using-base-href="false">

--- a/app/test/task/testdata/goldens/documentation/oxygen/1.0.0/oxygen/TypeEnum/values-constant.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/1.0.0/oxygen/TypeEnum/values-constant.html
@@ -13,11 +13,9 @@
     <link rel="canonical" href="https://pub.dev/documentation/oxygen/1.0.0/oxygen/TypeEnum/values-constant.html"/>
     <meta rel="alternate" href="/documentation/oxygen/latest/"/>
     <link rel="preconnect" href="https://fonts.gstatic.com"/>
-    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/github-markdown.css"/>
-    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/dartdoc/resources/github.css"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,300;0,400;0,500;0,700;1,400&amp;display=swap"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0"/>
-    <link rel="stylesheet" href="/static/hash-%%etag%%/dartdoc/resources/styles.css"/>
+    <link rel="stylesheet" href="/static/hash-%%etag%%/css/dartdoc.css"/>
     <link rel="icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
   </head>
   <body class="light-theme" data-base-href="../../" data-using-base-href="false">

--- a/app/test/task/testdata/goldens/documentation/oxygen/1.0.0/oxygen/main.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/1.0.0/oxygen/main.html
@@ -13,11 +13,9 @@
     <link rel="canonical" href="https://pub.dev/documentation/oxygen/1.0.0/oxygen/main.html"/>
     <meta rel="alternate" href="/documentation/oxygen/latest/"/>
     <link rel="preconnect" href="https://fonts.gstatic.com"/>
-    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/github-markdown.css"/>
-    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/dartdoc/resources/github.css"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,300;0,400;0,500;0,700;1,400&amp;display=swap"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0"/>
-    <link rel="stylesheet" href="/static/hash-%%etag%%/dartdoc/resources/styles.css"/>
+    <link rel="stylesheet" href="/static/hash-%%etag%%/css/dartdoc.css"/>
     <link rel="icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
   </head>
   <body class="light-theme" data-base-href="../" data-using-base-href="false">

--- a/app/test/task/testdata/goldens/documentation/oxygen/1.0.0/oxygen/oxygen-library.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/1.0.0/oxygen/oxygen-library.html
@@ -13,11 +13,9 @@
     <link rel="canonical" href="https://pub.dev/documentation/oxygen/1.0.0/oxygen/oxygen-library.html"/>
     <meta rel="alternate" href="/documentation/oxygen/latest/"/>
     <link rel="preconnect" href="https://fonts.gstatic.com"/>
-    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/github-markdown.css"/>
-    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/dartdoc/resources/github.css"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,300;0,400;0,500;0,700;1,400&amp;display=swap"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0"/>
-    <link rel="stylesheet" href="/static/hash-%%etag%%/dartdoc/resources/styles.css"/>
+    <link rel="stylesheet" href="/static/hash-%%etag%%/css/dartdoc.css"/>
     <link rel="icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
   </head>
   <body class="light-theme" data-base-href="../" data-using-base-href="false">

--- a/app/test/task/testdata/goldens/documentation/oxygen/2.0.0/index.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/2.0.0/index.html
@@ -11,11 +11,9 @@
     <title>oxygen - Dart API docs</title>
     <link rel="canonical" href="https://pub.dev/documentation/oxygen/2.0.0/"/>
     <link rel="preconnect" href="https://fonts.gstatic.com"/>
-    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/github-markdown.css"/>
-    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/dartdoc/resources/github.css"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,300;0,400;0,500;0,700;1,400&amp;display=swap"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0"/>
-    <link rel="stylesheet" href="/static/hash-%%etag%%/dartdoc/resources/styles.css"/>
+    <link rel="stylesheet" href="/static/hash-%%etag%%/css/dartdoc.css"/>
     <link rel="icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
   </head>
   <body class="light-theme" data-base-href="" data-using-base-href="false">

--- a/app/test/task/testdata/goldens/documentation/oxygen/2.0.0/oxygen/MainClass-class.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/2.0.0/oxygen/MainClass-class.html
@@ -11,11 +11,9 @@
     <title>MainClass class - oxygen library - Dart API</title>
     <link rel="canonical" href="https://pub.dev/documentation/oxygen/2.0.0/oxygen/MainClass-class.html"/>
     <link rel="preconnect" href="https://fonts.gstatic.com"/>
-    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/github-markdown.css"/>
-    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/dartdoc/resources/github.css"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,300;0,400;0,500;0,700;1,400&amp;display=swap"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0"/>
-    <link rel="stylesheet" href="/static/hash-%%etag%%/dartdoc/resources/styles.css"/>
+    <link rel="stylesheet" href="/static/hash-%%etag%%/css/dartdoc.css"/>
     <link rel="icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
   </head>
   <body class="light-theme" data-base-href="../" data-using-base-href="false">

--- a/app/test/task/testdata/goldens/documentation/oxygen/2.0.0/oxygen/MainClass/MainClass.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/2.0.0/oxygen/MainClass/MainClass.html
@@ -12,11 +12,9 @@
     <title>MainClass constructor - MainClass - oxygen library - Dart API</title>
     <link rel="canonical" href="https://pub.dev/documentation/oxygen/2.0.0/oxygen/MainClass/MainClass.html"/>
     <link rel="preconnect" href="https://fonts.gstatic.com"/>
-    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/github-markdown.css"/>
-    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/dartdoc/resources/github.css"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,300;0,400;0,500;0,700;1,400&amp;display=swap"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0"/>
-    <link rel="stylesheet" href="/static/hash-%%etag%%/dartdoc/resources/styles.css"/>
+    <link rel="stylesheet" href="/static/hash-%%etag%%/css/dartdoc.css"/>
     <link rel="icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
   </head>
   <body class="light-theme" data-base-href="../../" data-using-base-href="false">

--- a/app/test/task/testdata/goldens/documentation/oxygen/2.0.0/oxygen/MainClass/text.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/2.0.0/oxygen/MainClass/text.html
@@ -12,11 +12,9 @@
     <title>text property - MainClass class - oxygen library - Dart API</title>
     <link rel="canonical" href="https://pub.dev/documentation/oxygen/2.0.0/oxygen/MainClass/text.html"/>
     <link rel="preconnect" href="https://fonts.gstatic.com"/>
-    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/github-markdown.css"/>
-    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/dartdoc/resources/github.css"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,300;0,400;0,500;0,700;1,400&amp;display=swap"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0"/>
-    <link rel="stylesheet" href="/static/hash-%%etag%%/dartdoc/resources/styles.css"/>
+    <link rel="stylesheet" href="/static/hash-%%etag%%/css/dartdoc.css"/>
     <link rel="icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
   </head>
   <body class="light-theme" data-base-href="../../" data-using-base-href="false">

--- a/app/test/task/testdata/goldens/documentation/oxygen/2.0.0/oxygen/MainClass/toLowerCase.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/2.0.0/oxygen/MainClass/toLowerCase.html
@@ -12,11 +12,9 @@
     <title>toLowerCase method - MainClass class - oxygen library - Dart API</title>
     <link rel="canonical" href="https://pub.dev/documentation/oxygen/2.0.0/oxygen/MainClass/toLowerCase.html"/>
     <link rel="preconnect" href="https://fonts.gstatic.com"/>
-    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/github-markdown.css"/>
-    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/dartdoc/resources/github.css"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,300;0,400;0,500;0,700;1,400&amp;display=swap"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0"/>
-    <link rel="stylesheet" href="/static/hash-%%etag%%/dartdoc/resources/styles.css"/>
+    <link rel="stylesheet" href="/static/hash-%%etag%%/css/dartdoc.css"/>
     <link rel="icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
   </head>
   <body class="light-theme" data-base-href="../../" data-using-base-href="false">

--- a/app/test/task/testdata/goldens/documentation/oxygen/2.0.0/oxygen/MainClass/toString.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/2.0.0/oxygen/MainClass/toString.html
@@ -12,11 +12,9 @@
     <title>toString method - MainClass class - oxygen library - Dart API</title>
     <link rel="canonical" href="https://pub.dev/documentation/oxygen/2.0.0/oxygen/MainClass/toString.html"/>
     <link rel="preconnect" href="https://fonts.gstatic.com"/>
-    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/github-markdown.css"/>
-    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/dartdoc/resources/github.css"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,300;0,400;0,500;0,700;1,400&amp;display=swap"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0"/>
-    <link rel="stylesheet" href="/static/hash-%%etag%%/dartdoc/resources/styles.css"/>
+    <link rel="stylesheet" href="/static/hash-%%etag%%/css/dartdoc.css"/>
     <link rel="icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
   </head>
   <body class="light-theme" data-base-href="../../" data-using-base-href="false">

--- a/app/test/task/testdata/goldens/documentation/oxygen/2.0.0/oxygen/TypeEnum.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/2.0.0/oxygen/TypeEnum.html
@@ -11,11 +11,9 @@
     <title>TypeEnum enum - oxygen library - Dart API</title>
     <link rel="canonical" href="https://pub.dev/documentation/oxygen/2.0.0/oxygen/TypeEnum.html"/>
     <link rel="preconnect" href="https://fonts.gstatic.com"/>
-    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/github-markdown.css"/>
-    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/dartdoc/resources/github.css"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,300;0,400;0,500;0,700;1,400&amp;display=swap"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0"/>
-    <link rel="stylesheet" href="/static/hash-%%etag%%/dartdoc/resources/styles.css"/>
+    <link rel="stylesheet" href="/static/hash-%%etag%%/css/dartdoc.css"/>
     <link rel="icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
   </head>
   <body class="light-theme" data-base-href="../" data-using-base-href="false">

--- a/app/test/task/testdata/goldens/documentation/oxygen/2.0.0/oxygen/TypeEnum/TypeEnum.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/2.0.0/oxygen/TypeEnum/TypeEnum.html
@@ -12,11 +12,9 @@
     <title>TypeEnum constructor - TypeEnum - oxygen library - Dart API</title>
     <link rel="canonical" href="https://pub.dev/documentation/oxygen/2.0.0/oxygen/TypeEnum/TypeEnum.html"/>
     <link rel="preconnect" href="https://fonts.gstatic.com"/>
-    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/github-markdown.css"/>
-    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/dartdoc/resources/github.css"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,300;0,400;0,500;0,700;1,400&amp;display=swap"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0"/>
-    <link rel="stylesheet" href="/static/hash-%%etag%%/dartdoc/resources/styles.css"/>
+    <link rel="stylesheet" href="/static/hash-%%etag%%/css/dartdoc.css"/>
     <link rel="icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
   </head>
   <body class="light-theme" data-base-href="../../" data-using-base-href="false">

--- a/app/test/task/testdata/goldens/documentation/oxygen/2.0.0/oxygen/TypeEnum/values-constant.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/2.0.0/oxygen/TypeEnum/values-constant.html
@@ -12,11 +12,9 @@
     <title>values constant - TypeEnum enum - oxygen library - Dart API</title>
     <link rel="canonical" href="https://pub.dev/documentation/oxygen/2.0.0/oxygen/TypeEnum/values-constant.html"/>
     <link rel="preconnect" href="https://fonts.gstatic.com"/>
-    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/github-markdown.css"/>
-    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/dartdoc/resources/github.css"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,300;0,400;0,500;0,700;1,400&amp;display=swap"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0"/>
-    <link rel="stylesheet" href="/static/hash-%%etag%%/dartdoc/resources/styles.css"/>
+    <link rel="stylesheet" href="/static/hash-%%etag%%/css/dartdoc.css"/>
     <link rel="icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
   </head>
   <body class="light-theme" data-base-href="../../" data-using-base-href="false">

--- a/app/test/task/testdata/goldens/documentation/oxygen/2.0.0/oxygen/main.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/2.0.0/oxygen/main.html
@@ -11,11 +11,9 @@
     <title>main function - oxygen library - Dart API</title>
     <link rel="canonical" href="https://pub.dev/documentation/oxygen/2.0.0/oxygen/main.html"/>
     <link rel="preconnect" href="https://fonts.gstatic.com"/>
-    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/github-markdown.css"/>
-    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/dartdoc/resources/github.css"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,300;0,400;0,500;0,700;1,400&amp;display=swap"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0"/>
-    <link rel="stylesheet" href="/static/hash-%%etag%%/dartdoc/resources/styles.css"/>
+    <link rel="stylesheet" href="/static/hash-%%etag%%/css/dartdoc.css"/>
     <link rel="icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
   </head>
   <body class="light-theme" data-base-href="../" data-using-base-href="false">

--- a/app/test/task/testdata/goldens/documentation/oxygen/2.0.0/oxygen/oxygen-library.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/2.0.0/oxygen/oxygen-library.html
@@ -11,11 +11,9 @@
     <title>oxygen library - Dart API</title>
     <link rel="canonical" href="https://pub.dev/documentation/oxygen/2.0.0/oxygen/oxygen-library.html"/>
     <link rel="preconnect" href="https://fonts.gstatic.com"/>
-    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/github-markdown.css"/>
-    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/dartdoc/resources/github.css"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,300;0,400;0,500;0,700;1,400&amp;display=swap"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0"/>
-    <link rel="stylesheet" href="/static/hash-%%etag%%/dartdoc/resources/styles.css"/>
+    <link rel="stylesheet" href="/static/hash-%%etag%%/css/dartdoc.css"/>
     <link rel="icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
   </head>
   <body class="light-theme" data-base-href="../" data-using-base-href="false">

--- a/app/test/task/testdata/goldens/documentation/oxygen/latest/index.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/latest/index.html
@@ -11,11 +11,9 @@
     <title>oxygen - Dart API docs</title>
     <link rel="canonical" href="https://pub.dev/documentation/oxygen/latest/"/>
     <link rel="preconnect" href="https://fonts.gstatic.com"/>
-    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/github-markdown.css"/>
-    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/dartdoc/resources/github.css"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,300;0,400;0,500;0,700;1,400&amp;display=swap"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0"/>
-    <link rel="stylesheet" href="/static/hash-%%etag%%/dartdoc/resources/styles.css"/>
+    <link rel="stylesheet" href="/static/hash-%%etag%%/css/dartdoc.css"/>
     <link rel="icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
   </head>
   <body class="light-theme" data-base-href="" data-using-base-href="false">

--- a/app/test/task/testdata/goldens/documentation/oxygen/latest/oxygen/MainClass-class.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/latest/oxygen/MainClass-class.html
@@ -11,11 +11,9 @@
     <title>MainClass class - oxygen library - Dart API</title>
     <link rel="canonical" href="https://pub.dev/documentation/oxygen/latest/oxygen/MainClass-class.html"/>
     <link rel="preconnect" href="https://fonts.gstatic.com"/>
-    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/github-markdown.css"/>
-    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/dartdoc/resources/github.css"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,300;0,400;0,500;0,700;1,400&amp;display=swap"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0"/>
-    <link rel="stylesheet" href="/static/hash-%%etag%%/dartdoc/resources/styles.css"/>
+    <link rel="stylesheet" href="/static/hash-%%etag%%/css/dartdoc.css"/>
     <link rel="icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
   </head>
   <body class="light-theme" data-base-href="../" data-using-base-href="false">

--- a/app/test/task/testdata/goldens/documentation/oxygen/latest/oxygen/MainClass/MainClass.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/latest/oxygen/MainClass/MainClass.html
@@ -12,11 +12,9 @@
     <title>MainClass constructor - MainClass - oxygen library - Dart API</title>
     <link rel="canonical" href="https://pub.dev/documentation/oxygen/latest/oxygen/MainClass/MainClass.html"/>
     <link rel="preconnect" href="https://fonts.gstatic.com"/>
-    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/github-markdown.css"/>
-    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/dartdoc/resources/github.css"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,300;0,400;0,500;0,700;1,400&amp;display=swap"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0"/>
-    <link rel="stylesheet" href="/static/hash-%%etag%%/dartdoc/resources/styles.css"/>
+    <link rel="stylesheet" href="/static/hash-%%etag%%/css/dartdoc.css"/>
     <link rel="icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
   </head>
   <body class="light-theme" data-base-href="../../" data-using-base-href="false">

--- a/app/test/task/testdata/goldens/documentation/oxygen/latest/oxygen/MainClass/text.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/latest/oxygen/MainClass/text.html
@@ -12,11 +12,9 @@
     <title>text property - MainClass class - oxygen library - Dart API</title>
     <link rel="canonical" href="https://pub.dev/documentation/oxygen/latest/oxygen/MainClass/text.html"/>
     <link rel="preconnect" href="https://fonts.gstatic.com"/>
-    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/github-markdown.css"/>
-    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/dartdoc/resources/github.css"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,300;0,400;0,500;0,700;1,400&amp;display=swap"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0"/>
-    <link rel="stylesheet" href="/static/hash-%%etag%%/dartdoc/resources/styles.css"/>
+    <link rel="stylesheet" href="/static/hash-%%etag%%/css/dartdoc.css"/>
     <link rel="icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
   </head>
   <body class="light-theme" data-base-href="../../" data-using-base-href="false">

--- a/app/test/task/testdata/goldens/documentation/oxygen/latest/oxygen/MainClass/toLowerCase.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/latest/oxygen/MainClass/toLowerCase.html
@@ -12,11 +12,9 @@
     <title>toLowerCase method - MainClass class - oxygen library - Dart API</title>
     <link rel="canonical" href="https://pub.dev/documentation/oxygen/latest/oxygen/MainClass/toLowerCase.html"/>
     <link rel="preconnect" href="https://fonts.gstatic.com"/>
-    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/github-markdown.css"/>
-    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/dartdoc/resources/github.css"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,300;0,400;0,500;0,700;1,400&amp;display=swap"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0"/>
-    <link rel="stylesheet" href="/static/hash-%%etag%%/dartdoc/resources/styles.css"/>
+    <link rel="stylesheet" href="/static/hash-%%etag%%/css/dartdoc.css"/>
     <link rel="icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
   </head>
   <body class="light-theme" data-base-href="../../" data-using-base-href="false">

--- a/app/test/task/testdata/goldens/documentation/oxygen/latest/oxygen/MainClass/toString.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/latest/oxygen/MainClass/toString.html
@@ -12,11 +12,9 @@
     <title>toString method - MainClass class - oxygen library - Dart API</title>
     <link rel="canonical" href="https://pub.dev/documentation/oxygen/latest/oxygen/MainClass/toString.html"/>
     <link rel="preconnect" href="https://fonts.gstatic.com"/>
-    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/github-markdown.css"/>
-    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/dartdoc/resources/github.css"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,300;0,400;0,500;0,700;1,400&amp;display=swap"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0"/>
-    <link rel="stylesheet" href="/static/hash-%%etag%%/dartdoc/resources/styles.css"/>
+    <link rel="stylesheet" href="/static/hash-%%etag%%/css/dartdoc.css"/>
     <link rel="icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
   </head>
   <body class="light-theme" data-base-href="../../" data-using-base-href="false">

--- a/app/test/task/testdata/goldens/documentation/oxygen/latest/oxygen/TypeEnum.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/latest/oxygen/TypeEnum.html
@@ -11,11 +11,9 @@
     <title>TypeEnum enum - oxygen library - Dart API</title>
     <link rel="canonical" href="https://pub.dev/documentation/oxygen/latest/oxygen/TypeEnum.html"/>
     <link rel="preconnect" href="https://fonts.gstatic.com"/>
-    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/github-markdown.css"/>
-    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/dartdoc/resources/github.css"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,300;0,400;0,500;0,700;1,400&amp;display=swap"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0"/>
-    <link rel="stylesheet" href="/static/hash-%%etag%%/dartdoc/resources/styles.css"/>
+    <link rel="stylesheet" href="/static/hash-%%etag%%/css/dartdoc.css"/>
     <link rel="icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
   </head>
   <body class="light-theme" data-base-href="../" data-using-base-href="false">

--- a/app/test/task/testdata/goldens/documentation/oxygen/latest/oxygen/TypeEnum/TypeEnum.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/latest/oxygen/TypeEnum/TypeEnum.html
@@ -12,11 +12,9 @@
     <title>TypeEnum constructor - TypeEnum - oxygen library - Dart API</title>
     <link rel="canonical" href="https://pub.dev/documentation/oxygen/latest/oxygen/TypeEnum/TypeEnum.html"/>
     <link rel="preconnect" href="https://fonts.gstatic.com"/>
-    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/github-markdown.css"/>
-    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/dartdoc/resources/github.css"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,300;0,400;0,500;0,700;1,400&amp;display=swap"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0"/>
-    <link rel="stylesheet" href="/static/hash-%%etag%%/dartdoc/resources/styles.css"/>
+    <link rel="stylesheet" href="/static/hash-%%etag%%/css/dartdoc.css"/>
     <link rel="icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
   </head>
   <body class="light-theme" data-base-href="../../" data-using-base-href="false">

--- a/app/test/task/testdata/goldens/documentation/oxygen/latest/oxygen/TypeEnum/values-constant.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/latest/oxygen/TypeEnum/values-constant.html
@@ -12,11 +12,9 @@
     <title>values constant - TypeEnum enum - oxygen library - Dart API</title>
     <link rel="canonical" href="https://pub.dev/documentation/oxygen/latest/oxygen/TypeEnum/values-constant.html"/>
     <link rel="preconnect" href="https://fonts.gstatic.com"/>
-    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/github-markdown.css"/>
-    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/dartdoc/resources/github.css"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,300;0,400;0,500;0,700;1,400&amp;display=swap"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0"/>
-    <link rel="stylesheet" href="/static/hash-%%etag%%/dartdoc/resources/styles.css"/>
+    <link rel="stylesheet" href="/static/hash-%%etag%%/css/dartdoc.css"/>
     <link rel="icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
   </head>
   <body class="light-theme" data-base-href="../../" data-using-base-href="false">

--- a/app/test/task/testdata/goldens/documentation/oxygen/latest/oxygen/main.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/latest/oxygen/main.html
@@ -11,11 +11,9 @@
     <title>main function - oxygen library - Dart API</title>
     <link rel="canonical" href="https://pub.dev/documentation/oxygen/latest/oxygen/main.html"/>
     <link rel="preconnect" href="https://fonts.gstatic.com"/>
-    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/github-markdown.css"/>
-    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/dartdoc/resources/github.css"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,300;0,400;0,500;0,700;1,400&amp;display=swap"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0"/>
-    <link rel="stylesheet" href="/static/hash-%%etag%%/dartdoc/resources/styles.css"/>
+    <link rel="stylesheet" href="/static/hash-%%etag%%/css/dartdoc.css"/>
     <link rel="icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
   </head>
   <body class="light-theme" data-base-href="../" data-using-base-href="false">

--- a/app/test/task/testdata/goldens/documentation/oxygen/latest/oxygen/oxygen-library.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/latest/oxygen/oxygen-library.html
@@ -11,11 +11,9 @@
     <title>oxygen library - Dart API</title>
     <link rel="canonical" href="https://pub.dev/documentation/oxygen/latest/oxygen/oxygen-library.html"/>
     <link rel="preconnect" href="https://fonts.gstatic.com"/>
-    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/css/github-markdown.css"/>
-    <link rel="stylesheet" type="text/css" href="/static/hash-%%etag%%/dartdoc/resources/github.css"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,300;0,400;0,500;0,700;1,400&amp;display=swap"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0"/>
-    <link rel="stylesheet" href="/static/hash-%%etag%%/dartdoc/resources/styles.css"/>
+    <link rel="stylesheet" href="/static/hash-%%etag%%/css/dartdoc.css"/>
     <link rel="icon" href="/favicon.ico?hash=mocked_hash_985685822"/>
   </head>
   <body class="light-theme" data-base-href="../" data-using-base-href="false">

--- a/pkg/web_css/build.sh
+++ b/pkg/web_css/build.sh
@@ -18,3 +18,8 @@ dart run sass \
   --style=compressed \
   "${WEB_CSS_DIR}/lib/style.scss" \
   "${OUTPUT_DIR}/style.css"
+
+dart run sass \
+  --style=compressed \
+  "${WEB_CSS_DIR}/lib/dartdoc.scss" \
+  "${OUTPUT_DIR}/dartdoc.css"

--- a/pkg/web_css/lib/dartdoc.scss
+++ b/pkg/web_css/lib/dartdoc.scss
@@ -1,0 +1,16 @@
+/* Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+   for details. All rights reserved. Use of this source code is governed by a
+   BSD-style license that can be found in the LICENSE file. */
+
+// Include third-party CSS into a single output file
+// to reduce the number of HTTP requests.
+
+// Note: this is not part of dartdoc
+@use '../../../third_party/css/github-markdown.css';
+
+// TODO: Consider using same github.css we use on pub.dev
+@use '../../../third_party/dartdoc/resources/github.css';
+@use '../../../third_party/dartdoc/resources/styles.css';
+@use '../../../static/css/staging-ribbon.css';
+
+@import 'src/_themes';

--- a/pkg/web_css/lib/src/_themes.scss
+++ b/pkg/web_css/lib/src/_themes.scss
@@ -1,0 +1,30 @@
+/* Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+   for details. All rights reserved. Use of this source code is governed by a
+   BSD-style license that can be found in the LICENSE file. */
+
+/* Note: light-theme was added to prevent non-visible table text in dartdoc's dark mode. */
+.light-theme .markdown-body table tr {
+  background-color: #fff;
+  border-top: 1px solid #c6cbd1;
+}
+
+/* Note: light-theme was added to prevent non-visible table text in dartdoc's dark mode. */
+.light-theme .markdown-body table tr:nth-child(2n) {
+  background-color: #f6f8fa;
+}
+
+/* Note: light-theme was added to prevent non-visible table text in dartdoc's dark mode. */
+.light-theme .markdown-body .highlight pre,
+.light-theme .markdown-body pre {
+  background-color: #f6f8fa;
+}
+.dark-theme .markdown-body pre {
+  /* TODO(https://github.com/dart-lang/pub-dev/issues/7101): Investigate if this should be fixed in dartdoc's styles.css: the dark theme is not applied there. */
+  background-color: inherit;
+}
+
+.dark-theme .hljs .hljs-deletion,
+.dark-theme .hljs .hljs-addition {
+  /* TODO(https://github.com/dart-lang/pub-dev/issues/7101): Investigate if this should be fixed in dartdoc's styles.css: the dark theme is not applied there. */
+  color: black;
+}

--- a/pkg/web_css/lib/style.scss
+++ b/pkg/web_css/lib/style.scss
@@ -20,4 +20,5 @@
 @import 'src/_scores';
 @import 'src/_search';
 @import 'src/_tags';
-@import 'src/topics';
+@import 'src/_themes';
+@import 'src/_topics';

--- a/third_party/css/github-markdown.css
+++ b/third_party/css/github-markdown.css
@@ -212,17 +212,6 @@
   border: 1px solid #dfe2e5;
 }
 
-/* Note: light-theme was added to prevent non-visible table text in dartdoc's dark mode. */
-.light-theme .markdown-body table tr {
-  background-color: #fff;
-  border-top: 1px solid #c6cbd1;
-}
-
-/* Note: light-theme was added to prevent non-visible table text in dartdoc's dark mode. */
-.light-theme .markdown-body table tr:nth-child(2n) {
-  background-color: #f6f8fa;
-}
-
 .markdown-body table img {
   background-color: transparent;
 }
@@ -382,22 +371,6 @@
   font-size: 85%;
   line-height: 1.45;
   border-radius: 3px;
-}
-
-/* Note: light-theme was added to prevent non-visible table text in dartdoc's dark mode. */
-.light-theme .markdown-body .highlight pre,
-.light-theme .markdown-body pre {
-  background-color: #f6f8fa;
-}
-.dark-theme .markdown-body pre {
-  /* TODO(https://github.com/dart-lang/pub-dev/issues/7101): Investigate if this should be fixed in dartdoc's styles.css: the dark theme is not applied there. */
-  background-color: inherit;
-}
-
-.dark-theme .hljs .hljs-deletion,
-.dark-theme .hljs .hljs-addition {
-  /* TODO(https://github.com/dart-lang/pub-dev/issues/7101): Investigate if this should be fixed in dartdoc's styles.css: the dark theme is not applied there. */
-  color: black;
 }
 
 .markdown-body pre code,


### PR DESCRIPTION
- Creating `dartdoc.scss` helps to make customizations explicit, compilation makes it a single file, reducing the overall page latencies.
- Moved pub-related custom styles from `github-markdown.css` into `pkg/web_css`.