### PR TITLE
Update task_payload.dart

### DIFF
--- a/pkg/_pub_shared/lib/data/task_payload.dart
+++ b/pkg/_pub_shared/lib/data/task_payload.dart
@@ -31,6 +31,9 @@ class Payload {
   final String pubHostedUrl;
 
   /// Lists of (`version`, `token`) for versions to process.
+  ///
+  /// Given in order of priority, with the assumption that the first entry
+  /// is the one it's most important to process.
   final List<VersionTokenPair> versions;
 
   // json_serializable boiler-plate


### PR DESCRIPTION
This is probably an important invariant.

I think it's fine that we don't ask the `pub_worker` to sort these, it's probably very reasonable that the server does that.