### PR TITLE
Reduce Score creation in the search ranking step.

### DIFF
--- a/app/lib/search/token_index.dart
+++ b/app/lib/search/token_index.dart
@@ -297,10 +297,14 @@ class IndexedScore<K> {
   }
 
   void multiplyAllFrom(IndexedScore other) {
-    assert(other._values.length == _values.length);
+    multiplyAllFromValues(other._values);
+  }
+
+  void multiplyAllFromValues(List<double> values) {
+    assert(_values.length == values.length);
     for (var i = 0; i < _values.length; i++) {
       if (_values[i] == 0.0) continue;
-      final v = other._values[i];
+      final v = values[i];
       _values[i] = v == 0.0 ? 0.0 : _values[i] * v;
     }
   }


### PR DESCRIPTION
- The precalculated `_adjustedOverallScores` can be accessed via integer index, no need for Map lookup.
- When ranking packages with the same score, the updated timestamp lookup can also be done with indeger index.
- We can remove two map creation (one `toScore()` and one `mapValues()`) from the most frequently used search path.