### PR TITLE
Bump runtimeVersion to fix metadata issue in ExportedApi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ AppEngine version, listed here to ease deployment and troubleshooting.
 
 ## Next Release (replace with git tag when deployed)
  * Note: `search` increased `description` weight from `0.9` to `1.0`.
- * Bump runtimeVersion to `2024.11.08`.
+ * Bump runtimeVersion to `2024.11.11`.
+ * Enabled generation of `ExportedApi`.
 
 ## `20241107t132800-all`
  * `search` uses the `IndexedScore` to reduce memory allocations.

--- a/app/lib/shared/versions.dart
+++ b/app/lib/shared/versions.dart
@@ -24,7 +24,7 @@ final RegExp runtimeVersionPattern = RegExp(r'^\d{4}\.\d{2}\.\d{2}$');
 /// when the version switch happens.
 const _acceptedRuntimeVersions = <String>[
   // The current [runtimeVersion].
-  '2024.11.08',
+  '2024.11.11',
   // Fallback runtime versions.
   '2024.10.29',
   '2024.10.21',


### PR DESCRIPTION
Bumping runtimeVersion after https://github.com/dart-lang/pub-dev/pull/8260 to ensure that we don't use the data from this runtimeVersion on staging.