### PR TITLE
Use brighness for links, opacity for monochrome icons.

### DIFF
--- a/app/lib/frontend/templates/views/pkg/versions/version_row.dart
+++ b/app/lib/frontend/templates/views/pkg/versions/version_row.dart
@@ -60,7 +60,7 @@ d.Node versionRowNode(
           rel: 'nofollow',
           title: 'Download $package ${version.version} archive',
           child: d.img(
-            classes: ['version-table-icon', 'filter-invert-on-dark'],
+            classes: ['pub-monochrome-icon', 'filter-invert-on-dark'],
             image: d.Image(
               src: staticUrls.downloadIcon,
               alt: 'Download $package ${version.version} archive',
@@ -91,7 +91,7 @@ d.Node _documentationCell(
       rel: 'nofollow',
       title: 'Go to the documentation of $package ${version.version}',
       child: d.img(
-        classes: ['version-table-icon', 'filter-invert-on-dark'],
+        classes: ['pub-monochrome-icon', 'filter-invert-on-dark'],
         image: d.Image(
           src: staticUrls.documentationIcon,
           alt: 'Go to the documentation of $package ${version.version}',
@@ -106,7 +106,7 @@ d.Node _documentationCell(
       rel: 'nofollow',
       title: 'Check the analysis logs for $package ${version.version}',
       child: d.img(
-        classes: ['version-table-icon', 'filter-invert-on-dark'],
+        classes: ['pub-monochrome-icon', 'filter-invert-on-dark'],
         image: d.Image(
           src: staticUrls.documentationFailedIcon,
           alt: 'Check the analysis logs for $package ${version.version}',

--- a/app/test/frontend/golden/pkg_versions_page.html
+++ b/app/test/frontend/golden/pkg_versions_page.html
@@ -249,12 +249,12 @@
                         </td>
                         <td class="documentation">
                           <a href="/documentation/oxygen/1.2.0/" rel="nofollow" title="Go to the documentation of oxygen 1.2.0">
-                            <img class="version-table-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/description-24px.svg" alt="Go to the documentation of oxygen 1.2.0" width="24" height="24"/>
+                            <img class="pub-monochrome-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/description-24px.svg" alt="Go to the documentation of oxygen 1.2.0" width="24" height="24"/>
                           </a>
                         </td>
                         <td class="archive">
                           <a href="/api/archives/oxygen-1.2.0.tar.gz" rel="nofollow" title="Download oxygen 1.2.0 archive">
-                            <img class="version-table-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/vertical_align_bottom-24px.svg" alt="Download oxygen 1.2.0 archive" width="24" height="24"/>
+                            <img class="pub-monochrome-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/vertical_align_bottom-24px.svg" alt="Download oxygen 1.2.0 archive" width="24" height="24"/>
                           </a>
                         </td>
                       </tr>
@@ -271,12 +271,12 @@
                         </td>
                         <td class="documentation">
                           <a href="/documentation/oxygen/1.0.0/" rel="nofollow" title="Go to the documentation of oxygen 1.0.0">
-                            <img class="version-table-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/description-24px.svg" alt="Go to the documentation of oxygen 1.0.0" width="24" height="24"/>
+                            <img class="pub-monochrome-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/description-24px.svg" alt="Go to the documentation of oxygen 1.0.0" width="24" height="24"/>
                           </a>
                         </td>
                         <td class="archive">
                           <a href="/api/archives/oxygen-1.0.0.tar.gz" rel="nofollow" title="Download oxygen 1.0.0 archive">
-                            <img class="version-table-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/vertical_align_bottom-24px.svg" alt="Download oxygen 1.0.0 archive" width="24" height="24"/>
+                            <img class="pub-monochrome-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/vertical_align_bottom-24px.svg" alt="Download oxygen 1.0.0 archive" width="24" height="24"/>
                           </a>
                         </td>
                       </tr>
@@ -316,12 +316,12 @@
                         </td>
                         <td class="documentation">
                           <a href="/documentation/oxygen/2.0.0-dev/" rel="nofollow" title="Go to the documentation of oxygen 2.0.0-dev">
-                            <img class="version-table-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/description-24px.svg" alt="Go to the documentation of oxygen 2.0.0-dev" width="24" height="24"/>
+                            <img class="pub-monochrome-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/description-24px.svg" alt="Go to the documentation of oxygen 2.0.0-dev" width="24" height="24"/>
                           </a>
                         </td>
                         <td class="archive">
                           <a href="/api/archives/oxygen-2.0.0-dev.tar.gz" rel="nofollow" title="Download oxygen 2.0.0-dev archive">
-                            <img class="version-table-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/vertical_align_bottom-24px.svg" alt="Download oxygen 2.0.0-dev archive" width="24" height="24"/>
+                            <img class="pub-monochrome-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/vertical_align_bottom-24px.svg" alt="Download oxygen 2.0.0-dev archive" width="24" height="24"/>
                           </a>
                         </td>
                       </tr>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions.html
@@ -235,12 +235,12 @@
                         </td>
                         <td class="documentation">
                           <a href="/documentation/oxygen/2.0.0/" rel="nofollow" title="Go to the documentation of oxygen 2.0.0">
-                            <img class="version-table-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/description-24px.svg" alt="Go to the documentation of oxygen 2.0.0" width="24" height="24"/>
+                            <img class="pub-monochrome-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/description-24px.svg" alt="Go to the documentation of oxygen 2.0.0" width="24" height="24"/>
                           </a>
                         </td>
                         <td class="archive">
                           <a href="/api/archives/oxygen-2.0.0.tar.gz" rel="nofollow" title="Download oxygen 2.0.0 archive">
-                            <img class="version-table-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/vertical_align_bottom-24px.svg" alt="Download oxygen 2.0.0 archive" width="24" height="24"/>
+                            <img class="pub-monochrome-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/vertical_align_bottom-24px.svg" alt="Download oxygen 2.0.0 archive" width="24" height="24"/>
                           </a>
                         </td>
                       </tr>
@@ -257,12 +257,12 @@
                         </td>
                         <td class="documentation">
                           <a href="/documentation/oxygen/1.0.0/" rel="nofollow" title="Go to the documentation of oxygen 1.0.0">
-                            <img class="version-table-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/description-24px.svg" alt="Go to the documentation of oxygen 1.0.0" width="24" height="24"/>
+                            <img class="pub-monochrome-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/description-24px.svg" alt="Go to the documentation of oxygen 1.0.0" width="24" height="24"/>
                           </a>
                         </td>
                         <td class="archive">
                           <a href="/api/archives/oxygen-1.0.0.tar.gz" rel="nofollow" title="Download oxygen 1.0.0 archive">
-                            <img class="version-table-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/vertical_align_bottom-24px.svg" alt="Download oxygen 1.0.0 archive" width="24" height="24"/>
+                            <img class="pub-monochrome-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/vertical_align_bottom-24px.svg" alt="Download oxygen 1.0.0 archive" width="24" height="24"/>
                           </a>
                         </td>
                       </tr>

--- a/pkg/web_css/lib/src/_base.scss
+++ b/pkg/web_css/lib/src/_base.scss
@@ -89,6 +89,22 @@ button {
   }
 }
 
+// The class annotates an image icon with either black or white pixels on
+// a transparent base layer.
+// The default display with the muted opacity will move the icon's color
+// towards the gray spectrum, and on hovering it will show high contrast.
+//
+// Note: The `filter: brightness()` used below with the `a` element does
+//       not work with monochrome images, as the linear transformation
+//       will keep the pixels with rgb(0,0,0) the same.
+.pub-monochrome-icon {
+  opacity: 0.6;
+
+  a:hover & {
+    opacity: 1;
+  }
+}
+
 a {
   text-decoration: none;
   color: var(--pub-link-text-color);
@@ -103,10 +119,8 @@ a {
   }
 
   .light-theme & {
-    opacity: 1;
-
     &:hover {
-      opacity: 0.8;
+      filter: brightness(80%);
     }
   }
 

--- a/pkg/web_css/lib/src/_pkg.scss
+++ b/pkg/web_css/lib/src/_pkg.scss
@@ -115,10 +115,6 @@
       font-size: 24px;
     }
   }
-
-  .version-table-icon {
-    opacity: 0.7;
-  }
 }
 
 .changelog-entry {


### PR DESCRIPTION
- #8493
- Setting the `filter: brightness(...%)` is much better for our links, as their color is now pushed towards stronger contrast.
- However, it does not work with the monochrome icons, introducing a new class for it and using it on the version's tab icons.

Hovering on the versions tab icons before:
<img width="65" alt="image" src="https://github.com/user-attachments/assets/dd045384-89e7-41ad-a9a1-9e0d003b157e" />
<img width="61" alt="image" src="https://github.com/user-attachments/assets/ad890837-324c-4c18-9bb3-6dff05d32f88" />

Hovering on the versions tab icons after:
<img width="63" alt="image" src="https://github.com/user-attachments/assets/63cca462-906b-4e32-9171-b35eb378ac95" />
<img width="64" alt="image" src="https://github.com/user-attachments/assets/79d28d8a-1634-43b2-aa15-4aa9a135b640" />

Note: the difference is that the current behavior reduced the contrast, while the new one increases it. It can also be tested on staging now.