### PR TITLE
Padding, border and box-shadow changes in search completion.

### DIFF
--- a/pkg/web_css/lib/src/_search.scss
+++ b/pkg/web_css/lib/src/_search.scss
@@ -112,7 +112,8 @@
   appearance: none;
   width: 25ex;
   border: 1px solid #000;
-  border-radius: 5px;
+  border-radius: 0 0 5px 5px;
+  box-shadow: 1px 1px 4px rgba(0, 0, 0, 0.33);
   max-height: 20em;
   background: var(--pub-searchbar_suggest-background-color);
   color: var(--pub-searchbar_suggest-text-color);
@@ -123,7 +124,7 @@
   >.completion-option {
     cursor: pointer;
     white-space: nowrap;
-    padding: 1px 4px;
+    padding: 4px 8px;
 
     &:hover {
       background-color: var(--pub-searchbar_suggest_hover-background-color);


### PR DESCRIPTION
- Filing separately from the bg- and text-color changes.
- Before/after:
 
<img width="249" alt="image" src="https://github.com/user-attachments/assets/4c51d2cb-e5bf-4881-8e18-3e4d0d1a070b" />
<img width="247" alt="image" src="https://github.com/user-attachments/assets/3d73f991-3c3a-4228-b07b-0b80b36e904f" />
