### PR TITLE
Expose only known exception messages when scanning a tar archive.

### DIFF
--- a/pkg/pub_package_reader/lib/pub_package_reader.dart
+++ b/pkg/pub_package_reader/lib/pub_package_reader.dart
@@ -110,10 +110,13 @@ Future<PackageSummary> summarizePackageArchive(
       maxFileCount: maxFileCount,
       maxTotalLengthBytes: maxArchiveSize,
     );
-  } catch (e, st) {
+  } on TarException catch (e, st) {
     _logger.info('Failed to scan tar archive.', e, st);
     return PackageSummary.fail(
         ArchiveIssue('Failed to scan tar archive. ($e)'));
+  } catch (e, st) {
+    _logger.info('Failed to scan tar archive.', e, st);
+    return PackageSummary.fail(ArchiveIssue('Failed to scan tar archive.'));
   }
 
   // symlinks check

--- a/pkg/pub_package_reader/lib/src/tar_utils.dart
+++ b/pkg/pub_package_reader/lib/src/tar_utils.dart
@@ -145,7 +145,7 @@ class TarArchive {
       if (entry.type == TypeFlag.dir) {
         final maskBits = entry.header.mode & _executableMask;
         if (maskBits != _executableMask) {
-          throw Exception(
+          throw TarException(
               'Directory "${entry.name}" has no executable mode bit.');
         }
       }
@@ -153,24 +153,25 @@ class TarArchive {
       if (entry.type == TypeFlag.dir || entry.header.hasContent) {
         final maskBits = entry.header.mode & _defaultMode;
         if (maskBits != _defaultMode) {
-          throw Exception(
+          throw TarException(
               'Entry "${entry.name}" has no default mode bits (644).');
         }
       }
 
       fileCount++;
       if (maxFileCount != null && fileCount > maxFileCount) {
-        throw Exception('Maximum file count reached: $maxFileCount.');
+        throw TarException('Maximum file count reached: $maxFileCount.');
       }
 
       totalLengthBytes += entry.size;
       if (maxTotalLengthBytes != null &&
           totalLengthBytes > maxTotalLengthBytes) {
-        throw Exception('Maximum total length reached: $maxTotalLengthBytes.');
+        throw TarException(
+            'Maximum total length reached: $maxTotalLengthBytes.');
       }
 
       if (!names.add(entry.name)) {
-        throw Exception('Duplicate tar entry: `${entry.name}`.');
+        throw TarException('Duplicate tar entry: `${entry.name}`.');
       }
       if (entry.header.linkName != null) {
         symlinks[entry.name] = entry.header.linkName!;
@@ -190,3 +191,12 @@ Map<String, String> _normalizeNames(List<String> names) {
 }
 
 String _normalize(String path) => p.normalize(path).trim();
+
+class TarException implements Exception {
+  final String message;
+
+  TarException(this.message);
+
+  @override
+  String toString() => message;
+}

--- a/pkg/pub_package_reader/test/archive_surface_test.dart
+++ b/pkg/pub_package_reader/test/archive_surface_test.dart
@@ -53,8 +53,7 @@ void main() {
       await archiveFile.writeAsBytes(gzip.encode(<int>[1, 2, 3, 4, 5, 6, 7]));
       final summary = await summarizePackageArchive(archiveFile.path);
       expect(summary.issues, isNotEmpty);
-      expect(summary.issues.single.message,
-          'Failed to scan tar archive. (FormatException: Invalid header: Unexpected end of file)');
+      expect(summary.issues.single.message, 'Failed to scan tar archive.');
     });
 
     test('file is too large', () async {

--- a/pkg/pub_package_reader/test/end2end_test.dart
+++ b/pkg/pub_package_reader/test/end2end_test.dart
@@ -55,7 +55,7 @@ void main() {
 
       await expandWithBytes(path, <int>[1]);
       expect((await summarizePackageArchive(path)).issues.single.message,
-          'Failed to scan tar archive. (FormatException: Illegal content after the end of the tar archive.)');
+          'Failed to scan tar archive.');
     });
 
     test('maxContentLength', () async {
@@ -73,7 +73,7 @@ void main() {
               .issues
               .single
               .message,
-          'Failed to scan tar archive. (FormatException: Illegal content after the end of the tar archive.)');
+          'Failed to scan tar archive.');
     });
   });
 }

--- a/pkg/pub_package_reader/test/file_count_test.dart
+++ b/pkg/pub_package_reader/test/file_count_test.dart
@@ -52,7 +52,7 @@ void main() {
       final summary =
           await summarizePackageArchive(archiveFile.path, maxFileCount: 1024);
       expect(summary.issues.single.message,
-          'Failed to scan tar archive. (Exception: Maximum file count reached: 1024.)');
+          'Failed to scan tar archive. (Maximum file count reached: 1024.)');
     });
   });
 }

--- a/pkg/pub_package_reader/test/file_list_test.dart
+++ b/pkg/pub_package_reader/test/file_list_test.dart
@@ -86,7 +86,7 @@ void main() {
 
       final summary = await summarizePackageArchive(archiveFile.path);
       expect(summary.issues.single.message,
-          'Failed to scan tar archive. (Exception: Duplicate tar entry: `README.md`.)');
+          'Failed to scan tar archive. (Duplicate tar entry: `README.md`.)');
     });
   });
 }


### PR DESCRIPTION
Follow-up to #7807