### PR TITLE
Migrate the hash-link markdown post-processing into the new HTML-noded based version

### DIFF
--- a/app/test/frontend/golden/help_page.html
+++ b/app/test/frontend/golden/help_page.html
@@ -115,7 +115,7 @@
           <img class="standalone-side-image" src="/static/hash-%%etag%%/img/packages-side.webp" alt="" width="400" height="400" role="presentation"/>
         </div>
         <div class="standalone-content">
-          <h1 class="hash-header" id="help">
+          <h1 id="help" class="hash-header">
             Help
             <a href="#help" class="hash-link">#</a>
           </h1>

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -218,7 +218,7 @@
             <div class="detail-container detail-body-main">
               <div class="detail-tabs-content">
                 <section class="tab-content detail-tab-readme-content -active markdown-body">
-                  <h1 class="hash-header" id="oxygen">
+                  <h1 id="oxygen" class="hash-header">
                     oxygen
                     <a href="#oxygen" class="hash-link">#</a>
                   </h1>

--- a/app/test/frontend/golden/pkg_show_page_discontinued.html
+++ b/app/test/frontend/golden/pkg_show_page_discontinued.html
@@ -211,7 +211,7 @@
             <div class="detail-container detail-body-main">
               <div class="detail-tabs-content">
                 <section class="tab-content detail-tab-readme-content -active markdown-body">
-                  <h1 class="hash-header" id="pkg">
+                  <h1 id="pkg" class="hash-header">
                     pkg
                     <a href="#pkg" class="hash-link">#</a>
                   </h1>

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -207,7 +207,7 @@
             <div class="detail-container detail-body-main">
               <div class="detail-tabs-content">
                 <section class="tab-content detail-tab-readme-content -active markdown-body">
-                  <h1 class="hash-header" id="flutter_titanium">
+                  <h1 id="flutter_titanium" class="hash-header">
                     flutter_titanium
                     <a href="#flutter_titanium" class="hash-link">#</a>
                   </h1>

--- a/app/test/frontend/golden/pkg_show_page_publisher.html
+++ b/app/test/frontend/golden/pkg_show_page_publisher.html
@@ -206,7 +206,7 @@
             <div class="detail-container detail-body-main">
               <div class="detail-tabs-content">
                 <section class="tab-content detail-tab-readme-content -active markdown-body">
-                  <h1 class="hash-header" id="neon">
+                  <h1 id="neon" class="hash-header">
                     neon
                     <a href="#neon" class="hash-link">#</a>
                   </h1>

--- a/app/test/frontend/golden/pkg_show_page_retracted.html
+++ b/app/test/frontend/golden/pkg_show_page_retracted.html
@@ -194,7 +194,7 @@
             <div class="detail-container detail-body-main">
               <div class="detail-tabs-content">
                 <section class="tab-content detail-tab-readme-content -active markdown-body">
-                  <h1 class="hash-header" id="pkg">
+                  <h1 id="pkg" class="hash-header">
                     pkg
                     <a href="#pkg" class="hash-link">#</a>
                   </h1>

--- a/app/test/frontend/golden/pkg_show_page_retracted_non_retracted_version.html
+++ b/app/test/frontend/golden/pkg_show_page_retracted_non_retracted_version.html
@@ -202,7 +202,7 @@
             <div class="detail-container detail-body-main">
               <div class="detail-tabs-content">
                 <section class="tab-content detail-tab-readme-content -active markdown-body">
-                  <h1 class="hash-header" id="pkg">
+                  <h1 id="pkg" class="hash-header">
                     pkg
                     <a href="#pkg" class="hash-link">#</a>
                   </h1>

--- a/app/test/frontend/golden/pkg_show_version_page.html
+++ b/app/test/frontend/golden/pkg_show_version_page.html
@@ -212,7 +212,7 @@
             <div class="detail-container detail-body-main">
               <div class="detail-tabs-content">
                 <section class="tab-content detail-tab-readme-content -active markdown-body">
-                  <h1 class="hash-header" id="oxygen">
+                  <h1 id="oxygen" class="hash-header">
                     oxygen
                     <a href="#oxygen" class="hash-link">#</a>
                   </h1>

