### PR TITLE
Fix inconsistency between package list and package page copy icon opacities

### DIFF
--- a/app/lib/frontend/handlers/experimental.dart
+++ b/app/lib/frontend/handlers/experimental.dart
@@ -9,13 +9,7 @@ import '../../shared/cookie_utils.dart';
 typedef PublicFlag = ({String name, String description});
 
 const _publicFlags = <PublicFlag>{
-  (name: 'dark', description: 'Dark mode'),
-  (name: 'search-completion', description: 'Completions for the search bar'),
   (name: 'search-topics', description: 'Show matching topics when searching'),
-  (
-    name: 'download-counts-version-chart',
-    description: 'Show downloads counts version chart'
-  ),
 };
 
 final _allFlags = <String>{
@@ -92,13 +86,9 @@ class ExperimentalFlags {
     return params;
   }
 
-  bool get isSearchCompletionEnabled => true;
   bool get isSearchTopicsEnabled => isEnabled('search-topics');
 
-  bool get isDarkModeEnabled => true;
   bool get isDarkModeDefault => isEnabled('dark-as-default');
-
-  bool get showDownloadCountsVersionChart => true;
 
   String encodedAsCookie() => _enabled.join(':');
 

--- a/app/lib/frontend/templates/views/pkg/package_list.dart
+++ b/app/lib/frontend/templates/views/pkg/package_list.dart
@@ -225,7 +225,8 @@ d.Node _item({
         classes: ['packages-header'],
         children: [
           d.h3(classes: [
-            'packages-title'
+            'packages-title',
+            'pub-monochrome-icon-hoverable',
           ], children: [
             d.a(href: url, text: name),
             if (copyIcon != null) copyIcon,

--- a/app/lib/frontend/templates/views/pkg/score_tab.dart
+++ b/app/lib/frontend/templates/views/pkg/score_tab.dart
@@ -14,7 +14,6 @@ import 'package:pub_dev/shared/utils.dart';
 import '../../../../scorecard/models.dart' hide ReportStatus;
 import '../../../../shared/urls.dart' as urls;
 import '../../../dom/dom.dart' as d;
-import '../../../request_context.dart';
 import '../../../static_files.dart';
 
 /// Renders the score page content.
@@ -95,8 +94,7 @@ d.Node scoreTabNode({
           d.text(' for details.'),
         ],
       ),
-    if (card.weeklyVersionDownloads != null &&
-        requestContext.experimentalFlags.showDownloadCountsVersionChart)
+    if (card.weeklyVersionDownloads != null)
       _downloadsChart(card.weeklyVersionDownloads!),
   ]);
 }

--- a/app/lib/frontend/templates/views/shared/detail/header.dart
+++ b/app/lib/frontend/templates/views/shared/detail/header.dart
@@ -111,7 +111,10 @@ d.Node detailHeaderNode({
             d.div(
               classes: ['detail-header-content-block'],
               children: [
-                d.h1(classes: ['title'], child: titleNode),
+                d.h1(
+                  classes: ['title', 'pub-monochrome-icon-hoverable'],
+                  child: titleNode,
+                ),
                 d.div(classes: ['metadata'], child: metadataNode),
                 if (tagsNode != null || likeCount != null)
                   d.div(

--- a/app/lib/frontend/templates/views/shared/search_banner.dart
+++ b/app/lib/frontend/templates/views/shared/search_banner.dart
@@ -5,7 +5,6 @@
 import 'dart:convert';
 
 import 'package:_pub_shared/data/completion.dart';
-import 'package:pub_dev/frontend/request_context.dart';
 
 import '../../../dom/dom.dart' as d;
 import '../../../static_files.dart' show staticUrls;
@@ -36,8 +35,7 @@ d.Node searchBannerNode({
         value: queryText,
         attributes: {
           'title': 'Search',
-          if (requestContext.experimentalFlags.isSearchCompletionEnabled)
-            'data-widget': 'completion',
+          'data-widget': 'completion',
           'data-completion-src': '/api/search-input-completion-data',
           'data-completion-class': 'search-completion',
         },

--- a/app/lib/frontend/templates/views/shared/site_header.dart
+++ b/app/lib/frontend/templates/views/shared/site_header.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:pub_dev/frontend/request_context.dart';
-
 import '../../../../account/models.dart' show SessionData;
 import '../../../../shared/urls.dart' as urls;
 import '../../../dom/dom.dart' as d;
@@ -116,22 +114,15 @@ d.Node siteHeaderNode({
             _userBlock(userSession),
         ],
       ),
-      _themeSwitcher(),
+      // TODO: consider using Material symbols similar to dartdoc:
+      // <span id="dark-theme-button" class="material-symbols-outlined">dark_mode</span>
+      // <span id="light-theme-button" class="material-symbols-outlined">light_mode</span>
+      d.button(
+        classes: ['-pub-theme-toggle'],
+        ariaLabel: 'light/dark theme toggle',
+      ),
     ],
   );
-}
-
-d.Node _themeSwitcher() {
-  // <span id="dark-theme-button" class="material-symbols-outlined">dark_mode</span>
-  // <span id="light-theme-button" class="material-symbols-outlined">light_mode</span>
-  if (requestContext.experimentalFlags.isDarkModeEnabled) {
-    return d.fragment([
-      d.button(
-          classes: ['-pub-theme-toggle'], ariaLabel: 'light/dark theme toggle'),
-    ]);
-  } else {
-    return d.fragment([]);
-  }
 }
 
 d.Node _userBlock(SessionData userSession) {

--- a/app/test/frontend/golden/my_activity_log_page.html
+++ b/app/test/frontend/golden/my_activity_log_page.html
@@ -142,7 +142,7 @@
                 <img class="detail-header-image" src="https://www.gravatar.com/avatar/92c525024f1911332fe1d0f7dd750977?d=retro&amp;s=200=s400" alt="user profile picture" width="200" height="200"/>
               </div>
               <div class="detail-header-content-block">
-                <h1 class="title">admin</h1>
+                <h1 class="title pub-monochrome-icon-hoverable">admin</h1>
                 <div class="metadata">
                   <p>admin@pub.dev</p>
                   <p>

--- a/app/test/frontend/golden/my_liked_packages.html
+++ b/app/test/frontend/golden/my_liked_packages.html
@@ -143,7 +143,7 @@
                 <img class="detail-header-image" src="https://www.gravatar.com/avatar/f1983c9193966b63c29c141c02db9a34?d=retro&amp;s=200=s400" alt="user profile picture" width="200" height="200"/>
               </div>
               <div class="detail-header-content-block">
-                <h1 class="title">user</h1>
+                <h1 class="title pub-monochrome-icon-hoverable">user</h1>
                 <div class="metadata">
                   <p>user@pub.dev</p>
                   <p>

--- a/app/test/frontend/golden/my_packages.html
+++ b/app/test/frontend/golden/my_packages.html
@@ -142,7 +142,7 @@
                 <img class="detail-header-image" src="https://www.gravatar.com/avatar/f1983c9193966b63c29c141c02db9a34?d=retro&amp;s=200=s400" alt="user profile picture" width="200" height="200"/>
               </div>
               <div class="detail-header-content-block">
-                <h1 class="title">user</h1>
+                <h1 class="title pub-monochrome-icon-hoverable">user</h1>
                 <div class="metadata">
                   <p>user@pub.dev</p>
                   <p>
@@ -183,7 +183,7 @@
                   <div class="packages">
                     <div class="packages-item">
                       <div class="packages-header">
-                        <h3 class="packages-title">
+                        <h3 class="packages-title pub-monochrome-icon-hoverable">
                           <a href="/packages/oxygen">oxygen</a>
                           <span class="pkg-page-title-copy">
                             <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^1.2.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>
@@ -266,7 +266,7 @@
                     </div>
                     <div class="packages-item">
                       <div class="packages-header">
-                        <h3 class="packages-title">
+                        <h3 class="packages-title pub-monochrome-icon-hoverable">
                           <a href="/packages/neon">neon</a>
                           <span class="pkg-page-title-copy">
                             <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;neon: ^1.0.0&quot; to clipboard" width="18" height="18" title="Copy &quot;neon: ^1.0.0&quot; to clipboard" data-copy-content="neon: ^1.0.0" data-ga-click-event="copy-package-version"/>

--- a/app/test/frontend/golden/my_publishers.html
+++ b/app/test/frontend/golden/my_publishers.html
@@ -142,7 +142,7 @@
                 <img class="detail-header-image" src="https://www.gravatar.com/avatar/f1983c9193966b63c29c141c02db9a34?d=retro&amp;s=200=s400" alt="user profile picture" width="200" height="200"/>
               </div>
               <div class="detail-header-content-block">
-                <h1 class="title">user</h1>
+                <h1 class="title pub-monochrome-icon-hoverable">user</h1>
                 <div class="metadata">
                   <p>user@pub.dev</p>
                   <p>

--- a/app/test/frontend/golden/pkg_activity_log_page.html
+++ b/app/test/frontend/golden/pkg_activity_log_page.html
@@ -141,7 +141,7 @@
           <div class="detail-container">
             <div class="detail-header-outer-block">
               <div class="detail-header-content-block">
-                <h1 class="title">
+                <h1 class="title pub-monochrome-icon-hoverable">
                   oxygen 1.2.0
                   <span class="pkg-page-title-copy">
                     <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^1.2.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>

--- a/app/test/frontend/golden/pkg_admin_page.html
+++ b/app/test/frontend/golden/pkg_admin_page.html
@@ -141,7 +141,7 @@
           <div class="detail-container">
             <div class="detail-header-outer-block">
               <div class="detail-header-content-block">
-                <h1 class="title">
+                <h1 class="title pub-monochrome-icon-hoverable">
                   oxygen 1.2.0
                   <span class="pkg-page-title-copy">
                     <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^1.2.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>

--- a/app/test/frontend/golden/pkg_changelog_page.html
+++ b/app/test/frontend/golden/pkg_changelog_page.html
@@ -115,7 +115,7 @@
           <div class="detail-container">
             <div class="detail-header-outer-block">
               <div class="detail-header-content-block">
-                <h1 class="title">
+                <h1 class="title pub-monochrome-icon-hoverable">
                   oxygen 1.2.0
                   <span class="pkg-page-title-copy">
                     <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^1.2.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>

--- a/app/test/frontend/golden/pkg_example_page.html
+++ b/app/test/frontend/golden/pkg_example_page.html
@@ -115,7 +115,7 @@
           <div class="detail-container">
             <div class="detail-header-outer-block">
               <div class="detail-header-content-block">
-                <h1 class="title">
+                <h1 class="title pub-monochrome-icon-hoverable">
                   oxygen 1.2.0
                   <span class="pkg-page-title-copy">
                     <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^1.2.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>

--- a/app/test/frontend/golden/pkg_index_page.html
+++ b/app/test/frontend/golden/pkg_index_page.html
@@ -431,7 +431,7 @@
           <div class="packages">
             <div class="packages-item">
               <div class="packages-header">
-                <h3 class="packages-title">
+                <h3 class="packages-title pub-monochrome-icon-hoverable">
                   <a href="https://api.dart.dev/library-page.html">dart:core</a>
                 </h3>
               </div>
@@ -450,7 +450,7 @@
             </div>
             <div class="packages-item">
               <div class="packages-header">
-                <h3 class="packages-title">
+                <h3 class="packages-title pub-monochrome-icon-hoverable">
                   <a href="/packages/oxygen">oxygen</a>
                   <span class="pkg-page-title-copy">
                     <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^1.2.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>
@@ -533,7 +533,7 @@
             </div>
             <div class="packages-item">
               <div class="packages-header">
-                <h3 class="packages-title">
+                <h3 class="packages-title pub-monochrome-icon-hoverable">
                   <a href="/packages/flutter_titanium">flutter_titanium</a>
                   <span class="pkg-page-title-copy">
                     <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;flutter_titanium: ^1.10.0&quot; to clipboard" width="18" height="18" title="Copy &quot;flutter_titanium: ^1.10.0&quot; to clipboard" data-copy-content="flutter_titanium: ^1.10.0" data-ga-click-event="copy-package-version"/>

--- a/app/test/frontend/golden/pkg_install_page.html
+++ b/app/test/frontend/golden/pkg_install_page.html
@@ -115,7 +115,7 @@
           <div class="detail-container">
             <div class="detail-header-outer-block">
               <div class="detail-header-content-block">
-                <h1 class="title">
+                <h1 class="title pub-monochrome-icon-hoverable">
                   oxygen 1.2.0
                   <span class="pkg-page-title-copy">
                     <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^1.2.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>

--- a/app/test/frontend/golden/pkg_score_page.html
+++ b/app/test/frontend/golden/pkg_score_page.html
@@ -115,7 +115,7 @@
           <div class="detail-container">
             <div class="detail-header-outer-block">
               <div class="detail-header-content-block">
-                <h1 class="title">
+                <h1 class="title pub-monochrome-icon-hoverable">
                   oxygen 1.2.0
                   <span class="pkg-page-title-copy">
                     <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^1.2.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>

--- a/app/test/frontend/golden/pkg_score_page_with_downloads_chart.html
+++ b/app/test/frontend/golden/pkg_score_page_with_downloads_chart.html
@@ -115,7 +115,7 @@
           <div class="detail-container">
             <div class="detail-header-outer-block">
               <div class="detail-header-content-block">
-                <h1 class="title">
+                <h1 class="title pub-monochrome-icon-hoverable">
                   oxygen 1.2.0
                   <span class="pkg-page-title-copy">
                     <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^1.2.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -115,7 +115,7 @@
           <div class="detail-container">
             <div class="detail-header-outer-block">
               <div class="detail-header-content-block">
-                <h1 class="title">
+                <h1 class="title pub-monochrome-icon-hoverable">
                   oxygen 1.2.0
                   <span class="pkg-page-title-copy">
                     <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^1.2.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>

--- a/app/test/frontend/golden/pkg_show_page_discontinued.html
+++ b/app/test/frontend/golden/pkg_show_page_discontinued.html
@@ -115,7 +115,7 @@
           <div class="detail-container">
             <div class="detail-header-outer-block">
               <div class="detail-header-content-block">
-                <h1 class="title">
+                <h1 class="title pub-monochrome-icon-hoverable">
                   pkg 1.0.0
                   <span class="pkg-page-title-copy">
                     <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;pkg: ^1.0.0&quot; to clipboard" width="18" height="18" title="Copy &quot;pkg: ^1.0.0&quot; to clipboard" data-copy-content="pkg: ^1.0.0" data-ga-click-event="copy-package-version"/>

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -115,7 +115,7 @@
           <div class="detail-container">
             <div class="detail-header-outer-block">
               <div class="detail-header-content-block">
-                <h1 class="title">
+                <h1 class="title pub-monochrome-icon-hoverable">
                   flutter_titanium 1.10.0
                   <span class="pkg-page-title-copy">
                     <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;flutter_titanium: ^1.10.0&quot; to clipboard" width="18" height="18" title="Copy &quot;flutter_titanium: ^1.10.0&quot; to clipboard" data-copy-content="flutter_titanium: ^1.10.0" data-ga-click-event="copy-package-version"/>

--- a/app/test/frontend/golden/pkg_show_page_publisher.html
+++ b/app/test/frontend/golden/pkg_show_page_publisher.html
@@ -115,7 +115,7 @@
           <div class="detail-container">
             <div class="detail-header-outer-block">
               <div class="detail-header-content-block">
-                <h1 class="title">
+                <h1 class="title pub-monochrome-icon-hoverable">
                   neon 1.0.0
                   <span class="pkg-page-title-copy">
                     <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;neon: ^1.0.0&quot; to clipboard" width="18" height="18" title="Copy &quot;neon: ^1.0.0&quot; to clipboard" data-copy-content="neon: ^1.0.0" data-ga-click-event="copy-package-version"/>

--- a/app/test/frontend/golden/pkg_show_page_retracted.html
+++ b/app/test/frontend/golden/pkg_show_page_retracted.html
@@ -115,7 +115,7 @@
           <div class="detail-container">
             <div class="detail-header-outer-block">
               <div class="detail-header-content-block">
-                <h1 class="title">
+                <h1 class="title pub-monochrome-icon-hoverable">
                   pkg 1.0.0
                   <span class="pkg-page-title-copy">
                     <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;pkg: ^1.0.0&quot; to clipboard" width="18" height="18" title="Copy &quot;pkg: ^1.0.0&quot; to clipboard" data-copy-content="pkg: ^1.0.0" data-ga-click-event="copy-package-version"/>

--- a/app/test/frontend/golden/pkg_show_page_retracted_non_retracted_version.html
+++ b/app/test/frontend/golden/pkg_show_page_retracted_non_retracted_version.html
@@ -115,7 +115,7 @@
           <div class="detail-container">
             <div class="detail-header-outer-block">
               <div class="detail-header-content-block">
-                <h1 class="title">
+                <h1 class="title pub-monochrome-icon-hoverable">
                   pkg 2.0.0
                   <span class="pkg-page-title-copy">
                     <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;pkg: ^2.0.0&quot; to clipboard" width="18" height="18" title="Copy &quot;pkg: ^2.0.0&quot; to clipboard" data-copy-content="pkg: ^2.0.0" data-ga-click-event="copy-package-version"/>

--- a/app/test/frontend/golden/pkg_show_version_page.html
+++ b/app/test/frontend/golden/pkg_show_version_page.html
@@ -115,7 +115,7 @@
           <div class="detail-container">
             <div class="detail-header-outer-block">
               <div class="detail-header-content-block">
-                <h1 class="title">
+                <h1 class="title pub-monochrome-icon-hoverable">
                   oxygen 1.2.0
                   <span class="pkg-page-title-copy">
                     <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^1.2.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>

--- a/app/test/frontend/golden/pkg_versions_page.html
+++ b/app/test/frontend/golden/pkg_versions_page.html
@@ -115,7 +115,7 @@
           <div class="detail-container">
             <div class="detail-header-outer-block">
               <div class="detail-header-content-block">
-                <h1 class="title">
+                <h1 class="title pub-monochrome-icon-hoverable">
                   oxygen 1.2.0
                   <span class="pkg-page-title-copy">
                     <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^1.2.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>

--- a/app/test/frontend/golden/publisher_activity_log_page.html
+++ b/app/test/frontend/golden/publisher_activity_log_page.html
@@ -117,7 +117,7 @@
           <div class="detail-container">
             <div class="detail-header-outer-block">
               <div class="detail-header-content-block">
-                <h1 class="title">example.com</h1>
+                <h1 class="title pub-monochrome-icon-hoverable">example.com</h1>
                 <div class="metadata">
                   <p>
                     <span class="detail-header-metadata-ref">

--- a/app/test/frontend/golden/publisher_admin_page.html
+++ b/app/test/frontend/golden/publisher_admin_page.html
@@ -117,7 +117,7 @@
           <div class="detail-container">
             <div class="detail-header-outer-block">
               <div class="detail-header-content-block">
-                <h1 class="title">example.com</h1>
+                <h1 class="title pub-monochrome-icon-hoverable">example.com</h1>
                 <div class="metadata">
                   <p>
                     <span class="detail-header-metadata-ref">

--- a/app/test/frontend/golden/publisher_packages_page.html
+++ b/app/test/frontend/golden/publisher_packages_page.html
@@ -117,7 +117,7 @@
           <div class="detail-container">
             <div class="detail-header-outer-block">
               <div class="detail-header-content-block">
-                <h1 class="title">example.com</h1>
+                <h1 class="title pub-monochrome-icon-hoverable">example.com</h1>
                 <div class="metadata">
                   <p>
                     <span class="detail-header-metadata-ref">
@@ -185,7 +185,7 @@
                   <div class="packages">
                     <div class="packages-item">
                       <div class="packages-header">
-                        <h3 class="packages-title">
+                        <h3 class="packages-title pub-monochrome-icon-hoverable">
                           <a href="/packages/neon">neon</a>
                           <span class="pkg-page-title-copy">
                             <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;neon: ^1.0.0&quot; to clipboard" width="18" height="18" title="Copy &quot;neon: ^1.0.0&quot; to clipboard" data-copy-content="neon: ^1.0.0" data-ga-click-event="copy-package-version"/>
@@ -266,7 +266,7 @@
                     </div>
                     <div class="packages-item">
                       <div class="packages-header">
-                        <h3 class="packages-title">
+                        <h3 class="packages-title pub-monochrome-icon-hoverable">
                           <a href="/packages/flutter_titanium">flutter_titanium</a>
                           <span class="pkg-page-title-copy">
                             <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;flutter_titanium: ^1.10.0&quot; to clipboard" width="18" height="18" title="Copy &quot;flutter_titanium: ^1.10.0&quot; to clipboard" data-copy-content="flutter_titanium: ^1.10.0" data-ga-click-event="copy-package-version"/>

--- a/app/test/frontend/golden/publisher_unlisted_packages_page.html
+++ b/app/test/frontend/golden/publisher_unlisted_packages_page.html
@@ -117,7 +117,7 @@
           <div class="detail-container">
             <div class="detail-header-outer-block">
               <div class="detail-header-content-block">
-                <h1 class="title">example.com</h1>
+                <h1 class="title pub-monochrome-icon-hoverable">example.com</h1>
                 <div class="metadata">
                   <p>
                     <span class="detail-header-metadata-ref">
@@ -191,7 +191,7 @@
                   <div class="packages">
                     <div class="packages-item">
                       <div class="packages-header">
-                        <h3 class="packages-title">
+                        <h3 class="packages-title pub-monochrome-icon-hoverable">
                           <a href="/packages/neon">neon</a>
                           <span class="pkg-page-title-copy">
                             <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;neon: ^1.0.0&quot; to clipboard" width="18" height="18" title="Copy &quot;neon: ^1.0.0&quot; to clipboard" data-copy-content="neon: ^1.0.0" data-ga-click-event="copy-package-version"/>
@@ -272,7 +272,7 @@
                     </div>
                     <div class="packages-item">
                       <div class="packages-header">
-                        <h3 class="packages-title">
+                        <h3 class="packages-title pub-monochrome-icon-hoverable">
                           <a href="/packages/flutter_titanium">flutter_titanium</a>
                           <span class="pkg-page-title-copy">
                             <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;flutter_titanium: ^1.10.0&quot; to clipboard" width="18" height="18" title="Copy &quot;flutter_titanium: ^1.10.0&quot; to clipboard" data-copy-content="flutter_titanium: ^1.10.0" data-ga-click-event="copy-package-version"/>

--- a/app/test/frontend/golden/search_page.html
+++ b/app/test/frontend/golden/search_page.html
@@ -432,7 +432,7 @@
           <div class="packages">
             <div class="packages-item">
               <div class="packages-header">
-                <h3 class="packages-title">
+                <h3 class="packages-title pub-monochrome-icon-hoverable">
                   <a href="/packages/oxygen">oxygen</a>
                   <span class="pkg-page-title-copy">
                     <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^1.2.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^1.2.0&quot; to clipboard" data-copy-content="oxygen: ^1.2.0" data-ga-click-event="copy-package-version"/>
@@ -526,7 +526,7 @@
             </div>
             <div class="packages-item">
               <div class="packages-header">
-                <h3 class="packages-title">
+                <h3 class="packages-title pub-monochrome-icon-hoverable">
                   <a href="/packages/flutter_titanium">flutter_titanium</a>
                   <span class="pkg-page-title-copy">
                     <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;flutter_titanium: ^1.10.0&quot; to clipboard" width="18" height="18" title="Copy &quot;flutter_titanium: ^1.10.0&quot; to clipboard" data-copy-content="flutter_titanium: ^1.10.0" data-ga-click-event="copy-package-version"/>

--- a/app/test/search/backend_test.dart
+++ b/app/test/search/backend_test.dart
@@ -17,7 +17,7 @@ void main() {
       final descr = await searchBackend.fetchSdkLibraryDescriptions(
         baseUri: index.baseUri,
         libraryRelativeUrls: {
-          'dart:async': 'dart-async/dart-async-library.html',
+          'dart:async': 'dart-async/index.html',
         },
       );
       expect(descr, {

--- a/app/test/task/testdata/goldens/packages/oxygen.html
+++ b/app/test/task/testdata/goldens/packages/oxygen.html
@@ -115,7 +115,7 @@
           <div class="detail-container">
             <div class="detail-header-outer-block">
               <div class="detail-header-content-block">
-                <h1 class="title">
+                <h1 class="title pub-monochrome-icon-hoverable">
                   oxygen 2.0.0
                   <span class="pkg-page-title-copy">
                     <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^2.0.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^2.0.0&quot; to clipboard" data-copy-content="oxygen: ^2.0.0" data-ga-click-event="copy-package-version"/>

--- a/app/test/task/testdata/goldens/packages/oxygen/changelog.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/changelog.html
@@ -115,7 +115,7 @@
           <div class="detail-container">
             <div class="detail-header-outer-block">
               <div class="detail-header-content-block">
-                <h1 class="title">
+                <h1 class="title pub-monochrome-icon-hoverable">
                   oxygen 2.0.0
                   <span class="pkg-page-title-copy">
                     <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^2.0.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^2.0.0&quot; to clipboard" data-copy-content="oxygen: ^2.0.0" data-ga-click-event="copy-package-version"/>

--- a/app/test/task/testdata/goldens/packages/oxygen/example.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/example.html
@@ -115,7 +115,7 @@
           <div class="detail-container">
             <div class="detail-header-outer-block">
               <div class="detail-header-content-block">
-                <h1 class="title">
+                <h1 class="title pub-monochrome-icon-hoverable">
                   oxygen 2.0.0
                   <span class="pkg-page-title-copy">
                     <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^2.0.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^2.0.0&quot; to clipboard" data-copy-content="oxygen: ^2.0.0" data-ga-click-event="copy-package-version"/>

--- a/app/test/task/testdata/goldens/packages/oxygen/install.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/install.html
@@ -115,7 +115,7 @@
           <div class="detail-container">
             <div class="detail-header-outer-block">
               <div class="detail-header-content-block">
-                <h1 class="title">
+                <h1 class="title pub-monochrome-icon-hoverable">
                   oxygen 2.0.0
                   <span class="pkg-page-title-copy">
                     <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^2.0.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^2.0.0&quot; to clipboard" data-copy-content="oxygen: ^2.0.0" data-ga-click-event="copy-package-version"/>

--- a/app/test/task/testdata/goldens/packages/oxygen/license.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/license.html
@@ -115,7 +115,7 @@
           <div class="detail-container">
             <div class="detail-header-outer-block">
               <div class="detail-header-content-block">
-                <h1 class="title">
+                <h1 class="title pub-monochrome-icon-hoverable">
                   oxygen 2.0.0
                   <span class="pkg-page-title-copy">
                     <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^2.0.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^2.0.0&quot; to clipboard" data-copy-content="oxygen: ^2.0.0" data-ga-click-event="copy-package-version"/>

--- a/app/test/task/testdata/goldens/packages/oxygen/score.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/score.html
@@ -115,7 +115,7 @@
           <div class="detail-container">
             <div class="detail-header-outer-block">
               <div class="detail-header-content-block">
-                <h1 class="title">
+                <h1 class="title pub-monochrome-icon-hoverable">
                   oxygen 2.0.0
                   <span class="pkg-page-title-copy">
                     <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^2.0.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^2.0.0&quot; to clipboard" data-copy-content="oxygen: ^2.0.0" data-ga-click-event="copy-package-version"/>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions.html
@@ -115,7 +115,7 @@
           <div class="detail-container">
             <div class="detail-header-outer-block">
               <div class="detail-header-content-block">
-                <h1 class="title">
+                <h1 class="title pub-monochrome-icon-hoverable">
                   oxygen 2.0.0
                   <span class="pkg-page-title-copy">
                     <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^2.0.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^2.0.0&quot; to clipboard" data-copy-content="oxygen: ^2.0.0" data-ga-click-event="copy-package-version"/>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0.html
@@ -115,7 +115,7 @@
           <div class="detail-container">
             <div class="detail-header-outer-block">
               <div class="detail-header-content-block">
-                <h1 class="title">
+                <h1 class="title pub-monochrome-icon-hoverable">
                   oxygen 1.0.0
                   <span class="pkg-page-title-copy">
                     <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^1.0.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^1.0.0&quot; to clipboard" data-copy-content="oxygen: ^1.0.0" data-ga-click-event="copy-package-version"/>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/changelog.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/changelog.html
@@ -115,7 +115,7 @@
           <div class="detail-container">
             <div class="detail-header-outer-block">
               <div class="detail-header-content-block">
-                <h1 class="title">
+                <h1 class="title pub-monochrome-icon-hoverable">
                   oxygen 1.0.0
                   <span class="pkg-page-title-copy">
                     <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^1.0.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^1.0.0&quot; to clipboard" data-copy-content="oxygen: ^1.0.0" data-ga-click-event="copy-package-version"/>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/example.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/example.html
@@ -115,7 +115,7 @@
           <div class="detail-container">
             <div class="detail-header-outer-block">
               <div class="detail-header-content-block">
-                <h1 class="title">
+                <h1 class="title pub-monochrome-icon-hoverable">
                   oxygen 1.0.0
                   <span class="pkg-page-title-copy">
                     <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^1.0.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^1.0.0&quot; to clipboard" data-copy-content="oxygen: ^1.0.0" data-ga-click-event="copy-package-version"/>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/install.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/install.html
@@ -115,7 +115,7 @@
           <div class="detail-container">
             <div class="detail-header-outer-block">
               <div class="detail-header-content-block">
-                <h1 class="title">
+                <h1 class="title pub-monochrome-icon-hoverable">
                   oxygen 1.0.0
                   <span class="pkg-page-title-copy">
                     <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^1.0.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^1.0.0&quot; to clipboard" data-copy-content="oxygen: ^1.0.0" data-ga-click-event="copy-package-version"/>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/license.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/license.html
@@ -115,7 +115,7 @@
           <div class="detail-container">
             <div class="detail-header-outer-block">
               <div class="detail-header-content-block">
-                <h1 class="title">
+                <h1 class="title pub-monochrome-icon-hoverable">
                   oxygen 1.0.0
                   <span class="pkg-page-title-copy">
                     <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^1.0.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^1.0.0&quot; to clipboard" data-copy-content="oxygen: ^1.0.0" data-ga-click-event="copy-package-version"/>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/score.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/score.html
@@ -115,7 +115,7 @@
           <div class="detail-container">
             <div class="detail-header-outer-block">
               <div class="detail-header-content-block">
-                <h1 class="title">
+                <h1 class="title pub-monochrome-icon-hoverable">
                   oxygen 1.0.0
                   <span class="pkg-page-title-copy">
                     <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^1.0.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^1.0.0&quot; to clipboard" data-copy-content="oxygen: ^1.0.0" data-ga-click-event="copy-package-version"/>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/2.0.0.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/2.0.0.html
@@ -115,7 +115,7 @@
           <div class="detail-container">
             <div class="detail-header-outer-block">
               <div class="detail-header-content-block">
-                <h1 class="title">
+                <h1 class="title pub-monochrome-icon-hoverable">
                   oxygen 2.0.0
                   <span class="pkg-page-title-copy">
                     <img class="pub-monochrome-icon pkg-page-title-copy-icon filter-invert-on-dark" src="/static/hash-%%etag%%/img/content-copy-icon.svg" alt="copy &quot;oxygen: ^2.0.0&quot; to clipboard" width="18" height="18" title="Copy &quot;oxygen: ^2.0.0&quot; to clipboard" data-copy-content="oxygen: ^2.0.0" data-ga-click-event="copy-package-version"/>

--- a/pkg/pub_integration/test/search_completition_test.dart
+++ b/pkg/pub_integration/test/search_completition_test.dart
@@ -44,8 +44,6 @@ void main() {
       final user = await fakeTestScenario.createAnonymousTestUser();
 
       await user.withBrowserPage((page) async {
-        await page.gotoOrigin('/experimental?search-completion=1');
-
         await page.gotoOrigin('/');
         await page.keyboard.type('is:un');
         await Future.delayed(Duration(milliseconds: 200));
@@ -59,8 +57,6 @@ void main() {
       });
 
       await user.withBrowserPage((page) async {
-        await page.gotoOrigin('/experimental?search-completion=1');
-
         await page.gotoOrigin('/packages?q=abc');
         await page.focus('input[name="q"]');
         // go to the end of the input field and start typing

--- a/pkg/pub_integration/test/theme_switch_test.dart
+++ b/pkg/pub_integration/test/theme_switch_test.dart
@@ -41,8 +41,6 @@ void main() {
 
       // test keyboard navigation
       await user.withBrowserPage((page) async {
-        await page.gotoOrigin('/experimental?dark=1');
-
         Future<void> expectDarkTheme() async {
           expect(await page.$OrNull('body.light-theme'), isNull);
           expect(await page.$OrNull('body.dark-theme'), isNotNull);

--- a/pkg/web_css/lib/src/_base.scss
+++ b/pkg/web_css/lib/src/_base.scss
@@ -101,6 +101,7 @@ button {
   opacity: var(--pub-monochrome-opacity-initial);
   transition: opacity 0.3s;
 
+  .pub-monochrome-icon-hoverable:hover &,
   &:focus,
   a:hover & {
     opacity: var(--pub-monochrome-opacity-hover);

--- a/pkg/web_css/lib/src/_list.scss
+++ b/pkg/web_css/lib/src/_list.scss
@@ -196,15 +196,7 @@
     margin: 0px -30px 6px -30px;
     padding: 15px 30px;
 
-    .pkg-page-title-copy-icon {
-      opacity: 0.15;
-    }
-
     &:hover {
-      .pkg-page-title-copy-icon {
-        opacity: 0.25;
-      }
-
       background: var(--pub-neutral-hover-bgColor);
     }
   }

--- a/pkg/web_css/lib/src/_pkg.scss
+++ b/pkg/web_css/lib/src/_pkg.scss
@@ -473,10 +473,6 @@
     // Lower contrast than the regular monochrome icon rules.
     --pub-monochrome-opacity-initial: 0.3;
     --pub-monochrome-opacity-hover: 0.7;
-
-    h1.title:hover & {
-      opacity: var(--pub-monochrome-opacity-hover);
-    }
   }
 
   .pkg-page-title-copy-feedback {


### PR DESCRIPTION
- Adding `pub-monochrome-icon-hoverable` class to indicate a parent/container element that should trigger the opacity change in its descendant icon.