### PR TITLE
Always run full Package.latest* calculation when a version changes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ AppEngine version, listed here to ease deployment and troubleshooting.
  * Bumped runtimeVersion to `2024.09.04`.
  * Upgraded stable Dart analysis SDK to `3.5.2`
  * Upgraded dartdoc to `8.1.0`.
+ * Note: `Package.latest*` fields are recalculated with a full list of `PackageVersion` entities.
 
 ## `20240829t084400-all`
  * Bumped runtimeVersion to `2024.08.27`.

--- a/app/lib/admin/actions/moderate_package_versions.dart
+++ b/app/lib/admin/actions/moderate_package_versions.dart
@@ -88,15 +88,15 @@ Set the moderated flag on a package version (updating the flag and the timestamp
 
         // Update references to latest versions.
         final pkg = await tx.lookupValue<Package>(p.key);
-        if (pkg.mayAffectLatestVersions(v.semanticVersion)) {
-          final versions =
-              await tx.query<PackageVersion>(pkg.key).run().toList();
-          pkg.updateLatestVersionReferences(
-            versions,
-            dartSdkVersion: currentDartSdk.semanticVersion,
-            flutterSdkVersion: currentFlutterSdk.semanticVersion,
-            replaced: v,
-          );
+        final versions = await tx.query<PackageVersion>(pkg.key).run().toList();
+        pkg.updateVersions(
+          versions,
+          dartSdkVersion: currentDartSdk.semanticVersion,
+          flutterSdkVersion: currentFlutterSdk.semanticVersion,
+          replaced: v,
+        );
+        if (pkg.latestVersionKey == null) {
+          throw InvalidInputException('xx');
         }
         pkg.updated = clock.now().toUtc();
         tx.insert(pkg);

--- a/app/lib/admin/backend.dart
+++ b/app/lib/admin/backend.dart
@@ -14,7 +14,6 @@ import 'package:convert/convert.dart';
 import 'package:gcloud/service_scope.dart' as ss;
 import 'package:logging/logging.dart';
 import 'package:pool/pool.dart';
-import 'package:pub_semver/pub_semver.dart';
 
 import '../account/backend.dart';
 import '../account/consent_backend.dart';
@@ -444,7 +443,6 @@ class AdminBackend {
       final versionNames = versions.map((v) => v.version).toList();
       if (versionNames.contains(version)) {
         tx.delete(packageKey.append(PackageVersion, id: version));
-        package.versionCount--;
         package.updated = clock.now().toUtc();
       } else {
         print('Package $packageName does not have a version $version.');
@@ -455,14 +453,11 @@ class AdminBackend {
             'Last version detected. Use full package removal without the version qualifier.');
       }
 
-      if (package.mayAffectLatestVersions(Version.parse(version))) {
-        package.updateLatestVersionReferences(
-          versions.where((v) => v.version != version).toList(),
-          dartSdkVersion: currentDartSdk.semanticVersion,
-          flutterSdkVersion: currentFlutterSdk.semanticVersion,
-        );
-      }
-
+      package.updateVersions(
+        versions.where((v) => v.version != version).toList(),
+        dartSdkVersion: currentDartSdk.semanticVersion,
+        flutterSdkVersion: currentFlutterSdk.semanticVersion,
+      );
       package.deletedVersions ??= <String>[];
       if (!package.deletedVersions!.contains(version)) {
         package.deletedVersions!.add(version);

--- a/app/lib/shared/integrity.dart
+++ b/app/lib/shared/integrity.dart
@@ -365,7 +365,10 @@ class IntegrityChecker {
       // to prevent false alarms that could happing if a new version is being published
       // while the integrity check is running.
       if (!pv.created!.isAfter(p.lastVersionPublished!)) {
-        versionCountUntilLastPublished++;
+        // Moderated versions are not counted.
+        if (!pv.isModerated) {
+          versionCountUntilLastPublished++;
+        }
       }
     }
     if (p.versionCount != versionCountUntilLastPublished) {

--- a/app/test/package/models_test.dart
+++ b/app/test/package/models_test.dart
@@ -327,6 +327,8 @@ class _PublishSequence {
     ..name = 'pkg'
     ..created = DateTime(2021, 01, 29);
 
+  final _versions = <PackageVersion>[];
+
   void publish(String version, {int sdk = 0}) {
     final minSdk = sdk > 0 ? _futureSdk : (sdk < 0 ? _pastSdk : _currentSdk);
     final pv = PackageVersion.init()
@@ -341,7 +343,8 @@ class _PublishSequence {
           'sdk': '>=$minSdk <3.0.0',
         },
       });
-    _p.updateVersion(pv,
+    _versions.add(pv);
+    _p.updateVersions(_versions,
         dartSdkVersion: _currentSdk,
         flutterSdkVersion: Version.parse('3.20.0'));
   }

--- a/app/test/package/retracted_test.dart
+++ b/app/test/package/retracted_test.dart
@@ -206,6 +206,9 @@ void main() {
       final origLastVersionPublished = pkg.lastVersionPublished;
       final origLatestPublished = pkg.latestPublished;
       final origLatestPrereleasePublished = pkg.latestPrereleasePublished;
+      final pv200devPublished =
+          (await packageBackend.lookupPackageVersion('oxygen', '2.0.0-dev'))!
+              .created;
 
       final client =
           await createFakeAuthPubApiClient(email: adminAtPubDevEmail);
@@ -249,6 +252,7 @@ void main() {
       expect(pkg3.latestPrereleaseVersion, '2.0.0-dev');
       expect(
           pkg3.latestPrereleasePublished, isNot(origLatestPrereleasePublished));
+      expect(pkg3.latestPrereleasePublished, pv200devPublished);
       expect(pkg3.lastVersionPublished, origLastVersionPublished);
 
       // Retract all dev


### PR DESCRIPTION
- Fixes #7870
- Also calculates `lastVersionPublished` and `versionCount` fields.
- Update integrity check to take moderation status into account.