### PR TITLE
Increased contrast in the detail tab selected text color.

### DIFF
--- a/pkg/web_css/lib/src/_variables.scss
+++ b/pkg/web_css/lib/src/_variables.scss
@@ -117,7 +117,7 @@
   --pub-copy_feedback-background-color: #fafaff;
   --pub-detail_tab-text-color: var(--pub-neutral-textColor);
   --pub-detail_tab-underline-color: #dddddd;
-  --pub-detail_tab-active-color: #1967d2;
+  --pub-detail_tab-active-color: var(--pub-link-text-color);
   --pub-weekly-chart-main-color: var(--pub-link-text-color);
   --pub-weekly-chart-tooltip-text-color: var(--pub-color-white);
   --pub-detail_tab-admin-color: #990000;
@@ -174,7 +174,7 @@
   --pub-copy_feedback-background-color: #404040;
   --pub-detail_tab-text-color: var(--pub-neutral-textColor);
   --pub-detail_tab-underline-color: #888888;
-  --pub-detail_tab-active-color: color-mix(in srgb, var(--pub-link-text-color), var(--pub-inset-bgColor) 20%);
+  --pub-detail_tab-active-color: var(--pub-link-text-color);
   --pub-detail_tab-admin-color: #e03030;
   --pub-home_title-text-color: #31b0fc;
   --pub-weekly-chart-main-color: var(--pub-link-text-color);


### PR DESCRIPTION
- Issue reported by Lighthouse.
- Instead of using a blended color in dark mode, now using the link color in both light and dark mode.

Before/after:
<img width="160" alt="image" src="https://github.com/user-attachments/assets/86926596-8159-41e4-ae10-b72673e2af0e" />
<img width="161" alt="image" src="https://github.com/user-attachments/assets/7ac210d9-beff-4073-8ac8-1326896d81be" />
