### PR TITLE
Parse `#<topic>` expressions in SearchForm's parsed query text, and support it through the data serialization.

### DIFF
--- a/pkg/_pub_shared/lib/search/search_form.dart
+++ b/pkg/_pub_shared/lib/search/search_form.dart
@@ -228,10 +228,7 @@ class TagsPredicate {
   /// Returns the list of tag values that can be passed to search service URL.
   List<String> toQueryParameters() {
     return _values.entries.map((e) {
-      var tag = e.key;
-      if (tag.startsWith('topic:')) {
-        tag = '#${tag.substring(6)}';
-      }
+      final tag = e.key;
       return e.value ? tag : '-$tag';
     }).toList();
   }

--- a/pkg/_pub_shared/lib/search/search_form.dart
+++ b/pkg/_pub_shared/lib/search/search_form.dart
@@ -17,8 +17,8 @@ final RegExp _allDependencyRegExp =
 final _sortRegExp = RegExp('sort:([a-z]+)');
 final _updatedRegExp = RegExp('updated:([0-9][0-9a-z]*)');
 final _tagRegExp =
-    RegExp(r'([\+|\-]?[a-z0-9]+:[a-z0-9\-_\.]+)', caseSensitive: false);
-final _topicRegExp = RegExp(r'([\+|\-])?#([a-z0-9-]{2,32})');
+    RegExp(r'([\+\-]?[a-z0-9]+:[a-z0-9\-_\.]+)', caseSensitive: false);
+final _topicRegExp = RegExp(r'([\+\-])?#([a-z0-9-]{2,32})');
 
 /// The tag prefixes that we can detect in the user-provided search query.
 final _detectedTagPrefixes = <String>{

--- a/pkg/_pub_shared/test/search/search_form_test.dart
+++ b/pkg/_pub_shared/test/search/search_form_test.dart
@@ -212,19 +212,19 @@ void main() {
       final query = SearchForm(query: 'abc #xyz');
       final pq = query.parsedQuery;
       expect(pq.text, 'abc');
-      expect(pq.tagsPredicate.toQueryParameters(), ['#xyz']);
+      expect(pq.tagsPredicate.toQueryParameters(), ['topic:xyz']);
       expect(pq.tagsPredicate.matches(['topic:xyz']), true);
       expect(pq.tagsPredicate.matches(['topic:abc']), false);
-      expect(pq.toString(), '#xyz abc');
+      expect(pq.toString(), 'topic:xyz abc');
     });
 
     test('negative hash is parsed', () {
       final query = SearchForm(query: '-#abc');
       final pq = query.parsedQuery;
-      expect(pq.tagsPredicate.toQueryParameters(), ['-#abc']);
+      expect(pq.tagsPredicate.toQueryParameters(), ['-topic:abc']);
       expect(pq.tagsPredicate.matches(['topic:xyz']), true);
       expect(pq.tagsPredicate.matches(['topic:abc']), false);
-      expect(pq.toString(), '-#abc');
+      expect(pq.toString(), '-topic:abc');
     });
 
     test('negative tag predicate in the serialization parsing', () {

--- a/pkg/_pub_shared/test/search/search_form_test.dart
+++ b/pkg/_pub_shared/test/search/search_form_test.dart
@@ -211,9 +211,26 @@ void main() {
     test('text + topic with hash prefix', () {
       final query = SearchForm(query: 'abc #xyz');
       final pq = query.parsedQuery;
-      expect(pq.text, 'abc #xyz');
-      expect(pq.tagsPredicate.toQueryParameters(), []);
-      expect(pq.toString(), 'abc #xyz');
+      expect(pq.text, 'abc');
+      expect(pq.tagsPredicate.toQueryParameters(), ['#xyz']);
+      expect(pq.tagsPredicate.matches(['topic:xyz']), true);
+      expect(pq.tagsPredicate.matches(['topic:abc']), false);
+      expect(pq.toString(), '#xyz abc');
+    });
+
+    test('negative hash is parsed', () {
+      final query = SearchForm(query: '-#abc');
+      final pq = query.parsedQuery;
+      expect(pq.tagsPredicate.toQueryParameters(), ['-#abc']);
+      expect(pq.tagsPredicate.matches(['topic:xyz']), true);
+      expect(pq.tagsPredicate.matches(['topic:abc']), false);
+      expect(pq.toString(), '-#abc');
+    });
+
+    test('negative tag predicate in the serialization parsing', () {
+      final tp = TagsPredicate.parseQueryValues(['-#abc']);
+      expect(tp.matches(['topic:abc']), false);
+      expect(tp.matches(['topic:xyz']), true);
     });
   });
 

--- a/pkg/_pub_shared/test/search/search_form_test.dart
+++ b/pkg/_pub_shared/test/search/search_form_test.dart
@@ -199,6 +199,22 @@ void main() {
       expect(query.parsedQuery.tagsPredicate.toQueryParameters(),
           ['publisher:example.com']);
     });
+
+    test('text + topic with tag prefix', () {
+      final query = SearchForm(query: 'abc topic:xyz');
+      final pq = query.parsedQuery;
+      expect(pq.text, 'abc');
+      expect(pq.tagsPredicate.toQueryParameters(), ['topic:xyz']);
+      expect(pq.toString(), 'topic:xyz abc');
+    });
+
+    test('text + topic with hash prefix', () {
+      final query = SearchForm(query: 'abc #xyz');
+      final pq = query.parsedQuery;
+      expect(pq.text, 'abc #xyz');
+      expect(pq.tagsPredicate.toQueryParameters(), []);
+      expect(pq.toString(), 'abc #xyz');
+    });
   });
 
   group('Search URLs', () {


### PR DESCRIPTION
- part of #8189, follow-up to #8227
- this does not reverse the topic expression canonicalization of #8227, but enables that option to be done later
- separated the new tests into two commits, they can be compared before-after the current change
