### PR TITLE
Fix ReservedPackage.emails check.

### DIFF
--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -1025,11 +1025,10 @@ class PackageBackend {
     bool isAllowedUser = false;
     if (agent is AuthenticatedUser) {
       final email = agent.user.email;
-      if (reservedPackage != null) {
-        final reservedEmails = reservedPackage.emails;
-        isAllowedUser = email != null && reservedEmails.contains(email);
-      } else {
-        isAllowedUser = email != null && email.endsWith('@google.com');
+      if (email != null) {
+        final reservedEmails = reservedPackage?.emails ?? const <String>[];
+        isAllowedUser =
+            reservedEmails.contains(email) || email.endsWith('@google.com');
       }
     }
 


### PR DESCRIPTION
The prior version checked the `@google.com` emails only when there was no `ReservedPackage` entry. However, the `emails` field documentation says `This is on top of the `@google.com` email addresses.`, so we should check the postfix regardless whether we have such entry or not.