### PR TITLE
Remove unnecessary getLatestVersion call.

### DIFF
--- a/app/lib/dartdoc/models.dart
+++ b/app/lib/dartdoc/models.dart
@@ -35,4 +35,5 @@ class ResolvedDocUrlVersion {
   Map<String, dynamic> toJson() => _$ResolvedDocUrlVersionToJson(this);
 
   bool get isEmpty => version.isEmpty || urlSegment.isEmpty;
+  bool get isLatestStable => urlSegment == 'latest';
 }

--- a/app/lib/task/handlers.dart
+++ b/app/lib/task/handlers.dart
@@ -3,7 +3,6 @@ import 'dart:io' show gzip;
 
 import 'package:pub_dev/dartdoc/dartdoc_page.dart';
 import 'package:pub_dev/dartdoc/models.dart';
-import 'package:pub_dev/package/backend.dart';
 import 'package:pub_dev/shared/exceptions.dart';
 import 'package:pub_dev/shared/handlers.dart';
 import 'package:pub_dev/shared/redis_cache.dart';
@@ -92,13 +91,12 @@ Future<shelf.Response> handleDartDoc(
               DartDocSidebar.fromJson(dataJson as Map<String, dynamic>);
           return utf8.encode(sidebar.content);
         }
-        final latestVersion = await packageBackend.getLatestVersion(package);
         final page = DartDocPage.fromJson(dataJson as Map<String, dynamic>);
         final html = page.render(DartDocPageOptions(
           package: package,
           version: version,
           urlSegment: resolvedDocUrlVersion.urlSegment,
-          isLatestStable: version == latestVersion,
+          isLatestStable: resolvedDocUrlVersion.isLatestStable,
           path: path,
           searchQueryParameter: searchQueryParameter,
         ));

--- a/app/test/task/testdata/goldens/documentation/oxygen/2.0.0/index.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/2.0.0/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <meta name="robots" content="noindex"/>
     <script type="text/javascript" src="https://www.googletagmanager.com/gtm.js?id=GTM-MX6DBN9" async="async"></script>
     <script type="text/javascript" src="/static/hash-%%etag%%/js/gtm.js"></script>
     <meta charset="utf-8"/>
@@ -10,6 +11,7 @@
     <meta name="description" content="oxygen API docs, for the Dart programming language."/>
     <title>oxygen - Dart API docs</title>
     <link rel="canonical" href="https://pub.dev/documentation/oxygen/2.0.0/"/>
+    <meta rel="alternate" href="/documentation/oxygen/latest/"/>
     <link rel="preconnect" href="https://fonts.gstatic.com"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,300;0,400;0,500;0,700;1,400&amp;display=swap"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0"/>
@@ -26,7 +28,7 @@
       </a>
       <ol class="breadcrumbs gt-separated dark hidden-xs">
         <li>
-          <a href="/packages/oxygen">oxygen package</a>
+          <a href="/packages/oxygen/versions/2.0.0">oxygen package</a>
         </li>
         <li class="self-crumb">documentation</li>
       </ol>
@@ -68,7 +70,7 @@
         </header>
         <ol id="sidebar-nav" class="breadcrumbs gt-separated dark hidden-l">
           <li>
-            <a href="/packages/oxygen">oxygen package</a>
+            <a href="/packages/oxygen/versions/2.0.0">oxygen package</a>
           </li>
           <li class="self-crumb">documentation</li>
         </ol>

--- a/app/test/task/testdata/goldens/documentation/oxygen/2.0.0/oxygen/MainClass-class.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/2.0.0/oxygen/MainClass-class.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <meta name="robots" content="noindex"/>
     <script type="text/javascript" src="https://www.googletagmanager.com/gtm.js?id=GTM-MX6DBN9" async="async"></script>
     <script type="text/javascript" src="/static/hash-%%etag%%/js/gtm.js"></script>
     <meta charset="utf-8"/>
@@ -10,6 +11,7 @@
     <meta name="description" content="API docs for the MainClass class from the oxygen library, for the Dart programming language."/>
     <title>MainClass class - oxygen library - Dart API</title>
     <link rel="canonical" href="https://pub.dev/documentation/oxygen/2.0.0/oxygen/MainClass-class.html"/>
+    <meta rel="alternate" href="/documentation/oxygen/latest/"/>
     <link rel="preconnect" href="https://fonts.gstatic.com"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,300;0,400;0,500;0,700;1,400&amp;display=swap"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0"/>
