### PR TITLE
Disallow email with commas.

### DIFF
--- a/app/lib/service/email/email_templates.dart
+++ b/app/lib/service/email/email_templates.dart
@@ -86,6 +86,9 @@ bool isValidEmail(String email) {
   // strict pattern check
   if (!_strictEmailRegExp.hasMatch(email)) return false;
 
+  // also reject commas
+  if (email.contains(',')) return false;
+
   // checking for IPv4 or IPv6 addresses
   var isInternetAddress = false;
   try {

--- a/app/test/service/email/email_templates_test.dart
+++ b/app/test/service/email/email_templates_test.dart
@@ -98,6 +98,10 @@ void main() {
       // verify that we have rejected emails
       expect(rejectedEmails, hasLength(215));
     });
+
+    test('reject multiple addresses', () {
+      expect(isValidEmail('abc@example.com,efg@example.com'), false);
+    });
   });
 
   group('EmailAddress format', () {


### PR DESCRIPTION
These cannot be sent, they are not valid according to RFC 5321.

We can consider doing a strict RFC 5321 validation later.