### PR TITLE
'updated:<duration>' search query filter for packages updated in the last <duration> days

### DIFF
--- a/app/lib/search/mem_index.dart
+++ b/app/lib/search/mem_index.dart
@@ -128,9 +128,9 @@ class InMemoryPackageIndex {
     }
 
     // filter on updatedInDays
-    if (query.updatedInDays != null && query.updatedInDays! > 0) {
-      final threshold =
-          Duration(days: query.updatedInDays!, hours: 11, minutes: 59);
+    final updatedInDays = query.parsedQuery.updatedInDays;
+    if (updatedInDays != null && updatedInDays > 0) {
+      final threshold = Duration(days: updatedInDays);
       final now = clock.now();
       packages.removeWhere((package) {
         final doc = _packages[package]!;

--- a/app/lib/search/mem_index.dart
+++ b/app/lib/search/mem_index.dart
@@ -127,15 +127,14 @@ class InMemoryPackageIndex {
       });
     }
 
-    // filter on updatedInDays
-    final updatedInDays = query.parsedQuery.updatedInDays;
-    if (updatedInDays != null && updatedInDays > 0) {
-      final threshold = Duration(days: updatedInDays);
+    // filter on updatedDuration
+    final updatedDuration = query.parsedQuery.updatedDuration;
+    if (updatedDuration != null && updatedDuration > Duration.zero) {
       final now = clock.now();
       packages.removeWhere((package) {
         final doc = _packages[package]!;
         final diff = now.difference(doc.updated);
-        return diff > threshold;
+        return diff > updatedDuration;
       });
     }
 

--- a/app/lib/search/search_service.dart
+++ b/app/lib/search/search_service.dart
@@ -156,7 +156,6 @@ class ServiceSearchQuery {
   final String? publisherId;
 
   final int? minPoints;
-  final int? updatedInDays;
 
   /// The value of the `sort` URL query parameter.
   final SearchOrder? order;
@@ -168,7 +167,6 @@ class ServiceSearchQuery {
     TagsPredicate? tagsPredicate,
     String? publisherId,
     required this.minPoints,
-    this.updatedInDays,
     this.order,
     this.offset,
     this.limit,
@@ -182,7 +180,6 @@ class ServiceSearchQuery {
     String? publisherId,
     SearchOrder? order,
     int? minPoints,
-    int? updatedInDays,
     int offset = 0,
     int? limit = 10,
   }) {
@@ -192,7 +189,6 @@ class ServiceSearchQuery {
       tagsPredicate: tagsPredicate,
       publisherId: publisherId,
       minPoints: minPoints,
-      updatedInDays: updatedInDays,
       order: order,
       offset: offset,
       limit: limit,
@@ -209,8 +205,6 @@ class ServiceSearchQuery {
 
     final minPoints =
         int.tryParse(uri.queryParameters['minPoints'] ?? '0') ?? 0;
-    final updatedInDays =
-        int.tryParse(uri.queryParameters['updatedInDays'] ?? '');
     final offset = int.tryParse(uri.queryParameters['offset'] ?? '0') ?? 0;
     final limit = int.tryParse(uri.queryParameters['limit'] ?? '0') ?? 0;
 
@@ -220,7 +214,6 @@ class ServiceSearchQuery {
       publisherId: publisherId,
       order: order,
       minPoints: minPoints,
-      updatedInDays: updatedInDays,
       offset: max(0, offset),
       limit: max(_minSearchLimit, limit),
     );
@@ -240,7 +233,6 @@ class ServiceSearchQuery {
       publisherId: publisherId ?? this.publisherId,
       order: order ?? this.order,
       minPoints: minPoints,
-      updatedInDays: updatedInDays,
       offset: offset ?? this.offset,
       limit: limit ?? this.limit,
     );
@@ -254,8 +246,6 @@ class ServiceSearchQuery {
       'offset': offset?.toString(),
       if (minPoints != null && minPoints! > 0)
         'minPoints': minPoints.toString(),
-      if (updatedInDays != null && updatedInDays! > 0)
-        'updatedInDays': updatedInDays.toString(),
       'limit': limit?.toString(),
       'order': order?.name,
     };

--- a/app/test/search/mem_index_test.dart
+++ b/app/test/search/mem_index_test.dart
@@ -450,7 +450,8 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
     });
 
     test('no results with updatedInDays', () async {
-      final result = index.search(ServiceSearchQuery.parse(updatedInDays: 1));
+      final result =
+          index.search(ServiceSearchQuery.parse(query: 'updated:1d'));
       expect(json.decode(json.encode(result)), {
         'timestamp': isNotNull,
         'totalCount': 0,
@@ -462,7 +463,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
     test('filter with updatedInDays', () async {
       final days = clock.now().difference(lastPackageUpdated).inDays;
       final result1 =
-          index.search(ServiceSearchQuery.parse(updatedInDays: days - 1));
+          index.search(ServiceSearchQuery.parse(query: 'updated:${days - 1}d'));
       expect(json.decode(json.encode(result1)), {
         'timestamp': isNotNull,
         'totalCount': 0,
@@ -471,7 +472,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
       });
 
       final result2 =
-          index.search(ServiceSearchQuery.parse(updatedInDays: days + 1));
+          index.search(ServiceSearchQuery.parse(query: 'updated:${days + 1}d'));
       expect(json.decode(json.encode(result2)), {
         'timestamp': isNotNull,
         'totalCount': 1,

--- a/doc/help-search.md
+++ b/doc/help-search.md
@@ -26,6 +26,11 @@
 
   - `runtime:<runtime>`: Searches for packages that support the given runtime. `runtime` can be one of `web`, `native-jit` and `native-aot`.
 
+  - `updated:<duration>`: Searches for packages updated in the given past days,
+    with the following recognized formats: `3d` (3 days), `2w` (two weeks), `6m` (6 months), `2y` 2 years.
+
+  - `has:executable`: Search for packages with Dart files in their `bin/` directory.
+
 ## Filters
 
 The search UI also supports filters.

--- a/pkg/_pub_shared/lib/search/search_form.dart
+++ b/pkg/_pub_shared/lib/search/search_form.dart
@@ -15,6 +15,7 @@ final RegExp _refDependencyRegExp =
 final RegExp _allDependencyRegExp =
     RegExp(r'dependency\*:([_a-z0-9]+)', caseSensitive: false);
 final _sortRegExp = RegExp('sort:([a-z]+)');
+final _updatedRegExp = RegExp('updated:([0-9]+[dwmy]?)');
 final _tagRegExp =
     RegExp(r'([\+|\-]?[a-z0-9]+:[a-z0-9\-_\.]+)', caseSensitive: false);
 
@@ -67,6 +68,33 @@ SearchOrder? parseSearchOrder(String? value) {
     if (v.name == value) return v;
   }
   return null;
+}
+
+int? parseUpdatedInDays(String value) {
+  if (value.isEmpty) return null;
+  var amount = value;
+  var multiplier = 1;
+  final end = value.substring(value.length - 1).toLowerCase();
+  switch (end) {
+    case 'd':
+      amount = value.substring(0, value.length - 1);
+      multiplier = 1;
+      break;
+    case 'w':
+      amount = value.substring(0, value.length - 1);
+      multiplier = 7;
+      break;
+    case 'm':
+      amount = value.substring(0, value.length - 1);
+      multiplier = 30;
+      break;
+    case 'y':
+      amount = value.substring(0, value.length - 1);
+      multiplier = 365;
+      break;
+  }
+  final parsedAmount = int.tryParse(amount);
+  return parsedAmount == null ? null : parsedAmount * multiplier;
 }
 
 /// Filter conditions on tags.
@@ -205,6 +233,8 @@ class ParsedQueryText {
   /// Detected tags in the user-provided query.
   TagsPredicate tagsPredicate;
 
+  final int? updatedInDays;
+
   final SearchOrder? order;
 
   ParsedQueryText._(
@@ -213,6 +243,7 @@ class ParsedQueryText {
     this.refDependencies,
     this.allDependencies,
     this.tagsPredicate,
+    this.updatedInDays,
     this.order,
   );
 
@@ -244,6 +275,10 @@ class ParsedQueryText {
     final orderValues = extractRegExp(_sortRegExp);
     final order =
         orderValues.isEmpty ? null : parseSearchOrder(orderValues.last);
+    final updatedInDaysValue = extractRegExp(_updatedRegExp);
+    final updatedInDays = updatedInDaysValue.isEmpty
+        ? null
+        : parseUpdatedInDays(updatedInDaysValue.last);
 
     final tagValues = extractRegExp(
       _tagRegExp,
@@ -262,6 +297,7 @@ class ParsedQueryText {
       dependencies,
       allDependencies,
       tagsPredicate,
+      updatedInDays,
       order,
     );
   }
@@ -275,6 +311,7 @@ class ParsedQueryText {
       refDependencies,
       allDependencies,
       tagsPredicate ?? this.tagsPredicate,
+      updatedInDays,
       order,
     );
   }

--- a/pkg/_pub_shared/test/search/search_form_test.dart
+++ b/pkg/_pub_shared/test/search/search_form_test.dart
@@ -76,24 +76,24 @@ void main() {
 
   group('updated window parsing', () {
     test('invalid values', () {
-      expect(parseUpdatedInDays(''), null);
-      expect(parseUpdatedInDays('d'), null);
-      expect(parseUpdatedInDays('1dd'), null);
-      expect(parseUpdatedInDays('1.1m'), null);
+      expect(parseTime(''), null);
+      expect(parseTime('d'), null);
+      expect(parseTime('1dd'), null);
+      expect(parseTime('1.1m'), null);
     });
 
     test('valid values', () {
-      expect(parseUpdatedInDays('1212'), 1212);
-      expect(parseUpdatedInDays('1212d'), 1212);
-      expect(parseUpdatedInDays('10w'), 70);
-      expect(parseUpdatedInDays('6m'), 180);
-      expect(parseUpdatedInDays('1y'), 365);
+      expect(parseTime('1212d'), Duration(days: 1212));
+      expect(parseTime('10w'), Duration(days: 70));
+      expect(parseTime('6m'), Duration(days: 186));
+      expect(parseTime('1y'), Duration(days: 365));
+      expect(parseTime('2mo12h'), Duration(days: 62, hours: 12));
     });
 
     test('full query', () {
       final q = SearchForm(query: 'abc updated:2w');
       expect(q.parsedQuery.text, 'abc');
-      expect(q.parsedQuery.updatedInDays, 14);
+      expect(q.parsedQuery.updatedDuration, Duration(days: 14));
     });
   });
 

--- a/pkg/_pub_shared/test/search/search_form_test.dart
+++ b/pkg/_pub_shared/test/search/search_form_test.dart
@@ -74,6 +74,29 @@ void main() {
     });
   });
 
+  group('updated window parsing', () {
+    test('invalid values', () {
+      expect(parseUpdatedInDays(''), null);
+      expect(parseUpdatedInDays('d'), null);
+      expect(parseUpdatedInDays('1dd'), null);
+      expect(parseUpdatedInDays('1.1m'), null);
+    });
+
+    test('valid values', () {
+      expect(parseUpdatedInDays('1212'), 1212);
+      expect(parseUpdatedInDays('1212d'), 1212);
+      expect(parseUpdatedInDays('10w'), 70);
+      expect(parseUpdatedInDays('6m'), 180);
+      expect(parseUpdatedInDays('1y'), 365);
+    });
+
+    test('full query', () {
+      final q = SearchForm(query: 'abc updated:2w');
+      expect(q.parsedQuery.text, 'abc');
+      expect(q.parsedQuery.updatedInDays, 14);
+    });
+  });
+
   group('SearchOrder enum', () {
     test('serialization', () {
       for (var value in SearchOrder.values) {


### PR DESCRIPTION
- Fixes #7701
- Removes unused `updatedInDays` direct parameter from `ServiceSearchQuery`, applies the same logic in the parsed query.
- Note: only `7m` or `5d` is supported, the combination of `7m5d` is not supported.
- Note: deployed to staging (though its data has not been updated in the past few months, but https://staging.pub.dev/packages?q=updated%3A13w shows it working.