### PR TITLE
Clear required flag for isBlocked fields + remove some fields.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Important changes to data models, configuration, and migrations between each
 AppEngine version, listed here to ease deployment and troubleshooting.
 
 ## Next Release (replace with git tag when deployed)
+ * Note: removed required flag from `isBlocked` fields. 
+ * Note: started deleting `Package.blocked` and `Package.blockedReason`.
 
 ## `20241217t132200-all`
  * Bump runtimeVersion to `2024.12.17`.

--- a/app/lib/account/models.dart
+++ b/app/lib/account/models.dart
@@ -52,7 +52,9 @@ class User extends db.ExpandoModel<String> {
   /// [isBlocked] is set when a user account is blocked (is on administrative hold).
   /// When this happens user-data is preserved, but the user should not be able
   /// to perform any action.
-  @db.BoolProperty(required: true)
+  ///
+  /// TODO: remove after runtime version `2024.12.17` is no longer running.
+  @db.BoolProperty(required: false)
   bool isBlocked = false;
 
   /// `true` if user was moderated (pending moderation or deletion).

--- a/app/lib/package/models.dart
+++ b/app/lib/package/models.dart
@@ -126,16 +126,10 @@ class Package extends db.ExpandoModel<String> {
 
   /// Set to `true` if package should not be displayed anywhere, because of
   /// pending moderation or deletion.
-  @db.BoolProperty(required: true)
+  ///
+  /// TODO: remove after runtime version `2024.12.17` is no longer running.
+  @db.BoolProperty(required: false)
   bool isBlocked = false;
-
-  /// The reason why the package was blocked.
-  @db.StringProperty(indexed: false)
-  String? blockedReason;
-
-  /// The timestamp when the package was blocked.
-  @db.DateTimeProperty()
-  DateTime? blocked;
 
   /// `true` if package was moderated (pending moderation or deletion).
   @db.BoolProperty(required: true)

--- a/app/lib/publisher/models.dart
+++ b/app/lib/publisher/models.dart
@@ -61,7 +61,9 @@ class Publisher extends db.ExpandoModel<String> {
   ///   membership information, or invite new members.
   /// - Administrator roles of the publisher must not be able to publisher a new version
   ///   for packages of the publisher, or change any of the existing package's properties.
-  @db.BoolProperty(required: true)
+  ///
+  /// TODO: remove after runtime version `2024.12.17` is no longer running.
+  @db.BoolProperty(required: false)
   bool isBlocked = false;
 
   /// `true` if publisher was moderated (pending moderation or deletion).

--- a/app/test/tool/maintenance/migrate_isblocked_test.dart
+++ b/app/test/tool/maintenance/migrate_isblocked_test.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:clock/clock.dart';
 import 'package:pub_dev/account/backend.dart';
 import 'package:pub_dev/package/backend.dart';
 import 'package:pub_dev/publisher/backend.dart';
@@ -14,24 +13,6 @@ import '../../shared/test_services.dart';
 
 void main() {
   group('Migrate isBlocked', () {
-    testWithProfile('package', expectedLogMessages: [
-      'SHOUT Deleting object from public bucket: "packages/oxygen-1.0.0.tar.gz".',
-      'SHOUT Deleting object from public bucket: "packages/oxygen-1.2.0.tar.gz".',
-      'SHOUT Deleting object from public bucket: "packages/oxygen-2.0.0-dev.tar.gz".',
-    ], fn: () async {
-      final p1 = await packageBackend.lookupPackage('oxygen');
-      await dbService.commit(inserts: [
-        p1!
-          ..isBlocked = true
-          ..blocked = clock.now()
-          ..blockedReason = 'abc'
-      ]);
-      await migrateIsBlocked();
-
-      final p2 = await packageBackend.lookupPackage('oxygen');
-      expect(p2!.isModerated, true);
-    });
-
     testWithProfile('publisher', fn: () async {
       final p1 = await publisherBackend.getPublisher('example.com');
       await dbService.commit(inserts: [p1!..isBlocked = true]);


### PR DESCRIPTION
- #8336
- We cannot remove the `isBlocked` fields yet, first we need to move away from deployments that use it as required. This PR prepares for that.
- The `blocked` and `blockReason` fields can be removed already.
- Note: I've also noticed some differences in how we treated `isBlocked` and `isModerated`, I'll address those in follow-up PRs in smaller bits, as it raised a few questions on which behavior we want to follow.