### PR TITLE
Add topics-tag class on infobox topic links.

### DIFF
--- a/app/lib/frontend/templates/views/pkg/info_box.dart
+++ b/app/lib/frontend/templates/views/pkg/info_box.dart
@@ -54,7 +54,7 @@ d.Node packageInfoBoxNode({
     );
   }
   final dependencies = _dependencyListNode(version.pubspec?.dependencies);
-  final topics = _topicstNode(version.pubspec?.canonicalizedTopics);
+  final topics = _topicsNode(version.pubspec?.canonicalizedTopics);
 
   final screenshots = data.scoreCard.panaReport?.screenshots;
   String? thumbnailUrl;
@@ -206,7 +206,7 @@ d.Node? _licenseNode({
   ]);
 }
 
-d.Node? _topicstNode(List<String>? topics) {
+d.Node? _topicsNode(List<String>? topics) {
   if (topics == null || topics.isEmpty) return null;
 
   final nodes = <d.Node>[];
@@ -217,6 +217,7 @@ d.Node? _topicstNode(List<String>? topics) {
     final ct = canonicalTopics.asMap[topic];
     final description = ct?.description;
     final node = d.a(
+      classes: ['topics-tag'],
       href: urls.searchUrl(q: 'topic:$topic'),
       text: '#$topic',
       title: description,

--- a/app/test/frontend/golden/pkg_activity_log_page.html
+++ b/app/test/frontend/golden/pkg_activity_log_page.html
@@ -396,7 +396,7 @@
             </p>
             <h3 class="title">Topics</h3>
             <p>
-              <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
+              <a class="topics-tag" href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
             </p>
             <h3 class="title">Documentation</h3>
             <p>
@@ -472,7 +472,7 @@
           </p>
           <h3 class="title">Topics</h3>
           <p>
-            <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
+            <a class="topics-tag" href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
           </p>
           <h3 class="title">Documentation</h3>
           <p>

--- a/app/test/frontend/golden/pkg_admin_page.html
+++ b/app/test/frontend/golden/pkg_admin_page.html
@@ -681,7 +681,7 @@
             </p>
             <h3 class="title">Topics</h3>
             <p>
-              <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
+              <a class="topics-tag" href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
             </p>
             <h3 class="title">Documentation</h3>
             <p>
@@ -757,7 +757,7 @@
           </p>
           <h3 class="title">Topics</h3>
           <p>
-            <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
+            <a class="topics-tag" href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
           </p>
           <h3 class="title">Documentation</h3>
           <p>

--- a/app/test/frontend/golden/pkg_changelog_page.html
+++ b/app/test/frontend/golden/pkg_changelog_page.html
@@ -266,7 +266,7 @@
             </p>
             <h3 class="title">Topics</h3>
             <p>
-              <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
+              <a class="topics-tag" href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
             </p>
             <h3 class="title">Documentation</h3>
             <p>
@@ -343,7 +343,7 @@
           </p>
           <h3 class="title">Topics</h3>
           <p>
-            <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
+            <a class="topics-tag" href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
           </p>
           <h3 class="title">Documentation</h3>
           <p>

--- a/app/test/frontend/golden/pkg_example_page.html
+++ b/app/test/frontend/golden/pkg_example_page.html
@@ -263,7 +263,7 @@
             </p>
             <h3 class="title">Topics</h3>
             <p>
-              <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
+              <a class="topics-tag" href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
             </p>
             <h3 class="title">Documentation</h3>
             <p>
@@ -340,7 +340,7 @@
           </p>
           <h3 class="title">Topics</h3>
           <p>
-            <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
+            <a class="topics-tag" href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
           </p>
           <h3 class="title">Documentation</h3>
           <p>

--- a/app/test/frontend/golden/pkg_install_page.html
+++ b/app/test/frontend/golden/pkg_install_page.html
@@ -289,7 +289,7 @@
             </p>
             <h3 class="title">Topics</h3>
             <p>
-              <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
+              <a class="topics-tag" href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
             </p>
             <h3 class="title">Documentation</h3>
             <p>
@@ -366,7 +366,7 @@
           </p>
           <h3 class="title">Topics</h3>
           <p>
-            <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
+            <a class="topics-tag" href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
           </p>
           <h3 class="title">Documentation</h3>
           <p>

--- a/app/test/frontend/golden/pkg_score_page.html
+++ b/app/test/frontend/golden/pkg_score_page.html
@@ -351,7 +351,7 @@
             </p>
             <h3 class="title">Topics</h3>
             <p>
-              <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
+              <a class="topics-tag" href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
             </p>
             <h3 class="title">Documentation</h3>
             <p>
@@ -428,7 +428,7 @@
           </p>
           <h3 class="title">Topics</h3>
           <p>
-            <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
+            <a class="topics-tag" href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
           </p>
           <h3 class="title">Documentation</h3>
           <p>

--- a/app/test/frontend/golden/pkg_score_page_with_downloads_chart.html
+++ b/app/test/frontend/golden/pkg_score_page_with_downloads_chart.html
@@ -351,7 +351,7 @@
             </p>
             <h3 class="title">Topics</h3>
             <p>
-              <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
+              <a class="topics-tag" href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
             </p>
             <h3 class="title">Documentation</h3>
             <p>
@@ -428,7 +428,7 @@
           </p>
           <h3 class="title">Topics</h3>
           <p>
-            <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
+            <a class="topics-tag" href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
           </p>
           <h3 class="title">Documentation</h3>
           <p>

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -266,7 +266,7 @@
             </p>
             <h3 class="title">Topics</h3>
             <p>
-              <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
+              <a class="topics-tag" href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
             </p>
             <h3 class="title">Documentation</h3>
             <p>
@@ -343,7 +343,7 @@
           </p>
           <h3 class="title">Topics</h3>
           <p>
-            <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
+            <a class="topics-tag" href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
           </p>
           <h3 class="title">Documentation</h3>
           <p>

--- a/app/test/frontend/golden/pkg_show_page_discontinued.html
+++ b/app/test/frontend/golden/pkg_show_page_discontinued.html
@@ -257,7 +257,7 @@
             </p>
             <h3 class="title">Topics</h3>
             <p>
-              <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
+              <a class="topics-tag" href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
             </p>
             <h3 class="title">Documentation</h3>
             <p>
@@ -332,7 +332,7 @@
           </p>
           <h3 class="title">Topics</h3>
           <p>
-            <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
+            <a class="topics-tag" href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
           </p>
           <h3 class="title">Documentation</h3>
           <p>

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -255,7 +255,7 @@
             </p>
             <h3 class="title">Topics</h3>
             <p>
-              <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
+              <a class="topics-tag" href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
             </p>
             <h3 class="title">Documentation</h3>
             <p>
@@ -336,7 +336,7 @@
           </p>
           <h3 class="title">Topics</h3>
           <p>
-            <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
+            <a class="topics-tag" href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
           </p>
           <h3 class="title">Documentation</h3>
           <p>

--- a/app/test/frontend/golden/pkg_show_page_publisher.html
+++ b/app/test/frontend/golden/pkg_show_page_publisher.html
@@ -257,7 +257,7 @@
             </p>
             <h3 class="title">Topics</h3>
             <p>
-              <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
+              <a class="topics-tag" href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
             </p>
             <h3 class="title">Documentation</h3>
             <p>
@@ -329,7 +329,7 @@
           </p>
           <h3 class="title">Topics</h3>
           <p>
-            <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
+            <a class="topics-tag" href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
           </p>
           <h3 class="title">Documentation</h3>
           <p>

--- a/app/test/frontend/golden/pkg_show_page_retracted.html
+++ b/app/test/frontend/golden/pkg_show_page_retracted.html
@@ -242,7 +242,7 @@
             </p>
             <h3 class="title">Topics</h3>
             <p>
-              <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
+              <a class="topics-tag" href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
             </p>
             <h3 class="title">Funding</h3>
             <p>
@@ -314,7 +314,7 @@
           </p>
           <h3 class="title">Topics</h3>
           <p>
-            <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
+            <a class="topics-tag" href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
           </p>
           <h3 class="title">Funding</h3>
           <p>

--- a/app/test/frontend/golden/pkg_show_page_retracted_non_retracted_version.html
+++ b/app/test/frontend/golden/pkg_show_page_retracted_non_retracted_version.html
@@ -248,7 +248,7 @@
             </p>
             <h3 class="title">Topics</h3>
             <p>
-              <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
+              <a class="topics-tag" href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
             </p>
             <h3 class="title">Documentation</h3>
             <p>
@@ -323,7 +323,7 @@
           </p>
           <h3 class="title">Topics</h3>
           <p>
-            <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
+            <a class="topics-tag" href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
           </p>
           <h3 class="title">Documentation</h3>
           <p>

--- a/app/test/frontend/golden/pkg_show_version_page.html
+++ b/app/test/frontend/golden/pkg_show_version_page.html
@@ -260,7 +260,7 @@
             </p>
             <h3 class="title">Topics</h3>
             <p>
-              <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
+              <a class="topics-tag" href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
             </p>
             <h3 class="title">Documentation</h3>
             <p>
@@ -337,7 +337,7 @@
           </p>
           <h3 class="title">Topics</h3>
           <p>
-            <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
+            <a class="topics-tag" href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
           </p>
           <h3 class="title">Documentation</h3>
           <p>

--- a/app/test/frontend/golden/pkg_versions_page.html
+++ b/app/test/frontend/golden/pkg_versions_page.html
@@ -373,7 +373,7 @@
             </p>
             <h3 class="title">Topics</h3>
             <p>
-              <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
+              <a class="topics-tag" href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
             </p>
             <h3 class="title">Documentation</h3>
             <p>
@@ -450,7 +450,7 @@
           </p>
           <h3 class="title">Topics</h3>
           <p>
-            <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
+            <a class="topics-tag" href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
           </p>
           <h3 class="title">Documentation</h3>
           <p>

--- a/app/test/task/testdata/goldens/packages/oxygen.html
+++ b/app/test/task/testdata/goldens/packages/oxygen.html
@@ -254,7 +254,7 @@
             </p>
             <h3 class="title">Topics</h3>
             <p>
-              <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
+              <a class="topics-tag" href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
             </p>
             <h3 class="title">Documentation</h3>
             <p>
@@ -333,7 +333,7 @@
           </p>
           <h3 class="title">Topics</h3>
           <p>
-            <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
+            <a class="topics-tag" href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
           </p>
           <h3 class="title">Documentation</h3>
           <p>

--- a/app/test/task/testdata/goldens/packages/oxygen/changelog.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/changelog.html
@@ -260,7 +260,7 @@
             </p>
             <h3 class="title">Topics</h3>
             <p>
-              <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
+              <a class="topics-tag" href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
             </p>
             <h3 class="title">Documentation</h3>
             <p>
@@ -339,7 +339,7 @@
           </p>
           <h3 class="title">Topics</h3>
           <p>
-            <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
+            <a class="topics-tag" href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
           </p>
           <h3 class="title">Documentation</h3>
           <p>

--- a/app/test/task/testdata/goldens/packages/oxygen/example.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/example.html
@@ -255,7 +255,7 @@
             </p>
             <h3 class="title">Topics</h3>
             <p>
-              <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
+              <a class="topics-tag" href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
             </p>
             <h3 class="title">Documentation</h3>
             <p>
@@ -334,7 +334,7 @@
           </p>
           <h3 class="title">Topics</h3>
           <p>
-            <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
+            <a class="topics-tag" href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
           </p>
           <h3 class="title">Documentation</h3>
           <p>

--- a/app/test/task/testdata/goldens/packages/oxygen/install.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/install.html
@@ -283,7 +283,7 @@
             </p>
             <h3 class="title">Topics</h3>
             <p>
-              <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
+              <a class="topics-tag" href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
             </p>
             <h3 class="title">Documentation</h3>
             <p>
@@ -362,7 +362,7 @@
           </p>
           <h3 class="title">Topics</h3>
           <p>
-            <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
+            <a class="topics-tag" href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
           </p>
           <h3 class="title">Documentation</h3>
           <p>

--- a/app/test/task/testdata/goldens/packages/oxygen/license.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/license.html
@@ -256,7 +256,7 @@
             </p>
             <h3 class="title">Topics</h3>
             <p>
-              <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
+              <a class="topics-tag" href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
             </p>
             <h3 class="title">Documentation</h3>
             <p>
@@ -335,7 +335,7 @@
           </p>
           <h3 class="title">Topics</h3>
           <p>
-            <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
+            <a class="topics-tag" href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
           </p>
           <h3 class="title">Documentation</h3>
           <p>

--- a/app/test/task/testdata/goldens/packages/oxygen/score.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/score.html
@@ -564,7 +564,7 @@
             </p>
             <h3 class="title">Topics</h3>
             <p>
-              <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
+              <a class="topics-tag" href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
             </p>
             <h3 class="title">Documentation</h3>
             <p>
@@ -643,7 +643,7 @@
           </p>
           <h3 class="title">Topics</h3>
           <p>
-            <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
+            <a class="topics-tag" href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
           </p>
           <h3 class="title">Documentation</h3>
           <p>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions.html
@@ -316,7 +316,7 @@
             </p>
             <h3 class="title">Topics</h3>
             <p>
-              <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
+              <a class="topics-tag" href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
             </p>
             <h3 class="title">Documentation</h3>
             <p>
@@ -395,7 +395,7 @@
           </p>
           <h3 class="title">Topics</h3>
           <p>
-            <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
+            <a class="topics-tag" href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
           </p>
           <h3 class="title">Documentation</h3>
           <p>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0.html
@@ -258,7 +258,7 @@
             </p>
             <h3 class="title">Topics</h3>
             <p>
-              <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
+              <a class="topics-tag" href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
             </p>
             <h3 class="title">Documentation</h3>
             <p>
@@ -337,7 +337,7 @@
           </p>
           <h3 class="title">Topics</h3>
           <p>
-            <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
+            <a class="topics-tag" href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
           </p>
           <h3 class="title">Documentation</h3>
           <p>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/changelog.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/changelog.html
@@ -264,7 +264,7 @@
             </p>
             <h3 class="title">Topics</h3>
             <p>
-              <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
+              <a class="topics-tag" href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
             </p>
             <h3 class="title">Documentation</h3>
             <p>
@@ -343,7 +343,7 @@
           </p>
           <h3 class="title">Topics</h3>
           <p>
-            <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
+            <a class="topics-tag" href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
           </p>
           <h3 class="title">Documentation</h3>
           <p>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/example.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/example.html
@@ -259,7 +259,7 @@
             </p>
             <h3 class="title">Topics</h3>
             <p>
-              <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
+              <a class="topics-tag" href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
             </p>
             <h3 class="title">Documentation</h3>
             <p>
@@ -338,7 +338,7 @@
           </p>
           <h3 class="title">Topics</h3>
           <p>
-            <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
+            <a class="topics-tag" href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
           </p>
           <h3 class="title">Documentation</h3>
           <p>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/install.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/install.html
@@ -287,7 +287,7 @@
             </p>
             <h3 class="title">Topics</h3>
             <p>
-              <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
+              <a class="topics-tag" href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
             </p>
             <h3 class="title">Documentation</h3>
             <p>
@@ -366,7 +366,7 @@
           </p>
           <h3 class="title">Topics</h3>
           <p>
-            <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
+            <a class="topics-tag" href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
           </p>
           <h3 class="title">Documentation</h3>
           <p>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/license.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/license.html
@@ -260,7 +260,7 @@
             </p>
             <h3 class="title">Topics</h3>
             <p>
-              <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
+              <a class="topics-tag" href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
             </p>
             <h3 class="title">Documentation</h3>
             <p>
@@ -339,7 +339,7 @@
           </p>
           <h3 class="title">Topics</h3>
           <p>
-            <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
+            <a class="topics-tag" href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
           </p>
           <h3 class="title">Documentation</h3>
           <p>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/score.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/score.html
@@ -568,7 +568,7 @@
             </p>
             <h3 class="title">Topics</h3>
             <p>
-              <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
+              <a class="topics-tag" href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
             </p>
             <h3 class="title">Documentation</h3>
             <p>
@@ -647,7 +647,7 @@
           </p>
           <h3 class="title">Topics</h3>
           <p>
-            <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
+            <a class="topics-tag" href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
           </p>
           <h3 class="title">Documentation</h3>
           <p>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/2.0.0.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/2.0.0.html
@@ -254,7 +254,7 @@
             </p>
             <h3 class="title">Topics</h3>
             <p>
-              <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
+              <a class="topics-tag" href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
             </p>
             <h3 class="title">Documentation</h3>
             <p>
@@ -333,7 +333,7 @@
           </p>
           <h3 class="title">Topics</h3>
           <p>
-            <a href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
+            <a class="topics-tag" href="/packages?q=topic%3Achemical-element" rel="nofollow">#chemical-element</a>
           </p>
           <h3 class="title">Documentation</h3>
           <p>

--- a/pkg/_pub_shared/test/utils/flutter_archive_test.dart
+++ b/pkg/_pub_shared/test/utils/flutter_archive_test.dart
@@ -17,7 +17,7 @@ void main() {
     );
     expect(
       DateTime.now().difference(archive.latestBeta!.releaseDate!).inDays,
-      lessThan(45),
+      lessThan(60),
     );
     expect(archive.latestStable?.semanticDartSdkVersion, isNotNull);
     expect(archive.latestBeta?.semanticDartSdkVersion, isNotNull);


### PR DESCRIPTION
- Lightroom reported the issue on the package page, as the click areas of the links are not enough / overlapping.
- The PR adds `topics-tag` to the links, the same tag we are using on listing pages.

Before/after:

<img width="161" alt="image" src="https://github.com/user-attachments/assets/a0c918c0-9d4f-48c0-8f4f-cf3f35d82f9e" />
<img width="156" alt="image" src="https://github.com/user-attachments/assets/44022deb-30cd-488a-a773-083ef324fdea" />
