### PR TITLE
Fix markdown table row background and borders.

### DIFF
--- a/pkg/web_css/lib/src/_base.scss
+++ b/pkg/web_css/lib/src/_base.scss
@@ -276,7 +276,7 @@ pre {
       border-top: none; /* overrides github-markdown.css */
 
       &:nth-child(2n) {
-        background-color: inherit; /* overrides github-markdown.css */
+        background-color: var(--pub-overlay-gray-08); /* overrides github-markdown.css */
       }
     }
 
@@ -284,12 +284,12 @@ pre {
       font-family: var(--pub-font-family-body);
       font-size: 16px;
       font-weight: 400; /* overrides github-markdown.css */
-      border-bottom: 1px solid #c8c8ca;
+      border-bottom: 1px solid var(--pub-overlay-gray-80);
       text-align: left;
     }
 
     td {
-      border-bottom: 1px solid #f5f5f7;
+      border-bottom: 1px solid var(--pub-overlay-gray-30);
     }
 
     img {

--- a/pkg/web_css/lib/src/_variables.scss
+++ b/pkg/web_css/lib/src/_variables.scss
@@ -30,6 +30,13 @@
   --pub-color-white:         #ffffff;
   --pub-color-dangerRed:     #ff4242;
 
+  // These colors are a combination of middle-gray (#808080) and a transparency
+  // (alpha) channel, specifying an opaque color that mutes whatever the original
+  // color was behind it.
+  --pub-overlay-gray-08: #80808008;
+  --pub-overlay-gray-30: #80808030;
+  --pub-overlay-gray-80: #80808080;
+
   --pub-hash_link-text-color: #ccc;
   --pub-footer-background-color: #27323a;
   --pub-footer-text-color: #f8f9fa;


### PR DESCRIPTION
- Fixes #6981
- Instead of using yet another color for light and dark theme, the table can get away with gray+transparent overlay colors, used for the border and the background.

Light theme before/after:
<img width="598" alt="image" src="https://github.com/user-attachments/assets/7dd4ff54-cab0-46f9-a011-af7a7d591956" />
<img width="589" alt="image" src="https://github.com/user-attachments/assets/04f258b9-7ca6-457c-a244-216a0ca7f093" />

Dark theme before/after:
<img width="592" alt="image" src="https://github.com/user-attachments/assets/a21e4a7a-a854-4d74-b904-b8d7212568a5" />
<img width="604" alt="image" src="https://github.com/user-attachments/assets/3761cb70-501f-4aad-8e78-b307668182fb" />

(The screenshots don't do much justice to it, will push to staging).