### PR TITLE
Long-term rate limits for package uploads.

### DIFF
--- a/app/config/dartlang-pub.yaml
+++ b/app/config/dartlang-pub.yaml
@@ -75,6 +75,10 @@ rateLimits:
     burst: 3
     hourly: 6
     daily: 12
+    weekly: 20      #  20 versions/week
+    # monthly: 32   # ~ 8 versions/week
+    # quarterly: 50 # ~ 4 versions/week
+    # yearly: 100   # ~ 2 versions/week
   - operation: package-published
     scope: user
     burst: 200

--- a/app/lib/shared/configuration.dart
+++ b/app/lib/shared/configuration.dart
@@ -543,16 +543,40 @@ class RateLimit {
   /// Maximum number of operations in 24 hours.
   final int? daily;
 
+  /// Maximum number of operations in 7 days.
+  final int? weekly;
+
+  /// Maximum number of operations in 30 days.
+  final int? monthly;
+
+  /// Maximum number of operations in 91 days.
+  final int? quarterly;
+
+  /// Maximum number of operations in 365 days.
+  final int? yearly;
+
   RateLimit({
     required this.operation,
     required this.scope,
     this.burst,
     this.hourly,
     this.daily,
+    this.weekly,
+    this.monthly,
+    this.quarterly,
+    this.yearly,
   });
 
   factory RateLimit.fromJson(Map<String, dynamic> json) =>
       _$RateLimitFromJson(json);
 
   Map<String, dynamic> toJson() => _$RateLimitToJson(this);
+
+  late final isEmpty = burst == null &&
+      hourly == null &&
+      daily == null &&
+      weekly == null &&
+      monthly == null &&
+      quarterly == null &&
+      yearly == null;
 }

--- a/app/lib/shared/configuration.g.dart
+++ b/app/lib/shared/configuration.g.dart
@@ -251,7 +251,17 @@ RateLimit _$RateLimitFromJson(Map<String, dynamic> json) => $checkedCreate(
       ($checkedConvert) {
         $checkKeys(
           json,
-          allowedKeys: const ['operation', 'scope', 'burst', 'hourly', 'daily'],
+          allowedKeys: const [
+            'operation',
+            'scope',
+            'burst',
+            'hourly',
+            'daily',
+            'weekly',
+            'monthly',
+            'quarterly',
+            'yearly'
+          ],
         );
         final val = RateLimit(
           operation: $checkedConvert('operation', (v) => v as String),
@@ -260,6 +270,10 @@ RateLimit _$RateLimitFromJson(Map<String, dynamic> json) => $checkedCreate(
           burst: $checkedConvert('burst', (v) => (v as num?)?.toInt()),
           hourly: $checkedConvert('hourly', (v) => (v as num?)?.toInt()),
           daily: $checkedConvert('daily', (v) => (v as num?)?.toInt()),
+          weekly: $checkedConvert('weekly', (v) => (v as num?)?.toInt()),
+          monthly: $checkedConvert('monthly', (v) => (v as num?)?.toInt()),
+          quarterly: $checkedConvert('quarterly', (v) => (v as num?)?.toInt()),
+          yearly: $checkedConvert('yearly', (v) => (v as num?)?.toInt()),
         );
         return val;
       },
@@ -280,6 +294,10 @@ Map<String, dynamic> _$RateLimitToJson(RateLimit instance) {
   writeNotNull('burst', instance.burst);
   writeNotNull('hourly', instance.hourly);
   writeNotNull('daily', instance.daily);
+  writeNotNull('weekly', instance.weekly);
+  writeNotNull('monthly', instance.monthly);
+  writeNotNull('quarterly', instance.quarterly);
+  writeNotNull('yearly', instance.yearly);
   return val;
 }
 

--- a/app/test/shared/configuration_test.dart
+++ b/app/test/shared/configuration_test.dart
@@ -5,6 +5,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:pub_dev/audit/models.dart';
 import 'package:pub_dev/shared/configuration.dart';
 import 'package:test/test.dart';
 import 'package:yaml/yaml.dart' as yaml;
@@ -73,7 +74,21 @@ void main() {
       // no duplicate rules
       expect(rateLimits.map((e) => '${e.operation}/${e.scope}').toSet().length,
           rateLimits.length);
-      // some rules for prod config
+      // only package-uploaded rules have long-term rules
+      for (final limit in rateLimits) {
+        if (limit.weekly != null ||
+            limit.monthly != null ||
+            limit.quarterly != null ||
+            limit.yearly != null) {
+          if (limit.operation == AuditLogRecordKind.packagePublished) {
+            // uploads are handling custom timestamps
+          } else {
+            fail(
+                'Rate limit operation "${limit.operation}" does not support long-term rules.');
+          }
+        }
+      }
+      // some rules are present in the prod config
       if (config.isProduction) {
         expect(rateLimits, hasLength(greaterThan(10)));
       }


### PR DESCRIPTION
- #8053
- The current rate limit implementation relies on reading all of the audit log records from the datastore and keeping them in memory. While we could read a full year's worth of logs into the memory, it seemed better to provide a separate path for package uploads, as we do have the timestamps at the time of rate limit checks.
- I've added additional checks that (a) we shouldn't specify long-term rate limits for other actions and (b) if we do and we don't provide the timestamps, it should fail.
- In order to reduce the surprises, I think we could start introducing the `weekly` limit, and then shortly after that the `monthly`, while the `quarterly` limit should be added only later this year, and the `yearly` in the next year. That way packages that would be over the specific limit have time to adopt.
- Giving a feedback of the remaining limit may come in a subsequent PR.