### PR TITLE
Limit the content size of the blob index.

### DIFF
--- a/app/lib/task/backend.dart
+++ b/app/lib/task/backend.dart
@@ -5,6 +5,7 @@ import 'dart:typed_data';
 
 import 'package:_pub_shared/data/task_api.dart' as api;
 import 'package:_pub_shared/data/task_payload.dart';
+import 'package:_pub_shared/worker/limits.dart';
 import 'package:chunked_stream/chunked_stream.dart' show MaximumSizeExceeded;
 import 'package:clock/clock.dart';
 import 'package:collection/collection.dart';
@@ -788,7 +789,7 @@ class TaskBackend {
     try {
       return await _bucket.readAsBytes(
         path, offset: offset, length: length,
-        maxSize: 10 * 1024 * 1024, // sanity limit
+        maxSize: blobContentSizeLimit, // sanity limit
       );
     } on DetailedApiRequestError catch (e) {
       if (e.status == 404) {

--- a/pkg/_pub_shared/lib/worker/limits.dart
+++ b/pkg/_pub_shared/lib/worker/limits.dart
@@ -1,0 +1,6 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// The maximum size of the compressed blob content that we want to store and serve.
+const blobContentSizeLimit = 10 * 1024 * 1024;

--- a/pkg/indexed_blob/lib/indexed_blob.dart
+++ b/pkg/indexed_blob/lib/indexed_blob.dart
@@ -75,17 +75,36 @@ final class IndexedBlobBuilder {
   ///
   /// This cannot be called concurrently, callers must await this operation
   /// being completed.
+  /// 
+  /// When [skipAfterSize] is set, the blob file may contain the streamed content
+  /// up to the specified number of bytes, but will skip updating the index file
+  /// after the threshold is reached.
   ///
   /// If an exception is thrown generated blob is not valid.
-  Future<void> addFile(String path, Stream<List<int>> content) async {
+  Future<void> addFile(
+    String path,
+    Stream<List<int>> content, {
+    int skipAfterSize = 0,
+  }) async {
     _checkState();
     try {
       _isAdding = true;
       final start = _offset;
+      var totalSize = 0;
       await _blob.addStream(content.map((chunk) {
+        totalSize += chunk.length;
+        if (skipAfterSize > 0 && totalSize > skipAfterSize) {
+          // Do not store the remaining chunks, we will not store the entry.
+          return const [];
+        }
+
         _offset += chunk.length;
         return chunk;
       }));
+
+      if (skipAfterSize > 0 && totalSize > skipAfterSize) {
+        return;
+      }
 
       var target = _index;
       final segments = path.split('/');

--- a/pkg/indexed_blob/lib/indexed_blob.dart
+++ b/pkg/indexed_blob/lib/indexed_blob.dart
@@ -75,7 +75,7 @@ final class IndexedBlobBuilder {
   ///
   /// This cannot be called concurrently, callers must await this operation
   /// being completed.
-  /// 
+  ///
   /// When [skipAfterSize] is set, the blob file may contain the streamed content
   /// up to the specified number of bytes, but will skip updating the index file
   /// after the threshold is reached.

--- a/pkg/pub_worker/lib/src/analyze.dart
+++ b/pkg/pub_worker/lib/src/analyze.dart
@@ -10,6 +10,7 @@ import 'dart:isolate' show Isolate;
 
 import 'package:_pub_shared/data/task_payload.dart';
 import 'package:_pub_shared/pubapi.dart';
+import 'package:_pub_shared/worker/limits.dart';
 import 'package:api_builder/api_builder.dart';
 import 'package:clock/clock.dart' show clock;
 import 'package:http/http.dart' show Client, ClientException;
@@ -201,7 +202,11 @@ Future<void> _analyzePackage(
           continue; // We'll add this at the very end!
         }
         try {
-          await builder.addFile(path, f.openRead().transform(gzip.encoder));
+          await builder.addFile(
+            path,
+            f.openRead().transform(gzip.encoder),
+            skipAfterSize: blobContentSizeLimit,
+          );
         } on IOException {
           log.writeln('ERROR: Failed to read output file at "$path"');
         }


### PR DESCRIPTION
Since the file content is compressed, and the compression ratio is not known upfront, I've added the check in `addFile`: it will stop writing to the blob writer and skip the indexing if the threshold is reached. We could add additional checks in special cases (e.g. `.tar.gz` can be assumed to be the same size before and after further compression, but I think this solution may be generic and simple enough.