### PR TITLE
Timeouts and VM exit for index building process.

### DIFF
--- a/app/test/shared/timer_import_test.dart
+++ b/app/test/shared/timer_import_test.dart
@@ -26,7 +26,10 @@ void main() {
     // TODO: consider refactor/redesign
     'lib/shared/redis_cache.dart',
 
-    // Uses timer to auto-kill worker isolates.
+    // Uses timer to kill long-running processing.
+    'lib/shared/utils.dart',
+
+    // Uses timer to prevent long GCs.
     'lib/service/entrypoint/_isolate.dart',
 
     // Uses timer to send stats periodically to the frontend isolate.


### PR DESCRIPTION
- The callback will start a timer that, if not cancelled, will call `exit` to make sure the VM is restarted.
- Added regular timeouts to storage download and also upload calls.