### PR TITLE
Detect redirecting page in the dartdoc-generated output + render in-place

### DIFF
--- a/app/lib/fake/backend/fake_pub_worker.dart
+++ b/app/lib/fake/backend/fake_pub_worker.dart
@@ -237,6 +237,7 @@ Map<String, String> _fakeDartdocFiles(
       usingBaseHref: null,
       aboveSidebarUrl: null,
       belowSidebarUrl: null,
+      redirectPath: null,
     ).toJson()),
     'index.json': '{}',
     'pub-data.json': json.encode(pubData),
@@ -251,6 +252,7 @@ Map<String, String> _fakeDartdocFiles(
       usingBaseHref: null,
       aboveSidebarUrl: null,
       belowSidebarUrl: null,
+      redirectPath: null,
     ).toJson()),
   };
 }

--- a/app/test/dartdoc/dartdoc_page_test.dart
+++ b/app/test/dartdoc/dartdoc_page_test.dart
@@ -34,6 +34,24 @@ import '../shared/utils.dart';
 // we may need to update either the test or the rendering templates until
 // there are only known and accepted differences between the two.
 void main() {
+  group('DartDocPage parsing edge cases', () {
+    test('parse redirect URL', () {
+      final redirectContent = '''<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <link rel="canonical" href="../retry" />
+    <meta http-equiv="refresh" content="0; url=../retry" />
+  </head>
+  <body>
+    <p><a href="../retry">New URL</a></p>
+  </body>
+</html>''';
+      final page = DartDocPage.parse(redirectContent);
+      expect(page.isEmpty(), true);
+      expect(page.redirectPath, '../retry');
+    });
+  });
+
   group('DartDocPage rendering', () {
     final tempDir = Directory.systemTemp.createTempSync();
     final pkgDir = p.join(tempDir.path, 'pkg');

--- a/pkg/_pub_shared/lib/dartdoc/dartdoc_page.g.dart
+++ b/pkg/_pub_shared/lib/dartdoc/dartdoc_page.g.dart
@@ -40,6 +40,7 @@ DartDocPage _$DartDocPageFromJson(Map<String, dynamic> json) => DartDocPage(
       usingBaseHref: json['usingBaseHref'] as String?,
       aboveSidebarUrl: json['aboveSidebarUrl'] as String?,
       belowSidebarUrl: json['belowSidebarUrl'] as String?,
+      redirectPath: json['redirectPath'] as String?,
     );
 
 Map<String, dynamic> _$DartDocPageToJson(DartDocPage instance) =>
@@ -54,4 +55,5 @@ Map<String, dynamic> _$DartDocPageToJson(DartDocPage instance) =>
       'usingBaseHref': instance.usingBaseHref,
       'aboveSidebarUrl': instance.aboveSidebarUrl,
       'belowSidebarUrl': instance.belowSidebarUrl,
+      'redirectPath': instance.redirectPath,
     };


### PR DESCRIPTION
This is a temporary fix for the dartdoc-generated redirect files. The proper fix will be to return a redirect HTTP response, but that needs a significant change in the current rendering and cache logic, and I'd rather do it in a follow-up PR.