### PR TITLE
Do not use pana's License.path, use 'license' label instead.

### DIFF
--- a/app/lib/frontend/templates/views/pkg/info_box.dart
+++ b/app/lib/frontend/templates/views/pkg/info_box.dart
@@ -166,7 +166,6 @@ d.Node? _licenseNode({
   required String licenseUrl,
   required bool isPending,
 }) {
-  final paths = licenses.map((e) => e.path).toSet().toList();
   final labels = isPending
       ? '(pending)'
       : licenses.map((e) => e.spdxIdentifier).toSet().join(', ');
@@ -177,7 +176,7 @@ d.Node? _licenseNode({
     ),
     d.text(labels),
     d.text(' ('),
-    d.a(href: licenseUrl, text: paths.join(', ')),
+    d.a(href: licenseUrl, text: 'license'),
     d.text(')'),
   ]);
 }

--- a/app/test/frontend/golden/pkg_activity_log_page.html
+++ b/app/test/frontend/golden/pkg_activity_log_page.html
@@ -414,7 +414,7 @@
             <p>
               <img class="inline-icon-img" src="/static/hash-%%etag%%/img/material-icon-balance.svg" alt="" width="14" height="14" role="presentation"/>
               BSD-3-Clause (
-              <a href="/packages/oxygen/license">LICENSE</a>
+              <a href="/packages/oxygen/license">license</a>
               )
             </p>
             <h3 class="title">More</h3>
@@ -490,7 +490,7 @@
           <p>
             <img class="inline-icon-img" src="/static/hash-%%etag%%/img/material-icon-balance.svg" alt="" width="14" height="14" role="presentation"/>
             BSD-3-Clause (
-            <a href="/packages/oxygen/license">LICENSE</a>
+            <a href="/packages/oxygen/license">license</a>
             )
           </p>
           <h3 class="title">More</h3>

--- a/app/test/frontend/golden/pkg_admin_page.html
+++ b/app/test/frontend/golden/pkg_admin_page.html
@@ -655,7 +655,7 @@
             <p>
               <img class="inline-icon-img" src="/static/hash-%%etag%%/img/material-icon-balance.svg" alt="" width="14" height="14" role="presentation"/>
               BSD-3-Clause (
-              <a href="/packages/oxygen/license">LICENSE</a>
+              <a href="/packages/oxygen/license">license</a>
               )
             </p>
             <h3 class="title">More</h3>
@@ -731,7 +731,7 @@
           <p>
             <img class="inline-icon-img" src="/static/hash-%%etag%%/img/material-icon-balance.svg" alt="" width="14" height="14" role="presentation"/>
             BSD-3-Clause (
-            <a href="/packages/oxygen/license">LICENSE</a>
+            <a href="/packages/oxygen/license">license</a>
             )
           </p>
           <h3 class="title">More</h3>

--- a/app/test/frontend/golden/pkg_changelog_page.html
+++ b/app/test/frontend/golden/pkg_changelog_page.html
@@ -284,7 +284,7 @@
             <p>
               <img class="inline-icon-img" src="/static/hash-%%etag%%/img/material-icon-balance.svg" alt="" width="14" height="14" role="presentation"/>
               BSD-3-Clause (
-              <a href="/packages/oxygen/license">LICENSE</a>
+              <a href="/packages/oxygen/license">license</a>
               )
             </p>
             <h3 class="title">More</h3>
@@ -361,7 +361,7 @@
           <p>
             <img class="inline-icon-img" src="/static/hash-%%etag%%/img/material-icon-balance.svg" alt="" width="14" height="14" role="presentation"/>
             BSD-3-Clause (
-            <a href="/packages/oxygen/license">LICENSE</a>
+            <a href="/packages/oxygen/license">license</a>
             )
           </p>
           <h3 class="title">More</h3>

