### PR TITLE
Transform GitHub markdown task list's rendered <input> into icons.

### DIFF
--- a/app/lib/shared/markdown.dart
+++ b/app/lib/shared/markdown.dart
@@ -292,7 +292,7 @@ class _TaskListRewriteNodeVisitor implements m.NodeVisitor {
     }
     final children = element.children;
     if (children == null || children.isEmpty) {
-      return null;
+      return;
     }
     final first = children.first;
     if (first is m.Element &&

--- a/app/test/shared/markdown_test.dart
+++ b/app/test/shared/markdown_test.dart
@@ -15,6 +15,17 @@ void main() {
       expect(markdownToHtml('# ABC def'),
           '<h1 class="hash-header" id="abc-def">ABC def <a href="#abc-def" class="hash-link">#</a></h1>\n');
     });
+
+    test('task list', () {
+      expect(
+        markdownToHtml('- [ ] a\n- [X] b\n- [ ] c\n'),
+        '<ul>\n'
+        '<li>❌ a</li>\n'
+        '<li>✅ b</li>\n'
+        '<li>❌ c</li>\n'
+        '</ul>\n',
+      );
+    });
   });
 
   group('Valid custom base URL', () {


### PR DESCRIPTION
Fixes #8039.