### PR TITLE
Fix retraction-related latest stable/prerelease/preview version calculation.

### DIFF
--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -1065,6 +1065,12 @@ class PackageBackend {
         lastKnownStable: toolStableFlutterSdkVersion);
     final existingPackage = await lookupPackage(newVersion.package);
     final isNew = existingPackage == null;
+    final existingLatestVersion = isNew
+        ? null
+        : await lookupPackageVersion(
+            existingPackage.name!, existingPackage.latestVersion!);
+    final existingLatestIsRetracted =
+        existingLatestVersion?.isRetracted ?? false;
 
     // check authorizations before the transaction
     await _requireUploadAuthorization(
@@ -1158,6 +1164,7 @@ class PackageBackend {
         newVersion,
         dartSdkVersion: currentDartSdk.semanticVersion,
         flutterSdkVersion: currentFlutterSdk.semanticVersion,
+        existingLatestIsRetracted: existingLatestIsRetracted,
       );
       package!.updated = clock.now().toUtc();
       package!.versionCount++;

--- a/app/lib/package/models.dart
+++ b/app/lib/package/models.dart
@@ -340,6 +340,7 @@ class Package extends db.ExpandoModel<String> {
     PackageVersion pv, {
     required Version dartSdkVersion,
     required Version flutterSdkVersion,
+    bool existingLatestIsRetracted = false,
   }) {
     final newVersion = pv.semanticVersion;
     final isOnStableSdk = !pv.pubspec!.isPreviewForCurrentSdk(
@@ -347,20 +348,23 @@ class Package extends db.ExpandoModel<String> {
       flutterSdkVersion: flutterSdkVersion,
     );
 
-    if (latestVersionKey == null ||
+    if (existingLatestIsRetracted ||
+        latestVersionKey == null ||
         (isNewer(latestSemanticVersion, newVersion, pubSorted: true) &&
             (latestSemanticVersion.isPreRelease || isOnStableSdk))) {
       latestVersionKey = pv.key;
       latestPublished = pv.created;
     }
 
-    if (latestPreviewVersionKey == null ||
+    if (existingLatestIsRetracted ||
+        latestPreviewVersionKey == null ||
         isNewer(latestPreviewSemanticVersion!, newVersion, pubSorted: true)) {
       latestPreviewVersionKey = pv.key;
       latestPreviewPublished = pv.created;
     }
 
-    if (latestPrereleaseVersionKey == null ||
+    if (existingLatestIsRetracted ||
+        latestPrereleaseVersionKey == null ||
         isNewer(latestPrereleaseSemanticVersion!, newVersion,
             pubSorted: false)) {
       latestPrereleaseVersionKey = pv.key;


### PR DESCRIPTION
- Fixes #7852.
- I was able to create a reproduction of the bug, and it turns out it was not in the version update at retraction, it was at upload time, when all of the versions are retracted.