### PR TITLE
Update overrides.dart

### DIFF
--- a/app/lib/package/overrides.dart
+++ b/app/lib/package/overrides.dart
@@ -42,6 +42,7 @@ final _reservedPackageNames = <String>[
   'hook',
   'kotlin', // for yousefi@
   'ok_http', // https://github.com/dart-lang/http/tree/master/pkgs/ok_http
+  'credilio_sbm', // for owner of package:crediliosbm
 ].map(reducePackageName).toList();
 
 const redirectPackageUrls = <String, String>{


### PR DESCRIPTION
Allowlist us to create `credilio_sbm` on behalf of the owner of `crediliosbm`

This just allows us to create the package, we can then transfer it to the owner of `crediliosbm`.