### PR TITLE
Follow-up fix to token test.

### DIFF
--- a/app/test/service/openid/github_actions_id_token_test.dart
+++ b/app/test/service/openid/github_actions_id_token_test.dart
@@ -52,7 +52,7 @@ void main() {
 
       // extract and parse token
       final map = json.decode(rs.body) as Map<String, dynamic>;
-      expect(map.keys.toSet(), {'value'});
+      expect(map.keys.contains('value'), true);
       final tokenValue = map['value'] as String;
       final token = JsonWebToken.parse(tokenValue);
 


### PR DESCRIPTION
Apparently #8641 was not enough, as `count` may be present sometime. Better to ignore it and focus only on the part we actually use.