### PR TITLE
Fallback to non-verified URLs only when a package analysis was not completed.

### DIFF
--- a/app/lib/package/models.dart
+++ b/app/lib/package/models.dart
@@ -1131,27 +1131,32 @@ class PackagePageData {
   bool get isLatestStable => version.version == package.latestVersion;
 
   late final packageLinks = () {
-    // start with the URLs from pubspec.yaml
+    // If the repository failed the verification tests, we are not displaying
+    // any links.
+    final result = scoreCard.panaReport?.result;
+    final repositoryStatus = result?.repositoryStatus;
+    if (repositoryStatus == RepositoryStatus.failed) {
+      return PackageLinks._();
+    }
+
+    // If the analysis completed, return the URLs from it.
+    if (result != null) {
+      return PackageLinks._(
+        homepageUrl: result.homepageUrl,
+        repositoryUrl: result.repositoryUrl,
+        issueTrackerUrl: result.issueTrackerUrl,
+        documentationUrl: result.documentationUrl,
+        contributingUrl: result.contributingUrl,
+      );
+    }
+
+    // Fallback: if the analysis did not complete yet, display inferred URLs from pubspec.yaml
     final pubspec = version.pubspec!;
-    final inferred = PackageLinks.infer(
+    return PackageLinks.infer(
       homepageUrl: pubspec.homepage,
       documentationUrl: pubspec.documentation,
       repositoryUrl: pubspec.repository,
       issueTrackerUrl: pubspec.issueTracker,
-    );
-
-    // Use verified URLs when they are available.
-    final result = scoreCard.panaReport?.result;
-    if (result == null) {
-      return inferred;
-    }
-
-    return PackageLinks._(
-      homepageUrl: result.homepageUrl ?? inferred.homepageUrl,
-      repositoryUrl: result.repositoryUrl ?? inferred.repositoryUrl,
-      issueTrackerUrl: result.issueTrackerUrl ?? inferred.issueTrackerUrl,
-      documentationUrl: result.documentationUrl ?? inferred.documentationUrl,
-      contributingUrl: result.contributingUrl ?? inferred.contributingUrl,
     );
   }();
 

--- a/app/test/frontend/golden/pkg_activity_log_page.html
+++ b/app/test/frontend/golden/pkg_activity_log_page.html
@@ -391,8 +391,6 @@
               <br/>
               <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
               <br/>
-              <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
-              <br/>
               <a class="link" href="https://github.com/example/oxygen/blob/master/CONTRIBUTING.md" rel="ugc">Contributing</a>
               <br/>
             </p>
@@ -468,8 +466,6 @@
             <a class="link" href="https://oxygen.example.com/" rel="ugc">Homepage</a>
             <br/>
             <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
-            <br/>
-            <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
             <br/>
             <a class="link" href="https://github.com/example/oxygen/blob/master/CONTRIBUTING.md" rel="ugc">Contributing</a>
             <br/>

--- a/app/test/frontend/golden/pkg_admin_page.html
+++ b/app/test/frontend/golden/pkg_admin_page.html
@@ -676,8 +676,6 @@
               <br/>
               <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
               <br/>
-              <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
-              <br/>
               <a class="link" href="https://github.com/example/oxygen/blob/master/CONTRIBUTING.md" rel="ugc">Contributing</a>
               <br/>
             </p>
@@ -753,8 +751,6 @@
             <a class="link" href="https://oxygen.example.com/" rel="ugc">Homepage</a>
             <br/>
             <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
-            <br/>
-            <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
             <br/>
             <a class="link" href="https://github.com/example/oxygen/blob/master/CONTRIBUTING.md" rel="ugc">Contributing</a>
             <br/>

--- a/app/test/frontend/golden/pkg_changelog_page.html
+++ b/app/test/frontend/golden/pkg_changelog_page.html
@@ -261,8 +261,6 @@
               <br/>
               <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
               <br/>
-              <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
-              <br/>
               <a class="link" href="https://github.com/example/oxygen/blob/master/CONTRIBUTING.md" rel="ugc">Contributing</a>
               <br/>
             </p>
@@ -339,8 +337,6 @@
             <a class="link" href="https://oxygen.example.com/" rel="ugc">Homepage</a>
             <br/>
             <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
-            <br/>
-            <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
             <br/>
             <a class="link" href="https://github.com/example/oxygen/blob/master/CONTRIBUTING.md" rel="ugc">Contributing</a>
             <br/>

--- a/app/test/frontend/golden/pkg_example_page.html
+++ b/app/test/frontend/golden/pkg_example_page.html
@@ -258,8 +258,6 @@
               <br/>
               <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
               <br/>
-              <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
-              <br/>
               <a class="link" href="https://github.com/example/oxygen/blob/master/CONTRIBUTING.md" rel="ugc">Contributing</a>
               <br/>
             </p>
@@ -336,8 +334,6 @@
             <a class="link" href="https://oxygen.example.com/" rel="ugc">Homepage</a>
             <br/>
             <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
-            <br/>
-            <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
             <br/>
             <a class="link" href="https://github.com/example/oxygen/blob/master/CONTRIBUTING.md" rel="ugc">Contributing</a>
             <br/>

--- a/app/test/frontend/golden/pkg_install_page.html
+++ b/app/test/frontend/golden/pkg_install_page.html
@@ -284,8 +284,6 @@
               <br/>
               <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
               <br/>
-              <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
-              <br/>
               <a class="link" href="https://github.com/example/oxygen/blob/master/CONTRIBUTING.md" rel="ugc">Contributing</a>
               <br/>
             </p>
@@ -362,8 +360,6 @@
             <a class="link" href="https://oxygen.example.com/" rel="ugc">Homepage</a>
             <br/>
             <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
-            <br/>
-            <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
             <br/>
             <a class="link" href="https://github.com/example/oxygen/blob/master/CONTRIBUTING.md" rel="ugc">Contributing</a>
             <br/>

--- a/app/test/frontend/golden/pkg_score_page.html
+++ b/app/test/frontend/golden/pkg_score_page.html
@@ -346,8 +346,6 @@
               <br/>
               <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
               <br/>
-              <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
-              <br/>
               <a class="link" href="https://github.com/example/oxygen/blob/master/CONTRIBUTING.md" rel="ugc">Contributing</a>
               <br/>
             </p>
@@ -424,8 +422,6 @@
             <a class="link" href="https://oxygen.example.com/" rel="ugc">Homepage</a>
             <br/>
             <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
-            <br/>
-            <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
             <br/>
             <a class="link" href="https://github.com/example/oxygen/blob/master/CONTRIBUTING.md" rel="ugc">Contributing</a>
             <br/>

--- a/app/test/frontend/golden/pkg_score_page_with_downloads_chart.html
+++ b/app/test/frontend/golden/pkg_score_page_with_downloads_chart.html
@@ -346,8 +346,6 @@
               <br/>
               <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
               <br/>
-              <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
-              <br/>
               <a class="link" href="https://github.com/example/oxygen/blob/master/CONTRIBUTING.md" rel="ugc">Contributing</a>
               <br/>
             </p>
@@ -424,8 +422,6 @@
             <a class="link" href="https://oxygen.example.com/" rel="ugc">Homepage</a>
             <br/>
             <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
-            <br/>
-            <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
             <br/>
             <a class="link" href="https://github.com/example/oxygen/blob/master/CONTRIBUTING.md" rel="ugc">Contributing</a>
             <br/>

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -261,8 +261,6 @@
               <br/>
               <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
               <br/>
-              <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
-              <br/>
               <a class="link" href="https://github.com/example/oxygen/blob/master/CONTRIBUTING.md" rel="ugc">Contributing</a>
               <br/>
             </p>
@@ -339,8 +337,6 @@
             <a class="link" href="https://oxygen.example.com/" rel="ugc">Homepage</a>
             <br/>
             <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
-            <br/>
-            <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
             <br/>
             <a class="link" href="https://github.com/example/oxygen/blob/master/CONTRIBUTING.md" rel="ugc">Contributing</a>
             <br/>

--- a/app/test/frontend/golden/pkg_show_page_discontinued.html
+++ b/app/test/frontend/golden/pkg_show_page_discontinued.html
@@ -250,11 +250,7 @@
             <h3 class="title pkg-infobox-metadata">Metadata</h3>
             <p>pkg is awesome</p>
             <p>
-              <a class="link" href="https://pkg.example.com/" rel="ugc">Homepage</a>
-              <br/>
               <a class="link" href="https://github.com/example/pkg" rel="ugc">Repository (GitHub)</a>
-              <br/>
-              <a class="link" href="https://github.com/example/pkg/issues" rel="ugc">View/report issues</a>
               <br/>
               <a class="link" href="https://github.com/example/pkg/blob/main/CONTRIBUTING.md" rel="ugc">Contributing</a>
               <br/>
@@ -329,11 +325,7 @@
           <h3 class="title pkg-infobox-metadata">Metadata</h3>
           <p>pkg is awesome</p>
           <p>
-            <a class="link" href="https://pkg.example.com/" rel="ugc">Homepage</a>
-            <br/>
             <a class="link" href="https://github.com/example/pkg" rel="ugc">Repository (GitHub)</a>
-            <br/>
-            <a class="link" href="https://github.com/example/pkg/issues" rel="ugc">View/report issues</a>
             <br/>
             <a class="link" href="https://github.com/example/pkg/blob/main/CONTRIBUTING.md" rel="ugc">Contributing</a>
             <br/>

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -250,8 +250,6 @@
               <br/>
               <a class="link" href="https://github.com/example/flutter_titanium" rel="ugc">Repository (GitHub)</a>
               <br/>
-              <a class="link" href="https://github.com/example/flutter_titanium/issues" rel="ugc">View/report issues</a>
-              <br/>
               <a class="link" href="https://github.com/example/flutter_titanium/blob/master/CONTRIBUTING.md" rel="ugc">Contributing</a>
               <br/>
             </p>
@@ -332,8 +330,6 @@
             <a class="link" href="https://flutter_titanium.example.com/" rel="ugc">Homepage</a>
             <br/>
             <a class="link" href="https://github.com/example/flutter_titanium" rel="ugc">Repository (GitHub)</a>
-            <br/>
-            <a class="link" href="https://github.com/example/flutter_titanium/issues" rel="ugc">View/report issues</a>
             <br/>
             <a class="link" href="https://github.com/example/flutter_titanium/blob/master/CONTRIBUTING.md" rel="ugc">Contributing</a>
             <br/>

--- a/app/test/frontend/golden/pkg_show_page_publisher.html
+++ b/app/test/frontend/golden/pkg_show_page_publisher.html
@@ -252,8 +252,6 @@
               <br/>
               <a class="link" href="https://github.com/example/neon" rel="ugc">Repository (GitHub)</a>
               <br/>
-              <a class="link" href="https://github.com/example/neon/issues" rel="ugc">View/report issues</a>
-              <br/>
               <a class="link" href="https://github.com/example/neon/blob/master/CONTRIBUTING.md" rel="ugc">Contributing</a>
               <br/>
             </p>
@@ -333,8 +331,6 @@
             <a class="link" href="https://neon.example.com/" rel="ugc">Homepage</a>
             <br/>
             <a class="link" href="https://github.com/example/neon" rel="ugc">Repository (GitHub)</a>
-            <br/>
-            <a class="link" href="https://github.com/example/neon/issues" rel="ugc">View/report issues</a>
             <br/>
             <a class="link" href="https://github.com/example/neon/blob/master/CONTRIBUTING.md" rel="ugc">Contributing</a>
             <br/>

--- a/app/test/frontend/golden/pkg_show_page_retracted_non_retracted_version.html
+++ b/app/test/frontend/golden/pkg_show_page_retracted_non_retracted_version.html
@@ -241,11 +241,7 @@
             <h3 class="title pkg-infobox-metadata">Metadata</h3>
             <p>pkg is awesome</p>
             <p>
-              <a class="link" href="https://pkg.example.com/" rel="ugc">Homepage</a>
-              <br/>
               <a class="link" href="https://github.com/example/pkg" rel="ugc">Repository (GitHub)</a>
-              <br/>
-              <a class="link" href="https://github.com/example/pkg/issues" rel="ugc">View/report issues</a>
               <br/>
               <a class="link" href="https://github.com/example/pkg/blob/main/CONTRIBUTING.md" rel="ugc">Contributing</a>
               <br/>
@@ -320,11 +316,7 @@
           <h3 class="title pkg-infobox-metadata">Metadata</h3>
           <p>pkg is awesome</p>
           <p>
-            <a class="link" href="https://pkg.example.com/" rel="ugc">Homepage</a>
-            <br/>
             <a class="link" href="https://github.com/example/pkg" rel="ugc">Repository (GitHub)</a>
-            <br/>
-            <a class="link" href="https://github.com/example/pkg/issues" rel="ugc">View/report issues</a>
             <br/>
             <a class="link" href="https://github.com/example/pkg/blob/main/CONTRIBUTING.md" rel="ugc">Contributing</a>
             <br/>

--- a/app/test/frontend/golden/pkg_show_version_page.html
+++ b/app/test/frontend/golden/pkg_show_version_page.html
@@ -255,8 +255,6 @@
               <br/>
               <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
               <br/>
-              <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
-              <br/>
               <a class="link" href="https://github.com/example/oxygen/blob/master/CONTRIBUTING.md" rel="ugc">Contributing</a>
               <br/>
             </p>
@@ -333,8 +331,6 @@
             <a class="link" href="https://oxygen.example.com/" rel="ugc">Homepage</a>
             <br/>
             <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
-            <br/>
-            <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
             <br/>
             <a class="link" href="https://github.com/example/oxygen/blob/master/CONTRIBUTING.md" rel="ugc">Contributing</a>
             <br/>

--- a/app/test/frontend/golden/pkg_versions_page.html
+++ b/app/test/frontend/golden/pkg_versions_page.html
@@ -368,8 +368,6 @@
               <br/>
               <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
               <br/>
-              <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
-              <br/>
               <a class="link" href="https://github.com/example/oxygen/blob/master/CONTRIBUTING.md" rel="ugc">Contributing</a>
               <br/>
             </p>
@@ -446,8 +444,6 @@
             <a class="link" href="https://oxygen.example.com/" rel="ugc">Homepage</a>
             <br/>
             <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
-            <br/>
-            <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
             <br/>
             <a class="link" href="https://github.com/example/oxygen/blob/master/CONTRIBUTING.md" rel="ugc">Contributing</a>
             <br/>

--- a/app/test/task/testdata/goldens/packages/oxygen.html
+++ b/app/test/task/testdata/goldens/packages/oxygen.html
@@ -251,8 +251,6 @@
               <br/>
               <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
               <br/>
-              <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
-              <br/>
             </p>
             <h3 class="title">Topics</h3>
             <p>
@@ -331,8 +329,6 @@
             <a class="link" href="https://oxygen.example.com/" rel="ugc">Homepage</a>
             <br/>
             <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
-            <br/>
-            <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
             <br/>
           </p>
           <h3 class="title">Topics</h3>

--- a/app/test/task/testdata/goldens/packages/oxygen/changelog.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/changelog.html
@@ -257,8 +257,6 @@
               <br/>
               <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
               <br/>
-              <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
-              <br/>
             </p>
             <h3 class="title">Topics</h3>
             <p>
@@ -337,8 +335,6 @@
             <a class="link" href="https://oxygen.example.com/" rel="ugc">Homepage</a>
             <br/>
             <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
-            <br/>
-            <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
             <br/>
           </p>
           <h3 class="title">Topics</h3>

--- a/app/test/task/testdata/goldens/packages/oxygen/example.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/example.html
@@ -252,8 +252,6 @@
               <br/>
               <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
               <br/>
-              <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
-              <br/>
             </p>
             <h3 class="title">Topics</h3>
             <p>
@@ -332,8 +330,6 @@
             <a class="link" href="https://oxygen.example.com/" rel="ugc">Homepage</a>
             <br/>
             <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
-            <br/>
-            <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
             <br/>
           </p>
           <h3 class="title">Topics</h3>

--- a/app/test/task/testdata/goldens/packages/oxygen/install.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/install.html
@@ -280,8 +280,6 @@
               <br/>
               <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
               <br/>
-              <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
-              <br/>
             </p>
             <h3 class="title">Topics</h3>
             <p>
@@ -360,8 +358,6 @@
             <a class="link" href="https://oxygen.example.com/" rel="ugc">Homepage</a>
             <br/>
             <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
-            <br/>
-            <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
             <br/>
           </p>
           <h3 class="title">Topics</h3>

--- a/app/test/task/testdata/goldens/packages/oxygen/license.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/license.html
@@ -253,8 +253,6 @@
               <br/>
               <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
               <br/>
-              <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
-              <br/>
             </p>
             <h3 class="title">Topics</h3>
             <p>
@@ -333,8 +331,6 @@
             <a class="link" href="https://oxygen.example.com/" rel="ugc">Homepage</a>
             <br/>
             <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
-            <br/>
-            <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
             <br/>
           </p>
           <h3 class="title">Topics</h3>

--- a/app/test/task/testdata/goldens/packages/oxygen/score.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/score.html
@@ -561,8 +561,6 @@
               <br/>
               <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
               <br/>
-              <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
-              <br/>
             </p>
             <h3 class="title">Topics</h3>
             <p>
@@ -641,8 +639,6 @@
             <a class="link" href="https://oxygen.example.com/" rel="ugc">Homepage</a>
             <br/>
             <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
-            <br/>
-            <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
             <br/>
           </p>
           <h3 class="title">Topics</h3>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions.html
@@ -313,8 +313,6 @@
               <br/>
               <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
               <br/>
-              <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
-              <br/>
             </p>
             <h3 class="title">Topics</h3>
             <p>
@@ -393,8 +391,6 @@
             <a class="link" href="https://oxygen.example.com/" rel="ugc">Homepage</a>
             <br/>
             <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
-            <br/>
-            <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
             <br/>
           </p>
           <h3 class="title">Topics</h3>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0.html
@@ -255,8 +255,6 @@
               <br/>
               <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
               <br/>
-              <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
-              <br/>
             </p>
             <h3 class="title">Topics</h3>
             <p>
@@ -335,8 +333,6 @@
             <a class="link" href="https://oxygen.example.com/" rel="ugc">Homepage</a>
             <br/>
             <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
-            <br/>
-            <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
             <br/>
           </p>
           <h3 class="title">Topics</h3>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/changelog.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/changelog.html
@@ -261,8 +261,6 @@
               <br/>
               <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
               <br/>
-              <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
-              <br/>
             </p>
             <h3 class="title">Topics</h3>
             <p>
@@ -341,8 +339,6 @@
             <a class="link" href="https://oxygen.example.com/" rel="ugc">Homepage</a>
             <br/>
             <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
-            <br/>
-            <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
             <br/>
           </p>
           <h3 class="title">Topics</h3>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/example.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/example.html
@@ -256,8 +256,6 @@
               <br/>
               <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
               <br/>
-              <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
-              <br/>
             </p>
             <h3 class="title">Topics</h3>
             <p>
@@ -336,8 +334,6 @@
             <a class="link" href="https://oxygen.example.com/" rel="ugc">Homepage</a>
             <br/>
             <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
-            <br/>
-            <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
             <br/>
           </p>
           <h3 class="title">Topics</h3>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/install.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/install.html
@@ -284,8 +284,6 @@
               <br/>
               <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
               <br/>
-              <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
-              <br/>
             </p>
             <h3 class="title">Topics</h3>
             <p>
@@ -364,8 +362,6 @@
             <a class="link" href="https://oxygen.example.com/" rel="ugc">Homepage</a>
             <br/>
             <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
-            <br/>
-            <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
             <br/>
           </p>
           <h3 class="title">Topics</h3>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/license.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/license.html
@@ -257,8 +257,6 @@
               <br/>
               <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
               <br/>
-              <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
-              <br/>
             </p>
             <h3 class="title">Topics</h3>
             <p>
@@ -337,8 +335,6 @@
             <a class="link" href="https://oxygen.example.com/" rel="ugc">Homepage</a>
             <br/>
             <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
-            <br/>
-            <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
             <br/>
           </p>
           <h3 class="title">Topics</h3>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/score.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/score.html
@@ -565,8 +565,6 @@
               <br/>
               <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
               <br/>
-              <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
-              <br/>
             </p>
             <h3 class="title">Topics</h3>
             <p>
@@ -645,8 +643,6 @@
             <a class="link" href="https://oxygen.example.com/" rel="ugc">Homepage</a>
             <br/>
             <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
-            <br/>
-            <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
             <br/>
           </p>
           <h3 class="title">Topics</h3>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/2.0.0.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/2.0.0.html
@@ -251,8 +251,6 @@
               <br/>
               <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
               <br/>
-              <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
-              <br/>
             </p>
             <h3 class="title">Topics</h3>
             <p>
@@ -331,8 +329,6 @@
             <a class="link" href="https://oxygen.example.com/" rel="ugc">Homepage</a>
             <br/>
             <a class="link" href="https://github.com/example/oxygen" rel="ugc">Repository (GitHub)</a>
-            <br/>
-            <a class="link" href="https://github.com/example/oxygen/issues" rel="ugc">View/report issues</a>
             <br/>
           </p>
           <h3 class="title">Topics</h3>


### PR DESCRIPTION
- The previous logic mixed the display of (pana-)verified and non-verified (inferred-only) URLs.
- The new logic will always prefer analysis content if it is available.
- If the repository verification tests failed, we don't display any of the URLs (assuming the package is non-updated clone).
- Non-verified URLs will be displayed only on when the package analysis has not been completed.

Note: the URLs in question are displayed in the infobox.