### PR TITLE
Turn the search Score into an extension type

### DIFF
--- a/app/lib/search/sdk_mem_index.dart
+++ b/app/lib/search/sdk_mem_index.dart
@@ -141,7 +141,7 @@ class SdkMemIndex {
       final libraryWeight = _libraryWeights[library] ?? 1.0;
       final weightedResults = isQualifiedQuery
           ? plainResults
-          : plainResults.map(
+          : plainResults.mapValues(
               (key, value) {
                 final dir = p.dirname(key);
                 final w = (_apiPageDirWeights[dir] ?? 1.0) * libraryWeight;
@@ -169,9 +169,7 @@ class SdkMemIndex {
               description: _descriptionPerLibrary[hit.library],
               url: _baseUriPerLibrary[hit.library] ?? _baseUri.toString(),
               score: hit.score,
-              apiPages: hit.top
-                  .getValues()
-                  .entries
+              apiPages: hit.top.entries
                   .map(
                     (e) => ApiPageRef(
                       path: e.key,

--- a/app/test/search/package_name_index_test.dart
+++ b/app/test/search/package_name_index_test.dart
@@ -19,7 +19,7 @@ void main() {
 
     test('fluent vs fluent_ui', () {
       expect(
-        index.search('fluent').getValues(),
+        index.search('fluent'),
         {
           'fluent': 1.0,
           'fluent_ui': 1.0,
@@ -29,7 +29,7 @@ void main() {
 
     test('get vs get_it', () {
       expect(
-        index.search('get').getValues(),
+        index.search('get'),
         {
           'get': 1.0,
           'get_it': 1.0,
@@ -38,14 +38,14 @@ void main() {
     });
 
     test('get_it', () {
-      expect(index.search('get_it').getValues(), {
+      expect(index.search('get_it'), {
         'get_it': 1.0,
       });
     });
 
     test('modular vs modular_flutter', () {
       expect(
-        index.search('modular').getValues(),
+        index.search('modular'),
         {
           'modular': 1.0,
           'modular_flutter': 1.0,
@@ -55,21 +55,21 @@ void main() {
 
     test('mixed parts: fluent it', () {
       expect(
-        index.search('fluent it').getValues(),
+        index.search('fluent it'),
         {},
       );
     });
 
     test('mixed parts: fluent flutter', () {
       expect(
-        index.search('fluent flutter').getValues(),
+        index.search('fluent flutter'),
         {},
       );
     });
 
     test('prefix: f', () {
       expect(
-        index.search('f').getValues(),
+        index.search('f'),
         {
           'fluent': 1.0,
           'fluent_ui': 1.0,
@@ -80,7 +80,7 @@ void main() {
 
     test('prefix: fl', () {
       expect(
-        index.search('fl').getValues(),
+        index.search('fl'),
         {
           'fluent': 1.0,
           'fluent_ui': 1.0,
@@ -91,7 +91,7 @@ void main() {
 
     test('prefix: flu', () {
       expect(
-        index.search('flu').getValues(),
+        index.search('flu'),
         {
           'fluent': 1.0,
           'fluent_ui': 1.0,
@@ -102,21 +102,21 @@ void main() {
 
     test('prefix: fluf', () {
       expect(
-        index.search('fluf').getValues(),
+        index.search('fluf'),
         {'fluent': 0.5, 'fluent_ui': 0.5, 'modular_flutter': 0.5},
       );
     });
 
     test('prefix: fluff', () {
       expect(
-        index.search('fluff').getValues(),
+        index.search('fluff'),
         {},
       );
     });
 
     test('prefix: fluffy', () {
       expect(
-        index.search('fluffy').getValues(),
+        index.search('fluffy'),
         {},
       );
     });

--- a/app/test/search/token_index_test.dart
+++ b/app/test/search/token_index_test.dart
@@ -113,24 +113,24 @@ void main() {
     });
 
     test('remove low scores', () {
-      expect(score.getValues(), {
+      expect(score, {
         'a': 100.0,
         'b': 30.0,
         'c': 55.0,
       });
-      expect(score.removeLowValues(fraction: 0.31).getValues(), {
+      expect(score.removeLowValues(fraction: 0.31), {
         'a': 100.0,
         'c': 55.0,
       });
-      expect(score.removeLowValues(minValue: 56.0).getValues(), {
+      expect(score.removeLowValues(minValue: 56.0), {
         'a': 100.0,
       });
     });
 
     test('top', () {
-      expect(score.top(1).getValues(), {'a': 100.0});
-      expect(score.top(2).getValues(), {'a': 100.0, 'c': 55.0});
-      expect(score.top(2, minValue: 60).getValues(), {'a': 100.0});
+      expect(score.top(1), {'a': 100.0});
+      expect(score.top(2), {'a': 100.0, 'c': 55.0});
+      expect(score.top(2, minValue: 60), {'a': 100.0});
     });
   });
 }


### PR DESCRIPTION
This might slightly reduce memory allocations during the index setup, but mostly simplifies the implementation as there was a mix of re-exposing members similar to `Map` and just accessing the underlying map anyway.