--- a/app/test/frontend/golden/pkg_example_page.html
+++ b/app/test/frontend/golden/pkg_example_page.html
@@ -281,7 +281,7 @@
             <p>
               <img class="inline-icon-img" src="/static/hash-%%etag%%/img/material-icon-balance.svg" alt="" width="14" height="14" role="presentation"/>
               BSD-3-Clause (
-              <a href="/packages/oxygen/license">LICENSE</a>
+              <a href="/packages/oxygen/license">license</a>
               )
             </p>
             <h3 class="title">More</h3>
@@ -358,7 +358,7 @@
           <p>
             <img class="inline-icon-img" src="/static/hash-%%etag%%/img/material-icon-balance.svg" alt="" width="14" height="14" role="presentation"/>
             BSD-3-Clause (
-            <a href="/packages/oxygen/license">LICENSE</a>
+            <a href="/packages/oxygen/license">license</a>
             )
           </p>
           <h3 class="title">More</h3>

--- a/app/test/frontend/golden/pkg_install_page.html
+++ b/app/test/frontend/golden/pkg_install_page.html
@@ -307,7 +307,7 @@
             <p>
               <img class="inline-icon-img" src="/static/hash-%%etag%%/img/material-icon-balance.svg" alt="" width="14" height="14" role="presentation"/>
               BSD-3-Clause (
-              <a href="/packages/oxygen/license">LICENSE</a>
+              <a href="/packages/oxygen/license">license</a>
               )
             </p>
             <h3 class="title">More</h3>
@@ -384,7 +384,7 @@
           <p>
             <img class="inline-icon-img" src="/static/hash-%%etag%%/img/material-icon-balance.svg" alt="" width="14" height="14" role="presentation"/>
             BSD-3-Clause (
-            <a href="/packages/oxygen/license">LICENSE</a>
+            <a href="/packages/oxygen/license">license</a>
             )
           </p>
           <h3 class="title">More</h3>

--- a/app/test/frontend/golden/pkg_score_page.html
+++ b/app/test/frontend/golden/pkg_score_page.html
@@ -369,7 +369,7 @@
             <p>
               <img class="inline-icon-img" src="/static/hash-%%etag%%/img/material-icon-balance.svg" alt="" width="14" height="14" role="presentation"/>
               BSD-3-Clause (
-              <a href="/packages/oxygen/license">LICENSE</a>
+              <a href="/packages/oxygen/license">license</a>
               )
             </p>
             <h3 class="title">More</h3>
@@ -446,7 +446,7 @@
           <p>
             <img class="inline-icon-img" src="/static/hash-%%etag%%/img/material-icon-balance.svg" alt="" width="14" height="14" role="presentation"/>
             BSD-3-Clause (
-            <a href="/packages/oxygen/license">LICENSE</a>
+            <a href="/packages/oxygen/license">license</a>
             )
           </p>
           <h3 class="title">More</h3>

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -284,7 +284,7 @@
             <p>
               <img class="inline-icon-img" src="/static/hash-%%etag%%/img/material-icon-balance.svg" alt="" width="14" height="14" role="presentation"/>
               BSD-3-Clause (
-              <a href="/packages/oxygen/license">LICENSE</a>
+              <a href="/packages/oxygen/license">license</a>
               )
             </p>
             <h3 class="title">More</h3>
@@ -361,7 +361,7 @@
           <p>
             <img class="inline-icon-img" src="/static/hash-%%etag%%/img/material-icon-balance.svg" alt="" width="14" height="14" role="presentation"/>
             BSD-3-Clause (
-            <a href="/packages/oxygen/license">LICENSE</a>
+            <a href="/packages/oxygen/license">license</a>
             )
           </p>
           <h3 class="title">More</h3>

