### PR TITLE
Differentiate between 'pending' and 'will not analyze' on score tab's point highlights.

### DIFF
--- a/app/lib/frontend/templates/views/pkg/score_tab.dart
+++ b/app/lib/frontend/templates/views/pkg/score_tab.dart
@@ -38,7 +38,7 @@ d.Node scoreTabNode({
       classes: ['score-key-figures'],
       children: [
         _likeKeyFigureNode(likeCount),
-        _pubPointsKeyFigureNode(report),
+        _pubPointsKeyFigureNode(report, showPending),
         _popularityKeyFigureNode(card.popularityScore),
       ],
     ),
@@ -266,11 +266,11 @@ d.Node _popularityKeyFigureNode(double? popularity) {
   );
 }
 
-d.Node _pubPointsKeyFigureNode(Report? report) {
+d.Node _pubPointsKeyFigureNode(Report? report, bool showPending) {
   if (report == null) {
     return _keyFigureNode(
-      value: '',
-      supplemental: 'pending',
+      value: showPending ? '' : '-',
+      supplemental: showPending ? 'pending' : '/ -',
       label: 'pub points',
     );
   }


### PR DESCRIPTION
I think we shouldn't say pending for versions that we do not want to analyze.