### PR TITLE
Updated link colors to increase contrasts

### DIFF
--- a/pkg/web_css/lib/src/_variables.scss
+++ b/pkg/web_css/lib/src/_variables.scss
@@ -76,7 +76,7 @@
   --pub-spinner_frame-background-color: rgba(0, 0, 0, 0.2);
 
   // Material Design theme customizations
-  --mdc-theme-primary: #0175c2;
+  --mdc-theme-primary: #1967d2;
   --mdc-theme-secondary: #0066d9;
   --mdc-typography-font-family: var(--pub-default-text-font_family);
 }
@@ -104,7 +104,7 @@
   --pub-markdown-alert-caution:   #cf222e; // danger-emphasis from GitHub
 
   --pub-code-text-color: var(--pub-neutral-textColor);
-  --pub-link-text-color: #0175c2;
+  --pub-link-text-color: #1967d2;
   --pub-badge-default-color: var(--pub-link-text-color);
   --pub-badge-red-color: var(--pub-color-dangerRed);
   --pub-copy_feedback-background-color: #fafaff;
@@ -139,12 +139,12 @@
 .dark-theme {
   @include dash_variables.dark-theme;
 
-  --pub-color-darkGunmetal:    #1f262a; // close to #1d2026
+  --pub-color-eerieBlack:      #1b1b1b;
   --pub-color-shadowBlack:     #373737;
   --pub-color-anchorBlack:     #41424c;
   --pub-color-nipponUltraBlue: #23607f;
 
-  --pub-neutral-bgColor:       var(--pub-color-darkGunmetal);
+  --pub-neutral-bgColor:       var(--pub-color-eerieBlack);
   --pub-neutral-borderColor:   var(--pub-color-anchorBlack);
   --pub-neutral-textColor:     var(--dash-surface-fgColor);
   --pub-neutral-hover-bgColor: var(--pub-color-shadowBlack);
@@ -159,7 +159,7 @@
   --pub-markdown-alert-caution:   #cf222e; // danger-emphasis from GitHub
 
   --pub-code-text-color: var(--pub-neutral-textColor);
-  --pub-link-text-color: #40c4ff;
+  --pub-link-text-color: #47b0f8;
   --pub-badge-default-color: var(--pub-link-text-color);
   --pub-badge-red-color: var(--pub-color-dangerRed);
   --pub-copy_feedback-background-color: #404040;


### PR DESCRIPTION
Follow-ups to Lighthouse low contrast reports:
- The light theme's link color is now switched to dart.dev's choice of color (gets a bit darker).
- The dark theme's link color, and also the default background become less vibrant.

Light mode before/after:
<img width="219" alt="image" src="https://github.com/user-attachments/assets/af05d366-ce7e-4197-88a4-a1fe3c81fc2d" />
<img width="229" alt="image" src="https://github.com/user-attachments/assets/cf549a7b-8c6f-4b74-9011-f93c4fcb0402" />

Dark mode before/after:
<img width="221" alt="image" src="https://github.com/user-attachments/assets/70db1f07-cb83-425c-a71d-79c85c020650" />
<img width="230" alt="image" src="https://github.com/user-attachments/assets/118e838d-4fb5-4a07-8391-f38b2383fb6e" />

