### PR TITLE
Run all periodic task + another integrity check after each test.

### DIFF
--- a/app/lib/service/entrypoint/analyzer.dart
+++ b/app/lib/service/entrypoint/analyzer.dart
@@ -68,8 +68,7 @@ Future _workerMain(EntryMessage message) async {
   await taskBackend.start();
   registerScopeExitCallback(() => taskBackend.stop());
 
-  setupAnalyzerPeriodicTasks();
-  setupSearchPeriodicTasks();
+  setupPeriodTaskSchedulers();
 
   // wait indefinitely
   await Completer().future;

--- a/app/lib/tool/neat_task/pub_dev_tasks.dart
+++ b/app/lib/tool/neat_task/pub_dev_tasks.dart
@@ -34,199 +34,207 @@ import 'datastore_status_provider.dart';
 
 final _logger = Logger('pub_dev_tasks');
 
-/// Periodic task that are not tied to a specific service.
-void _setupGenericPeriodicTasks() {
-  // Tries to send pending outgoing emails.
-  _15mins(
-    name: 'send-outgoing-emails',
-    isRuntimeVersioned: false,
-    task: () async {
-      final acquireAbort = Completer();
-      final acquireTimer = Timer(Duration(minutes: 2), () {
-        acquireAbort.complete();
-      });
+/// Creates and initialized periodic task schedulers.
+void setupPeriodTaskSchedulers() {
+  for (final scheduler in createPeriodicTaskSchedulers()) {
+    ss.registerScopeExitCallback(() => scheduler.stop());
+    scheduler.start();
+  }
+}
 
-      try {
-        final lock = GlobalLock.create(
-          'send-outgoing-emails',
-          expiration: Duration(minutes: 20),
-        );
-        await lock.withClaim(
-          (claim) async {
-            await emailBackend.trySendAllOutgoingEmails(
-              stopAfter: Duration(minutes: 10),
-            );
-          },
-          abort: acquireAbort,
-        );
-      } finally {
-        acquireTimer.cancel();
-      }
-    },
-  );
+/// List of periodic task schedulers.
+List<NeatPeriodicTaskScheduler> createPeriodicTaskSchedulers() {
+  return [
+    // Tries to send pending outgoing emails.
+    _15mins(
+      name: 'send-outgoing-emails',
+      isRuntimeVersioned: false,
+      task: () async {
+        final acquireAbort = Completer();
+        final acquireTimer = Timer(Duration(minutes: 2), () {
+          acquireAbort.complete();
+        });
 
-  // Deletes outgoing email entries that had failed to deliver.
-  _daily(
-    name: 'delete-outgoing-emails',
-    isRuntimeVersioned: false,
-    task: emailBackend.deleteDeadOutgoingEmails,
-  );
-
-  // Backfills the fields that are new to the current release.
-  _daily(
-    name: 'backfill-new-fields',
-    isRuntimeVersioned: true,
-    task: backfillNewFields,
-  );
-
-  // Deletes expired audit log records.
-  _daily(
-    name: 'delete-expired-audit-log-records',
-    isRuntimeVersioned: false,
-    task: () async => await auditBackend.deleteExpiredRecords(),
-  );
-
-  // Deletes expired consent invites.
-  _daily(
-    name: 'delete-expired-consents',
-    isRuntimeVersioned: false,
-    task: () async => await consentBackend.deleteObsoleteConsents(),
-  );
-
-  // Deletes expired sessions.
-  _daily(
-    name: 'delete-expired-sessions',
-    isRuntimeVersioned: false,
-    task: () async => await accountBackend.deleteExpiredSessions(),
-  );
-
-  // Updates Package's stable, prerelease and preview version fields in case a
-  // new Dart SDK got released.
-  _daily(
-    name: 'update-package-versions',
-    isRuntimeVersioned: false,
-    task: () async => await packageBackend.updateAllPackageVersions(),
-  );
-
-  // Updates the public archive bucket from the canonical bucket, for the
-  // unlikely case where an archive may be missing.
-  _daily(
-    name: 'sync-public-bucket-from-canonical-bucket',
-    isRuntimeVersioned: false,
-    task: () async =>
-        await packageBackend.tarballStorage.updatePublicArchiveBucket(),
-  );
-
-  // Exports the package name completion data to a bucket.
-  _daily(
-    name: 'synchronize-exported-api',
-    isRuntimeVersioned: true,
-    task: () async => await apiExporter?.synchronizeExportedApi(),
-  );
-
-  // Deletes moderated packages, versions, publishers and users.
-  _weekly(
-    name: 'delete-moderated-subjects',
-    isRuntimeVersioned: false,
-    task: () async => adminBackend.deleteModeratedSubjects(),
-  );
-
-  // Deletes task status entities where the status hasn't been updated
-  // for more than a month.
-  _weekly(
-    name: 'delete-old-neat-task-statuses',
-    isRuntimeVersioned: false,
-    task: () => deleteOldNeatTaskStatuses(dbService),
-  );
-
-  // Deletes orphaned like entities that are missing a reference.
-  _weekly(
-    name: 'remove-orphaned-likes',
-    isRuntimeVersioned: false,
-    task: removeOrphanedLikes,
-  );
-
-  // Updates Package.likes with the correct new value.
-  _weekly(
-    name: 'update-package-likes',
-    isRuntimeVersioned: false,
-    task: updatePackageLikes,
-  );
-
-  // Updates PackageState in taskBackend
-  _weekly(
-    name: 'backfill-task-tracking-state',
-    isRuntimeVersioned: true,
-    task: taskBackend.backfillTrackingState,
-  );
-
-  // Deletes task results for old runtime versions
-  _weekly(
-    name: 'garbage-collect-task-results',
-    isRuntimeVersioned: false,
-    task: taskBackend.garbageCollect,
-  );
-
-  // Delete very old instances that have been abandoned
-  _daily(
-    name: 'garbage-collect-old-instances',
-    isRuntimeVersioned: false,
-    task: () async => await deleteAbandonedInstances(
-      project: activeConfiguration.taskWorkerProject!,
+        try {
+          final lock = GlobalLock.create(
+            'send-outgoing-emails',
+            expiration: Duration(minutes: 20),
+          );
+          await lock.withClaim(
+            (claim) async {
+              await emailBackend.trySendAllOutgoingEmails(
+                stopAfter: Duration(minutes: 10),
+              );
+            },
+            abort: acquireAbort,
+          );
+        } finally {
+          acquireTimer.cancel();
+        }
+      },
     ),
-  );
 
-  _daily(
+    // Deletes outgoing email entries that had failed to deliver.
+    _daily(
+      name: 'delete-outgoing-emails',
+      isRuntimeVersioned: false,
+      task: emailBackend.deleteDeadOutgoingEmails,
+    ),
+
+    // Backfills the fields that are new to the current release.
+    _daily(
+      name: 'backfill-new-fields',
+      isRuntimeVersioned: true,
+      task: backfillNewFields,
+    ),
+
+    // Deletes expired audit log records.
+    _daily(
+      name: 'delete-expired-audit-log-records',
+      isRuntimeVersioned: false,
+      task: () async => await auditBackend.deleteExpiredRecords(),
+    ),
+
+    // Deletes expired consent invites.
+    _daily(
+      name: 'delete-expired-consents',
+      isRuntimeVersioned: false,
+      task: () async => await consentBackend.deleteObsoleteConsents(),
+    ),
+
+    // Deletes expired sessions.
+    _daily(
+      name: 'delete-expired-sessions',
+      isRuntimeVersioned: false,
+      task: () async => await accountBackend.deleteExpiredSessions(),
+    ),
+
+    // Updates Package's stable, prerelease and preview version fields in case a
+    // new Dart SDK got released.
+    _daily(
+      name: 'update-package-versions',
+      isRuntimeVersioned: false,
+      task: () async => await packageBackend.updateAllPackageVersions(),
+    ),
+
+    // Updates the public archive bucket from the canonical bucket, for the
+    // unlikely case where an archive may be missing.
+    _daily(
+      name: 'sync-public-bucket-from-canonical-bucket',
+      isRuntimeVersioned: false,
+      task: () async =>
+          await packageBackend.tarballStorage.updatePublicArchiveBucket(),
+    ),
+
+    // Exports the package name completion data to a bucket.
+    _daily(
+      name: 'synchronize-exported-api',
+      isRuntimeVersioned: true,
+      task: () async => await apiExporter?.synchronizeExportedApi(),
+    ),
+
+    // Deletes moderated packages, versions, publishers and users.
+    _weekly(
+      name: 'delete-moderated-subjects',
+      isRuntimeVersioned: false,
+      task: () async => adminBackend.deleteModeratedSubjects(),
+    ),
+
+    // Deletes task status entities where the status hasn't been updated
+    // for more than a month.
+    _weekly(
+      name: 'delete-old-neat-task-statuses',
+      isRuntimeVersioned: false,
+      task: () => deleteOldNeatTaskStatuses(dbService),
+    ),
+
+    // Deletes orphaned like entities that are missing a reference.
+    _weekly(
+      name: 'remove-orphaned-likes',
+      isRuntimeVersioned: false,
+      task: removeOrphanedLikes,
+    ),
+
+    // Updates Package.likes with the correct new value.
+    _weekly(
+      name: 'update-package-likes',
+      isRuntimeVersioned: false,
+      task: updatePackageLikes,
+    ),
+
+    // Updates PackageState in taskBackend
+    _weekly(
+      name: 'backfill-task-tracking-state',
+      isRuntimeVersioned: true,
+      task: taskBackend.backfillTrackingState,
+    ),
+
+    // Deletes task results for old runtime versions
+    _weekly(
+      name: 'garbage-collect-task-results',
+      isRuntimeVersioned: false,
+      task: taskBackend.garbageCollect,
+    ),
+
+    // Delete very old instances that have been abandoned
+    _daily(
+      name: 'garbage-collect-old-instances',
+      isRuntimeVersioned: false,
+      task: () async => await deleteAbandonedInstances(
+        project: activeConfiguration.taskWorkerProject!,
+      ),
+    ),
+
+    _daily(
       name: 'sync-download-counts',
       isRuntimeVersioned: false,
-      task: syncDownloadCounts);
+      task: syncDownloadCounts,
+    ),
 
-  _daily(
+    _daily(
       name: 'compute-download-counts-30-days-totals',
       isRuntimeVersioned: false,
-      task: compute30DaysTotalTask);
+      task: compute30DaysTotalTask,
+    ),
 
-  _daily(name: 'count-topics', isRuntimeVersioned: false, task: countTopics);
+    _daily(
+      name: 'count-topics',
+      isRuntimeVersioned: false,
+      task: countTopics,
+    ),
 
-  _daily(
+    _daily(
       name: 'sync-security-advisories',
       isRuntimeVersioned: false,
-      task: syncSecurityAdvisories);
+      task: syncSecurityAdvisories,
+    ),
 
-  // TODO: setup tasks to remove known obsolete (but now unmapped) fields from entities
-}
+    // Checks the Datastore integrity of the model objects.
+    _weekly(
+      name: 'check-datastore-integrity',
+      isRuntimeVersioned: true,
+      task: () async => await IntegrityChecker(dbService, concurrency: 2)
+          .verifyAndLogIssues(),
+      timeout: Duration(days: 1),
+    ),
+    // Deletes the old search snapshots
+    _weekly(
+      name: 'delete-old-search-snapshots',
+      isRuntimeVersioned: true,
+      task: () => searchBackend.deleteOldData(),
+    ),
 
-/// Setup the tasks that we are running in the analyzer service.
-void setupAnalyzerPeriodicTasks() {
-  _setupGenericPeriodicTasks();
-
-  // Checks the Datastore integrity of the model objects.
-  _weekly(
-    name: 'check-datastore-integrity',
-    isRuntimeVersioned: true,
-    task: () async =>
-        await IntegrityChecker(dbService, concurrency: 2).verifyAndLogIssues(),
-    timeout: Duration(days: 1),
-  );
-}
-
-/// Setup the tasks that we are running in the search service.
-void setupSearchPeriodicTasks() {
-  // Deletes the old search snapshots
-  _weekly(
-    name: 'delete-old-search-snapshots',
-    isRuntimeVersioned: true,
-    task: () => searchBackend.deleteOldData(),
-  );
+    // TODO: setup tasks to remove known obsolete (but now unmapped) fields from entities
+  ];
 }
 
 // ignore: non_constant_identifier_names
-void _15mins({
+NeatPeriodicTaskScheduler _15mins({
   required String name,
   required bool isRuntimeVersioned,
   required NeatPeriodicTask task,
 }) {
-  final scheduler = NeatPeriodicTaskScheduler(
+  return NeatPeriodicTaskScheduler(
     name: name,
     interval: Duration(minutes: 15),
     timeout: Duration(minutes: 10),
@@ -234,17 +242,14 @@ void _15mins({
         isRuntimeVersioned: isRuntimeVersioned),
     task: _wrapMemoryLogging(name, task),
   );
-
-  ss.registerScopeExitCallback(() => scheduler.stop());
-  scheduler.start();
 }
 
-void _daily({
+NeatPeriodicTaskScheduler _daily({
   required String name,
   required bool isRuntimeVersioned,
   required NeatPeriodicTask task,
 }) {
-  final scheduler = NeatPeriodicTaskScheduler(
+  return NeatPeriodicTaskScheduler(
     name: name,
     interval: Duration(hours: 24),
     timeout: Duration(hours: 12),
@@ -252,18 +257,15 @@ void _daily({
         isRuntimeVersioned: isRuntimeVersioned),
     task: _wrapMemoryLogging(name, task),
   );
-
-  ss.registerScopeExitCallback(() => scheduler.stop());
-  scheduler.start();
 }
 
-void _weekly({
+NeatPeriodicTaskScheduler _weekly({
   required String name,
   required bool isRuntimeVersioned,
   required NeatPeriodicTask task,
   Duration timeout = const Duration(hours: 12),
 }) {
-  final scheduler = NeatPeriodicTaskScheduler(
+  return NeatPeriodicTaskScheduler(
     name: name,
     interval: Duration(days: 6), // shifts the day when the task is triggered
     timeout: timeout,
@@ -271,9 +273,6 @@ void _weekly({
         isRuntimeVersioned: isRuntimeVersioned),
     task: _wrapMemoryLogging(name, task),
   );
-
-  ss.registerScopeExitCallback(() => scheduler.stop());
-  scheduler.start();
 }
 
 NeatPeriodicTask _wrapMemoryLogging(String name, NeatPeriodicTask task) {

--- a/app/test/shared/test_services.dart
+++ b/app/test/shared/test_services.dart
@@ -31,7 +31,7 @@ import 'package:pub_dev/shared/redis_cache.dart';
 import 'package:pub_dev/shared/versions.dart';
 import 'package:pub_dev/task/cloudcompute/fakecloudcompute.dart';
 import 'package:pub_dev/task/global_lock.dart';
-import 'package:pub_dev/tool/backfill/backfill_new_fields.dart';
+import 'package:pub_dev/tool/neat_task/pub_dev_tasks.dart';
 import 'package:pub_dev/tool/test_profile/import_source.dart';
 import 'package:pub_dev/tool/test_profile/importer.dart';
 import 'package:pub_dev/tool/test_profile/models.dart';
@@ -141,8 +141,10 @@ Future<void> _postTestVerification({
     throw Exception('Integrity problem expected but not present.');
   }
 
-  // TODO: run all background tasks here
-  await backfillNewFields();
+  // run all background tasks here
+  for (final scheduler in createPeriodicTaskSchedulers()) {
+    await scheduler.trigger();
+  }
 
   // re-run integrity checks on the updated state
   final laterProblems =


### PR DESCRIPTION
- Follow-up to #8356.
- Split the creation of the tasks from starting them, so we can selectively run them at the end of the test cases.
- Also updated the `testWithFakeTime` to use the same verification.