### PR TITLE
Make PackageNameIndex immutable

### DIFF
--- a/app/test/search/package_name_index_test.dart
+++ b/app/test/search/package_name_index_test.dart
@@ -7,15 +7,14 @@ import 'package:test/test.dart';
 
 void main() {
   group('PackageNameIndex', () {
-    final index = PackageNameIndex()
-      ..addAll([
-        'fluent',
-        'fluent_ui',
-        'get',
-        'get_it',
-        'modular',
-        'modular_flutter',
-      ]);
+    final index = PackageNameIndex([
+      'fluent',
+      'fluent_ui',
+      'get',
+      'get_it',
+      'modular',
+      'modular_flutter',
+    ]);
 
     test('fluent vs fluent_ui', () {
       expect(


### PR DESCRIPTION
- Part of the split of #8225
- Passing in the package name list will allow a more natural transition to list-based score calculation (as seen in #8225).