### PR TITLE
Wider gaps in pagination buttons.

### DIFF
--- a/pkg/web_css/lib/src/_list.scss
+++ b/pkg/web_css/lib/src/_list.scss
@@ -341,7 +341,8 @@
     background: var(--pub-inset-bgColor);
     font-size: 14px;
     border-radius: 3px;
-    margin-top: 40px;
+    margin: 40px 3px 0 3px;
+    min-width: 42px; // otherwise page "1" would be much narrower than e.g. page "2"
 
     &.-disabled {
       pointer-events: none;


### PR DESCRIPTION
- Fixes #8305.
- Also adds `min-width` so that buttons like "1" don't get too narrow.

![image](https://github.com/user-attachments/assets/5f8bb7f1-5c90-4a21-ac9d-f56ea809eefe)
