### PR TITLE
Remove some of the links from the sitemap.txt (temporary workaround)

### DIFF
--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -129,8 +129,8 @@ class PackageBackend {
     return db.query<Package>().run().map((p) => p.name!);
   }
 
-  /// Retrieves the names of all packages that need to be included in sitemap.txt.
-  Stream<String> sitemapPackageNames() {
+  /// Retrieves the packages that need to be included in sitemap.txt.
+  Stream<Package> sitemapPackageNames() {
     final query = db.query<Package>()
       ..filter(
           'updated >', clock.now().toUtc().subtract(robotsVisibilityMaxAge));
@@ -138,8 +138,7 @@ class PackageBackend {
         .run()
         .where((p) => p.isVisible)
         .where((p) => p.isIncludedInRobots)
-        .where((p) => !isSoftRemoved(p.name!))
-        .map((p) => p.name!);
+        .where((p) => !isSoftRemoved(p.name!));
   }
 
   /// Retrieves package versions ordered by their published date descending.


### PR DESCRIPTION
- #2776
- The current method duplicates the number of links by presenting both the package page and the documentation page for each package that was updated in the past two years. However, we are over 50k URLs and we need to split or reduce the number of links.
- Temporary workaround: reduce the documentation links for packages that were updated more than a year ago (but within two years otherwise they would have been already excluded).
- Also removes `/web` and `/flutter` URLs as they are now redirects to search.