### PR TITLE
Reduced memory use on processing the new upload.

### DIFF
--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -904,8 +904,7 @@ class PackageBackend {
       _logger.info('Examining tarball content ($guid).');
       final sw = Stopwatch()..start();
       final file = File(filename);
-      final fileBytes = await file.readAsBytes();
-      final sha256Hash = sha256.convert(fileBytes).bytes;
+      final sha256Hash = (await file.openRead().transform(sha256).single).bytes;
       final archive = await summarizePackageArchive(
         filename,
         maxContentLength: maxAssetContentLength,
@@ -946,7 +945,7 @@ class PackageBackend {
           await tarballStorage.matchArchiveContentInCanonical(
         pubspec.name,
         versionString,
-        fileBytes,
+        file,
       );
       if (canonicalContentMatch == ContentMatchStatus.different) {
         throw PackageRejectedException.versionExists(

--- a/app/lib/package/tarball_storage.dart
+++ b/app/lib/package/tarball_storage.dart
@@ -83,7 +83,7 @@ class TarballStorage {
     if (!md5hash.byteToByteEquals(info.md5Hash)) {
       return ContentMatchStatus.different;
     }
-    // limit memory use while doing the byte-to-byte comparison
+    // Limit memory use while doing the byte-to-byte comparison by streaming it chunk-wise.
     final raf = await file.open();
     var remainingLength = info.length;
     try {


### PR DESCRIPTION
- This is a the low-hanging fruit before having an implementation of separate isolates (#8195).
- Hash calculation is stream based, and content comparison depends on the chunk of bytes we get back from the storage bucket. In theory this could be still arbitrarily large, but in practice I think it won't be.