### PR TITLE
More retry on pub_worker: increased delay factor + more exceptions.

### DIFF
--- a/pkg/pub_worker/lib/src/analyze.dart
+++ b/pkg/pub_worker/lib/src/analyze.dart
@@ -205,6 +205,7 @@ Future<void> _analyzePackage(
     final r = await retry(
       () => api.taskUploadResult(package, version),
       retryIf: _retryIf,
+      delayFactor: Duration(seconds: 5),
     );
 
     // Create BlobIndex
@@ -236,6 +237,7 @@ Future<void> _analyzePackage(
     await retry(
       () => api.taskUploadFinished(package, version),
       retryIf: _retryIf,
+      delayFactor: Duration(seconds: 5),
     );
   } finally {
     await tempDir.delete(recursive: true);
@@ -261,6 +263,7 @@ Future<void> _reportPackageSkipped(
   final r = await retry(
     () => api.taskUploadResult(package, version),
     retryIf: _retryIf,
+    delayFactor: Duration(seconds: 5),
   );
 
   final output = await BlobIndexPair.build(r.blobId, (addFile) async {
@@ -301,6 +304,7 @@ Future<void> _reportPackageSkipped(
   await retry(
     () => api.taskUploadFinished(package, version),
     retryIf: _retryIf,
+    delayFactor: Duration(seconds: 5),
   );
 }
 

--- a/pkg/pub_worker/lib/src/upload.dart
+++ b/pkg/pub_worker/lib/src/upload.dart
@@ -2,11 +2,12 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:async';
 import 'dart:io';
 
 import 'package:_pub_shared/data/package_api.dart' show UploadInfo;
 import 'package:http/http.dart'
-    show MultipartRequest, MultipartFile, Client, Response;
+    show Client, ClientException, MultipartFile, MultipartRequest, Response;
 import 'package:http_parser/http_parser.dart' show MediaType;
 import 'package:logging/logging.dart' show Logger;
 import 'package:meta/meta.dart';
@@ -60,7 +61,13 @@ Future<void> upload(
       throw UploadException(
         'Unhandled HTTP status = ${res.statusCode}, body: ${res.body}',
       );
-    }, retryIf: (e) => e is IOException || e is IntermittentUploadException);
+    },
+        retryIf: (e) =>
+            e is IOException ||
+            e is IntermittentUploadException ||
+            e is ClientException ||
+            e is TimeoutException,
+        delayFactor: Duration(seconds: 5));
 
 @sealed
 class UploadException implements Exception {


### PR DESCRIPTION
After reviewing the error messages and stack traces, I think the bulk of the issue originates from either not retrying on some exceptions, or giving up too soon. This PR should address most of these, both for uploading the result or reporting them back to the pub.dev server.