### PR TITLE
Use ScorePool for dartdoc and SDK search results.

### DIFF
--- a/app/lib/search/sdk_mem_index.dart
+++ b/app/lib/search/sdk_mem_index.dart
@@ -137,7 +137,8 @@ class SdkMemIndex {
       final isQualifiedQuery = query.contains(library.split(':').last);
 
       final tokens = _tokensPerLibrary[library]!;
-      final plainResults = tokens.searchWords(words).top(3, minValue: 0.05);
+      final plainResults = tokens.withSearchWords(
+          words, (score) => score.top(3, minValue: 0.05));
       if (plainResults.isEmpty) continue;
 
       final libraryWeight = _libraryWeights[library] ?? 1.0;


### PR DESCRIPTION
This reduces the memory allocations on requests a bit further, reducing latencies up to 10% in the local benchmark.