--- a/app/test/frontend/golden/pkg_show_page_discontinued.html
+++ b/app/test/frontend/golden/pkg_show_page_discontinued.html
@@ -277,7 +277,7 @@
             <p>
               <img class="inline-icon-img" src="/static/hash-%%etag%%/img/material-icon-balance.svg" alt="" width="14" height="14" role="presentation"/>
               BSD-3-Clause (
-              <a href="/packages/pkg/license">LICENSE</a>
+              <a href="/packages/pkg/license">license</a>
               )
             </p>
             <h3 class="title">More</h3>
@@ -354,7 +354,7 @@
           <p>
             <img class="inline-icon-img" src="/static/hash-%%etag%%/img/material-icon-balance.svg" alt="" width="14" height="14" role="presentation"/>
             BSD-3-Clause (
-            <a href="/packages/pkg/license">LICENSE</a>
+            <a href="/packages/pkg/license">license</a>
             )
           </p>
           <h3 class="title">More</h3>

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -273,7 +273,7 @@
             <p>
               <img class="inline-icon-img" src="/static/hash-%%etag%%/img/material-icon-balance.svg" alt="" width="14" height="14" role="presentation"/>
               BSD-3-Clause (
-              <a href="/packages/flutter_titanium/license">LICENSE</a>
+              <a href="/packages/flutter_titanium/license">license</a>
               )
             </p>
             <h3 class="title">Dependencies</h3>
@@ -354,7 +354,7 @@
           <p>
             <img class="inline-icon-img" src="/static/hash-%%etag%%/img/material-icon-balance.svg" alt="" width="14" height="14" role="presentation"/>
             BSD-3-Clause (
-            <a href="/packages/flutter_titanium/license">LICENSE</a>
+            <a href="/packages/flutter_titanium/license">license</a>
             )
           </p>
           <h3 class="title">Dependencies</h3>

--- a/app/test/frontend/golden/pkg_show_page_publisher.html
+++ b/app/test/frontend/golden/pkg_show_page_publisher.html
@@ -275,7 +275,7 @@
             <p>
               <img class="inline-icon-img" src="/static/hash-%%etag%%/img/material-icon-balance.svg" alt="" width="14" height="14" role="presentation"/>
               BSD-3-Clause (
-              <a href="/packages/neon/license">LICENSE</a>
+              <a href="/packages/neon/license">license</a>
               )
             </p>
             <h3 class="title">More</h3>
@@ -355,7 +355,7 @@
           <p>
             <img class="inline-icon-img" src="/static/hash-%%etag%%/img/material-icon-balance.svg" alt="" width="14" height="14" role="presentation"/>
             BSD-3-Clause (
-            <a href="/packages/neon/license">LICENSE</a>
+            <a href="/packages/neon/license">license</a>
             )
           </p>
           <h3 class="title">More</h3>

--- a/app/test/frontend/golden/pkg_show_page_retracted.html
+++ b/app/test/frontend/golden/pkg_show_page_retracted.html
@@ -253,7 +253,7 @@
             <p>
               <img class="inline-icon-img" src="/static/hash-%%etag%%/img/material-icon-balance.svg" alt="" width="14" height="14" role="presentation"/>
               unknown (
-              <a href="/packages/pkg/versions/1.0.0/license">LICENSE</a>
+              <a href="/packages/pkg/versions/1.0.0/license">license</a>
               )
             </p>
             <h3 class="title">More</h3>
@@ -323,7 +323,7 @@
           <p>
             <img class="inline-icon-img" src="/static/hash-%%etag%%/img/material-icon-balance.svg" alt="" width="14" height="14" role="presentation"/>
             unknown (
-            <a href="/packages/pkg/versions/1.0.0/license">LICENSE</a>
+            <a href="/packages/pkg/versions/1.0.0/license">license</a>
             )
           </p>
           <h3 class="title">More</h3>

