### PR TITLE
Increase the contrast for the copy icon in the search list.

### DIFF
--- a/pkg/web_css/lib/src/_list.scss
+++ b/pkg/web_css/lib/src/_list.scss
@@ -193,7 +193,15 @@
     margin: 0px -30px 6px -30px;
     padding: 15px 30px;
 
+    .pkg-page-title-copy-icon {
+      opacity: 0.15;
+    }
+
     &:hover {
+      .pkg-page-title-copy-icon {
+        opacity: 0.25;
+      }
+
       background: var(--pub-neutral-hover-bgColor);
     }
   }


### PR DESCRIPTION
- Fixes #8309
- Deployed to staging.

![image](https://github.com/user-attachments/assets/d7fb9e82-645e-4db1-b1e6-a51533094383)

![image](https://github.com/user-attachments/assets/7e97a567-9882-4ebb-a58f-564395869c4c)

![image](https://github.com/user-attachments/assets/515d62ed-d196-4729-8ea8-d0d3e87d672e)

![image](https://github.com/user-attachments/assets/6a0e0525-3b99-4144-bc29-c9cd8f878aa6)
