### PR TITLE
Use dartdoc 8.3.0 for packages that depend on macros.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Important changes to data models, configuration, and migrations between each
 AppEngine version, listed here to ease deployment and troubleshooting.
 
 ## Next Release (replace with git tag when deployed)
+ * Bump runtimeVersion to `2024.11.26`.
+ * `dartdoc 8.3.0` is used for packages depending on `package:macros`. 
 
 ## `20241121t150900-all`
  * Bump runtimeVersion to `2024.11.21`.

--- a/app/lib/shared/versions.dart
+++ b/app/lib/shared/versions.dart
@@ -24,10 +24,10 @@ final RegExp runtimeVersionPattern = RegExp(r'^\d{4}\.\d{2}\.\d{2}$');
 /// when the version switch happens.
 const _acceptedRuntimeVersions = <String>[
   // The current [runtimeVersion].
-  '2024.11.21',
+  '2024.11.26',
   // Fallback runtime versions.
+  '2024.11.21',
   '2024.11.18',
-  '2024.11.11',
 ];
 
 /// Sets the current runtime versions.


### PR DESCRIPTION
This is a temporary override to get `package:analyzer` documentation generated.