### PR TITLE
Move getting the blobId closer to its actual use.

### DIFF
--- a/pkg/pub_worker/lib/src/analyze.dart
+++ b/pkg/pub_worker/lib/src/analyze.dart
@@ -164,13 +164,6 @@ Future<void> _analyzePackage(
       log.writeln('STOPPED: ${clock.now().toUtc().toIso8601String()}');
     }
 
-    // Upload results, if there is any
-    _log.info('api.taskUploadResult("$package", "$version")');
-    final r = await retry(
-      () => api.taskUploadResult(package, version),
-      retryIf: _retryIf,
-    );
-
     // Create a file to store the blob, and add everything to it.
     final blobFile = File(p.join(tempDir.path, 'files.blob'));
     final builder = IndexedBlobBuilder(blobFile.openWrite());
@@ -199,6 +192,13 @@ Future<void> _analyzePackage(
     await builder.addFile(
       'log.txt',
       logFile.openRead().transform(gzip.encoder),
+    );
+
+    // Upload results, if there is any
+    _log.info('api.taskUploadResult("$package", "$version")');
+    final r = await retry(
+      () => api.taskUploadResult(package, version),
+      retryIf: _retryIf,
     );
 
     // Create BlobIndex


### PR DESCRIPTION
I have no evidence that the index building process time would affect the errors much, but moving it closer to its use seems to be a safe bet.