### PR TITLE
Balance text wrapping on headings.

### DIFF
--- a/pkg/web_css/lib/src/_base_dash.scss
+++ b/pkg/web_css/lib/src/_base_dash.scss
@@ -42,6 +42,11 @@ button, input, textarea, select {
   font-size: inherit;
 }
 
+// Balance text wrapping on headings.
+h1, h2, h3, h4, h5, h6 {
+  text-wrap: balance;
+}
+
 // Links are underlined when hovered.
 a {
   cursor: pointer;


### PR DESCRIPTION
- Part of the left-outs from #8568.
- I think this is worth to make it the default, as the headers are nicer to read.
- The before/after/diff screenshots:

Markdown samples:
<img width="915" alt="image" src="https://github.com/user-attachments/assets/0bb5da65-633e-4f32-a5b5-0db1623313f0" />

Admin page heading:
<img width="904" alt="image" src="https://github.com/user-attachments/assets/9b76939d-3437-4649-b32b-8b99884dd76d" />
