### PR TITLE
Redirect to static feedback message if report form is successful.

### DIFF
--- a/app/lib/frontend/handlers/pubapi.client.dart
+++ b/app/lib/frontend/handlers/pubapi.client.dart
@@ -599,8 +599,8 @@ class PubApiClient {
     ));
   }
 
-  Future<_i3.Message> postReport(_i4.ReportForm payload) async {
-    return _i3.Message.fromJson(await _client.requestJson(
+  Future<_i3.FormResponse> postReport(_i4.ReportForm payload) async {
+    return _i3.FormResponse.fromJson(await _client.requestJson(
       verb: 'post',
       path: '/api/report',
       body: payload.toJson(),

--- a/app/lib/frontend/handlers/pubapi.dart
+++ b/app/lib/frontend/handlers/pubapi.dart
@@ -584,8 +584,7 @@ class PubApi {
       listAdvisoriesForPackage(request, package);
 
   @EndPoint.post('/api/report')
-  Future<Message> postReport(Request request, ReportForm body) async {
-    final message = await processReportPageHandler(request, body);
-    return Message(message: message);
+  Future<FormResponse> postReport(Request request, ReportForm body) async {
+    return await processReportPageHandler(request, body);
   }
 }

--- a/app/lib/frontend/templates/report.dart
+++ b/app/lib/frontend/templates/report.dart
@@ -16,6 +16,22 @@ const _subjectKindLabels = {
   ModerationSubjectKind.publisher: 'publisher',
 };
 
+/// Renders the feedback page with a simple paragraph of [message].
+String renderReportFeedback({
+  required String title,
+  required String message,
+}) {
+  return renderLayoutPage(
+    PageType.standalone,
+    d.fragment([
+      d.h1(text: title),
+      d.p(text: message),
+    ]),
+    title: title,
+    noIndex: true,
+  );
+}
+
 /// Renders the create publisher page.
 String renderReportPage({
   SessionData? sessionData,

--- a/pkg/_pub_shared/lib/data/package_api.dart
+++ b/pkg/_pub_shared/lib/data/package_api.dart
@@ -190,6 +190,23 @@ class Message {
   Map<String, dynamic> toJson() => _$MessageToJson(this);
 }
 
+/// A message wrapper for pub client API compatibility.
+@JsonSerializable(includeIfNull: false)
+class FormResponse {
+  final String? message;
+  final String? redirectTo;
+
+  FormResponse({
+    required this.message,
+    required this.redirectTo,
+  });
+
+  factory FormResponse.fromJson(Map<String, dynamic> json) =>
+      _$FormResponseFromJson(json);
+
+  Map<String, dynamic> toJson() => _$FormResponseToJson(this);
+}
+
 /// Used in `pub` client for finding which versions exist.
 /// (`listVersions` method in pubapi)
 @JsonSerializable(includeIfNull: false)

--- a/pkg/_pub_shared/lib/data/package_api.g.dart
+++ b/pkg/_pub_shared/lib/data/package_api.g.dart
@@ -155,6 +155,25 @@ Map<String, dynamic> _$MessageToJson(Message instance) => <String, dynamic>{
       'message': instance.message,
     };
 
+FormResponse _$FormResponseFromJson(Map<String, dynamic> json) => FormResponse(
+      message: json['message'] as String?,
+      redirectTo: json['redirectTo'] as String?,
+    );
+
+Map<String, dynamic> _$FormResponseToJson(FormResponse instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('message', instance.message);
+  writeNotNull('redirectTo', instance.redirectTo);
+  return val;
+}
+
 PackageData _$PackageDataFromJson(Map<String, dynamic> json) => PackageData(
       name: json['name'] as String,
       isDiscontinued: json['isDiscontinued'] as bool?,

--- a/pkg/_pub_shared/lib/src/pubapi.client.dart
+++ b/pkg/_pub_shared/lib/src/pubapi.client.dart
@@ -599,8 +599,8 @@ class PubApiClient {
     ));
   }
 
-  Future<_i3.Message> postReport(_i4.ReportForm payload) async {
-    return _i3.Message.fromJson(await _client.requestJson(
+  Future<_i3.FormResponse> postReport(_i4.ReportForm payload) async {
+    return _i3.FormResponse.fromJson(await _client.requestJson(
       verb: 'post',
       path: '/api/report',
       body: payload.toJson(),

--- a/pkg/pub_integration/test/report_test.dart
+++ b/pkg/pub_integration/test/report_test.dart
@@ -65,10 +65,10 @@ void main() {
           await page.waitFocusAndType('#report-email', 'reporter@pub.dev');
           await page.waitFocusAndType(
               '#report-message', 'Huston, we have a problem.');
-          await page.waitAndClick('#report-submit', waitForOneResponse: true);
-          expect(await page.content,
-              contains('The report was submitted successfully.'));
-          await page.waitAndClickOnDialogOk();
+          await page.waitAndClick('#report-submit');
+          await page.waitForNavigation();
+          expect(
+              await page.content, contains('has been submitted successfully'));
         },
       );
 
@@ -197,10 +197,9 @@ void main() {
 
         await page.waitFocusAndType(
             '#report-message', 'Huston, I have a different idea.');
-        await page.waitAndClick('#report-submit', waitForOneResponse: true);
-        expect(await page.content,
-            contains('The appeal was submitted successfully.'));
-        await page.waitAndClickOnDialogOk();
+        await page.waitAndClick('#report-submit');
+        await page.waitForNavigation();
+        expect(await page.content, contains('has been submitted successfully'));
       });
 
       final appealEmail = await supportUser.readLatestEmail();

--- a/pkg/web_app/lib/src/admin_pages.dart
+++ b/pkg/web_app/lib/src/admin_pages.dart
@@ -52,11 +52,23 @@ void _initGenericForm() {
           fn: () =>
               api_client.sendJson(verb: 'POST', path: endpoint, body: body),
           successMessage: null,
-          onSuccess: (result) async {
-            final message =
-                result == null ? null : result['message']?.toString();
-            await modalMessage('Success', text(message ?? 'OK.'));
-            window.location.reload();
+          onSuccess: (r) async {
+            final result = r ?? <String, dynamic>{};
+            final redirectTo = result['redirectTo']?.toString();
+
+            // We shall display a minimal feedback when both the redirect and the message is omitted.
+            final message = result['message']?.toString() ??
+                (redirectTo == null ? 'Success. The page will reload.' : null);
+
+            if (message != null) {
+              await modalMessage('Success', text(message));
+            }
+
+            if (redirectTo != null) {
+              window.location.href = redirectTo;
+            } else {
+              window.location.reload();
+            }
           },
         );
       });


### PR DESCRIPTION
- Fixes #7990
- Introduces a new `FormResponse` object that has more fields for the generic form-handling.
- The generic form handling now has a redirect path that does not involve displaying a modal window when it is successful (although it may do so if the message field is present).