### PR TITLE
Improve /experimental

### DIFF
--- a/app/lib/frontend/handlers/experimental.dart
+++ b/app/lib/frontend/handlers/experimental.dart
@@ -6,16 +6,18 @@ import 'package:meta/meta.dart';
 
 import '../../shared/cookie_utils.dart';
 
-const _publicFlags = <String>{
-  'dark',
-  'download-counts',
-  'search-completion',
-  'search-topics',
+typedef PublicFlag = ({String name, String description});
+
+const _publicFlags = <PublicFlag>{
+  (name: 'dark', description: 'Dark mode'),
+  (name: 'download-counts', description: 'Download count metrics'),
+  (name: 'search-completion', description: 'Completions for the search bar'),
+  (name: 'search-topics', description: 'Show matching topics when searching'),
 };
 
-const _allFlags = <String>{
+final _allFlags = <String>{
   'dark-as-default',
-  ..._publicFlags,
+  ..._publicFlags.map((x) => x.name),
 };
 
 /// The name of the experimental cookie.
@@ -33,7 +35,8 @@ class ExperimentalFlags {
   ExperimentalFlags(Set<String> enabled)
       : _enabled = enabled.intersection(_allFlags);
 
-  static final List<String> publicFlags = _publicFlags.toList()..sort();
+  static final List<PublicFlag> publicFlags = _publicFlags.toList()
+    ..sort((a, b) => a.name.compareTo(b.name));
   static final ExperimentalFlags empty = ExperimentalFlags(const {});
 
   factory ExperimentalFlags.parseFromCookie(String? value) {

--- a/app/lib/frontend/handlers/misc.dart
+++ b/app/lib/frontend/handlers/misc.dart
@@ -223,7 +223,7 @@ Future<shelf.Response> experimentalHandler(shelf.Request request) async {
 <body>
     <h1>Experiments</h1>
     <p>
-      Experiments are not part of the official pub.dev site.
+      Experiments are not an official part of the pub.dev site.
     <p>
       They showcase features we are working on, that are not yet ready for
       deployment, and might still not:

--- a/app/lib/frontend/handlers/misc.dart
+++ b/app/lib/frontend/handlers/misc.dart
@@ -204,29 +204,48 @@ Future<shelf.Response> experimentalHandler(shelf.Request request) async {
 
   final clearUri = Uri(
       path: '/experimental', queryParameters: flags.urlParametersForToggle());
-  final clearLink = flags.isEmpty ? '' : '(<a href="$clearUri">clear</a>).';
-  final publicBlock = ExperimentalFlags.publicFlags.map((f) {
-    final change = flags.isEnabled(f) ? '0' : '1';
-    final uri = Uri(path: '/experimental', queryParameters: {f: change});
-    return '<a href="$uri">toggle: <b>$f</b></a><br />';
-  }).join();
+  final clearLink = flags.isEmpty ? '' : '(<a href="$clearUri">clear all</a>).';
+  final publicBlock = '''
+<ul>
+  ${ExperimentalFlags.publicFlags.map((f) {
+    final change = flags.isEnabled(f.name) ? '0' : '1';
+    final uri = Uri(path: '/experimental', queryParameters: {f.name: change});
+    return '<li><b>${f.description}</b> <a href="$uri">(toggle)</a>';
+  }).join()}
+</ul>
+''';
   return htmlResponse('''
 <!doctype html>
 <html>
 <head>
-  <meta http-equiv="refresh" content="15; url=/">
   <meta name="robots" content="noindex" />
 </head>
 <body>
-  <center>
+    <h1>Experiments</h1>
+    <p>
+      Experiments are not part of the official pub.dev site.
+    <p>
+      They showcase features we are working on, that are not yet ready for
+      deployment, and might still not:
+      <ul>
+      <li> work fully or as expected, 
+      <li> be well documented,
+      <li> have good accesibility,
+      <li> have the final polished styling.
+      </ul>
+    <p>
+      Enable experiments at your own discresion.
+    <p>
+      An experiment is no promise of an actual later launch of that given feature.
+    <p>
+      Still, feel free to provide feedback on the
+      <a href="https://github.com/dart-lang/pub-dev/issues">issue tracker</a>.
+      Be sure to mention what experiments were enabled.
     <p>
       Experiments enabled: <b>$flags</b><br>$clearLink
-    </p>
-    <p>$publicBlock</p>
+    <p>$publicBlock
     <p>
-      (redirecting to <a href="/">pub.dev</a> in 15 seconds).
-    </p>
-  </center>
+      After enabling experiments go back to <a href="/">pub.dev</a>.
 </body>
 </html>''', headers: {
     HttpHeaders.setCookieHeader: buildSetCookieValue(


### PR DESCRIPTION
* Add disclaimer and a bit of context
* Remove timeout
* (short-form) Descriptions for public experiments
* a bit of styling changes (still the page should IMO appear "raw" to not appear part of the product).
<img width="759" alt="image" src="https://github.com/user-attachments/assets/276c9b2d-9d37-40a7-8a2f-1f2eaf82a9be">

Before
<img width="391" alt="image" src="https://github.com/user-attachments/assets/0b902abc-a77f-450c-8c6a-96f5fdfe7d3c">
