### PR TITLE
Use IndexedScores in package and SDK doc page search + fixing weight.

### DIFF
--- a/app/lib/search/token_index.dart
+++ b/app/lib/search/token_index.dart
@@ -216,13 +216,14 @@ class TokenIndex {
   /// Search the index for [words], with a (term-match / document coverage percent)
   /// scoring.
   Score searchWords(List<String> words, {double weight = 1.0}) {
+    if (words.isEmpty) return Score.empty;
     IndexedScore? score;
+    weight = math.pow(weight, 1 / words.length).toDouble();
     for (final w in words) {
       final s = IndexedScore(_ids);
       searchAndAccumulate(w, score: s, weight: weight);
       if (score == null) {
         score = s;
-        // NOTE: in the subsequent round(s), weight will be re-applied on the next word(s) too.
       } else {
         score.multiplyAllFrom(s);
       }

--- a/app/test/search/api_doc_page_test.dart
+++ b/app/test/search/api_doc_page_test.dart
@@ -99,7 +99,7 @@ void main() {
         'packageHits': [
           {
             'package': 'foo',
-            'score': closeTo(0.18, 0.01), // find WebPageGenerator
+            'score': closeTo(0.26, 0.01), // find WebPageGenerator
             'apiPages': [
               {'path': 'generator.html'},
             ],
@@ -119,7 +119,7 @@ void main() {
         'packageHits': [
           {
             'package': 'foo',
-            'score': closeTo(0.11, 0.01), // find WebPageGenerator
+            'score': closeTo(0.16, 0.01), // find WebPageGenerator
             'apiPages': [
               {'path': 'generator.html'},
             ],


### PR DESCRIPTION
- Last part of the split in #8225.
- documentation searches use the `searchWords` method, and by applying the reuse of the internal `IndexedScore`, we spare Map building for multi-word searches
- Also fixes the `weight` handling: previously it was applied on each word, making the score of such queries really low. Instead, we should either reset it to `1.0` (as in #8225), or use a power-exponent adjustment (as in the separate commit). I think the adjustment here is better for the understanding.
- `_scoreDocs` is no longer used
- `searchWords`'s `limitToIds` parameter is no longer used
