### PR TITLE
Stop removing 's' (depluralization) from package name matching.

### DIFF
--- a/app/lib/search/mem_index.dart
+++ b/app/lib/search/mem_index.dart
@@ -619,10 +619,7 @@ class PackageNameIndex {
     IndexedScore<String>? filterOnNonZeros,
   }) {
     assert(score.keys.length == _packageNames.length);
-    final singularWord = word.length <= 3 || !word.endsWith('s')
-        ? word
-        : word.substring(0, word.length - 1);
-    final lowercasedWord = singularWord.toLowerCase();
+    final lowercasedWord = word.toLowerCase();
     final collapsedWord = _removeUnderscores(lowercasedWord);
     final parts =
         collapsedWord.length <= 3 ? [collapsedWord] : trigrams(collapsedWord);

--- a/app/test/search/maps_test.dart
+++ b/app/test/search/maps_test.dart
@@ -30,7 +30,7 @@ void main() {
         'sdkLibraryHits': [],
         'packageHits': [
           {'package': 'maps', 'score': 1.0},
-          {'package': 'map', 'score': 1.0},
+          {'package': 'map', 'score': 0.5},
         ],
       });
     });

--- a/app/test/search/mem_index_test.dart
+++ b/app/test/search/mem_index_test.dart
@@ -562,8 +562,8 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
       final match2 = index.search(
           ServiceSearchQuery.parse(query: 'apps', order: SearchOrder.text));
       expect(match2.packageHits.map((e) => e.toJson()), [
-        {'package': 'app', 'score': 1.0},
         {'package': 'apps', 'score': 1.0},
+        {'package': 'app', 'score': 0.5},
       ]);
     });
 


### PR DESCRIPTION
- https://github.com/dart-lang/pub-dev/issues/8688
- alternative to #8692
