### PR TITLE
Rename CSS migrate border-color

### DIFF
--- a/pkg/web_css/lib/src/_form.scss
+++ b/pkg/web_css/lib/src/_form.scss
@@ -61,7 +61,7 @@
   border-width: 0px;
 
   .mdc-data-table__row {
-    border-top-color: var(--pub-inset-bgColor);
+    border-top-color: var(--pub-neutral-borderColor);
 
     &:hover {
       background: inherit;
@@ -105,7 +105,7 @@
 .detail-tab-admin-content {
   h2 {
     &:not(:first-of-type) {
-      border-top: 1px solid #ccc;
+      border-top: 1px solid var(--pub-neutral-borderColor);
       margin-top: 16px;
       padding-top: 16px;
     }

--- a/pkg/web_css/lib/src/_variables.scss
+++ b/pkg/web_css/lib/src/_variables.scss
@@ -24,6 +24,7 @@
   --pub-color-dangerRed: #ff4242;
 
   --pub-neutral-bgColor:       var(--pub-color-white);
+  --pub-neutral-borderColor:   var(--pub-color-smokeWhite);
   --pub-neutral-hover-bgColor: var(--pub-color-snowWhite);
   --pub-inset-bgColor:         var(--pub-color-smokeWhite);
   --pub-selected-bgColor:      var(--pub-color-bubblesBlue);
@@ -108,6 +109,7 @@
   --pub-color-nipponUltraBlue: #23607f;
 
   --pub-neutral-bgColor:       var(--pub-color-darkGunmetal);
+  --pub-neutral-borderColor:   var(--pub-color-anchorBlack);
   --pub-neutral-hover-bgColor: var(--pub-color-shadowBlack);
   --pub-inset-bgColor:         var(--pub-color-anchorBlack);
   --pub-selected-bgColor:      var(--pub-color-nipponUltraBlue);


### PR DESCRIPTION
- The last part of the reimplementation of #8104.
- Fixes color use where bgColor was used.
- Migrates top-border color of admin sections from `#ccc` to `#f5f5f7` (light theme) or `#41424c` (dark theme).