### PR TITLE
Remove fallback URL resolver.

### DIFF
--- a/app/lib/shared/urls.dart
+++ b/app/lib/shared/urls.dart
@@ -17,25 +17,6 @@ const httpsApiDartDev = 'https://api.dart.dev/';
 /// rejected and the URL mustn't be displayed.
 const trustedUrlSchemes = <String>['http', 'https', 'mailto'];
 
-/// Extensions that are considered to be images.
-final _imageExtensions = <String>{
-  '.apng',
-  '.avif',
-  '.gif',
-  '.jpg',
-  '.jpeg',
-  '.png',
-  '.svg',
-  '.webp',
-};
-
-/// Common repository URL replacement patterns.
-const _repositoryReplacePrefixes = {
-  'http://github.com': 'https://github.com',
-  'https://www.github.com': 'https://github.com',
-  'https://www.gitlab.com': 'https://gitlab.com',
-};
-
 /// Hostnames that are trusted in user-generated content (and don't get rel="ugc").
 const trustedTargetHost = [
   'api.dart.dev',
@@ -294,42 +275,6 @@ String? inferIssueTrackerUrl(String? baseUrl) {
   return null;
 }
 
-/// Infer base URL that can be used to link files from.
-String? inferBaseUrl({String? homepageUrl, String? repositoryUrl}) {
-  var baseUrl = repositoryUrl ?? homepageUrl;
-  if (baseUrl == null) return null;
-
-  // In a few cases people specify only a deep repository URL for their
-  // package (e.g. a monorepo for multiple packages). While we default the
-  // base URL to be the repository URL, this check allows us to use the deep
-  // URL for linking.
-  if (homepageUrl != null && homepageUrl.startsWith(baseUrl)) {
-    baseUrl = homepageUrl;
-  }
-
-  // URL cleanup
-  final prefixReplacements = const <String, String>{
-    'http://github.com/': 'https://github.com/',
-    'http://www.github.com/': 'https://github.com/',
-    'https://www.github.com/': 'https://github.com/',
-    'http://gitlab.com/': 'https://gitlab.com/',
-    'http://www.gitlab.com/': 'https://gitlab.com/',
-    'https://www.gitlab.com/': 'https://gitlab.com/',
-  };
-  for (final prefix in prefixReplacements.keys) {
-    if (baseUrl!.startsWith(prefix)) {
-      baseUrl = baseUrl.replaceFirst(prefix, prefixReplacements[prefix]!);
-    }
-  }
-  if ((baseUrl!.startsWith('https://github.com/') ||
-          baseUrl.startsWith('https://gitlab.com/')) &&
-      baseUrl.endsWith('.git')) {
-    baseUrl = baseUrl.substring(0, baseUrl.length - 4);
-  }
-
-  return baseUrl;
-}
-
 /// Infer the hosting/service provider for a given URL.
 String? inferServiceProviderName(String? url) {
   if (url == null) {
@@ -382,57 +327,6 @@ String myLikedPackagesUrl() => '/my-liked-packages';
 String myPublishersUrl() => '/my-publishers';
 String myActivityLogUrl() => '/my-activity-log';
 String createPublisherUrl() => '/create-publisher';
-
-/// Returns an URL that is likely the downloadable URL of the given path.
-String? getRepositoryUrl(
-  String? repository,
-  String relativePath, {
-  String branch = 'master',
-}) {
-  if (repository == null || repository.isEmpty) return null;
-  for (final key in _repositoryReplacePrefixes.keys) {
-    if (repository!.startsWith(key)) {
-      repository =
-          repository.replaceFirst(key, _repositoryReplacePrefixes[key]!);
-    }
-  }
-  try {
-    final uri = Uri.parse(repository!);
-    final segments = List.of(uri.pathSegments);
-    while (segments.isNotEmpty && segments.last.isEmpty) {
-      segments.removeLast();
-    }
-
-    if (repository.startsWith('https://github.com/') ||
-        repository.startsWith('https://gitlab.com/')) {
-      if (segments.length >= 2 &&
-          segments[1].endsWith('.git') &&
-          segments[1].length > 4) {
-        segments[1] = segments[1].substring(0, segments[1].length - 4);
-      }
-
-      final extension = p.extension(relativePath).toLowerCase();
-      final isRaw = _imageExtensions.contains(extension);
-      final typeSegment = isRaw ? 'raw' : 'blob';
-
-      if (segments.length < 2) {
-        return null;
-      } else if (segments.length == 2) {
-        final newUrl = uri.replace(pathSegments: segments).toString();
-        return p.url.join(newUrl, typeSegment, branch, relativePath);
-      } else if (segments[2] == 'tree' || segments[2] == 'blob') {
-        segments[2] = typeSegment;
-        final newUrl = uri.replace(pathSegments: segments).toString();
-        return p.url.join(newUrl, relativePath);
-      } else {
-        return null;
-      }
-    }
-  } catch (_) {
-    return null;
-  }
-  return null;
-}
 
 /// Parses [url] and returns the [Uri] object only if the result Uri is valid
 /// (e.g. is relative or has recognized scheme).

--- a/app/test/shared/urls_test.dart
+++ b/app/test/shared/urls_test.dart
@@ -117,66 +117,6 @@ void main() {
     });
   });
 
