### PR TITLE
Fix code coverage collection for integration tests.

### DIFF
--- a/pkg/code_coverage/lib/test_runner.dart
+++ b/pkg/code_coverage/lib/test_runner.dart
@@ -98,7 +98,6 @@ Future<Process> _startCollect(int port, String outputFile) async {
   final p = await Process.start(
     'dart',
     [
-      'pub',
       'run',
       'coverage:collect_coverage',
       '--uri=http://localhost:$port',
@@ -123,7 +122,6 @@ Future<void> _convertToLcov(
   await Process.run(
     'dart',
     [
-      'pub',
       'run',
       'coverage:format_coverage',
       '--packages',

--- a/pkg/pub_integration/lib/src/fake_pub_server_process.dart
+++ b/pkg/pub_integration/lib/src/fake_pub_server_process.dart
@@ -261,7 +261,6 @@ class _CoverageConfig {
     _process = await Process.start(
       'dart',
       [
-        'pub',
         'run',
         'coverage:collect_coverage',
         '--uri=http://localhost:$vmPort',


### PR DESCRIPTION
With the `pub` tool being part of the executable, the process failed with:
```
Package "coverage" is not an immediate dependency.
Cannot run executables in transitive dependencies.
```
