### PR TITLE
Fix footer's link wrapping in Firefox.

### DIFF
--- a/pkg/web_css/lib/src/_footer.scss
+++ b/pkg/web_css/lib/src/_footer.scss
@@ -15,6 +15,7 @@
   color: var(--pub-footer-text-color);
 
   > a.link {
+    display: inline-block;
     color: var(--pub-footer-text-color);
     padding-right: 12px;
     text-wrap: nowrap;


### PR DESCRIPTION
- Fixes #8386.
- In Firefox it seems that the continuous `text-wrap: nowrap` is aggregated together and doesn't wrap any of the text in the link list. Adding the `display` property (strengthening the nowrap feature) fixes it in Firefox too.