### PR TITLE
Fix automatic status on resolving an appeal.

### DIFF
--- a/app/lib/admin/actions/moderation_case_resolve.dart
+++ b/app/lib/admin/actions/moderation_case_resolve.dart
@@ -72,14 +72,20 @@ Closes the moderation case and updates the status based on the actions logged on
           final appealedCase = await tx.lookupValue<ModerationCase>(dbService
               .emptyKey
               .append(ModerationCase, id: mc.appealedCaseId!));
-          final appealHadModeratedAction =
+          final appealedCaseHadModeratedAction =
               appealedCase.getActionLog().hasModeratedAction();
-          if (appealHadModeratedAction) {
-            status = hasModeratedAction
-                ? ModerationStatus.moderationReverted
-                : ModerationStatus.moderationUpheld;
+          final compositeActionLog = ModerationActionLog(entries: [
+            ...appealedCase.getActionLog().entries,
+            ...mc.getActionLog().entries,
+          ]);
+          final compositeHasModeratedAction =
+              compositeActionLog.hasModeratedAction();
+          if (appealedCaseHadModeratedAction) {
+            status = compositeHasModeratedAction
+                ? ModerationStatus.moderationUpheld
+                : ModerationStatus.moderationReverted;
           } else {
-            status = hasModeratedAction
+            status = compositeHasModeratedAction
                 ? ModerationStatus.noActionReverted
                 : ModerationStatus.noActionUpheld;
           }

--- a/app/test/admin/moderation_case_resolve_test.dart
+++ b/app/test/admin/moderation_case_resolve_test.dart
@@ -115,7 +115,7 @@ void main() {
         reason: 'The package violated our policy.',
       );
 
-      final mc = await _prepare(apply: true, appealCaseId: mc1.caseId);
+      final mc = await _prepare(apply: false, appealCaseId: mc1.caseId);
       expect(await _close(mc.caseId), 'moderation-reverted');
     });
 


### PR DESCRIPTION
- Previous behavior (with bad test): (1) package gets moderated (2) appeal is filed (3) moderation is reverted (4) appeal is closed with automatic status: `moderation-upheld`. The correct status for this is `moderation-reverted`.
- The new behavior merged the actions from the original (appealed) `ModerationCase` and the current (appeal) `ModerationCase` and calculates the cumulative effect. If there are no moderated entities left, the case is considered `reverted` otherwise `upheld`.
