### PR TITLE
Refactor proposal: use unnamed callback function in with*HttpPubApiClient methods.

### DIFF
--- a/app/lib/fake/backend/fake_auth_provider.dart
+++ b/app/lib/fake/backend/fake_auth_provider.dart
@@ -419,10 +419,10 @@ Future<String> _acquireCsrfToken({
 ///
 /// The [email] is used to create an HTTP session and the related CSRF token is
 /// extracted from the session, both are sent alongside the requests.
-Future<R> withFakeAuthHttpPubApiClient<R>({
+Future<R> withFakeAuthHttpPubApiClient<R>(
+  Future<R> Function(PubApiClient client) fn, {
   required String email,
   List<String>? scopes,
-  required Future<R> Function(PubApiClient client) fn,
   String? pubHostedUrl,
   Set<String>? experimental,
 }) async {
@@ -440,8 +440,8 @@ Future<R> withFakeAuthHttpPubApiClient<R>({
     sessionId: sessionId,
     csrfToken: csrfToken,
     pubHostedUrl: pubHostedUrl,
-    fn: fn,
     experimental: experimental,
+    fn,
   );
 }
 

--- a/app/lib/tool/test_profile/importer.dart
+++ b/app/lib/tool/test_profile/importer.dart
@@ -49,7 +49,7 @@ Future<void> importProfile({
       email: firstMemberEmail,
       scopes: [webmasterScope],
       pubHostedUrl: pubHostedUrl,
-      fn: (client) async {
+      (client) async {
         try {
           await client.createPublisher(p.name);
         } on RequestException catch (e) {
@@ -98,7 +98,7 @@ Future<void> importProfile({
           bearerToken: createFakeAuthTokenForEmail(uploaderEmail,
               audience: activeConfiguration.pubClientAudience),
           pubHostedUrl: pubHostedUrl,
-          fn: (client) => client.uploadPackageBytes(bytes),
+          (client) => client.uploadPackageBytes(bytes),
         );
         published = true;
       } catch (e, st) {
@@ -123,7 +123,7 @@ Future<void> importProfile({
     await withFakeAuthHttpPubApiClient(
       email: activeEmail!,
       pubHostedUrl: pubHostedUrl,
-      fn: (client) async {
+      (client) async {
         // update publisher
         if (testPackage.publisher != null) {
           await client.setPackagePublisher(
@@ -155,7 +155,7 @@ Future<void> importProfile({
         bearerToken:
             createFakeServiceAccountToken(email: adminUserEmail ?? activeEmail),
         pubHostedUrl: pubHostedUrl,
-        fn: (client) async {
+        (client) async {
           await client.adminPostAssignedTags(
             packageName,
             PatchAssignedTags(
@@ -173,7 +173,7 @@ Future<void> importProfile({
     await withFakeAuthHttpPubApiClient(
       email: u.email,
       pubHostedUrl: pubHostedUrl,
-      fn: (client) async {
+      (client) async {
         // creates user (regardless of likes being specified)
         await client.listPackageLikes();
 
@@ -197,7 +197,7 @@ Future<void> importProfile({
         await withFakeAuthHttpPubApiClient(
           email: userEmail,
           pubHostedUrl: pubHostedUrl,
-          fn: (client) async {
+          (client) async {
             await client.likePackage(p.name);
           },
         );

--- a/app/lib/tool/utils/pub_api_client.dart
+++ b/app/lib/tool/utils/pub_api_client.dart
@@ -98,13 +98,13 @@ class _FakeTimeClient implements http.Client {
 ///
 /// If [bearerToken], [sessionId] or [csrfToken] is specified, the corresponding
 /// HTTP header will be sent alongside the request.
-Future<R> withHttpPubApiClient<R>({
+Future<R> withHttpPubApiClient<R>(
+  Future<R> Function(PubApiClient client) fn, {
   String? bearerToken,
   String? sessionId,
   String? csrfToken,
   String? pubHostedUrl,
   Set<String>? experimental,
-  required Future<R> Function(PubApiClient client) fn,
 }) async {
   final httpClient = httpClientWithAuthorization(
     tokenProvider: () async => bearerToken,

--- a/app/test/account/consent_backend_test.dart
+++ b/app/test/account/consent_backend_test.dart
@@ -28,7 +28,7 @@ void main() {
       await withFakeAuthHttpPubApiClient(
         email: adminEmail,
         pubHostedUrl: activeConfiguration.primarySiteUri.toString(),
-        fn: (client) async {
+        (client) async {
           await client.invitePackageUploader(
               'oxygen', InviteUploaderRequest(email: userAtPubDevEmail));
         },
@@ -309,15 +309,13 @@ void main() {
 
   group('Sanity check', () {
     testWithProfile('consent parameter length', fn: () async {
-      await withFakeAuthHttpPubApiClient(
-          email: adminAtPubDevEmail,
-          fn: (c) async {
-            await expectApiException(
-              c.consentInfo('abcd' * 500),
-              status: 400,
-              code: 'InvalidInput',
-            );
-          });
+      await withFakeAuthHttpPubApiClient(email: adminAtPubDevEmail, (c) async {
+        await expectApiException(
+          c.consentInfo('abcd' * 500),
+          status: 400,
+          code: 'InvalidInput',
+        );
+      });
     });
   });
 }

--- a/app/test/admin/exported_api_sync_test.dart
+++ b/app/test/admin/exported_api_sync_test.dart
@@ -21,7 +21,7 @@ void main() {
     }) async {
       await withHttpPubApiClient(
         bearerToken: siteAdminToken,
-        fn: (api) async {
+        (api) async {
           await api.adminInvokeAction(
             'exported-api-sync',
             AdminInvokeActionArguments(arguments: {

--- a/app/test/admin/moderate_package_test.dart
+++ b/app/test/admin/moderate_package_test.dart
@@ -34,7 +34,7 @@ void main() {
   group('Moderate package', () {
     Future<ModerationCase> _report(String package) async {
       await withHttpPubApiClient(
-        fn: (client) async {
+        (client) async {
           await client.postReport(ReportForm(
             email: 'user@pub.dev',
             subject: 'package:$package',

--- a/app/test/admin/moderate_package_version_test.dart
+++ b/app/test/admin/moderate_package_version_test.dart
@@ -34,7 +34,7 @@ void main() {
   group('Moderate package version', () {
     Future<ModerationCase> _report(String package, String version) async {
       await withHttpPubApiClient(
-        fn: (client) async {
+        (client) async {
           await client.postReport(ReportForm(
             email: 'user@pub.dev',
             subject: 'package-version:$package/$version',

--- a/app/test/admin/moderate_publisher_test.dart
+++ b/app/test/admin/moderate_publisher_test.dart
@@ -25,7 +25,7 @@ void main() {
   group('Moderate Publisher', () {
     Future<ModerationCase> _report(String publisherId) async {
       await withHttpPubApiClient(
-        fn: (client) async {
+        (client) async {
           await client.postReport(ReportForm(
             email: 'user@pub.dev',
             subject: 'publisher:$publisherId',

--- a/app/test/admin/moderate_user_test.dart
+++ b/app/test/admin/moderate_user_test.dart
@@ -29,7 +29,7 @@ void main() {
   group('Moderate User', () {
     Future<ModerationCase> _report(String package) async {
       await withHttpPubApiClient(
-        fn: (client) async {
+        (client) async {
           await client.postReport(account_api.ReportForm(
             email: 'user@pub.dev',
             subject: 'package:$package',

--- a/app/test/admin/moderation_case_resolve_test.dart
+++ b/app/test/admin/moderation_case_resolve_test.dart
@@ -19,7 +19,7 @@ void main() {
       required bool? apply,
     }) async {
       await withHttpPubApiClient(
-        fn: (client) async {
+        (client) async {
           await client.postReport(ReportForm(
             email: 'user@pub.dev',
             caseId: appealCaseId,

--- a/app/test/admin/moderation_transparency_metrics_test.dart
+++ b/app/test/admin/moderation_transparency_metrics_test.dart
@@ -22,7 +22,7 @@ void main() {
       String? caseId,
     }) async {
       await withHttpPubApiClient(
-        fn: (client) async {
+        (client) async {
           await client.postReport(account_api.ReportForm(
             email: email ?? 'user@pub.dev',
             subject: 'package:$package',

--- a/app/test/frontend/handlers/report_test.dart
+++ b/app/test/frontend/handlers/report_test.dart
@@ -79,7 +79,7 @@ void main() {
   group('Report API test', () {
     testWithProfile('unauthenticated email missing', fn: () async {
       await withHttpPubApiClient(
-        fn: (client) async {
+        (client) async {
           await expectApiException(
             client.postReport(ReportForm(
               message: 'Problem.',
@@ -100,7 +100,7 @@ void main() {
         await withHttpPubApiClient(
           sessionId: sessionId,
           csrfToken: csrfToken,
-          fn: (client) async {
+          (client) async {
             await expectApiException(
               client.postReport(ReportForm(
                 email: 'any@pub.dev',
@@ -118,7 +118,7 @@ void main() {
 
     testWithProfile('subject missing', fn: () async {
       await withHttpPubApiClient(
-        fn: (client) async {
+        (client) async {
           await expectApiException(
             client.postReport(ReportForm(
               email: 'user@pub.dev',
@@ -135,7 +135,7 @@ void main() {
 
     testWithProfile('subject is invalid', fn: () async {
       await withHttpPubApiClient(
-        fn: (client) async {
+        (client) async {
           await expectApiException(
             client.postReport(ReportForm(
               email: 'user@pub.dev',
@@ -153,7 +153,7 @@ void main() {
 
     testWithProfile('package missing', fn: () async {
       await withHttpPubApiClient(
-        fn: (client) async {
+        (client) async {
           await expectApiException(
             client.postReport(ReportForm(
               email: 'user@pub.dev',
@@ -171,7 +171,7 @@ void main() {
 
     testWithProfile('version missing', fn: () async {
       await withHttpPubApiClient(
-        fn: (client) async {
+        (client) async {
           await expectApiException(
             client.postReport(ReportForm(
               email: 'user@pub.dev',
@@ -189,7 +189,7 @@ void main() {
 
     testWithProfile('publisher missing', fn: () async {
       await withHttpPubApiClient(
-        fn: (client) async {
+        (client) async {
           await expectApiException(
             client.postReport(ReportForm(
               email: 'user@pub.dev',
@@ -212,7 +212,7 @@ void main() {
         await withHttpPubApiClient(
           sessionId: sessionId,
           csrfToken: csrfToken,
-          fn: (client) async {
+          (client) async {
             await expectApiException(
               client.postReport(ReportForm(
                 subject: 'package:oxygen',
@@ -230,7 +230,7 @@ void main() {
 
     testWithProfile('unauthenticated report success', fn: () async {
       await withHttpPubApiClient(
-        fn: (client) async {
+        (client) async {
           final msg = await client.postReport(ReportForm(
             email: 'user2@pub.dev',
             subject: 'package:oxygen',
@@ -259,7 +259,7 @@ void main() {
         await withHttpPubApiClient(
           sessionId: sessionId,
           csrfToken: csrfToken,
-          fn: (client) async {
+          (client) async {
             final msg = await client.postReport(ReportForm(
               message: 'Huston, we have a problem.',
               subject: 'package:oxygen',
@@ -308,7 +308,7 @@ void main() {
 
     testWithProfile('failure: case does not exists', fn: () async {
       await withHttpPubApiClient(
-        fn: (client) async {
+        (client) async {
           await expectApiException(
             client.postReport(ReportForm(
               email: 'user2@pub.dev',
@@ -327,7 +327,7 @@ void main() {
     testWithProfile('failure: case is not closed', fn: () async {
       await _prepareApplied(status: ModerationStatus.pending);
       await withHttpPubApiClient(
-        fn: (client) async {
+        (client) async {
           await expectApiException(
             client.postReport(ReportForm(
               email: 'user2@pub.dev',
@@ -346,7 +346,7 @@ void main() {
     testWithProfile('failure: subject is not on the case', fn: () async {
       await _prepareApplied();
       await withHttpPubApiClient(
-        fn: (client) async {
+        (client) async {
           await expectApiException(
             client.postReport(ReportForm(
               email: 'user2@pub.dev',
@@ -371,7 +371,7 @@ void main() {
 
       // first report: success
       await withHttpPubApiClient(
-        fn: (client) async {
+        (client) async {
           final msg = await client.postReport(ReportForm(
             email: 'user2@pub.dev',
             subject: 'package-version:oxygen/1.2.0',
@@ -400,7 +400,7 @@ void main() {
       );
 
       // second report: rejected
-      await withHttpPubApiClient(fn: (client) async {
+      await withHttpPubApiClient((client) async {
         await expectApiException(
           client.postReport(ReportForm(
             email: 'user2@pub.dev',
@@ -423,7 +423,7 @@ void main() {
 
       await withFakeAuthHttpPubApiClient(
         email: 'admin@pub.dev',
-        fn: (client) async {
+        (client) async {
           final msg = await client.postReport(ReportForm(
             subject: 'package-version:oxygen/1.2.0',
             caseId: 'case/1',

--- a/app/test/package/api_export/api_exporter_test.dart
+++ b/app/test/package/api_export/api_exporter_test.dart
@@ -295,7 +295,7 @@ Future<void> _testExportedApiSynchronization(
 
     await withHttpPubApiClient(
       bearerToken: createFakeServiceAccountToken(email: 'admin@pub.dev'),
-      fn: (adminApi) async {
+      (adminApi) async {
         await adminApi.adminInvokeAction(
           'moderate-package-version',
           AdminInvokeActionArguments(arguments: {
@@ -334,17 +334,17 @@ Future<void> _testExportedApiSynchronization(
   {
     await withHttpPubApiClient(
         bearerToken: createFakeServiceAccountToken(email: 'admin@pub.dev'),
-        fn: (adminApi) async {
-          await adminApi.adminInvokeAction(
-            'moderate-package-version',
-            AdminInvokeActionArguments(arguments: {
-              'case': 'none',
-              'package': 'bar',
-              'version': '2.0.0',
-              'state': 'false',
-            }),
-          );
-        });
+        (adminApi) async {
+      await adminApi.adminInvokeAction(
+        'moderate-package-version',
+        AdminInvokeActionArguments(arguments: {
+          'case': 'none',
+          'package': 'bar',
+          'version': '2.0.0',
+          'state': 'false',
+        }),
+      );
+    });
 
     // Synchronize again
     await synchronize();
@@ -376,16 +376,16 @@ Future<void> _testExportedApiSynchronization(
 
     await withHttpPubApiClient(
         bearerToken: createFakeServiceAccountToken(email: 'admin@pub.dev'),
-        fn: (adminApi) async {
-          await adminApi.adminInvokeAction(
-            'moderate-package',
-            AdminInvokeActionArguments(arguments: {
-              'case': 'none',
-              'package': 'bar',
-              'state': 'true',
-            }),
-          );
-        });
+        (adminApi) async {
+      await adminApi.adminInvokeAction(
+        'moderate-package',
+        AdminInvokeActionArguments(arguments: {
+          'case': 'none',
+          'package': 'bar',
+          'state': 'true',
+        }),
+      );
+    });
 
     // Synchronize again
     await synchronize();
@@ -408,16 +408,16 @@ Future<void> _testExportedApiSynchronization(
   {
     await withHttpPubApiClient(
         bearerToken: createFakeServiceAccountToken(email: 'admin@pub.dev'),
-        fn: (adminApi) async {
-          await adminApi.adminInvokeAction(
-            'moderate-package',
-            AdminInvokeActionArguments(arguments: {
-              'case': 'none',
-              'package': 'bar',
-              'state': 'false',
-            }),
-          );
-        });
+        (adminApi) async {
+      await adminApi.adminInvokeAction(
+        'moderate-package',
+        AdminInvokeActionArguments(arguments: {
+          'case': 'none',
+          'package': 'bar',
+          'state': 'false',
+        }),
+      );
+    });
 
     // Synchronize again
     await synchronize();

--- a/app/test/package/upload_test.dart
+++ b/app/test/package/upload_test.dart
@@ -273,7 +273,7 @@ void main() {
           fn: () async {
         await withFakeAuthHttpPubApiClient(
           email: adminAtPubDevEmail,
-          fn: (client) async {
+          (client) async {
             await client.setAutomatedPublishing(
               'oxygen',
               AutomatedPublishingConfig(
@@ -305,7 +305,7 @@ void main() {
           fn: () async {
         await withFakeAuthHttpPubApiClient(
           email: adminAtPubDevEmail,
-          fn: (client) async {
+          (client) async {
             await client.setAutomatedPublishing(
               'oxygen',
               AutomatedPublishingConfig(
@@ -346,7 +346,7 @@ void main() {
       testWithProfile('successful upload with service account', fn: () async {
         await withFakeAuthHttpPubApiClient(
           email: adminAtPubDevEmail,
-          fn: (client) async {
+          (client) async {
             await client.setAutomatedPublishing(
               'oxygen',
               AutomatedPublishingConfig(
@@ -416,7 +416,7 @@ void main() {
           fn: () async {
         await withFakeAuthHttpPubApiClient(
           email: adminAtPubDevEmail,
-          fn: (client) async {
+          (client) async {
             await client.setAutomatedPublishing(
               'oxygen',
               AutomatedPublishingConfig(
@@ -451,7 +451,7 @@ void main() {
           fn: () async {
         await withFakeAuthHttpPubApiClient(
           email: adminAtPubDevEmail,
-          fn: (client) async {
+          (client) async {
             await client.setAutomatedPublishing(
               'oxygen',
               AutomatedPublishingConfig(
@@ -486,7 +486,7 @@ void main() {
           fn: () async {
         await withFakeAuthHttpPubApiClient(
           email: adminAtPubDevEmail,
-          fn: (client) async {
+          (client) async {
             await client.setAutomatedPublishing(
               'oxygen',
               AutomatedPublishingConfig(
@@ -522,7 +522,7 @@ void main() {
           fn: () async {
         await withFakeAuthHttpPubApiClient(
           email: adminAtPubDevEmail,
-          fn: (client) async {
+          (client) async {
             await client.setAutomatedPublishing(
               'oxygen',
               AutomatedPublishingConfig(
@@ -557,7 +557,7 @@ void main() {
           fn: () async {
         await withFakeAuthHttpPubApiClient(
           email: adminAtPubDevEmail,
-          fn: (client) async {
+          (client) async {
             await client.setAutomatedPublishing(
               'oxygen',
               AutomatedPublishingConfig(
@@ -593,7 +593,7 @@ void main() {
         Future<void> setupPublishingAndLock() async {
           await withFakeAuthHttpPubApiClient(
             email: adminAtPubDevEmail,
-            fn: (client) async {
+            (client) async {
               await client.setAutomatedPublishing(
                 'oxygen',
                 AutomatedPublishingConfig(
@@ -659,7 +659,7 @@ void main() {
           fn: () async {
         await withFakeAuthHttpPubApiClient(
           email: adminAtPubDevEmail,
-          fn: (client) async {
+          (client) async {
             await client.setAutomatedPublishing(
               'oxygen',
               AutomatedPublishingConfig(
@@ -688,7 +688,7 @@ void main() {
           fn: () async {
         await withFakeAuthHttpPubApiClient(
           email: adminAtPubDevEmail,
-          fn: (client) async {
+          (client) async {
             await client.setAutomatedPublishing(
               'oxygen',
               AutomatedPublishingConfig(
@@ -726,7 +726,7 @@ void main() {
           ), fn: () async {
         await withFakeAuthHttpPubApiClient(
           email: adminAtPubDevEmail,
-          fn: (client) async {
+          (client) async {
             await client.setAutomatedPublishing(
               '_dummy_pkg',
               AutomatedPublishingConfig(
@@ -799,7 +799,7 @@ void main() {
           fn: () async {
         await withFakeAuthHttpPubApiClient(
           email: adminAtPubDevEmail,
-          fn: (client) async {
+          (client) async {
             await client.setAutomatedPublishing(
               'oxygen',
               AutomatedPublishingConfig(
@@ -837,7 +837,7 @@ void main() {
           fn: () async {
         await withFakeAuthHttpPubApiClient(
           email: adminAtPubDevEmail,
-          fn: (client) async {
+          (client) async {
             await client.setAutomatedPublishing(
               'oxygen',
               AutomatedPublishingConfig(
@@ -876,7 +876,7 @@ void main() {
           fn: () async {
         await withFakeAuthHttpPubApiClient(
           email: adminAtPubDevEmail,
-          fn: (client) async {
+          (client) async {
             await client.setAutomatedPublishing(
               'oxygen',
               AutomatedPublishingConfig(


### PR DESCRIPTION
This is more an idea than a strong opinion, but #8485 reminded me that we started using named `fn` callbacks before the language allowed different orders for named and ordered parameters. Now, since the language allows the mix, it may be worth checking if the all-named or the mixed-order version is working better for us. Any opinions?