### PR TITLE
GeneratedTest[Package|Version] and minimal TestArchiveTemplate.

### DIFF
--- a/app/lib/tool/test_profile/import_source.dart
+++ b/app/lib/tool/test_profile/import_source.dart
@@ -98,7 +98,10 @@ class ImportSource {
   }
 
   Future<List<int>> getGeneratedArchiveBytes(
-      String package, String version) async {
+    String package,
+    String version,
+    TestArchiveTemplate? template,
+  ) async {
     final key = '$package/$version';
     final hasher = createHasher(key);
     if (_archives.containsKey(key)) {
@@ -109,7 +112,8 @@ class ImportSource {
     final hasRepository = hasher('hasRepository', max: 20) > 0;
     final isLegacy = version.contains('legacy');
 
-    final sdkConstraint = isLegacy ? '>=1.12.0 <2.0.0' : '^3.0.0';
+    final sdkConstraint =
+        template?.sdkConstraint ?? (isLegacy ? '>=1.12.0 <2.0.0' : '^3.0.0');
 
     final isFlutter = package.startsWith('flutter_');
     final screenshot = TestScreenshot.success();

--- a/app/lib/tool/test_profile/models.dart
+++ b/app/lib/tool/test_profile/models.dart
@@ -22,7 +22,7 @@ class TestProfile {
   final List<TestPackage> importedPackages;
 
   /// Packages that will be generated locally using the provided parameters and semi-random templates.
-  final List<TestPackage> generatedPackages;
+  final List<GeneratedTestPackage> generatedPackages;
   final List<TestPublisher> publishers;
   final List<TestUser> users;
 
@@ -31,12 +31,12 @@ class TestProfile {
 
   TestProfile({
     List<TestPackage>? importedPackages,
-    List<TestPackage>? generatedPackages,
+    List<GeneratedTestPackage>? generatedPackages,
     List<TestPublisher>? publishers,
     List<TestUser>? users,
     this.defaultUser,
   })  : importedPackages = importedPackages ?? <TestPackage>[],
-        generatedPackages = generatedPackages ?? <TestPackage>[],
+        generatedPackages = generatedPackages ?? <GeneratedTestPackage>[],
         publishers = publishers ?? <TestPublisher>[],
         users = users ?? <TestUser>[];
 
@@ -98,14 +98,7 @@ class TestPackage {
   });
 
   factory TestPackage.fromJson(Map<String, dynamic> json) {
-    // convert simple String versions to objects
-    final versions = json['versions'] as List?;
-    json = {
-      ...json,
-      'versions':
-          versions?.map((v) => v is String ? {'version': v} : v).toList(),
-    };
-    return _$TestPackageFromJson(json);
+    return _$TestPackageFromJson(_expandPackageJson(json));
   }
 
   Map<String, dynamic> toJson() => _$TestPackageToJson(this);
@@ -128,6 +121,86 @@ class TestVersion {
 
   @override
   String toString() => '$version';
+}
+
+@JsonSerializable(explicitToJson: true, includeIfNull: false)
+class GeneratedTestPackage extends TestPackage {
+  @override
+  // ignore: overridden_fields
+  final List<GeneratedTestVersion>? versions;
+
+  final TestArchiveTemplate? template;
+
+  GeneratedTestPackage({
+    required super.name,
+    super.uploaders,
+    super.publisher,
+    this.versions,
+    super.isDiscontinued,
+    super.replacedBy,
+    super.isUnlisted,
+    super.isFlutterFavorite,
+    super.retractedVersions,
+    super.likeCount,
+    this.template,
+  });
+
+  factory GeneratedTestPackage.fromJson(Map<String, dynamic> json) {
+    return _$GeneratedTestPackageFromJson(_expandPackageJson(json));
+  }
+
+  @override
+  Map<String, dynamic> toJson() => _$GeneratedTestPackageToJson(this);
+}
+
+Map<String, dynamic> _expandPackageJson(Map<String, dynamic> json) {
+  // convert simple String versions to objects
+  final versions = json['versions'] as List?;
+  return {
+    ...json,
+    'versions': versions?.map((v) => v is String ? {'version': v} : v).toList(),
+  };
+}
+
+@JsonSerializable(explicitToJson: true, includeIfNull: false)
+class GeneratedTestVersion extends TestVersion {
+  final TestArchiveTemplate? template;
+
+  GeneratedTestVersion({
+    required super.version,
+    super.created,
+    this.template,
+  });
+
+  factory GeneratedTestVersion.fromJson(Map<String, dynamic> json) =>
+      _$GeneratedTestVersionFromJson(json);
+
+  @override
+  Map<String, dynamic> toJson() => _$GeneratedTestVersionToJson(this);
+
+  @override
+  String toString() => '$version';
+}
+
+@JsonSerializable(explicitToJson: true, includeIfNull: false)
+class TestArchiveTemplate {
+  final String? sdkConstraint;
+
+  TestArchiveTemplate({
+    this.sdkConstraint,
+  });
+
+  factory TestArchiveTemplate.fromJson(Map<String, dynamic> json) =>
+      _$TestArchiveTemplateFromJson(json);
+
+  TestArchiveTemplate overrideWith(TestArchiveTemplate? other) {
+    if (other == null) return this;
+    return TestArchiveTemplate(
+      sdkConstraint: other.sdkConstraint ?? sdkConstraint,
+    );
+  }
+
+  Map<String, dynamic> toJson() => _$TestArchiveTemplateToJson(this);
 }
 
 @JsonSerializable(explicitToJson: true, includeIfNull: false)

--- a/app/lib/tool/test_profile/models.g.dart
+++ b/app/lib/tool/test_profile/models.g.dart
@@ -11,7 +11,7 @@ TestProfile _$TestProfileFromJson(Map<String, dynamic> json) => TestProfile(
           ?.map((e) => TestPackage.fromJson(e as Map<String, dynamic>))
           .toList(),
       generatedPackages: (json['generatedPackages'] as List<dynamic>?)
-          ?.map((e) => TestPackage.fromJson(e as Map<String, dynamic>))
+          ?.map((e) => GeneratedTestPackage.fromJson(e as Map<String, dynamic>))
           .toList(),
       publishers: (json['publishers'] as List<dynamic>?)
           ?.map((e) => TestPublisher.fromJson(e as Map<String, dynamic>))
@@ -81,6 +81,83 @@ Map<String, dynamic> _$TestVersionToJson(TestVersion instance) =>
       'version': instance.version,
       if (instance.created?.toIso8601String() case final value?)
         'created': value,
+    };
+
+GeneratedTestPackage _$GeneratedTestPackageFromJson(
+        Map<String, dynamic> json) =>
+    GeneratedTestPackage(
+      name: json['name'] as String,
+      uploaders: (json['uploaders'] as List<dynamic>?)
+          ?.map((e) => e as String)
+          .toList(),
+      publisher: json['publisher'] as String?,
+      versions: (json['versions'] as List<dynamic>?)
+          ?.map((e) => GeneratedTestVersion.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      isDiscontinued: json['isDiscontinued'] as bool?,
+      replacedBy: json['replacedBy'] as String?,
+      isUnlisted: json['isUnlisted'] as bool?,
+      isFlutterFavorite: json['isFlutterFavorite'] as bool?,
+      retractedVersions: (json['retractedVersions'] as List<dynamic>?)
+          ?.map((e) => e as String)
+          .toList(),
+      likeCount: (json['likeCount'] as num?)?.toInt(),
+      template: json['template'] == null
+          ? null
+          : TestArchiveTemplate.fromJson(
+              json['template'] as Map<String, dynamic>),
+    );
+
+Map<String, dynamic> _$GeneratedTestPackageToJson(
+        GeneratedTestPackage instance) =>
+    <String, dynamic>{
+      'name': instance.name,
+      if (instance.uploaders case final value?) 'uploaders': value,
+      if (instance.publisher case final value?) 'publisher': value,
+      if (instance.isDiscontinued case final value?) 'isDiscontinued': value,
+      if (instance.replacedBy case final value?) 'replacedBy': value,
+      if (instance.isUnlisted case final value?) 'isUnlisted': value,
+      if (instance.isFlutterFavorite case final value?)
+        'isFlutterFavorite': value,
+      if (instance.retractedVersions case final value?)
+        'retractedVersions': value,
+      if (instance.likeCount case final value?) 'likeCount': value,
+      if (instance.versions?.map((e) => e.toJson()).toList() case final value?)
+        'versions': value,
+      if (instance.template?.toJson() case final value?) 'template': value,
+    };
+
+GeneratedTestVersion _$GeneratedTestVersionFromJson(
+        Map<String, dynamic> json) =>
+    GeneratedTestVersion(
+      version: json['version'] as String,
+      created: json['created'] == null
+          ? null
+          : DateTime.parse(json['created'] as String),
+      template: json['template'] == null
+          ? null
+          : TestArchiveTemplate.fromJson(
+              json['template'] as Map<String, dynamic>),
+    );
+
+Map<String, dynamic> _$GeneratedTestVersionToJson(
+        GeneratedTestVersion instance) =>
+    <String, dynamic>{
+      'version': instance.version,
+      if (instance.created?.toIso8601String() case final value?)
+        'created': value,
+      if (instance.template?.toJson() case final value?) 'template': value,
+    };
+
+TestArchiveTemplate _$TestArchiveTemplateFromJson(Map<String, dynamic> json) =>
+    TestArchiveTemplate(
+      sdkConstraint: json['sdkConstraint'] as String?,
+    );
+
+Map<String, dynamic> _$TestArchiveTemplateToJson(
+        TestArchiveTemplate instance) =>
+    <String, dynamic>{
+      if (instance.sdkConstraint case final value?) 'sdkConstraint': value,
     };
 
 TestPublisher _$TestPublisherFromJson(Map<String, dynamic> json) =>

--- a/app/lib/tool/test_profile/normalizer.dart
+++ b/app/lib/tool/test_profile/normalizer.dart
@@ -10,7 +10,7 @@ TestProfile normalize(TestProfile profile) {
   final users = <String, TestUser>{};
   final publishers = <String, TestPublisher>{};
   final importedPackages = <String, TestPackage>{};
-  final generatedPackages = <String, TestPackage>{};
+  final generatedPackages = <String, GeneratedTestPackage>{};
 
   profile.users.forEach((user) {
     users[user.email] = user;

--- a/app/test/dartdoc/doc_url_test.dart
+++ b/app/test/dartdoc/doc_url_test.dart
@@ -16,15 +16,15 @@ void main() {
     final _testProfile = TestProfile(
       defaultUser: 'admin@pub.dev',
       generatedPackages: [
-        TestPackage(
+        GeneratedTestPackage(
           name: 'oxygen',
           versions: [
-            TestVersion(version: '1.0.0'), // won't get analyzed
-            TestVersion(version: '1.0.1'), // won't get analyzed
-            TestVersion(version: '1.1.0'), // will get analyzed
-            TestVersion(version: '2.0.0'), // won't get analyzed
-            TestVersion(version: '2.0.1'), // will get analyzed
-            TestVersion(version: '2.1.0'), // will get analyzed
+            GeneratedTestVersion(version: '1.0.0'), // won't get analyzed
+            GeneratedTestVersion(version: '1.0.1'), // won't get analyzed
+            GeneratedTestVersion(version: '1.1.0'), // will get analyzed
+            GeneratedTestVersion(version: '2.0.0'), // won't get analyzed
+            GeneratedTestVersion(version: '2.0.1'), // will get analyzed
+            GeneratedTestVersion(version: '2.1.0'), // will get analyzed
           ],
         ),
       ],

--- a/app/test/frontend/handlers/custom_api_test.dart
+++ b/app/test/frontend/handlers/custom_api_test.dart
@@ -192,11 +192,11 @@ void main() {
       'many versions',
       testProfile: TestProfile(
         generatedPackages: [
-          TestPackage(
+          GeneratedTestPackage(
             name: 'pkg',
             versions: List.generate(
               99,
-              (index) => TestVersion(version: '1.$index.0'),
+              (index) => GeneratedTestVersion(version: '1.$index.0'),
             ),
           ),
         ],

--- a/app/test/frontend/handlers/listing_test.dart
+++ b/app/test/frontend/handlers/listing_test.dart
@@ -86,10 +86,11 @@ void main() {
     testWithProfile('/packages?page=2',
         testProfile: TestProfile(
           defaultUser: 'admin@pub.dev',
-          generatedPackages: List<TestPackage>.generate(
+          generatedPackages: List.generate(
               15,
-              (i) => TestPackage(
-                  name: 'pkg$i', versions: [TestVersion(version: '1.0.0')])),
+              (i) => GeneratedTestPackage(
+                  name: 'pkg$i',
+                  versions: [GeneratedTestVersion(version: '1.0.0')])),
         ), fn: () async {
       final present = ['pkg1', 'pkg4', 'pkg5', 'pkg12'];
       final absent = ['pkg0', 'pkg3', 'pkg6', 'pkg9', 'pkg10'];
@@ -104,7 +105,7 @@ void main() {
       '/flutter/packages',
       testProfile: TestProfile(
         generatedPackages:
-            List.generate(3, (i) => TestPackage(name: 'package_$i')),
+            List.generate(3, (i) => GeneratedTestPackage(name: 'package_$i')),
         defaultUser: 'admin@pub.dev',
       ),
       fn: () async {
@@ -125,9 +126,9 @@ void main() {
     testWithProfile(
       'Flutter listings',
       testProfile: TestProfile(
-        generatedPackages: List<TestPackage>.generate(
+        generatedPackages: List.generate(
           15,
-          (i) => TestPackage(
+          (i) => GeneratedTestPackage(
             name: 'flutter_pkg$i',
             isFlutterFavorite: true,
           ),

--- a/app/test/frontend/handlers/package_test.dart
+++ b/app/test/frontend/handlers/package_test.dart
@@ -125,9 +125,9 @@ void main() {
       'package pages without homepage',
       testProfile: TestProfile(
         generatedPackages: [
-          TestPackage(
+          GeneratedTestPackage(
               name: 'pkg',
-              versions: [TestVersion(version: '1.0.0-nohomepage')]),
+              versions: [GeneratedTestVersion(version: '1.0.0-nohomepage')]),
         ],
         defaultUser: 'admin@pub.dev',
       ),

--- a/app/test/frontend/handlers/publisher_test.dart
+++ b/app/test/frontend/handlers/publisher_test.dart
@@ -98,8 +98,8 @@ void main() {
       'unlisted packages',
       testProfile: TestProfile(
         generatedPackages: [
-          TestPackage(name: 'pkg_a', publisher: 'example.com'),
-          TestPackage(
+          GeneratedTestPackage(name: 'pkg_a', publisher: 'example.com'),
+          GeneratedTestPackage(
             name: 'pkg_b',
             publisher: 'example.com',
             isUnlisted: true,

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -270,10 +270,10 @@ void main() {
     testWithProfile('package show page with discontinued version',
         testProfile: TestProfile(
           generatedPackages: [
-            TestPackage(name: 'other'),
-            TestPackage(
+            GeneratedTestPackage(name: 'other'),
+            GeneratedTestPackage(
               name: 'pkg',
-              versions: [TestVersion(version: '1.0.0')],
+              versions: [GeneratedTestVersion(version: '1.0.0')],
               isDiscontinued: true,
               replacedBy: 'other',
             ),
@@ -293,11 +293,11 @@ void main() {
     testWithProfile('package show page with retracted version',
         testProfile: TestProfile(
           generatedPackages: [
-            TestPackage(
+            GeneratedTestPackage(
               name: 'pkg',
               versions: [
-                TestVersion(version: '1.0.0'),
-                TestVersion(version: '2.0.0'),
+                GeneratedTestVersion(version: '1.0.0'),
+                GeneratedTestVersion(version: '2.0.0'),
               ],
               retractedVersions: ['1.0.0'],
             ),
@@ -327,11 +327,11 @@ void main() {
     testWithProfile('package show page with non-retracted version',
         testProfile: TestProfile(
           generatedPackages: [
-            TestPackage(
+            GeneratedTestPackage(
               name: 'pkg',
               versions: [
-                TestVersion(version: '1.0.0'),
-                TestVersion(version: '2.0.0'),
+                GeneratedTestVersion(version: '1.0.0'),
+                GeneratedTestVersion(version: '2.0.0'),
               ],
               retractedVersions: ['1.0.0'],
             ),

--- a/app/test/package/api_export/api_exporter_test.dart
+++ b/app/test/package/api_export/api_exporter_test.dart
@@ -29,10 +29,10 @@ final _log = Logger('api_export.test');
 final _testProfile = TestProfile(
   defaultUser: userAtPubDevEmail,
   generatedPackages: [
-    TestPackage(
+    GeneratedTestPackage(
       name: 'foo',
       versions: [
-        TestVersion(version: '1.0.0'),
+        GeneratedTestVersion(version: '1.0.0'),
       ],
     ),
   ],
@@ -139,9 +139,9 @@ Future<void> _testExportedApiSynchronization(
       profile: TestProfile(
         defaultUser: userAtPubDevEmail,
         generatedPackages: [
-          TestPackage(
+          GeneratedTestPackage(
             name: 'bar',
-            versions: [TestVersion(version: '2.0.0')],
+            versions: [GeneratedTestVersion(version: '2.0.0')],
             publisher: 'example.com',
           ),
         ],
@@ -184,9 +184,9 @@ Future<void> _testExportedApiSynchronization(
       profile: TestProfile(
         defaultUser: userAtPubDevEmail,
         generatedPackages: [
-          TestPackage(
+          GeneratedTestPackage(
             name: 'bar',
-            versions: [TestVersion(version: '3.0.0')],
+            versions: [GeneratedTestVersion(version: '3.0.0')],
             publisher: 'example.com',
           ),
         ],

--- a/app/test/package/name_tracker_test.dart
+++ b/app/test/package/name_tracker_test.dart
@@ -151,7 +151,7 @@ void main() {
     testWithProfile(
       'aaa_bbb deleted, aaa_bbbs plural',
       testProfile: TestProfile(
-        generatedPackages: [TestPackage(name: 'aaa_bbb')],
+        generatedPackages: [GeneratedTestPackage(name: 'aaa_bbb')],
         defaultUser: 'user@pub.dev',
       ),
       fn: () async {

--- a/app/test/package/package_publisher_test.dart
+++ b/app/test/package/package_publisher_test.dart
@@ -154,8 +154,8 @@ void main() {
   group('Move between publishers', () {
     TestProfile _profile() => TestProfile(
           generatedPackages: [
-            TestPackage(name: 'one', publisher: 'verified.com'),
-            TestPackage(name: 'two', publisher: 'example.com'),
+            GeneratedTestPackage(name: 'one', publisher: 'verified.com'),
+            GeneratedTestPackage(name: 'two', publisher: 'example.com'),
           ],
           defaultUser: 'admin@pub.dev',
         );

--- a/app/test/package/retracted_test.dart
+++ b/app/test/package/retracted_test.dart
@@ -188,11 +188,11 @@ void main() {
         testProfile: TestProfile(
           defaultUser: 'admin@pub.dev',
           generatedPackages: [
-            TestPackage(name: 'oxygen', versions: [
-              TestVersion(version: '1.0.0'),
-              TestVersion(version: '1.2.0'),
-              TestVersion(version: '2.0.0-dev'),
-              TestVersion(version: '2.1.0-dev'),
+            GeneratedTestPackage(name: 'oxygen', versions: [
+              GeneratedTestVersion(version: '1.0.0'),
+              GeneratedTestVersion(version: '1.2.0'),
+              GeneratedTestVersion(version: '2.0.0-dev'),
+              GeneratedTestVersion(version: '2.1.0-dev'),
             ]),
           ],
         ), fn: () async {
@@ -310,15 +310,15 @@ void main() {
   group('different combinations', () {
     final _testProfile = TestProfile(
       generatedPackages: [
-        TestPackage(
+        GeneratedTestPackage(
           name: 'pkg',
           versions: [
-            TestVersion(version: '1.2.0'),
-            TestVersion(version: '1.3.0-dev'),
-            TestVersion(version: '2.0.0-dev'),
+            GeneratedTestVersion(version: '1.2.0'),
+            GeneratedTestVersion(version: '1.3.0-dev'),
+            GeneratedTestVersion(version: '2.0.0-dev'),
           ],
         ),
-        TestPackage(name: 'oxygen'),
+        GeneratedTestPackage(name: 'oxygen'),
       ],
       defaultUser: adminAtPubDevEmail,
     );

--- a/app/test/package/upload_test.dart
+++ b/app/test/package/upload_test.dart
@@ -719,8 +719,8 @@ void main() {
           'successful upload with GitHub Actions (exempted package)',
           testProfile: TestProfile(
             generatedPackages: [
-              TestPackage(name: '_dummy_pkg'),
-              TestPackage(name: 'oxygen'),
+              GeneratedTestPackage(name: '_dummy_pkg'),
+              GeneratedTestPackage(name: 'oxygen'),
             ],
             defaultUser: 'admin@pub.dev',
           ), fn: () async {
@@ -1229,12 +1229,12 @@ void main() {
       'max version count',
       testProfile: TestProfile(
         defaultUser: 'admin@pub.dev',
-        generatedPackages: <TestPackage>[
-          TestPackage(name: 'oxygen'),
-          TestPackage(
+        generatedPackages: [
+          GeneratedTestPackage(name: 'oxygen'),
+          GeneratedTestPackage(
               name: 'busy_pkg',
-              versions:
-                  List.generate(100, (i) => TestVersion(version: '1.0.$i'))),
+              versions: List.generate(
+                  100, (i) => GeneratedTestVersion(version: '1.0.$i'))),
         ],
       ),
       fn: () async {

--- a/app/test/shared/test_models.dart
+++ b/app/test/shared/test_models.dart
@@ -15,24 +15,24 @@ final emptyTestProfile = TestProfile(
 final defaultTestProfile = TestProfile(
   defaultUser: 'admin@pub.dev',
   generatedPackages: [
-    TestPackage(
+    GeneratedTestPackage(
       name: 'oxygen',
       versions: [
-        TestVersion(version: '1.0.0'),
-        TestVersion(version: '1.2.0'),
-        TestVersion(version: '2.0.0-dev'),
+        GeneratedTestVersion(version: '1.0.0'),
+        GeneratedTestVersion(version: '1.2.0'),
+        GeneratedTestVersion(version: '2.0.0-dev'),
       ],
     ),
-    TestPackage(
+    GeneratedTestPackage(
       name: 'neon',
-      versions: [TestVersion(version: '1.0.0')],
+      versions: [GeneratedTestVersion(version: '1.0.0')],
       publisher: 'example.com',
     ),
-    TestPackage(
+    GeneratedTestPackage(
       name: 'flutter_titanium',
       versions: [
-        TestVersion(version: '1.9.0'),
-        TestVersion(version: '1.10.0'),
+        GeneratedTestVersion(version: '1.9.0'),
+        GeneratedTestVersion(version: '1.10.0'),
       ],
     ),
   ],

--- a/app/test/task/end2end_test.dart
+++ b/app/test/task/end2end_test.dart
@@ -30,11 +30,11 @@ final _regenerateGoldens = false;
 final _testProfile = TestProfile(
   defaultUser: 'admin@pub.dev',
   generatedPackages: [
-    TestPackage(
+    GeneratedTestPackage(
       name: 'oxygen',
       versions: [
-        TestVersion(version: '1.0.0'),
-        TestVersion(version: '2.0.0'),
+        GeneratedTestVersion(version: '1.0.0'),
+        GeneratedTestVersion(version: '2.0.0'),
       ],
     ),
   ],

--- a/app/test/task/fallback_test.dart
+++ b/app/test/task/fallback_test.dart
@@ -20,10 +20,10 @@ void main() {
       await env.run(
         testProfile: TestProfile(
           generatedPackages: [
-            TestPackage(
+            GeneratedTestPackage(
               name: 'oxygen',
               versions: [
-                TestVersion(version: '1.0.0'),
+                GeneratedTestVersion(version: '1.0.0'),
               ],
             ),
           ],
@@ -97,8 +97,8 @@ void main() {
         await importProfile(
           profile: TestProfile(
             generatedPackages: [
-              TestPackage(name: 'oxygen', versions: [
-                TestVersion(version: '9.0.0'),
+              GeneratedTestPackage(name: 'oxygen', versions: [
+                GeneratedTestVersion(version: '9.0.0'),
               ]),
             ],
             defaultUser: adminAtPubDevEmail,

--- a/app/test/task/task_test.dart
+++ b/app/test/task/task_test.dart
@@ -53,17 +53,17 @@ void main() {
       testProfile: TestProfile(
         defaultUser: 'admin@pub.dev',
         generatedPackages: [
-          TestPackage(
+          GeneratedTestPackage(
             name: 'oxygen',
             versions: [
-              TestVersion(version: '1.0.0'),
-              TestVersion(version: '1.1.0'),
-              TestVersion(version: '1.2.0'),
-              TestVersion(version: '2.0.0-dev'),
+              GeneratedTestVersion(version: '1.0.0'),
+              GeneratedTestVersion(version: '1.1.0'),
+              GeneratedTestVersion(version: '1.2.0'),
+              GeneratedTestVersion(version: '2.0.0-dev'),
             ],
           ),
-          TestPackage(name: 'neon'),
-          TestPackage(name: 'flutter_titanium'),
+          GeneratedTestPackage(name: 'neon'),
+          GeneratedTestPackage(name: 'flutter_titanium'),
         ],
         users: [
           TestUser(email: 'admin@pub.dev', likes: []),
@@ -239,9 +239,9 @@ void main() {
       testProfile: TestProfile(
         defaultUser: 'admin@pub.dev',
         generatedPackages: [
-          TestPackage(
+          GeneratedTestPackage(
             name: 'neon',
-            versions: [TestVersion(version: '1.0.0')],
+            versions: [GeneratedTestVersion(version: '1.0.0')],
             publisher: 'example.com',
           ),
         ],
@@ -282,18 +282,18 @@ void main() {
       testProfile: TestProfile(
         defaultUser: 'admin@pub.dev',
         generatedPackages: [
-          TestPackage(
+          GeneratedTestPackage(
             name: 'neon',
             versions: [
-              TestVersion(version: '6.0.0'),
-              TestVersion(version: '5.1.0'),
-              TestVersion(version: '5.0.0'),
-              TestVersion(version: '4.0.0'),
-              TestVersion(version: '3.2.0'),
-              TestVersion(version: '3.1.0'),
-              TestVersion(version: '3.0.0'),
-              TestVersion(version: '2.0.0'),
-              TestVersion(version: '1.0.0'),
+              GeneratedTestVersion(version: '6.0.0'),
+              GeneratedTestVersion(version: '5.1.0'),
+              GeneratedTestVersion(version: '5.0.0'),
+              GeneratedTestVersion(version: '4.0.0'),
+              GeneratedTestVersion(version: '3.2.0'),
+              GeneratedTestVersion(version: '3.1.0'),
+              GeneratedTestVersion(version: '3.0.0'),
+              GeneratedTestVersion(version: '2.0.0'),
+              GeneratedTestVersion(version: '1.0.0'),
             ],
             publisher: 'example.com',
             isDiscontinued: true,
@@ -316,9 +316,9 @@ void main() {
       profile: TestProfile(
         defaultUser: 'admin@pub.dev',
         generatedPackages: [
-          TestPackage(
+          GeneratedTestPackage(
             name: 'neon',
-            versions: [TestVersion(version: '1.0.0')],
+            versions: [GeneratedTestVersion(version: '1.0.0')],
             publisher: 'example.com',
           ),
         ],
@@ -417,9 +417,9 @@ void main() {
       testProfile: TestProfile(
         defaultUser: 'admin@pub.dev',
         generatedPackages: [
-          TestPackage(
+          GeneratedTestPackage(
             name: 'neon',
-            versions: [TestVersion(version: '1.0.0')],
+            versions: [GeneratedTestVersion(version: '1.0.0')],
             publisher: 'example.com',
           ),
         ],
@@ -502,9 +502,9 @@ void main() {
       profile: TestProfile(
         defaultUser: 'admin@pub.dev',
         generatedPackages: [
-          TestPackage(
+          GeneratedTestPackage(
             name: 'neon',
-            versions: [TestVersion(version: '2.0.0')],
+            versions: [GeneratedTestVersion(version: '2.0.0')],
             publisher: 'example.com',
           ),
         ],
@@ -540,9 +540,9 @@ void main() {
       testProfile: TestProfile(
         defaultUser: 'admin@pub.dev',
         generatedPackages: [
-          TestPackage(
+          GeneratedTestPackage(
             name: 'neon',
-            versions: [TestVersion(version: '1.0.0')],
+            versions: [GeneratedTestVersion(version: '1.0.0')],
             publisher: 'example.com',
           ),
         ],
@@ -638,9 +638,9 @@ void main() {
       profile: TestProfile(
         defaultUser: 'admin@pub.dev',
         generatedPackages: [
-          TestPackage(
+          GeneratedTestPackage(
             name: 'neon',
-            versions: [TestVersion(version: '2.0.0')],
+            versions: [GeneratedTestVersion(version: '2.0.0')],
             publisher: 'example.com',
           ),
         ],
@@ -677,14 +677,14 @@ void main() {
       testProfile: TestProfile(
         defaultUser: 'admin@pub.dev',
         generatedPackages: [
-          TestPackage(
+          GeneratedTestPackage(
             name: 'neon',
-            versions: [TestVersion(version: '1.0.0')],
+            versions: [GeneratedTestVersion(version: '1.0.0')],
             publisher: 'example.com',
           ),
-          TestPackage(
+          GeneratedTestPackage(
             name: 'oxygen',
-            versions: [TestVersion(version: '1.0.0')],
+            versions: [GeneratedTestVersion(version: '1.0.0')],
             publisher: 'example.com',
           ),
         ],
@@ -698,9 +698,9 @@ void main() {
     testProfile: TestProfile(
       defaultUser: 'admin@pub.dev',
       generatedPackages: [
-        TestPackage(
+        GeneratedTestPackage(
           name: 'neon',
-          versions: [TestVersion(version: '1.0.0')],
+          versions: [GeneratedTestVersion(version: '1.0.0')],
         ),
       ],
       users: [
@@ -728,15 +728,15 @@ void main() {
           profile: TestProfile(
             defaultUser: 'admin@pub.dev',
             generatedPackages: [
-              TestPackage(
+              GeneratedTestPackage(
                 name: 'neon',
                 versions: [
-                  TestVersion(version: '1.1.0'),
-                  TestVersion(version: '1.2.0'),
-                  TestVersion(version: '2.0.0'),
-                  TestVersion(version: '3.0.0'),
-                  TestVersion(version: '4.0.0'),
-                  TestVersion(version: '5.0.0'),
+                  GeneratedTestVersion(version: '1.1.0'),
+                  GeneratedTestVersion(version: '1.2.0'),
+                  GeneratedTestVersion(version: '2.0.0'),
+                  GeneratedTestVersion(version: '3.0.0'),
+                  GeneratedTestVersion(version: '4.0.0'),
+                  GeneratedTestVersion(version: '5.0.0'),
                 ],
               ),
             ],

--- a/app/test/tool/test_profile/importer_test.dart
+++ b/app/test/tool/test_profile/importer_test.dart
@@ -82,7 +82,7 @@ void main() {
       'sample',
       testProfile: TestProfile(
         defaultUser: 'dev@example.com',
-        generatedPackages: [TestPackage(name: 'sample')],
+        generatedPackages: [GeneratedTestPackage(name: 'sample')],
       ),
       fn: () async {
         final users = await dbService.query<User>().run().toList();
@@ -110,7 +110,7 @@ void main() {
       'fill in likes',
       testProfile: TestProfile(
         generatedPackages: [
-          TestPackage(
+          GeneratedTestPackage(
             name: 'sample',
             likeCount: 10,
           ),


### PR DESCRIPTION
- Follow-up to #8634.
- While the `GeneratedTestPackage` and `GeneratedTestVersion` split is done, the use of `TestArchiveTemplate` is only minimal and can be considered only as the preview of how we should do drive the templates: typed and specific to certain goals (see `preview_test.dart`, where it replaces the subclassed `ImportSource` with the `template` variable.