--- a/app/test/shared/markdown_test.dart
+++ b/app/test/shared/markdown_test.dart
@@ -14,7 +14,7 @@ void main() {
 
     test('render link id and class', () {
       expect(markdownToHtml('# ABC def'),
-          '<h1 class="hash-header" id="abc-def">ABC def <a href="#abc-def" class="hash-link">#</a></h1>\n');
+          '<h1 id="abc-def" class="hash-header">ABC def <a href="#abc-def" class="hash-link">#</a></h1>\n');
     });
 
     test('task list', () {
@@ -298,7 +298,7 @@ void main() {
               '\n'
               '- change1',
               isChangelog: true),
-          '<h1 class="hash-header" id="changelog">Changelog <a href="#changelog" class="hash-link">#</a></h1>\n'
+          '<h1 id="changelog" class="hash-header">Changelog <a href="#changelog" class="hash-link">#</a></h1>\n'
           '<div class="changelog-entry">\n'
           '<h2 class="changelog-version hash-header" id="100">1.0.0 <a href="#100" class="hash-link">#</a></h2>\n'
           '<div class="changelog-content">\n'
@@ -316,7 +316,7 @@ void main() {
               '## 1.0.0\n\n- change1\n\n- change2\n\n'
               '## 0.9.0\n\nMostly refactoring',
               isChangelog: true),
-          '<h1 class="hash-header" id="changelog">Changelog <a href="#changelog" class="hash-link">#</a></h1>\n'
+          '<h1 id="changelog" class="hash-header">Changelog <a href="#changelog" class="hash-link">#</a></h1>\n'
           '<div class="changelog-entry">\n'
           '<h2 class="changelog-version hash-header" id="100">1.0.0 <a href="#100" class="hash-link">#</a></h2>\n'
           '<div class="changelog-content">\n'
@@ -362,7 +362,7 @@ void main() {
       expect(lines.where((l) => l.contains('changelog-version')), [
         '<h2 class="changelog-version hash-header" id="210">2.1.0 <a href="#210" class="hash-link">#</a></h2>',
         '<h2 class="changelog-version hash-header" id="200">2.0.0 <a href="#200" class="hash-link">#</a></h2>',
-        '<h2 class="changelog-version hash-header" id="100-2">1.0.0 <a href="#100" class="hash-link">#</a></h2>',
+        '<h2 class="changelog-version hash-header" id="100-2">1.0.0 <a href="#100-2" class="hash-link">#</a></h2>',
       ]);
     });
 

--- a/app/test/task/testdata/goldens/packages/oxygen.html
+++ b/app/test/task/testdata/goldens/packages/oxygen.html
@@ -204,7 +204,7 @@
             <div class="detail-container detail-body-main">
               <div class="detail-tabs-content">
                 <section class="tab-content detail-tab-readme-content -active markdown-body">
-                  <h1 class="hash-header" id="oxygen">
+                  <h1 id="oxygen" class="hash-header">
                     oxygen
                     <a href="#oxygen" class="hash-link">#</a>
                   </h1>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0.html
@@ -208,7 +208,7 @@
             <div class="detail-container detail-body-main">
               <div class="detail-tabs-content">
                 <section class="tab-content detail-tab-readme-content -active markdown-body">
-                  <h1 class="hash-header" id="oxygen">
+                  <h1 id="oxygen" class="hash-header">
                     oxygen
                     <a href="#oxygen" class="hash-link">#</a>
                   </h1>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/2.0.0.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/2.0.0.html
@@ -204,7 +204,7 @@
             <div class="detail-container detail-body-main">
               <div class="detail-tabs-content">
                 <section class="tab-content detail-tab-readme-content -active markdown-body">
-                  <h1 class="hash-header" id="oxygen">
+                  <h1 id="oxygen" class="hash-header">
                     oxygen
                     <a href="#oxygen" class="hash-link">#</a>
                   </h1>


### PR DESCRIPTION
- #8590
- The templates test changes are only attribute reordering (the class attribute gets to the end of the list if there was no class attribute before).