### PR TITLE
Fix if condition to prevent NPE on cache race situations.

### DIFF
--- a/app/lib/frontend/templates/package_versions.dart
+++ b/app/lib/frontend/templates/package_versions.dart
@@ -61,11 +61,11 @@ String renderPkgVersionsPage(
   final blocks = <d.Node>[];
   if (stableVersionRows.isNotEmpty &&
       prereleaseVersionRows.isNotEmpty &&
-      data.latestReleases.showPrerelease) {
+      latestPrereleaseVersion != null) {
     blocks.add(d.p(
       children: [
         d.text('The latest prerelease was '),
-        d.a(href: '#prerelease', text: latestPrereleaseVersion!.version),
+        d.a(href: '#prerelease', text: latestPrereleaseVersion.version),
         d.text(' '),
         d.xAgoTimestamp(latestPrereleaseVersion.published!, datePrefix: 'on'),
         d.text('.'),


### PR DESCRIPTION
Fixes #8502

Otherwise the list of versions may be behind the current value, leaving the possibility of NPE.