### PR TITLE
Fix documentation URL preprocessing to recognize directories with dots.

### DIFF
--- a/app/lib/frontend/handlers/documentation.dart
+++ b/app/lib/frontend/handlers/documentation.dart
@@ -143,6 +143,13 @@ DocFilePath? parseRequestUri(Uri uri) {
   return DocFilePath(package, version, path);
 }
 
+const _nonExpandedExtensions = {
+  '.html',
+  '.json',
+  '.gz',
+  '.png',
+  '.svg',
+};
 // NOTE: This is a best-effort detection on the segments.
 //       Instead, we should rather check if the file (or the updated path)
 //       is in the generated output, and base the decision on the file list.
@@ -159,7 +166,7 @@ bool _expandToIndexHtml(List<String> segments) {
     return false;
   }
   final ext = p.extension(segments.last);
-  return ext != '.html';
+  return !_nonExpandedExtensions.contains(ext);
 }
 
 bool _isValidVersion(String version) {

--- a/app/test/frontend/handlers/documentation_test.dart
+++ b/app/test/frontend/handlers/documentation_test.dart
@@ -78,6 +78,18 @@ void main() {
       testUri(
           '/documentation/pkg/1.0.0/A%20_0.html', 'pkg', '1.0.0', 'A _0.html');
     });
+
+    test('library with dots are recognized', () {
+      testUri('/documentation/pkg/latest/a.b.c', 'pkg', 'latest',
+          'a.b.c/index.html');
+      testUri('/documentation/pkg/latest/a.b.c/', 'pkg', 'latest',
+          'a.b.c/index.html');
+    });
+
+    test('static assets are left as-is', () {
+      testUri('/documentation/pkg/latest/static-assets/search.svg', 'pkg',
+          'latest', 'static-assets/search.svg');
+    });
   });
 
   group('dartdoc handlers', () {
@@ -110,6 +122,9 @@ void main() {
       await expectRedirectResponse(
           await issueGet('/documentation/oxygen/1.0.0/abc'),
           '/documentation/oxygen/1.0.0/abc/');
+      await expectRedirectResponse(
+          await issueGet('/documentation/oxygen/1.0.0/abc.def'),
+          '/documentation/oxygen/1.0.0/abc.def/');
       await expectRedirectResponse(
           await issueGet('/documentation/oxygen/latest/abc/def'),
           '/documentation/oxygen/latest/abc/def/');


### PR DESCRIPTION
- Fixes #8398.
- Note: the blob index use is currently inefficient, because we hide the use of the index behind method calls that re-read it from the cache. We should either expose the index directly or have some method that returns a composite result on such queries.