### PR TITLE
Slightly lower score for depluralized matches.

### DIFF
--- a/app/test/search/maps_test.dart
+++ b/app/test/search/maps_test.dart
@@ -30,7 +30,7 @@ void main() {
         'sdkLibraryHits': [],
         'packageHits': [
           {'package': 'maps', 'score': 1.0},
-          {'package': 'map', 'score': 1.0},
+          {'package': 'map', 'score': 0.99},
         ],
       });
     });

--- a/app/test/search/mem_index_test.dart
+++ b/app/test/search/mem_index_test.dart
@@ -562,8 +562,8 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
       final match2 = index.search(
           ServiceSearchQuery.parse(query: 'apps', order: SearchOrder.text));
       expect(match2.packageHits.map((e) => e.toJson()), [
-        {'package': 'app', 'score': 1.0},
         {'package': 'apps', 'score': 1.0},
+        {'package': 'app', 'score': 0.99},
       ]);
     });
 

--- a/app/test/search/package_name_index_test.dart
+++ b/app/test/search/package_name_index_test.dart
@@ -127,4 +127,20 @@ void main() {
       });
     });
   });
+
+  group('redis', () {
+    final index = PackageNameIndex([
+      'redis',
+      'x_redis_client',
+      'credit_union',
+    ]);
+
+    test('redis', () {
+      expect(index.search('redis'), {
+        'redis': 1.0,
+        'x_redis_client': 1.0,
+        'credit_union': 0.99,
+      });
+    });
+  });
 }


### PR DESCRIPTION
#8688

- fixes the oversight that the substring check should be done on the lowercased value.
- does not really solve the de-pluralization problem space, but slightly reduces the miss-attribution ranks