--- a/app/test/frontend/golden/pkg_show_page_retracted_non_retracted_version.html
+++ b/app/test/frontend/golden/pkg_show_page_retracted_non_retracted_version.html
@@ -268,7 +268,7 @@
             <p>
               <img class="inline-icon-img" src="/static/hash-%%etag%%/img/material-icon-balance.svg" alt="" width="14" height="14" role="presentation"/>
               BSD-3-Clause (
-              <a href="/packages/pkg/license">LICENSE</a>
+              <a href="/packages/pkg/license">license</a>
               )
             </p>
             <h3 class="title">More</h3>
@@ -345,7 +345,7 @@
           <p>
             <img class="inline-icon-img" src="/static/hash-%%etag%%/img/material-icon-balance.svg" alt="" width="14" height="14" role="presentation"/>
             BSD-3-Clause (
-            <a href="/packages/pkg/license">LICENSE</a>
+            <a href="/packages/pkg/license">license</a>
             )
           </p>
           <h3 class="title">More</h3>

--- a/app/test/frontend/golden/pkg_show_version_page.html
+++ b/app/test/frontend/golden/pkg_show_version_page.html
@@ -278,7 +278,7 @@
             <p>
               <img class="inline-icon-img" src="/static/hash-%%etag%%/img/material-icon-balance.svg" alt="" width="14" height="14" role="presentation"/>
               BSD-3-Clause (
-              <a href="/packages/oxygen/license">LICENSE</a>
+              <a href="/packages/oxygen/license">license</a>
               )
             </p>
             <h3 class="title">More</h3>
@@ -355,7 +355,7 @@
           <p>
             <img class="inline-icon-img" src="/static/hash-%%etag%%/img/material-icon-balance.svg" alt="" width="14" height="14" role="presentation"/>
             BSD-3-Clause (
-            <a href="/packages/oxygen/license">LICENSE</a>
+            <a href="/packages/oxygen/license">license</a>
             )
           </p>
           <h3 class="title">More</h3>

--- a/app/test/frontend/golden/pkg_versions_page.html
+++ b/app/test/frontend/golden/pkg_versions_page.html
@@ -391,7 +391,7 @@
             <p>
               <img class="inline-icon-img" src="/static/hash-%%etag%%/img/material-icon-balance.svg" alt="" width="14" height="14" role="presentation"/>
               BSD-3-Clause (
-              <a href="/packages/oxygen/license">LICENSE</a>
+              <a href="/packages/oxygen/license">license</a>
               )
             </p>
             <h3 class="title">More</h3>
@@ -468,7 +468,7 @@
           <p>
             <img class="inline-icon-img" src="/static/hash-%%etag%%/img/material-icon-balance.svg" alt="" width="14" height="14" role="presentation"/>
             BSD-3-Clause (
-            <a href="/packages/oxygen/license">LICENSE</a>
+            <a href="/packages/oxygen/license">license</a>
             )
           </p>
           <h3 class="title">More</h3>

--- a/app/test/task/testdata/goldens/packages/oxygen.html
+++ b/app/test/task/testdata/goldens/packages/oxygen.html
@@ -274,7 +274,7 @@
             <p>
               <img class="inline-icon-img" src="/static/hash-%%etag%%/img/material-icon-balance.svg" alt="" width="14" height="14" role="presentation"/>
               unknown (
-              <a href="/packages/oxygen/license">LICENSE</a>
+              <a href="/packages/oxygen/license">license</a>
               )
             </p>
             <h3 class="title">More</h3>
@@ -355,7 +355,7 @@
           <p>
             <img class="inline-icon-img" src="/static/hash-%%etag%%/img/material-icon-balance.svg" alt="" width="14" height="14" role="presentation"/>
             unknown (
-            <a href="/packages/oxygen/license">LICENSE</a>
+            <a href="/packages/oxygen/license">license</a>
             )
           </p>
           <h3 class="title">More</h3>

