### PR TITLE
Fix Github Actions token test.

### DIFF
--- a/app/test/service/openid/github_actions_id_token_test.dart
+++ b/app/test/service/openid/github_actions_id_token_test.dart
@@ -52,7 +52,7 @@ void main() {
 
       // extract and parse token
       final map = json.decode(rs.body) as Map<String, dynamic>;
-      expect(map.keys.toSet(), {'count', 'value'});
+      expect(map.keys.toSet(), {'value'});
       final tokenValue = map['value'] as String;
       final token = JsonWebToken.parse(tokenValue);
 


### PR DESCRIPTION
The output seems to have changed and github seems to be dropping the `count` field. I don't think we use it anywhere.