### PR TITLE
Keep isSoftRemoved calls in-iteration, prevent List updates.

### DIFF
--- a/app/bin/tools/search_benchmark.dart
+++ b/app/bin/tools/search_benchmark.dart
@@ -19,9 +19,9 @@ Future<void> main(List<String> args) async {
       json.decode(utf8.decode(gzip.decode(await file.readAsBytes())))
           as Map<String, Object?>;
   final snapshot = SearchSnapshot.fromJson(content);
-  snapshot.documents!
-      .removeWhere((packageName, doc) => isSoftRemoved(packageName));
-  final index = InMemoryPackageIndex(documents: snapshot.documents!.values);
+  final index = InMemoryPackageIndex(
+      documents:
+          snapshot.documents!.values.where((d) => !isSoftRemoved(d.package)));
 
   // NOTE: please add more queries to this list, especially if there is a performance bottleneck.
   final queries = [

--- a/app/lib/frontend/handlers/custom_api.dart
+++ b/app/lib/frontend/handlers/custom_api.dart
@@ -79,7 +79,7 @@ Future<shelf.Response> apiPackageNamesHandler(shelf.Request request) async {
   final bytes = await cache.packageNamesDataJsonGz().get(() async {
     final packageNames = await nameTracker.getVisiblePackageNames();
     return gzip.encode(jsonUtf8Encoder.convert({
-      'packages': packageNames.where((p) => !isSoftRemoved(p)).toList(),
+      'packages': packageNames,
       // pagination is off for now
       'nextUrl': null,
     }));

--- a/app/lib/frontend/handlers/custom_api.dart
+++ b/app/lib/frontend/handlers/custom_api.dart
@@ -78,10 +78,8 @@ Future<shelf.Response> apiPackageNamesHandler(shelf.Request request) async {
 
   final bytes = await cache.packageNamesDataJsonGz().get(() async {
     final packageNames = await nameTracker.getVisiblePackageNames();
-    packageNames.removeWhere(isSoftRemoved);
-
     return gzip.encode(jsonUtf8Encoder.convert({
-      'packages': packageNames,
+      'packages': packageNames.where((p) => !isSoftRemoved(p)).toList(),
       // pagination is off for now
       'nextUrl': null,
     }));

--- a/app/lib/package/name_tracker.dart
+++ b/app/lib/package/name_tracker.dart
@@ -8,6 +8,7 @@ import 'package:clock/clock.dart';
 import 'package:gcloud/service_scope.dart' as ss;
 import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
+import 'package:pub_dev/package/overrides.dart';
 import 'package:pub_package_reader/pub_package_reader.dart';
 
 import '../shared/datastore.dart';
@@ -51,7 +52,7 @@ class TrackedPackage {
         updated: p.updated!,
         latestVersion: p.latestVersion!,
         lastPublished: p.lastVersionPublished!,
-        isVisible: p.isVisible,
+        isVisible: p.isVisible && !isSoftRemoved(p.name!),
       );
 
   @visibleForTesting
@@ -125,7 +126,7 @@ class NameTracker {
 
   /// Get the names of all visible packages.
   ///
-  /// Packages that are _withdrawn_ are not listed here.
+  /// Packages that are _moderated_ or _soft removed_ are NOT listed here.
   /// Packages that are _unlisted_ or _discontinued_ are **included in this list**.
   ///
   /// If it is called before the first scan was done, it will wait for

--- a/app/lib/search/backend.dart
+++ b/app/lib/search/backend.dart
@@ -132,6 +132,9 @@ class SearchBackend {
       if (!claim.valid) {
         return;
       }
+      if (isSoftRemoved(package)) {
+        return;
+      }
       // Skip if the last document timestamp is before [updated].
       // 1-minute window is kept to reduce clock-skew.
       if (updated != null) {
@@ -469,9 +472,6 @@ class SearchBackend {
         return null;
       }
       final snapshot = SearchSnapshot.fromJson(map);
-      snapshot.documents!
-          .removeWhere((packageName, doc) => isSoftRemoved(packageName));
-
       final count = snapshot.documents!.length;
       _logger.info('Got $count packages from snapshot at ${snapshot.updated}');
       return snapshot.documents?.values.toList();


### PR DESCRIPTION
This is about 1-1.5% of the time when loading the search snapshot.