### PR TITLE
Fix ARIA attributes for x-ago texts.

### DIFF
--- a/app/lib/frontend/dom/dom.dart
+++ b/app/lib/frontend/dom/dom.dart
@@ -109,8 +109,11 @@ Node xAgoTimestamp(DateTime timestamp, {String? datePrefix}) {
     href: '',
     title: title,
     attributes: {
-      'aria-label': text,
-      'aria-role': 'button',
+      // Note: We change the `text` and the `title` when the user clicks this button.
+      //       We do not use `aria-label`, so that the screenreader will read the
+      //       appropriate change.
+      //       We do not use `aria-pressed`, so that the screenreader will not read
+      //       "toggle button pressed" as part of the text.
       'role': 'button',
       'data-timestamp': timestamp.millisecondsSinceEpoch.toString(),
     },

--- a/app/test/frontend/golden/my_activity_log_page.html
+++ b/app/test/frontend/golden/my_activity_log_page.html
@@ -146,7 +146,7 @@
                   <p>admin@pub.dev</p>
                   <p>
                     Joined
-                    <a class="-x-ago" href="" title="on %%user-created-date%%" aria-label="%%x-ago%%" aria-role="button" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
+                    <a class="-x-ago" href="" title="on %%user-created-date%%" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                   </p>
                 </div>
               </div>
@@ -185,7 +185,7 @@
                     <tbody>
                       <tr>
                         <td class="date">
-                          <a class="-x-ago" href="" title="%%user-created-date%%" aria-label="%%x-ago%%" aria-role="button" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
+                          <a class="-x-ago" href="" title="%%user-created-date%%" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                         </td>
                         <td class="summary">
                           <div class="markdown-body">
@@ -203,7 +203,7 @@
                       </tr>
                       <tr>
                         <td class="date">
-                          <a class="-x-ago" href="" title="%%user-created-date%%" aria-label="%%x-ago%%" aria-role="button" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
+                          <a class="-x-ago" href="" title="%%user-created-date%%" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                         </td>
                         <td class="summary">
                           <div class="markdown-body">
@@ -221,7 +221,7 @@
                       </tr>
                       <tr>
                         <td class="date">
-                          <a class="-x-ago" href="" title="%%user-created-date%%" aria-label="%%x-ago%%" aria-role="button" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
+                          <a class="-x-ago" href="" title="%%user-created-date%%" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                         </td>
                         <td class="summary">
                           <div class="markdown-body">
@@ -239,7 +239,7 @@
                       </tr>
                       <tr>
                         <td class="date">
-                          <a class="-x-ago" href="" title="%%user-created-date%%" aria-label="%%x-ago%%" aria-role="button" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
+                          <a class="-x-ago" href="" title="%%user-created-date%%" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                         </td>
                         <td class="summary">
                           <div class="markdown-body">
@@ -255,7 +255,7 @@
                       </tr>
                       <tr>
                         <td class="date">
-                          <a class="-x-ago" href="" title="%%user-created-date%%" aria-label="%%x-ago%%" aria-role="button" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
+                          <a class="-x-ago" href="" title="%%user-created-date%%" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                         </td>
                         <td class="summary">
                           <div class="markdown-body">
@@ -273,7 +273,7 @@
                       </tr>
                       <tr>
                         <td class="date">
-                          <a class="-x-ago" href="" title="%%user-created-date%%" aria-label="%%x-ago%%" aria-role="button" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
+                          <a class="-x-ago" href="" title="%%user-created-date%%" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                         </td>
                         <td class="summary">
                           <div class="markdown-body">
@@ -291,7 +291,7 @@
                       </tr>
                       <tr>
                         <td class="date">
-                          <a class="-x-ago" href="" title="%%user-created-date%%" aria-label="%%x-ago%%" aria-role="button" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
+                          <a class="-x-ago" href="" title="%%user-created-date%%" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                         </td>
                         <td class="summary">
                           <div class="markdown-body">
@@ -307,7 +307,7 @@
                       </tr>
                       <tr>
                         <td class="date">
-                          <a class="-x-ago" href="" title="%%user-created-date%%" aria-label="%%x-ago%%" aria-role="button" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
+                          <a class="-x-ago" href="" title="%%user-created-date%%" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                         </td>
                         <td class="summary">
                           <div class="markdown-body">
@@ -325,7 +325,7 @@
                       </tr>
                       <tr>
                         <td class="date">
-                          <a class="-x-ago" href="" title="%%user-created-date%%" aria-label="%%x-ago%%" aria-role="button" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
+                          <a class="-x-ago" href="" title="%%user-created-date%%" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                         </td>
                         <td class="summary">
                           <div class="markdown-body">
@@ -341,7 +341,7 @@
                       </tr>
                       <tr>
                         <td class="date">
-                          <a class="-x-ago" href="" title="%%user-created-date%%" aria-label="%%x-ago%%" aria-role="button" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
+                          <a class="-x-ago" href="" title="%%user-created-date%%" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                         </td>
                         <td class="summary">
                           <div class="markdown-body">
@@ -359,7 +359,7 @@
                       </tr>
                       <tr>
                         <td class="date">
-                          <a class="-x-ago" href="" title="%%user-created-date%%" aria-label="%%x-ago%%" aria-role="button" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
+                          <a class="-x-ago" href="" title="%%user-created-date%%" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                         </td>
                         <td class="summary">
                           <div class="markdown-body">

--- a/app/test/frontend/golden/my_liked_packages.html
+++ b/app/test/frontend/golden/my_liked_packages.html
@@ -147,7 +147,7 @@
                   <p>user@pub.dev</p>
                   <p>
                     Joined
-                    <a class="-x-ago" href="" title="on %%user-created-date%%" aria-label="%%x-ago%%" aria-role="button" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
+                    <a class="-x-ago" href="" title="on %%user-created-date%%" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                   </p>
                 </div>
               </div>
@@ -192,7 +192,7 @@
                       </div>
                       <p class="packages-metadata">
                         Liked
-                        <a class="-x-ago" href="" title="on %%liked1-date%%" aria-label="%%x-ago%%" aria-role="button" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
+                        <a class="-x-ago" href="" title="on %%liked1-date%%" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                       </p>
                     </div>
                     <div class="packages-item">
@@ -210,7 +210,7 @@
                       </div>
                       <p class="packages-metadata">
                         Liked
-                        <a class="-x-ago" href="" title="on %%liked1-date%%" aria-label="%%x-ago%%" aria-role="button" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
+                        <a class="-x-ago" href="" title="on %%liked1-date%%" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                       </p>
                     </div>
                   </div>

--- a/app/test/frontend/golden/my_packages.html
+++ b/app/test/frontend/golden/my_packages.html
@@ -146,7 +146,7 @@
                   <p>user@pub.dev</p>
                   <p>
                     Joined
-                    <a class="-x-ago" href="" title="on %%oxygen-created-date%%" aria-label="%%x-ago%%" aria-role="button" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
+                    <a class="-x-ago" href="" title="on %%oxygen-created-date%%" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                   </p>
                 </div>
               </div>
@@ -232,11 +232,11 @@
                               v
                               <a href="/packages/oxygen" title="Visit oxygen 1.2.0 page">1.2.0</a>
                               (
-                              <a class="-x-ago" href="" title="%%oxygen-created-date%%" aria-label="%%x-ago%%" aria-role="button" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
+                              <a class="-x-ago" href="" title="%%oxygen-created-date%%" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                               ) /
                               <a href="/packages/oxygen/versions/2.0.0-dev" title="Visit oxygen 2.0.0-dev page">2.0.0-dev</a>
                               (
-                              <a class="-x-ago" href="" title="%%oxygen-created-date%%" aria-label="%%x-ago%%" aria-role="button" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
+                              <a class="-x-ago" href="" title="%%oxygen-created-date%%" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                               )
                             </span>
                             <span class="packages-metadata-block">
@@ -315,7 +315,7 @@
                               v
                               <a href="/packages/neon" title="Visit neon 1.0.0 page">1.0.0</a>
                               (
-                              <a class="-x-ago" href="" title="%%oxygen-created-date%%" aria-label="%%x-ago%%" aria-role="button" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
+                              <a class="-x-ago" href="" title="%%oxygen-created-date%%" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                               )
                             </span>
                             <span class="packages-metadata-block">

--- a/app/test/frontend/golden/my_publishers.html
+++ b/app/test/frontend/golden/my_publishers.html
@@ -146,7 +146,7 @@
                   <p>user@pub.dev</p>
                   <p>
                     Joined
-                    <a class="-x-ago" href="" title="on %%user-created-date%%" aria-label="%%x-ago%%" aria-role="button" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
+                    <a class="-x-ago" href="" title="on %%user-created-date%%" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                   </p>
                 </div>
               </div>
@@ -181,7 +181,7 @@
                       </h3>
                       <p>
                         Registered
-                        <a class="-x-ago" href="" title="on %%publisher-created-date%%" aria-label="%%x-ago%%" aria-role="button" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
+                        <a class="-x-ago" href="" title="on %%publisher-created-date%%" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                         .
                       </p>
                     </div>

--- a/app/test/frontend/golden/pkg_activity_log_page.html
+++ b/app/test/frontend/golden/pkg_activity_log_page.html
@@ -153,7 +153,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <a class="-x-ago" href="" title="%%published-date%%" aria-label="%%x-ago%%" aria-role="button" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
+                    <a class="-x-ago" href="" title="%%published-date%%" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                   </span>
                   • Latest:
                   <span>
@@ -256,7 +256,7 @@
                     <tbody>
                       <tr>
                         <td class="date">
-                          <a class="-x-ago" href="" title="%%published-date%%" aria-label="%%x-ago%%" aria-role="button" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
+                          <a class="-x-ago" href="" title="%%published-date%%" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                         </td>
                         <td class="summary">
                           <div class="markdown-body">
@@ -266,7 +266,7 @@
                       </tr>
                       <tr>
                         <td class="date">
-                          <a class="-x-ago" href="" title="%%published-date%%" aria-label="%%x-ago%%" aria-role="button" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
+                          <a class="-x-ago" href="" title="%%published-date%%" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                         </td>
                         <td class="summary">
                           <div class="markdown-body">
@@ -284,7 +284,7 @@
                       </tr>
                       <tr>
                         <td class="date">
-                          <a class="-x-ago" href="" title="%%published-date%%" aria-label="%%x-ago%%" aria-role="button" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
+                          <a class="-x-ago" href="" title="%%published-date%%" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                         </td>
                         <td class="summary">
                           <div class="markdown-body">
@@ -302,7 +302,7 @@
                       </tr>
                       <tr>
                         <td class="date">
-                          <a class="-x-ago" href="" title="%%published-date%%" aria-label="%%x-ago%%" aria-role="button" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
+                          <a class="-x-ago" href="" title="%%published-date%%" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                         </td>
                         <td class="summary">
                           <div class="markdown-body">
@@ -322,7 +322,7 @@
                       </tr>
                       <tr>
                         <td class="date">
-                          <a class="-x-ago" href="" title="%%published-date%%" aria-label="%%x-ago%%" aria-role="button" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
+                          <a class="-x-ago" href="" title="%%published-date%%" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                         </td>
                         <td class="summary">
                           <div class="markdown-body">
@@ -340,7 +340,7 @@
                       </tr>
                       <tr>
                         <td class="date">
-                          <a class="-x-ago" href="" title="%%activity-5-date%%" aria-label="%%x-ago%%" aria-role="button" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
+                          <a class="-x-ago" href="" title="%%activity-5-date%%" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                         </td>
                         <td class="summary">
                           <div class="markdown-body">

--- a/app/test/frontend/golden/pkg_admin_page.html
+++ b/app/test/frontend/golden/pkg_admin_page.html
@@ -153,7 +153,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <a class="-x-ago" href="" title="%%published-date%%" aria-label="%%x-ago%%" aria-role="button" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
+                    <a class="-x-ago" href="" title="%%published-date%%" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                   </span>
                   • Latest:
                   <span>

--- a/app/test/frontend/golden/pkg_changelog_page.html
+++ b/app/test/frontend/golden/pkg_changelog_page.html
@@ -127,7 +127,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <a class="-x-ago" href="" title="%%published-date%%" aria-label="%%x-ago%%" aria-role="button" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
+                    <a class="-x-ago" href="" title="%%published-date%%" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                   </span>
                   • Latest:
                   <span>

--- a/app/test/frontend/golden/pkg_example_page.html
+++ b/app/test/frontend/golden/pkg_example_page.html
@@ -127,7 +127,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <a class="-x-ago" href="" title="%%published-date%%" aria-label="%%x-ago%%" aria-role="button" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
+                    <a class="-x-ago" href="" title="%%published-date%%" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                   </span>
                   • Latest:
                   <span>

--- a/app/test/frontend/golden/pkg_index_page.html
+++ b/app/test/frontend/golden/pkg_index_page.html
@@ -499,11 +499,11 @@
                       v
                       <a href="/packages/oxygen" title="Visit oxygen 1.2.0 page">1.2.0</a>
                       (
-                      <a class="-x-ago" href="" title="%%oxygen-created-date%%" aria-label="%%x-ago%%" aria-role="button" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
+                      <a class="-x-ago" href="" title="%%oxygen-created-date%%" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                       ) /
                       <a href="/packages/oxygen/versions/2.0.0-dev" title="Visit oxygen 2.0.0-dev page">2.0.0-dev</a>
                       (
-                      <a class="-x-ago" href="" title="%%oxygen-created-date%%" aria-label="%%x-ago%%" aria-role="button" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
+                      <a class="-x-ago" href="" title="%%oxygen-created-date%%" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                       )
                     </span>
                     <span class="packages-metadata-block">
@@ -582,7 +582,7 @@
                       v
                       <a href="/packages/flutter_titanium" title="Visit flutter_titanium 1.10.0 page">1.10.0</a>
                       (
-                      <a class="-x-ago" href="" title="%%oxygen-created-date%%" aria-label="%%x-ago%%" aria-role="button" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
+                      <a class="-x-ago" href="" title="%%oxygen-created-date%%" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                       )
                     </span>
                     <span class="packages-metadata-block">

--- a/app/test/frontend/golden/pkg_install_page.html
+++ b/app/test/frontend/golden/pkg_install_page.html
@@ -127,7 +127,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <a class="-x-ago" href="" title="%%published-date%%" aria-label="%%x-ago%%" aria-role="button" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
+                    <a class="-x-ago" href="" title="%%published-date%%" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                   </span>
                   • Latest:
                   <span>

--- a/app/test/frontend/golden/pkg_score_page.html
+++ b/app/test/frontend/golden/pkg_score_page.html
@@ -127,7 +127,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <a class="-x-ago" href="" title="%%published-date%%" aria-label="%%x-ago%%" aria-role="button" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
+                    <a class="-x-ago" href="" title="%%published-date%%" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                   </span>
                   • Latest:
                   <span>
@@ -234,7 +234,7 @@
                   </div>
                   <p class="analysis-info">
                     We analyzed this package
-                    <a class="-x-ago" href="" title="on %%published-date%%" aria-label="%%x-ago%%" aria-role="button" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
+                    <a class="-x-ago" href="" title="on %%published-date%%" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                     , and awarded it 54 pub points (of a possible 70):
                   </p>
                   <div class="pkg-report">

--- a/app/test/frontend/golden/pkg_score_page_with_downloads_chart.html
+++ b/app/test/frontend/golden/pkg_score_page_with_downloads_chart.html
@@ -127,7 +127,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <a class="-x-ago" href="" title="%%published-date%%" aria-label="%%x-ago%%" aria-role="button" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
+                    <a class="-x-ago" href="" title="%%published-date%%" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                   </span>
                   • Latest:
                   <span>
@@ -234,7 +234,7 @@
                   </div>
                   <p class="analysis-info">
                     We analyzed this package
-                    <a class="-x-ago" href="" title="on %%published-date%%" aria-label="%%x-ago%%" aria-role="button" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
+                    <a class="-x-ago" href="" title="on %%published-date%%" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                     , and awarded it 54 pub points (of a possible 70):
                   </p>
                   <div class="pkg-report">

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -127,7 +127,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <a class="-x-ago" href="" title="%%published-date%%" aria-label="%%x-ago%%" aria-role="button" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
+                    <a class="-x-ago" href="" title="%%published-date%%" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                   </span>
                   • Latest:
                   <span>

--- a/app/test/frontend/golden/pkg_show_page_discontinued.html
+++ b/app/test/frontend/golden/pkg_show_page_discontinued.html
@@ -127,7 +127,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <a class="-x-ago" href="" title="%%published-date%%" aria-label="%%x-ago%%" aria-role="button" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
+                    <a class="-x-ago" href="" title="%%published-date%%" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                   </span>
                 </div>
                 <div class="detail-tags-and-like">

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -127,7 +127,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <a class="-x-ago" href="" title="%%published-date%%" aria-label="%%x-ago%%" aria-role="button" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
+                    <a class="-x-ago" href="" title="%%published-date%%" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                   </span>
                 </div>
                 <div class="detail-tags-and-like">

--- a/app/test/frontend/golden/pkg_show_page_publisher.html
+++ b/app/test/frontend/golden/pkg_show_page_publisher.html
@@ -127,7 +127,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <a class="-x-ago" href="" title="%%published-date%%" aria-label="%%x-ago%%" aria-role="button" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
+                    <a class="-x-ago" href="" title="%%published-date%%" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                   </span>
                   •
                   <a class="-pub-publisher" href="/publishers/example.com">

--- a/app/test/frontend/golden/pkg_show_page_retracted.html
+++ b/app/test/frontend/golden/pkg_show_page_retracted.html
@@ -127,7 +127,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <a class="-x-ago" href="" title="%%published-date%%" aria-label="%%x-ago%%" aria-role="button" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
+                    <a class="-x-ago" href="" title="%%published-date%%" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                   </span>
                   • Latest:
                   <span>

--- a/app/test/frontend/golden/pkg_show_page_retracted_non_retracted_version.html
+++ b/app/test/frontend/golden/pkg_show_page_retracted_non_retracted_version.html
@@ -127,7 +127,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <a class="-x-ago" href="" title="%%published-date%%" aria-label="%%x-ago%%" aria-role="button" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
+                    <a class="-x-ago" href="" title="%%published-date%%" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                   </span>
                 </div>
                 <div class="detail-tags-and-like">

--- a/app/test/frontend/golden/pkg_show_version_page.html
+++ b/app/test/frontend/golden/pkg_show_version_page.html
@@ -127,7 +127,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <a class="-x-ago" href="" title="%%published-date%%" aria-label="%%x-ago%%" aria-role="button" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
+                    <a class="-x-ago" href="" title="%%published-date%%" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                   </span>
                   • Latest:
                   <span>

--- a/app/test/frontend/golden/pkg_versions_page.html
+++ b/app/test/frontend/golden/pkg_versions_page.html
@@ -127,7 +127,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <a class="-x-ago" href="" title="%%version-created-date%%" aria-label="%%x-ago%%" aria-role="button" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
+                    <a class="-x-ago" href="" title="%%version-created-date%%" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                   </span>
                   • Latest:
                   <span>
@@ -212,7 +212,7 @@
                   <p>
                     The latest prerelease was
                     <a href="#prerelease">2.0.0-dev</a>
-                    <a class="-x-ago" href="" title="on %%version-created-date%%" aria-label="%%x-ago%%" aria-role="button" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
+                    <a class="-x-ago" href="" title="on %%version-created-date%%" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                     .
                   </p>
                   <h2 id="stable">Stable versions of oxygen</h2>
@@ -245,7 +245,7 @@
                         </td>
                         <td class="sdk">3.0</td>
                         <td class="uploaded">
-                          <a class="-x-ago" href="" title="%%version-created-date%%" aria-label="%%x-ago%%" aria-role="button" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
+                          <a class="-x-ago" href="" title="%%version-created-date%%" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                         </td>
                         <td class="documentation">
                           <a href="/documentation/oxygen/1.2.0/" rel="nofollow" title="Go to the documentation of oxygen 1.2.0">
@@ -267,7 +267,7 @@
                         </td>
                         <td class="sdk">3.0</td>
                         <td class="uploaded">
-                          <a class="-x-ago" href="" title="%%version-created-date%%" aria-label="%%x-ago%%" aria-role="button" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
+                          <a class="-x-ago" href="" title="%%version-created-date%%" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                         </td>
                         <td class="documentation">
                           <a href="/documentation/oxygen/1.0.0/" rel="nofollow" title="Go to the documentation of oxygen 1.0.0">
@@ -312,7 +312,7 @@
                         </td>
                         <td class="sdk">3.0</td>
                         <td class="uploaded">
-                          <a class="-x-ago" href="" title="%%version-created-date%%" aria-label="%%x-ago%%" aria-role="button" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
+                          <a class="-x-ago" href="" title="%%version-created-date%%" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                         </td>
                         <td class="documentation">
                           <a href="/documentation/oxygen/2.0.0-dev/" rel="nofollow" title="Go to the documentation of oxygen 2.0.0-dev">

--- a/app/test/frontend/golden/publisher_activity_log_page.html
+++ b/app/test/frontend/golden/publisher_activity_log_page.html
@@ -130,7 +130,7 @@
                   </p>
                   <p>
                     Publisher registered
-                    <a class="-x-ago" href="" title="on %%publisher-created-date%%" aria-label="%%x-ago%%" aria-role="button" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
+                    <a class="-x-ago" href="" title="on %%publisher-created-date%%" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                   </p>
                 </div>
               </div>
@@ -173,7 +173,7 @@
                     <tbody>
                       <tr>
                         <td class="date">
-                          <a class="-x-ago" href="" title="%%publisher-created-date%%" aria-label="%%x-ago%%" aria-role="button" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
+                          <a class="-x-ago" href="" title="%%publisher-created-date%%" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                         </td>
                         <td class="summary">
                           <div class="markdown-body">
@@ -191,7 +191,7 @@
                       </tr>
                       <tr>
                         <td class="date">
-                          <a class="-x-ago" href="" title="%%publisher-created-date%%" aria-label="%%x-ago%%" aria-role="button" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
+                          <a class="-x-ago" href="" title="%%publisher-created-date%%" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                         </td>
                         <td class="summary">
                           <div class="markdown-body">

--- a/app/test/frontend/golden/publisher_admin_page.html
+++ b/app/test/frontend/golden/publisher_admin_page.html
@@ -130,7 +130,7 @@
                   </p>
                   <p>
                     Publisher registered
-                    <a class="-x-ago" href="" title="on %%publisher-created-date%%" aria-label="%%x-ago%%" aria-role="button" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
+                    <a class="-x-ago" href="" title="on %%publisher-created-date%%" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                   </p>
                 </div>
               </div>

--- a/app/test/frontend/golden/publisher_list_page.html
+++ b/app/test/frontend/golden/publisher_list_page.html
@@ -122,7 +122,7 @@
           </h3>
           <p>
             Registered
-            <a class="-x-ago" href="" title="on %%example-created-date%%" aria-label="%%x-ago%%" aria-role="button" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
+            <a class="-x-ago" href="" title="on %%example-created-date%%" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
             .
           </p>
         </div>
@@ -132,7 +132,7 @@
           </h3>
           <p>
             Registered
-            <a class="-x-ago" href="" title="on %%other-created-date%%" aria-label="%%x-ago%%" aria-role="button" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
+            <a class="-x-ago" href="" title="on %%other-created-date%%" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
             .
           </p>
         </div>

--- a/app/test/frontend/golden/publisher_packages_page.html
+++ b/app/test/frontend/golden/publisher_packages_page.html
@@ -130,7 +130,7 @@
                   </p>
                   <p>
                     Publisher registered
-                    <a class="-x-ago" href="" title="on %%neon-created-date%%" aria-label="%%x-ago%%" aria-role="button" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
+                    <a class="-x-ago" href="" title="on %%neon-created-date%%" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                   </p>
                 </div>
               </div>
@@ -234,7 +234,7 @@
                               v
                               <a href="/packages/neon" title="Visit neon 1.0.0 page">1.0.0</a>
                               (
-                              <a class="-x-ago" href="" title="%%neon-created-date%%" aria-label="%%x-ago%%" aria-role="button" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
+                              <a class="-x-ago" href="" title="%%neon-created-date%%" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                               )
                             </span>
                             <span class="packages-metadata-block">
@@ -315,7 +315,7 @@
                               v
                               <a href="/packages/flutter_titanium" title="Visit flutter_titanium 1.10.0 page">1.10.0</a>
                               (
-                              <a class="-x-ago" href="" title="%%neon-created-date%%" aria-label="%%x-ago%%" aria-role="button" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
+                              <a class="-x-ago" href="" title="%%neon-created-date%%" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                               )
                             </span>
                             <span class="packages-metadata-block">

--- a/app/test/frontend/golden/publisher_unlisted_packages_page.html
+++ b/app/test/frontend/golden/publisher_unlisted_packages_page.html
@@ -130,7 +130,7 @@
                   </p>
                   <p>
                     Publisher registered
-                    <a class="-x-ago" href="" title="on %%neon-created-date%%" aria-label="%%x-ago%%" aria-role="button" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
+                    <a class="-x-ago" href="" title="on %%neon-created-date%%" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                   </p>
                 </div>
               </div>
@@ -240,7 +240,7 @@
                               v
                               <a href="/packages/neon" title="Visit neon 1.0.0 page">1.0.0</a>
                               (
-                              <a class="-x-ago" href="" title="%%neon-created-date%%" aria-label="%%x-ago%%" aria-role="button" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
+                              <a class="-x-ago" href="" title="%%neon-created-date%%" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                               )
                             </span>
                             <span class="packages-metadata-block">
@@ -321,7 +321,7 @@
                               v
                               <a href="/packages/flutter_titanium" title="Visit flutter_titanium 1.10.0 page">1.10.0</a>
                               (
-                              <a class="-x-ago" href="" title="%%neon-created-date%%" aria-label="%%x-ago%%" aria-role="button" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
+                              <a class="-x-ago" href="" title="%%neon-created-date%%" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                               )
                             </span>
                             <span class="packages-metadata-block">

--- a/app/test/frontend/golden/search_page.html
+++ b/app/test/frontend/golden/search_page.html
@@ -481,11 +481,11 @@
                       v
                       <a href="/packages/oxygen" title="Visit oxygen 1.2.0 page">1.2.0</a>
                       (
-                      <a class="-x-ago" href="" title="%%oxygen-created-date%%" aria-label="%%x-ago%%" aria-role="button" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
+                      <a class="-x-ago" href="" title="%%oxygen-created-date%%" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                       ) /
                       <a href="/packages/oxygen/versions/2.0.0-dev" title="Visit oxygen 2.0.0-dev page">2.0.0-dev</a>
                       (
-                      <a class="-x-ago" href="" title="%%oxygen-created-date%%" aria-label="%%x-ago%%" aria-role="button" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
+                      <a class="-x-ago" href="" title="%%oxygen-created-date%%" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                       )
                     </span>
                     <span class="packages-metadata-block">
@@ -575,7 +575,7 @@
                       v
                       <a href="/packages/flutter_titanium" title="Visit flutter_titanium 1.10.0 page">1.10.0</a>
                       (
-                      <a class="-x-ago" href="" title="%%oxygen-created-date%%" aria-label="%%x-ago%%" aria-role="button" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
+                      <a class="-x-ago" href="" title="%%oxygen-created-date%%" role="button" data-timestamp="%%millis%%">%%x-ago%%</a>
                       )
                     </span>
                     <span class="packages-metadata-block">

--- a/app/test/task/testdata/goldens/packages/oxygen.html
+++ b/app/test/task/testdata/goldens/packages/oxygen.html
@@ -127,7 +127,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <a class="-x-ago" href="" title="%%short-dateformat%%" aria-label="%%time-ago%%" aria-role="button" role="button" data-timestamp="%%time-ago-millis%%">%%time-ago%%</a>
+                    <a class="-x-ago" href="" title="%%short-dateformat%%" role="button" data-timestamp="%%time-ago-millis%%">%%time-ago%%</a>
                   </span>
                   <span class="package-badge" title="Package is compatible with Dart 3.">Dart 3 compatible</span>
                 </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/changelog.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/changelog.html
@@ -127,7 +127,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <a class="-x-ago" href="" title="%%short-dateformat%%" aria-label="%%time-ago%%" aria-role="button" role="button" data-timestamp="%%time-ago-millis%%">%%time-ago%%</a>
+                    <a class="-x-ago" href="" title="%%short-dateformat%%" role="button" data-timestamp="%%time-ago-millis%%">%%time-ago%%</a>
                   </span>
                   <span class="package-badge" title="Package is compatible with Dart 3.">Dart 3 compatible</span>
                 </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/example.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/example.html
@@ -127,7 +127,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <a class="-x-ago" href="" title="%%short-dateformat%%" aria-label="%%time-ago%%" aria-role="button" role="button" data-timestamp="%%time-ago-millis%%">%%time-ago%%</a>
+                    <a class="-x-ago" href="" title="%%short-dateformat%%" role="button" data-timestamp="%%time-ago-millis%%">%%time-ago%%</a>
                   </span>
                   <span class="package-badge" title="Package is compatible with Dart 3.">Dart 3 compatible</span>
                 </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/install.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/install.html
@@ -127,7 +127,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <a class="-x-ago" href="" title="%%short-dateformat%%" aria-label="%%time-ago%%" aria-role="button" role="button" data-timestamp="%%time-ago-millis%%">%%time-ago%%</a>
+                    <a class="-x-ago" href="" title="%%short-dateformat%%" role="button" data-timestamp="%%time-ago-millis%%">%%time-ago%%</a>
                   </span>
                   <span class="package-badge" title="Package is compatible with Dart 3.">Dart 3 compatible</span>
                 </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/license.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/license.html
@@ -127,7 +127,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <a class="-x-ago" href="" title="%%short-dateformat%%" aria-label="%%time-ago%%" aria-role="button" role="button" data-timestamp="%%time-ago-millis%%">%%time-ago%%</a>
+                    <a class="-x-ago" href="" title="%%short-dateformat%%" role="button" data-timestamp="%%time-ago-millis%%">%%time-ago%%</a>
                   </span>
                   <span class="package-badge" title="Package is compatible with Dart 3.">Dart 3 compatible</span>
                 </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/score.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/score.html
@@ -127,7 +127,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <a class="-x-ago" href="" title="%%short-dateformat%%" aria-label="%%time-ago%%" aria-role="button" role="button" data-timestamp="%%time-ago-millis%%">%%time-ago%%</a>
+                    <a class="-x-ago" href="" title="%%short-dateformat%%" role="button" data-timestamp="%%time-ago-millis%%">%%time-ago%%</a>
                   </span>
                   <span class="package-badge" title="Package is compatible with Dart 3.">Dart 3 compatible</span>
                 </div>
@@ -226,7 +226,7 @@
                   </div>
                   <p class="analysis-info">
                     We analyzed this package
-                    <a class="-x-ago" href="" title="on %%short-dateformat%%" aria-label="%%time-ago%%" aria-role="button" role="button" data-timestamp="%%time-ago-millis%%">%%time-ago%%</a>
+                    <a class="-x-ago" href="" title="on %%short-dateformat%%" role="button" data-timestamp="%%time-ago-millis%%">%%time-ago%%</a>
                     , and awarded it 140 pub points (of a possible 160):
                   </p>
                   <div class="pkg-report">

--- a/app/test/task/testdata/goldens/packages/oxygen/versions.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions.html
@@ -127,7 +127,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <a class="-x-ago" href="" title="%%short-dateformat%%" aria-label="%%time-ago%%" aria-role="button" role="button" data-timestamp="%%time-ago-millis%%">%%time-ago%%</a>
+                    <a class="-x-ago" href="" title="%%short-dateformat%%" role="button" data-timestamp="%%time-ago-millis%%">%%time-ago%%</a>
                   </span>
                   <span class="package-badge" title="Package is compatible with Dart 3.">Dart 3 compatible</span>
                 </div>
@@ -231,7 +231,7 @@
                         </td>
                         <td class="sdk">3.0</td>
                         <td class="uploaded">
-                          <a class="-x-ago" href="" title="%%short-dateformat%%" aria-label="%%time-ago%%" aria-role="button" role="button" data-timestamp="%%time-ago-millis%%">%%time-ago%%</a>
+                          <a class="-x-ago" href="" title="%%short-dateformat%%" role="button" data-timestamp="%%time-ago-millis%%">%%time-ago%%</a>
                         </td>
                         <td class="documentation">
                           <a href="/documentation/oxygen/2.0.0/" rel="nofollow" title="Go to the documentation of oxygen 2.0.0">
@@ -253,7 +253,7 @@
                         </td>
                         <td class="sdk">3.0</td>
                         <td class="uploaded">
-                          <a class="-x-ago" href="" title="%%short-dateformat%%" aria-label="%%time-ago%%" aria-role="button" role="button" data-timestamp="%%time-ago-millis%%">%%time-ago%%</a>
+                          <a class="-x-ago" href="" title="%%short-dateformat%%" role="button" data-timestamp="%%time-ago-millis%%">%%time-ago%%</a>
                         </td>
                         <td class="documentation">
                           <a href="/documentation/oxygen/1.0.0/" rel="nofollow" title="Go to the documentation of oxygen 1.0.0">

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0.html
@@ -127,7 +127,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <a class="-x-ago" href="" title="%%short-dateformat%%" aria-label="%%time-ago%%" aria-role="button" role="button" data-timestamp="%%time-ago-millis%%">%%time-ago%%</a>
+                    <a class="-x-ago" href="" title="%%short-dateformat%%" role="button" data-timestamp="%%time-ago-millis%%">%%time-ago%%</a>
                   </span>
                   <span class="package-badge" title="Package is compatible with Dart 3.">Dart 3 compatible</span>
                   • Latest:

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/changelog.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/changelog.html
@@ -127,7 +127,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <a class="-x-ago" href="" title="%%short-dateformat%%" aria-label="%%time-ago%%" aria-role="button" role="button" data-timestamp="%%time-ago-millis%%">%%time-ago%%</a>
+                    <a class="-x-ago" href="" title="%%short-dateformat%%" role="button" data-timestamp="%%time-ago-millis%%">%%time-ago%%</a>
                   </span>
                   <span class="package-badge" title="Package is compatible with Dart 3.">Dart 3 compatible</span>
                   • Latest:

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/example.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/example.html
@@ -127,7 +127,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <a class="-x-ago" href="" title="%%short-dateformat%%" aria-label="%%time-ago%%" aria-role="button" role="button" data-timestamp="%%time-ago-millis%%">%%time-ago%%</a>
+                    <a class="-x-ago" href="" title="%%short-dateformat%%" role="button" data-timestamp="%%time-ago-millis%%">%%time-ago%%</a>
                   </span>
                   <span class="package-badge" title="Package is compatible with Dart 3.">Dart 3 compatible</span>
                   • Latest:

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/install.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/install.html
@@ -127,7 +127,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <a class="-x-ago" href="" title="%%short-dateformat%%" aria-label="%%time-ago%%" aria-role="button" role="button" data-timestamp="%%time-ago-millis%%">%%time-ago%%</a>
+                    <a class="-x-ago" href="" title="%%short-dateformat%%" role="button" data-timestamp="%%time-ago-millis%%">%%time-ago%%</a>
                   </span>
                   <span class="package-badge" title="Package is compatible with Dart 3.">Dart 3 compatible</span>
                   • Latest:

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/license.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/license.html
@@ -127,7 +127,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <a class="-x-ago" href="" title="%%short-dateformat%%" aria-label="%%time-ago%%" aria-role="button" role="button" data-timestamp="%%time-ago-millis%%">%%time-ago%%</a>
+                    <a class="-x-ago" href="" title="%%short-dateformat%%" role="button" data-timestamp="%%time-ago-millis%%">%%time-ago%%</a>
                   </span>
                   <span class="package-badge" title="Package is compatible with Dart 3.">Dart 3 compatible</span>
                   • Latest:

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/score.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/score.html
@@ -127,7 +127,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <a class="-x-ago" href="" title="%%short-dateformat%%" aria-label="%%time-ago%%" aria-role="button" role="button" data-timestamp="%%time-ago-millis%%">%%time-ago%%</a>
+                    <a class="-x-ago" href="" title="%%short-dateformat%%" role="button" data-timestamp="%%time-ago-millis%%">%%time-ago%%</a>
                   </span>
                   <span class="package-badge" title="Package is compatible with Dart 3.">Dart 3 compatible</span>
                   • Latest:
@@ -230,7 +230,7 @@
                   </div>
                   <p class="analysis-info">
                     We analyzed this package
-                    <a class="-x-ago" href="" title="on %%short-dateformat%%" aria-label="%%time-ago%%" aria-role="button" role="button" data-timestamp="%%time-ago-millis%%">%%time-ago%%</a>
+                    <a class="-x-ago" href="" title="on %%short-dateformat%%" role="button" data-timestamp="%%time-ago-millis%%">%%time-ago%%</a>
                     , and awarded it 140 pub points (of a possible 160):
                   </p>
                   <div class="pkg-report">

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/2.0.0.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/2.0.0.html
@@ -127,7 +127,7 @@
                 <div class="metadata">
                   Published
                   <span>
-                    <a class="-x-ago" href="" title="%%short-dateformat%%" aria-label="%%time-ago%%" aria-role="button" role="button" data-timestamp="%%time-ago-millis%%">%%time-ago%%</a>
+                    <a class="-x-ago" href="" title="%%short-dateformat%%" role="button" data-timestamp="%%time-ago-millis%%">%%time-ago%%</a>
                   </span>
                   <span class="package-badge" title="Package is compatible with Dart 3.">Dart 3 compatible</span>
                 </div>


### PR DESCRIPTION
- The `aria-role` was renamed to `role`.
- The `aria-label` prevents the screen-readers to read the changed content.