--- a/app/test/task/testdata/goldens/packages/oxygen/changelog.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/changelog.html
@@ -280,7 +280,7 @@
             <p>
               <img class="inline-icon-img" src="/static/hash-%%etag%%/img/material-icon-balance.svg" alt="" width="14" height="14" role="presentation"/>
               unknown (
-              <a href="/packages/oxygen/license">LICENSE</a>
+              <a href="/packages/oxygen/license">license</a>
               )
             </p>
             <h3 class="title">More</h3>
@@ -361,7 +361,7 @@
           <p>
             <img class="inline-icon-img" src="/static/hash-%%etag%%/img/material-icon-balance.svg" alt="" width="14" height="14" role="presentation"/>
             unknown (
-            <a href="/packages/oxygen/license">LICENSE</a>
+            <a href="/packages/oxygen/license">license</a>
             )
           </p>
           <h3 class="title">More</h3>

--- a/app/test/task/testdata/goldens/packages/oxygen/example.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/example.html
@@ -277,7 +277,7 @@
             <p>
               <img class="inline-icon-img" src="/static/hash-%%etag%%/img/material-icon-balance.svg" alt="" width="14" height="14" role="presentation"/>
               unknown (
-              <a href="/packages/oxygen/license">LICENSE</a>
+              <a href="/packages/oxygen/license">license</a>
               )
             </p>
             <h3 class="title">More</h3>
@@ -358,7 +358,7 @@
           <p>
             <img class="inline-icon-img" src="/static/hash-%%etag%%/img/material-icon-balance.svg" alt="" width="14" height="14" role="presentation"/>
             unknown (
-            <a href="/packages/oxygen/license">LICENSE</a>
+            <a href="/packages/oxygen/license">license</a>
             )
           </p>
           <h3 class="title">More</h3>

--- a/app/test/task/testdata/goldens/packages/oxygen/install.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/install.html
@@ -303,7 +303,7 @@
             <p>
               <img class="inline-icon-img" src="/static/hash-%%etag%%/img/material-icon-balance.svg" alt="" width="14" height="14" role="presentation"/>
               unknown (
-              <a href="/packages/oxygen/license">LICENSE</a>
+              <a href="/packages/oxygen/license">license</a>
               )
             </p>
             <h3 class="title">More</h3>
@@ -384,7 +384,7 @@
           <p>
             <img class="inline-icon-img" src="/static/hash-%%etag%%/img/material-icon-balance.svg" alt="" width="14" height="14" role="presentation"/>
             unknown (
-            <a href="/packages/oxygen/license">LICENSE</a>
+            <a href="/packages/oxygen/license">license</a>
             )
           </p>
           <h3 class="title">More</h3>

--- a/app/test/task/testdata/goldens/packages/oxygen/license.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/license.html
@@ -276,7 +276,7 @@
             <p>
               <img class="inline-icon-img" src="/static/hash-%%etag%%/img/material-icon-balance.svg" alt="" width="14" height="14" role="presentation"/>
               unknown (
-              <a href="/packages/oxygen/license">LICENSE</a>
+              <a href="/packages/oxygen/license">license</a>
               )
             </p>
             <h3 class="title">More</h3>
@@ -357,7 +357,7 @@
           <p>
             <img class="inline-icon-img" src="/static/hash-%%etag%%/img/material-icon-balance.svg" alt="" width="14" height="14" role="presentation"/>
             unknown (
-            <a href="/packages/oxygen/license">LICENSE</a>
+            <a href="/packages/oxygen/license">license</a>
             )
           </p>
           <h3 class="title">More</h3>

--- a/app/test/task/testdata/goldens/packages/oxygen/score.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/score.html
@@ -603,7 +603,7 @@
             <p>
               <img class="inline-icon-img" src="/static/hash-%%etag%%/img/material-icon-balance.svg" alt="" width="14" height="14" role="presentation"/>
               unknown (
-              <a href="/packages/oxygen/license">LICENSE</a>
+              <a href="/packages/oxygen/license">license</a>
               )
             </p>
             <h3 class="title">More</h3>
