### PR TITLE
Dark mode styles for less-used material components.

### DIFF
--- a/pkg/web_css/lib/src/_detail_page.scss
+++ b/pkg/web_css/lib/src/_detail_page.scss
@@ -189,7 +189,7 @@ $detail-tabs-tablet-width: calc(100% - 240px);
     }
 
     &:focus-within {
-      border-color: #000;
+      border-color: var(--pub-default-text-color);
     }
   }
 }

--- a/pkg/web_css/lib/src/_form.scss
+++ b/pkg/web_css/lib/src/_form.scss
@@ -132,6 +132,13 @@
       background: var(--mdc_pub-text_field-background-color);
       border-color: var(--mdc_pub-text_field-border-color);
     }
+
+    &:hover {
+      .mdc-notched-outline__leading,
+      .mdc-notched-outline__trailing {
+        border-color: var(--pub-default-text-color) !important;
+      }
+    }
   }
 
   .mdc-select:not(.mdc-select--disabled) {
@@ -164,5 +171,12 @@
   }
   .mdc-data-table__cell {
     color: var(--pub-default-text-color);
+  }
+
+  .mdc-dialog__surface {
+    .mdc-dialog__title,
+    .mdc-dialog__content {
+      color: var(--pub-default-text-color);
+    }
   }
 }

--- a/pkg/web_css/lib/src/_variables.scss
+++ b/pkg/web_css/lib/src/_variables.scss
@@ -46,6 +46,11 @@
   --mdc-theme-on-secondary: var(--pub-default-text-color);
   --mdc-theme-on-surface: var(--pub-default-text-color);
   --mdc-checkbox-unchecked-color: #777777;
+  --mdc-checkbox-disabled-color: #666666;
+  --mdc-filled-button-container-color: rgba(255, 255, 255, 0.1);
+  --mdc-filled-button-label-text-color: var(--pub-default-text-color);
+  --mdc-protected-button-disabled-container-color: rgba(255, 255, 255, 0.1);
+  --mdc-protected-button-disabled-label-text-color: var(--pub-default-text-color);
 
   // Pub-specific Material Design overrides
   --mdc_pub-data_table-border-color: var(--mdc-checkbox-unchecked-color);


### PR DESCRIPTION
- #4416
- I think I've checked most of the admin UIs to get a semi-decent look out of the components.

Note: unfortunately I needed to use the `!important` override (or the rule would have been too obscure).