### PR TITLE
 Move doc-weight correction to pre-calculation of term weights.

### DIFF
--- a/app/test/search/token_index_test.dart
+++ b/app/test/search/token_index_test.dart
@@ -68,7 +68,7 @@ void main() {
       });
 
       expect(index.search('riak client'), {
-        'uri://riak_client': closeTo(0.99, 0.01),
+        'uri://riak_client': closeTo(0.98, 0.01),
       });
     });
 


### PR DESCRIPTION
- Part of the split of #8225
- Fixed the `Map<String, double> search(String text)` method used by tests: previously it did not split the query text to multiple terms, only used the token matching to extract multiple tokens.
- The change in term-weights calculation slightly changes the final score of multi-term hits, as the `wordSizeExponent` is not applied on the document weights inside the loop, and when we multiply the scores, this effect lowers their final score a bit.
- However, the change is mostly a noise when it is observed outside of the narrow `TokenIndex` in the test, and should not change the rank order (for a specific query) much, as is shown in all the other tests that did not change, while they combine the name+description+readme token indexes.
