### PR TITLE
Improve token index performance by using fewer memory during search.

### DIFF
--- a/app/bin/tools/search_benchmark.dart
+++ b/app/bin/tools/search_benchmark.dart
@@ -1,0 +1,41 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:pub_dev/package/overrides.dart';
+import 'package:pub_dev/search/mem_index.dart';
+import 'package:pub_dev/search/models.dart';
+import 'package:pub_dev/search/search_service.dart';
+
+/// Loads a search snapshot and executes queries on it, benchmarking their total time to complete.
+Future<void> main(List<String> args) async {
+  // Assumes that the first argument is a search snapshot file.
+  final file = File(args.first);
+  final content =
+      json.decode(utf8.decode(gzip.decode(await file.readAsBytes())))
+          as Map<String, Object?>;
+  final snapshot = SearchSnapshot.fromJson(content);
+  snapshot.documents!
+      .removeWhere((packageName, doc) => isSoftRemoved(packageName));
+  final index = InMemoryPackageIndex(documents: snapshot.documents!.values);
+
+  // NOTE: please add more queries to this list, especially if there is a performance bottleneck.
+  final queries = [
+    'json',
+    'camera',
+    'android camera',
+    'sql database',
+  ];
+
+  final sw = Stopwatch()..start();
+  var count = 0;
+  for (var i = 0; i < 100; i++) {
+    index.search(ServiceSearchQuery.parse(query: queries[i % queries.length]));
+    count++;
+  }
+  sw.stop();
+  print('${(sw.elapsedMilliseconds / count).toStringAsFixed(2)} ms/request');
+}

