### PR TITLE
Hide the automatically displayed webkit-only clear/cancel search button.

### DIFF
--- a/pkg/web_css/lib/src/_search.scss
+++ b/pkg/web_css/lib/src/_search.scss
@@ -47,6 +47,12 @@
     &:focus {
       outline: none;
     }
+
+    // This is a non-standard feature, supported only by webkit browsers
+    // https://developer.mozilla.org/en-US/docs/Web/CSS/::-webkit-search-cancel-button
+    &::-webkit-search-cancel-button {
+      display: none;
+    }
   }
 
   >.icon {

--- a/pkg/web_css/test/expression_test.dart
+++ b/pkg/web_css/test/expression_test.dart
@@ -42,6 +42,7 @@ void main() {
         'keyframes',
         'last-child',
         'nth-child',
+        '-webkit-search-cancel-button',
       ]);
       // composite patterns
       expressions.removeWhere((e) => e.startsWith('home-block-'));


### PR DESCRIPTION
- Fixes #8535
- I don't remember that we've explicitly wanted to display this icon, or we ever cared about it. As it is not displayed in Firefox, better to remove it for now, and if we want to have such feature, we should do a proper cross-browser solution.
- Note: Google and Github search uses a custom icon, and not this style.

![image](https://github.com/user-attachments/assets/74340402-0ee3-49f9-a626-c34d30c23b12)
