### PR TITLE
Hide sort control when there is no result to be sorted.

### DIFF
--- a/app/lib/frontend/templates/listing.dart
+++ b/app/lib/frontend/templates/listing.dart
@@ -90,7 +90,7 @@ d.Node listingInfo({
   return listingInfoNode(
     totalCount: totalCount,
     ownedBy: ownedBy,
-    sortControlNode: _renderSortControl(searchForm),
+    sortControlNode: totalCount > 0 ? _renderSortControl(searchForm) : null,
     messageMarkdown: messageFromBackend,
   );
 }

--- a/app/lib/frontend/templates/views/shared/listing_info.dart
+++ b/app/lib/frontend/templates/views/shared/listing_info.dart
@@ -7,7 +7,7 @@ import '../../../dom/dom.dart' as d;
 d.Node listingInfoNode({
   required int totalCount,
   required String? ownedBy,
-  required d.Node sortControlNode,
+  required d.Node? sortControlNode,
   required String? messageMarkdown,
 }) {
   final packageOrPackages = totalCount == 1 ? 'package' : 'packages';
@@ -27,7 +27,7 @@ d.Node listingInfoNode({
           if (messageMarkdown != null) d.markdown(messageMarkdown),
         ],
       ),
-      sortControlNode,
+      if (sortControlNode != null) sortControlNode,
     ],
   );
 }


### PR DESCRIPTION
Reduces the link surface, so indiscriminate crawlers have fewer things to request from us.