### PR TITLE
Increase description/topic weights by removing the document length compensation.

### DIFF
--- a/app/lib/search/mem_index.dart
+++ b/app/lib/search/mem_index.dart
@@ -79,6 +79,7 @@ class InMemoryPackageIndex {
     _descrIndex = TokenIndex(
       packageKeys,
       _documents.map((d) => d.description).toList(),
+      skipDocumentWeight: true,
     );
     _readmeIndex = TokenIndex(
       packageKeys,

--- a/app/lib/search/token_index.dart
+++ b/app/lib/search/token_index.dart
@@ -34,7 +34,11 @@ class TokenIndex<K> {
 
   late final _length = _ids.length;
 
-  TokenIndex(List<K> ids, List<String?> values) : _ids = ids {
+  TokenIndex(
+    List<K> ids,
+    List<String?> values, {
+    bool skipDocumentWeight = false,
+  }) : _ids = ids {
     assert(ids.length == values.length);
     final length = values.length;
     for (var i = 0; i < length; i++) {
@@ -48,7 +52,8 @@ class TokenIndex<K> {
         continue;
       }
       // Document weight is a highly scaled-down proxy of the length.
-      final dw = 1 + math.log(1 + tokens.length) / 100;
+      final dw =
+          skipDocumentWeight ? 1.0 : 1 + math.log(1 + tokens.length) / 100;
       for (final e in tokens.entries) {
         final token = e.key;
         final weights = _inverseIds.putIfAbsent(token, () => {});

--- a/app/test/search/bluetooth_test.dart
+++ b/app/test/search/bluetooth_test.dart
@@ -40,7 +40,7 @@ void main() {
         'packageHits': [
           {
             'package': 'flutter_blue',
-            'score': closeTo(0.98, 0.01),
+            'score': 1.0,
           },
         ],
       });

--- a/app/test/search/in_app_payments_test.dart
+++ b/app/test/search/in_app_payments_test.dart
@@ -52,7 +52,7 @@ Add _In-App Payments_ to your Flutter app with this plugin.''')),
         'packageHits': [
           {
             'package': 'flutter_iap',
-            'score': closeTo(0.70, 0.01),
+            'score': closeTo(0.73, 0.01),
           },
         ],
       });

--- a/app/test/search/json_tool_test.dart
+++ b/app/test/search/json_tool_test.dart
@@ -68,8 +68,8 @@ void main() {
         'totalCount': 3,
         'sdkLibraryHits': [],
         'packageHits': [
+          {'package': 'json2entity', 'score': 1.0},
           {'package': 'jsontool', 'score': 1.0},
-          {'package': 'json2entity', 'score': closeTo(0.97, 0.01)},
           {'package': 'json_to_model', 'score': closeTo(0.73, 0.01)},
         ],
       });

--- a/app/test/search/mem_index_test.dart
+++ b/app/test/search/mem_index_test.dart
@@ -109,7 +109,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'packageHits': [
           {
             'package': 'http',
-            'score': closeTo(0.93, 0.01),
+            'score': closeTo(0.96, 0.01),
           },
         ],
       });
@@ -140,7 +140,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'sdkLibraryHits': [],
         'packageHits': [
           {'package': 'http', 'score': closeTo(0.69, 0.01)},
-          {'package': 'async', 'score': closeTo(0.63, 0.01)},
+          {'package': 'async', 'score': closeTo(0.65, 0.01)},
         ],
       });
     });
@@ -381,7 +381,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'totalCount': 1,
         'sdkLibraryHits': [],
         'packageHits': [
-          {'package': 'http', 'score': closeTo(0.93, 0.01)},
+          {'package': 'http', 'score': closeTo(0.96, 0.01)},
         ],
       });
     });
@@ -494,7 +494,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'totalCount': 1,
         'sdkLibraryHits': [],
         'packageHits': [
-          {'package': 'http', 'score': closeTo(0.98, 0.01)},
+          {'package': 'http', 'score': 1.0},
         ],
       });
 
@@ -505,8 +505,8 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'totalCount': 3,
         'sdkLibraryHits': [],
         'packageHits': [
-          {'package': 'chrome_net', 'score': closeTo(0.98, 0.01)},
-          {'package': 'async', 'score': closeTo(0.98, 0.01)},
+          {'package': 'async', 'score': 1.0},
+          {'package': 'chrome_net', 'score': 1.0},
           {'package': 'http', 'score': closeTo(0.72, 0.01)},
         ],
       });
@@ -520,7 +520,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'totalCount': 1,
         'sdkLibraryHits': [],
         'packageHits': [
-          {'package': 'http', 'score': closeTo(0.70, 0.01)},
+          {'package': 'http', 'score': closeTo(0.72, 0.01)},
         ],
       });
     });
@@ -690,7 +690,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
           'sdkLibraryHits': [],
           'packageHits': [
             {'package': 'flutter_modular', 'score': 1.0},
-            {'package': 'serveme', 'score': closeTo(0.97, 0.01)},
+            {'package': 'serveme', 'score': 1.0},
           ]
         },
       );

--- a/app/test/search/rest_api_test.dart
+++ b/app/test/search/rest_api_test.dart
@@ -57,7 +57,7 @@ Recent versions (0.3.x and 0.4.x) of this plugin require [extensible codec funct
         'packageHits': [
           {
             'package': 'currency_cloud',
-            'score': closeTo(0.95, 0.01),
+            'score': 1.0,
           },
           {
             'package': 'cloud_firestore', // finds `rest` in name


### PR DESCRIPTION
- This is a follow-up to #8246 in relation with #8139.
- While we have increased the weight in #8246, the overall score of a hit with a non-name match was about 0.97-0.98, while a name match was always 1.0. This is because we have applied the document length compensation in the weight of the description index, and the longer it gets, the more we reduce it, while we don't do anything like that with the name matching.
- While we could have reduced the name scores, I think in this case it is actually better to just skip applying the document weight compensation for the description index (while still keeping it for the readme index).
- The updated test cases show that this is now indeed fixes the ranking difference.