### PR TITLE
Provide width and height for sparkline

### DIFF
--- a/pkg/web_app/lib/src/widget/weekly_sparkline/widget.dart
+++ b/pkg/web_app/lib/src/widget/weekly_sparkline/widget.dart
@@ -15,6 +15,11 @@ void create(HTMLElement element, Map<String, String> options) {
   }
 
   final svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+
+  // Safari needs these to render the svg.
+  svg.setAttribute('height', '100%');
+  svg.setAttribute('width', '100%');
+
   element.append(svg);
 
   final toolTip = HTMLDivElement()


### PR DESCRIPTION
Fixes https://github.com/dart-lang/pub-dev/issues/8400

Tested manually with Safari:

<img width="998" alt="image" src="https://github.com/user-attachments/assets/9e54daeb-8637-4f1c-a427-d502da1d01cf" />

