### PR TITLE
Differentiate between name match with underscores and without them.

### DIFF
--- a/app/test/search/package_name_index_test.dart
+++ b/app/test/search/package_name_index_test.dart
@@ -119,5 +119,12 @@ void main() {
         {},
       );
     });
+
+    test('substring: entu', () {
+      expect(index.search('entu'), {
+        'fluent': 0.5,
+        'fluent_ui': 0.99, // not 1.0
+      });
+    });
   });
 }

--- a/app/test/search/stack_trace_test.dart
+++ b/app/test/search/stack_trace_test.dart
@@ -36,7 +36,7 @@ void main() {
         'packageHits': [
           {
             'package': 'stack_trace',
-            'score': 1.0,
+            'score': 0.99,
           },
         ],
       });


### PR DESCRIPTION
I've noticed that when searching for `abcdef`, package with `XXXabc_defXXX` also ranked high. The difference in this PR may not be much, but when the results are close, it could make a difference. It also adds a sanity check on the length.  