### PR TITLE
Use retry callback block for admin API in API exporter tests.

### DIFF
--- a/app/test/admin/exported_api_sync_test.dart
+++ b/app/test/admin/exported_api_sync_test.dart
@@ -19,13 +19,17 @@ void main() {
       List<String>? packages,
       bool forceWrite = false,
     }) async {
-      final api = createPubApiClient(authToken: siteAdminToken);
-      await api.adminInvokeAction(
-        'exported-api-sync',
-        AdminInvokeActionArguments(arguments: {
-          'packages': packages?.join(' ') ?? 'ALL',
-          if (forceWrite) 'force-write': 'true',
-        }),
+      await withHttpPubApiClient(
+        bearerToken: siteAdminToken,
+        fn: (api) async {
+          await api.adminInvokeAction(
+            'exported-api-sync',
+            AdminInvokeActionArguments(arguments: {
+              'packages': packages?.join(' ') ?? 'ALL',
+              if (forceWrite) 'force-write': 'true',
+            }),
+          );
+        },
       );
     }
 

--- a/app/test/package/api_export/api_exporter_test.dart
+++ b/app/test/package/api_export/api_exporter_test.dart
@@ -293,17 +293,19 @@ Future<void> _testExportedApiSynchronization(
     // recently created files as a guard against race conditions.
     fakeTime.elapseSync(days: 1);
 
-    final adminApi = createPubApiClient(
-      authToken: createFakeServiceAccountToken(email: 'admin@pub.dev'),
-    );
-    await adminApi.adminInvokeAction(
-      'moderate-package-version',
-      AdminInvokeActionArguments(arguments: {
-        'case': 'none',
-        'package': 'bar',
-        'version': '2.0.0',
-        'state': 'true',
-      }),
+    await withHttpPubApiClient(
+      bearerToken: createFakeServiceAccountToken(email: 'admin@pub.dev'),
+      fn: (adminApi) async {
+        await adminApi.adminInvokeAction(
+          'moderate-package-version',
+          AdminInvokeActionArguments(arguments: {
+            'case': 'none',
+            'package': 'bar',
+            'version': '2.0.0',
+            'state': 'true',
+          }),
+        );
+      },
     );
 
     // Synchronize again
@@ -330,18 +332,19 @@ Future<void> _testExportedApiSynchronization(
 
   _log.info('## Version reinstated');
   {
-    final adminApi = createPubApiClient(
-      authToken: createFakeServiceAccountToken(email: 'admin@pub.dev'),
-    );
-    await adminApi.adminInvokeAction(
-      'moderate-package-version',
-      AdminInvokeActionArguments(arguments: {
-        'case': 'none',
-        'package': 'bar',
-        'version': '2.0.0',
-        'state': 'false',
-      }),
-    );
+    await withHttpPubApiClient(
+        bearerToken: createFakeServiceAccountToken(email: 'admin@pub.dev'),
+        fn: (adminApi) async {
+          await adminApi.adminInvokeAction(
+            'moderate-package-version',
+            AdminInvokeActionArguments(arguments: {
+              'case': 'none',
+              'package': 'bar',
+              'version': '2.0.0',
+              'state': 'false',
+            }),
+          );
+        });
 
     // Synchronize again
     await synchronize();
@@ -371,17 +374,18 @@ Future<void> _testExportedApiSynchronization(
     // recently created files as a guard against race conditions.
     fakeTime.elapseSync(days: 1);
 
-    final adminApi = createPubApiClient(
-      authToken: createFakeServiceAccountToken(email: 'admin@pub.dev'),
-    );
-    await adminApi.adminInvokeAction(
-      'moderate-package',
-      AdminInvokeActionArguments(arguments: {
-        'case': 'none',
-        'package': 'bar',
-        'state': 'true',
-      }),
-    );
+    await withHttpPubApiClient(
+        bearerToken: createFakeServiceAccountToken(email: 'admin@pub.dev'),
+        fn: (adminApi) async {
+          await adminApi.adminInvokeAction(
+            'moderate-package',
+            AdminInvokeActionArguments(arguments: {
+              'case': 'none',
+              'package': 'bar',
+              'state': 'true',
+            }),
+          );
+        });
 
     // Synchronize again
     await synchronize();
@@ -402,17 +406,18 @@ Future<void> _testExportedApiSynchronization(
 
   _log.info('## Package reinstated');
   {
-    final adminApi = createPubApiClient(
-      authToken: createFakeServiceAccountToken(email: 'admin@pub.dev'),
-    );
-    await adminApi.adminInvokeAction(
-      'moderate-package',
-      AdminInvokeActionArguments(arguments: {
-        'case': 'none',
-        'package': 'bar',
-        'state': 'false',
-      }),
-    );
+    await withHttpPubApiClient(
+        bearerToken: createFakeServiceAccountToken(email: 'admin@pub.dev'),
+        fn: (adminApi) async {
+          await adminApi.adminInvokeAction(
+            'moderate-package',
+            AdminInvokeActionArguments(arguments: {
+              'case': 'none',
+              'package': 'bar',
+              'state': 'false',
+            }),
+          );
+        });
 
     // Synchronize again
     await synchronize();


### PR DESCRIPTION
- #8483 - I don't see other reasons for it to be flaky.
- #8337 - storage access methods are doing it already, we should continue with pub API uses
- #7825 - this method could be a generic callback for such use cases

Note: I would also refactor this method in a follow-up PR (rename to contain the name `retry` in it, also `fn` can be regular parameter). Then we should also migrate all tests that are using `createPubApiClient` and also use it in the application code too