### PR TITLE
Merge dotenv and environment-variables into env

### DIFF
--- a/doc/topics.yaml
+++ b/doc/topics.yaml
@@ -58,6 +58,11 @@
 # The editorial guidelines are intended to evolve as we gain more experience
 # merging/managing topics.
 topics:
+- topic: env
+  description: Packages that facilitate environment configuration.
+  aliases:
+  - dotenv
+  - environment-variables
 - topic: form
   description: Packages that facilitate form display or processing.
   aliases:


### PR DESCRIPTION
Hello,

This PR adds `env` to replace similar topics `dotenv` and `environment-variables`.

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
