### PR TITLE
Notify uploader(s) when remaining version count is less than 100.

### DIFF
--- a/app/lib/frontend/handlers/pubapi.dart
+++ b/app/lib/frontend/handlers/pubapi.dart
@@ -154,14 +154,9 @@ class PubApi {
   @EndPoint.get('/api/packages/versions/newUploadFinish/<uploadId>')
   Future<SuccessMessage> finishPackageUpload(
       Request request, String uploadId) async {
-    final pv = await packageBackend.publishUploadedBlob(uploadId);
+    final messages = await packageBackend.publishUploadedBlob(uploadId);
     return SuccessMessage(
-      success: Message(
-        message: 'Successfully uploaded '
-            '${urls.pkgPageUrl(pv.package, includeHost: true)} '
-            'version ${pv.version}, '
-            'it may take up-to 10 minutes before the new version is available.',
-      ),
+      success: Message(message: messages.join('\n')),
     );
   }
 

--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -1165,8 +1165,9 @@ class PackageBackend {
         // We need to decrease the remaining version count as the newly uploaded
         // version is not yet in it.
         final limitAfterUpload = remainingVersionCount - 1;
+        final s = limitAfterUpload == 1 ? '' : 's';
         uploadMessages.add(
-            'The package "${package!.name!}" has $limitAfterUpload versions left '
+            'The package "${package!.name!}" has $limitAfterUpload version$s left '
             'before reaching the limit of $maxVersionCount. '
             'Please contact support@pub.dev');
       }

--- a/app/lib/service/email/email_templates.dart
+++ b/app/lib/service/email/email_templates.dart
@@ -204,21 +204,21 @@ EmailMessage createPackageUploadedEmail({
   required String packageVersion,
   required String displayId,
   required List<EmailAddress> authorizedUploaders,
+  required List<String> uploadMessages,
 }) {
   final url =
       pkgPageUrl(packageName, version: packageVersion, includeHost: true);
   final subject = 'Package uploaded: $packageName $packageVersion';
-  final bodyText = '''Dear package maintainer,  
+  final paragraphs = [
+    'Dear package maintainer,',
+    '$displayId has published a new version ($packageVersion) of the $packageName package to the Dart package site ($primaryHost).',
+    'For details, go to $url',
+    ...uploadMessages,
+    _footer('package'),
+  ];
 
-$displayId has published a new version ($packageVersion) of the $packageName package to the Dart package site ($primaryHost).
-
-For details, go to $url
-
-${_footer('package')}
-''';
-
-  return EmailMessage(
-      _notificationsFrom, authorizedUploaders, subject, bodyText);
+  return EmailMessage(_notificationsFrom, authorizedUploaders, subject,
+      paragraphs.join('\n\n'));
 }
 
 /// Creates the [EmailMessage] that will be sent to users about new invitations

--- a/app/test/package/upload_test.dart
+++ b/app/test/package/upload_test.dart
@@ -1238,7 +1238,30 @@ void main() {
         ],
       ),
       fn: () async {
-        packageBackend.maxVersionsPerPackage = 100;
+        packageBackend.maxVersionsPerPackage = 102;
+
+        final tarball101 = await packageArchiveBytes(
+            pubspecContent: generatePubspecYaml('busy_pkg', '1.0.101'));
+        final rs101 = await createPubApiClient(authToken: adminClientToken)
+            .uploadPackageBytes(tarball101);
+        expect(
+            rs101.success.message,
+            contains(
+                'The package "busy_pkg" has 1 versions left before reaching the limit of 102. '
+                'Please contact support@pub.dev'));
+
+        final tarball102 = await packageArchiveBytes(
+            pubspecContent: generatePubspecYaml('busy_pkg', '1.0.102'));
+        final rs102 = await createPubApiClient(authToken: adminClientToken)
+            .uploadPackageBytes(tarball102);
+        expect(
+            rs102.success.message,
+            contains(
+                'The package "busy_pkg" has 0 versions left before reaching the limit of 102. '
+                'Please contact support@pub.dev'));
+        expect(fakeEmailSender.sentMessages.last.bodyText,
+            contains('has 0 versions left before reaching the limit'));
+
         final tarball = await packageArchiveBytes(
             pubspecContent: generatePubspecYaml('busy_pkg', '2.0.0'));
         final rs = createPubApiClient(authToken: adminClientToken)

--- a/app/test/package/upload_test.dart
+++ b/app/test/package/upload_test.dart
@@ -1247,7 +1247,7 @@ void main() {
         expect(
             rs101.success.message,
             contains(
-                'The package "busy_pkg" has 1 versions left before reaching the limit of 102. '
+                'The package "busy_pkg" has 1 version left before reaching the limit of 102. '
                 'Please contact support@pub.dev'));
 
         final tarball102 = await packageArchiveBytes(

--- a/app/test/service/email/email_templates_test.dart
+++ b/app/test/service/email/email_templates_test.dart
@@ -169,6 +169,7 @@ void main() {
           EmailAddress(name: 'Joe', 'joe@example.com'),
           EmailAddress('uploader@example.com')
         ],
+        uploadMessages: [],
       );
       expect(message.from.toString(), contains('@pub.dev'));
       expect(message.recipients.map((e) => e.toString()).toList(), [


### PR DESCRIPTION
- Fixes #8053.
- Prior discussion concluded that #8063 has way more complexity than needed, but we could send a message to the uploader(s) that they are near the current version count limit. This PR creates a message for the pub client and also includes it in the notification email that is sent to the admins of the package / publisher.
