### PR TITLE
Typo fixed

### DIFF
--- a/doc/help-search.md
+++ b/doc/help-search.md
@@ -36,7 +36,7 @@
 The search UI also supports filters.
 On a wide screen, 
 the filter options will appear to the left of the search results.
-On a non-wide screen, to open the filter options,
+On a narrow screen, to open the filter options,
 click the filter icon to the right of the search bar.
 
   - To filter by Dart or Flutter support, 


### PR DESCRIPTION
**Fix typo in documentation**

Corrected a typo in the documentation where "non-wide" was mistakenly used instead of "narrow." This change ensures clarity and accuracy in the documentation.