### PR TITLE
Use pub-monochrome-icon in the package title's copy icon.

### DIFF
--- a/app/lib/frontend/templates/views/pkg/title_content.dart
+++ b/app/lib/frontend/templates/views/pkg/title_content.dart
@@ -20,7 +20,11 @@ d.Node copyIcon({required String package, required String version}) {
     classes: ['pkg-page-title-copy'],
     children: [
       d.img(
-        classes: ['pkg-page-title-copy-icon', 'filter-invert-on-dark'],
+        classes: [
+          'pub-monochrome-icon',
+          'pkg-page-title-copy-icon',
+          'filter-invert-on-dark',
+        ],
         attributes: {
           'data-copy-content': '$package: ^$version',
           'data-ga-click-event': 'copy-package-version',

--- a/app/test/frontend/golden/my_packages.html
+++ b/app/test/frontend/golden/my_packages.html
@@ -185,7 +185,7 @@
                         <h3 class="packages-title">
                           <a href="/packages/oxygen">oxygen</a>
                           <span class="pkg-page-title-copy">
-                            <img class="pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^1.2.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>
+                            <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^1.2.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>
                             <div class="pkg-page-title-copy-feedback">
                               <span class="code">oxygen: ^1.2.0</span>
                               copied to clipboard
@@ -268,7 +268,7 @@
                         <h3 class="packages-title">
                           <a href="/packages/neon">neon</a>
                           <span class="pkg-page-title-copy">
-                            <img class="pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;neon: ^1.0.0&quot; to clipboard" width="18" height="18" title="Copy &quot;neon: ^1.0.0&quot; to clipboard" data-copy-content="neon: ^1.0.0" data-ga-click-event="copy-package-version"/>
+                            <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;neon: ^1.0.0&quot; to clipboard" width="18" height="18" title="Copy &quot;neon: ^1.0.0&quot; to clipboard" data-copy-content="neon: ^1.0.0" data-ga-click-event="copy-package-version"/>
                             <div class="pkg-page-title-copy-feedback">
                               <span class="code">neon: ^1.0.0</span>
                               copied to clipboard

--- a/app/test/frontend/golden/pkg_activity_log_page.html
+++ b/app/test/frontend/golden/pkg_activity_log_page.html
@@ -143,7 +143,7 @@
                 <h1 class="title">
                   oxygen 1.2.0
                   <span class="pkg-page-title-copy">
-                    <img class="pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^1.2.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>
+                    <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^1.2.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>
                     <div class="pkg-page-title-copy-feedback">
                       <span class="code">oxygen: ^1.2.0</span>
                       copied to clipboard

--- a/app/test/frontend/golden/pkg_admin_page.html
+++ b/app/test/frontend/golden/pkg_admin_page.html
@@ -143,7 +143,7 @@
                 <h1 class="title">
                   oxygen 1.2.0
                   <span class="pkg-page-title-copy">
-                    <img class="pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^1.2.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>
+                    <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^1.2.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>
                     <div class="pkg-page-title-copy-feedback">
                       <span class="code">oxygen: ^1.2.0</span>
                       copied to clipboard

--- a/app/test/frontend/golden/pkg_changelog_page.html
+++ b/app/test/frontend/golden/pkg_changelog_page.html
@@ -117,7 +117,7 @@
                 <h1 class="title">
                   oxygen 1.2.0
                   <span class="pkg-page-title-copy">
-                    <img class="pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^1.2.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>
+                    <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^1.2.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>
                     <div class="pkg-page-title-copy-feedback">
                       <span class="code">oxygen: ^1.2.0</span>
                       copied to clipboard

--- a/app/test/frontend/golden/pkg_example_page.html
+++ b/app/test/frontend/golden/pkg_example_page.html
@@ -117,7 +117,7 @@
                 <h1 class="title">
                   oxygen 1.2.0
                   <span class="pkg-page-title-copy">
-                    <img class="pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^1.2.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>
+                    <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^1.2.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>
                     <div class="pkg-page-title-copy-feedback">
                       <span class="code">oxygen: ^1.2.0</span>
                       copied to clipboard

--- a/app/test/frontend/golden/pkg_index_page.html
+++ b/app/test/frontend/golden/pkg_index_page.html
@@ -452,7 +452,7 @@
                 <h3 class="packages-title">
                   <a href="/packages/oxygen">oxygen</a>
                   <span class="pkg-page-title-copy">
-                    <img class="pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^1.2.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>
+                    <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^1.2.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>
                     <div class="pkg-page-title-copy-feedback">
                       <span class="code">oxygen: ^1.2.0</span>
                       copied to clipboard
@@ -535,7 +535,7 @@
                 <h3 class="packages-title">
                   <a href="/packages/flutter_titanium">flutter_titanium</a>
                   <span class="pkg-page-title-copy">
-                    <img class="pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;flutter_titanium: ^1.10.0&quot; to clipboard" width="18" height="18" title="Copy &quot;flutter_titanium: ^1.10.0&quot; to clipboard" data-copy-content="flutter_titanium: ^1.10.0" data-ga-click-event="copy-package-version"/>
+                    <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;flutter_titanium: ^1.10.0&quot; to clipboard" width="18" height="18" title="Copy &quot;flutter_titanium: ^1.10.0&quot; to clipboard" data-copy-content="flutter_titanium: ^1.10.0" data-ga-click-event="copy-package-version"/>
                     <div class="pkg-page-title-copy-feedback">
                       <span class="code">flutter_titanium: ^1.10.0</span>
                       copied to clipboard

--- a/app/test/frontend/golden/pkg_install_page.html
+++ b/app/test/frontend/golden/pkg_install_page.html
@@ -117,7 +117,7 @@
                 <h1 class="title">
                   oxygen 1.2.0
                   <span class="pkg-page-title-copy">
-                    <img class="pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^1.2.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>
+                    <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^1.2.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>
                     <div class="pkg-page-title-copy-feedback">
                       <span class="code">oxygen: ^1.2.0</span>
                       copied to clipboard

--- a/app/test/frontend/golden/pkg_score_page.html
+++ b/app/test/frontend/golden/pkg_score_page.html
@@ -117,7 +117,7 @@
                 <h1 class="title">
                   oxygen 1.2.0
                   <span class="pkg-page-title-copy">
-                    <img class="pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^1.2.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>
+                    <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^1.2.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>
                     <div class="pkg-page-title-copy-feedback">
                       <span class="code">oxygen: ^1.2.0</span>
                       copied to clipboard

--- a/app/test/frontend/golden/pkg_score_page_with_downloads_chart.html
+++ b/app/test/frontend/golden/pkg_score_page_with_downloads_chart.html
@@ -117,7 +117,7 @@
                 <h1 class="title">
                   oxygen 1.2.0
                   <span class="pkg-page-title-copy">
-                    <img class="pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^1.2.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>
+                    <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^1.2.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>
                     <div class="pkg-page-title-copy-feedback">
                       <span class="code">oxygen: ^1.2.0</span>
                       copied to clipboard

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -117,7 +117,7 @@
                 <h1 class="title">
                   oxygen 1.2.0
                   <span class="pkg-page-title-copy">
-                    <img class="pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^1.2.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>
+                    <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^1.2.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>
                     <div class="pkg-page-title-copy-feedback">
                       <span class="code">oxygen: ^1.2.0</span>
                       copied to clipboard

--- a/app/test/frontend/golden/pkg_show_page_discontinued.html
+++ b/app/test/frontend/golden/pkg_show_page_discontinued.html
@@ -117,7 +117,7 @@
                 <h1 class="title">
                   pkg 1.0.0
                   <span class="pkg-page-title-copy">
-                    <img class="pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;pkg: ^1.0.0&quot; to clipboard" width="18" height="18" title="Copy &quot;pkg: ^1.0.0&quot; to clipboard" data-copy-content="pkg: ^1.0.0" data-ga-click-event="copy-package-version"/>
+                    <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;pkg: ^1.0.0&quot; to clipboard" width="18" height="18" title="Copy &quot;pkg: ^1.0.0&quot; to clipboard" data-copy-content="pkg: ^1.0.0" data-ga-click-event="copy-package-version"/>
                     <div class="pkg-page-title-copy-feedback">
                       <span class="code">pkg: ^1.0.0</span>
                       copied to clipboard

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -117,7 +117,7 @@
                 <h1 class="title">
                   flutter_titanium 1.10.0
                   <span class="pkg-page-title-copy">
-                    <img class="pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;flutter_titanium: ^1.10.0&quot; to clipboard" width="18" height="18" title="Copy &quot;flutter_titanium: ^1.10.0&quot; to clipboard" data-copy-content="flutter_titanium: ^1.10.0" data-ga-click-event="copy-package-version"/>
+                    <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;flutter_titanium: ^1.10.0&quot; to clipboard" width="18" height="18" title="Copy &quot;flutter_titanium: ^1.10.0&quot; to clipboard" data-copy-content="flutter_titanium: ^1.10.0" data-ga-click-event="copy-package-version"/>
                     <div class="pkg-page-title-copy-feedback">
                       <span class="code">flutter_titanium: ^1.10.0</span>
                       copied to clipboard

--- a/app/test/frontend/golden/pkg_show_page_publisher.html
+++ b/app/test/frontend/golden/pkg_show_page_publisher.html
@@ -117,7 +117,7 @@
                 <h1 class="title">
                   neon 1.0.0
                   <span class="pkg-page-title-copy">
-                    <img class="pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;neon: ^1.0.0&quot; to clipboard" width="18" height="18" title="Copy &quot;neon: ^1.0.0&quot; to clipboard" data-copy-content="neon: ^1.0.0" data-ga-click-event="copy-package-version"/>
+                    <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;neon: ^1.0.0&quot; to clipboard" width="18" height="18" title="Copy &quot;neon: ^1.0.0&quot; to clipboard" data-copy-content="neon: ^1.0.0" data-ga-click-event="copy-package-version"/>
                     <div class="pkg-page-title-copy-feedback">
                       <span class="code">neon: ^1.0.0</span>
                       copied to clipboard

--- a/app/test/frontend/golden/pkg_show_page_retracted.html
+++ b/app/test/frontend/golden/pkg_show_page_retracted.html
@@ -117,7 +117,7 @@
                 <h1 class="title">
                   pkg 1.0.0
                   <span class="pkg-page-title-copy">
-                    <img class="pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;pkg: ^1.0.0&quot; to clipboard" width="18" height="18" title="Copy &quot;pkg: ^1.0.0&quot; to clipboard" data-copy-content="pkg: ^1.0.0" data-ga-click-event="copy-package-version"/>
+                    <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;pkg: ^1.0.0&quot; to clipboard" width="18" height="18" title="Copy &quot;pkg: ^1.0.0&quot; to clipboard" data-copy-content="pkg: ^1.0.0" data-ga-click-event="copy-package-version"/>
                     <div class="pkg-page-title-copy-feedback">
                       <span class="code">pkg: ^1.0.0</span>
                       copied to clipboard

--- a/app/test/frontend/golden/pkg_show_page_retracted_non_retracted_version.html
+++ b/app/test/frontend/golden/pkg_show_page_retracted_non_retracted_version.html
@@ -117,7 +117,7 @@
                 <h1 class="title">
                   pkg 2.0.0
                   <span class="pkg-page-title-copy">
-                    <img class="pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;pkg: ^2.0.0&quot; to clipboard" width="18" height="18" title="Copy &quot;pkg: ^2.0.0&quot; to clipboard" data-copy-content="pkg: ^2.0.0" data-ga-click-event="copy-package-version"/>
+                    <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;pkg: ^2.0.0&quot; to clipboard" width="18" height="18" title="Copy &quot;pkg: ^2.0.0&quot; to clipboard" data-copy-content="pkg: ^2.0.0" data-ga-click-event="copy-package-version"/>
                     <div class="pkg-page-title-copy-feedback">
                       <span class="code">pkg: ^2.0.0</span>
                       copied to clipboard

--- a/app/test/frontend/golden/pkg_show_version_page.html
+++ b/app/test/frontend/golden/pkg_show_version_page.html
@@ -117,7 +117,7 @@
                 <h1 class="title">
                   oxygen 1.2.0
                   <span class="pkg-page-title-copy">
-                    <img class="pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^1.2.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>
+                    <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^1.2.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>
                     <div class="pkg-page-title-copy-feedback">
                       <span class="code">oxygen: ^1.2.0</span>
                       copied to clipboard

--- a/app/test/frontend/golden/pkg_versions_page.html
+++ b/app/test/frontend/golden/pkg_versions_page.html
@@ -117,7 +117,7 @@
                 <h1 class="title">
                   oxygen 1.2.0
                   <span class="pkg-page-title-copy">
-                    <img class="pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^1.2.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>
+                    <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^1.2.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>
                     <div class="pkg-page-title-copy-feedback">
                       <span class="code">oxygen: ^1.2.0</span>
                       copied to clipboard

--- a/app/test/frontend/golden/publisher_packages_page.html
+++ b/app/test/frontend/golden/publisher_packages_page.html
@@ -187,7 +187,7 @@
                         <h3 class="packages-title">
                           <a href="/packages/neon">neon</a>
                           <span class="pkg-page-title-copy">
-                            <img class="pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;neon: ^1.0.0&quot; to clipboard" width="18" height="18" title="Copy &quot;neon: ^1.0.0&quot; to clipboard" data-copy-content="neon: ^1.0.0" data-ga-click-event="copy-package-version"/>
+                            <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;neon: ^1.0.0&quot; to clipboard" width="18" height="18" title="Copy &quot;neon: ^1.0.0&quot; to clipboard" data-copy-content="neon: ^1.0.0" data-ga-click-event="copy-package-version"/>
                             <div class="pkg-page-title-copy-feedback">
                               <span class="code">neon: ^1.0.0</span>
                               copied to clipboard
@@ -268,7 +268,7 @@
                         <h3 class="packages-title">
                           <a href="/packages/flutter_titanium">flutter_titanium</a>
                           <span class="pkg-page-title-copy">
-                            <img class="pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;flutter_titanium: ^1.10.0&quot; to clipboard" width="18" height="18" title="Copy &quot;flutter_titanium: ^1.10.0&quot; to clipboard" data-copy-content="flutter_titanium: ^1.10.0" data-ga-click-event="copy-package-version"/>
+                            <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;flutter_titanium: ^1.10.0&quot; to clipboard" width="18" height="18" title="Copy &quot;flutter_titanium: ^1.10.0&quot; to clipboard" data-copy-content="flutter_titanium: ^1.10.0" data-ga-click-event="copy-package-version"/>
                             <div class="pkg-page-title-copy-feedback">
                               <span class="code">flutter_titanium: ^1.10.0</span>
                               copied to clipboard

--- a/app/test/frontend/golden/publisher_unlisted_packages_page.html
+++ b/app/test/frontend/golden/publisher_unlisted_packages_page.html
@@ -193,7 +193,7 @@
                         <h3 class="packages-title">
                           <a href="/packages/neon">neon</a>
                           <span class="pkg-page-title-copy">
-                            <img class="pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;neon: ^1.0.0&quot; to clipboard" width="18" height="18" title="Copy &quot;neon: ^1.0.0&quot; to clipboard" data-copy-content="neon: ^1.0.0" data-ga-click-event="copy-package-version"/>
+                            <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;neon: ^1.0.0&quot; to clipboard" width="18" height="18" title="Copy &quot;neon: ^1.0.0&quot; to clipboard" data-copy-content="neon: ^1.0.0" data-ga-click-event="copy-package-version"/>
                             <div class="pkg-page-title-copy-feedback">
                               <span class="code">neon: ^1.0.0</span>
                               copied to clipboard
@@ -274,7 +274,7 @@
                         <h3 class="packages-title">
                           <a href="/packages/flutter_titanium">flutter_titanium</a>
                           <span class="pkg-page-title-copy">
-                            <img class="pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;flutter_titanium: ^1.10.0&quot; to clipboard" width="18" height="18" title="Copy &quot;flutter_titanium: ^1.10.0&quot; to clipboard" data-copy-content="flutter_titanium: ^1.10.0" data-ga-click-event="copy-package-version"/>
+                            <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;flutter_titanium: ^1.10.0&quot; to clipboard" width="18" height="18" title="Copy &quot;flutter_titanium: ^1.10.0&quot; to clipboard" data-copy-content="flutter_titanium: ^1.10.0" data-ga-click-event="copy-package-version"/>
                             <div class="pkg-page-title-copy-feedback">
                               <span class="code">flutter_titanium: ^1.10.0</span>
                               copied to clipboard

--- a/app/test/frontend/golden/search_page.html
+++ b/app/test/frontend/golden/search_page.html
@@ -434,7 +434,7 @@
                 <h3 class="packages-title">
                   <a href="/packages/oxygen">oxygen</a>
                   <span class="pkg-page-title-copy">
-                    <img class="pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^1.2.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>
+                    <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^1.2.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>
                     <div class="pkg-page-title-copy-feedback">
                       <span class="code">oxygen: ^1.2.0</span>
                       copied to clipboard
@@ -528,7 +528,7 @@
                 <h3 class="packages-title">
                   <a href="/packages/flutter_titanium">flutter_titanium</a>
                   <span class="pkg-page-title-copy">
-                    <img class="pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;flutter_titanium: ^1.10.0&quot; to clipboard" width="18" height="18" title="Copy &quot;flutter_titanium: ^1.10.0&quot; to clipboard" data-copy-content="flutter_titanium: ^1.10.0" data-ga-click-event="copy-package-version"/>
+                    <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;flutter_titanium: ^1.10.0&quot; to clipboard" width="18" height="18" title="Copy &quot;flutter_titanium: ^1.10.0&quot; to clipboard" data-copy-content="flutter_titanium: ^1.10.0" data-ga-click-event="copy-package-version"/>
                     <div class="pkg-page-title-copy-feedback">
                       <span class="code">flutter_titanium: ^1.10.0</span>
                       copied to clipboard

--- a/app/test/task/testdata/goldens/packages/oxygen.html
+++ b/app/test/task/testdata/goldens/packages/oxygen.html
@@ -117,7 +117,7 @@
                 <h1 class="title">
                   oxygen 2.0.0
                   <span class="pkg-page-title-copy">
-                    <img class="pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^2.0.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^2.0.0&quot; to clipboard" data-copy-content="oxygen: ^2.0.0" data-ga-click-event="copy-package-version"/>
+                    <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^2.0.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^2.0.0&quot; to clipboard" data-copy-content="oxygen: ^2.0.0" data-ga-click-event="copy-package-version"/>
                     <div class="pkg-page-title-copy-feedback">
                       <span class="code">oxygen: ^2.0.0</span>
                       copied to clipboard

--- a/app/test/task/testdata/goldens/packages/oxygen/changelog.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/changelog.html
@@ -117,7 +117,7 @@
                 <h1 class="title">
                   oxygen 2.0.0
                   <span class="pkg-page-title-copy">
-                    <img class="pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^2.0.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^2.0.0&quot; to clipboard" data-copy-content="oxygen: ^2.0.0" data-ga-click-event="copy-package-version"/>
+                    <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^2.0.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^2.0.0&quot; to clipboard" data-copy-content="oxygen: ^2.0.0" data-ga-click-event="copy-package-version"/>
                     <div class="pkg-page-title-copy-feedback">
                       <span class="code">oxygen: ^2.0.0</span>
                       copied to clipboard

--- a/app/test/task/testdata/goldens/packages/oxygen/example.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/example.html
@@ -117,7 +117,7 @@
                 <h1 class="title">
                   oxygen 2.0.0
                   <span class="pkg-page-title-copy">
-                    <img class="pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^2.0.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^2.0.0&quot; to clipboard" data-copy-content="oxygen: ^2.0.0" data-ga-click-event="copy-package-version"/>
+                    <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^2.0.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^2.0.0&quot; to clipboard" data-copy-content="oxygen: ^2.0.0" data-ga-click-event="copy-package-version"/>
                     <div class="pkg-page-title-copy-feedback">
                       <span class="code">oxygen: ^2.0.0</span>
                       copied to clipboard

--- a/app/test/task/testdata/goldens/packages/oxygen/install.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/install.html
@@ -117,7 +117,7 @@
                 <h1 class="title">
                   oxygen 2.0.0
                   <span class="pkg-page-title-copy">
-                    <img class="pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^2.0.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^2.0.0&quot; to clipboard" data-copy-content="oxygen: ^2.0.0" data-ga-click-event="copy-package-version"/>
+                    <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^2.0.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^2.0.0&quot; to clipboard" data-copy-content="oxygen: ^2.0.0" data-ga-click-event="copy-package-version"/>
                     <div class="pkg-page-title-copy-feedback">
                       <span class="code">oxygen: ^2.0.0</span>
                       copied to clipboard

--- a/app/test/task/testdata/goldens/packages/oxygen/license.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/license.html
@@ -117,7 +117,7 @@
                 <h1 class="title">
                   oxygen 2.0.0
                   <span class="pkg-page-title-copy">
-                    <img class="pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^2.0.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^2.0.0&quot; to clipboard" data-copy-content="oxygen: ^2.0.0" data-ga-click-event="copy-package-version"/>
+                    <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^2.0.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^2.0.0&quot; to clipboard" data-copy-content="oxygen: ^2.0.0" data-ga-click-event="copy-package-version"/>
                     <div class="pkg-page-title-copy-feedback">
                       <span class="code">oxygen: ^2.0.0</span>
                       copied to clipboard

--- a/app/test/task/testdata/goldens/packages/oxygen/score.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/score.html
@@ -117,7 +117,7 @@
                 <h1 class="title">
                   oxygen 2.0.0
                   <span class="pkg-page-title-copy">
-                    <img class="pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^2.0.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^2.0.0&quot; to clipboard" data-copy-content="oxygen: ^2.0.0" data-ga-click-event="copy-package-version"/>
+                    <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^2.0.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^2.0.0&quot; to clipboard" data-copy-content="oxygen: ^2.0.0" data-ga-click-event="copy-package-version"/>
                     <div class="pkg-page-title-copy-feedback">
                       <span class="code">oxygen: ^2.0.0</span>
                       copied to clipboard

--- a/app/test/task/testdata/goldens/packages/oxygen/versions.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions.html
@@ -117,7 +117,7 @@
                 <h1 class="title">
                   oxygen 2.0.0
                   <span class="pkg-page-title-copy">
-                    <img class="pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^2.0.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^2.0.0&quot; to clipboard" data-copy-content="oxygen: ^2.0.0" data-ga-click-event="copy-package-version"/>
+                    <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^2.0.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^2.0.0&quot; to clipboard" data-copy-content="oxygen: ^2.0.0" data-ga-click-event="copy-package-version"/>
                     <div class="pkg-page-title-copy-feedback">
                       <span class="code">oxygen: ^2.0.0</span>
                       copied to clipboard

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0.html
@@ -117,7 +117,7 @@
                 <h1 class="title">
                   oxygen 1.0.0
                   <span class="pkg-page-title-copy">
-                    <img class="pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^1.0.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^1.0.0&quot; to clipboard" data-copy-content="oxygen: ^1.0.0" data-ga-click-event="copy-package-version"/>
+                    <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^1.0.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^1.0.0&quot; to clipboard" data-copy-content="oxygen: ^1.0.0" data-ga-click-event="copy-package-version"/>
                     <div class="pkg-page-title-copy-feedback">
                       <span class="code">oxygen: ^1.0.0</span>
                       copied to clipboard

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/changelog.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/changelog.html
@@ -117,7 +117,7 @@
                 <h1 class="title">
                   oxygen 1.0.0
                   <span class="pkg-page-title-copy">
-                    <img class="pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^1.0.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^1.0.0&quot; to clipboard" data-copy-content="oxygen: ^1.0.0" data-ga-click-event="copy-package-version"/>
+                    <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^1.0.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^1.0.0&quot; to clipboard" data-copy-content="oxygen: ^1.0.0" data-ga-click-event="copy-package-version"/>
                     <div class="pkg-page-title-copy-feedback">
                       <span class="code">oxygen: ^1.0.0</span>
                       copied to clipboard

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/example.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/example.html
@@ -117,7 +117,7 @@
                 <h1 class="title">
                   oxygen 1.0.0
                   <span class="pkg-page-title-copy">
-                    <img class="pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^1.0.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^1.0.0&quot; to clipboard" data-copy-content="oxygen: ^1.0.0" data-ga-click-event="copy-package-version"/>
+                    <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^1.0.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^1.0.0&quot; to clipboard" data-copy-content="oxygen: ^1.0.0" data-ga-click-event="copy-package-version"/>
                     <div class="pkg-page-title-copy-feedback">
                       <span class="code">oxygen: ^1.0.0</span>
                       copied to clipboard

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/install.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/install.html
@@ -117,7 +117,7 @@
                 <h1 class="title">
                   oxygen 1.0.0
                   <span class="pkg-page-title-copy">
-                    <img class="pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^1.0.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^1.0.0&quot; to clipboard" data-copy-content="oxygen: ^1.0.0" data-ga-click-event="copy-package-version"/>
+                    <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^1.0.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^1.0.0&quot; to clipboard" data-copy-content="oxygen: ^1.0.0" data-ga-click-event="copy-package-version"/>
                     <div class="pkg-page-title-copy-feedback">
                       <span class="code">oxygen: ^1.0.0</span>
                       copied to clipboard

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/license.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/license.html
@@ -117,7 +117,7 @@
                 <h1 class="title">
                   oxygen 1.0.0
                   <span class="pkg-page-title-copy">
-                    <img class="pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^1.0.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^1.0.0&quot; to clipboard" data-copy-content="oxygen: ^1.0.0" data-ga-click-event="copy-package-version"/>
+                    <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^1.0.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^1.0.0&quot; to clipboard" data-copy-content="oxygen: ^1.0.0" data-ga-click-event="copy-package-version"/>
                     <div class="pkg-page-title-copy-feedback">
                       <span class="code">oxygen: ^1.0.0</span>
                       copied to clipboard

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/score.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/score.html
@@ -117,7 +117,7 @@
                 <h1 class="title">
                   oxygen 1.0.0
                   <span class="pkg-page-title-copy">
-                    <img class="pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^1.0.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^1.0.0&quot; to clipboard" data-copy-content="oxygen: ^1.0.0" data-ga-click-event="copy-package-version"/>
+                    <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^1.0.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^1.0.0&quot; to clipboard" data-copy-content="oxygen: ^1.0.0" data-ga-click-event="copy-package-version"/>
                     <div class="pkg-page-title-copy-feedback">
                       <span class="code">oxygen: ^1.0.0</span>
                       copied to clipboard

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/2.0.0.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/2.0.0.html
@@ -117,7 +117,7 @@
                 <h1 class="title">
                   oxygen 2.0.0
                   <span class="pkg-page-title-copy">
-                    <img class="pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^2.0.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^2.0.0&quot; to clipboard" data-copy-content="oxygen: ^2.0.0" data-ga-click-event="copy-package-version"/>
+                    <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^2.0.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^2.0.0&quot; to clipboard" data-copy-content="oxygen: ^2.0.0" data-ga-click-event="copy-package-version"/>
                     <div class="pkg-page-title-copy-feedback">
                       <span class="code">oxygen: ^2.0.0</span>
                       copied to clipboard

--- a/pkg/web_css/lib/src/_base.scss
+++ b/pkg/web_css/lib/src/_base.scss
@@ -98,10 +98,12 @@ button {
 //       not work with monochrome images, as the linear transformation
 //       will keep the pixels with rgb(0,0,0) the same.
 .pub-monochrome-icon {
-  opacity: 0.6;
+  opacity: var(--pub-monochrome-opacity-initial);
+  transition: opacity 0.3s;
 
+  &:focus,
   a:hover & {
-    opacity: 1;
+    opacity: var(--pub-monochrome-opacity-hover);
   }
 }
 

--- a/pkg/web_css/lib/src/_pkg.scss
+++ b/pkg/web_css/lib/src/_pkg.scss
@@ -461,12 +461,13 @@
     width: 20px;
     height: 20px;
     cursor: pointer;
-    opacity: 0.1;
-    transition: opacity 0.3s;
 
-    &:focus,
+    // Lower contrast than the regular monochrome icon rules.
+    --pub-monochrome-opacity-initial: 0.3;
+    --pub-monochrome-opacity-hover: 0.7;
+
     h1.title:hover & {
-      opacity: 0.5;
+      opacity: var(--pub-monochrome-opacity-hover);
     }
   }
 

--- a/pkg/web_css/lib/src/_variables.scss
+++ b/pkg/web_css/lib/src/_variables.scss
@@ -92,6 +92,10 @@
   --pub-downloads-chart-color-bg-4:rgb(154, 103, 0, 0.3);
   --pub-downloads-chart-color-5: #12a4af;
   --pub-downloads-chart-color-bg-5: rgb(18, 164, 175, 0.3);
+
+  // Opacity values used to display monochrome icons.
+  --pub-monochrome-opacity-initial: 0.6;
+  --pub-monochrome-opacity-hover: 1.0;
 }
 
 /// Variables that are specific to the light theme.


### PR DESCRIPTION
- Fixes #8536
- Expanded monochrome icon style to also include focus and transition.
- Using CSS variable to control `opacity`, so that components that want to have different opacity ranges doesn't need to repeat all the hover/focus rules, though in this case we still need the title as parent (may be refactored in the future).

Before:
<img width="155" alt="image" src="https://github.com/user-attachments/assets/aadf81ac-5a0e-4502-948e-041fdd67137d" />
<img width="148" alt="image" src="https://github.com/user-attachments/assets/9516b08f-4c79-4a67-ad09-bd66bdc5ceb9" />

After:
<img width="165" alt="image" src="https://github.com/user-attachments/assets/3133b5e9-1e7e-477f-9589-6a6a75dc67a7" />
<img width="160" alt="image" src="https://github.com/user-attachments/assets/d77d5a8b-364a-4927-88d0-357de2dc594c" />

Before:
<img width="157" alt="image" src="https://github.com/user-attachments/assets/380d0868-bce7-4fa0-9a08-4bfcc8048b14" />
<img width="157" alt="image" src="https://github.com/user-attachments/assets/a129dc37-85bd-4ead-83fb-3f18cdb1656a" />

After:
<img width="166" alt="image" src="https://github.com/user-attachments/assets/002f9b7b-cb92-4a5f-a6bb-75ed34dca1c4" />
<img width="157" alt="image" src="https://github.com/user-attachments/assets/978cb5fa-213f-4199-a118-cf9fbf1acfab" />
