### PR TITLE
Remove popularity from the UI, finalize download counts experiment.

### DIFF
--- a/app/lib/frontend/handlers/custom_api.dart
+++ b/app/lib/frontend/handlers/custom_api.dart
@@ -247,7 +247,6 @@ Future<VersionScore> packageVersionScoreHandler(
       maxPoints: card.maxPubPoints,
       likeCount: pkg.likes,
       downloadCount30Days: card.thirtyDaysDownloadCounts,
-      popularityScore: card.popularityScore,
       tags: tags.toList(),
       lastUpdated: updated,
     );

--- a/app/lib/frontend/handlers/experimental.dart
+++ b/app/lib/frontend/handlers/experimental.dart
@@ -10,7 +10,6 @@ typedef PublicFlag = ({String name, String description});
 
 const _publicFlags = <PublicFlag>{
   (name: 'dark', description: 'Dark mode'),
-  (name: 'download-counts', description: 'Download count metrics'),
   (name: 'search-completion', description: 'Completions for the search bar'),
   (name: 'search-topics', description: 'Show matching topics when searching'),
   (
@@ -101,7 +100,6 @@ class ExperimentalFlags {
 
   bool get showDownloadCountsVersionChart =>
       isEnabled('download-counts-version-chart');
-  bool get showDownloadCounts => true;
 
   String encodedAsCookie() => _enabled.join(':');
 

--- a/app/lib/frontend/templates/_consts.dart
+++ b/app/lib/frontend/templates/_consts.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:_pub_shared/search/tags.dart';
-import 'package:pub_dev/frontend/request_context.dart';
 
 import '../dom/dom.dart' as d;
 
@@ -116,19 +115,14 @@ final _sortDicts = const <SortDict>[
       label: 'most pub points',
       tooltip: 'Packages are sorted by pub points.'),
   SortDict(
-      id: 'popularity',
-      label: 'popularity',
-      tooltip: 'Packages are sorted by their popularity score.'),
+      id: 'downloads',
+      label: 'downloads',
+      tooltip: 'Packages are sorted by their download counts.'),
 ];
 
 List<SortDict> getSortDicts(bool isSearch) {
   final removeId = isSearch ? 'listing_relevance' : 'search_relevance';
   return <SortDict>[
     ..._sortDicts.where((d) => d.id != removeId),
-    if (requestContext.experimentalFlags.showDownloadCounts)
-      SortDict(
-          id: 'downloads',
-          label: 'downloads',
-          tooltip: 'Packages are sorted by their download counts.'),
   ];
 }

--- a/app/lib/frontend/templates/views/pkg/info_box.dart
+++ b/app/lib/frontend/templates/views/pkg/info_box.dart
@@ -4,7 +4,6 @@
 
 import 'package:_pub_shared/format/encoding.dart';
 import 'package:pana/pana.dart';
-import 'package:pub_dev/frontend/request_context.dart';
 import 'package:pub_dev/service/download_counts/download_counts.dart';
 import 'package:pubspec_parse/pubspec_parse.dart' as pubspek;
 
@@ -83,8 +82,7 @@ d.Node packageInfoBoxNode({
         collectionsIcon(),
       ]),
     _publisher(package.publisherId),
-    if (data.weeklyDownloadCounts != null &&
-        requestContext.experimentalFlags.showDownloadCounts)
+    if (data.weeklyDownloadCounts != null)
       _downloadsChart(data.weeklyDownloadCounts!),
     _metadata(
       description: version.pubspec!.description,

--- a/app/lib/frontend/templates/views/pkg/labeled_scores.dart
+++ b/app/lib/frontend/templates/views/pkg/labeled_scores.dart
@@ -3,8 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:_pub_shared/format/number_format.dart';
-import 'package:pub_dev/frontend/request_context.dart';
-import 'package:pub_dev/shared/popularity_storage.dart';
 
 import '../../../dom/dom.dart' as d;
 
@@ -31,30 +29,20 @@ d.Node labeledScoresNode({
         classes: ['packages-score', 'packages-score-health'],
         child: _labeledScore('points', grantedPubPoints?.toString(), sign: ''),
       ),
-      requestContext.experimentalFlags.showDownloadCounts
-          ? d.div(
-              attributes: {
-                'title':
-                    'Number of downloads of this package during the past 30 days'
-              },
-              classes: ['packages-score', 'packages-score-downloads'],
-              child: _labeledScore(
-                'downloads',
-                thirtyDaysDownloads != null
-                    ? '${compactFormat(thirtyDaysDownloads).value}'
-                        '${compactFormat(thirtyDaysDownloads).suffix}'
-                    : null,
-                sign: '',
-              ),
-            )
-          : d.div(
-              classes: ['packages-score', 'packages-score-popularity'],
-              child: _labeledScore(
-                'popularity',
-                popularityStorage.isInvalid ? null : popularity.toString(),
-                sign: popularityStorage.isInvalid ? '' : '%',
-              ),
-            ),
+      d.div(
+        attributes: {
+          'title': 'Number of downloads of this package during the past 30 days'
+        },
+        classes: ['packages-score', 'packages-score-downloads'],
+        child: _labeledScore(
+          'downloads',
+          thirtyDaysDownloads != null
+              ? '${compactFormat(thirtyDaysDownloads).value}'
+                  '${compactFormat(thirtyDaysDownloads).suffix}'
+              : null,
+          sign: '',
+        ),
+      ),
     ],
   );
 }

