### PR TITLE
Migrate isBlocked flags to isModerated.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ AppEngine version, listed here to ease deployment and troubleshooting.
  * Upgraded dartdoc to `8.3.0`.
  * Upgraded pana to `0.22.16`.
  * Upgraded dependencies.
+ * Note: started migrating `isBlocked` flags to `isModerated`.
 
 ## `20241121t150900-all`
  * Bump runtimeVersion to `2024.11.21`.

--- a/app/lib/tool/backfill/backfill_new_fields.dart
+++ b/app/lib/tool/backfill/backfill_new_fields.dart
@@ -2,7 +2,14 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:clock/clock.dart';
 import 'package:logging/logging.dart';
+import 'package:pub_dev/account/models.dart';
+import 'package:pub_dev/package/api_export/api_exporter.dart';
+import 'package:pub_dev/package/backend.dart';
+import 'package:pub_dev/package/models.dart';
+import 'package:pub_dev/publisher/models.dart';
+import 'package:pub_dev/shared/datastore.dart';
 
 final _logger = Logger('backfill_new_fields');
 
@@ -12,5 +19,72 @@ final _logger = Logger('backfill_new_fields');
 /// CHANGELOG.md must be updated with the new fields, and the next
 /// release could remove the backfill from here.
 Future<void> backfillNewFields() async {
-  _logger.info('Nothing to backfill');
+  await migrateIsBlocked();
+}
+
+/// Migrates entities from the `isBlocked` fields to the new `isModerated` instead.
+Future<void> migrateIsBlocked() async {
+  _logger.info('Migrating isBlocked...');
+  final pkgQuery = dbService.query<Package>()..filter('isBlocked =', true);
+  await for (final entity in pkgQuery.run()) {
+    await withRetryTransaction(dbService, (tx) async {
+      final pkg = await tx.lookupValue<Package>(entity.key);
+      // sanity check
+      if (!pkg.isBlocked) {
+        return;
+      }
+      pkg
+        ..isModerated = true
+        ..moderatedAt = pkg.moderatedAt ?? pkg.blocked ?? clock.now()
+        ..isBlocked = false
+        ..blocked = null
+        ..blockedReason = null;
+      tx.insert(pkg);
+    });
+
+    // sync exported API(s)
+    await apiExporter?.synchronizePackage(entity.name!, forceDelete: true);
+
+    // retract or re-populate public archive files
+    await packageBackend.tarballStorage.updatePublicArchiveBucket(
+      package: entity.name!,
+      ageCheckThreshold: Duration.zero,
+      deleteIfOlder: Duration.zero,
+    );
+  }
+
+  final publisherQuery = dbService.query<Publisher>()
+    ..filter('isBlocked =', true);
+  await for (final entity in publisherQuery.run()) {
+    await withRetryTransaction(dbService, (tx) async {
+      final publisher = await tx.lookupValue<Publisher>(entity.key);
+      // sanity check
+      if (!publisher.isBlocked) {
+        return;
+      }
+      publisher
+        ..isModerated = true
+        ..moderatedAt = publisher.moderatedAt ?? clock.now()
+        ..isBlocked = false;
+      tx.insert(publisher);
+    });
+  }
+
+  final userQuery = dbService.query<User>()..filter('isBlocked =', true);
+  await for (final entity in userQuery.run()) {
+    await withRetryTransaction(dbService, (tx) async {
+      final user = await tx.lookupValue<User>(entity.key);
+      // sanity check
+      if (!user.isBlocked) {
+        return;
+      }
+      user
+        ..isModerated = true
+        ..moderatedAt = user.moderatedAt ?? clock.now()
+        ..isBlocked = false;
+      tx.insert(user);
+    });
+  }
+
+  _logger.info('isBlocked migration completed.');
 }

--- a/app/test/tool/maintenance/migrate_isblocked_test.dart
+++ b/app/test/tool/maintenance/migrate_isblocked_test.dart
@@ -1,0 +1,52 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:pub_dev/account/backend.dart';
+import 'package:pub_dev/package/backend.dart';
+import 'package:pub_dev/publisher/backend.dart';
+import 'package:pub_dev/shared/datastore.dart';
+import 'package:pub_dev/tool/backfill/backfill_new_fields.dart';
+import 'package:test/test.dart';
+
+import '../../shared/test_services.dart';
+
+void main() {
+  group('Migrate isBlocked', () {
+    testWithProfile('package', fn: () async {
+      final p1 = await packageBackend.lookupPackage('oxygen');
+      await dbService.commit(
+          inserts: [p1!..updateIsBlocked(isBlocked: true, reason: 'abc')]);
+      await migrateIsBlocked();
+
+      final p2 = await packageBackend.lookupPackage('oxygen');
+      expect(p2!.isModerated, true);
+    });
+
+    testWithProfile('publisher', fn: () async {
+      final p1 = await publisherBackend.getPublisher('example.com');
+      await dbService.commit(inserts: [p1!..markForBlocked()]);
+      final members =
+          await publisherBackend.listPublisherMembers('example.com');
+      for (final m in members) {
+        await accountBackend.updateBlockedFlag(m.userId, true);
+      }
+      final neon = await packageBackend.lookupPackage('neon');
+      await dbService.commit(inserts: [neon!..isDiscontinued = true]);
+
+      await migrateIsBlocked();
+
+      final p2 = await publisherBackend.getPublisher('example.com');
+      expect(p2!.isModerated, true);
+    });
+
+    testWithProfile('user', fn: () async {
+      final u1 = await accountBackend.lookupUserByEmail('user@pub.dev');
+      await dbService.commit(inserts: [u1..isBlocked = true]);
+      await migrateIsBlocked();
+
+      final u2 = await accountBackend.lookupUserByEmail('user@pub.dev');
+      expect(u2.isModerated, true);
+    });
+  });
+}

--- a/pkg/fake_gcloud/lib/mem_datastore.dart
+++ b/pkg/fake_gcloud/lib/mem_datastore.dart
@@ -172,6 +172,9 @@ class MemDatastore implements Datastore {
         return -1;
       }
     }
+    if (a is bool && b is bool) {
+      return a == b ? 0 : (a ? 1 : -1);
+    }
     if (a is Key && b is Key) {
       if (a.elements.length != 1) {
         throw UnimplementedError();


### PR DESCRIPTION
- #8336
- added the migration as part of the new-field pub-task, as there seems to be little reason to create a separate task for it (which will be removed and then reported as not working)
- added a test that does not use the admin action to set the flags - they can be also removed (in a separate PR)
- added the migration to be part of the post-test part of the profile-based tests, so that we can make sure we don't have any inconsistency after they run (to be extended to all periodic tasks in a follow-up PR) 