### PR TITLE
Form redirect + redirecting on report/appeal submission.

### DIFF
--- a/app/lib/frontend/handlers/pubapi.dart
+++ b/app/lib/frontend/handlers/pubapi.dart
@@ -585,7 +585,6 @@ class PubApi {
 
   @EndPoint.post('/api/report')
   Future<Message> postReport(Request request, ReportForm body) async {
-    final message = await processReportPageHandler(request, body);
-    return Message(message: message);
+    return await processReportPageHandler(request, body);
   }
 }

--- a/app/lib/frontend/templates/report.dart
+++ b/app/lib/frontend/templates/report.dart
@@ -16,12 +16,29 @@ const _subjectKindLabels = {
   ModerationSubjectKind.publisher: 'publisher',
 };
 
+/// Renders the feedback page with a simple paragraph of [message].
+String renderReportFeedback({
+  required String title,
+  required String message,
+}) {
+  return renderLayoutPage(
+    PageType.standalone,
+    d.fragment([
+      d.h1(text: title),
+      d.p(text: message),
+    ]),
+    title: title,
+    noIndex: true,
+  );
+}
+
 /// Renders the create publisher page.
 String renderReportPage({
   SessionData? sessionData,
   required ModerationSubject subject,
   required String? url,
   required String? caseId,
+  required String onSuccessGotoUrl,
 }) {
   final isAppeal = caseId != null;
   final title = isAppeal ? 'Appeal a resolution' : 'Report a problem';
@@ -33,6 +50,7 @@ String renderReportPage({
         id: 'report-page-form',
         attributes: {
           'data-form-api-endpoint': '/api/report',
+          'data-form-success-goto': onSuccessGotoUrl,
         },
         children: [
           d.input(type: 'hidden', name: 'subject', value: subject.fqn),

--- a/app/test/frontend/golden/report_page.html
+++ b/app/test/frontend/golden/report_page.html
@@ -107,7 +107,7 @@
     <div id="banner-container"></div>
     <main class="container">
       <div class="report-main">
-        <div id="report-page-form" data-form-api-endpoint="/api/report">
+        <div id="report-page-form" data-form-api-endpoint="/api/report" data-form-success-goto="https://pub.dev/report?feedback=report-submitted">
           <input type="hidden" name="subject" value="package:oxygen"/>
           <input type="hidden" name="url" value="https://pub.dev/packages/oxygen/example"/>
           <h1>Report a problem</h1>

--- a/app/test/frontend/golden/report_page_appeal.html
+++ b/app/test/frontend/golden/report_page_appeal.html
@@ -107,7 +107,7 @@
     <div id="banner-container"></div>
     <main class="container">
       <div class="report-main">
-        <div id="report-page-form" data-form-api-endpoint="/api/report">
+        <div id="report-page-form" data-form-api-endpoint="/api/report" data-form-success-goto="https://pub.dev/report?feedback=appeal-submitted">
           <input type="hidden" name="subject" value="package:oxygen"/>
           <input type="hidden" name="caseId" value="fake-case-id"/>
           <h1>Appeal a resolution</h1>

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -818,6 +818,7 @@ void main() {
         subject: ModerationSubject.package('oxygen'),
         url: 'https://pub.dev/packages/oxygen/example',
         caseId: null,
+        onSuccessGotoUrl: 'https://pub.dev/report?feedback=report-submitted',
       );
       expectGoldenFile(html, 'report_page.html');
     });
@@ -830,6 +831,7 @@ void main() {
         subject: ModerationSubject.package('oxygen'),
         url: null,
         caseId: 'fake-case-id',
+        onSuccessGotoUrl: 'https://pub.dev/report?feedback=appeal-submitted',
       );
       expectGoldenFile(html, 'report_page_appeal.html');
     });

--- a/pkg/pub_integration/test/report_test.dart
+++ b/pkg/pub_integration/test/report_test.dart
@@ -65,10 +65,10 @@ void main() {
           await page.waitFocusAndType('#report-email', 'reporter@pub.dev');
           await page.waitFocusAndType(
               '#report-message', 'Huston, we have a problem.');
-          await page.waitAndClick('#report-submit', waitForOneResponse: true);
-          expect(await page.content,
-              contains('The report was submitted successfully.'));
-          await page.waitAndClickOnDialogOk();
+          await page.waitAndClick('#report-submit');
+          await page.waitForNavigation();
+          expect(
+              await page.content, contains('has been submitted successfully'));
         },
       );
 
@@ -197,10 +197,9 @@ void main() {
 
         await page.waitFocusAndType(
             '#report-message', 'Huston, I have a different idea.');
-        await page.waitAndClick('#report-submit', waitForOneResponse: true);
-        expect(await page.content,
-            contains('The appeal was submitted successfully.'));
-        await page.waitAndClickOnDialogOk();
+        await page.waitAndClick('#report-submit');
+        await page.waitForNavigation();
+        expect(await page.content, contains('has been submitted successfully'));
       });
 
       final appealEmail = await supportUser.readLatestEmail();

--- a/pkg/web_app/lib/src/admin_pages.dart
+++ b/pkg/web_app/lib/src/admin_pages.dart
@@ -31,6 +31,7 @@ void initAdminPages() {
 void _initGenericForm() {
   for (final form in document.querySelectorAll('[data-form-api-endpoint]')) {
     final endpoint = form.dataset['form-api-endpoint']!;
+    final onSuccessGotoUrl = form.dataset['form-success-goto'];
 
     for (final button in form.querySelectorAll('[data-form-api-button]')) {
       button.onClick.listen((event) async {
@@ -52,10 +53,19 @@ void _initGenericForm() {
           fn: () =>
               api_client.sendJson(verb: 'POST', path: endpoint, body: body),
           successMessage: null,
-          onSuccess: (result) async {
-            final message =
-                result == null ? null : result['message']?.toString();
-            await modalMessage('Success', text(message ?? 'OK.'));
+          onSuccess: (r) async {
+            final result = r ?? <String, dynamic>{};
+            // Goto a new location to display the feedback message.
+            if (onSuccessGotoUrl != null) {
+              window.location.href = onSuccessGotoUrl;
+              return;
+            }
+
+            // We shall display a minimal feedback the message is omitted.
+            final message = result['message']?.toString() ??
+                'Success. The page will reload.';
+            await modalMessage('Success', text(message));
+
             window.location.reload();
           },
         );


### PR DESCRIPTION
- Fixes #7990.
- Alternative to #7997. Differences: keeps the `Message` object, but uses data attribute for goto URLs.