### PR TITLE
Fix fake_gcloud list() iteration

### DIFF
--- a/app/test/admin/exported_api_sync_test.dart
+++ b/app/test/admin/exported_api_sync_test.dart
@@ -99,10 +99,7 @@ void main() {
       });
     });
 
-    testWithProfile('deleted files + full sync', expectedLogMessages: [
-      // TODO: review why we have unhandled errors here
-      RegExp(r'^SEVERE Unhandled error in API handler \(incidentId: .*\)'),
-    ], fn: () async {
+    testWithProfile('deleted files + full sync', fn: () async {
       await syncExportedApi();
       final oldRoot = await listExportedApi();
 

--- a/pkg/fake_gcloud/lib/mem_storage.dart
+++ b/pkg/fake_gcloud/lib/mem_storage.dart
@@ -317,7 +317,7 @@ class _Bucket implements Bucket {
     final isDirPrefix =
         prefix.isEmpty || (delimiter.isNotEmpty && prefix.endsWith(delimiter));
     final segments = <String>{};
-    for (final name in _files.keys) {
+    for (final name in [..._files.keys]) {
       bool matchesPrefix() {
         // without prefix, return everything
         if (prefix!.isEmpty) return true;


### PR DESCRIPTION
- Follow-up to #8425.
- Turns out the fake gcloud implementation of the `Bucket.list()` was failing because of concurrent modification under a iterator.