### PR TITLE
Make generation of `ListSecurityAdvisoryResponse` reusable.

### DIFF
--- a/app/lib/frontend/handlers/package.dart
+++ b/app/lib/frontend/handlers/package.dart
@@ -531,17 +531,5 @@ Future<ListAdvisoriesResponse> listAdvisoriesForPackage(
     throw NotFoundException.resource(packageName);
   }
 
-  final advisories =
-      await securityAdvisoryBackend.lookupSecurityAdvisories(packageName);
-  if (advisories.isEmpty) {
-    return ListAdvisoriesResponse(advisories: []);
-  }
-  final advisoriesUpdated = advisories.fold(
-      advisories.first.syncTime,
-      (previousValue, advisory) => advisory.syncTime.isAfter(previousValue)
-          ? advisory.syncTime
-          : previousValue);
-  return ListAdvisoriesResponse(
-      advisories: advisories.map((e) => e.advisory).toList(),
-      advisoriesUpdated: advisoriesUpdated);
+  return await securityAdvisoryBackend.listAdvisoriesResponse(packageName);
 }

--- a/app/lib/service/security_advisories/backend.dart
+++ b/app/lib/service/security_advisories/backend.dart
@@ -5,7 +5,8 @@
 import 'dart:async';
 import 'dart:convert';
 
-import 'package:_pub_shared/data/advisories_api.dart' show OSV;
+import 'package:_pub_shared/data/advisories_api.dart'
+    show ListAdvisoriesResponse, OSV;
 import 'package:basics/basics.dart';
 import 'package:clock/clock.dart';
 import 'package:collection/collection.dart';
@@ -48,6 +49,16 @@ class SecurityAdvisoryBackend {
           .map((SecurityAdvisory adv) => SecurityAdvisoryData.fromModel(adv))
           .toList();
     }))!;
+  }
+
+  /// Create a [ListAdvisoriesResponse] for [package] using advisories from
+  /// cache.
+  Future<ListAdvisoriesResponse> listAdvisoriesResponse(String package) async {
+    final advisories = await lookupSecurityAdvisories(package);
+    return ListAdvisoriesResponse(
+      advisories: advisories.map((e) => e.advisory).toList(),
+      advisoriesUpdated: advisories.map((a) => a.syncTime).maxOrNull,
+    );
   }
 
   Future<SecurityAdvisory?> lookupById(String id) async {


### PR DESCRIPTION
This should allow us to use the same logic as we use in the response handler when the `ApiExporter` wants to generate responses for `/advisories`.

