### PR TITLE
Fix session warning banner: visibility and dark theme.

### DIFF
--- a/pkg/web_css/lib/src/_base.scss
+++ b/pkg/web_css/lib/src/_base.scss
@@ -459,15 +459,18 @@ a.-x-ago {
   top: 0;
   left: 0;
   right: 0;
-  background: var(--pub-session_warning-background-color);
+  background: var(--pub-selected-bgColor);
+  color: var(--pub-neutral-textColor);
   padding: 12px 24px;
   text-align: center;
   font-size: 14px;
   font-weight: bold;
   box-shadow: 0px 0px 2px 2px rgba(0, 0, 0, 0.05);
+  z-index: 101; // TODO: depend on variables with the site header
 
   button {
     background-color: transparent;
+    color: var(--pub-neutral-textColor);
     margin-left: 8px;
     padding: 8px;
   }

--- a/pkg/web_css/lib/src/_variables.scss
+++ b/pkg/web_css/lib/src/_variables.scss
@@ -53,8 +53,6 @@
   --pub-searchbar_suggest_hover-background-color: #455060;
   --pub-searchbar_suggest-text-color: #a9a9a9;
 
-  --pub-session_warning-background-color: #ffffaa;
-
   --pub-site_header_banner-background-color: #1C2834;
   --pub-site_header_banner-text-color: #f8f9fa;
   --pub-site_header_banner_hover-background-color: #2b3d50; // 10% lighter than bg color


### PR DESCRIPTION
- The session warning banner is displayed when the user session is close to expiry or was expired (on a page that may use the session cookies).
- This warning banner was broken for a while now, probably because of the change in the disposable banners. Adjusting the `z-index` to create a temporary fix there.
- The previous design had a yellow background, but I don't think we need that much color here, using the same background as the disposable banner use seems to be fine.
- Long-term fix may involve migrating this banner to use the same template and widget location as the disposable  banners.

<img width="380" alt="image" src="https://github.com/user-attachments/assets/f1d15347-8a19-4598-9649-8e1782e1b454" />

--

<img width="389" alt="image" src="https://github.com/user-attachments/assets/469ec934-cd1b-4a08-9ba5-22f13da38708" />
