### PR TITLE
Upgrade package:gcloud

### DIFF
--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -310,10 +310,10 @@ packages:
     dependency: "direct main"
     description:
       name: gcloud
-      sha256: b8fbff52ff1cfdb2bb3c53eb039c0ee3745618632969b60ec25d55b31fbb36dd
+      sha256: "2b9c755be0b38facdf886f41626a6405faf06bdb2d76b8525e06d4ce5ea5b32a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.13"
+    version: "0.8.15"
   glob:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   fake_async: ^1.2.0
   fake_gcloud:
     path: ../pkg/fake_gcloud
-  gcloud: '^0.8.13'
+  gcloud: ^0.8.15
   googleapis: ^13.0.0
   googleapis_auth: ^1.1.0
   html: ^0.15.0

--- a/pkg/fake_gcloud/lib/mem_datastore.dart
+++ b/pkg/fake_gcloud/lib/mem_datastore.dart
@@ -231,9 +231,9 @@ class MemDatastore implements Datastore {
               return c < 0;
             case FilterRelation.LessThanOrEqual:
               return c <= 0;
-            case FilterRelation.GreatherThan:
+            case FilterRelation.GreaterThan:
               return c > 0;
-            case FilterRelation.GreatherThanOrEqual:
+            case FilterRelation.GreaterThanOrEqual:
               return c >= 0;
             default:
               throw UnimplementedError('Not handled relation: ${f.relation}');

--- a/pkg/fake_gcloud/lib/mem_storage.dart
+++ b/pkg/fake_gcloud/lib/mem_storage.dart
@@ -58,7 +58,11 @@ class MemStorage implements Storage {
   }
 
   @override
-  Future<void> copyObject(String src, String dest) async {
+  Future<void> copyObject(
+    String src,
+    String dest, {
+    ObjectMetadata? metadata,
+  }) async {
     _logger.info('Copy object from $src to $dest');
     final srcUri = Uri.parse(src);
     final destUri = Uri.parse(dest);

--- a/pkg/fake_gcloud/pubspec.lock
+++ b/pkg/fake_gcloud/pubspec.lock
@@ -106,10 +106,10 @@ packages:
     dependency: "direct main"
     description:
       name: gcloud
-      sha256: b8fbff52ff1cfdb2bb3c53eb039c0ee3745618632969b60ec25d55b31fbb36dd
+      sha256: "2b9c755be0b38facdf886f41626a6405faf06bdb2d76b8525e06d4ce5ea5b32a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.13"
+    version: "0.8.15"
   glob:
     dependency: transitive
     description:

--- a/pkg/fake_gcloud/pubspec.yaml
+++ b/pkg/fake_gcloud/pubspec.yaml
@@ -6,7 +6,7 @@ environment:
   sdk: ^3.5.0
 
 dependencies:
-  gcloud: '^0.8.10'
+  gcloud: ^0.8.15
   logging: '>=0.11.3 <2.0.0'
 
 dev_dependencies:


### PR DESCRIPTION
This gives us a version of `package:gcloud` which can take metadata when it does a copy operation.