### PR TITLE
Reduce TestProfile mutable API: uploaders can be inferred directly from the profile.

### DIFF
--- a/app/lib/tool/test_profile/importer.dart
+++ b/app/lib/tool/test_profile/importer.dart
@@ -237,7 +237,9 @@ List<String> _potentialActiveEmails(TestProfile profile, String packageName) {
           profile.generatedPackages.firstWhere((p) => p.name == packageName);
 
   // uploaders
-  if (testPackage.publisher == null) return testPackage.uploaders!;
+  if (testPackage.publisher == null) {
+    return testPackage.uploaders ?? [profile.resolvedDefaultUser];
+  }
 
   // publisher
   final members = profile.publishers

--- a/app/lib/tool/test_profile/models.dart
+++ b/app/lib/tool/test_profile/models.dart
@@ -66,6 +66,16 @@ class TestProfile {
     final v = p?.versions?.firstWhereOrNull((v) => v.version == version);
     return v != null;
   }
+
+  /// The [defaultUser] if specified, otherwise:
+  /// - the first entry in the [users] list,
+  /// - the first specified member in the [publishers] list,
+  /// - the first specfied uploader in the [importedPackages] or the [generatedPackages] list.
+  late final resolvedDefaultUser = defaultUser ??
+      users.firstOrNull?.email ??
+      publishers.expand((p) => p.members).map((m) => m.email).firstOrNull ??
+      importedPackages.expand((p) => p.uploaders ?? <String>[]).firstOrNull ??
+      generatedPackages.expand((p) => p.uploaders ?? <String>[]).first;
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)
@@ -108,12 +118,11 @@ class TestPackage {
   Map<String, dynamic> toJson() => _$TestPackageToJson(this);
 
   TestPackage change({
-    List<String>? uploaders,
     List<TestVersion>? versions,
   }) {
     return TestPackage(
       name: name,
-      uploaders: uploaders ?? this.uploaders,
+      uploaders: uploaders,
       publisher: publisher,
       versions: versions ?? this.versions,
       replacedBy: replacedBy,

--- a/app/lib/tool/test_profile/normalizer.dart
+++ b/app/lib/tool/test_profile/normalizer.dart
@@ -42,8 +42,6 @@ TestProfile normalize(
     });
   });
 
-  final defaultUser = profile.defaultUser ?? users.keys.first;
-
   // add missing packages from resolved versions
   if (resolvedVersions != null) {
     resolvedVersions.forEach((rv) {
@@ -57,7 +55,7 @@ TestProfile normalize(
                 versions: [
                   TestVersion(version: rv.version, created: rv.created),
                 ],
-                uploaders: [defaultUser],
+                uploaders: [profile.resolvedDefaultUser],
               ));
     });
     // update versions from resolved versions
@@ -89,27 +87,12 @@ TestProfile normalize(
     _createPublisherIfNeeded(
       publishers,
       publisher,
-      memberEmail: defaultUser,
+      memberEmail: profile.resolvedDefaultUser,
     );
   }
 
-  for (final package in importedPackages.values.toList()) {
-    if (package.publisher == null &&
-        (package.uploaders == null || package.uploaders!.isEmpty)) {
-      importedPackages[package.name] = package.change(uploaders: [defaultUser]);
-    }
-  }
-
-  for (final package in generatedPackages.values.toList()) {
-    if (package.publisher == null &&
-        (package.uploaders == null || package.uploaders!.isEmpty)) {
-      generatedPackages[package.name] =
-          package.change(uploaders: [defaultUser]);
-    }
-  }
-
   return TestProfile(
-    defaultUser: defaultUser,
+    defaultUser: profile.resolvedDefaultUser,
     users: users.values.toList(),
     publishers: publishers.values.toList(),
     importedPackages: importedPackages.values.toList(),

--- a/app/test/tool/test_profile/model_normalization_test.dart
+++ b/app/test/tool/test_profile/model_normalization_test.dart
@@ -69,7 +69,6 @@ generatedPackages:
           'generatedPackages': [
             {
               'name': 'foo',
-              'uploaders': ['user@domain.com'],
               'versions': [
                 {'version': '1.0.0'},
                 {'version': '2.0.0'},
@@ -109,7 +108,6 @@ generatedPackages:
           'generatedPackages': [
             {
               'name': 'foo',
-              'uploaders': ['user@domain.com'],
               'versions': [
                 {'version': '1.1.0', 'created': isNotEmpty},
               ],


### PR DESCRIPTION
- Follow-up to #8634.
- The update-only mutability of `TestPackage` makes it harder to subclass it (especially if the `TestVersion` is also going to subclassed). Since we can infer the same default uploader from the `TestProfile` during import, there is no need to update it.
- Note: I'm planning to also remove the `versions` update in a subsequent PR.