### PR TITLE
Different tag index: document index lists for each tag.

### DIFF
--- a/app/lib/search/mem_index.dart
+++ b/app/lib/search/mem_index.dart
@@ -28,7 +28,10 @@ class InMemoryPackageIndex {
   late final TokenIndex<String> _readmeIndex;
   late final TokenIndex<IndexedApiDocPage> _apiSymbolIndex;
   late final _scorePool = ScorePool(_packageNameIndex._packageNames);
-  final _tagDocumentIndexes = <String, List<int>>{};
+
+  /// Maps the tag strings to a list of document index values
+  /// (`PackageDocument doc.tags -> List<_documents.indexOf(doc)>`).
+  final _tagDocumentIndices = <String, List<int>>{};
   final _documentTagIds = <List<int>>[];
 
   /// Adjusted score takes the overall score and transforms
@@ -63,7 +66,7 @@ class InMemoryPackageIndex {
       // transform tags into numberical IDs
       final tagIds = <int>[];
       for (final tag in doc.tags) {
-        _tagDocumentIndexes.putIfAbsent(tag, () => []).add(i);
+        _tagDocumentIndices.putIfAbsent(tag, () => []).add(i);
       }
       tagIds.sort();
       _documentTagIds.add(tagIds);
@@ -159,7 +162,7 @@ class InMemoryPackageIndex {
         query.tagsPredicate.appendPredicate(query.parsedQuery.tagsPredicate);
     if (combinedTagsPredicate.isNotEmpty) {
       for (final entry in combinedTagsPredicate.entries) {
-        final docIndexes = _tagDocumentIndexes[entry.key];
+        final docIndexes = _tagDocumentIndices[entry.key];
 
         if (entry.value) {
           // predicate is required, zeroing the gaps between index values

--- a/app/lib/search/search_service.dart
+++ b/app/lib/search/search_service.dart
@@ -341,6 +341,12 @@ class PackageSearchResult {
         sdkLibraryHits = sdkLibraryHits ?? <SdkLibraryHit>[],
         statusCode = statusCode;
 
+  factory PackageSearchResult.empty() => PackageSearchResult(
+        timestamp: clock.now(),
+        totalCount: 0,
+        packageHits: [],
+      );
+
   PackageSearchResult.error({
     required this.errorMessage,
     required this.statusCode,

--- a/app/lib/search/token_index.dart
+++ b/app/lib/search/token_index.dart
@@ -219,6 +219,14 @@ class IndexedScore<K> {
     _values[index] = math.max(_values[index], value);
   }
 
+  /// Sets the positions greater than or equal to [start] and less than [end],
+  /// to [fillValue].
+  void fillRange(int start, int end, double fillValue) {
+    assert(start <= end);
+    if (start == end) return;
+    _values.fillRange(start, end, fillValue);
+  }
+
   void removeWhere(bool Function(int index, K key) fn) {
     for (var i = 0; i < length; i++) {
       if (isNotPositive(i)) continue;


### PR DESCRIPTION
- This is a follow-up on #8377 to implement the idea where we keep the document index list for each tag.
- The change itself is mostly neutral on memory, and local benchmark shows about 2-3% improvements in latencies.
- However, it reduces the "smart" factor (complexity) of the index, and I think this has even further potential for improvement, if we change it to value ranges + pre-sort the document list for the default predicates. (to be explored in a separate PR).