### PR TITLE
Using IndexedScore as part of the search pre-filtering.

### DIFF
--- a/app/lib/search/search_service.dart
+++ b/app/lib/search/search_service.dart
@@ -132,6 +132,8 @@ class PackageDocument {
 
   @JsonKey(includeFromJson: false, includeToJson: false)
   late final Set<String> tagsForLookup = Set.of(tags);
+
+  late final packageNameLowerCased = package.toLowerCase();
 }
 
 /// A reference to an API doc page


### PR DESCRIPTION
- Part of the split of #8225, but also extends the use of `IndexedScore` into pre-filtering.
- The package name prefix check uses the `packageNameLowerCased` to calculate the lower-cased names only a single time (at least while the index is alive).
- The filtering uses the `_documents` array with indexed access instead of the `Map` lookup.
- The filtering won't update the `Set` of package names at each step, instead uses the mutable list of values. This list will be used to also drive the text search in #8225.
- The `TokenIndex` is also updated to partially use the new `IndexedScore`.