### PR TITLE
Fix mode bits when importing an old archive in test profile.

### DIFF
--- a/app/lib/shared/utils.dart
+++ b/app/lib/shared/utils.dart
@@ -9,6 +9,7 @@ import 'dart:collection';
 import 'dart:convert';
 import 'dart:io';
 import 'dart:math';
+import 'dart:typed_data';
 
 import 'package:appengine/appengine.dart';
 import 'package:intl/intl.dart';
@@ -298,5 +299,16 @@ extension StringExt on String {
   String? trimToNull() {
     final v = trim();
     return v.isEmpty ? null : v;
+  }
+}
+
+extension ByteFolderExt on Stream<List<int>> {
+  Future<Uint8List> foldBytes() async {
+    final contents = await toList();
+    final buffer = BytesBuilder(copy: false);
+    for (final chunk in contents) {
+      buffer.add(chunk);
+    }
+    return buffer.toBytes();
   }
 }

--- a/app/test/package/screenshots_test.dart
+++ b/app/test/package/screenshots_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:pub_dev/package/screenshots/backend.dart';
+import 'package:pub_dev/shared/utils.dart';
 import 'package:test/test.dart';
 
 import '../shared/test_services.dart';
@@ -20,9 +21,7 @@ void main() {
           1);
 
       expect(
-          await imageStorage.bucket
-              .read('new_pkg/1.2.3/image.svg')
-              .fold<List<int>>(<int>[], (buffer, data) => buffer..addAll(data)),
+          await imageStorage.bucket.read('new_pkg/1.2.3/image.svg').foldBytes(),
           [1]);
     });
 

--- a/app/test/tool/test_profile/importer_test.dart
+++ b/app/test/tool/test_profile/importer_test.dart
@@ -23,7 +23,7 @@ void main() {
         packages: [
           TestPackage(
             name: 'retry',
-            versions: [TestVersion(version: '3.1.1')],
+            versions: [TestVersion(version: '3.1.0')],
             publisher: 'example.com',
           )
         ],
@@ -37,10 +37,10 @@ void main() {
         final packages = await dbService.query<Package>().run().toList();
         expect(packages.single.name, 'retry');
         expect(packages.single.publisherId, 'example.com');
-        expect(packages.single.latestVersion, '3.1.1');
+        expect(packages.single.latestVersion, '3.1.0');
 
         final versions = await dbService.query<PackageVersion>().run().toList();
-        expect(versions.single.version, '3.1.1');
+        expect(versions.single.version, '3.1.0');
         expect(versions.single.uploader, users.single.userId);
 
         final publishers = await dbService.query<Publisher>().run().toList();


### PR DESCRIPTION
- Fixes #8127 and allows importing `retry 3.1.0`.
- I think this should be enough to import some old archives that are otherwise good quality. If the need arises, we may expand on this feature.