@@ -684,7 +684,7 @@
           <p>
             <img class="inline-icon-img" src="/static/hash-%%etag%%/img/material-icon-balance.svg" alt="" width="14" height="14" role="presentation"/>
             unknown (
-            <a href="/packages/oxygen/license">LICENSE</a>
+            <a href="/packages/oxygen/license">license</a>
             )
           </p>
           <h3 class="title">More</h3>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions.html
@@ -336,7 +336,7 @@
             <p>
               <img class="inline-icon-img" src="/static/hash-%%etag%%/img/material-icon-balance.svg" alt="" width="14" height="14" role="presentation"/>
               unknown (
-              <a href="/packages/oxygen/license">LICENSE</a>
+              <a href="/packages/oxygen/license">license</a>
               )
             </p>
             <h3 class="title">More</h3>
@@ -417,7 +417,7 @@
           <p>
             <img class="inline-icon-img" src="/static/hash-%%etag%%/img/material-icon-balance.svg" alt="" width="14" height="14" role="presentation"/>
             unknown (
-            <a href="/packages/oxygen/license">LICENSE</a>
+            <a href="/packages/oxygen/license">license</a>
             )
           </p>
           <h3 class="title">More</h3>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0.html
@@ -278,7 +278,7 @@
             <p>
               <img class="inline-icon-img" src="/static/hash-%%etag%%/img/material-icon-balance.svg" alt="" width="14" height="14" role="presentation"/>
               unknown (
-              <a href="/packages/oxygen/versions/1.0.0/license">LICENSE</a>
+              <a href="/packages/oxygen/versions/1.0.0/license">license</a>
               )
             </p>
             <h3 class="title">More</h3>
@@ -359,7 +359,7 @@
           <p>
             <img class="inline-icon-img" src="/static/hash-%%etag%%/img/material-icon-balance.svg" alt="" width="14" height="14" role="presentation"/>
             unknown (
-            <a href="/packages/oxygen/versions/1.0.0/license">LICENSE</a>
+            <a href="/packages/oxygen/versions/1.0.0/license">license</a>
             )
           </p>
           <h3 class="title">More</h3>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/changelog.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/changelog.html
@@ -284,7 +284,7 @@
             <p>
               <img class="inline-icon-img" src="/static/hash-%%etag%%/img/material-icon-balance.svg" alt="" width="14" height="14" role="presentation"/>
               unknown (
-              <a href="/packages/oxygen/versions/1.0.0/license">LICENSE</a>
+              <a href="/packages/oxygen/versions/1.0.0/license">license</a>
               )
             </p>
             <h3 class="title">More</h3>
@@ -365,7 +365,7 @@
           <p>
             <img class="inline-icon-img" src="/static/hash-%%etag%%/img/material-icon-balance.svg" alt="" width="14" height="14" role="presentation"/>
             unknown (
-            <a href="/packages/oxygen/versions/1.0.0/license">LICENSE</a>
+            <a href="/packages/oxygen/versions/1.0.0/license">license</a>
             )
           </p>
           <h3 class="title">More</h3>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/example.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/example.html
@@ -281,7 +281,7 @@
             <p>
               <img class="inline-icon-img" src="/static/hash-%%etag%%/img/material-icon-balance.svg" alt="" width="14" height="14" role="presentation"/>
               unknown (
-              <a href="/packages/oxygen/versions/1.0.0/license">LICENSE</a>
+              <a href="/packages/oxygen/versions/1.0.0/license">license</a>
               )
             </p>
             <h3 class="title">More</h3>
@@ -362,7 +362,7 @@
           <p>
             <img class="inline-icon-img" src="/static/hash-%%etag%%/img/material-icon-balance.svg" alt="" width="14" height="14" role="presentation"/>
             unknown (
-            <a href="/packages/oxygen/versions/1.0.0/license">LICENSE</a>
+            <a href="/packages/oxygen/versions/1.0.0/license">license</a>
             )
           </p>
           <h3 class="title">More</h3>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/install.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/install.html
