### PR TITLE
Flutter setup: use http archive for stable/beta version, use git only for master.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Important changes to data models, configuration, and migrations between each
 AppEngine version, listed here to ease deployment and troubleshooting.
 
 ## Next Release (replace with git tag when deployed)
+ * Note: `setup-flutter.sh` uses http archives for stable/beta channel.
 
 ## `20240627t084200-all`
  * Bumped runtimeVersion to `2024.06.25`.

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -2,7 +2,7 @@ FROM gcr.io/google-containers/debian-base-amd64:v2.0.0
 
 RUN apt-get update && \
   apt-get upgrade -y && \
-  apt-get install -y unzip ca-certificates curl bash git && \
+  apt-get install -y unzip ca-certificates curl bash git xz-utils && \
   rm -rf /var/lib/apt/lists/*
 
 ENV PUB_ENVIRONMENT="bot.pub_dev.pub_worker"

--- a/pkg/pub_worker/lib/src/bin/pana_wrapper.dart
+++ b/pkg/pub_worker/lib/src/bin/pana_wrapper.dart
@@ -255,11 +255,13 @@ Future<({String configKind, String? dartSdkPath, String? flutterSdkPath})>
         sdkKind: 'dart',
         configKind: bundle.configKind,
         version: bundle.dart,
+        channel: bundle.channel,
       );
       final flutterSdkPath = await _installSdk(
         sdkKind: 'flutter',
         configKind: bundle.configKind,
         version: bundle.flutter,
+        channel: bundle.channel,
       );
 
       return (
@@ -280,6 +282,7 @@ Future<({String configKind, String? dartSdkPath, String? flutterSdkPath})>
 
 Future<String?> _installSdk({
   required String sdkKind,
+  required String channel,
   required String configKind,
   required String version,
 }) async {
@@ -300,6 +303,7 @@ Future<String?> _installSdk({
             'tool/setup-$sdkKind.sh',
             sdkPath,
             version,
+            channel,
           ],
           workingDirectory: '/home/worker/pub-dev',
           environment: {
@@ -322,11 +326,13 @@ Future<String?> _installSdk({
 }
 
 class _SdkBundle {
+  final String channel;
   final String configKind;
   final String dart;
   final String flutter;
 
   _SdkBundle({
+    required this.channel,
     required this.configKind,
     required this.dart,
     required this.flutter,
@@ -352,17 +358,20 @@ Future<List<_SdkBundle>> _detectSdkBundles() async {
     if (latestStableDartSdkVersion != null &&
         latestStableFlutterSdkVersion != null)
       _SdkBundle(
+        channel: 'stable',
         configKind: 'latest-stable',
         dart: latestStableDartSdkVersion,
         flutter: latestStableFlutterSdkVersion,
       ),
     if (latestBetaDartSdkVersion != null && latestBetaFlutterSdkVersion != null)
       _SdkBundle(
+        channel: 'beta',
         configKind: 'latest-beta',
         dart: latestBetaDartSdkVersion,
         flutter: latestBetaFlutterSdkVersion,
       ),
     _SdkBundle(
+      channel: 'master',
       configKind: 'master',
       dart: 'master',
       flutter: 'master',

--- a/pkg/pub_worker/test/dockerized_end2end_test.dart
+++ b/pkg/pub_worker/test/dockerized_end2end_test.dart
@@ -76,7 +76,8 @@ void main() {
           final result = await server.waitForResult(package, version);
 
           final docIndex = result.index.lookup('doc/index.html');
-          expect(docIndex, isNotNull);
+          expect(docIndex, isNotNull,
+              reason: '$package must have documentation');
 
           final panaSummaryBytes = result.lookup('summary.json');
           expect(panaSummaryBytes, isNotNull);

--- a/tool/setup-flutter.sh
+++ b/tool/setup-flutter.sh
@@ -15,9 +15,34 @@ then
 fi
 
 # Download and extract Flutter SDK into the target directory.
-git clone -b "$2" --single-branch https://github.com/flutter/flutter.git "$1"
+if [[ "$2" == "master" ]]
+then
+  git clone -b "$2" --single-branch https://github.com/flutter/flutter.git "$1"
+else
+  CHANNEL=${3:-stable}
 
-# Downloads the Dart SDK and disables analytics tracking – which we always want.
-# This will add 400 MB.
+  # Create a temporary directory to extract the archive to.
+  WORK_DIR=`mktemp -d`
+  if [[ ! "$WORK_DIR" || ! -d "$WORK_DIR" ]]; then
+    echo "Could not create temporary directory."
+    exit 1
+  fi
+
+  # Download and extract Flutter SDK
+  cd "$WORK_DIR"
+  curl -sS "https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_$2-${CHANNEL}.tar.xz" >flutter.tar.xz
+  tar xf flutter.tar.xz
+  rm flutter.tar.xz
+
+  # Move from temp to destination.
+  DEST_PARENT=`dirname "$1"`
+  mkdir -p "$DEST_PARENT"
+  mv "$WORK_DIR/flutter" "$1"
+fi
+
+# When using `git clone` above, the first command downloads the Dart SDK (adds ~400MB),
+# which should be already included in the tar archive. However, the tar archive requires
+# to run `flutter doctor` to work properly.
 cd "$1"
 ./bin/flutter --no-version-check config --no-analytics
+./bin/flutter --no-version-check doctor


### PR DESCRIPTION
Reduces external network traffic for dynamically downloaded Flutter SDKs.