### PR TITLE
Retry commands that may time out fake server or the browser starts in tests.

### DIFF
--- a/pkg/pub_integration/pubspec.yaml
+++ b/pkg/pub_integration/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   path: ^1.8.0
   pub_semver: ^2.0.0
   puppeteer: 3.16.0
+  retry: ^3.1.2
   oauth2: ^2.0.0
 
 dev_dependencies:


### PR DESCRIPTION
Note: this may be only part of the solution, maybe the low-hanging fruit for reducing the CI flakes. E.g. the current `pub get` call is guarded with a lock file, maybe we should have a similar one for `pkg/web_app` and `pkg/web_css` too.