### PR TITLE
Reduce flaky screenshots.

### DIFF
--- a/pkg/web_css/lib/src/_base.scss
+++ b/pkg/web_css/lib/src/_base.scss
@@ -493,3 +493,13 @@ a.-x-ago {
     margin-left: 36px;
   }
 }
+
+.-pub-ongoing-screenshot {
+  // Disables flashing caret (cursor) in input fields by making it invisible.
+  caret-color: transparent;
+
+  // Instantaneous transitions - no ambiguous delay in the end state.
+  * {
+    transition-duration: 0s !important;
+  }
+}

--- a/pkg/web_css/test/expression_test.dart
+++ b/pkg/web_css/test/expression_test.dart
@@ -57,6 +57,8 @@ void main() {
         'cookie-notice-container',
         'cookie-notice-button',
       ]);
+      // test-only style
+      expressions.remove('-pub-ongoing-screenshot');
       // markdown alert classes
       expressions.removeAll([
         'markdown-alert-note',


### PR DESCRIPTION
- #8580
- Adds a generic `-pub-ongoing-screenshot` class to the `<body>` element, that can be used to introduce styles that are scoped to be present only for screenshotting.
- Setting the caret (blinking cursor) to transparent, so that it doesn't matter in which blink state it is in.
- Overriding transition duration to zero.
- Waiting an arbitrary small time after updating the styles and viewport, but before taking the screenshot in the hope it stabilizes the view better.