### PR TITLE
Additional style for exact package name highlights.

### DIFF
--- a/pkg/web_css/lib/src/_list.scss
+++ b/pkg/web_css/lib/src/_list.scss
@@ -47,7 +47,9 @@
 }
 
 .listing-highlight-block {
-  margin: 8px 0px;
+  border-left: 0.25em solid var(--pub-markdown-alert-note);
+  padding: .5rem 1rem;
+  margin: 4px 0px;
 }
 
 .sort-control {


### PR DESCRIPTION
https://github.com/dart-lang/pub-dev/issues/8518

<img width="272" alt="image" src="https://github.com/user-attachments/assets/db50dcc7-b0e6-4564-a8ea-72221a51c741" />
