### PR TITLE
Implementing redirect on dartdoc-generated redirect file.

### DIFF
--- a/app/lib/dartdoc/models.dart
+++ b/app/lib/dartdoc/models.dart
@@ -42,3 +42,52 @@ class ResolvedDocUrlVersion {
   bool get isEmpty => version.isEmpty || urlSegment.isEmpty;
   bool get isLatestStable => urlSegment == 'latest';
 }
+
+/// Describes the status of a dartdoc page.
+@JsonSerializable(includeIfNull: false)
+class DocPageStatus {
+  final DocPageStatusCode code;
+  final String? redirectPath;
+  final String? errorMessage;
+
+  DocPageStatus({
+    required this.code,
+    this.redirectPath,
+    this.errorMessage,
+  });
+
+  factory DocPageStatus.ok() {
+    return DocPageStatus(code: DocPageStatusCode.ok);
+  }
+
+  factory DocPageStatus.redirect(String redirectPath) {
+    return DocPageStatus(
+      code: DocPageStatusCode.redirect,
+      redirectPath: redirectPath,
+    );
+  }
+
+  factory DocPageStatus.missing(String errorMessage) {
+    return DocPageStatus(
+      code: DocPageStatusCode.missing,
+      errorMessage: errorMessage,
+    );
+  }
+
+  factory DocPageStatus.fromJson(Map<String, dynamic> json) =>
+      _$DocPageStatusFromJson(json);
+
+  Map<String, dynamic> toJson() => _$DocPageStatusToJson(this);
+}
+
+/// Explicit status of [DocPageStatus].
+enum DocPageStatusCode {
+  /// page generated and ready to be served
+  ok,
+
+  /// page generated and redirects to a new URL
+  redirect,
+
+  /// page does not exists
+  missing,
+}

--- a/app/lib/dartdoc/models.g.dart
+++ b/app/lib/dartdoc/models.g.dart
@@ -30,3 +30,32 @@ Map<String, dynamic> _$ResolvedDocUrlVersionToJson(
   writeNotNull('message', instance.message);
   return val;
 }
+
+DocPageStatus _$DocPageStatusFromJson(Map<String, dynamic> json) =>
+    DocPageStatus(
+      code: $enumDecode(_$DocPageStatusCodeEnumMap, json['code']),
+      redirectPath: json['redirectPath'] as String?,
+      errorMessage: json['errorMessage'] as String?,
+    );
+
+Map<String, dynamic> _$DocPageStatusToJson(DocPageStatus instance) {
+  final val = <String, dynamic>{
+    'code': _$DocPageStatusCodeEnumMap[instance.code]!,
+  };
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('redirectPath', instance.redirectPath);
+  writeNotNull('errorMessage', instance.errorMessage);
+  return val;
+}
+
+const _$DocPageStatusCodeEnumMap = {
+  DocPageStatusCode.ok: 'ok',
+  DocPageStatusCode.redirect: 'redirect',
+  DocPageStatusCode.missing: 'missing',
+};

--- a/app/lib/shared/redis_cache.dart
+++ b/app/lib/shared/redis_cache.dart
@@ -378,6 +378,22 @@ class CachePatterns {
           .withPrefix('dartdoc-html/')
           .withTTL(Duration(minutes: 10))['$package/$urlSegment/$path'];
 
+  /// Cache for sanitized and re-rendered dartdoc HTML files.
+  Entry<DocPageStatus> dartdocPageStatus(
+    String package,
+    String urlSegment,
+    String path,
+  ) =>
+      _cache
+          .withPrefix('dartdoc-status/')
+          .withTTL(Duration(minutes: 10))
+          .withCodec(utf8)
+          .withCodec(json)
+          .withCodec(wrapAsCodec(
+              encode: (DocPageStatus s) => s.toJson(),
+              decode: (data) => DocPageStatus.fromJson(
+                  data as Map<String, dynamic>)))['$package/$urlSegment/$path'];
+
   /// Stores the OpenID Data (including the JSON Web Key list).
   ///
   /// GitHub does not provide `Cache-Control` header for their

--- a/app/lib/task/backend.dart
+++ b/app/lib/task/backend.dart
@@ -869,6 +869,18 @@ class TaskBackend {
     return index;
   }
 
+  /// Whether the task result for the given [package]/[version] has any result
+  /// dartdoc-generated file in [path].
+  Future<bool> hasDartdocTaskResult(
+      String package, String version, String path) async {
+    version = canonicalizeVersion(version)!;
+    final index = await _taskResultIndex(package, version);
+    if (index == null) {
+      return false;
+    }
+    return index.lookup('doc/$path') != null;
+  }
+
   /// Return gzipped result from task for the given [package]/[version] or
   /// `null`.
   Future<List<int>?> gzippedTaskResult(

--- a/app/lib/task/backend.dart
+++ b/app/lib/task/backend.dart
@@ -869,18 +869,6 @@ class TaskBackend {
     return index;
   }
 
-  /// Whether the task result for the given [package]/[version] has any result
-  /// dartdoc-generated file in [path].
-  Future<bool> hasDartdocTaskResult(
-      String package, String version, String path) async {
-    version = canonicalizeVersion(version)!;
-    final index = await _taskResultIndex(package, version);
-    if (index == null) {
-      return false;
-    }
-    return index.lookup('doc/$path') != null;
-  }
-
   /// Return gzipped result from task for the given [package]/[version] or
   /// `null`.
   Future<List<int>?> gzippedTaskResult(

--- a/pkg/pub_integration/test/dartdoc_search_test.dart
+++ b/pkg/pub_integration/test/dartdoc_search_test.dart
@@ -60,6 +60,18 @@ void main() {
             startsWith('$origin/documentation/oxygen/latest/oxygen/'));
         expect(page.url, endsWith('.html'));
       });
+
+      // test library page (future redirect)
+      await user.withBrowserPage((page) async {
+        await page.gotoOrigin(
+            '/documentation/oxygen/latest/oxygen/oxygen-library.html');
+        await Future.delayed(Duration(milliseconds: 200));
+        // NOTE: This test does nothing substantial right now, but once we migrate
+        //       to dartdoc 8.3, this will test the redirect handler.
+        expect(page.url,
+            '$origin/documentation/oxygen/latest/oxygen/oxygen-library.html');
+        expect(await page.content, contains('TypeEnum'));
+      });
     });
   }, timeout: Timeout.factor(testTimeoutFactor));
 }


### PR DESCRIPTION
- Follow-up to #8342, implementing the redirect instead of in-place rendering.
- Updated the document serving handler by adding a second cached value about the status of a page, whether is served, missing or redirected.
- Optimized the code for the optimistic happy path, trying to serve the cached bytes first (if any), then trying the cached status (if any), then calculating and updating both as the final fallback path.
- Added a test that should fail / should be updated when we migrate to 8.3 dartdoc.
