### PR TITLE
Skip color expressions test

### DIFF
--- a/pkg/web_css/test/color_expressions_test.dart
+++ b/pkg/web_css/test/color_expressions_test.dart
@@ -16,8 +16,8 @@ const _colors = {
 
 void main() {
   group('Color restrictions and rules', () {
-    test('text and bg colors are only defined in _variables.scss', skip: true,
-        () {
+    test('text and bg colors are only defined in _variables.scss',
+        skip: 'https://github.com/dart-lang/pub-dev/issues/8248', () {
       final files = Directory('lib')
           .listSync(recursive: true)
           .whereType<File>()

--- a/pkg/web_css/test/color_expressions_test.dart
+++ b/pkg/web_css/test/color_expressions_test.dart
@@ -16,7 +16,8 @@ const _colors = {
 
 void main() {
   group('Color restrictions and rules', () {
-    test('text and bg colors are only defined in _variables.scss', () {
+    test('text and bg colors are only defined in _variables.scss', skip: true,
+        () {
       final files = Directory('lib')
           .listSync(recursive: true)
           .whereType<File>()


### PR DESCRIPTION
Skipping until further investigated. Should be enabled again once issue is resolved. Tracked in https://github.com/dart-lang/pub-dev/issues/8248