@@ -26,7 +28,7 @@
       </a>
       <ol class="breadcrumbs gt-separated dark hidden-xs">
         <li>
-          <a href="/packages/oxygen">oxygen package</a>
+          <a href="/packages/oxygen/versions/2.0.0">oxygen package</a>
         </li>
         <li>
           <a href="../index.html">documentation</a>
@@ -235,7 +237,7 @@
         </header>
         <ol id="sidebar-nav" class="breadcrumbs gt-separated dark hidden-l">
           <li>
-            <a href="/packages/oxygen">oxygen package</a>
+            <a href="/packages/oxygen/versions/2.0.0">oxygen package</a>
           </li>
           <li>
             <a href="../index.html">documentation</a>

--- a/app/test/task/testdata/goldens/documentation/oxygen/2.0.0/oxygen/MainClass/MainClass.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/2.0.0/oxygen/MainClass/MainClass.html
@@ -11,6 +11,7 @@
     <meta name="description" content="API docs for the MainClass constructor from Class MainClass from the oxygen library, for the Dart programming language."/>
     <title>MainClass constructor - MainClass - oxygen library - Dart API</title>
     <link rel="canonical" href="https://pub.dev/documentation/oxygen/2.0.0/oxygen/MainClass/MainClass.html"/>
+    <meta rel="alternate" href="/documentation/oxygen/latest/"/>
     <link rel="preconnect" href="https://fonts.gstatic.com"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,300;0,400;0,500;0,700;1,400&amp;display=swap"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0"/>
@@ -27,7 +28,7 @@
       </a>
       <ol class="breadcrumbs gt-separated dark hidden-xs">
         <li>
-          <a href="/packages/oxygen">oxygen package</a>
+          <a href="/packages/oxygen/versions/2.0.0">oxygen package</a>
         </li>
         <li>
           <a href="../../index.html">documentation</a>
@@ -93,7 +94,7 @@
         </header>
         <ol id="sidebar-nav" class="breadcrumbs gt-separated dark hidden-l">
           <li>
-            <a href="/packages/oxygen">oxygen package</a>
+            <a href="/packages/oxygen/versions/2.0.0">oxygen package</a>
           </li>
           <li>
             <a href="../../index.html">documentation</a>

--- a/app/test/task/testdata/goldens/documentation/oxygen/2.0.0/oxygen/MainClass/text.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/2.0.0/oxygen/MainClass/text.html
@@ -11,6 +11,7 @@
     <meta name="description" content="API docs for the text property from the MainClass class, for the Dart programming language."/>
     <title>text property - MainClass class - oxygen library - Dart API</title>
     <link rel="canonical" href="https://pub.dev/documentation/oxygen/2.0.0/oxygen/MainClass/text.html"/>
+    <meta rel="alternate" href="/documentation/oxygen/latest/"/>
     <link rel="preconnect" href="https://fonts.gstatic.com"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,300;0,400;0,500;0,700;1,400&amp;display=swap"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0"/>
@@ -27,7 +28,7 @@
       </a>
       <ol class="breadcrumbs gt-separated dark hidden-xs">
         <li>
-          <a href="/packages/oxygen">oxygen package</a>
+          <a href="/packages/oxygen/versions/2.0.0">oxygen package</a>
         </li>
         <li>
           <a href="../../index.html">documentation</a>
@@ -84,7 +85,7 @@
         </header>
         <ol id="sidebar-nav" class="breadcrumbs gt-separated dark hidden-l">
           <li>
-            <a href="/packages/oxygen">oxygen package</a>
+            <a href="/packages/oxygen/versions/2.0.0">oxygen package</a>
           </li>
           <li>
             <a href="../../index.html">documentation</a>

--- a/app/test/task/testdata/goldens/documentation/oxygen/2.0.0/oxygen/MainClass/toLowerCase.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/2.0.0/oxygen/MainClass/toLowerCase.html
@@ -11,6 +11,7 @@
     <meta name="description" content="API docs for the toLowerCase method from the MainClass class, for the Dart programming language."/>
     <title>toLowerCase method - MainClass class - oxygen library - Dart API</title>
     <link rel="canonical" href="https://pub.dev/documentation/oxygen/2.0.0/oxygen/MainClass/toLowerCase.html"/>
+    <meta rel="alternate" href="/documentation/oxygen/latest/"/>
     <link rel="preconnect" href="https://fonts.gstatic.com"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,300;0,400;0,500;0,700;1,400&amp;display=swap"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0"/>
@@ -27,7 +28,7 @@
       </a>
       <ol class="breadcrumbs gt-separated dark hidden-xs">
         <li>
