### PR TITLE
New ModerationCase.source values

### DIFF
--- a/app/lib/admin/models.dart
+++ b/app/lib/admin/models.dart
@@ -158,10 +158,16 @@ class ModerationCase extends db.ExpandoModel<String> {
 abstract class ModerationSource {
   static const externalNotification = 'external-notification';
   static const internalNotification = 'internal-notification';
+  static const trustedFlagger = 'trusted-flagger';
+  static const authorities = 'authorities';
+  static const legalReferral = 'legal-referral';
 
   static const _values = [
     externalNotification,
     internalNotification,
+    trustedFlagger,
+    authorities,
+    legalReferral,
   ];
   static bool isValidSource(String value) => _values.contains(value);
 }


### PR DESCRIPTION
- #7535
- as an alternative to #7801, because I've found it a bit confusing in a test that both the `kind` and the `source` become `notification`. Maybe we should only replace `internal-notification` with these new values?