@@ -307,7 +307,7 @@
             <p>
               <img class="inline-icon-img" src="/static/hash-%%etag%%/img/material-icon-balance.svg" alt="" width="14" height="14" role="presentation"/>
               unknown (
-              <a href="/packages/oxygen/versions/1.0.0/license">LICENSE</a>
+              <a href="/packages/oxygen/versions/1.0.0/license">license</a>
               )
             </p>
             <h3 class="title">More</h3>
@@ -388,7 +388,7 @@
           <p>
             <img class="inline-icon-img" src="/static/hash-%%etag%%/img/material-icon-balance.svg" alt="" width="14" height="14" role="presentation"/>
             unknown (
-            <a href="/packages/oxygen/versions/1.0.0/license">LICENSE</a>
+            <a href="/packages/oxygen/versions/1.0.0/license">license</a>
             )
           </p>
           <h3 class="title">More</h3>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/license.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/license.html
@@ -280,7 +280,7 @@
             <p>
               <img class="inline-icon-img" src="/static/hash-%%etag%%/img/material-icon-balance.svg" alt="" width="14" height="14" role="presentation"/>
               unknown (
-              <a href="/packages/oxygen/versions/1.0.0/license">LICENSE</a>
+              <a href="/packages/oxygen/versions/1.0.0/license">license</a>
               )
             </p>
             <h3 class="title">More</h3>
@@ -361,7 +361,7 @@
           <p>
             <img class="inline-icon-img" src="/static/hash-%%etag%%/img/material-icon-balance.svg" alt="" width="14" height="14" role="presentation"/>
             unknown (
-            <a href="/packages/oxygen/versions/1.0.0/license">LICENSE</a>
+            <a href="/packages/oxygen/versions/1.0.0/license">license</a>
             )
           </p>
           <h3 class="title">More</h3>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/score.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/score.html
@@ -607,7 +607,7 @@
             <p>
               <img class="inline-icon-img" src="/static/hash-%%etag%%/img/material-icon-balance.svg" alt="" width="14" height="14" role="presentation"/>
               unknown (
-              <a href="/packages/oxygen/versions/1.0.0/license">LICENSE</a>
+              <a href="/packages/oxygen/versions/1.0.0/license">license</a>
               )
             </p>
             <h3 class="title">More</h3>
@@ -688,7 +688,7 @@
           <p>
             <img class="inline-icon-img" src="/static/hash-%%etag%%/img/material-icon-balance.svg" alt="" width="14" height="14" role="presentation"/>
             unknown (
-            <a href="/packages/oxygen/versions/1.0.0/license">LICENSE</a>
+            <a href="/packages/oxygen/versions/1.0.0/license">license</a>
             )
           </p>
           <h3 class="title">More</h3>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/2.0.0.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/2.0.0.html
@@ -274,7 +274,7 @@
             <p>
               <img class="inline-icon-img" src="/static/hash-%%etag%%/img/material-icon-balance.svg" alt="" width="14" height="14" role="presentation"/>
               unknown (
-              <a href="/packages/oxygen/license">LICENSE</a>
+              <a href="/packages/oxygen/license">license</a>
               )
             </p>
             <h3 class="title">More</h3>
@@ -355,7 +355,7 @@
           <p>
             <img class="inline-icon-img" src="/static/hash-%%etag%%/img/material-icon-balance.svg" alt="" width="14" height="14" role="presentation"/>
             unknown (
-            <a href="/packages/oxygen/license">LICENSE</a>
+            <a href="/packages/oxygen/license">license</a>
             )
           </p>
           <h3 class="title">More</h3>


### PR DESCRIPTION
Context: for a long while now, we only accept the `LICENSE` file as the source of the package license(s). `pana` will remove the `path` field in an upcoming release, we should not use it anymore: https://github.com/dart-lang/pana/pull/1385