### PR TITLE
Only check dart files in `hook/` folder

### DIFF
--- a/pkg/pub_package_reader/lib/pub_package_reader.dart
+++ b/pkg/pub_package_reader/lib/pub_package_reader.dart
@@ -860,7 +860,8 @@ Iterable<ArchiveIssue> checkHooks(
   Version? minimumSdkConstraint,
   Set<String> fileNames,
 ) sync* {
-  final hookFiles = fileNames.where((f) => f.startsWith('hook/'));
+  final hookFiles =
+      fileNames.where((f) => f.startsWith('hook/') && f.endsWith('.dart'));
   for (final hookFile in hookFiles) {
     if (!_allowedHookFiles.containsKey(hookFile)) {
       yield ArchiveIssue(

--- a/pkg/pub_package_reader/test/package_archive_test.dart
+++ b/pkg/pub_package_reader/test/package_archive_test.dart
@@ -1003,6 +1003,13 @@ dev_dependencies:
         }),
         isEmpty,
       );
+
+      expect(
+        checkHooks(Version.parse('3.6.0'), {
+          'hook/README.md',
+        }),
+        isEmpty,
+      );
     });
 
     test('prevented', () {


### PR DESCRIPTION
Prevent https://github.com/dart-lang/i18n/actions/runs/10467296550/job/28985763260 from happening.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
