### PR TITLE
Rewrite/redirect '#<topic>' search expressions to 'topic:<topic>'

### DIFF
--- a/app/lib/service/topics/models.dart
+++ b/app/lib/service/topics/models.dart
@@ -7,7 +7,6 @@ import 'dart:io';
 
 import 'package:json_annotation/json_annotation.dart';
 import 'package:logging/logging.dart';
-import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 import 'package:pub_dev/frontend/static_files.dart';
 import 'package:yaml/yaml.dart';
@@ -92,7 +91,6 @@ class CanonicalTopicFileContent {
 }
 
 /// True, if [topic] is formatted like a valid topic.
-@visibleForTesting
 bool isValidTopicFormat(String topic) =>
     RegExp(r'^[a-z0-9-]{2,32}$').hasMatch(topic) &&
     !topic.contains('--') &&

--- a/app/test/frontend/handlers/redirects_test.dart
+++ b/app/test/frontend/handlers/redirects_test.dart
@@ -117,5 +117,19 @@ void main() {
         'https://api.flutter.dev/',
       );
     });
+
+    testWithProfile('search canonicalization: topic name', fn: () async {
+      await expectRedirectResponse(
+        await issueGet('/packages?q=topic%3Awidgets'),
+        '/packages?q=topic%3Awidget',
+      );
+    });
+
+    testWithProfile('search canonicalization: topic shortcut', fn: () async {
+      await expectRedirectResponse(
+        await issueGet('/packages?q=%23hash'),
+        '/packages?q=topic%3Ahash',
+      );
+    });
   });
 }

--- a/app/test/search/backend_test.dart
+++ b/app/test/search/backend_test.dart
@@ -69,5 +69,12 @@ void main() {
         'topic:widget abc',
       );
     });
+
+    test('query with topic shortcut `#`', () {
+      expect(
+        canonicalizeSearchForm(_parse('#widget #testing'))?.query,
+        'topic:widget topic:testing',
+      );
+    });
   });
 }


### PR DESCRIPTION
- This was mentioned while we have discussed #8189.
- We don't actively keep track of the topics, if we want to restrict the rewrite to existing topics, we should probably cache the topic names locally too.