### PR TITLE
Migrate Publisher.isBlocked uses before removing the field.

### DIFF
--- a/app/lib/admin/actions/moderate_publisher.dart
+++ b/app/lib/admin/actions/moderate_publisher.dart
@@ -36,7 +36,7 @@ can't be updated, administrators must not be able to update publisher options.
       'publisherId must be given',
     );
 
-    final publisher = await publisherBackend.getPublisher(publisherId!);
+    final publisher = await publisherBackend.lookupPublisher(publisherId!);
     InvalidInputException.check(
         publisher != null, 'Unable to locate publisher.');
 

--- a/app/lib/admin/actions/moderate_user.dart
+++ b/app/lib/admin/actions/moderate_user.dart
@@ -105,7 +105,7 @@ The active web sessions of the user will be expired.
         final publishers =
             await publisherBackend.listPublishersForUser(user.userId);
         for (final e in publishers.publishers!) {
-          final p = await publisherBackend.getPublisher(e.publisherId);
+          final p = await publisherBackend.lookupPublisher(e.publisherId);
           if (p == null) {
             continue;
           }

--- a/app/lib/admin/actions/publisher_info.dart
+++ b/app/lib/admin/actions/publisher_info.dart
@@ -22,7 +22,7 @@ Loads and displays the publisher information.
       '`publisher` must be given',
     );
 
-    final p = await publisherBackend.getPublisher(publisherId!);
+    final p = await publisherBackend.lookupPublisher(publisherId!);
     if (p == null) {
       throw NotFoundException.resource(publisherId);
     }

--- a/app/lib/admin/actions/publisher_members_list.dart
+++ b/app/lib/admin/actions/publisher_members_list.dart
@@ -18,7 +18,7 @@ Get information about a publisher and list all its members.
     final publisherId = options['publisher'] ??
         (throw InvalidInputException('Missing --publisher argument.'));
 
-    final publisher = await publisherBackend.getPublisher(publisherId);
+    final publisher = await publisherBackend.lookupPublisher(publisherId);
     if (publisher == null) {
       throw NotFoundException.resource(publisherId);
     }

--- a/app/lib/admin/tools/package_publisher.dart
+++ b/app/lib/admin/tools/package_publisher.dart
@@ -27,7 +27,7 @@ Future<String> executeSetPackagePublisher(List<String> args) async {
   }
 
   final package = (await packageBackend.lookupPackage(packageName))!;
-  final publisher = await publisherBackend.getPublisher(publisherId);
+  final publisher = await publisherBackend.lookupPublisher(publisherId);
   if (publisher == null) {
     return 'No such publisher.';
   }

--- a/app/lib/frontend/handlers/account.dart
+++ b/app/lib/frontend/handlers/account.dart
@@ -251,7 +251,7 @@ Future<AccountPublisherOptions> accountPublisherOptionsHandler(
     shelf.Request request, String publisherId) async {
   checkPublisherIdParam(publisherId);
   final user = await requireAuthenticatedWebUser();
-  final publisher = await publisherBackend.getPublisher(publisherId);
+  final publisher = await publisherBackend.getListedPublisher(publisherId);
   if (publisher == null) {
     throw NotFoundException.resource('publisher "$publisherId"');
   }

--- a/app/lib/frontend/handlers/publisher.dart
+++ b/app/lib/frontend/handlers/publisher.dart
@@ -82,7 +82,7 @@ Future<shelf.Response> publisherPackagesPageHandler(
     }
   }
 
