### PR TITLE
Resolve json_serializable warning in `advisories_api.dart`

### DIFF
--- a/pkg/_pub_shared/lib/data/advisories_api.dart
+++ b/pkg/_pub_shared/lib/data/advisories_api.dart
@@ -54,7 +54,7 @@ class OSV {
 
   /// A list of IDs of the same vulnerability in other databases, in the form of
   /// the [id] field.
-  @JsonKey(defaultValue: <String>[])
+  @JsonKey()
   List<String> aliases;
 
   /// A list of IDs of closely related vulnerabilities, such as the same problem

--- a/pkg/_pub_shared/lib/data/advisories_api.g.dart
+++ b/pkg/_pub_shared/lib/data/advisories_api.g.dart
@@ -33,7 +33,7 @@ OSV _$OSVFromJson(Map<String, dynamic> json) => OSV(
       aliases: (json['aliases'] as List<dynamic>?)
               ?.map((e) => e as String)
               .toList() ??
-          [],
+          const <String>[],
       related:
           (json['related'] as List<dynamic>?)?.map((e) => e as String).toList(),
       summary: json['summary'] as String?,


### PR DESCRIPTION
Resolves the following warning on rebuilding the generated file, by relying on specifying the default value in the constructor.

```
[WARNING] json_serializable on lib/data/advisories_api.dart:
The constructor parameter for `aliases` has a default value `const <String>[]`, but the `JsonKey.defaultValue` value `[]` will be used for missing or `null` values in JSON decoding.
```
