### PR TITLE
Use styles from site-shared/dash_design

### DIFF
--- a/pkg/web_css/lib/src/_variables.scss
+++ b/pkg/web_css/lib/src/_variables.scss
@@ -22,7 +22,6 @@
   --pub-color-snowWhite:     #fafafa; // slight deviation from official snow-white (fffafa)
   --pub-color-smokeWhite:    #f5f5f7; // slight deviation from official white-smoke (f5f5f5)
   --pub-color-bubblesBlue:   #e7f8ff; // slight deviation from official bubbles-blue (e7feff)
-  // --pub-color-gunpowderGray: #4a4a4a; // hsl(0, 0%, 29%);
 
   --pub-color-dangerRed: #ff4242;
 
@@ -122,7 +121,6 @@
   --pub-color-shadowBlack:     #373737;
   --pub-color-anchorBlack:     #41424c;
   --pub-color-nipponUltraBlue: #23607f;
-  // --pub-color-gainsboro:       #dcdcdc;
 
   --pub-neutral-bgColor:       var(--pub-color-darkGunmetal);
   --pub-neutral-borderColor:   var(--pub-color-anchorBlack);

--- a/pkg/web_css/lib/src/_variables.scss
+++ b/pkg/web_css/lib/src/_variables.scss
@@ -16,17 +16,19 @@
 //   - `[property]` may be `color`, `opacity` for specific values, or a `value` for multi-part properties.
 
 :root {
+  @include dash_variables.light-theme;
+
   --pub-color-white:         #ffffff;
   --pub-color-snowWhite:     #fafafa; // slight deviation from official snow-white (fffafa)
   --pub-color-smokeWhite:    #f5f5f7; // slight deviation from official white-smoke (f5f5f5)
   --pub-color-bubblesBlue:   #e7f8ff; // slight deviation from official bubbles-blue (e7feff)
-  --pub-color-gunpowderGray: #4a4a4a; // hsl(0, 0%, 29%);
+  // --pub-color-gunpowderGray: #4a4a4a; // hsl(0, 0%, 29%);
 
   --pub-color-dangerRed: #ff4242;
 
   --pub-neutral-bgColor:       var(--pub-color-white);
   --pub-neutral-borderColor:   var(--pub-color-smokeWhite);
-  --pub-neutral-textColor:     var(--pub-color-gunpowderGray);
+  --pub-neutral-textColor:     var(--dash-surface-fgColor);
   --pub-neutral-hover-bgColor: var(--pub-color-snowWhite);
   --pub-inset-bgColor:         var(--pub-color-smokeWhite);
   --pub-selected-bgColor:      var(--pub-color-bubblesBlue);
@@ -114,15 +116,17 @@
 }
 
 .dark-theme {
+  @include dash_variables.dark-theme;
+
   --pub-color-darkGunmetal:    #1f262a; // close to #1d2026
   --pub-color-shadowBlack:     #373737;
   --pub-color-anchorBlack:     #41424c;
   --pub-color-nipponUltraBlue: #23607f;
-  --pub-color-gainsboro:       #dcdcdc;
+  // --pub-color-gainsboro:       #dcdcdc;
 
   --pub-neutral-bgColor:       var(--pub-color-darkGunmetal);
   --pub-neutral-borderColor:   var(--pub-color-anchorBlack);
-  --pub-neutral-textColor:     var(--pub-color-gainsboro);
+  --pub-neutral-textColor:     var(--dash-surface-fgColor);
   --pub-neutral-hover-bgColor: var(--pub-color-shadowBlack);
   --pub-inset-bgColor:         var(--pub-color-anchorBlack);
   --pub-selected-bgColor:      var(--pub-color-nipponUltraBlue);

--- a/pkg/web_css/lib/style.scss
+++ b/pkg/web_css/lib/style.scss
@@ -2,6 +2,8 @@
 // to reduce the number of HTTP requests.
 @use '../../../third_party/css/github-markdown.css';
 
+@use '../../../third_party/site-shared/dash_design/lib/styles/variables.scss' as dash_variables;
+
 .light-theme {
   @import "../../../third_party/highlight/github";
 }


### PR DESCRIPTION
- Updated the variable tests to also use the dash_design files.
- I've commented out the two colors that this replaces for now. I'm going to remove them with a follow-up PR when we have more colors in the shared style sheet that we import.
- No effective color change for us.