### PR TITLE
Simpler tag styling + dark theme.

### DIFF
--- a/pkg/web_css/lib/src/_tags.scss
+++ b/pkg/web_css/lib/src/_tags.scss
@@ -12,21 +12,10 @@
 
 /* Tags that are simple labels. */
 .package-tag {
-  background: #eef9fe;
+  background: var(--pub-tag_simplebadge-background-color);
   text-transform: uppercase;
-  color: #2465df;
+  color: var(--pub-tag_simplebadge-text-color);
   padding: 4px 8px;
-
-  &.missing {
-    background: #f0f0f0;
-    color: #555;
-  }
-
-  &.unidentified,
-  &.unlisted {
-    background: #fff0f0;
-    color: #555;
-  }
 
   &.legacy,
   &.retracted {
@@ -37,19 +26,19 @@
 
 /* Tag that are combinations of two components e.g. Dart/Flutter extended badges. */
 .-pub-tag-badge {
-  background: #e7f8ff;
+  background: var(--pub-tag_sdkbadge-background-color);
 
   > .tag-badge-main,
   > .tag-badge-sub {
     display: inline-block;
     text-transform: uppercase;
     padding: 4px 8px;
-    color: #1967d2;
+    color: var(--pub-tag_sdkbadge-text-color);
   }
 
   > .tag-badge-main {
-    color: #1967d2;
-    border-right: 1px solid rgba(25, 103, 210, 0.5); // #1967d2 + 0.5 opacity
+    color: var(--pub-tag_sdkbadge-text-color);
+    border-right: 1px solid var(--pub-tag_sdkbadge-separator-color);
     font-weight: 500;
   }
 }

--- a/pkg/web_css/lib/src/_variables.scss
+++ b/pkg/web_css/lib/src/_variables.scss
@@ -29,6 +29,11 @@
   --pub-sort_control_selected-background-color: #e7f8ff;
   --pub-sort_control_selected-text-color: var(--pub-default-text-color);
   --pub-summary_hover-background-color: color-mix(in srgb, var(--pub-link-text-color), var(--pub-default-background-color) 80%);
+  --pub-tag_simplebadge-background-color: #f0f0f0;
+  --pub-tag_simplebadge-text-color: #444444;
+  --pub-tag_sdkbadge-background-color: #e7f8ff;
+  --pub-tag_sdkbadge-separator-color: rgba(25, 103, 210, 0.5); // #1967d2 + 0.5 opacity;
+  --pub-tag_sdkbadge-text-color: #1967d2;
 
   // Material Design theme customizations
   --mdc-theme-primary: #0175c2;
@@ -59,6 +64,11 @@
   --pub-sort_control_selected-background-color: #206080;
   --pub-sort_control_selected-text-color: var(--pub-default-text-color);
   --pub-summary_hover-background-color: color-mix(in srgb, var(--pub-link-text-color), var(--pub-default-background-color) 80%);
+  --pub-tag_simplebadge-background-color: var(--pub-code-background-color);
+  --pub-tag_simplebadge-text-color: var(--pub-default-text-color);
+  --pub-tag_sdkbadge-background-color: #206080;
+  --pub-tag_sdkbadge-separator-color: var(--pub-default-text-color);
+  --pub-tag_sdkbadge-text-color: var(--pub-default-text-color);
 
   // Material Design theme customizations
   --mdc-theme-surface: var(--pub-default-background-color);


### PR DESCRIPTION
- #4416
- I think the `.package-tag` original background and text color is not used anywhere, we always override it. I've merged and simplified the used styles, keeping a grey default, red for important notification and updated the SDK/platform tags for dark mode.

<img width="617" alt="image" src="https://github.com/user-attachments/assets/f5cbdbb4-a12f-4948-8142-3650deb5741f">
<img width="622" alt="image" src="https://github.com/user-attachments/assets/b1bb4933-4f50-4ada-8cec-281c229080bc">
