### PR TITLE
Darker background colors in dark mode for increased contrast.

### DIFF
--- a/pkg/web_css/lib/src/_variables.scss
+++ b/pkg/web_css/lib/src/_variables.scss
@@ -148,16 +148,16 @@
 .dark-theme {
   @include dash_variables.dark-theme;
 
-  --pub-color-eerieBlack:      #1b1b1b;
-  --pub-color-shadowBlack:     #373737;
-  --pub-color-anchorBlack:     #41424c;
+  --pub-color-darkBlack:       #121317;
+  --pub-color-darkGunmetal:    #242b32;
+  --pub-color-darkGray:        #2f3034; /* derived from dark black by making it lighter */
   --pub-color-nipponUltraBlue: #23607f;
 
-  --pub-neutral-bgColor:       var(--pub-color-eerieBlack);
-  --pub-neutral-borderColor:   var(--pub-color-anchorBlack);
+  --pub-neutral-bgColor:       var(--pub-color-darkBlack);
+  --pub-neutral-borderColor:   var(--pub-color-darkGunmetal);
   --pub-neutral-textColor:     var(--dash-surface-fgColor);
-  --pub-neutral-hover-bgColor: var(--pub-color-shadowBlack);
-  --pub-inset-bgColor:         var(--pub-color-anchorBlack);
+  --pub-neutral-hover-bgColor: var(--pub-color-darkGray);
+  --pub-inset-bgColor:         var(--pub-color-darkGunmetal);
   --pub-selected-bgColor:      var(--pub-color-nipponUltraBlue);
 
   // Note: these colors are copied from GitHub styles
@@ -178,7 +178,7 @@
   --pub-detail_tab-admin-color: #e03030;
   --pub-home_title-text-color: #31b0fc;
   --pub-weekly-chart-main-color: var(--pub-link-text-color);
-  --pub-weekly-chart-tooltip-text-color: var(--pub-color-anchorBlack);
+  --pub-weekly-chart-tooltip-text-color: var(--pub-color-darkGunmetal);
   --pub-home_card-box_shadow-color: rgba(255, 255, 255, 0.2);
   --pub-home_card_title-text-color: var(--pub-home_title-text-color);
   --pub-home_card_hover-box_shadow-color: rgba(255, 255, 255, 0.3);


### PR DESCRIPTION
Following further Lighthouse reports on not enough contrast in certain context, and also comparing the brightness and (de)saturation of these colors with other dark mode palettes.

- `#1b1b1b` -> `#121317` (default background)
- `#373737` -> `#2f3034` (hover bg)
- `#41424c` -> `#242b32` (inset, code highlight bg)

Before/after example for hover: 
<img width="168" alt="image" src="https://github.com/user-attachments/assets/8d97e4e6-cebb-4391-9524-8ea368c15edc" />
<img width="158" alt="image" src="https://github.com/user-attachments/assets/597061cd-cf8a-44dc-bbd4-7653bc5e838d" />

Before/after example for code highlight:
<img width="600" alt="image" src="https://github.com/user-attachments/assets/bde16666-147b-4652-8fcd-152979908ae1" />
<img width="593" alt="image" src="https://github.com/user-attachments/assets/55860841-686e-4bbf-964d-3c3651c80362" />
