### PR TITLE
Underline links on hover by default

### DIFF
--- a/pkg/web_css/lib/src/_base.scss
+++ b/pkg/web_css/lib/src/_base.scss
@@ -120,6 +120,10 @@ a {
     padding: 4px 12px;
   }
 
+  &:hover {
+    text-decoration: underline;
+  }
+
   .light-theme & {
     &:hover {
       filter: brightness(80%);

--- a/pkg/web_css/lib/src/_detail_page.scss
+++ b/pkg/web_css/lib/src/_detail_page.scss
@@ -380,6 +380,7 @@ $detail-tabs-tablet-width: calc(100% - 240px);
     border-bottom: 2px solid;
     border-bottom-color: transparent;
     cursor: pointer;
+    text-decoration: none;
 
     &:hover {
       border-bottom-color: var(--pub-detail_tab-underline-color);

--- a/pkg/web_css/lib/src/_list.scss
+++ b/pkg/web_css/lib/src/_list.scss
@@ -371,6 +371,7 @@
       padding: 10px 16px;
       color: inherit;
       font-weight: 600;
+      text-decoration: none;
     }
   }
 }
@@ -448,6 +449,7 @@
 
     a {
       color: var(--pub-neutral-textColor);
+      text-decoration: none;
     }
 
     label {

--- a/pkg/web_css/lib/src/_scores.scss
+++ b/pkg/web_css/lib/src/_scores.scss
@@ -9,6 +9,7 @@
   align-items: center;
 
   font-family: var(--pub-font-family-body);
+  text-decoration: none;
 
   &:hover {
     opacity: 1.0;

--- a/pkg/web_css/lib/src/_tags.scss
+++ b/pkg/web_css/lib/src/_tags.scss
@@ -34,6 +34,7 @@
     text-transform: uppercase;
     padding: 4px 8px;
     color: var(--pub-tag_sdkbadge-text-color);
+    text-decoration: none;
   }
 
   > .tag-badge-main {


### PR DESCRIPTION
dart.dev and docs.flutter.dev updated to do this for most links as well to meet the requirement of using more than color to distinguish link interactivity.

Resolves https://github.com/dart-lang/pub-dev/issues/7391