### PR TITLE
Increase font weight in detail page tabs labels to improve contrast.

### DIFF
--- a/pkg/web_css/lib/src/_detail_page.scss
+++ b/pkg/web_css/lib/src/_detail_page.scss
@@ -373,6 +373,7 @@ $detail-tabs-tablet-width: calc(100% - 240px);
 
   > .tab-button,
   > .tab-link > a {
+    font-weight: 500;
     display: block;
     color: var(--pub-detail_tab-text-color);
     padding: 12px 0px;
@@ -387,8 +388,9 @@ $detail-tabs-tablet-width: calc(100% - 240px);
   }
 
   > .tab-button {
+    font-weight: 500;
     &.-active {
-      font-weight: 500;
+      font-weight: 600;
       color: var(--pub-detail_tab-active-color);
       border-bottom-color: var(--pub-detail_tab-active-color);
     }


### PR DESCRIPTION
Fixes #8306

I've tried to find different (red) color combinations for the dark mode, but it turns out the issue was more about the thin font over the dark gray background. Once the weight is increased, Lighthouse seems to be happier with the contrasts.

Before/after in light mode:
<img width="599" alt="image" src="https://github.com/user-attachments/assets/3c9c10ce-5e1f-43a2-b29b-9467b6516354" />
<img width="598" alt="image" src="https://github.com/user-attachments/assets/95904bd5-6b7a-4e57-b3be-d54ea19f3506" />

Before/after in dark mode:
<img width="601" alt="image" src="https://github.com/user-attachments/assets/f86f1e51-ebcc-4075-9a90-277af087305d" />
<img width="602" alt="image" src="https://github.com/user-attachments/assets/13e2dce8-665b-4de6-8e43-422c337a001b" />

An alternative could be to apply the font width only in the dark theme.