### PR TITLE
New naming scheme for theme roles + migrating some background colors.

### DIFF
--- a/pkg/web_css/lib/dartdoc.scss
+++ b/pkg/web_css/lib/dartdoc.scss
@@ -31,7 +31,7 @@
 
 /* Note: light-theme was added to prevent non-visible table text in dartdoc's dark mode. */
 .light-theme .markdown-body table tr {
-  background-color: var(--pub-default-background-color);
+  background-color: var(--pub-neutral-bgColor);
   border-top: 1px solid #c6cbd1;
 }
 

--- a/pkg/web_css/lib/src/_base.scss
+++ b/pkg/web_css/lib/src/_base.scss
@@ -10,7 +10,7 @@
 }
 
 body {
-  background-color: var(--pub-default-background-color);
+  background-color: var(--pub-neutral-bgColor);
   color: var(--pub-default-text-color);
   font-size: 14px;
   line-height: 1.6;
@@ -64,7 +64,7 @@ summary {
   transition: background-color 0.3s;
 
   &:hover {
-    background: var(--pub-summary_hover-background-color);
+    background: var(--pub-neutral-hover-bgColor);
   }
 
   &:focus {
@@ -98,7 +98,7 @@ a {
 
   &.link-button {
     background: var(--pub-link-text-color);
-    color: var(--pub-default-background-color);
+    color: var(--pub-neutral-bgColor);
     display: inline-block;
     padding: 4px 12px;
   }
@@ -147,7 +147,7 @@ strong {
 
 .markdown-body code,
 code {
-  background: var(--pub-code-background-color);
+  background: var(--pub-inset-bgColor);
   border: none;
   border-radius: 4px;
   font-family: var(--pub-code-text-font_family);
@@ -158,7 +158,7 @@ code {
 .dark-theme .hljs,
 .markdown-body pre,
 pre {
-  background: var(--pub-code-background-color);
+  background: var(--pub-inset-bgColor);
   color: var(--pub-code-text-color);
 }
 
@@ -214,7 +214,7 @@ pre {
 
     font-size: 11px;
     padding: 8px;
-    background: var(--pub-copy_feedback-background-color);
+    background: var(--pub-neutral-hover-bgColor);
     box-shadow: 0px 0px 2px 2px rgba(0, 0, 0, 0.05);
 
     white-space: nowrap;
@@ -386,7 +386,7 @@ pre {
 .announcement-banner {
   padding: 10px 0;
 
-  background: var(--pub-home_announcement-background-color);
+  background: var(--pub-selected-bgColor);
   font-size: 16px;
 
   text-align: center;

--- a/pkg/web_css/lib/src/_detail_page.scss
+++ b/pkg/web_css/lib/src/_detail_page.scss
@@ -13,7 +13,7 @@ $detail-tabs-tablet-width: calc(100% - 240px);
 .-wide-header-detail-page {
   .detail-header,
   .detail-tabs-wide-header {
-    background: var(--pub-code-background-color);
+    background: var(--pub-inset-bgColor);
     color: var(--pub-default-text-color);
   }
 
@@ -300,7 +300,7 @@ $detail-tabs-tablet-width: calc(100% - 240px);
   margin: 0 0 24px -12px;
   padding: 0;
 
-  background: var(--pub-detail_tab-background-color);
+  background: var(--pub-inset-bgColor);
   display: flex;
   align-items: center;
   flex-wrap: wrap;

--- a/pkg/web_css/lib/src/_form.scss
+++ b/pkg/web_css/lib/src/_form.scss
@@ -61,14 +61,14 @@
   border-width: 0px;
 
   .mdc-data-table__row {
-    border-top-color: var(--pub-code-background-color);
+    border-top-color: var(--pub-neutral-borderColor);
 
     &:hover {
       background: inherit;
     }
 
     &:nth-child(even) {
-      background: var(--pub-code-background-color);
+      background: var(--pub-inset-bgColor);
     }
   }
 

--- a/pkg/web_css/lib/src/_home.scss
+++ b/pkg/web_css/lib/src/_home.scss
@@ -80,7 +80,7 @@
 
   &.home-block-ff,
   &.home-block-pow {
-    background: var(--pub-code-background-color);
+    background: var(--pub-inset-bgColor);
   }
 
   .home-block-image {
@@ -100,7 +100,7 @@
   }
 
   .mini-list-item {
-    background: var(--pub-home_card-background-color);
+    background: var(--pub-neutral-bgColor);
     border-radius: 4px;
     box-shadow: 0px 2px 7px 0px var(--pub-home_card-box_shadow-color);
     padding: 28px 30px 30px; // title's top gap is about 2px (30-2 => 28)
@@ -108,13 +108,13 @@
     min-height: 100px;
 
     &:hover {
-      background: var(--pub-home_card_hover-background-color);
+      background: var(--pub-neutral-hover-bgColor);
       box-shadow: 0px 4px 9px 0px var(--pub-home_card_hover-box_shadow-color);
 
       @media (min-width: $device-desktop-min-width) {
         .mini-list-item-body {
           &:before {
-            background: var(--pub-home_card_hover_fadeout-background-value);
+            background: linear-gradient(transparent 90%, var(--pub-neutral-hover-bgColor));
           }
         }
       }
@@ -206,8 +206,8 @@
          top: 0;
          bottom: 0;
          right: 0;
-         background: var(--pub-home_card_fadeout-background-value);
-       }
+         background: linear-gradient(transparent 90%, var(--pub-neutral-bgColor));
+        }
     }
   }
 

--- a/pkg/web_css/lib/src/_list.scss
+++ b/pkg/web_css/lib/src/_list.scss
@@ -36,7 +36,7 @@
   }
 
   .count {
-    background: var(--pub-code-background-color);
+    background: var(--pub-inset-bgColor);
     display: inline-block;
     font-size: 12px;
     font-family: monospace;
@@ -60,19 +60,19 @@
     .sort-control-option {
       display: block;
       width: 100%;
-      background: var(--pub-sort_control-background-color);
+      background: var(--pub-neutral-bgColor);
       color: var(--pub-sort_control-text-color);
       font-size: 14px;
       padding: 12px 12px;
       text-align: left;
 
       &:hover {
-        background: var(--pub-sort_control_hover-background-color);
+        background: var(--pub-neutral-hover-bgColor);
         color: var(--pub-sort_control_hover-text-color);
       }
 
       &.selected {
-        background: var(--pub-sort_control_selected-background-color);
+        background: var(--pub-selected-bgColor);
         color: var(--pub-sort_control_selected-text-color);
       }
     }
@@ -190,7 +190,7 @@
     padding: 15px 30px;
 
     &:hover {
-      background: var(--pub-pkg_list_item_hover-background-color);
+      background: var(--pub-neutral-hover-bgColor);
     }
   }
 
@@ -305,7 +305,7 @@
     margin-right: 8px;
 
     &:hover {
-      background: var(--pub-pkg_list_item_hover-background-color);
+      background: var(--pub-neutral-hover-bgColor);
     }
 
     .publishers-item-title {
@@ -333,8 +333,8 @@
   > li {
     display: inline-block;
     text-transform: uppercase;
-    color: var(--pub-pagination-active-color);
-    background: var(--pub-pagination-background-color);
+    color: var(--pub-link-text-color);
+    background: var(--pub-inset-bgColor);
     font-size: 14px;
     border-radius: 3px;
     margin-top: 40px;
@@ -346,8 +346,8 @@
 
     &.-active {
       pointer-events: none;
-      color: var(--pub-pagination-background-color);
-      background: var(--pub-pagination-active-color);
+      color: var(--pub-pagination_active-text-color);
+      background: var(--pub-link-text-color);
     }
 
     > a {
@@ -427,7 +427,7 @@
     cursor: pointer;
 
     &:hover {
-      background-color: var(--pub-code-background-color);
+      background-color: var(--pub-neutral-hover-bgColor);
     }
 
     a {

--- a/pkg/web_css/lib/src/_pkg.scss
+++ b/pkg/web_css/lib/src/_pkg.scss
@@ -4,7 +4,7 @@
 
 .package-badge {
   display: inline-block;
-  background: var(--pub-default-background-color);
+  background: var(--pub-neutral-bgColor);
   border: 1px solid var(--pub-badge-default-color);
   border-radius: 20px;
   color: var(--pub-badge-default-color);
@@ -305,7 +305,7 @@
     left: 32px;
     font-size: 11px;
     padding: 8px;
-    background: var(--pub-copy_feedback-background-color);
+    background: var(--pub-neutral-hover-bgColor);
     box-shadow: 0px 0px 2px 2px rgba(0, 0, 0, 0.05);
     white-space: nowrap;
 

--- a/pkg/web_css/lib/src/_report.scss
+++ b/pkg/web_css/lib/src/_report.scss
@@ -23,7 +23,7 @@
     cursor: pointer;
 
     &:hover {
-      background: var(--pub-report-hover-background-color);
+      background: var(--pub-neutral-hover-bgColor);
     }
   }
 

--- a/pkg/web_css/lib/src/_search.scss
+++ b/pkg/web_css/lib/src/_search.scss
@@ -112,7 +112,7 @@
   width: 25ex;
   border: 1px solid #000;
   max-height: 20em;
-  background-color: var(--pub-default-background-color);
+  background-color: var(--pub-neutral-bgColor);
   font-size: 16px;
   margin-left: 48px; // counter padding-left on .search-bar>.input
   margin-top: -14px; // counter padding-top on .search-bar>.input
@@ -121,13 +121,13 @@
     cursor: pointer;
     white-space: nowrap;
     padding: 0px 3px;
+
+    &:hover {
+      background-color: var(--pub-neutral-hover-bgColor);
+    }
   }
 
   >.completion-option-selected {
-    background-color: var(--pub-search_completition_selected-background-color);
-
-    &:hover {
-      background-color: var(--pub-search_completition_selected-background-color);
-    }
+    background-color: var(--pub-selected-bgColor);
   }
 }

--- a/pkg/web_css/lib/src/_tags.scss
+++ b/pkg/web_css/lib/src/_tags.scss
@@ -12,7 +12,7 @@
 
 /* Tags that are simple labels. */
 .package-tag {
-  background: var(--pub-tag_simplebadge-background-color);
+  background: var(--pub-inset-bgColor);
   text-transform: uppercase;
   color: var(--pub-tag_simplebadge-text-color);
   padding: 4px 8px;
@@ -26,7 +26,7 @@
 
 /* Tag that are combinations of two components e.g. Dart/Flutter extended badges. */
 .-pub-tag-badge {
-  background: var(--pub-tag_sdkbadge-background-color);
+  background: var(--pub-selected-bgColor);
 
   > .tag-badge-main,
   > .tag-badge-sub {
@@ -58,7 +58,7 @@
   >.-discontinued-replacedby {
     display: inline-block;
     padding: 2px 6px;
-    background: var(--pub-default-background-color);
+    background: var(--pub-neutral-bgColor);
     color: var(--pub-default-text-color);
   }
 }

--- a/pkg/web_css/lib/src/_variables.scss
+++ b/pkg/web_css/lib/src/_variables.scss
@@ -3,20 +3,35 @@
 // color definitions:
 // `--pub-color-<qualifier><baseColor>`
 //
-// components:
+// theme roles:
+// `--pub-<role>[-<modifier>]-<property>`, where:
+//   - `<role>` may be: `neutral`, `inset`
+//   - `<modifier>` may be: `hover`, `selected`
+//   - `<property>` may be: `bgColor`, `textColor`, `linkColor`
+//
+// components (**deprecated**):
 // `--pub-[component]-[role]-[property]`, where
 //   - `[component]` may be: `default`, `button`, `link`, `card`, ...
 //   - `[role]` may be the `background`, `text`, `border`, ... (multiple parts are separated by `_`)
 //   - `[property]` may be `color`, `opacity` for specific values, or a `value` for multi-part properties.
 
 :root {
-  --pub-color-dangerRed: #ff4242;
+  --pub-color-white:      #ffffff;
+  --pub-color-offWhite:   #faf9f6;
+  --pub-color-smokeWhite: #f5f5f7; // slight deviation from official white-smoke (f5f5f5)
+  --pub-color-aliceBlue:  #f0f8ff;
 
-  --pub-default-background-color: #ffffff;
+  --pub-color-dangerRed:  #ff4242;
+
+  --pub-neutral-bgColor:       var(--pub-color-white);
+  --pub-neutral-borderColor:   var(--pub-color-smokeWhite);
+  --pub-neutral-hover-bgColor: var(--pub-color-offWhite);
+  --pub-inset-bgColor:         var(--pub-color-smokeWhite);
+  --pub-selected-bgColor:      var(--pub-color-aliceBlue);
+
   --pub-default-headline-font_family: "Google Sans Display", "Google Sans", "Roboto", sans-serif;
   --pub-default-text-color: hsl(0, 0%, 29%);
   --pub-default-text-font_family: "Google Sans Text", "Google Sans", "Roboto", sans-serif;
-  --pub-code-background-color: #f5f5f7;
   --pub-code-text-color: var(--pub-default-text-color);
   --pub-link-text-color: #0175c2;
   --pub-code-text-font_family: "Google Sans Mono", "Roboto Mono", "Source Code Pro", Menlo, "Bitstream Vera Sans Mono", "DejaVu Sans Mono", Monaco, Consolas, monospace;
@@ -26,67 +41,50 @@
   --pub-carousel_nav-background-color: rgba(0,0,0,0.7);
   --pub-carousel_nav_hover-background-color: #4285f4;
   --pub-carousel_screenshot-background-color: rgba(0,0,0,0.7);
-  --pub-carousel_screenshot-text-color: #ffffff;
+  --pub-carousel_screenshot-text-color: var(--pub-color-white);
   --pub-collections_icon-background-color: #aeaeae;
-  --pub-thumbnail_container-background-color: #ffffff;
-  --pub-copy_feedback-background-color: #fafaff;
-  --pub-detail_tab-background-color: var(--pub-code-background-color);
+  --pub-thumbnail_container-background-color: var(--pub-color-white); // same in dark mode
   --pub-detail_tab-text-color: var(--pub-default-text-color);
   --pub-detail_tab-underline-color: #dddddd;
   --pub-detail_tab-active-color: #1967d2;
   --pub-detail_tab-admin-color: #990000;
   --pub-hash_link-text-color: #ccc;
   --pub-footer-background-color: #27323a;
-  --pub-footer-text-color: #f8f9fa;
+  --pub-footer-text-color: var(--pub-color-smokeWhite);
   --pub-home_title-text-color: #254a76;
-  --pub-home_announcement-background-color: #e7f8ff;
-  --pub-home_banner-text-color: #ffffff;
+  --pub-home_banner-text-color: var(--pub-color-white);
   --pub-home_banner-link-color: #31b0fc;
-  --pub-home_card-background-color: #ffffff;
   --pub-home_card-box_shadow-color: rgba(0, 0, 0, 0.3);
-  --pub-home_card_fadeout-background-value: linear-gradient(transparent 90%, white);
   --pub-home_card_title-text-color: #1967d2;
-  --pub-home_card_hover-background-color: #fafafa;
   --pub-home_card_hover-box_shadow-color: rgba(0, 0, 0, 0.4);
-  --pub-home_card_hover_fadeout-background-value: linear-gradient(transparent 90%, var(--pub-home_card_hover-background-color));
-  --pub-pagination-background-color: var(--pub-code-background-color);
-  --pub-pagination-active-color: var(--pub-link-text-color);
+  --pub-pagination_active-text-color: var(--pub-inset-bgColor);
   --pub-pagination-inactive-color: #aaaaaa;
   --pub-input-placeholder-color: #888;
-  --pub-pkg_list_item_hover-background-color: #fafafa;
   --pub-pkg_list_recent_item-text-color: #6d7278;
   --pub-remove_button-background-color: var(--pub-color-dangerRed);
-  --pub-remove_button-text-color: #ffffff;
+  --pub-remove_button-text-color: var(--pub-color-white);
   --pub-report_header_score_error-text-color: #e13701;
   --pub-report_header_score_warning-text-color: #ffa500;  
-  --pub-report-hover-background-color: #f0f0f0;
   --pub-score_label-text-color: #6d7278;
   --pub-score_value-text-color: var(--pub-link-text-color);
   --pub-searchbar-background-color: #132030;
   --pub-searchbar-text-color: #8d9399;
   --pub-searchbar_input-background-color: #35404d;
-  --pub-searchbar_input-text-color: #ffffff;
-  --pub-search_completition_selected-background-color: #ccc;
+  --pub-searchbar_input-text-color: var(--pub-color-white);
   --pub-session_warning-background-color: #ffffaa;
   --pub-site_header_banner-background-color: #1C2834;
-  --pub-site_header_banner-text-color: #f8f9fa;
+  --pub-site_header_banner-text-color: var(--pub-color-smokeWhite);
   --pub-site_header_banner_hover-background-color: #2b3d50; // 10% lighter than bg color
   --pub-site_header_popup-background-color: #1f3044;
-  --pub-site_header_popup-text-color: #f8f9fa;
+  --pub-site_header_popup-text-color: var(--pub-color-smokeWhite);
   --pub-site_header_popup-border-color: #4a5868; // mix of bg+fg color
-  --pub-sort_control-background-color: #ffffff;
   --pub-sort_control-text-color: var(--pub-default-text-color);
-  --pub-sort_control_hover-background-color: #f5f5f7;
   --pub-sort_control_hover-text-color: var(--pub-default-text-color);
-  --pub-sort_control_selected-background-color: #e7f8ff;
   --pub-sort_control_selected-text-color: var(--pub-default-text-color);
   --pub-spinner_frame-background-color: rgba(0, 0, 0, 0.2);
-  --pub-summary_hover-background-color: color-mix(in srgb, var(--pub-link-text-color), var(--pub-default-background-color) 80%);
-  --pub-tag_simplebadge-background-color: #f0f0f0;
   --pub-tag_simplebadge-text-color: #444444;
   --pub_tag_simplebadge_warning-background-color: #c0392b;
-  --pub_tag_simplebadge_warning-text-color: #f8f8f8;
-  --pub-tag_sdkbadge-background-color: #e7f8ff;
+  --pub_tag_simplebadge_warning-text-color: var(--pub-color-smokeWhite);
   --pub-tag_sdkbadge-separator-color: rgba(25, 103, 210, 0.5); // #1967d2 + 0.5 opacity;
   --pub-tag_sdkbadge-text-color: #1967d2;
   --pub-full_page_mask-background-color: rgba(0, 0, 0, 0.5); // Used to make the inaccessible UI parts fade into the background.
@@ -104,49 +102,43 @@
 }
 
 .dark-theme {
-  --pub-default-background-color: #212121;
+  --pub-color-charcoalBlack:   #212121;
+  --pub-color-shadowBlack:     #373737;
+  --pub-color-anchorBlack:     #41424c;
+  --pub-color-nipponUltraBlue: #23607f;
+
+  --pub-neutral-bgColor:       var(--pub-color-charcoalBlack);
+  --pub-neutral-borderColor:   var(--pub-color-anchorBlack);
+  --pub-neutral-hover-bgColor: var(--pub-color-shadowBlack);
+  --pub-inset-bgColor:         var(--pub-color-anchorBlack);
+  --pub-selected-bgColor:      var(--pub-color-nipponUltraBlue);
+
   --pub-default-text-color: #e0e0e0;
-  --pub-code-background-color: #474747;
   --pub-code-text-color: var(--pub-default-text-color);
   --pub-link-text-color: #40c4ff;
   --pub-badge-default-color: var(--pub-link-text-color);
   --pub-badge-red-color: var(--pub-color-dangerRed);
-  --pub-copy_feedback-background-color: #404040;
-  --pub-detail_tab-background-color: var(--pub-code-background-color);
   --pub-detail_tab-text-color: var(--pub-default-text-color);
   --pub-detail_tab-underline-color: #888888;
-  --pub-detail_tab-active-color: color-mix(in srgb, var(--pub-link-text-color), var(--pub-detail_tab-background-color) 20%);
+  --pub-detail_tab-active-color: #31b0fc;
   --pub-detail_tab-admin-color: #e03030;
   --pub-home_title-text-color: #31b0fc;
-  --pub-home_card-background-color: #303030;
   --pub-home_card-box_shadow-color: rgba(255, 255, 255, 0.2);
-  --pub-home_card_fadeout-background-value: linear-gradient(transparent 90%, var(--pub-home_card-background-color));
   --pub-home_card_title-text-color: var(--pub-home_title-text-color);
-  --pub-home_card_hover-background-color: #383838;
   --pub-home_card_hover-box_shadow-color: rgba(255, 255, 255, 0.3);
-  --pub-home_card_hover_fadeout-background-value: linear-gradient(transparent 90%, var(--pub-home_card_hover-background-color));
-  --pub-pagination-background-color: var(--pub-code-background-color);
-  --pub-pagination-active-color: var(--pub-link-text-color);
+  --pub-pagination_active-text-color: var(--pub-color-anchorBlack);
   --pub-pagination-inactive-color: #aaaaaa;
-  --pub-pkg_list_item_hover-background-color: #333333;
-  --pub-report-hover-background-color: #333333;
   --pub-score_label-text-color: #a0b0b8;
   --pub-score_value-text-color: var(--pub-link-text-color);
-  --pub-sort_control-background-color: #333333;
   --pub-sort_control-text-color: var(--pub-default-text-color);
-  --pub-sort_control_hover-background-color: var(--pub-code-background-color);
   --pub-sort_control_hover-text-color: var(--pub-default-text-color);
-  --pub-sort_control_selected-background-color: #206080;
   --pub-sort_control_selected-text-color: var(--pub-default-text-color);
-  --pub-summary_hover-background-color: color-mix(in srgb, var(--pub-link-text-color), var(--pub-default-background-color) 80%);
-  --pub-tag_simplebadge-background-color: var(--pub-code-background-color);
   --pub-tag_simplebadge-text-color: var(--pub-default-text-color);
-  --pub-tag_sdkbadge-background-color: #206080;
   --pub-tag_sdkbadge-separator-color: var(--pub-default-text-color);
   --pub-tag_sdkbadge-text-color: var(--pub-default-text-color);
 
   // Material Design theme customizations
-  --mdc-theme-surface: var(--pub-default-background-color);
+  --mdc-theme-surface: var(--pub-neutral-bgColor);
   --mdc-theme-on-primary: var(--pub-default-text-color);
   --mdc-theme-on-secondary: var(--pub-default-text-color);
   --mdc-theme-on-surface: var(--pub-default-text-color);


### PR DESCRIPTION
- Deployed to staging for further verification.
- Started to separate named colors in an explicit way like `smokeWhite` and `aliceBlue`. These names are either from the HTML color names or if there is no such name, a widely used name is picked for it.
- Merged very similar colors into a single one, e.g. `f8f8f8` and `f8f9fa` is both merged into `f5f5f7`. Fewer colors makes a more consistent color palette, and the contrast/separation between them is easier to review.
- Started to refactor and use names that first focus on their role `neutral`, `inset`, `selected` and then specify their property like `bgColor` or `hover-bgColor`. This makes it much easier to pick the appropriate variable when selecting colors for a component, e.g. selection or hovering should be consistent across the components this way.
- The PR is mostly for some of the background colors, but wanted to verify the naming style before spending much time on it.