### PR TITLE
Merge topics form and forms

### DIFF
--- a/doc/topics.yaml
+++ b/doc/topics.yaml
@@ -77,6 +77,6 @@ topics:
   aliases:
   - internationalization
 - topic: form
-  description: Packages to extend form functionality in Flutter or create new form implementations.
+  description: Packages that facilitate form display or processing.
   aliases:
   - forms

--- a/doc/topics.yaml
+++ b/doc/topics.yaml
@@ -76,3 +76,7 @@ topics:
   description: Packages that facilitate internationalization.
   aliases:
   - internationalization
+- topic: form
+  description: Packages to extend form functionality in Flutter or create new form implementations.
+  aliases:
+  - forms


### PR DESCRIPTION
Add `form` like canonical topic and merge with `forms`

Motivation: https://github.com/flutter-form-builder-ecosystem/flutter_form_builder/discussions/1454

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
