### PR TITLE
Upgrade package:gcloud to fix metadata issue in GCS

### DIFF
--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   fake_async: ^1.2.0
   fake_gcloud:
     path: ../pkg/fake_gcloud
-  gcloud: ^0.8.16
+  gcloud: ^0.8.17
   googleapis: ^13.0.0
   googleapis_auth: ^1.1.0
   html: ^0.15.0

--- a/pkg/fake_gcloud/pubspec.yaml
+++ b/pkg/fake_gcloud/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  gcloud: ^0.8.16
+  gcloud: ^0.8.17
   logging: '>=0.11.3 <2.0.0'
   clock: ^1.1.0
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -314,10 +314,10 @@ packages:
     dependency: transitive
     description:
       name: gcloud
-      sha256: "17e9f6b377972d2e6883edcbdacbcf402895b2fce0b265a19b5e8bd63cbf12a1"
+      sha256: "4023f8f3dde8324ca8d17bd419767986764ac90a1173b207d4bc0e1784e9095f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.16"
+    version: "0.8.17"
   glob:
     dependency: transitive
     description:


### PR DESCRIPTION
This should fix the metadata issue where `package:gcloud` assigns `ContentEncoding` to meta-data properties like `ContentDisposition` and `ContentLanguage`.

