### PR TITLE
Remove no longer needed opacity overrides.

### DIFF
--- a/pkg/web_css/lib/src/_home.scss
+++ b/pkg/web_css/lib/src/_home.scss
@@ -296,7 +296,6 @@
 
     &:hover,
     &:focus-within {
-      > a { opacity: 1; } // Overrides default a:hover.
       .pow-video-overlay-img-active { display: inline-block; }
       .pow-video-overlay-img-inactive { display: none; }
     }

--- a/pkg/web_css/lib/src/_scores.scss
+++ b/pkg/web_css/lib/src/_scores.scss
@@ -10,10 +10,6 @@
 
   font-family: var(--pub-font-family-body);
 
-  &:hover {
-    opacity: 1.0;
-  }
-
   .packages-score {
     min-width: 45px;
 


### PR DESCRIPTION
- #8493
- Since we no longer update the opacity on links, these overrides are obsolete.