### PR TITLE
Merging some aspects of the ExportedApi with the bucket exporter.

### DIFF
--- a/app/lib/search/backend.dart
+++ b/app/lib/search/backend.dart
@@ -495,24 +495,29 @@ class SearchBackend {
         'delete-old-search-snapshots cleared $counts entries ($runtimeVersion)');
   }
 
+  /// Creates the content for the /api/package-name-completion-data endpoint.
+  Future<Map<String, Object?>> getPackageNameCompletionData() async {
+    final rs = await searchClient.search(
+      ServiceSearchQuery.parse(
+        tagsPredicate: TagsPredicate.regularSearch(),
+        limit: 20000,
+      ),
+      // Do not cache response at the search client level, as we'll be caching
+      // it in a processed form much longer.
+      skipCache: true,
+      // Do not apply rate limit here.
+      sourceIp: null,
+    );
+    return {
+      'packages': rs.packageHits.map((p) => p.package).toList(),
+    };
+  }
+
   /// Creates the gzipped byte content for the /api/package-name-completion-data endpoint.
   Future<List<int>> getPackageNameCompletionDataJsonGz() async {
     final bytes = await cache.packageNameCompletionDataJsonGz().get(() async {
-      final rs = await searchClient.search(
-        ServiceSearchQuery.parse(
-          tagsPredicate: TagsPredicate.regularSearch(),
-          limit: 20000,
-        ),
-        // Do not cache response at the search client level, as we'll be caching
-        // it in a processed form much longer.
-        skipCache: true,
-        // Do not apply rate limit here.
-        sourceIp: null,
-      );
-
-      return gzip.encode(jsonUtf8Encoder.convert({
-        'packages': rs.packageHits.map((p) => p.package).toList(),
-      }));
+      final data = await getPackageNameCompletionData();
+      return gzip.encode(jsonUtf8Encoder.convert(data));
     });
     return bytes!;
   }

--- a/app/test/package/export_api_to_bucket_test.dart
+++ b/app/test/package/export_api_to_bucket_test.dart
@@ -45,20 +45,20 @@ void main() {
             .toList();
         expect(files.toSet(), {
           '$runtimeVersion/api/package-name-completion-data',
-          'current/api/package-name-completion-data',
+          'latest/api/package-name-completion-data',
           '$runtimeVersion/api/packages/flutter_titanium',
           '$runtimeVersion/api/packages/neon',
           '$runtimeVersion/api/packages/oxygen',
-          'current/api/packages/flutter_titanium',
-          'current/api/packages/neon',
-          'current/api/packages/oxygen',
+          'latest/api/packages/flutter_titanium',
+          'latest/api/packages/neon',
+          'latest/api/packages/oxygen',
         });
 
         Future<Object?> readAndDecodeJson(String path) async => json
             .decode(utf8.decode(gzip.decode(await bucket.readAsBytes(path))));
 
         expect(
-          await readAndDecodeJson('current/api/packages/neon'),
+          await readAndDecodeJson('latest/api/packages/neon'),
           {
             'name': 'neon',
             'latest': isNotEmpty,
@@ -67,7 +67,7 @@ void main() {
         );
 
         expect(
-          await readAndDecodeJson('current/api/package-name-completion-data'),
+          await readAndDecodeJson('latest/api/package-name-completion-data'),
           {
             'packages': hasLength(3),
           },
@@ -81,7 +81,7 @@ void main() {
       final bucket =
           storageService.bucket(activeConfiguration.exportedApiBucketName!);
       final originalBytes =
-          await bucket.readAsBytes('current/api/packages/oxygen');
+          await bucket.readAsBytes('latest/api/packages/oxygen');
 
       final pubspecContent = generatePubspecYaml('oxygen', '9.0.0');
       final message = await createPubApiClient(authToken: adminClientToken)
@@ -91,7 +91,7 @@ void main() {
 
       await Future.delayed(Duration(seconds: 1));
       final updatedBytes =
-          await bucket.readAsBytes('current/api/packages/oxygen');
+          await bucket.readAsBytes('latest/api/packages/oxygen');
       expect(originalBytes.length, lessThan(updatedBytes.length));
     });
   });


### PR DESCRIPTION
- #8133
- `ExportedApi` now checks length and md5 before overriding an existing object and retries the upload.
- bucket exporter uses `ExportedApi` for actual write operations.

 