### PR TITLE
Replace drop-shadow with only borders in dark mode.

### DIFF
--- a/pkg/web_css/lib/src/_home.scss
+++ b/pkg/web_css/lib/src/_home.scss
@@ -106,16 +106,16 @@
   }
 
   .mini-list-item {
+    @include variables.elevated-content-border;
+
     background: var(--pub-neutral-bgColor);
     border-radius: 4px;
-    box-shadow: 0px 2px 7px 0px var(--pub-home_card-box_shadow-color);
     padding: 28px 30px 30px; // title's top gap is about 2px (30-2 => 28)
     margin-bottom: 10px;
     min-height: 100px;
 
     &:hover {
       background: var(--pub-neutral-hover-bgColor);
-      box-shadow: 0px 4px 9px 0px var(--pub-home_card_hover-box_shadow-color);
 
       @media (min-width: variables.$device-desktop-min-width) {
         .mini-list-item-body {

--- a/pkg/web_css/lib/src/_variables.scss
+++ b/pkg/web_css/lib/src/_variables.scss
@@ -244,6 +244,24 @@
   }
 }
 
+@mixin elevated-content-border {
+  .light-theme & {
+    box-shadow: 0px 2px 7px 0px var(--pub-home_card-box_shadow-color);
+
+    &:hover {
+      box-shadow: 0px 4px 9px 0px var(--pub-home_card_hover-box_shadow-color);
+    }
+  }
+
+  .dark-theme & {
+    border: 1px solid var(--pub-home_card-box_shadow-color);
+
+    &:hover {
+      border-color: var(--pub-home_card_hover-box_shadow-color);
+    }
+  }
+}
+
 $device-desktop-min-width: 641px;
 $device-mobile-max-width: 640px;
 $device-tablet-max-width: 979px;


### PR DESCRIPTION
I think this is the least controversial change to the dark-mode shadows we could do: replacing them with a thin border. We could still incorporate parts of #8475 if we wanted to...

Note: this does not add the extra border to the light mode, but I think we should also consider it (separately from this).

Before/after:
<img width="212" alt="image" src="https://github.com/user-attachments/assets/b6705ffc-fe6d-4544-a996-9b64ce8e55ef" />
<img width="206" alt="image" src="https://github.com/user-attachments/assets/7065453c-1c90-4637-b157-ac73ba1a2471" />

Before/after with hovering:
<img width="215" alt="image" src="https://github.com/user-attachments/assets/0954cd6b-5221-4809-a6d0-058891956c8f" />
<img width="205" alt="image" src="https://github.com/user-attachments/assets/fecd9910-e71a-42bd-ab95-5472f4193a8b" />
