### PR TITLE
Stricter retry verification.

### DIFF
--- a/pkg/fake_gcloud/lib/retry_enforcer_storage.dart
+++ b/pkg/fake_gcloud/lib/retry_enforcer_storage.dart
@@ -5,19 +5,41 @@
 import 'dart:async';
 
 import 'package:gcloud/storage.dart';
+import 'package:stack_trace/stack_trace.dart';
+
+const _skippedFirstFrames = {
+  'package:fake_gcloud/retry_enforcer_storage.dart',
+  'package:pub_dev/shared/storage.dart',
+};
 
 void _verifyRetryOnStack() {
   final st = StackTrace.current.toString();
-  if (st.contains('package:retry/')) return;
-  if (st.contains('retryAsync')) return; // lib/shared/utils.dart
+  final trace = Trace.current();
+
+  // The first frame index outside of this file.
+  var startFrameIndex = 0;
+  while (_skippedFirstFrames.any((skipped) =>
+      trace.frames[startFrameIndex].uri.toString().contains(skipped))) {
+    startFrameIndex++;
+  }
+
+  final firstRealFrame =
+      trace.frames.skip(startFrameIndex).firstOrNull?.toString();
+  if (firstRealFrame == null) {
+    return;
+  }
 
   // detect direct test calls
-  final linesWithoutThisFile = st
-      .split('\n')
-      .where((l) => !l.contains('retry_enforcer_storage.dart'))
-      .toList();
-  if (linesWithoutThisFile.isNotEmpty &&
-      linesWithoutThisFile.first.contains('_test.dart')) {
+  if (firstRealFrame.contains('_test.dart')) {
+    return;
+  }
+
+  // detect retry library
+  if (firstRealFrame.contains('package:retry/')) {
+    return;
+  }
+  // detect lib/shared/utils.dart use
+  if (firstRealFrame.contains('retryAsync')) {
     return;
   }
 

--- a/pkg/fake_gcloud/lib/retry_enforcer_storage.dart
+++ b/pkg/fake_gcloud/lib/retry_enforcer_storage.dart
@@ -13,7 +13,6 @@ const _skippedFirstFrames = {
 };
 
 void _verifyRetryOnStack() {
-  final st = StackTrace.current.toString();
   final trace = Trace.current();
 
   // The first frame index outside of this file.
@@ -43,8 +42,8 @@ void _verifyRetryOnStack() {
     return;
   }
 
-  print('Missing retry detected:\n$st\n');
-  throw AssertionError('retry is not present in stacktrace: $st');
+  print('Missing retry detected:\n$trace\n');
+  throw AssertionError('retry is not present in stacktrace: $trace');
 }
 
 Future<R> _verifyRetry<R>(

--- a/pkg/fake_gcloud/pubspec.yaml
+++ b/pkg/fake_gcloud/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   gcloud: ^0.8.18
   logging: '>=0.11.3 <2.0.0'
   _discoveryapis_commons: ^1.0.7
+  stack_trace: ^1.12.0
 
 dev_dependencies:
   coverage: any # test already depends on it


### PR DESCRIPTION
- #8337
- As we only check the first frame of the stack trace, we don't need to handle further re-entry detection.