### PR TITLE
Search index code cleanup + minor optimizations.

### DIFF
--- a/app/test/search/token_index_test.dart
+++ b/app/test/search/token_index_test.dart
@@ -106,28 +106,6 @@ void main() {
     });
   });
 
-  group('Score', () {
-    late Score score;
-    setUp(() {
-      score = Score({'a': 100.0, 'b': 30.0, 'c': 55.0});
-    });
-
-    test('remove low scores', () {
-      expect(score, {
-        'a': 100.0,
-        'b': 30.0,
-        'c': 55.0,
-      });
-      expect(score.removeLowValues(fraction: 0.31), {
-        'a': 100.0,
-        'c': 55.0,
-      });
-      expect(score.removeLowValues(minValue: 56.0), {
-        'a': 100.0,
-      });
-    });
-  });
-
   group('IndexedScore', () {
     final score = IndexedScore.fromMap({'a': 100.0, 'b': 30.0, 'c': 55.0});
 


### PR DESCRIPTION
- Removed the now-unused methods from `Score`.
- API package hits are stored in a flat array instead of a Map, reducing a bit of latency be doing fewer Map building and lookup.
- Slight improvement on token iteration.