-  final publisher = await publisherBackend.getPublisher(publisherId);
+  final publisher = await publisherBackend.lookupPublisher(publisherId);
   if (publisher == null) {
     // We may introduce search for publishers (e.g. somebody just mistyped a
     // domain name), but now we just have a formatted error page.
@@ -146,7 +146,7 @@ Future<shelf.Response> publisherPackagesPageHandler(
 /// Handles requests for `GET /publishers/<publisherId>/admin`.
 Future<shelf.Response> publisherAdminPageHandler(
     shelf.Request request, String publisherId) async {
-  final publisher = await publisherBackend.getPublisher(publisherId);
+  final publisher = await publisherBackend.getListedPublisher(publisherId);
   if (publisher == null) {
     // We may introduce search for publishers (e.g. somebody just mistyped a
     // domain name), but now we just have a formatted error page.
@@ -174,7 +174,7 @@ Future<shelf.Response> publisherAdminPageHandler(
 /// Handles requests for `GET /publishers/<publisherId>/activity-log`.
 Future<shelf.Response> publisherActivityLogPageHandler(
     shelf.Request request, String publisherId) async {
-  final publisher = await publisherBackend.getPublisher(publisherId);
+  final publisher = await publisherBackend.getListedPublisher(publisherId);
   if (publisher == null) {
     // We may introduce search for publishers (e.g. somebody just mistyped a
     // domain name), but now we just have a formatted error page.

--- a/app/lib/frontend/handlers/report.dart
+++ b/app/lib/frontend/handlers/report.dart
@@ -105,7 +105,7 @@ Future<void> verifyModerationSubjectExists(ModerationSubject? subject) async {
 
   final publisherId = subject?.publisherId;
   if (publisherId != null) {
-    final p = await publisherBackend.getPublisher(publisherId);
+    final p = await publisherBackend.lookupPublisher(publisherId);
     if (p == null) {
       throw NotFoundException('Publisher "$publisherId" does not exist.');
     }
@@ -223,7 +223,7 @@ Future<Message> processReportPageHandler(
       final pkg = await packageBackend.lookupPackage(subject.package!);
       isSubjectOwner = await packageBackend.isPackageAdmin(pkg!, user.userId);
     } else if (subject.isPublisher) {
-      final p = await publisherBackend.getPublisher(subject.publisherId!);
+      final p = await publisherBackend.lookupPublisher(subject.publisherId!);
       isSubjectOwner = await publisherBackend.isMemberAdmin(p!, user.userId);
     }
   }

--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -675,7 +675,7 @@ class PackageBackend {
       return p.containsUploader(userId);
     } else {
       final publisherId = p.publisherId!;
-      final publisher = await publisherBackend.getPublisher(publisherId);
+      final publisher = await publisherBackend.getListedPublisher(publisherId);
       if (publisher == null) {
         return false;
       }

--- a/app/lib/publisher/backend.dart
+++ b/app/lib/publisher/backend.dart
@@ -58,15 +58,18 @@ class PublisherBackend {
     return visible!;
   }
 
-  /// Loads a publisher. Returns `null` if it does not exists, or is blocked (not visible).
-  Future<Publisher?> getPublisher(String publisherId) async {
+  /// Loads a [Publisher] entity or `null` if there is no such entity.
+  Future<Publisher?> lookupPublisher(String publisherId) async {
     checkPublisherIdParam(publisherId);
     final pKey = _db.emptyKey.append(Publisher, id: publisherId);
-    final p = await _db.lookupOrNull<Publisher>(pKey);
-    if (p != null && p.isBlocked) {
-      return null;
-    }
-    return p;
+    return await _db.lookupOrNull<Publisher>(pKey);
+  }
+
+  /// Loads a [Publisher] entity or `null` if there is no such entity,
+  /// or if the entity is not listed / visible.
+  Future<Publisher?> getListedPublisher(String publisherId) async {
+    final p = await lookupPublisher(publisherId);
+    return p == null || p.isUnlisted ? null : p;
   }
 
   /// List publishers (in no specific order, it will be listed by their
@@ -250,7 +253,7 @@ class PublisherBackend {
   /// Gets the publisher data
   Future<api.PublisherInfo> getPublisherInfo(String publisherId) async {
     checkPublisherIdParam(publisherId);
-    final p = await getPublisher(publisherId);
+    final p = await getListedPublisher(publisherId);
     if (p == null) {
       throw NotFoundException('Publisher $publisherId does not exists.');
     }
@@ -598,12 +601,12 @@ Future<Publisher> requirePublisherAdmin(
     String? publisherId, String userId) async {
   ArgumentError.checkNotNull(userId, 'userId');
   ArgumentError.checkNotNull(publisherId, 'publisherId');
-  final p = await publisherBackend.getPublisher(publisherId!);
-  if (p == null) {
-    throw NotFoundException('Publisher $publisherId does not exists.');
-  }
-  if (p.isModerated) {
+  final p = await publisherBackend.lookupPublisher(publisherId!);
+  if (p != null && p.isModerated) {
     throw ModeratedException.publisher(publisherId);
+  }
+  if (p == null || p.isUnlisted) {
+    throw NotFoundException('Publisher $publisherId does not exists.');
   }
 
   final member = await publisherBackend._db

--- a/app/lib/publisher/backend.dart
+++ b/app/lib/publisher/backend.dart
@@ -117,7 +117,7 @@ class PublisherBackend {
       publishers.sort((a, b) => a.publisherId.compareTo(b.publisherId));
       return PublisherPage(
         publishers: publishers
-            .where((p) => !p.isBlocked)
+            .where((p) => p.isVisible)
             .map((p) => PublisherSummary(
                   publisherId: p.publisherId,
                   created: p.created!,
@@ -137,7 +137,6 @@ class PublisherBackend {
 
   /// Whether the User [userId] has admin permissions on the publisher.
   Future<bool> isMemberAdmin(Publisher publisher, String? userId) async {
-    if (publisher.isBlocked) return false;
     if (publisher.isModerated) return false;
     if (userId == null) return false;
     final member = await getPublisherMember(publisher, userId);

--- a/app/lib/publisher/models.dart
+++ b/app/lib/publisher/models.dart
@@ -89,7 +89,6 @@ class Publisher extends db.ExpandoModel<String> {
     description = '';
     websiteUrl = defaultPublisherWebsite(publisherId);
     isAbandoned = false;
-    isBlocked = false;
     isModerated = false;
   }
 
@@ -100,7 +99,7 @@ class Publisher extends db.ExpandoModel<String> {
   bool get hasContactEmail => contactEmail != null && contactEmail!.isNotEmpty;
 
   /// Whether we should not list the publisher page in sitemap or promote it in search engines.
-  bool get isUnlisted => isBlocked || isAbandoned || isModerated;
+  bool get isUnlisted => isAbandoned || isModerated;
   bool get isVisible => !isUnlisted;
 
   void updateIsModerated({required bool isModerated}) {

--- a/app/lib/shared/integrity.dart
+++ b/app/lib/shared/integrity.dart
@@ -262,7 +262,7 @@ class IntegrityChecker {
       publisherAttributes.increaseMemberCount(pm.publisherId);
       if (!publisherAttributes.publisherIds.contains(pm.publisherId)) {
         // double check actual status to prevent misreports on cache race conditions
-        final p = await publisherBackend.getPublisher(pm.publisherId);
+        final p = await publisherBackend.lookupPublisher(pm.publisherId);
         if (p == null) {
           yield 'PublisherMember "${pm.userId}" references a non-existing `publisherId`: "${pm.publisherId}".';
         }

--- a/app/test/account/consent_backend_test.dart
+++ b/app/test/account/consent_backend_test.dart
@@ -333,7 +333,7 @@ Future<void> _expireConsent(String? consentId) async {
 Future<void> _removeAdminRole(String publisherId, String email) async {
   await withFakeAuthRequestContext(email, () async {
     final agent = await requireAuthenticatedWebUser();
-    final publisher = await publisherBackend.getPublisher(publisherId);
+    final publisher = await publisherBackend.lookupPublisher(publisherId);
     final member =
         await publisherBackend.getPublisherMember(publisher!, agent.userId);
     member!.role = 'non-admin';

--- a/app/test/admin/api_test.dart
+++ b/app/test/admin/api_test.dart
@@ -349,7 +349,8 @@ void main() {
           expect(oxygen.uploaders, []);
           expect(oxygen.isDiscontinued, true);
 
-          final publisher = await publisherBackend.getPublisher('example.com');
+          final publisher =
+              await publisherBackend.lookupPublisher('example.com');
           expect(publisher!.contactEmail, isNull);
           expect(publisher.isAbandoned, isTrue);
 

--- a/app/test/admin/api_tool_test.dart
+++ b/app/test/admin/api_tool_test.dart
@@ -141,7 +141,7 @@ void main() {
 
   group('create and delete publisher', () {
     testWithProfile('publisher has packages', fn: () async {
-      final p1 = await publisherBackend.getPublisher('example.com');
+      final p1 = await publisherBackend.lookupPublisher('example.com');
       expect(p1, isNotNull);
 
       await expectLater(
@@ -161,7 +161,7 @@ void main() {
             },
           )));
 
-      final p2 = await publisherBackend.getPublisher('example.com');
+      final p2 = await publisherBackend.lookupPublisher('example.com');
       expect(p2, isNotNull);
     });
   });

--- a/app/test/admin/moderate_publisher_test.dart
+++ b/app/test/admin/moderate_publisher_test.dart
@@ -68,7 +68,7 @@ void main() {
         'before': {'isModerated': false, 'moderatedAt': null},
         'after': {'isModerated': true, 'moderatedAt': isNotEmpty},
       });
-      final p2 = await publisherBackend.getPublisher('example.com');
+      final p2 = await publisherBackend.lookupPublisher('example.com');
       expect(p2!.isModerated, isTrue);
 
       final r3 =
@@ -78,7 +78,7 @@ void main() {
         'before': {'isModerated': true, 'moderatedAt': isNotEmpty},
         'after': {'isModerated': false, 'moderatedAt': isNull},
       });
-      final p3 = await publisherBackend.getPublisher('example.com');
+      final p3 = await publisherBackend.lookupPublisher('example.com');
       expect(p3!.isModerated, isFalse);
     });
 
@@ -214,7 +214,7 @@ void main() {
       await adminBackend.deleteModeratedSubjects(before: clock.now().toUtc());
 
       // no publisher or member
-      expect(await publisherBackend.getPublisher('example.com'), isNull);
+      expect(await publisherBackend.lookupPublisher('example.com'), isNull);
       expect(
         await publisherBackend.listPublisherMembers('example.com'),
         isEmpty,

--- a/app/test/admin/moderate_user_test.dart
+++ b/app/test/admin/moderate_user_test.dart
@@ -301,7 +301,7 @@ void main() {
       expect(pkg.isDiscontinued, true);
 
       // publisher has no members
-      final publisher = await publisherBackend.getPublisher('example.com');
+      final publisher = await publisherBackend.lookupPublisher('example.com');
       expect(publisher!.isAbandoned, true);
       final members =
           await publisherBackend.listPublisherMembers('example.com');

--- a/app/test/admin/publisher_actions_test.dart
+++ b/app/test/admin/publisher_actions_test.dart
@@ -35,7 +35,7 @@ void main() {
         'creating, listing members and deleting publisher with no packages',
         fn: () async {
       final client = createPubApiClient(authToken: siteAdminToken);
-      final p0 = await publisherBackend.getPublisher('other.com');
+      final p0 = await publisherBackend.lookupPublisher('other.com');
       expect(p0, isNull);
       final rs1 = await client.adminInvokeAction(
         'publisher-create',
@@ -65,7 +65,7 @@ void main() {
           {'email': 'user@pub.dev', 'role': 'admin', 'userId': isA<String>()}
         ]
       });
-      final p1 = await publisherBackend.getPublisher('other.com');
+      final p1 = await publisherBackend.lookupPublisher('other.com');
       expect(p1, isNotNull);
       final rs2 = await client.adminInvokeAction('publisher-delete',
           AdminInvokeActionArguments(arguments: {'publisher': 'other.com'}));
@@ -74,7 +74,7 @@ void main() {
         'publisherId': 'other.com',
         'members-count': 1,
       });
-      final p2 = await publisherBackend.getPublisher('other.com');
+      final p2 = await publisherBackend.lookupPublisher('other.com');
       expect(p2, isNull);
     });
 

--- a/app/test/frontend/handlers/publisher_test.dart
+++ b/app/test/frontend/handlers/publisher_test.dart
@@ -37,10 +37,10 @@ void main() {
       );
     });
 
-    testWithProfile('publisher is blocked', fn: () async {
+    testWithProfile('publisher is moderated', fn: () async {
       final p = await dbService.lookupValue<Publisher>(
           dbService.emptyKey.append(Publisher, id: 'example.com'));
-      p.isBlocked = true;
+      p.updateIsModerated(isModerated: true);
       await dbService.commit(inserts: [p]);
       await expectHtmlResponse(
         await issueGet('/publishers/example.com/packages'),

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -545,7 +545,8 @@ void main() {
       processJobsWithFakeRunners: true,
       fn: () async {
         final searchForm = SearchForm();
-        final publisher = (await publisherBackend.getPublisher('example.com'))!;
+        final publisher =
+            (await publisherBackend.lookupPublisher('example.com'))!;
         final neon = (await scoreCardBackend.getPackageView('neon'))!;
         final titanium =
             (await scoreCardBackend.getPackageView('flutter_titanium'))!;
@@ -577,7 +578,8 @@ void main() {
       processJobsWithFakeRunners: true,
       fn: () async {
         final searchForm = SearchForm();
-        final publisher = (await publisherBackend.getPublisher('example.com'))!;
+        final publisher =
+            (await publisherBackend.lookupPublisher('example.com'))!;
         final neon = (await scoreCardBackend.getPackageView('neon'))!;
         final titanium =
             (await scoreCardBackend.getPackageView('flutter_titanium'))!;
@@ -609,7 +611,8 @@ void main() {
       'publisher admin page',
       processJobsWithFakeRunners: true,
       fn: () async {
-        final publisher = (await publisherBackend.getPublisher('example.com'))!;
+        final publisher =
+            (await publisherBackend.lookupPublisher('example.com'))!;
         final members =
             await publisherBackend.listPublisherMembers('example.com');
         final html = renderPublisherAdminPage(
@@ -635,7 +638,8 @@ void main() {
       'publisher activity log page',
       processJobsWithFakeRunners: true,
       fn: () async {
-        final publisher = (await publisherBackend.getPublisher('example.com'))!;
+        final publisher =
+            (await publisherBackend.lookupPublisher('example.com'))!;
         final activities =
             await auditBackend.listRecordsForPublisher('example.com');
         expect(activities.records, isNotEmpty);

--- a/app/test/package/package_publisher_test.dart
+++ b/app/test/package/package_publisher_test.dart
@@ -25,7 +25,7 @@ import 'backend_test_utils.dart';
 void main() {
   group('Get publisher info', () {
     _testNoPackage((client) => client.getPackagePublisher('no_package'));
-    _testPublisherBlocked((client) => client.publisherInfo('example.com'));
+    _testPublisherModerated((client) => client.publisherInfo('example.com'));
 
     testWithProfile('traditional package, not authenticated user',
         fn: () async {
@@ -46,7 +46,7 @@ void main() {
           PackagePublisherInfo(publisherId: 'no-domain.net'),
         ));
 
-    _testPublisherBlocked((client) => client.setPackagePublisher(
+    _testPublisherModerated((client) => client.setPackagePublisher(
           'oxygen',
           PackagePublisherInfo(publisherId: 'example.com'),
         ));
@@ -174,7 +174,7 @@ void main() {
       );
     });
 
-    _testPublisherBlocked(
+    _testPublisherModerated(
       (client) => client.setPackagePublisher(
         'one',
         PackagePublisherInfo(publisherId: 'example.com'),
@@ -183,7 +183,7 @@ void main() {
       publisherId: 'example.com',
     );
 
-    _testPublisherBlocked(
+    _testPublisherModerated(
       (client) => client.setPackagePublisher(
         'one',
         PackagePublisherInfo(publisherId: 'example.com'),
@@ -316,7 +316,7 @@ void _testNoPublisher(Future Function(PubApiClient client) fn) {
   });
 }
 
-void _testPublisherBlocked(
+void _testPublisherModerated(
   Future Function(PubApiClient client) fn, {
   String publisherId = 'example.com',
   TestProfile? testProfile,
@@ -324,12 +324,12 @@ void _testPublisherBlocked(
   String code = 'NotFound',
 }) {
   testWithProfile(
-    'Publisher $publisherId is blocked',
+    'Publisher $publisherId is moderated',
     testProfile: testProfile,
     fn: () async {
       final p = await dbService.lookupValue<Publisher>(
           dbService.emptyKey.append(Publisher, id: publisherId));
-      p.isBlocked = true;
+      p.updateIsModerated(isModerated: true);
       await dbService.commit(inserts: [p]);
 
       final client =

--- a/app/test/publisher/api_test.dart
+++ b/app/test/publisher/api_test.dart
@@ -799,10 +799,10 @@ void _testAdminAuthIssues(Future Function(PubApiClient client) fn) {
     await expectApiException(rs, status: 403, code: 'InsufficientPermissions');
   });
 
-  testWithProfile('Publisher is blocked / not visible', fn: () async {
+  testWithProfile('Publisher is not visible', fn: () async {
     final p = await dbService.lookupValue<Publisher>(
         dbService.emptyKey.append(Publisher, id: 'example.com'));
-    p.isBlocked = true;
+    p.updateIsModerated(isModerated: true);
     await dbService.commit(inserts: [p]);
 
     final client = await createFakeAuthPubApiClient(email: userAtPubDevEmail);

--- a/app/test/tool/maintenance/migrate_isblocked_test.dart
+++ b/app/test/tool/maintenance/migrate_isblocked_test.dart
@@ -3,8 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:pub_dev/account/backend.dart';
-import 'package:pub_dev/package/backend.dart';
-import 'package:pub_dev/publisher/backend.dart';
 import 'package:pub_dev/shared/datastore.dart';
 import 'package:pub_dev/tool/backfill/backfill_new_fields.dart';
 import 'package:test/test.dart';
@@ -13,23 +11,6 @@ import '../../shared/test_services.dart';
 
 void main() {
   group('Migrate isBlocked', () {
-    testWithProfile('publisher', fn: () async {
-      final p1 = await publisherBackend.lookupPublisher('example.com');
-      await dbService.commit(inserts: [p1!..isBlocked = true]);
-      final members =
-          await publisherBackend.listPublisherMembers('example.com');
-      for (final m in members) {
-        await accountBackend.updateBlockedFlag(m.userId, true);
-      }
-      final neon = await packageBackend.lookupPackage('neon');
-      await dbService.commit(inserts: [neon!..isDiscontinued = true]);
-
-      await migrateIsBlocked();
-
-      final p2 = await publisherBackend.lookupPublisher('example.com');
-      expect(p2!.isModerated, true);
-    });
-
     testWithProfile('user', fn: () async {
       final u1 = await accountBackend.lookupUserByEmail('user@pub.dev');
       await dbService.commit(inserts: [u1..isBlocked = true]);

--- a/app/test/tool/maintenance/migrate_isblocked_test.dart
+++ b/app/test/tool/maintenance/migrate_isblocked_test.dart
@@ -14,7 +14,7 @@ import '../../shared/test_services.dart';
 void main() {
   group('Migrate isBlocked', () {
     testWithProfile('publisher', fn: () async {
-      final p1 = await publisherBackend.getPublisher('example.com');
+      final p1 = await publisherBackend.lookupPublisher('example.com');
       await dbService.commit(inserts: [p1!..isBlocked = true]);
       final members =
           await publisherBackend.listPublisherMembers('example.com');
@@ -26,7 +26,7 @@ void main() {
 
       await migrateIsBlocked();
 
-      final p2 = await publisherBackend.getPublisher('example.com');
+      final p2 = await publisherBackend.lookupPublisher('example.com');
       expect(p2!.isModerated, true);
     });
 


### PR DESCRIPTION
- #8336
- The `PublisherBackend.getPublisher` relied on `isBlocked`, but not the `isModerated` flag. Its uses needed a review whether their method needs the `Publisher` entity only when it is visible or regardless of its visibility state. The first commit contains only that update.
- The other two commits are more straightforward removal of its use from lib and test, and also from migration (+ its test).
- The removal of the field still needs another site release before we can do it.