--- a/app/lib/frontend/templates/views/pkg/score_tab.dart
+++ b/app/lib/frontend/templates/views/pkg/score_tab.dart
@@ -7,7 +7,6 @@ import 'dart:convert';
 import 'package:_pub_shared/data/download_counts_data.dart';
 import 'package:_pub_shared/format/number_format.dart';
 import 'package:pana/models.dart';
-import 'package:pub_dev/shared/popularity_storage.dart';
 import 'package:pub_dev/shared/utils.dart';
 
 import '../../../../scorecard/models.dart' hide ReportStatus;
@@ -15,7 +14,6 @@ import '../../../../shared/urls.dart' as urls;
 import '../../../dom/dom.dart' as d;
 import '../../../request_context.dart';
 import '../../../static_files.dart';
-import '../../package_misc.dart' show formatScore;
 
 /// Renders the score page content.
 d.Node scoreTabNode({
@@ -45,9 +43,7 @@ d.Node scoreTabNode({
       children: [
         _likeKeyFigureNode(likeCount),
         _pubPointsKeyFigureNode(report, showPending),
-        requestContext.experimentalFlags.showDownloadCounts
-            ? _downloadCountsKeyFigureNode(card.thirtyDaysDownloadCounts)
-            : _popularityKeyFigureNode(card.popularityScore),
+        _downloadCountsKeyFigureNode(card.thirtyDaysDownloadCounts),
       ],
     ),
     if (showPending)
@@ -278,21 +274,6 @@ d.Node _likeKeyFigureNode(int? likeCount) {
         '${compactFormat(likeCount).suffix}',
     supplemental: '',
     label: 'likes',
-  );
-}
-
-d.Node _popularityKeyFigureNode(double? popularity) {
-  if (popularityStorage.isInvalid) {
-    return _keyFigureNode(
-      value: '--',
-      supplemental: '',
-      label: 'popularity',
-    );
-  }
-  return _keyFigureNode(
-    value: formatScore(popularity),
-    supplemental: '%',
-    label: 'popularity',
   );
 }
 

--- a/app/lib/scorecard/models.dart
+++ b/app/lib/scorecard/models.dart
@@ -12,7 +12,6 @@ import 'package:pub_dev/service/download_counts/backend.dart';
 import 'package:pub_dev/task/models.dart';
 
 import '../scorecard/backend.dart';
-import '../shared/popularity_storage.dart';
 import '../shared/utils.dart' show jsonUtf8Encoder, utf8JsonDecoder;
 
 part 'models.g.dart';
@@ -72,9 +71,7 @@ class ScoreCardData {
 
   List<String>? get tags => panaReport?.derivedTags;
 
-  // TODO: refactor code to use popularityStorage directly.
-  double get popularityScore => popularityStorage.lookup(packageName!);
-
+  // TODO: refactor code to use downloadCountsBackend directly.
   int? get thirtyDaysDownloadCounts =>
       downloadCountsBackend.lookup30DaysTotalCounts(packageName!);
 }

--- a/app/lib/search/backend.dart
+++ b/app/lib/search/backend.dart
@@ -24,7 +24,6 @@ import 'package:retry/retry.dart';
 import '../../publisher/backend.dart';
 import '../../service/download_counts/backend.dart';
 import '../../service/topics/models.dart';
-import '../../shared/popularity_storage.dart';
 import '../../shared/redis_cache.dart';
 import '../../shared/utils.dart';
 import '../package/backend.dart';
@@ -354,7 +353,6 @@ class SearchBackend {
       readme: compactReadme(readmeAsset?.textContent),
       downloadCount: downloadCountsBackend.lookup30DaysTotalCounts(pv.package),
       likeCount: p.likes,
-      popularityScore: popularityStorage.lookup(packageName),
       grantedPoints: scoreCard.grantedPubPoints,
       maxPoints: scoreCard.maxPubPoints,
       dependencies: _buildDependencies(pv.pubspec!, scoreCard),

--- a/app/lib/search/models.dart
+++ b/app/lib/search/models.dart
@@ -5,7 +5,6 @@
 import 'package:clock/clock.dart';
 import 'package:collection/collection.dart';
 import 'package:json_annotation/json_annotation.dart';
-import 'package:pub_dev/shared/popularity_storage.dart';
 
 import 'search_service.dart';
 
@@ -46,16 +45,6 @@ class SearchSnapshot {
     /// The score is normalized into the range of [0.0 - 1.0] using the
     /// ordered list of packages by like counts (same like count gets the same score).
     documents!.values.updateLikeScores();
-
-    /// Updates all popularity values to the currently cached one, otherwise
-    /// only updated package would have been on their new values.
-    for (final d in documents!.values) {
-      if (popularityStorage.isInvalid) {
-        d.popularityScore = d.likeScore;
-      } else {
-        d.popularityScore = popularityStorage.lookup(d.package);
-      }
-    }
   }
 
   Map<String, dynamic> toJson() => _$SearchSnapshotToJson(this);

--- a/app/test/frontend/golden/pkg_index_page.html
+++ b/app/test/frontend/golden/pkg_index_page.html
@@ -423,7 +423,6 @@
                 <button class="sort-control-option" data-value="created">newest package</button>
                 <button class="sort-control-option" data-value="like">most likes</button>
                 <button class="sort-control-option" data-value="points">most pub points</button>
-                <button class="sort-control-option" data-value="popularity">popularity</button>
                 <button class="sort-control-option" data-value="downloads">downloads</button>
               </div>
             </div>

--- a/app/test/frontend/golden/publisher_packages_page.html
+++ b/app/test/frontend/golden/publisher_packages_page.html
@@ -177,7 +177,6 @@
                         <button class="sort-control-option" data-value="created">newest package</button>
                         <button class="sort-control-option" data-value="like">most likes</button>
                         <button class="sort-control-option" data-value="points">most pub points</button>
-                        <button class="sort-control-option" data-value="popularity">popularity</button>
                         <button class="sort-control-option" data-value="downloads">downloads</button>
                       </div>
                     </div>

--- a/app/test/frontend/golden/publisher_unlisted_packages_page.html
+++ b/app/test/frontend/golden/publisher_unlisted_packages_page.html
@@ -177,7 +177,6 @@
                         <button class="sort-control-option" data-value="created">newest package</button>
                         <button class="sort-control-option" data-value="like">most likes</button>
                         <button class="sort-control-option" data-value="points">most pub points</button>
-                        <button class="sort-control-option" data-value="popularity">popularity</button>
                         <button class="sort-control-option" data-value="downloads">downloads</button>
                       </div>
                     </div>

--- a/app/test/frontend/golden/search_page.html
+++ b/app/test/frontend/golden/search_page.html
@@ -424,7 +424,6 @@
                 <button class="sort-control-option" data-value="created">newest package</button>
                 <button class="sort-control-option" data-value="like">most likes</button>
                 <button class="sort-control-option" data-value="points">most pub points</button>
-                <button class="sort-control-option" data-value="popularity">popularity</button>
                 <button class="sort-control-option" data-value="downloads">downloads</button>
               </div>
             </div>

--- a/app/test/frontend/handlers/custom_api_test.dart
+++ b/app/test/frontend/handlers/custom_api_test.dart
@@ -175,11 +175,11 @@ void main() {
       fn: () async {
         final rs = await issueGet('/api/packages/oxygen/score');
         final map = json.decode(await rs.readAsString());
+        // TODO: investigate why the download counts are missing here
         expect(map, {
           'grantedPoints': greaterThan(10),
           'maxPoints': greaterThan(50),
           'likeCount': 0,
-          'popularityScore': greaterThan(0),
           'tags': contains('sdk:dart'),
           'lastUpdated': isNotEmpty,
         });

--- a/app/test/search/handlers_test.dart
+++ b/app/test/search/handlers_test.dart
@@ -101,11 +101,11 @@ void main() {
           ['oxygen', 'neon', 'flutter_titanium'],
         );
         expect(
-          await queryPackageOrder('/packages?sort=popularity'),
-          ['flutter_titanium', 'neon', 'oxygen'],
+          await queryPackageOrder('/packages?sort=downloads'),
+          ['oxygen', 'flutter_titanium', 'neon'],
         );
         expect(
-          await queryPackageOrder('/packages?sort=popularity&q=sort:points'),
+          await queryPackageOrder('/packages?sort=downloads&q=sort:points'),
           ['oxygen', 'neon', 'flutter_titanium'],
         );
       },

--- a/app/test/task/end2end_test.dart
+++ b/app/test/task/end2end_test.dart
@@ -19,7 +19,7 @@ import '../shared/utils.dart';
 const String goldenDir = 'test/task/testdata/goldens';
 
 // TODO: generalize golden testing, use env var for regenerating all goldens.
-final _regenerateGoldens = true;
+final _regenerateGoldens = false;
 
 // We use a small test profile without flutter packages, because we have to
 // run pana+dartdoc for all these package versions, naturally this is slow.

--- a/pkg/_pub_shared/lib/data/package_api.dart
+++ b/pkg/_pub_shared/lib/data/package_api.dart
@@ -280,7 +280,6 @@ class VersionScore {
   final int? maxPoints;
   final int? likeCount;
   final int? downloadCount30Days;
-  final double? popularityScore;
   final List<String>? tags;
   final DateTime? lastUpdated;
 
@@ -289,7 +288,6 @@ class VersionScore {
     required this.maxPoints,
     required this.likeCount,
     required this.downloadCount30Days,
-    required this.popularityScore,
     required this.tags,
     required this.lastUpdated,
   });

--- a/pkg/_pub_shared/lib/data/package_api.g.dart
+++ b/pkg/_pub_shared/lib/data/package_api.g.dart
@@ -181,7 +181,6 @@ VersionScore _$VersionScoreFromJson(Map<String, dynamic> json) => VersionScore(
       maxPoints: (json['maxPoints'] as num?)?.toInt(),
       likeCount: (json['likeCount'] as num?)?.toInt(),
       downloadCount30Days: (json['downloadCount30Days'] as num?)?.toInt(),
-      popularityScore: (json['popularityScore'] as num?)?.toDouble(),
       tags: (json['tags'] as List<dynamic>?)?.map((e) => e as String).toList(),
       lastUpdated: json['lastUpdated'] == null
           ? null
@@ -195,7 +194,6 @@ Map<String, dynamic> _$VersionScoreToJson(VersionScore instance) =>
       if (instance.likeCount case final value?) 'likeCount': value,
       if (instance.downloadCount30Days case final value?)
         'downloadCount30Days': value,
-      if (instance.popularityScore case final value?) 'popularityScore': value,
       if (instance.tags case final value?) 'tags': value,
       if (instance.lastUpdated?.toIso8601String() case final value?)
         'lastUpdated': value,


### PR DESCRIPTION
Note: I think some tests may not be getting download counts in them, this needs some further investigation. We also need to remove popularity from the search content and logic, I think it is better done in a follow-up.