-          <a href="/packages/oxygen">oxygen package</a>
+          <a href="/packages/oxygen/versions/2.0.0">oxygen package</a>
         </li>
         <li>
           <a href="../../index.html">documentation</a>
@@ -93,7 +94,7 @@
         </header>
         <ol id="sidebar-nav" class="breadcrumbs gt-separated dark hidden-l">
           <li>
-            <a href="/packages/oxygen">oxygen package</a>
+            <a href="/packages/oxygen/versions/2.0.0">oxygen package</a>
           </li>
           <li>
             <a href="../../index.html">documentation</a>

--- a/app/test/task/testdata/goldens/documentation/oxygen/2.0.0/oxygen/MainClass/toString.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/2.0.0/oxygen/MainClass/toString.html
@@ -11,6 +11,7 @@
     <meta name="description" content="API docs for the toString method from the MainClass class, for the Dart programming language."/>
     <title>toString method - MainClass class - oxygen library - Dart API</title>
     <link rel="canonical" href="https://pub.dev/documentation/oxygen/2.0.0/oxygen/MainClass/toString.html"/>
+    <meta rel="alternate" href="/documentation/oxygen/latest/"/>
     <link rel="preconnect" href="https://fonts.gstatic.com"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,300;0,400;0,500;0,700;1,400&amp;display=swap"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0"/>
@@ -27,7 +28,7 @@
       </a>
       <ol class="breadcrumbs gt-separated dark hidden-xs">
         <li>
-          <a href="/packages/oxygen">oxygen package</a>
+          <a href="/packages/oxygen/versions/2.0.0">oxygen package</a>
         </li>
         <li>
           <a href="../../index.html">documentation</a>
@@ -112,7 +113,7 @@
         </header>
         <ol id="sidebar-nav" class="breadcrumbs gt-separated dark hidden-l">
           <li>
-            <a href="/packages/oxygen">oxygen package</a>
+            <a href="/packages/oxygen/versions/2.0.0">oxygen package</a>
           </li>
           <li>
             <a href="../../index.html">documentation</a>

--- a/app/test/task/testdata/goldens/documentation/oxygen/2.0.0/oxygen/TypeEnum.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/2.0.0/oxygen/TypeEnum.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <meta name="robots" content="noindex"/>
     <script type="text/javascript" src="https://www.googletagmanager.com/gtm.js?id=GTM-MX6DBN9" async="async"></script>
     <script type="text/javascript" src="/static/hash-%%etag%%/js/gtm.js"></script>
     <meta charset="utf-8"/>
@@ -10,6 +11,7 @@
     <meta name="description" content="API docs for the TypeEnum enum from the oxygen library, for the Dart programming language."/>
     <title>TypeEnum enum - oxygen library - Dart API</title>
     <link rel="canonical" href="https://pub.dev/documentation/oxygen/2.0.0/oxygen/TypeEnum.html"/>
+    <meta rel="alternate" href="/documentation/oxygen/latest/"/>
     <link rel="preconnect" href="https://fonts.gstatic.com"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,300;0,400;0,500;0,700;1,400&amp;display=swap"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0"/>
@@ -26,7 +28,7 @@
       </a>
       <ol class="breadcrumbs gt-separated dark hidden-xs">
         <li>
-          <a href="/packages/oxygen">oxygen package</a>
+          <a href="/packages/oxygen/versions/2.0.0">oxygen package</a>
         </li>
         <li>
           <a href="../index.html">documentation</a>
@@ -265,7 +267,7 @@
         </header>
         <ol id="sidebar-nav" class="breadcrumbs gt-separated dark hidden-l">
           <li>
-            <a href="/packages/oxygen">oxygen package</a>
+            <a href="/packages/oxygen/versions/2.0.0">oxygen package</a>
           </li>
           <li>
             <a href="../index.html">documentation</a>

--- a/app/test/task/testdata/goldens/documentation/oxygen/2.0.0/oxygen/TypeEnum/values-constant.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/2.0.0/oxygen/TypeEnum/values-constant.html
@@ -11,6 +11,7 @@
     <meta name="description" content="API docs for the values constant from the TypeEnum enum, for the Dart programming language."/>
     <title>values constant - TypeEnum enum - oxygen library - Dart API</title>
     <link rel="canonical" href="https://pub.dev/documentation/oxygen/2.0.0/oxygen/TypeEnum/values-constant.html"/>
