### PR TITLE
Control search index's text match scope through (local) latencies.

### DIFF
--- a/app/lib/search/mem_index.dart
+++ b/app/lib/search/mem_index.dart
@@ -226,7 +226,7 @@ class InMemoryPackageIndex {
       packageScores,
       parsedQueryText,
       includeNameMatches: (query.offset ?? 0) == 0,
-      textMatchExtent: query.textMatchExtent,
+      textMatchExtent: query.textMatchExtent ?? TextMatchExtent.api,
     );
 
     final nameMatches = textResults?.nameMatches;
@@ -288,7 +288,7 @@ class InMemoryPackageIndex {
         boundedList(indexedHits, offset: query.offset, limit: query.limit);
 
     late List<PackageHit> packageHits;
-    if (TextMatchExtent.shouldMatchApi(query.textMatchExtent) &&
+    if ((query.textMatchExtent ?? TextMatchExtent.api).shouldMatchApi() &&
         textResults != null &&
         (textResults.topApiPages?.isNotEmpty ?? false)) {
       packageHits = indexedHits.map((ps) {
@@ -336,7 +336,7 @@ class InMemoryPackageIndex {
     IndexedScore<String> packageScores,
     String? text, {
     required bool includeNameMatches,
-    required int? textMatchExtent,
+    required TextMatchExtent textMatchExtent,
   }) {
     if (text == null || text.isEmpty) {
       return null;
@@ -349,7 +349,7 @@ class InMemoryPackageIndex {
       return _TextResults.empty();
     }
 
-    final matchName = TextMatchExtent.shouldMatchName(textMatchExtent);
+    final matchName = textMatchExtent.shouldMatchName();
     if (!matchName) {
       packageScores.fillRange(0, packageScores.length, 0);
       return _TextResults.empty(
@@ -379,10 +379,9 @@ class InMemoryPackageIndex {
     /// However, API docs search should be filtered on the original list.
     final indexedPositiveList = packageScores.toIndexedPositiveList();
 
-    final matchDescription =
-        TextMatchExtent.shouldMatchDescription(textMatchExtent);
-    final matchReadme = TextMatchExtent.shouldMatchReadme(textMatchExtent);
-    final matchApi = TextMatchExtent.shouldMatchApi(textMatchExtent);
+    final matchDescription = textMatchExtent.shouldMatchDescription();
+    final matchReadme = textMatchExtent.shouldMatchReadme();
+    final matchApi = textMatchExtent.shouldMatchApi();
 
     for (final word in words) {
       if (includeNameMatches && _documentsByName.containsKey(word)) {

--- a/app/lib/search/mem_index.dart
+++ b/app/lib/search/mem_index.dart
@@ -226,6 +226,7 @@ class InMemoryPackageIndex {
       packageScores,
       parsedQueryText,
       includeNameMatches: (query.offset ?? 0) == 0,
+      textMatchExtent: query.textMatchExtent,
     );
 
     final nameMatches = textResults?.nameMatches;
@@ -287,7 +288,9 @@ class InMemoryPackageIndex {
         boundedList(indexedHits, offset: query.offset, limit: query.limit);
 
     late List<PackageHit> packageHits;
-    if (textResults != null && (textResults.topApiPages?.isNotEmpty ?? false)) {
+    if (TextMatchExtent.shouldMatchApi(query.textMatchExtent) &&
+        textResults != null &&
+        (textResults.topApiPages?.isNotEmpty ?? false)) {
       packageHits = indexedHits.map((ps) {
         final apiPages = textResults.topApiPages?[ps.index]
             // TODO(https://github.com/dart-lang/pub-dev/issues/7106): extract title for the page
@@ -305,6 +308,7 @@ class InMemoryPackageIndex {
       nameMatches: nameMatches,
       topicMatches: topicMatches,
       packageHits: packageHits,
+      errorMessage: textResults?.errorMessage,
     );
   }
 
@@ -332,61 +336,82 @@ class InMemoryPackageIndex {
     IndexedScore<String> packageScores,
     String? text, {
     required bool includeNameMatches,
+    required int? textMatchExtent,
   }) {
+    if (text == null || text.isEmpty) {
+      return null;
+    }
+
     final sw = Stopwatch()..start();
-    if (text != null && text.isNotEmpty) {
-      final words = splitForQuery(text);
-      if (words.isEmpty) {
-        for (var i = 0; i < packageScores.length; i++) {
-          packageScores.setValue(i, 0);
-        }
-        return _TextResults.empty();
+    final words = splitForQuery(text);
+    if (words.isEmpty) {
+      packageScores.fillRange(0, packageScores.length, 0);
+      return _TextResults.empty();
+    }
+
+    final matchName = TextMatchExtent.shouldMatchName(textMatchExtent);
+    if (!matchName) {
+      packageScores.fillRange(0, packageScores.length, 0);
+      return _TextResults.empty(
+          errorMessage:
+              'Search index in reduced mode: unable to match query text.');
+    }
+
+    bool aborted = false;
+    bool checkAborted() {
+      if (!aborted && sw.elapsed > _textSearchTimeout) {
+        aborted = true;
+        _logger.info(
+            '[pub-aborted-search-query] Aborted text search after ${sw.elapsedMilliseconds} ms.');
       }
+      return aborted;
+    }
 
-      bool aborted = false;
+    Set<String>? nameMatches;
+    if (includeNameMatches && _documentsByName.containsKey(text)) {
+      nameMatches ??= <String>{};
+      nameMatches.add(text);
+    }
 
-      bool checkAborted() {
-        if (!aborted && sw.elapsed > _textSearchTimeout) {
-          aborted = true;
-          _logger.info(
-              '[pub-aborted-search-query] Aborted text search after ${sw.elapsedMilliseconds} ms.');
-        }
-        return aborted;
-      }
+    // Multiple words are scored separately, and then the individual scores
+    // are multiplied. We can use a package filter that is applied after each
+    // word to reduce the scope of the later words based on the previous results.
+    /// However, API docs search should be filtered on the original list.
+    final indexedPositiveList = packageScores.toIndexedPositiveList();
 
-      Set<String>? nameMatches;
-      if (includeNameMatches && _documentsByName.containsKey(text)) {
+    final matchDescription =
+        TextMatchExtent.souldMatchDescription(textMatchExtent);
+    final matchReadme = TextMatchExtent.shouldMatchReadme(textMatchExtent);
+    final matchApi = TextMatchExtent.shouldMatchApi(textMatchExtent);
+
+    for (final word in words) {
+      if (includeNameMatches && _documentsByName.containsKey(word)) {
         nameMatches ??= <String>{};
-        nameMatches.add(text);
+        nameMatches.add(word);
       }
 
-      // Multiple words are scored separately, and then the individual scores
-      // are multiplied. We can use a package filter that is applied after each
-      // word to reduce the scope of the later words based on the previous results.
-      /// However, API docs search should be filtered on the original list.
-      final indexedPositiveList = packageScores.toIndexedPositiveList();
+      _scorePool.withScore(
+        value: 0.0,
+        fn: (wordScore) {
+          _packageNameIndex.searchWord(word,
+              score: wordScore, filterOnNonZeros: packageScores);
 
-      for (final word in words) {
-        if (includeNameMatches && _documentsByName.containsKey(word)) {
-          nameMatches ??= <String>{};
-          nameMatches.add(word);
-        }
-
-        _scorePool.withScore(
-          value: 0.0,
-          fn: (wordScore) {
-            _packageNameIndex.searchWord(word,
-                score: wordScore, filterOnNonZeros: packageScores);
+          if (matchDescription) {
             _descrIndex.searchAndAccumulate(word, score: wordScore);
+          }
+          if (matchReadme) {
             _readmeIndex.searchAndAccumulate(word,
                 weight: 0.75, score: wordScore);
-            packageScores.multiplyAllFrom(wordScore);
-          },
-        );
-      }
+          }
+          packageScores.multiplyAllFrom(wordScore);
+        },
+      );
+    }
 
-      final topApiPages =
-          List<List<MapEntry<String, double>>?>.filled(_documents.length, null);
+    final topApiPages =
+        List<List<MapEntry<String, double>>?>.filled(_documents.length, null);
+
+    if (matchApi) {
       const maxApiPageCount = 2;
       if (!checkAborted()) {
         _apiSymbolIndex.withSearchWords(words, weight: 0.70, (symbolPages) {
@@ -420,29 +445,28 @@ class InMemoryPackageIndex {
           }
         });
       }
+    }
 
-      // filter results based on exact phrases
-      final phrases = extractExactPhrases(text);
-      if (!aborted && phrases.isNotEmpty) {
-        for (var i = 0; i < packageScores.length; i++) {
-          if (packageScores.isNotPositive(i)) continue;
-          final doc = _documents[i];
-          final matchedAllPhrases = phrases.every((phrase) =>
-              doc.package.contains(phrase) ||
-              doc.description!.contains(phrase) ||
-              doc.readme!.contains(phrase));
-          if (!matchedAllPhrases) {
-            packageScores.setValue(i, 0);
-          }
+    // filter results based on exact phrases
+    final phrases = extractExactPhrases(text);
+    if (!aborted && phrases.isNotEmpty) {
+      for (var i = 0; i < packageScores.length; i++) {
+        if (packageScores.isNotPositive(i)) continue;
+        final doc = _documents[i];
+        final matchedAllPhrases = phrases.every((phrase) =>
+            (matchName && doc.package.contains(phrase)) ||
+            (matchDescription && doc.description!.contains(phrase)) ||
+            (matchReadme && doc.readme!.contains(phrase)));
+        if (!matchedAllPhrases) {
+          packageScores.setValue(i, 0);
         }
       }
-
-      return _TextResults(
-        topApiPages,
-        nameMatches: nameMatches?.toList(),
-      );
     }
-    return null;
+
+    return _TextResults(
+      topApiPages,
+      nameMatches: nameMatches?.toList(),
+    );
   }
 
   List<IndexedPackageHit> _rankWithValues(
@@ -521,15 +545,20 @@ class InMemoryPackageIndex {
 class _TextResults {
   final List<List<MapEntry<String, double>>?>? topApiPages;
   final List<String>? nameMatches;
+  final String? errorMessage;
 
-  factory _TextResults.empty() => _TextResults(
-        null,
-        nameMatches: null,
-      );
+  factory _TextResults.empty({String? errorMessage}) {
+    return _TextResults(
+      null,
+      nameMatches: null,
+      errorMessage: errorMessage,
+    );
+  }
 
   _TextResults(
     this.topApiPages, {
     required this.nameMatches,
+    this.errorMessage,
   });
 }
 

--- a/app/lib/search/mem_index.dart
+++ b/app/lib/search/mem_index.dart
@@ -380,7 +380,7 @@ class InMemoryPackageIndex {
     final indexedPositiveList = packageScores.toIndexedPositiveList();
 
     final matchDescription =
-        TextMatchExtent.souldMatchDescription(textMatchExtent);
+        TextMatchExtent.shouldMatchDescription(textMatchExtent);
     final matchReadme = TextMatchExtent.shouldMatchReadme(textMatchExtent);
     final matchApi = TextMatchExtent.shouldMatchApi(textMatchExtent);
 

--- a/app/lib/search/search_service.dart
+++ b/app/lib/search/search_service.dart
@@ -334,7 +334,7 @@ abstract class TextMatchExtent {
   static bool shouldMatchName(int? value) => (value ?? unspecified) >= name;
 
   /// Text search is on package names, descriptions and topic tags.
-  static bool souldMatchDescription(int? value) =>
+  static bool shouldMatchDescription(int? value) =>
       (value ?? unspecified) >= description;
 
   /// Text search is on names, descriptions, topic tags and readme content.

--- a/app/lib/service/entrypoint/search.dart
+++ b/app/lib/service/entrypoint/search.dart
@@ -43,7 +43,7 @@ class SearchCommand extends Command {
       );
       registerScopeExitCallback(index.close);
 
-      registerSearchIndex(IsolateSearchIndex(index));
+      registerSearchIndex(LatencyAwareSearchIndex(IsolateSearchIndex(index)));
 
       void scheduleRenew() {
         scheduleMicrotask(() async {

--- a/app/lib/service/entrypoint/search_index.dart
+++ b/app/lib/service/entrypoint/search_index.dart
@@ -183,17 +183,25 @@ class LatencyAwareSearchIndex implements SearchIndex {
   int _selectTextMatchExtent() {
     final latency = _latencyTracker.getLatency();
     if (latency < const Duration(seconds: 1)) {
+      _logger.info('[text-match-normal]');
       return TextMatchExtent.api;
     }
     if (latency < const Duration(seconds: 2)) {
+      _logger.info('[text-match-readme]');
       return TextMatchExtent.readme;
     }
     if (latency < const Duration(seconds: 4)) {
-      return TextMatchExtent.description;
+      _logger.info('[text-match-description]');
+      // TODO: use `TextMatchExtent.description` after we are confident about this change.
+      return TextMatchExtent.readme;
     }
     if (latency < const Duration(seconds: 10)) {
-      return TextMatchExtent.name;
+      _logger.info('[text-match-name]');
+      // TODO: use `TextMatchExtent.name` after we are confident about this change.
+      return TextMatchExtent.readme;
     }
-    return TextMatchExtent.none;
+    // TODO: use `TextMatchExtent.none` after we are confident about this change.
+    _logger.info('[text-match-none]');
+    return TextMatchExtent.readme;
   }
 }

--- a/app/lib/service/entrypoint/search_index.dart
+++ b/app/lib/service/entrypoint/search_index.dart
@@ -180,7 +180,7 @@ class LatencyAwareSearchIndex implements SearchIndex {
   /// Note: the latency here may be a residue of a large spike that happened
   ///       more than a few minute ago, therefore we are deciding on latency
   ///       range over the default 5 seconds timeout window.
-  int _selectTextMatchExtent() {
+  TextMatchExtent _selectTextMatchExtent() {
     final latency = _latencyTracker.getLatency();
     if (latency < const Duration(seconds: 1)) {
       _logger.info('[text-match-normal]');

--- a/app/lib/service/entrypoint/search_index.dart
+++ b/app/lib/service/entrypoint/search_index.dart
@@ -19,6 +19,7 @@ import 'package:pub_dev/service/services.dart';
 import 'package:pub_dev/shared/env_config.dart';
 import 'package:pub_dev/shared/logging.dart';
 import 'package:pub_dev/shared/monitoring.dart';
+import 'package:pub_dev/shared/utils.dart';
 
 final _logger = Logger('search_index');
 
@@ -135,5 +136,64 @@ class IsolateSearchIndex implements SearchIndex {
       errorMessage: 'Failed to process request.',
       statusCode: 500,
     );
+  }
+}
+
+/// A search index that adjusts the extent of the text matching based on the
+/// observed recent latency (adjusted with a 1-minute half-life decay).
+class LatencyAwareSearchIndex implements SearchIndex {
+  final SearchIndex _delegate;
+  final _latencyTracker = DecayingMaxLatencyTracker();
+
+  LatencyAwareSearchIndex(this._delegate);
+
+  @override
+  FutureOr<IndexInfo> indexInfo() => _delegate.indexInfo();
+
+  @override
+  FutureOr<bool> isReady() => _delegate.isReady();
+
+  @override
+  Future<PackageSearchResult> search(ServiceSearchQuery query) async {
+    final sw = Stopwatch()..start();
+    try {
+      return await _delegate.search(query.change(
+        textMatchExtent: _selectTextMatchExtent(),
+      ));
+    } finally {
+      sw.stop();
+      final elapsed = sw.elapsed;
+      // Note: The maximum latency value here limits how long an outlier
+      //       processing will affect later queries. With the current 1-minute
+      //       decay half-life, it will allow:
+      //       - name-only search after about 2.5 minutes,
+      //       - descriptions after 4 minutes,
+      //       - readmes after 6 minutes,
+      //       - everything after 7 minutes.
+      _latencyTracker.observe(
+          elapsed.inMinutes >= 1 ? const Duration(minutes: 1) : elapsed);
+    }
+  }
+
+  /// Selects the text match extent value based on the recent maximum latency.
+  ///
+  /// Note: the latency here may be a residue of a large spike that happened
+  ///       more than a few minute ago, therefore we are deciding on latency
+  ///       range over the default 5 seconds timeout window.
+  int _selectTextMatchExtent() {
+    final latency = _latencyTracker.getLatency();
+    if (latency < const Duration(seconds: 1)) {
+      return TextMatchExtent.api;
+    }
+    if (latency < const Duration(seconds: 2)) {
+      return TextMatchExtent.readme;
+    }
+    if (latency < const Duration(seconds: 4)) {
+      return TextMatchExtent.description;
+    }
+    if (latency < const Duration(seconds: 10)) {
+      return TextMatchExtent.name;
+    }
+    return TextMatchExtent.none;
   }
 }

--- a/app/lib/shared/utils.dart
+++ b/app/lib/shared/utils.dart
@@ -320,10 +320,9 @@ class DecayingMaxLatencyTracker {
   }) : _halfLifePeriod = halfLifePeriod ?? Duration(minutes: 1);
 
   void _decay({
-    required DateTime? now,
+    required DateTime now,
     Duration? updateDelay,
   }) {
-    now ??= clock.now();
     updateDelay ??= Duration.zero;
     final diff = now.difference(_lastUpdated);
     if (diff <= updateDelay) {
@@ -339,7 +338,10 @@ class DecayingMaxLatencyTracker {
     DateTime? now,
     Duration? updateDelay,
   }) {
-    _decay(now: now, updateDelay: updateDelay ?? const Duration(seconds: 1));
+    _decay(
+      now: now ?? clock.now(),
+      updateDelay: updateDelay ?? const Duration(seconds: 1),
+    );
     return Duration(microseconds: _value);
   }
 

--- a/app/lib/shared/utils.dart
+++ b/app/lib/shared/utils.dart
@@ -10,6 +10,7 @@ import 'dart:math';
 import 'dart:typed_data';
 
 import 'package:appengine/appengine.dart';
+import 'package:clock/clock.dart';
 import 'package:intl/intl.dart';
 // ignore: implementation_imports
 import 'package:mime/src/default_extension_map.dart' as mime;
@@ -303,5 +304,55 @@ extension ByteFolderExt on Stream<List<int>> {
       buffer.add(chunk);
     }
     return buffer.toBytes();
+  }
+}
+
+/// Tracks the maximum latency by observing each latency value and keeping the maximum.
+/// The tracked maximum value decays, halving its value in every minute.
+class DecayingMaxLatencyTracker {
+  final Duration _halfLifePeriod;
+
+  int _value = 0;
+  DateTime _lastUpdated = clock.now();
+
+  DecayingMaxLatencyTracker({
+    Duration? halfLifePeriod,
+  }) : _halfLifePeriod = halfLifePeriod ?? Duration(minutes: 1);
+
+  void _decay({
+    DateTime? now,
+    Duration? updateDelay,
+  }) {
+    now ??= clock.now();
+    updateDelay ??= Duration.zero;
+    final diff = now.difference(_lastUpdated);
+    if (diff <= updateDelay) {
+      return;
+    }
+    final multiplier =
+        pow(0.5, diff.inMicroseconds / _halfLifePeriod.inMicroseconds);
+    _value = (_value * multiplier).round();
+    _lastUpdated = now;
+  }
+
+  Duration getLatency({
+    DateTime? now,
+    Duration? updateDelay,
+  }) {
+    _decay(now: now, updateDelay: updateDelay ?? const Duration(seconds: 1));
+    return Duration(microseconds: _value);
+  }
+
+  void observe(
+    Duration duration, {
+    DateTime? now,
+  }) {
+    now ??= clock.now();
+    _decay(now: now);
+    final value = duration.inMicroseconds;
+    if (_value < value) {
+      _value = value;
+      _lastUpdated = now;
+    }
   }
 }

--- a/app/lib/shared/utils.dart
+++ b/app/lib/shared/utils.dart
@@ -320,7 +320,7 @@ class DecayingMaxLatencyTracker {
   }) : _halfLifePeriod = halfLifePeriod ?? Duration(minutes: 1);
 
   void _decay({
-    DateTime? now,
+    required DateTime? now,
     Duration? updateDelay,
   }) {
     now ??= clock.now();


### PR DESCRIPTION
- Controls both package index (#8671) and SDK index (#8670).
- While the changes inside the text search seems a lot, it is mostly the indent change, otherwise only skipping the index matches when the `textMatchExtent` field does not support it.
- Returns an `errorMessage` when not even the name index was used. (TBD: more noticeable exposure of such messages)
- Introduces latency tracking with half-life decay of one minute. Considered alternatives: aggregation over last-N-events, last-X-minute, sampling over Y-minutes window.
- This is scoped only at the local index level. To make this consistent across all search instances, we could synchronize such decaying value(s) through redis. TBD in a subsequent PR.
- Note: I've also considered enum or bools for controlling the match extent, but that was more complex without much gain.
