### PR TITLE
Sync exported APIs on moderation + delete a moderated version's exported files.

### DIFF
--- a/app/lib/admin/actions/moderate_package.dart
+++ b/app/lib/admin/actions/moderate_package.dart
@@ -4,6 +4,7 @@
 
 import '../../admin/backend.dart';
 import '../../admin/models.dart';
+import '../../package/api_export/api_exporter.dart';
 import '../../package/backend.dart';
 import '../../package/models.dart';
 import '../../shared/datastore.dart';
@@ -80,6 +81,9 @@ Note: the action may take a longer time to complete as the public archive bucket
 
         return pkg;
       });
+
+      // sync exported API(s)
+      await apiExporter?.synchronizePackage(package);
 
       // retract or re-populate public archive files
       await packageBackend.tarballStorage.updatePublicArchiveBucket(

--- a/app/lib/admin/actions/moderate_package_versions.dart
+++ b/app/lib/admin/actions/moderate_package_versions.dart
@@ -5,6 +5,7 @@
 import 'package:_pub_shared/utils/sdk_version_cache.dart';
 import 'package:clock/clock.dart';
 
+import '../../package/api_export/api_exporter.dart';
 import '../../package/backend.dart';
 import '../../package/models.dart';
 import '../../scorecard/backend.dart';
@@ -113,6 +114,9 @@ Set the moderated flag on a package version (updating the flag and the timestamp
 
         return v;
       });
+
+      // sync exported API(s)
+      await apiExporter?.synchronizePackage(package);
 
       // retract or re-populate public archive files
       await packageBackend.tarballStorage.updatePublicArchiveBucket(

--- a/app/lib/package/api_export/exported_api.dart
+++ b/app/lib/package/api_export/exported_api.dart
@@ -402,6 +402,13 @@ final class ExportedPackage {
       }),
     ]);
   }
+
+  /// Deletes the files related to this package and [version].
+  Future<void> deleteVersion(String version) async {
+    await Future.wait([
+      tarball(version).delete(),
+    ]);
+  }
 }
 
 /// Information about an object to be used as source in a copy operation.


### PR DESCRIPTION
- Added export sync on moderation + tests (archive files and version listing checks).
- Implemented explicit deletion of exported archive files when a moderation happens on a package version. Only the archive file is deleted for now.