### PR TITLE
Use ModeratedSubject's canonicalUrl when the page does not have canonical url (like admin pages)

### DIFF
--- a/app/lib/frontend/templates/layout.dart
+++ b/app/lib/frontend/templates/layout.dart
@@ -82,6 +82,7 @@ String renderLayoutPage(
     }
     return null;
   }();
+  final moderationUrl = canonicalUrl ?? moderationSubject?.canonicalUrl;
   return pageLayoutNode(
     title: title,
     description: pageDescription ?? _defaultPageDescription,
@@ -111,6 +112,7 @@ String renderLayoutPage(
     mainContent: contentNode,
     includeHighlightJs: type == PageType.package,
     schemaOrgSearchActionJson: isRoot ? _schemaOrgSearchAction : null,
+    moderationUrl: moderationUrl,
     moderationSubject: moderationSubject,
   ).toString();
 }

--- a/app/lib/frontend/templates/views/shared/layout.dart
+++ b/app/lib/frontend/templates/views/shared/layout.dart
@@ -27,6 +27,7 @@ d.Node pageLayoutNode({
   required d.Node mainContent,
   required bool includeHighlightJs,
   required Map<String, dynamic>? schemaOrgSearchActionJson,
+  required String? moderationUrl,
   required ModerationSubject? moderationSubject,
 }) {
   return d.fragment([
@@ -239,7 +240,7 @@ d.Node pageLayoutNode({
 
             d.element('main', classes: mainClasses, child: mainContent),
             _siteFooterNode(
-              canonicalUrl: canonicalUrl,
+              moderationUrl: moderationUrl,
               moderationSubject: moderationSubject,
             ),
             if (includeHighlightJs)
@@ -261,9 +262,10 @@ d.Node pageLayoutNode({
 
 /// Renders the footer content.
 ///
-/// The [canonicalUrl] must be the canonical URL for the current page.
+/// The [moderationUrl] must be the canonical URL for the current page
+/// (note: may not be displayed as canonical URL in case of admin pages).
 d.Node _siteFooterNode({
-  required String? canonicalUrl,
+  required String? moderationUrl,
   required ModerationSubject? moderationSubject,
 }) {
   d.Node link(String href, String label, {bool sep = true}) =>
@@ -282,14 +284,14 @@ d.Node _siteFooterNode({
       );
 
   final moderationNode = () {
-    if (moderationSubject == null) {
+    if (moderationSubject == null || moderationUrl == null) {
       return null;
     }
     if (moderationSubject.package != null) {
       return link(
         urls.reportPage(
           subject: moderationSubject.fqn,
-          url: canonicalUrl,
+          url: moderationUrl,
         ),
         'Report package',
         sep: false,
@@ -299,7 +301,7 @@ d.Node _siteFooterNode({
       return link(
         urls.reportPage(
           subject: moderationSubject.fqn,
-          url: canonicalUrl,
+          url: moderationUrl,
         ),
         'Report publisher',
         sep: false,


### PR DESCRIPTION
This is a prerequisite for #7976, otherwise the HTML validation logic would throw an assertion error.