### PR TITLE
Use default color and background in third-party github-markdown.css

### DIFF
--- a/third_party/css/github-markdown.css
+++ b/third_party/css/github-markdown.css
@@ -66,6 +66,11 @@
   padding: 0 1em;
   color: #6a737d;
   border-left: 0.25em solid #dfe2e5;
+
+  /* Note: pub.dev override. */
+  .dark-theme & {
+    color: inherit;
+  }
 }
 
 .markdown-body blockquote>:first-child {
@@ -88,6 +93,13 @@
   border-bottom-color: #959da5;
   border-radius: 3px;
   box-shadow: inset 0 -1px 0 #959da5;
+
+  /* Note: pub.dev override. */
+  .dark-theme & {
+    color: inherit;
+    background-color: inherit;
+    box-shadow: none;
+  }
 }
 
 .markdown-body h1,
@@ -144,6 +156,11 @@
 .markdown-body h6 {
   font-size: 0.85em;
   color: #6a737d;
+
+  /* Note: pub.dev override. */
+  .dark-theme & {
+    color: inherit;
+  }
 }
 
 .markdown-body ul,
@@ -261,6 +278,11 @@
   padding: 5px 0 0;
   clear: both;
   color: #24292e;
+
+  /* Note: pub.dev override. */
+  .dark-theme & {
+    color: inherit;
+  }
 }
 
 .markdown-body span.align-center {


### PR DESCRIPTION
- Fixes #8310
- This is a temporary fix for styles before spending much more time on properly including modern github-markdown styles, see #8323.

before/after:
<img width="131" alt="image" src="https://github.com/user-attachments/assets/e6d9a458-e4b3-493d-b6cc-71e6d0631499" />
<img width="132" alt="image" src="https://github.com/user-attachments/assets/9908d5d6-bcf5-4e3d-97b8-1d3ee2e8e92a" />
