### PR TITLE
Micro-optimizations of search score handling.

### DIFF
--- a/app/lib/search/token_index.dart
+++ b/app/lib/search/token_index.dart
@@ -164,9 +164,10 @@ class TokenIndex {
       }
       // Document weight is a highly scaled-down proxy of the length.
       final dw = 1 + math.log(1 + tokens.length) / 100;
-      for (final token in tokens.keys) {
+      for (final e in tokens.entries) {
+        final token = e.key;
         final weights = _inverseIds.putIfAbsent(token, () => {});
-        weights[i] = math.max(weights[i] ?? 0.0, tokens[token]! / dw);
+        weights[i] = math.max(weights[i] ?? 0.0, e.value / dw);
       }
     }
   }


### PR DESCRIPTION
- Part of the split of #8225.
- `PackageNameIndex.search` (used only in tests) is updated to update its `filterOnPackages` set on subsequent iteration. If this would be used elsewhere, it would probably improve the search by reducing the number of ngram-similarity calculation done by the index.
- `PackageNameIndex.searchWord` is updated to not insert entries below the 0.5 score threshold (so we don't need to update the map to remove them later).
- `PackageNameIndex.searchWord` also removed scores that were half of the largest score present, but in practice, with the combination of the 0.5 threshold (above) this does not have any further effect, as the maximum it would have removed would be 0.5 anyway. Removing that part is a no-op.
- The iteration change in the `TokenIndex` constructor spares us the internal lookup.