### PR TITLE
Integration verification test with script-callback based tool.

### DIFF
--- a/pkg/pub_integration/bin/fake_user_callback.dart
+++ b/pkg/pub_integration/bin/fake_user_callback.dart
@@ -1,0 +1,129 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:args/command_runner.dart';
+import 'package:pub_integration/src/fake_credentials.dart';
+import 'package:pub_integration/src/fake_pub_server_process.dart';
+import 'package:pub_integration/src/fake_test_context_provider.dart';
+import 'package:pub_integration/src/pub_puppeteer_helpers.dart';
+import 'package:pub_integration/src/test_browser.dart';
+
+Future<void> main(List<String> args) async {
+  final runner = CommandRunner<String>(
+    'fake_user_callback',
+    'Provides integration test details for fake server user authentication.',
+  )
+    ..addCommand(_ApiAccessTokenCommand())
+    ..addCommand(_ClientCredentialsJsonCommand())
+    ..addCommand(_BrowserCookiesCommand())
+    ..addCommand(_LastEmailCommand());
+  final rs = await runner.run(args);
+  print(rs);
+}
+
+class _ApiAccessTokenCommand extends Command<String> {
+  @override
+  String get name => 'api-access-token';
+
+  @override
+  String get description => 'Provides API access token';
+
+  _ApiAccessTokenCommand() {
+    argParser
+      ..addOption('pub-hosted-url')
+      ..addOption('email');
+  }
+
+  @override
+  Future<String> run() async {
+    final pubHostedUrl = argResults!['pub-hosted-url'] as String;
+    final email = argResults!['email'] as String;
+    return await createFakeGcpToken(pubHostedUrl: pubHostedUrl, email: email);
+  }
+}
+
+class _ClientCredentialsJsonCommand extends Command<String> {
+  @override
+  String get name => 'client-credentials-json';
+
+  @override
+  String get description =>
+      'Provides pub client credentials.json file content.';
+
+  _ClientCredentialsJsonCommand() {
+    argParser.addOption('email');
+  }
+
+  @override
+  Future<String> run() async {
+    final email = argResults!['email'] as String;
+    final map = fakeCredentialsMap(email: email);
+    return json.encode(map);
+  }
+}
+
+class _BrowserCookiesCommand extends Command<String> {
+  @override
+  String get name => 'browser-cookies';
+
+  @override
+  String get description =>
+      'Provides browser cookies for the signed-in user session';
+
+  _BrowserCookiesCommand() {
+    argParser
+      ..addOption('pub-hosted-url')
+      ..addOption('email')
+      ..addOption('scopes');
+  }
+
+  @override
+  Future<String> run() async {
+    final pubHostedUrl = argResults!['pub-hosted-url'] as String;
+    final email = argResults!['email'] as String;
+    final scopes = (argResults!['scopes'] as String?)?.split(',');
+    final testBrowser = TestBrowser(
+      origin: pubHostedUrl,
+    );
+    try {
+      await testBrowser.startBrowser();
+      final session = await testBrowser.createSession();
+      return await session.withPage(fn: (page) async {
+        await page.fakeAuthSignIn(email: email, scopes: scopes);
+        await page.gotoOrigin('/my-liked-packages');
+        final cookies = await page.cookies();
+        return json.encode(cookies.map((e) => e.toJson()).toList());
+      });
+    } finally {
+      await testBrowser.close();
+    }
+  }
+}
+
+class _LastEmailCommand extends Command<String> {
+  @override
+  String get name => 'last-email';
+
+  @override
+  String get description => 'Provides the last email body for the user';
+
+  _LastEmailCommand() {
+    argParser
+      ..addOption('email-output-dir')
+      ..addOption('email');
+  }
+
+  @override
+  Future<String> run() async {
+    final emailOutputDir = argResults!['email-output-dir'] as String;
+    final email = argResults!['email'] as String;
+
+    final reader = FakeEmailReaderFromOutputDirectory(emailOutputDir);
+    final map = await reader.readLatestEmail(recipient: email);
+    return map['bodyText'] as String;
+  }
+}

