### PR TITLE
Use IndexedScore for faster API doc and exact phrase scoring.

### DIFF
--- a/app/lib/search/sdk_mem_index.dart
+++ b/app/lib/search/sdk_mem_index.dart
@@ -18,7 +18,7 @@ class SdkMemIndex {
   final String _sdk;
   final String? _version;
   final Uri _baseUri;
-  final _tokensPerLibrary = <String, TokenIndex>{};
+  final _tokensPerLibrary = <String, TokenIndex<String>>{};
   final _baseUriPerLibrary = <String, String>{};
   final _descriptionPerLibrary = <String, String>{};
   final _libraryWeights = <String, double>{};
@@ -135,7 +135,8 @@ class SdkMemIndex {
       final isQualifiedQuery = query.contains(library.split(':').last);
 
       final tokens = _tokensPerLibrary[library]!;
-      final plainResults = tokens.searchWords(words).top(3, minValue: 0.05);
+      final plainResults =
+          tokens.searchWords(words).toScore().top(3, minValue: 0.05);
       if (plainResults.isEmpty) continue;
 
       final libraryWeight = _libraryWeights[library] ?? 1.0;

--- a/app/test/search/token_index_test.dart
+++ b/app/test/search/token_index_test.dart
@@ -18,7 +18,7 @@ void main() {
     });
 
     test('No match', () {
-      final TokenIndex index = TokenIndex.fromMap({
+      final index = TokenIndex.fromMap({
         'uri://http': 'http',
         'uri://http_magic': 'http_magic',
       });
@@ -30,7 +30,7 @@ void main() {
     });
 
     test('Scoring exact and partial matches', () {
-      final TokenIndex index = TokenIndex.fromMap({
+      final index = TokenIndex.fromMap({
         'uri://http': 'http',
         'uri://http_magic': 'http_magic',
       });
@@ -42,7 +42,7 @@ void main() {
 
     test('CamelCase indexing', () {
       final String queueText = '.DoubleLinkedQueue()';
-      final TokenIndex index = TokenIndex.fromMap({
+      final index = TokenIndex.fromMap({
         'queue': queueText,
         'queue_lower': queueText.toLowerCase(),
         'unmodifiable': 'CustomUnmodifiableMapBase',
@@ -57,7 +57,7 @@ void main() {
     });
 
     test('Wierd cases: riak client', () {
-      final TokenIndex index = TokenIndex.fromMap({
+      final index = TokenIndex.fromMap({
         'uri://cli': 'cli',
         'uri://riak_client': 'riak_client',
         'uri://teamspeak': 'teamspeak',


### PR DESCRIPTION
- Generic key for `TokenIndex` and `IndexedScore` now allows composite keys.
- The dartdoc API symbols index used String concatenation and split in place of composite keys, this change replaces those with the new key. Besides the key operations, we can also spare the Map creation here too.
- The exact phrase matches also benefits from skipping the Map creation and merging the score values directly into the `IndexedScore`.
- The `topApiPages` variable still uses a Map, it will be migrated in a subsequent PR (also the `_TextResults.score`).