### PR TITLE
Mitigate out of free space issues while running dartdoc postprocessing.

### DIFF
--- a/pkg/pub_worker/lib/src/bin/dartdoc_wrapper.dart
+++ b/pkg/pub_worker/lib/src/bin/dartdoc_wrapper.dart
@@ -103,6 +103,7 @@ Future<void> postProcessDartdoc({
     await tmpTar.deleteIgnoringErrors();
 
     _log.shout('Failed to run dartdoc post-processing.', e, st);
+    rethrow;
   }
 }
 

--- a/pkg/pub_worker/lib/src/bin/dartdoc_wrapper.dart
+++ b/pkg/pub_worker/lib/src/bin/dartdoc_wrapper.dart
@@ -98,12 +98,6 @@ Future<void> postProcessDartdoc({
     await tmpTar.rename(p.join(outputFolder, 'doc', 'package.tar.gz'));
   } catch (e, st) {
     // We are likely out of free disk space.
-    //
-    // One of the isolate has already stopped, the other may be still working.
-    // By deleting the dartdoc-generated content, the post-processing of the other
-    // isolate will stop too.
-    await Directory(docDir).deleteIgnoringErrors(recursive: true);
-
     // Cleanup the content as we won't use it.
     await tmpOutDir.deleteIgnoringErrors(recursive: true);
     await tmpTar.deleteIgnoringErrors();

--- a/pkg/pub_worker/lib/src/bin/dartdoc_wrapper.dart
+++ b/pkg/pub_worker/lib/src/bin/dartdoc_wrapper.dart
@@ -97,8 +97,8 @@ Future<void> postProcessDartdoc({
     await tmpOutDir.rename(p.join(outputFolder, 'doc'));
     await tmpTar.rename(p.join(outputFolder, 'doc', 'package.tar.gz'));
   } catch (e, st) {
-    // We are likely out of free disk space.
-    // Cleanup the content as we won't use it.
+    // We don't know what's wrong with the post-processing, and we treat
+    // the output as incorrect. Deleting, so it won't be included in the blob.
     await tmpOutDir.deleteIgnoringErrors(recursive: true);
     await tmpTar.deleteIgnoringErrors();
 

--- a/pkg/pub_worker/lib/src/bin/dartdoc_wrapper.dart
+++ b/pkg/pub_worker/lib/src/bin/dartdoc_wrapper.dart
@@ -24,15 +24,15 @@ Future<void> postProcessDartdoc({
   required String docDir,
 }) async {
   _log.info('Running dartdoc post-processing');
-  final tmpOutDir = p.join(outputFolder, '_doc');
-  await Directory(tmpOutDir).create(recursive: true);
+  final tmpOutDir = Directory(p.join(outputFolder, '_doc'));
+  await tmpOutDir.create(recursive: true);
   final processingFuture = Isolate.run(() async {
     final files = Directory(docDir)
         .list(recursive: true, followLinks: false)
         .whereType<File>();
     await for (final file in files) {
       final suffix = file.path.substring(docDir.length + 1);
-      final targetFile = File(p.join(tmpOutDir, suffix));
+      final targetFile = File(p.join(tmpOutDir.path, suffix));
       await targetFile.parent.create(recursive: true);
       final isDartDocSidebar =
           file.path.endsWith('.html') && file.path.endsWith('-sidebar.html');
@@ -85,14 +85,39 @@ Future<void> postProcessDartdoc({
     _log.info('Finished .tar.gz archive');
   });
 
-  await Future.wait([
-    processingFuture,
-    archiveFuture,
-  ]);
+  try {
+    await Future.wait([
+      processingFuture,
+      archiveFuture,
+    ]);
 
-  // Move from temporary output directory to final one, ensuring that
-  // documentation files won't be present unless all files have been processed.
-  // This helps if there is a timeout along the way.
-  await Directory(tmpOutDir).rename(p.join(outputFolder, 'doc'));
-  await tmpTar.rename(p.join(outputFolder, 'doc', 'package.tar.gz'));
+    // Move from temporary output directory to final one, ensuring that
+    // documentation files won't be present unless all files have been processed.
+    // This helps if there is a timeout along the way.
+    await tmpOutDir.rename(p.join(outputFolder, 'doc'));
+    await tmpTar.rename(p.join(outputFolder, 'doc', 'package.tar.gz'));
+  } catch (e, st) {
+    // We are likely out of free disk space.
+    //
+    // One of the isolate has already stopped, the other may be still working.
+    // By deleting the dartdoc-generated content, the post-processing of the other
+    // isolate will stop too.
+    await Directory(docDir).deleteIgnoringErrors(recursive: true);
+
+    // Cleanup the content as we won't use it.
+    await tmpOutDir.deleteIgnoringErrors(recursive: true);
+    await tmpTar.deleteIgnoringErrors();
+
+    _log.shout('Failed to run dartdoc post-processing.', e, st);
+  }
+}
+
+extension on FileSystemEntity {
+  Future<void> deleteIgnoringErrors({bool recursive = false}) async {
+    try {
+      await delete(recursive: recursive);
+    } catch (_) {
+      // ignored
+    }
+  }
 }


### PR DESCRIPTION
- #7981
- By deleting the input dartdoc data, the post-processing in both isolates will stop.
- We are deleting the partial output as we won't use it, and we may need free space to complete writing the log.txt and the blob files.