### PR TITLE
Use bit arrays for predicate matching in search.

### DIFF
--- a/app/bin/tools/search_benchmark.dart
+++ b/app/bin/tools/search_benchmark.dart
@@ -25,6 +25,9 @@ Future<void> main(List<String> args) async {
 
   // NOTE: please add more queries to this list, especially if there is a performance bottleneck.
   final queries = [
+    'sdk:dart',
+    'sdk:flutter platform:android',
+    'is:flutter-favorite',
     'chart',
     'json',
     'camera',

--- a/app/lib/search/token_index.dart
+++ b/app/lib/search/token_index.dart
@@ -227,24 +227,6 @@ class IndexedScore<K> {
     _values.fillRange(start, end, fillValue);
   }
 
-  void removeWhere(bool Function(int index, K key) fn) {
-    for (var i = 0; i < length; i++) {
-      if (isNotPositive(i)) continue;
-      if (fn(i, _keys[i])) {
-        _values[i] = 0.0;
-      }
-    }
-  }
-
-  void retainWhere(bool Function(int index, K key) fn) {
-    for (var i = 0; i < length; i++) {
-      if (isNotPositive(i)) continue;
-      if (!fn(i, _keys[i])) {
-        _values[i] = 0.0;
-      }
-    }
-  }
-
   void multiplyAllFrom(IndexedScore other) {
     multiplyAllFromValues(other._values);
   }

--- a/app/lib/third_party/bit_array/LICENSE
+++ b/app/lib/third_party/bit_array/LICENSE
@@ -1,0 +1,27 @@
+Copyright 2018, the project authors. All rights reserved.
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the name of the project nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+

--- a/app/lib/third_party/bit_array/README.md
+++ b/app/lib/third_party/bit_array/README.md
@@ -1,0 +1,1 @@
+Note: this library is vendored from `package:bit_array`.

--- a/app/lib/third_party/bit_array/bit_array.dart
+++ b/app/lib/third_party/bit_array/bit_array.dart
@@ -1,0 +1,489 @@
+import 'dart:collection';
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import 'bit_set.dart';
+
+/// Bit array to store bits.
+class BitArray extends BitSet {
+  Uint32List _data;
+  int _length;
+
+  BitArray._(this._data) : _length = _data.length << 5;
+
+  /// Creates a bit array with maximum [length] items.
+  ///
+  /// [length] will be rounded up to match the 32-bit boundary.
+  factory BitArray(int length) =>
+      BitArray._(Uint32List(_bufferLength32(length)));
+
+  /// Creates a bit array using a byte buffer.
+  factory BitArray.fromByteBuffer(ByteBuffer buffer) {
+    final data = buffer.asUint32List();
+    return BitArray._(data);
+  }
+
+  /// Creates a bit array using a generic bit set.
+  factory BitArray.fromBitSet(BitSet set, {int? length}) {
+    length ??= set.length;
+    final setDataLength = _bufferLength32(set.length);
+    final data = Uint32List(_bufferLength32(length));
+    data.setRange(0, setDataLength, set.asUint32Iterable());
+    return BitArray._(data);
+  }
+
+  /// Creates a bit array using a Uint8List.
+  factory BitArray.fromUint8List(Uint8List list) {
+    if (list.lengthInBytes % 4 != 0) {
+      throw FormatException('Uint8List length must be a multiplication of 4');
+    }
+    final data = list.buffer.asUint32List(
+      list.offsetInBytes,
+      list.lengthInBytes >> 2,
+    );
+    return BitArray._(data);
+  }
+
+  /// Create a bit array from a binary string.
+  factory BitArray.parseBinary(String bitString) {
+    final data = Uint32List((bitString.length + 31) >> 5);
+    var bitIndex = 0;
+    for (var i = bitString.length - 1; i >= 0; i--) {
+      if (bitString[i] == '0') {
+        bitIndex++;
+        // Nothing to do
+      } else if (bitString[i] == '1') {
+        final wordIndex = (bitIndex) >> 5;
+        data[wordIndex] |= 1 << (bitIndex % 32);
+        bitIndex++;
+      } else {
+        throw FormatException('Binary string should consist of 0s and 1s only');
+      }
+    }
+    return BitArray._(data);
+  }
+
+  /// The value of the bit with the specified [index].
+  @override
+  bool operator [](int index) {
+    return (_data[index >> 5] & _bitMask[index & 0x1f]) != 0;
+  }
+
+  /// Sets the bit specified by the [index] to the [value].
+  void operator []=(int index, bool value) {
+    if (value) {
+      setBit(index);
+    } else {
+      clearBit(index);
+    }
+  }
+
+  /// The number of bit in this [BitArray].
+  ///
+  /// [length] will be rounded up to match the 32-bit boundary.
+  ///
+  /// The valid index values for the array are `0` through `length - 1`.
+  @override
+  int get length => _length;
+  set length(int value) {
+    if (_length == value) {
+      return;
+    }
+    if (_bufferLength32(_length) == _bufferLength32(value)) {
+      return;
+    }
+    final data = Uint32List(_bufferLength32(value));
+    data.setRange(0, math.min(data.length, _data.length), _data);
+    _data = data;
+    _length = _data.length << 5;
+  }
+
+  /// The number of bits set to true.
+  @override
+  int get cardinality => _data.buffer.asUint8List().fold(
+        0,
+        (sum, value) => sum + _cardinalityBitCounts[value],
+      );
+
+  /// Whether the [BitArray] is empty == has only zero values.
+  bool get isEmpty {
+    return _data.every((i) => i == 0);
+  }
+
+  /// Whether the [BitArray] is not empty == has set values.
+  bool get isNotEmpty {
+    return _data.any((i) => i != 0);
+  }
+
+  /// Sets the bit specified by the [index] to false.
+  void clearBit(int index) {
+    _data[index >> 5] &= _clearMask[index & 0x1f];
+  }
+
+  /// Sets the bits specified by the [indexes] to false.
+  void clearBits(Iterable<int> indexes) {
+    indexes.forEach(clearBit);
+  }
+
+  /// Sets the bits where the [fn] returns true, to false.
+  ///
+  /// Calls [fn] only for index values where the bit is true.
+  void clearWhere(bool Function(int index) fn) {
+    var index = 0;
+    for (var i = 0; i < _data.length; i++) {
+      var d = _data[i];
+      if (d == 0) {
+        index += 32;
+        continue;
+      }
+      for (var j = 0; j < _bitMask.length; j++) {
+        final bm = _bitMask[j];
+        if ((d & bm) != 0 && fn(index)) {
+          d = d & _clearMask[j];
+        }
+        index++;
+      }
+      _data[i] = d;
+    }
+  }
+
+  /// Sets the bits from [start] (inclusive) up to [end] (exclusive) to false.
+  void clearRange(int start, int end) {
+    assert(start >= 0 && start < _length);
+    assert(start <= end && end <= _length);
+    if (start == end) return;
+    final dataStart = start >> 5;
+    final dataEnd = (end - 1) >> 5;
+    final maskStart = start & 0x1f;
+    final maskEnd = (end - 1) & 0x1f;
+
+    if (dataStart == dataEnd) {
+      _data[dataStart] &=
+          _accClearMaskSkipped[maskStart] ^ _accClearMaskTaken[maskEnd];
+      return;
+    }
+    if (maskStart == 0) {
+      _data[dataStart] = 0;
+    } else {
+      _data[dataStart] &= _accClearMaskSkipped[maskStart];
+    }
+    _data.fillRange(dataStart + 1, dataEnd, 0);
+    if (maskEnd == 31) {
+      _data[dataEnd] = 0;
+    } else {
+      _data[dataEnd] &= _accClearMaskTaken[maskEnd];
+    }
+  }
+
+  /// Sets all of the bits in the current [BitArray] to false.
+  void clearAll() {
+    _data.fillRange(0, _data.length, 0);
+  }
+
+  /// Sets the bit specified by the [index] to true.
+  void setBit(int index) {
+    _data[index >> 5] |= _bitMask[index & 0x1f];
+  }
+
+  /// Sets the bits specified by the [indexes] to true.
+  void setBits(Iterable<int> indexes) {
+    indexes.forEach(setBit);
+  }
+
+  /// Sets the bits where the [fn] returns true, to true.
+  ///
+  /// Calls [fn] only for index values where the bit is false.
+  void setWhere(bool Function(int index) fn) {
+    var index = 0;
+    for (var i = 0; i < _data.length; i++) {
+      var d = _data[i];
+      if (d == -1) {
+        index += 32;
+        continue;
+      }
+      for (var j = 0; j < _bitMask.length; j++) {
+        final bm = _bitMask[j];
+        if ((d & bm) == 0 && fn(index)) {
+          d = d | bm;
+        }
+        index++;
+      }
+      _data[i] = d;
+    }
+  }
+
+  /// Sets the bits from [start] (inclusive) up to [end] (exclusive) to false.
+  void setRange(int start, int end) {
+    assert(start >= 0 && start < _length);
+    assert(start <= end && end <= _length);
+    if (start == end) return;
+    final dataStart = start >> 5;
+    final dataEnd = (end - 1) >> 5;
+    final maskStart = start & 0x1f;
+    final maskEnd = (end - 1) & 0x1f;
+
+    if (dataStart == dataEnd) {
+      _data[dataStart] |=
+          _accBitMaskSkipped[maskStart] & _accBitMaskTaken[maskEnd];
+      return;
+    }
+    if (maskStart == 0) {
+      _data[dataStart] = -1;
+    } else {
+      _data[dataStart] |= _accBitMaskSkipped[maskStart];
+    }
+    _data.fillRange(dataStart + 1, dataEnd, -1);
+    if (maskEnd == 31) {
+      _data[dataEnd] = -1;
+    } else {
+      _data[dataEnd] |= _accBitMaskTaken[maskEnd];
+    }
+  }
+
+  /// Sets all the bit values in the current [BitArray] to true.
+  void setAll() {
+    _data.fillRange(0, _data.length, -1);
+  }
+
+  /// Inverts the bit specified by the [index].
+  void invertBit(int index) {
+    this[index] = !this[index];
+  }
+
+  /// Inverts the bits specified by the [indexes].
+  void invertBits(Iterable<int> indexes) {
+    indexes.forEach(invertBit);
+  }
+
+  /// Inverts all the bit values in the current [BitArray].
+  void invertAll() {
+    for (var i = 0; i < _data.length; i++) {
+      _data[i] = ~(_data[i]);
+    }
+  }
+
+  /// Update the current [BitArray] using a logical AND operation with the
+  /// corresponding elements in the specified [set].
+  /// Excess size of the [set] is ignored.
+  void and(BitSet set) {
+    var i = 0;
+    // Special-case for efficient merging of two arrays.
+    if (set is BitArray) {
+      final minLength = math.min(_data.length, set._data.length);
+      for (; i < minLength; i++) {
+        _data[i] &= set._data[i];
+      }
+    } else {
+      final iter = set.asUint32Iterable().iterator;
+      for (; i < _data.length && iter.moveNext(); i++) {
+        _data[i] &= iter.current;
+      }
+    }
+
+    for (; i < _data.length; i++) {
+      _data[i] = 0;
+    }
+  }
+
+  /// Update the current [BitArray] using a logical AND NOT operation with the
+  /// corresponding elements in the specified [set].
+  /// Excess size of the [set] is ignored.
+  void andNot(BitSet set) {
+    // Special-case for efficient merging of two arrays.
+    if (set is BitArray) {
+      final minLength = math.min(_data.length, set._data.length);
+      for (var i = 0; i < minLength; i++) {
+        _data[i] &= ~set._data[i];
+      }
+    } else {
+      final iter = set.asUint32Iterable().iterator;
+      for (var i = 0; i < _data.length && iter.moveNext(); i++) {
+        _data[i] &= ~iter.current;
+      }
+    }
+  }
+
+  /// Update the current [BitArray] using a logical OR operation with the
+  /// corresponding elements in the specified [set].
+  /// Excess size of the [set] is ignored.
+  void or(BitSet set) {
+    // Special-case for efficient merging of two arrays.
+    if (set is BitArray) {
+      final minLength = math.min(_data.length, set._data.length);
+      for (var i = 0; i < minLength; i++) {
+        _data[i] |= set._data[i];
+      }
+    } else {
+      final iter = set.asUint32Iterable().iterator;
+      for (var i = 0; i < _data.length && iter.moveNext(); i++) {
+        _data[i] |= iter.current;
+      }
+    }
+  }
+
+  /// Update the current [BitArray] using a logical XOR operation with the
+  /// corresponding elements in the specified [set].
+  /// Excess size of the [set] is ignored.
+  void xor(BitSet set) {
+    // Special-case for efficient merging of two arrays.
+    if (set is BitArray) {
+      final minLength = math.min(_data.length, set._data.length);
+      for (var i = 0; i < minLength; i++) {
+        _data[i] = _data[i] ^ set._data[i];
+      }
+    } else {
+      final iter = set.asUint32Iterable().iterator;
+      for (var i = 0; i < _data.length && iter.moveNext(); i++) {
+        _data[i] = _data[i] ^ iter.current;
+      }
+    }
+  }
+
+  /// Creates a copy of the current [BitArray].
+  @override
+  BitArray clone() {
+    final newData = Uint32List(_data.length);
+    newData.setRange(0, _data.length, _data);
+    return BitArray._(newData);
+  }
+
+  /// Creates a [BitArray] using a logical AND operation with the
+  /// corresponding elements in the specified [set].
+  /// Excess size of the [set] is ignored.
+  BitArray operator &(BitSet set) => clone()..and(set);
+
+  /// Creates a [BitArray] using a logical AND NOT operation with the
+  /// corresponding elements in the specified [set].
+  /// Excess size of the [set] is ignored.
+  BitArray operator %(BitSet set) => clone()..andNot(set);
+
+  /// Creates a [BitArray] using a logical OR operation with the
+  /// corresponding elements in the specified [set].
+  /// Excess size of the [set] is ignored.
+  BitArray operator |(BitSet set) => clone()..or(set);
+
+  /// Creates a [BitArray] using a logical XOR operation with the
+  /// corresponding elements in the specified [set].
+  /// Excess size of the [set] is ignored.
+  BitArray operator ^(BitSet set) => clone()..xor(set);
+
+  /// Creates a string of 0s and 1s of the content of the array.
+  String toBinaryString() {
+    final sb = StringBuffer();
+    for (var i = 0; i < length; i++) {
+      sb.write(this[i] ? '1' : '0');
+    }
+    return sb.toString();
+  }
+
+  /// The backing, mutable byte buffer of the [BitArray].
+  /// Use with caution.
+  ByteBuffer get byteBuffer => _data.buffer;
+
+  /// Returns an iterable wrapper of the bit array that iterates over the index
+  /// numbers and returns the 32-bit int blocks.
+  @override
+  Iterable<int> asUint32Iterable() => _data;
+
+  /// Returns an iterable wrapper of the bit array that iterates over the index
+  /// numbers that match [value] (by default the bits that are set).
+  @override
+  Iterable<int> asIntIterable([bool value = true]) {
+    return _IntIterable(this, value);
+  }
+}
+
+final _bitMask = List<int>.generate(32, (i) => 1 << i);
+final _accBitMaskTaken = List<int>.generate(
+  32,
+  (i) => _bitMask.take(i + 1).fold(0, (a, b) => a | b),
+);
+final _accBitMaskSkipped = List<int>.generate(
+  32,
+  (i) => _bitMask.skip(i).fold(0, (a, b) => a | b),
+);
+final _clearMask = List<int>.generate(32, (i) => ~(1 << i));
+final _accClearMaskSkipped = List<int>.generate(
+  32,
+  (i) => _clearMask.skip(i).fold(-1, (a, b) => a & b),
+);
+final _accClearMaskTaken = List<int>.generate(
+  32,
+  (i) => _clearMask.take(i + 1).fold(-1, (a, b) => a & b),
+);
+
+final _cardinalityBitCounts = List<int>.generate(256, _cardinalityOfByte);
+
+int _cardinalityOfByte(int value) {
+  var result = 0;
+  while (value > 0) {
+    if (value & 0x01 != 0) {
+      result++;
+    }
+    value = value >> 1;
+  }
+  return result;
+}
+
+class _IntIterable extends IterableBase<int> {
+  final BitArray _array;
+  final bool _value;
+  _IntIterable(this._array, this._value);
+
+  @override
+  Iterator<int> get iterator =>
+      _IntIterator(_array._data, _array.length, _value);
+}
+
+class _IntIterator implements Iterator<int> {
+  final Uint32List _buffer;
+  final int _length;
+  final bool _matchValue;
+  final int _skipMatch;
+  final int _cursorMax = (1 << 31);
+  int _current = -1;
+  int _cursor = 0;
+  int _cursorByte = 0;
+  int _cursorMask = 1;
+
+  _IntIterator(this._buffer, this._length, this._matchValue)
+      : _skipMatch = _matchValue ? 0x00 : 0xffffffff;
+
+  @override
+  int get current => _current;
+
+  @override
+  bool moveNext() {
+    while (_cursor < _length) {
+      final value = _buffer[_cursorByte];
+      if (_cursorMask == 1 && value == _skipMatch) {
+        _cursorByte++;
+        _cursor += 32;
+        continue;
+      }
+      final isSet = (value & _cursorMask) != 0;
+      if (isSet == _matchValue) {
+        _current = _cursor;
+        _increment();
+        return true;
+      }
+      _increment();
+    }
+    return false;
+  }
+
+  void _increment() {
+    if (_cursorMask == _cursorMax) {
+      _cursorMask = 1;
+      _cursorByte++;
+    } else {
+      _cursorMask <<= 1;
+    }
+    _cursor++;
+  }
+}
+
+int _bufferLength32(int length) {
+  final hasExtra = (length & 0x1f) != 0;
+  return (length >> 5) + (hasExtra ? 1 : 0);
+}

--- a/app/lib/third_party/bit_array/bit_set.dart
+++ b/app/lib/third_party/bit_array/bit_set.dart
@@ -1,0 +1,53 @@
+/// An integer-indexed collection to test membership status.
+abstract class BitSet {
+  /// Whether the value specified by the [index] is member of the collection.
+  bool operator [](int index);
+
+  /// The largest addressable or contained member of the [BitSet]:
+  /// - Immutable sets should return the largest contained member.
+  /// - Fixed-memory sets should return the maximum addressable value.
+  int get length;
+
+  /// The number of members.
+  int get cardinality;
+
+  /// Creates a copy of the current [BitSet].
+  BitSet clone();
+
+  /// Returns an iterable wrapper that returns the content of the [BitSet] as
+  /// 32-bit int blocks. Members are iterated from a zero-based index and each
+  /// block contains 32 values as a bit index.
+  Iterable<int> asUint32Iterable();
+
+  /// Returns an iterable wrapper of the [BitSet] that iterates over the index
+  /// members that are set to true.
+  Iterable<int> asIntIterable();
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (other is BitSet &&
+        runtimeType == other.runtimeType &&
+        length == other.length) {
+      final iter = asUint32Iterable().iterator;
+      final otherIter = other.asUint32Iterable().iterator;
+      while (iter.moveNext() && otherIter.moveNext()) {
+        if (iter.current != otherIter.current) {
+          return false;
+        }
+      }
+      return true;
+    }
+    return false;
+  }
+
+  @override
+  int get hashCode =>
+      asUint32Iterable().fold(
+        0,
+        (int previousValue, element) => previousValue ^ element.hashCode,
+      ) ^
+      length.hashCode;
+}

--- a/app/test/search/mem_index_test.dart
+++ b/app/test/search/mem_index_test.dart
@@ -89,6 +89,12 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
       index = InMemoryPackageIndex(documents: docs);
     });
 
+    test('empty index search', () {
+      final index = InMemoryPackageIndex(documents: []);
+      final rs = index.search(ServiceSearchQuery.parse(query: 'text'));
+      expect(rs.packageHits, isEmpty);
+    });
+
     test('package name match: async', () async {
       final PackageSearchResult result =
           index.search(ServiceSearchQuery.parse(query: 'AsynC'));


### PR DESCRIPTION
- #8671
- There are two further potential improvements, but I would implement them in a subsequent PRs: (a) reusing the bitarray instance, and (b) not creating/using a `PackageScore` instance when the `BitArray` would suffice.
- Measured around 5-10% improvement for predicate-only search, and around 1-4% for more complex text matching + predicates.
