### PR TITLE
Reduce the memory allocation during search with mutable IndexedScore.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Important changes to data models, configuration, and migrations between each
 AppEngine version, listed here to ease deployment and troubleshooting.
 
 ## Next Release (replace with git tag when deployed)
+ * `search` uses the `IndexedScore` to reduce memory allocations.
 
 ## `20241031t095600-all`
  * Bumped runtimeVersion to `2024.10.29`.

--- a/app/test/search/api_doc_page_test.dart
+++ b/app/test/search/api_doc_page_test.dart
@@ -99,7 +99,7 @@ void main() {
         'packageHits': [
           {
             'package': 'foo',
-            'score': closeTo(0.18, 0.01), // find WebPageGenerator
+            'score': closeTo(0.26, 0.01), // find WebPageGenerator
             'apiPages': [
               {'path': 'generator.html'},
             ],
@@ -119,7 +119,7 @@ void main() {
         'packageHits': [
           {
             'package': 'foo',
-            'score': closeTo(0.11, 0.01), // find WebPageGenerator
+            'score': closeTo(0.15, 0.01), // find WebPageGenerator
             'apiPages': [
               {'path': 'generator.html'},
             ],


### PR DESCRIPTION
- Follow-up to #8152.
- Fewer operation is required as document weight is part of the pre-calculation at index creation. Some scores in test did change, I think these changes are because of the changes of the generic method that is being used in search and they are fine.
- This change does not completely eliminate the Map-based immutable `Score`, but reduces its use (and its map-building operations) by extending the use of the list-based score across multiple token index and multiple words (fewer list allocations).
- Local search benchmark shows about 3-6% total query time improvements.
- Note: I'm also planning a follow-up PR that expands the concept on the filtering that happens before the text search part, possibly getting further benefits.