### PR TITLE
Remove unconditional placeholder from dartdoc page rendering.

### DIFF
--- a/app/lib/dartdoc/dartdoc_page.dart
+++ b/app/lib/dartdoc/dartdoc_page.dart
@@ -254,9 +254,6 @@ extension DartDocPageRender on DartDocPage {
             ],
           ),
           _left,
-          // TODO: remove this after all runtimes are rendered with dartdoc >=8.0.0
-          if (!left.contains('dartdoc-sidebar-left-content'))
-            d.div(id: 'dartdoc-sidebar-left-content', text: ''),
         ],
       );
 

--- a/app/test/dartdoc/dartdoc_page_test.dart
+++ b/app/test/dartdoc/dartdoc_page_test.dart
@@ -224,13 +224,6 @@ void main() {
               renderedFirstBreadcrumbs.remove();
             }
 
-            // removing unconditional placeholder
-            renderedXmlDoc.descendantElements
-                .firstWhereOrNull((e) =>
-                    e.localName == 'div' &&
-                    e.getAttribute('id') == 'dartdoc-sidebar-left-content')
-                ?.remove();
-
             // main content section -> div
             final fileMainContentDiv = fileXmlRoot.descendantElements
                 .firstWhere(

--- a/app/test/task/testdata/goldens/documentation/oxygen/1.0.0/index.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/1.0.0/index.html
@@ -85,7 +85,6 @@
             <a href="oxygen/">oxygen</a>
           </li>
         </ol>
-        <div id="dartdoc-sidebar-left-content"></div>
       </div>
       <div id="dartdoc-sidebar-right" class="sidebar sidebar-offcanvas-right"></div>
     </main>

--- a/app/test/task/testdata/goldens/documentation/oxygen/1.0.0/oxygen/index.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/1.0.0/oxygen/index.html
@@ -121,7 +121,6 @@
             <a href="../oxygen/">oxygen</a>
           </li>
         </ol>
-        <div id="dartdoc-sidebar-left-content"></div>
       </div>
       <div id="dartdoc-sidebar-right" class="sidebar sidebar-offcanvas-right">
         <h5>oxygen library</h5>

--- a/app/test/task/testdata/goldens/documentation/oxygen/2.0.0/index.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/2.0.0/index.html
@@ -85,7 +85,6 @@
             <a href="oxygen/">oxygen</a>
           </li>
         </ol>
-        <div id="dartdoc-sidebar-left-content"></div>
       </div>
       <div id="dartdoc-sidebar-right" class="sidebar sidebar-offcanvas-right"></div>
     </main>

--- a/app/test/task/testdata/goldens/documentation/oxygen/2.0.0/oxygen/index.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/2.0.0/oxygen/index.html
@@ -121,7 +121,6 @@
             <a href="../oxygen/">oxygen</a>
           </li>
         </ol>
-        <div id="dartdoc-sidebar-left-content"></div>
       </div>
       <div id="dartdoc-sidebar-right" class="sidebar sidebar-offcanvas-right">
         <h5>oxygen library</h5>

--- a/app/test/task/testdata/goldens/documentation/oxygen/latest/index.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/latest/index.html
@@ -83,7 +83,6 @@
             <a href="oxygen/">oxygen</a>
           </li>
         </ol>
-        <div id="dartdoc-sidebar-left-content"></div>
       </div>
       <div id="dartdoc-sidebar-right" class="sidebar sidebar-offcanvas-right"></div>
     </main>

--- a/app/test/task/testdata/goldens/documentation/oxygen/latest/oxygen/index.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/latest/oxygen/index.html
@@ -119,7 +119,6 @@
             <a href="../oxygen/">oxygen</a>
           </li>
         </ol>
-        <div id="dartdoc-sidebar-left-content"></div>
       </div>
       <div id="dartdoc-sidebar-right" class="sidebar sidebar-offcanvas-right">
         <h5>oxygen library</h5>


### PR DESCRIPTION
IIRC this was put in place because at the 8.0.0 we needed to support both old and new formats. This is no longer needed, dartdoc generates the element for files that need it (end2end tests remove it from some files but not all).