### PR TITLE
Updated retry handling in storage access.

### DIFF
--- a/app/lib/package/api_export/exported_api.dart
+++ b/app/lib/package/api_export/exported_api.dart
@@ -121,7 +121,7 @@ final class ExportedApi {
         // Only delete the item if it's older than _minGarbageAge
         // This avoids any races where we delete files we've just created
         // TODO: Conditionally deletion API from package:gcloud would be better!
-        await _bucket.tryDelete(item.name);
+        await _bucket.tryDeleteWithRetry(item.name);
       }
     });
 
@@ -137,7 +137,7 @@ final class ExportedApi {
           item.updated.isBefore(gcFilesBefore)) {
         // Only delete the item if it's older than _minGarbageAge
         // This avoids any races where we delete files we've just created
-        await _bucket.tryDelete(item.name);
+        await _bucket.tryDeleteWithRetry(item.name);
       }
     });
   }
@@ -184,7 +184,7 @@ final class ExportedApi {
         await _listBucket(
           prefix: entry.name,
           delimiter: '',
-          (entry) async => await _bucket.tryDelete(entry.name),
+          (entry) async => await _bucket.tryDeleteWithRetry(entry.name),
         );
       }
     }));
@@ -336,7 +336,7 @@ final class ExportedPackage {
               item.updated.isBefore(clock.agoBy(_minGarbageAge))) {
             // Only delete if the item if it's older than _minGarbageAge
             // This avoids any races where we delete files we've just created
-            await _owner._bucket.tryDelete(item.name);
+            await _owner._bucket.tryDeleteWithRetry(item.name);
           }
         });
 
@@ -380,7 +380,7 @@ final class ExportedPackage {
             if (info.updated.isBefore(clock.agoBy(_minGarbageAge))) {
               // Only delete if the item if it's older than _minGarbageAge
               // This avoids any races where we delete files we've just created
-              await _owner._bucket.tryDelete(item.name);
+              await _owner._bucket.tryDeleteWithRetry(item.name);
             }
           }
           // Ignore cases where tryInfo fails, assuming the object has been
@@ -399,7 +399,7 @@ final class ExportedPackage {
         await _owner._listBucket(
           prefix: prefix + '/api/archives/$_package-',
           delimiter: '',
-          (item) async => await _owner._bucket.tryDelete(item.name),
+          (item) async => await _owner._bucket.tryDeleteWithRetry(item.name),
         );
       }),
     ]);
@@ -442,7 +442,7 @@ sealed class ExportedObject {
   Future<void> delete() async {
     await Future.wait(_owner._prefixes.map((prefix) async {
       await _owner._pool.withResource(() async {
-        await _owner._bucket.tryDelete(prefix + _objectName);
+        await _owner._bucket.tryDeleteWithRetry(prefix + _objectName);
       });
     }));
   }

--- a/app/lib/package/tarball_storage.dart
+++ b/app/lib/package/tarball_storage.dart
@@ -176,8 +176,8 @@ class TarballStorage {
   Future<void> deleteArchiveFromAllBuckets(
       String package, String version) async {
     final objectName = tarballObjectName(package, version);
-    await deleteFromBucket(_canonicalBucket, objectName);
-    await deleteFromBucket(_publicBucket, objectName);
+    await _canonicalBucket.deleteWithRetry(objectName);
+    await _publicBucket.deleteWithRetry(objectName);
   }
 
   /// Deletes the package archive file from the canonical bucket.

--- a/app/lib/shared/utils.dart
+++ b/app/lib/shared/utils.dart
@@ -11,7 +11,6 @@ import 'dart:typed_data';
 
 import 'package:appengine/appengine.dart';
 import 'package:intl/intl.dart';
-import 'package:logging/logging.dart';
 // ignore: implementation_imports
 import 'package:mime/src/default_extension_map.dart' as mime;
 import 'package:path/path.dart' as p;
@@ -28,7 +27,6 @@ final Duration twoYears = const Duration(days: 2 * 365);
 /// Appengine.
 const _cloudTraceContextHeader = 'X-Cloud-Trace-Context';
 
-final Logger _logger = Logger('pub.utils');
 final _random = Random.secure();
 
 final DateFormat shortDateFormat = DateFormat.yMMMd();
@@ -169,30 +167,6 @@ List<T> boundedList<T>(List<T> list, {int? offset, int? limit}) {
     iterable = iterable.take(limit);
   }
   return iterable.toList();
-}
-
-/// Executes [body] and returns with the same result.
-/// When it throws an exception, it will be re-run until [maxAttempt] is reached.
-Future<R> retryAsync<R>(
-  Future<R> Function() body, {
-  int maxAttempt = 3,
-  bool Function(Exception)? shouldRetryOnError,
-  String description = 'Async operation',
-  Duration sleep = const Duration(seconds: 1),
-}) async {
-  for (int i = 1;; i++) {
-    try {
-      return await body();
-    } on Exception catch (e, st) {
-      _logger.info('$description failed (attempt: $i of $maxAttempt).', e, st);
-      if (i < maxAttempt &&
-          (shouldRetryOnError == null || shouldRetryOnError(e))) {
-        await Future.delayed(sleep);
-        continue;
-      }
-      rethrow;
-    }
-  }
 }
 
 /// Returns a UUID in v4 format as a `String`.


### PR DESCRIPTION
- removing `retryAsync` from `utils.dart`
- consolidating retry logic into the single `_retry` wrapper inside `storage.dart`
- renamed `tryDelete` -> `tryDeleteWithRetry` so that the name does reflect on the retry operation
- removed `deleteFromBucket`, using `Bucket.tryDeleteWithRetry` instead
