### PR TITLE
Adjust downloads sparkline chart

### DIFF
--- a/app/lib/frontend/templates/views/pkg/info_box.dart
+++ b/app/lib/frontend/templates/views/pkg/info_box.dart
@@ -72,9 +72,6 @@ d.Node packageInfoBoxNode({
   }
   return d.fragment([
     labeledScores,
-    if (data.weeklyDownloadCounts != null &&
-        requestContext.experimentalFlags.showDownloadCounts)
-      _block('Weekly Downloads', _downloadsChart(data.weeklyDownloadCounts!)),
     if (thumbnailUrl != null)
       d.div(classes: [
         'detail-screenshot-thumbnail'
@@ -86,6 +83,9 @@ d.Node packageInfoBoxNode({
         collectionsIcon(),
       ]),
     _publisher(package.publisherId),
+    if (data.weeklyDownloadCounts != null &&
+        requestContext.experimentalFlags.showDownloadCounts)
+      _block('Weekly Downloads', _downloadsChart(data.weeklyDownloadCounts!)),
     _metadata(
       description: version.pubspec!.description,
       metaLinks: metaLinks,

--- a/pkg/web_app/lib/src/widget/weekly_sparkline/widget.dart
+++ b/pkg/web_app/lib/src/widget/weekly_sparkline/widget.dart
@@ -25,12 +25,16 @@ void create(HTMLElement element, Map<String, String> options) {
     final decoded = decodeIntsFromLittleEndianBase64String(dataPoints);
     final newestDate = DateTime.fromMillisecondsSinceEpoch(decoded[0] * 1000);
     final weeklyDownloads = decoded.sublist(1);
+
+    // TODO(https://github.com/dart-lang/pub-dev/issues/8251): Update this to 52.
+    final dataListLength =
+        weeklyDownloads.length > 40 ? 40 : weeklyDownloads.length;
     return List.generate(
         weeklyDownloads.length,
         (i) => (
               date: newestDate.copyWith(day: newestDate.day - 7 * i),
               downloads: weeklyDownloads[i]
-            )).reversed.toList();
+            )).sublist(0, dataListLength).reversed.toList();
   }
 
   drawChart(svg, toolTip, chartSubText, prepareDataForSparkline(dataPoints));
@@ -94,7 +98,7 @@ void drawChart(Element svg, HTMLDivElement toolTip, HTMLDivElement chartSubText,
 
   sparklineSpot
     ..setAttribute('class', 'weekly-sparkline')
-    ..setAttribute('r', '2');
+    ..setAttribute('r', '3');
 
   sparklineBar.setAttribute('class', 'weekly-sparkline-bar');
   sparklineBar.setAttribute('x1', '0');


### PR DESCRIPTION
  - Move it further down
  - Reduce the datapoints list length to 40 (the amount of data we have)
  - Increase the sparkline cursor spot
