### PR TITLE
Use border-color instead of drop shadow for sort control widget.

### DIFF
--- a/pkg/web_css/lib/src/_list.scss
+++ b/pkg/web_css/lib/src/_list.scss
@@ -55,7 +55,8 @@
   .sort-control-popup {
     display: none;
 
-    box-shadow: 0px 0px 2px 0px rgba(0, 0, 0, 0.3);
+    border: 2px solid var(--pub-neutral-borderColor);
+    border-radius: 4px;
     position: absolute;
     right: 0px;
     white-space: nowrap;


### PR DESCRIPTION
- #8307
- The light mode didn't change much, the dark mode seems to be much better: 
<img width="164" alt="image" src="https://github.com/user-attachments/assets/1e67904e-898d-44c4-8bc2-40fe981f5216">
<img width="161" alt="image" src="https://github.com/user-attachments/assets/2382d0f6-ffac-4f34-a87f-c523c1cc42fb">
