### PR TITLE
Move object-name methods to PackageStorage.

### DIFF
--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -1938,13 +1938,6 @@ DerivedPackageVersionEntities derivePackageVersionEntities({
   return DerivedPackageVersionEntities(versionInfo, assets);
 }
 
-/// The GCS object name of a tarball object - excluding leading '/'.
-String tarballObjectName(String package, String version) =>
-    '${tarballObjectNamePackagePrefix(package)}$version.tar.gz';
-
-/// The GCS object prefix of a tarball object for a given [package] - excluding leading '/'.
-String tarballObjectNamePackagePrefix(String package) => 'packages/$package-';
-
 /// The GCS object name of an temporary object [guid] - excluding leading '/'.
 @visibleForTesting
 String tmpObjectName(String guid) => 'tmp/$guid';

--- a/app/lib/shared/integrity.dart
+++ b/app/lib/shared/integrity.dart
@@ -9,7 +9,6 @@ import 'package:_pub_shared/search/tags.dart';
 import 'package:_pub_shared/utils/http.dart';
 import 'package:clock/clock.dart';
 import 'package:crypto/crypto.dart';
-import 'package:gcloud/storage.dart';
 import 'package:http/http.dart' as http;
 import 'package:logging/logging.dart';
 import 'package:pool/pool.dart';
@@ -604,10 +603,8 @@ class IntegrityChecker {
     Uri archiveDownloadUri, {
     required bool shouldBeInPublicBucket,
   }) async* {
-    final canonicalInfo = await storageService
-        .bucket(activeConfiguration.canonicalPackagesBucketName!)
-        // ignore: invalid_use_of_visible_for_testing_member
-        .tryInfo(tarballObjectName(pv.package, pv.version!));
+    final canonicalInfo = await packageBackend.packageStorage
+        .getCanonicalBucketArchiveInfo(pv.package, pv.version!);
     if (canonicalInfo == null) {
       yield 'PackageVersion "${pv.qualifiedVersionKey}" has no matching canonical archive file.';
       return;
@@ -631,10 +628,8 @@ class IntegrityChecker {
       yield 'Canonical archive for PackageVersion "${pv.qualifiedVersionKey}" differs from public bucket.';
     }
 
-    final publicInfo = await storageService
-        .bucket(activeConfiguration.publicPackagesBucketName!)
-        // ignore: invalid_use_of_visible_for_testing_member
-        .tryInfo(tarballObjectName(pv.package, pv.version!));
+    final publicInfo = await packageBackend.packageStorage
+        .getPublicBucketArchiveInfo(pv.package, pv.version!);
     if (!canonicalInfo.hasSameSignatureAs(publicInfo)) {
       yield 'Canonical archive for PackageVersion "${pv.qualifiedVersionKey}" differs in the public bucket.';
     }

--- a/app/test/admin/moderate_package_test.dart
+++ b/app/test/admin/moderate_package_test.dart
@@ -8,7 +8,6 @@ import 'package:_pub_shared/data/account_api.dart';
 import 'package:_pub_shared/data/admin_api.dart';
 import 'package:_pub_shared/data/package_api.dart';
 import 'package:clock/clock.dart';
-import 'package:gcloud/storage.dart';
 import 'package:http/http.dart' as http;
 import 'package:pub_dev/account/backend.dart';
 import 'package:pub_dev/admin/actions/actions.dart';
@@ -21,7 +20,6 @@ import 'package:pub_dev/scorecard/backend.dart';
 import 'package:pub_dev/search/backend.dart';
 import 'package:pub_dev/shared/configuration.dart';
 import 'package:pub_dev/shared/datastore.dart';
-import 'package:pub_dev/shared/storage.dart';
 import 'package:test/test.dart';
 
 import '../admin/models_test.dart';
@@ -382,10 +380,9 @@ void main() {
       });
 
       // canonical file is present
-      final bucket = storageService
-          .bucket(activeConfiguration.canonicalPackagesBucketName!);
       expect(
-        await bucket.tryInfo(tarballObjectName('oxygen', '1.2.0')),
+        await packageBackend.packageStorage
+            .getCanonicalBucketArchiveInfo('oxygen', '1.2.0'),
         isNotNull,
       );
 
@@ -400,7 +397,8 @@ void main() {
         isNull,
       );
       expect(
-        await bucket.tryInfo(tarballObjectName('oxygen', '1.2.0')),
+        await packageBackend.packageStorage
+            .getCanonicalBucketArchiveInfo('oxygen', '1.2.0'),
         isNull,
       );
 

--- a/app/test/admin/moderate_package_version_test.dart
+++ b/app/test/admin/moderate_package_version_test.dart
@@ -8,7 +8,6 @@ import 'package:_pub_shared/data/account_api.dart';
 import 'package:_pub_shared/data/admin_api.dart';
 import 'package:_pub_shared/data/package_api.dart';
 import 'package:clock/clock.dart';
-import 'package:gcloud/storage.dart';
 import 'package:http/http.dart' as http;
 import 'package:pub_dev/admin/backend.dart';
 import 'package:pub_dev/admin/models.dart';
@@ -20,7 +19,6 @@ import 'package:pub_dev/search/backend.dart';
 import 'package:pub_dev/shared/configuration.dart';
 import 'package:pub_dev/shared/datastore.dart';
 import 'package:pub_dev/shared/exceptions.dart';
-import 'package:pub_dev/shared/storage.dart';
 import 'package:pub_dev/task/backend.dart';
 import 'package:test/test.dart';
 
@@ -430,10 +428,9 @@ void main() {
         'cleanup deletes datastore entities and canonical archive file',
         fn: () async {
       // canonical file is present
-      final bucket = storageService
-          .bucket(activeConfiguration.canonicalPackagesBucketName!);
       expect(
-        await bucket.tryInfo(tarballObjectName('oxygen', '1.0.0')),
+        await packageBackend.packageStorage
+            .getCanonicalBucketArchiveInfo('oxygen', '1.0.0'),
         isNotNull,
       );
 
@@ -462,7 +459,8 @@ void main() {
 
       // canonical file is not present
       expect(
-        await bucket.tryInfo(tarballObjectName('oxygen', '1.0.0')),
+        await packageBackend.packageStorage
+            .getCanonicalBucketArchiveInfo('oxygen', '1.0.0'),
         isNull,
       );
 
@@ -472,7 +470,8 @@ void main() {
         isNotNull,
       );
       expect(
-        await bucket.tryInfo(tarballObjectName('oxygen', '1.2.0')),
+        await packageBackend.packageStorage
+            .getCanonicalBucketArchiveInfo('oxygen', '1.2.0'),
         isNotNull,
       );
     });

--- a/app/test/package/tarball_storage_namer_test.dart
+++ b/app/test/package/tarball_storage_namer_test.dart
@@ -4,6 +4,7 @@
 
 import 'package:gcloud/storage.dart';
 import 'package:pub_dev/package/backend.dart';
+import 'package:pub_dev/package/package_storage.dart';
 import 'package:pub_dev/shared/configuration.dart';
 import 'package:pub_dev/shared/storage.dart';
 import 'package:test/test.dart';


### PR DESCRIPTION
- Continuing #8183 with a refactor `tarballObjectName` and related methods into `PackageStorage`.