+    <meta rel="alternate" href="/documentation/oxygen/latest/"/>
     <link rel="preconnect" href="https://fonts.gstatic.com"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,300;0,400;0,500;0,700;1,400&amp;display=swap"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0"/>
@@ -27,7 +28,7 @@
       </a>
       <ol class="breadcrumbs gt-separated dark hidden-xs">
         <li>
-          <a href="/packages/oxygen">oxygen package</a>
+          <a href="/packages/oxygen/versions/2.0.0">oxygen package</a>
         </li>
         <li>
           <a href="../../index.html">documentation</a>
@@ -85,7 +86,7 @@
         </header>
         <ol id="sidebar-nav" class="breadcrumbs gt-separated dark hidden-l">
           <li>
-            <a href="/packages/oxygen">oxygen package</a>
+            <a href="/packages/oxygen/versions/2.0.0">oxygen package</a>
           </li>
           <li>
             <a href="../../index.html">documentation</a>

--- a/app/test/task/testdata/goldens/documentation/oxygen/2.0.0/oxygen/main.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/2.0.0/oxygen/main.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <meta name="robots" content="noindex"/>
     <script type="text/javascript" src="https://www.googletagmanager.com/gtm.js?id=GTM-MX6DBN9" async="async"></script>
     <script type="text/javascript" src="/static/hash-%%etag%%/js/gtm.js"></script>
     <meta charset="utf-8"/>
@@ -10,6 +11,7 @@
     <meta name="description" content="API docs for the main function from the oxygen library, for the Dart programming language."/>
     <title>main function - oxygen library - Dart API</title>
     <link rel="canonical" href="https://pub.dev/documentation/oxygen/2.0.0/oxygen/main.html"/>
+    <meta rel="alternate" href="/documentation/oxygen/latest/"/>
     <link rel="preconnect" href="https://fonts.gstatic.com"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,300;0,400;0,500;0,700;1,400&amp;display=swap"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0"/>
@@ -26,7 +28,7 @@
       </a>
       <ol class="breadcrumbs gt-separated dark hidden-xs">
         <li>
-          <a href="/packages/oxygen">oxygen package</a>
+          <a href="/packages/oxygen/versions/2.0.0">oxygen package</a>
         </li>
         <li>
           <a href="../index.html">documentation</a>
@@ -80,7 +82,7 @@
         </header>
         <ol id="sidebar-nav" class="breadcrumbs gt-separated dark hidden-l">
           <li>
-            <a href="/packages/oxygen">oxygen package</a>
+            <a href="/packages/oxygen/versions/2.0.0">oxygen package</a>
           </li>
           <li>
             <a href="../index.html">documentation</a>

--- a/app/test/task/testdata/goldens/documentation/oxygen/2.0.0/oxygen/oxygen-library.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/2.0.0/oxygen/oxygen-library.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <meta name="robots" content="noindex"/>
     <script type="text/javascript" src="https://www.googletagmanager.com/gtm.js?id=GTM-MX6DBN9" async="async"></script>
     <script type="text/javascript" src="/static/hash-%%etag%%/js/gtm.js"></script>
     <meta charset="utf-8"/>
@@ -10,6 +11,7 @@
     <meta name="description" content="oxygen library API docs, for the Dart programming language."/>
     <title>oxygen library - Dart API</title>
     <link rel="canonical" href="https://pub.dev/documentation/oxygen/2.0.0/oxygen/oxygen-library.html"/>
+    <meta rel="alternate" href="/documentation/oxygen/latest/"/>
     <link rel="preconnect" href="https://fonts.gstatic.com"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,300;0,400;0,500;0,700;1,400&amp;display=swap"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0"/>
@@ -26,7 +28,7 @@
       </a>
       <ol class="breadcrumbs gt-separated dark hidden-xs">
         <li>
-          <a href="/packages/oxygen">oxygen package</a>
+          <a href="/packages/oxygen/versions/2.0.0">oxygen package</a>
         </li>
         <li>
           <a href="../index.html">documentation</a>
@@ -101,7 +103,7 @@
         </header>
         <ol id="sidebar-nav" class="breadcrumbs gt-separated dark hidden-l">
           <li>
-            <a href="/packages/oxygen">oxygen package</a>
+            <a href="/packages/oxygen/versions/2.0.0">oxygen package</a>
           </li>
           <li>
             <a href="../index.html">documentation</a>


### PR DESCRIPTION
By using the resolved URL segment (`/latest/`) we can remove the extra call, and it also makes the rendered dartdoc page's metadata and SEO slightly better (non-latest versions shouldn't be indexed, and they should provide alternative URL). 