### PR TITLE
Change font of score key figures

### DIFF
--- a/pkg/web_css/lib/src/_pkg.scss
+++ b/pkg/web_css/lib/src/_pkg.scss
@@ -154,7 +154,7 @@
   }
 
   .score-key-figure-value {
-    font-family: var(--pub-default-headline-font_family);
+    font-family: var(--pub-default-text-font_family);
     font-size: 32px;
     line-height: 1;
 


### PR DESCRIPTION
Goes from this  
![image](https://github.com/user-attachments/assets/48404f34-2169-4c91-835f-484b73022d6f)
to this
![image](https://github.com/user-attachments/assets/118888e7-5dcf-4981-841c-ad82d335de2e)

Reducing the height difference between the numbers and letters.
