### PR TITLE
Dark theme: early initialization and OS/browser-level setting detection.

### DIFF
--- a/pkg/web_app/lib/script.dart
+++ b/pkg/web_app/lib/script.dart
@@ -26,19 +26,20 @@ void main() {
   window.onPageShow.listen((_) {
     adjustQueryTextAfterPageShow();
   });
+  _setupDarkTheme();
+}
 
+void _setupDarkTheme() {
   // For now we are reusing dartdoc's theme switcher and local storage-based
   // setting to replace the body-level theme classname.
-  window.onLoad.listen((_) {
-    final classes = document.body?.classes;
-    if (classes != null && classes.contains('-experimental-dark-mode')) {
-      final colorTheme = window.localStorage['colorTheme'];
-      if (colorTheme == 'true') {
-        classes.remove('light-theme');
-        classes.add('dark-theme');
-      }
+  final classes = document.body?.classes;
+  if (classes != null && classes.contains('-experimental-dark-mode')) {
+    final colorTheme = window.localStorage['colorTheme'];
+    if (colorTheme == 'true') {
+      classes.remove('light-theme');
+      classes.add('dark-theme');
     }
-  });
+  }
 }
 
 void _setupAllEvents() {

--- a/pkg/web_app/lib/script.dart
+++ b/pkg/web_app/lib/script.dart
@@ -30,12 +30,23 @@ void main() {
 }
 
 void _setupDarkTheme() {
-  // For now we are reusing dartdoc's theme switcher and local storage-based
-  // setting to replace the body-level theme classname.
+  // Only trigger dark mode when the experiment is enabled on the server.
   final classes = document.body?.classes;
   if (classes != null && classes.contains('-experimental-dark-mode')) {
-    final colorTheme = window.localStorage['colorTheme'];
-    if (colorTheme == 'true') {
+    // Detects OS or browser-level theme preference by using media queries.
+    bool mediaPrefersDarkScheme = false;
+    try {
+      mediaPrefersDarkScheme =
+          window.matchMedia('(prefers-color-scheme: dark)').matches;
+    } catch (_) {
+      // ignore errors e.g. when media query matching is not supported
+    }
+
+    // Detects whether the dartdoc control was set to use dark theme
+    final dartdocDarkThemeIsSet = window.localStorage['colorTheme'] == 'true';
+
+    // Switch the top-level style marker to use dark theme instead of the light theme default.
+    if (mediaPrefersDarkScheme || dartdocDarkThemeIsSet) {
       classes.remove('light-theme');
       classes.add('dark-theme');
     }


### PR DESCRIPTION
#4416

The `window.onLoad` event happens too late in the page rendering process, some styles and the background's white color may have already rendered at that point. Since every other part of our script code is rendered synchronously in the `main` method, we should be fine doing it here.
My local testing did not produced the quick flush of the light-themed content anymore, but we may eventually need to move it to a blocking script (instead of the current deferred script execution). Let's keep it here for now for simplicity.

Also added the OS/browser-level detection through `matchMedia` check. It may not be supported with all the browsers, we need to use defensive try-catch to prevent unimplemented errors blocking further execution.  