### PR TITLE
Fix dark mode background gradient

### DIFF
--- a/pkg/web_css/lib/src/_variables.scss
+++ b/pkg/web_css/lib/src/_variables.scss
@@ -66,11 +66,11 @@
   --pub-home_title-text-color: #31b0fc;
   --pub-home_card-background-color: #303030;
   --pub-home_card-box_shadow-color: rgba(255, 255, 255, 0.2);
-  --pub-home_card_fadeout-background-value: linear-gradient(transparent 10%, var(--pub-home_card-background-color));
+  --pub-home_card_fadeout-background-value: linear-gradient(transparent 90%, var(--pub-home_card-background-color));
   --pub-home_card_title-text-color: var(--pub-home_title-text-color);
   --pub-home_card_hover-background-color: #383838;
   --pub-home_card_hover-box_shadow-color: rgba(255, 255, 255, 0.3);
-  --pub-home_card_hover_fadeout-background-value: linear-gradient(transparent 10%, var(--pub-home_card_hover-background-color));
+  --pub-home_card_hover_fadeout-background-value: linear-gradient(transparent 90%, var(--pub-home_card_hover-background-color));
   --pub-pagination-background-color: var(--pub-code-background-color);
   --pub-pagination-active-color: var(--pub-link-text-color);
   --pub-pagination-inactive-color: #aaaaaa;


### PR DESCRIPTION
- Fixes #7902
- The light mode starts with 90% transparency, and the dark theme looks more consistent when using the same 90%.
- Local screenshots that show that the gradient is happening:
<img width="162" alt="a" src="https://github.com/user-attachments/assets/516dbf7d-9556-4c9f-94a7-25526b9c01fa">
<img width="176" alt="b" src="https://github.com/user-attachments/assets/53032779-6a33-48b3-9add-c541d90e09a7">

It may be seemingly absent on pub.dev when the package has a publisher (but there is no degradation there with the style changes, it was always like that).