### PR TITLE
Include name matching in every query (that is on the first page) + separate name matching on each word.

### DIFF
--- a/app/test/search/angular_test.dart
+++ b/app/test/search/angular_test.dart
@@ -37,6 +37,7 @@ void main() {
       expect(json.decode(json.encode(result)), {
         'timestamp': isNotNull,
         'totalCount': 2,
+        'nameMatches': ['angular'],
         'sdkLibraryHits': [],
         'packageHits': [
           {'package': 'angular', 'score': 1.0},

--- a/app/test/search/api_doc_page_test.dart
+++ b/app/test/search/api_doc_page_test.dart
@@ -53,6 +53,7 @@ void main() {
       expect(json.decode(json.encode(result)), {
         'timestamp': isNotNull,
         'totalCount': 2,
+        'nameMatches': ['foo'],
         'sdkLibraryHits': [],
         'packageHits': [
           {'package': 'foo', 'score': 1.0}, // finds package name

--- a/app/test/search/flutter_iap_test.dart
+++ b/app/test/search/flutter_iap_test.dart
@@ -69,6 +69,7 @@ void main() {
       expect(json.decode(json.encode(result)), {
         'timestamp': isNotNull,
         'totalCount': 1,
+        'nameMatches': ['flutter_iap'],
         'sdkLibraryHits': [],
         'packageHits': [
           {'package': 'flutter_iap', 'score': 1.0},

--- a/app/test/search/haversine_test.dart
+++ b/app/test/search/haversine_test.dart
@@ -380,6 +380,7 @@ MIT'''),
       expect(json.decode(json.encode(result)), {
         'timestamp': isNotNull,
         'totalCount': 3,
+        'nameMatches': ['haversine'],
         'sdkLibraryHits': [],
         'packageHits': [
           {'package': 'haversine', 'score': 1.0},

--- a/app/test/search/maps_test.dart
+++ b/app/test/search/maps_test.dart
@@ -26,6 +26,7 @@ void main() {
       expect(json.decode(json.encode(result)), {
         'timestamp': isNotNull,
         'totalCount': 2,
+        'nameMatches': ['maps'],
         'sdkLibraryHits': [],
         'packageHits': [
           {'package': 'maps', 'score': 1.0},
@@ -40,6 +41,7 @@ void main() {
       expect(json.decode(json.encode(result)), {
         'timestamp': isNotNull,
         'totalCount': 2,
+        'nameMatches': ['map'],
         'sdkLibraryHits': [],
         'packageHits': [
           {'package': 'maps', 'score': 1.0},

--- a/app/test/search/mem_index_test.dart
+++ b/app/test/search/mem_index_test.dart
@@ -250,6 +250,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
       expect(json.decode(json.encode(result)), {
         'timestamp': isNotNull,
         'totalCount': 2,
+        'nameMatches': ['http'],
         'sdkLibraryHits': [],
         'packageHits': [
           {'package': 'http'},

--- a/app/test/search/travis_test.dart
+++ b/app/test/search/travis_test.dart
@@ -55,6 +55,7 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor i
       expect(json.decode(json.encode(result)), {
         'timestamp': isNotNull,
         'totalCount': 1,
+        'nameMatches': ['travis'],
         'sdkLibraryHits': [],
         'packageHits': [
           {'package': 'travis', 'score': 1.0},


### PR DESCRIPTION
E.g. we would display the name matching if the order by is on likes, but only on the first page.