### PR TITLE
Remove moderated package and version assets after 3 years.

### DIFF
--- a/app/lib/tool/neat_task/pub_dev_tasks.dart
+++ b/app/lib/tool/neat_task/pub_dev_tasks.dart
@@ -8,14 +8,15 @@ import 'dart:io';
 import 'package:gcloud/service_scope.dart' as ss;
 import 'package:logging/logging.dart';
 import 'package:neat_periodic_task/neat_periodic_task.dart';
-import 'package:pub_dev/package/export_api_to_bucket.dart';
-import 'package:pub_dev/service/download_counts/sync_download_counts.dart';
 
 import '../../account/backend.dart';
 import '../../account/consent_backend.dart';
+import '../../admin/backend.dart';
 import '../../audit/backend.dart';
 import '../../package/backend.dart';
+import '../../package/export_api_to_bucket.dart';
 import '../../search/backend.dart';
+import '../../service/download_counts/sync_download_counts.dart';
 import '../../service/email/backend.dart';
 import '../../service/security_advisories/sync_security_advisories.dart';
 import '../../service/topics/count_topics.dart';
@@ -120,6 +121,13 @@ void _setupGenericPeriodicTasks() {
     name: 'export-package-name-completion-data-to-bucket',
     isRuntimeVersioned: true,
     task: () async => await apiExporter?.uploadPkgNameCompletionData(),
+  );
+
+  // Deletes moderated packages, versions, publishers and users.
+  _daily(
+    name: 'delete-moderated-subjects',
+    isRuntimeVersioned: false,
+    task: () async => adminBackend.deleteModeratedSubjects(),
   );
 
   // Deletes task status entities where the status hasn't been updated

--- a/app/lib/tool/neat_task/pub_dev_tasks.dart
+++ b/app/lib/tool/neat_task/pub_dev_tasks.dart
@@ -124,7 +124,7 @@ void _setupGenericPeriodicTasks() {
   );
 
   // Deletes moderated packages, versions, publishers and users.
-  _daily(
+  _weekly(
     name: 'delete-moderated-subjects',
     isRuntimeVersioned: false,
     task: () async => adminBackend.deleteModeratedSubjects(),


### PR DESCRIPTION
- Reuses existing remove package logic, with the following updates:
  - reordering delete operations, in order to prevent information loss if the process fails mid-deletion,
  - also updates `replacedBy` fields if they are referencing the moderated package,
  - also deleted `AuditLogRecord` entities, otherwise the integrity check fails on them, (we could update the integrity checks to accept `ModertedPackage` existence in such cases though)
  - also adds previously deleted versions to the moderated package entity's list

- Deleting package version is simpler in comparison, it needs to remove only a few references.
- Deleting moderated publisher or user is implemented separately, left TODO for them. 