### PR TITLE
Migrate some markdown-based post-processing into a separate HTML-based method

### DIFF
--- a/app/test/shared/markdown_test.dart
+++ b/app/test/shared/markdown_test.dart
@@ -105,6 +105,26 @@ void main() {
           '<p><img src="https://github.com/example/project/raw/master/example/image.png" alt="text"></p>\n');
     });
 
+    test('relative image using html tag', () {
+      expect(
+        markdownToHtml(
+          '[<img src="../../../assets/flutter-favorite-badge.png" width="100" />]'
+          '(https://flutter.dev/docs/development/packages-and-plugins/favorites)',
+        ),
+        '<p><a href="https://flutter.dev/docs/development/packages-and-plugins/favorites">'
+        '<img src="../../../assets/flutter-favorite-badge.png" width="100"></a></p>\n',
+      );
+      expect(
+        markdownToHtml(
+          '[<img src="../../../assets/flutter-favorite-badge.png" width="100" />]'
+          '(https://flutter.dev/docs/development/packages-and-plugins/favorites)',
+          urlResolverFn: urlResolverFn,
+        ),
+        '<p><a href="https://flutter.dev/docs/development/packages-and-plugins/favorites">'
+        '<img src="../../../assets/flutter-favorite-badge.png" width="100"></a></p>\n',
+      );
+    });
+
     test('root link within site', () {
       expect(markdownToHtml('[text](/README.md)'), '<p>text</p>\n');
       expect(
@@ -133,7 +153,7 @@ void main() {
 
   group('Unsafe markdown', () {
     test('javascript link', () {
-      expect(markdownToHtml('[a](javascript:alert("x"))'), '<p><a>a</a></p>\n');
+      expect(markdownToHtml('[a](javascript:alert("x"))'), '<p>a</p>\n');
     });
   });
 


### PR DESCRIPTION
- #8590
- Migrates unsafe URL filter and task list processing.
- The unsafe filter changed, as the new logic replaces the entire element with its text content, while the prior logic removed only the `href`/`src` attribute (see test for the change).
- Also added further test for the relative link rewrite (with its migration in a subsequent PR).