### PR TITLE
fixed background color in site-header-nav for mobile size

### DIFF
--- a/pkg/web_css/lib/src/_site_header.scss
+++ b/pkg/web_css/lib/src/_site_header.scss
@@ -233,7 +233,7 @@
       bottom: 0;
       left: 0;
       width: 80%;
-      background: var(pub-site_header_popup-background-color);
+      background: var(--pub-site_header_popup-background-color);
       transform: translateX(-100%);
       transition: transform 0.3s ease;
       z-index: $z-index-nav-mask + 1;


### PR DESCRIPTION
### Fixes relevant issue: [site-header-nav backround color not displaying in mobile size](https://github.com/dart-lang/pub-dev/issues/8106)

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.