### PR TITLE
Verify more storage calls that they are inside a retry block.

### DIFF
--- a/app/lib/fake/backend/fake_download_counts.dart
+++ b/app/lib/fake/backend/fake_download_counts.dart
@@ -7,6 +7,7 @@ import 'dart:io';
 import 'package:gcloud/storage.dart';
 import 'package:pub_dev/service/download_counts/computations.dart';
 import 'package:pub_dev/shared/configuration.dart';
+import 'package:pub_dev/shared/storage.dart';
 import 'package:pub_dev/shared/utils.dart';
 
 Future<void> generateFakeDownloadCounts(
@@ -14,12 +15,12 @@ Future<void> generateFakeDownloadCounts(
   final file = File(dataFilePath).readAsBytesSync();
   await storageService
       .bucket(activeConfiguration.downloadCountsBucketName!)
-      .writeBytes(downloadCountsFileName, file);
+      .writeBytesWithRetry(downloadCountsFileName, file);
 }
 
 Future<void> generateFake30DaysTotals(Map<String, int> totals) async {
   await storageService
       .bucket(activeConfiguration.reportsBucketName!)
-      .writeBytes(
+      .writeBytesWithRetry(
           downloadCounts30DaysTotalsFileName, jsonUtf8Encoder.convert(totals));
 }

--- a/app/lib/fake/backend/fake_topics.dart
+++ b/app/lib/fake/backend/fake_topics.dart
@@ -6,11 +6,12 @@ import 'package:gcloud/storage.dart';
 
 import '../../service/topics/count_topics.dart';
 import '../../shared/configuration.dart';
+import '../../shared/storage.dart';
 import '../../shared/utils.dart';
 
 Future<void> generateFakeTopicValues() async {
   await storageService
       .bucket(activeConfiguration.reportsBucketName!)
-      .writeBytes(topicsJsonFileName,
+      .writeBytesWithRetry(topicsJsonFileName,
           jsonUtf8Encoder.convert({'ffi': 7, 'ui': 5, 'network': 6}));
 }

--- a/app/lib/shared/storage.dart
+++ b/app/lib/shared/storage.dart
@@ -201,6 +201,27 @@ extension BucketExt on Bucket {
       ),
     );
   }
+
+  /// Create an new object in the bucket with specified content with the default retry.
+  Future<ObjectInfo> writeBytesWithRetry(
+    String name,
+    List<int> bytes, {
+    ObjectMetadata? metadata,
+    Acl? acl,
+    PredefinedAcl? predefinedAcl,
+    String? contentType,
+  }) async {
+    return await _retry(
+      () async => await writeBytes(
+        name,
+        bytes,
+        metadata: metadata,
+        acl: acl,
+        predefinedAcl: predefinedAcl,
+        contentType: contentType,
+      ),
+    );
+  }
 }
 
 extension PageExt<T> on Page<T> {

--- a/pkg/fake_gcloud/lib/retry_enforcer_storage.dart
+++ b/pkg/fake_gcloud/lib/retry_enforcer_storage.dart
@@ -59,7 +59,6 @@ class RetryEnforcerStorage implements Storage {
   Future<bool> bucketExists(String bucketName) async {
     return await _verifyRetry(
       () => _storage.bucketExists(bucketName),
-      ignore: true,
     );
   }
 
@@ -67,7 +66,6 @@ class RetryEnforcerStorage implements Storage {
   Future<BucketInfo> bucketInfo(String bucketName) async {
     return await _verifyRetry(
       () async => await _storage.bucketInfo(bucketName),
-      ignore: true,
     );
   }
 
@@ -75,7 +73,6 @@ class RetryEnforcerStorage implements Storage {
   Future copyObject(String src, String dest, {ObjectMetadata? metadata}) async {
     return await _verifyRetry(
       () => _storage.copyObject(src, dest, metadata: metadata),
-      ignore: true,
     );
   }
 
@@ -91,7 +88,6 @@ class RetryEnforcerStorage implements Storage {
         predefinedAcl: predefinedAcl,
         acl: acl,
       ),
-      ignore: true,
     );
   }
 
@@ -99,7 +95,6 @@ class RetryEnforcerStorage implements Storage {
   Future deleteBucket(String bucketName) async {
     return await _verifyRetry(
       () => _storage.deleteBucket(bucketName),
-      ignore: true,
     );
   }
 
@@ -112,7 +107,6 @@ class RetryEnforcerStorage implements Storage {
   Future<Page<String>> pageBucketNames({int pageSize = 50}) async {
     return await _verifyRetry(
       () => _storage.pageBucketNames(pageSize: pageSize),
-      ignore: true,
     );
   }
 }
@@ -134,7 +128,6 @@ class _RetryEnforcerBucket implements Bucket {
   Future delete(String name) async {
     return await _verifyRetry(
       () async => await _bucket.delete(name),
-      ignore: true,
     );
   }
 
@@ -142,7 +135,6 @@ class _RetryEnforcerBucket implements Bucket {
   Future<ObjectInfo> info(String name) async {
     return await _verifyRetry(
       () async => await _bucket.info(name),
-      ignore: true,
     );
   }
 
@@ -167,7 +159,6 @@ class _RetryEnforcerBucket implements Bucket {
         delimiter: delimiter,
         pageSize: pageSize,
       )),
-      ignore: true,
     );
   }
 
@@ -222,7 +213,6 @@ class _RetryEnforcerBucket implements Bucket {
         predefinedAcl: predefinedAcl,
         contentType: contentType,
       ),
-      ignore: true,
     );
   }
 }
@@ -241,7 +231,6 @@ class _RetryEnforcerPage<T> implements Page<T> {
   Future<Page<T>> next({int pageSize = 50}) async {
     return await _verifyRetry(
       () async => _RetryEnforcerPage(await _page.next(pageSize: pageSize)),
-      ignore: true,
     );
   }
 }


### PR DESCRIPTION
- #8337
- Covering the non-admin API exporter tests + enabling most of the verification for most tests.