-  group('Infer base URL', () {
-    final repo = 'https://gitlab.com/user/repo';
-
-    test('only homepage is set', () {
-      expect(inferBaseUrl(homepageUrl: repo), repo);
-      expect(
-        inferBaseUrl(homepageUrl: '$repo/tree/master/dir'),
-        '$repo/tree/master/dir',
-      );
-    });
-
-    test('only repository is set', () {
-      expect(inferBaseUrl(repositoryUrl: repo), repo);
-      expect(
-        inferBaseUrl(repositoryUrl: '$repo/tree/master/dir'),
-        '$repo/tree/master/dir',
-      );
-    });
-
-    test('deep homepage, inferred repository', () {
-      final homepage = '$repo/tree/master/dir';
-      expect(
-        inferBaseUrl(
-          homepageUrl: homepage,
-          repositoryUrl: inferRepositoryUrl(homepage),
-        ),
-        '$repo/tree/master/dir',
-      );
-    });
-
-    test('unrelated homepage, simple repository', () {
-      final homepage = 'https://example.com/';
-      expect(
-        inferBaseUrl(
-          homepageUrl: homepage,
-          repositoryUrl: repo,
-        ),
-        repo,
-      );
-    });
-
-    test('URL cleanup', () {
-      expect(
-          inferBaseUrl(
-            homepageUrl: 'http://gitlab.com/user/repo.git',
-          ),
-          repo);
-      expect(
-          inferBaseUrl(
-            homepageUrl: 'http://www.gitlab.com/user/repo.git',
-          ),
-          repo);
-      expect(
-          inferBaseUrl(
-            homepageUrl: 'https://www.gitlab.com/user/repo.git',
-          ),
-          repo);
-    });
-  });
-
   group('search urls', () {
     test('non-identifier characters', () {
       expect(searchUrl(q: 'a b'), '/packages?q=a+b');

--- a/app/test/task/testdata/goldens/packages/oxygen/example.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/example.html
@@ -202,9 +202,7 @@
               <div class="detail-tabs-content">
                 <section class="tab-content detail-tab-example-content -active markdown-body">
                   <p style="font-family: monospace">
-                    <b>
-                      <a href="https://github.com/example/oxygen/blob/master/example/example.dart" rel="noopener noreferrer nofollow" target="_blank">example/example.dart</a>
-                    </b>
+                    <b>example/example.dart</b>
                   </p>
                   <pre>
                     <code class="language-dart">main() { print('example'); }</code>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/example.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/example.html
@@ -206,9 +206,7 @@
               <div class="detail-tabs-content">
                 <section class="tab-content detail-tab-example-content -active markdown-body">
                   <p style="font-family: monospace">
-                    <b>
-                      <a href="https://github.com/example/oxygen/blob/master/example/example.dart" rel="noopener noreferrer nofollow" target="_blank">example/example.dart</a>
-                    </b>
+                    <b>example/example.dart</b>
                   </p>
                   <pre>
                     <code class="language-dart">main() { print('example'); }</code>


### PR DESCRIPTION
- Removes the fallback URL resolver that used the unverified links to resolve relative references.
- Relative links are only resolved when a repository has been verified (and verification did not fail). 
- This change also fixed a few test cases, now that it uses the pana's url resolver all the time.