### PR TITLE
Remove tasks from post-test verifications.

### DIFF
--- a/app/lib/tool/neat_task/pub_dev_tasks.dart
+++ b/app/lib/tool/neat_task/pub_dev_tasks.dart
@@ -180,13 +180,19 @@ List<NeatPeriodicTaskScheduler> createPeriodicTaskSchedulers({
     ),
 
     // Delete very old instances that have been abandoned
-    _daily(
-      name: 'garbage-collect-old-instances',
-      isRuntimeVersioned: false,
-      task: () async => await deleteAbandonedInstances(
-        project: activeConfiguration.taskWorkerProject!,
+    //
+    // NOTE: This task will use Google Cloud API to remove worker instances.
+    //       The client is not configured for fake environment, we should skip
+    //       this task in post-test verifications.
+    // TODO: Write fake cloud abstractions to improve code coverage here.
+    if (!isPostTestVerification)
+      _daily(
+        name: 'garbage-collect-old-instances',
+        isRuntimeVersioned: false,
+        task: () async => await deleteAbandonedInstances(
+          project: activeConfiguration.taskWorkerProject!,
+        ),
       ),
-    ),
 
     _daily(
       name: 'sync-download-counts',

--- a/app/lib/tool/neat_task/pub_dev_tasks.dart
+++ b/app/lib/tool/neat_task/pub_dev_tasks.dart
@@ -194,11 +194,16 @@ List<NeatPeriodicTaskScheduler> createPeriodicTaskSchedulers({
         ),
       ),
 
-    _daily(
-      name: 'sync-download-counts',
-      isRuntimeVersioned: false,
-      task: syncDownloadCounts,
-    ),
+    // Syncs download counts from storage bucket.
+    //
+    // NOTE: This task reports missing files in the logs.
+    // TODO: Provide fake download data so that the task does not fail here.
+    if (!isPostTestVerification)
+      _daily(
+        name: 'sync-download-counts',
+        isRuntimeVersioned: false,
+        task: syncDownloadCounts,
+      ),
 
     _daily(
       name: 'compute-download-counts-30-days-totals',

--- a/app/test/shared/test_services.dart
+++ b/app/test/shared/test_services.dart
@@ -142,7 +142,8 @@ Future<void> _postTestVerification({
   }
 
   // run all background tasks here
-  for (final scheduler in createPeriodicTaskSchedulers()) {
+  final schedulers = createPeriodicTaskSchedulers(isPostTestVerification: true);
+  for (final scheduler in schedulers) {
     await scheduler.trigger();
   }
 


### PR DESCRIPTION
- In the context of #8422, we should not run post-test tasks that fail through their logs or rewrite them. As their rewrite is low-priority for now, let's just disable them for now.