### PR TITLE
Detect incompatible local Chrome versions when running puppeteer.

### DIFF
--- a/pkg/pub_integration/pubspec.yaml
+++ b/pkg/pub_integration/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   http: ^1.0.0
   path: ^1.8.0
   pub_semver: ^2.0.0
-  puppeteer: 3.12.0
+  puppeteer: 3.16.0
   oauth2: ^2.0.0
 
 dev_dependencies:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -690,10 +690,10 @@ packages:
     dependency: transitive
     description:
       name: puppeteer
-      sha256: de3f921154e5d336b14cdc05b674ac3db5701a5338f3cb0042868a5146f16e67
+      sha256: "7a990c68d33882b642214c351f66492d9a738afa4226a098ab70642357337fa2"
       url: "https://pub.dev"
     source: hosted
-    version: "3.12.0"
+    version: "3.16.0"
   retry:
     dependency: transitive
     description:


### PR DESCRIPTION
It looks like there is some known incompatibility with new chrome versions and the puppeteer package. Updating the code to check for version when attempting to run local chrome instance, and also removing the extra check from the CI environment (in case it upgraded the chrome version).

See https://github.com/xvrh/puppeteer-dart/issues/364
 