### PR TITLE
Introduce `ExportedPackage.garbageCollect(allVersionNumbers)`.

### DIFF
--- a/app/lib/package/api_export/exported_api.dart
+++ b/app/lib/package/api_export/exported_api.dart
@@ -102,7 +102,7 @@ final class ExportedApi {
       if (!allPackageNames.contains(packageName)) {
         final info = await _bucket.info(item.name);
         if (info.updated.isBefore(clock.agoBy(_minGarbageAge))) {
-          // Only delete if the item if it's older than _minGarbageAge
+          // Only delete the item if it's older than _minGarbageAge
           // This avoids any races where we delete files we've just created
           await package(packageName).delete();
         }
@@ -119,7 +119,7 @@ final class ExportedApi {
       if (!allPackageNames.contains(packageName)) {
         final info = await _bucket.info(item.name);
         if (info.updated.isBefore(clock.agoBy(_minGarbageAge))) {
-          // Only delete if the item if it's older than _minGarbageAge
+          // Only delete the item if it's older than _minGarbageAge
           // This avoids any races where we delete files we've just created
           await package(packageName).delete();
         }


### PR DESCRIPTION
 * Garbage collection of version numbers, specifically archives.
 * Use `tryDelete` instead of `delete` to avoid errors from racing deletion, when GCS then returns 404.
 * Introduce `_minGarbageAge` to avoid deleting files before they are at-least a day old. This way GC won't race against creation of new files.