--- a/pkg/pub_integration/lib/script/publishing.dart
+++ b/pkg/pub_integration/lib/script/publishing.dart
@@ -93,7 +93,7 @@ class PublishingScript {
       await dart.getDependencies(_dummyExampleDir.path);
       await dart.run(_dummyExampleDir.path, 'bin/main.dart');
 
-      if (pubHostedUrl.startsWith('http://localhost:')) {
+      if (!expectLiveSite) {
         // invite uploader
         // TODO: use page.invitePackageAdmin instead
         await adminUser.withBrowserPage((page) async {

--- a/pkg/pub_integration/lib/src/fake_pub_server_process.dart
+++ b/pkg/pub_integration/lib/src/fake_pub_server_process.dart
@@ -161,8 +161,10 @@ class FakePubServerProcess {
     }
   }
 
-  late final fakeEmailReader = FakeEmailReaderFromOutputDirectory(
-      p.join(_tmpDir, 'fake-email-sender-output-dir'));
+  late final fakeEmailOutputPath =
+      p.join(_tmpDir, 'fake-email-sender-output-dir');
+  late final fakeEmailReader =
+      FakeEmailReaderFromOutputDirectory(fakeEmailOutputPath);
 }
 
 class FakeEmailReaderFromOutputDirectory {

--- a/pkg/pub_integration/test/pub_integration_with_script_test.dart
+++ b/pkg/pub_integration/test/pub_integration_with_script_test.dart
@@ -1,0 +1,59 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:pub_integration/src/fake_pub_server_process.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Integration test using pkg/fake_pub_server with script', () {
+    late final FakePubServerProcess fakePubServerProcess;
+    late final String pubHostedUrl;
+
+    setUpAll(() async {
+      fakePubServerProcess = await FakePubServerProcess.start();
+      await fakePubServerProcess.started;
+      pubHostedUrl = 'http://localhost:${fakePubServerProcess.port}';
+    });
+
+    tearDownAll(() async {
+      await fakePubServerProcess.kill();
+    });
+
+    test('standard integration', () async {
+      final pr = await Process.run(
+        'dart',
+        [
+          'bin/verify_prod_pub.dart',
+          '--pub-hosted-url',
+          pubHostedUrl,
+          // admin user
+          '--user-a-email',
+          'user@example.com',
+          '--user-a-api-access-token-callback',
+          'dart bin/fake_user_callback.dart api-access-token --email user@example.com --pub-hosted-url $pubHostedUrl',
+          '--user-a-client-credentials-json-callback',
+          'dart bin/fake_user_callback.dart client-credentials-json --email user@example.com',
+          '--user-a-browser-cookies-callback',
+          'dart bin/fake_user_callback.dart browser-cookies --email user@example.com --pub-hosted-url $pubHostedUrl',
+          '--user-a-last-email-callback',
+          'dart bin/fake_user_callback.dart last-email --email user@example.com --email-output-dir ${fakePubServerProcess.fakeEmailOutputPath}',
+          // invited user
+          '--user-b-email',
+          'dev@example.com',
+          '--user-b-api-access-token-callback',
+          'dart bin/fake_user_callback.dart api-access-token --email dev@example.com --pub-hosted-url $pubHostedUrl',
+          '--user-b-client-credentials-json-callback',
+          'dart bin/fake_user_callback.dart client-credentials-json --email dev@example.com',
+          '--user-b-browser-cookies-callback',
+          'dart bin/fake_user_callback.dart browser-cookies --email dev@example.com --pub-hosted-url $pubHostedUrl',
+          '--user-b-last-email-callback',
+          'dart bin/fake_user_callback.dart last-email --email dev@example.com --email-output-dir ${fakePubServerProcess.fakeEmailOutputPath}',
+        ],
+      );
+      expect(pr.exitCode, 0, reason: [pr.stdout, pr.stderr].join('\n'));
+    }, timeout: Timeout.factor(4));
+  });
+}


### PR DESCRIPTION
- Replaced `client-[access|refresh]-token-callback` with `client-credentials-json-callback`, as there are further differences between the production version and the fake server version.
- Replaced `gmail-access-token-callback` with `last-email-callback`.
- Created a test that runs the tool to verify the fake server.