### PR TITLE
Document test reliance on #-account-logout

### DIFF
--- a/app/lib/frontend/templates/views/shared/site_header.dart
+++ b/app/lib/frontend/templates/views/shared/site_header.dart
@@ -170,7 +170,10 @@ d.Node _userBlock(SessionData userSession) {
             ),
             d.button(
               classes: ['nav-button'],
-              id: '-account-logout',
+              // DO NOT CHANGE: id=-account-logout
+              // Integration tests and auth_helper in post-deployment tests relies on this element
+              // being identifiable as #-account-logout when the user is signed-in.
+              id: '-account-logout', // DO NOT CHANGE!
               text: 'Sign out',
             ),
           ],


### PR DESCRIPTION
Our automated tests needs a mechanism to detect that the session is correctly authenticated.

If we don't document the reliance on this `id` we might accidentally change it, and then we'll see things break in both:
 * golden tests
 * integration tests
 * post-deployment tests (auth_helper)