### PR TITLE
Dark mode link hover: increase brightness instead lower opacity.

### DIFF
--- a/pkg/web_css/lib/src/_base.scss
+++ b/pkg/web_css/lib/src/_base.scss
@@ -93,11 +93,6 @@ a {
   text-decoration: none;
   color: var(--pub-link-text-color);
   cursor: pointer;
-  opacity: 1;
-
-  &:hover {
-    opacity: 0.8;
-  }
 
   // TODO: fix style to not use bgColor as text and text color as background
   &.link-button {
@@ -105,6 +100,20 @@ a {
     color: var(--pub-neutral-bgColor);
     display: inline-block;
     padding: 4px 12px;
+  }
+
+  .light-theme & {
+    opacity: 1;
+
+    &:hover {
+      opacity: 0.8;
+    }
+  }
+
+  .dark-theme & {
+    &:hover {
+      filter: brightness(120%);
+    }
   }
 }
 

--- a/pkg/web_css/lib/src/_variables.scss
+++ b/pkg/web_css/lib/src/_variables.scss
@@ -242,6 +242,13 @@
   .displayed-in-light-theme {
     display: none !important;
   }
+
+  a {
+    &:hover {
+      opacity: 1.0;
+      filter: brightness(120%);
+    }
+  }
 }
 
 @mixin elevated-content-border {

--- a/pkg/web_css/lib/src/_variables.scss
+++ b/pkg/web_css/lib/src/_variables.scss
@@ -242,13 +242,6 @@
   .displayed-in-light-theme {
     display: none !important;
   }
-
-  a {
-    &:hover {
-      opacity: 1.0;
-      filter: brightness(120%);
-    }
-  }
 }
 
 @mixin elevated-content-border {


### PR DESCRIPTION
- #8493
- Note: `filter: brightness()` did not work for me on images, but maybe other factors are at play.
- I'm not yet sure how to resolve the same opacity issue in light mode, given we are using it the current way for a long time, and also the brightness issue above, so I'm limiting this change to dark mode for now, as it seems to be an improvement there.
