### PR TITLE
Dont validate moderate user

### DIFF
--- a/app/lib/admin/actions/moderate_package.dart
+++ b/app/lib/admin/actions/moderate_package.dart
@@ -52,10 +52,7 @@ Note: the action may take a longer time to complete as the public archive bucket
     final note = options['note'];
 
     final refCase =
-        await adminBackend.loadAndVerifyModerationCaseForAdminAction(
-      caseId,
-      status: ModerationStatus.pending,
-    );
+        await adminBackend.loadAndVerifyModerationCaseForAdminAction(caseId);
 
     final p = await packageBackend.lookupPackage(package!);
     if (p == null) {

--- a/app/lib/admin/actions/moderate_package_versions.dart
+++ b/app/lib/admin/actions/moderate_package_versions.dart
@@ -62,10 +62,7 @@ Set the moderated flag on a package version (updating the flag and the timestamp
     final note = options['note'];
 
     final refCase =
-        await adminBackend.loadAndVerifyModerationCaseForAdminAction(
-      caseId,
-      status: ModerationStatus.pending,
-    );
+        await adminBackend.loadAndVerifyModerationCaseForAdminAction(caseId);
 
     final p = await packageBackend.lookupPackage(package!);
     if (p == null) {

--- a/app/lib/admin/actions/moderate_publisher.dart
+++ b/app/lib/admin/actions/moderate_publisher.dart
@@ -54,10 +54,7 @@ can't be updated, administrators must not be able to update publisher options.
     final note = options['note'];
 
     final refCase =
-        await adminBackend.loadAndVerifyModerationCaseForAdminAction(
-      caseId,
-      status: ModerationStatus.pending,
-    );
+        await adminBackend.loadAndVerifyModerationCaseForAdminAction(caseId);
 
     Publisher? publisher2;
     if (valueToSet != null) {

--- a/app/lib/admin/actions/moderate_user.dart
+++ b/app/lib/admin/actions/moderate_user.dart
@@ -13,7 +13,6 @@ import '../../publisher/backend.dart';
 import '../../shared/datastore.dart';
 
 import '../backend.dart';
-import '../models.dart';
 
 import 'actions.dart';
 

--- a/app/lib/admin/actions/moderate_user.dart
+++ b/app/lib/admin/actions/moderate_user.dart
@@ -51,7 +51,7 @@ The active web sessions of the user will be expired.
     final refCase =
         await adminBackend.loadAndVerifyModerationCaseForAdminAction(
       caseId,
-      status: ModerationStatus.pending,
+      status: null,
     );
 
     User? user;

--- a/app/lib/admin/actions/moderate_user.dart
+++ b/app/lib/admin/actions/moderate_user.dart
@@ -49,10 +49,7 @@ The active web sessions of the user will be expired.
     final note = options['note'];
 
     final refCase =
-        await adminBackend.loadAndVerifyModerationCaseForAdminAction(
-      caseId,
-      status: null,
-    );
+        await adminBackend.loadAndVerifyModerationCaseForAdminAction(caseId);
 
     User? user;
     if (looksLikeUserId(userIdOrEmail!)) {

--- a/app/lib/admin/backend.dart
+++ b/app/lib/admin/backend.dart
@@ -749,7 +749,7 @@ class AdminBackend {
         dbService.emptyKey.append(ModerationCase, id: caseId));
   }
 
-  /// Returns a valid [ModerationCase] if it exists and [status] is matching.
+  /// Returns a valid [ModerationCase] if it exists.
   /// Returns `null` if [caseId] is `none`.
   ///
   /// Throws exceptions otherwise.

--- a/app/lib/admin/backend.dart
+++ b/app/lib/admin/backend.dart
@@ -754,9 +754,8 @@ class AdminBackend {
   ///
   /// Throws exceptions otherwise.
   Future<ModerationCase?> loadAndVerifyModerationCaseForAdminAction(
-    String? caseId, {
-    required String? status,
-  }) async {
+    String? caseId,
+  ) async {
     InvalidInputException.check(
       caseId != null && caseId.isNotEmpty,
       'case must be given',
@@ -768,10 +767,6 @@ class AdminBackend {
     final refCase = await adminBackend.lookupModerationCase(caseId!);
     if (refCase == null) {
       throw NotFoundException.resource(caseId);
-    }
-    if (status != null && refCase.status != status) {
-      throw InvalidInputException(
-          'ModerationCase.status ("${refCase.status}") != "$status".');
     }
     return refCase;
   }

--- a/app/test/admin/moderate_package_test.dart
+++ b/app/test/admin/moderate_package_test.dart
@@ -398,22 +398,6 @@ void main() {
       },
     );
 
-    testWithProfile('status already closed', fn: () async {
-      final mc = await _report('oxygen');
-      await dbService.commit(inserts: [
-        mc
-          ..resolved = clock.now()
-          ..status = ModerationStatus.noAction
-      ]);
-
-      await expectApiException(
-        _moderate('oxygen', state: true, caseId: mc.caseId),
-        code: 'InvalidInput',
-        status: 400,
-        message: 'ModerationCase.status ("no-action") != "pending".',
-      );
-    });
-
     testWithProfile(
         'cleanup deletes datastore entities and canonical archive file',
         expectedLogMessages: [

--- a/app/test/admin/moderate_publisher_test.dart
+++ b/app/test/admin/moderate_publisher_test.dart
@@ -191,22 +191,6 @@ void main() {
       expect(docs3!.where((d) => d.package == 'neon'), isNotEmpty);
     });
 
-    testWithProfile('status already closed', fn: () async {
-      final mc = await _report('example.com');
-      await dbService.commit(inserts: [
-        mc
-          ..resolved = clock.now()
-          ..status = ModerationStatus.noAction
-      ]);
-
-      await expectApiException(
-        _moderate('example.com', state: true, caseId: mc.caseId),
-        code: 'InvalidInput',
-        status: 400,
-        message: 'ModerationCase.status ("no-action") != "pending".',
-      );
-    });
-
     testWithProfile('cleanup deletes datastore entities and abandons packages',
         fn: () async {
       // moderate and cleanup


### PR DESCRIPTION
Our flow sometimes has us close a ModerationCase after we moderate a package, and after that we discover that we want to moderate a user in relation to the same case.