### PR TITLE
Increase contrast of pub detail tags in dark mode

### DIFF
--- a/pkg/web_css/lib/src/_variables.scss
+++ b/pkg/web_css/lib/src/_variables.scss
@@ -151,7 +151,6 @@
   --pub-color-darkBlack:       #121317;
   --pub-color-darkGunmetal:    #242b32;
   --pub-color-darkGray:        #2f3034; /* derived from dark black by making it lighter */
-  --pub-color-nipponUltraBlue: #23607f;
   --pub-color-darkSteelBlue:   #144466;
 
   --pub-neutral-bgColor:       var(--pub-color-darkBlack);

--- a/pkg/web_css/lib/src/_variables.scss
+++ b/pkg/web_css/lib/src/_variables.scss
@@ -152,13 +152,14 @@
   --pub-color-darkGunmetal:    #242b32;
   --pub-color-darkGray:        #2f3034; /* derived from dark black by making it lighter */
   --pub-color-nipponUltraBlue: #23607f;
+  --pub-color-darkSteelBlue:   #144466;
 
   --pub-neutral-bgColor:       var(--pub-color-darkBlack);
   --pub-neutral-borderColor:   var(--pub-color-darkGunmetal);
   --pub-neutral-textColor:     var(--dash-surface-fgColor);
   --pub-neutral-hover-bgColor: var(--pub-color-darkGray);
   --pub-inset-bgColor:         var(--pub-color-darkGunmetal);
-  --pub-selected-bgColor:      var(--pub-color-nipponUltraBlue);
+  --pub-selected-bgColor:      var(--pub-color-darkSteelBlue);
 
   // Note: these colors are copied from GitHub styles
   --pub-markdown-alert-note:      #0969da; // accent-emphasis from GitHub
@@ -189,7 +190,7 @@
   --pub-sort_control_hover-text-color: var(--pub-neutral-textColor);
   --pub-sort_control_selected-text-color: var(--pub-neutral-textColor);
   --pub-tag_simplebadge-text-color: var(--pub-neutral-textColor);
-  --pub-tag_sdkbadge-separator-color: var(--pub-neutral-textColor);
+  --pub-tag_sdkbadge-separator-color: #226699;
   --pub-tag_sdkbadge-text-color: var(--pub-neutral-textColor);
 
   --pub-downloads-chart-frame-color: #55585a;


### PR DESCRIPTION
**After:**

<img width="400" alt="Screenshot of pub detail tags on provider package after change" src="https://github.com/user-attachments/assets/24056531-958b-4222-a068-572ba73c360e" /><br>

**Before:**

<img width="400" alt="Screenshot of pub detail tags on provider package before change" src="https://github.com/user-attachments/assets/a35334cd-368b-490a-b9f7-bcff14b94626" />