--- a/app/lib/search/sdk_mem_index.dart
+++ b/app/lib/search/sdk_mem_index.dart
@@ -80,6 +80,7 @@ class SdkMemIndex {
     DartdocIndex index, {
     Set<String>? allowedLibraries,
   }) async {
+    final textsPerLibrary = <String, Map<String, String>>{};
     for (final f in index.entries) {
       final library = f.qualifiedName?.split('.').first;
       if (library == null) continue;
@@ -92,10 +93,15 @@ class SdkMemIndex {
       if (f.isLibrary) {
         _baseUriPerLibrary[library] = _baseUri.resolve(f.href!).toString();
       }
-      final tokens = _tokensPerLibrary.putIfAbsent(library, () => TokenIndex());
 
       final text = f.qualifiedName?.replaceAll('.', ' ').replaceAll(':', ' ');
-      tokens.add(f.href!, text);
+      if (text != null && text.isNotEmpty) {
+        final texts = textsPerLibrary.putIfAbsent(library, () => {});
+        texts[f.href!] = text;
+      }
+    }
+    for (final e in textsPerLibrary.entries) {
+      _tokensPerLibrary[e.key] = TokenIndex.fromMap(e.value);
     }
   }
 

--- a/app/lib/search/token_index.dart
+++ b/app/lib/search/token_index.dart
@@ -155,16 +155,21 @@ class TokenMatch {
 
 /// Stores a token -> documentId inverted index with weights.
 class TokenIndex {
-  /// Maps token Strings to a weighted map of document ids.
-  final _inverseIds = <String, Map<String, double>>{};
+  final List<String> _ids;
+
+  /// Maps token Strings to a weighted documents (addressed via indexes).
+  final _inverseIds = <String, Map<int, double>>{};
 
   /// {id: size} map to store a value representative to the document length
-  final _docSizes = <String, double>{};
+  late final List<double> _docWeights;
 
-  TokenIndex(List<String> keys, List<String?> values) {
-    assert(keys.length == values.length);
-    for (var i = 0; i < keys.length; i++) {
-      final id = keys[i];
+  late final _length = _docWeights.length;
+
+  TokenIndex(List<String> ids, List<String?> values) : _ids = ids {
+    assert(ids.length == values.length);
+    final length = values.length;
+    _docWeights = List<double>.filled(length, 0.0);
+    for (var i = 0; i < length; i++) {
       final text = values[i];
 
       if (text == null) {
@@ -175,13 +180,11 @@ class TokenIndex {
         continue;
       }
       for (final token in tokens.keys) {
-        final weights =
-            _inverseIds.putIfAbsent(token, () => <String, double>{});
-        weights[id] = math.max(weights[id] ?? 0.0, tokens[token]!);
+        final weights = _inverseIds.putIfAbsent(token, () => {});
+        weights[i] = math.max(weights[i] ?? 0.0, tokens[token]!);
       }
-      // Document size is a highly scaled-down proxy of the length.
-      final docSize = 1 + math.log(1 + tokens.length) / 100;
-      _docSizes[id] = docSize;
+      // Document weight is a highly scaled-down proxy of the length.
+      _docWeights[i] = 1 + math.log(1 + tokens.length) / 100;
     }
   }
 
@@ -200,9 +203,8 @@ class TokenIndex {
     for (final word in splitForIndexing(text)) {
       final tokens = tokenize(word, isSplit: true) ?? {};
 
-      final present = tokens.keys
-          .where((token) => (_inverseIds[token]?.length ?? 0) > 0)
-          .toList();
+      final present =
+          tokens.keys.where((token) => _inverseIds.containsKey(token)).toList();
       if (present.isEmpty) {
         return TokenMatch();
       }
@@ -228,14 +230,12 @@ class TokenIndex {
   Map<String, double> _scoreDocs(TokenMatch tokenMatch,
       {double weight = 1.0, int wordCount = 1, Set<String>? limitToIds}) {
     // Summarize the scores for the documents.
-    final docScores = <String, double>{};
+    final docScores = List<double>.filled(_length, 0.0);
     for (final token in tokenMatch.tokens) {
       final docWeights = _inverseIds[token]!;
       for (final e in docWeights.entries) {
-        if (limitToIds != null && !limitToIds.contains(e.key)) continue;
-        final double prevValue = docScores[e.key] ?? 0.0;
-        final double currentValue = tokenMatch[token]! * e.value;
-        docScores[e.key] = math.max(prevValue, currentValue);
+        final i = e.key;
+        docScores[i] = math.max(docScores[i], tokenMatch[token]! * e.value);
       }
     }
 
@@ -244,15 +244,24 @@ class TokenIndex {
     // compensate the formula in order to prevent multiple exponential penalties.
     final double wordSizeExponent = 1.0 / wordCount;
 
+    final result = <String, double>{};
     // post-process match weights
-    docScores.updateAll((id, docScore) {
-      var docSize = _docSizes[id]!;
-      if (wordCount > 1) {
-        docSize = math.pow(docSize, wordSizeExponent).toDouble();
+    for (var i = 0; i < _length; i++) {
+      final id = _ids[i];
+      final w = docScores[i];
+      if (w <= 0.0) {
+        continue;
       }
-      return weight * docScore / docSize;
-    });
-    return docScores;
+      if (limitToIds != null && !limitToIds.contains(id)) {
+        continue;
+      }
+      var dw = _docWeights[i];
+      if (wordCount > 1) {
+        dw = math.pow(dw, wordSizeExponent).toDouble();
+      }
+      result[id] = w * weight / dw;
+    }
+    return result;
   }
 
   /// Search the index for [text], with a (term-match / document coverage percent)

--- a/app/test/search/token_index_test.dart
+++ b/app/test/search/token_index_test.dart
@@ -8,7 +8,7 @@ import 'package:test/test.dart';
 void main() {
   group('TokenIndex', () {
     test('partial token lookup', () {
-      final index = TokenIndex()..add('x', 'SomeCamelCasedWord and others');
+      final index = TokenIndex.fromMap({'x': 'SomeCamelCasedWord and others'});
       expect(index.lookupTokens('word').tokenWeights, {'word': 1.0});
       expect(index.lookupTokens('OtherCased').tokenWeights,
           {'cased': closeTo(0.70, 0.01)});
@@ -18,9 +18,10 @@ void main() {
     });
 
     test('No match', () {
-      final TokenIndex index = TokenIndex()
-        ..add('uri://http', 'http')
-        ..add('uri://http_magic', 'http_magic');
+      final TokenIndex index = TokenIndex.fromMap({
+        'uri://http': 'http',
+        'uri://http_magic': 'http_magic',
+      });
 
       expect(index.search('xml'), {
         // no match for http
@@ -29,9 +30,10 @@ void main() {
     });
 
     test('Scoring exact and partial matches', () {
-      final TokenIndex index = TokenIndex()
-        ..add('uri://http', 'http')
-        ..add('uri://http_magic', 'http_magic');
+      final TokenIndex index = TokenIndex.fromMap({
+        'uri://http': 'http',
+        'uri://http_magic': 'http_magic',
+      });
       expect(index.search('http'), {
         'uri://http': closeTo(0.993, 0.001),
         'uri://http_magic': closeTo(0.989, 0.001),
@@ -40,10 +42,11 @@ void main() {
 
     test('CamelCase indexing', () {
       final String queueText = '.DoubleLinkedQueue()';
-      final TokenIndex index = TokenIndex()
-        ..add('queue', queueText)
-        ..add('queue_lower', queueText.toLowerCase())
-        ..add('unmodifiable', 'CustomUnmodifiableMapBase');
+      final TokenIndex index = TokenIndex.fromMap({
+        'queue': queueText,
+        'queue_lower': queueText.toLowerCase(),
+        'unmodifiable': 'CustomUnmodifiableMapBase',
+      });
       expect(index.search('queue'), {
         'queue': closeTo(0.53, 0.01),
       });
@@ -54,10 +57,11 @@ void main() {
     });
 
     test('Wierd cases: riak client', () {
-      final TokenIndex index = TokenIndex()
-        ..add('uri://cli', 'cli')
-        ..add('uri://riak_client', 'riak_client')
-        ..add('uri://teamspeak', 'teamspeak');
+      final TokenIndex index = TokenIndex.fromMap({
+        'uri://cli': 'cli',
+        'uri://riak_client': 'riak_client',
+        'uri://teamspeak': 'teamspeak',
+      });
 
       expect(index.search('riak'), {
         'uri://riak_client': closeTo(0.99, 0.01),
@@ -68,24 +72,15 @@ void main() {
       });
     });
 
-    test('Free up memory', () {
-      final TokenIndex index = TokenIndex();
-      expect(index.tokenCount, 0);
-      index.add('url1', 'text');
-      expect(index.tokenCount, 1);
-      index.add('url2', 'another');
-      expect(index.tokenCount, 2);
-    });
-
     test('Do not overweight partial matches', () {
-      final index = TokenIndex()..add('flutter_qr_reader', 'flutter_qr_reader');
+      final index =
+          TokenIndex.fromMap({'flutter_qr_reader': 'flutter_qr_reader'});
       final data = index.search('ByteDataReader');
       // The partial match should not return more than 0.65 as score.
       expect(data, {'flutter_qr_reader': lessThan(0.65)});
     });
 
     test('longer words', () {
-      final index = TokenIndex();
       final names = [
         'location',
         'geolocator',
@@ -98,9 +93,7 @@ void main() {
         'location_picker',
         'background_location_updates',
       ];
-      for (final name in names) {
-        index.add(name, name);
-      }
+      final index = TokenIndex.fromMap(Map.fromIterables(names, names));
       final match = index.search('location');
       // location should be the top value, everything else should be lower
       final locationValue = match['location'];


### PR DESCRIPTION
- Refactored initialization, as we can be more efficient if the construction of the index does not assume that entries may be removed.
- Using `int` keys in the token map is slightly more efficient, but most of the gain is coming from using `List<double>` instead of `Map`.
- The change yields about 10% of time improvements in the benchmark.
- Added a small benchmark tool that can be used in the future for similar local checks.
