### PR TITLE
Download SDK index.jsons at docker build.

### DIFF
--- a/Dockerfile.app
+++ b/Dockerfile.app
@@ -33,6 +33,7 @@ WORKDIR /project/app
 RUN dart /project/tool/pub_get_offline.dart /project/app
 
 RUN /project/tool/setup-webp.sh /usr/local/bin
+RUN /project/tool/download-sdk-index-jsons.sh
 
 # Clear out any arguments the base images might have set
 CMD []

--- a/app/lib/search/dart_sdk_mem_index.dart
+++ b/app/lib/search/dart_sdk_mem_index.dart
@@ -38,10 +38,8 @@ SdkMemIndex? get dartSdkMemIndex =>
 Future<SdkMemIndex?> createDartSdkMemIndex() async {
   try {
     final index = await SdkMemIndex.dart();
-    final content = await searchBackend.fetchSdkIndexContentAsString(
-      baseUri: index.baseUri,
-      relativePath: 'index.json',
-    );
+    final content =
+        await searchBackend.loadOrFetchSdkIndexJsonAsString(index.indexJsonUri);
     await index.addDartdocIndex(DartdocIndex.parseJsonText(content));
     index.updateWeights(
       libraryWeights: dartSdkLibraryWeights,

--- a/app/lib/search/flutter_sdk_mem_index.dart
+++ b/app/lib/search/flutter_sdk_mem_index.dart
@@ -55,10 +55,8 @@ SdkMemIndex? get flutterSdkMemIndex =>
 Future<SdkMemIndex?> createFlutterSdkMemIndex() async {
   try {
     final index = SdkMemIndex.flutter();
-    final content = await searchBackend.fetchSdkIndexContentAsString(
-      baseUri: index.baseUri,
-      relativePath: 'index.json',
-    );
+    final content =
+        await searchBackend.loadOrFetchSdkIndexJsonAsString(index.indexJsonUri);
     await index.addDartdocIndex(DartdocIndex.parseJsonText(content),
         allowedLibraries: _allowedLibraries);
     index.updateWeights(

--- a/app/lib/search/sdk_mem_index.dart
+++ b/app/lib/search/sdk_mem_index.dart
@@ -4,7 +4,6 @@
 
 import 'dart:math';
 
-import 'package:_pub_shared/utils/http.dart';
 import 'package:meta/meta.dart';
 // ignore: implementation_imports
 import 'package:pana/src/dartdoc/dartdoc_index.dart';
@@ -36,37 +35,11 @@ class SdkMemIndex {
         _baseUri = baseUri;
 
   static Future<SdkMemIndex> dart() async {
-    final versions = <String>{
-      toolStableDartSdkVersion,
-      runtimeSdkVersion,
-    };
-    final client = httpRetryClient();
-    try {
-      for (final version in versions) {
-        final uri = _dartSdkBaseUri(version);
-        final rs = await client.head(uri);
-        if (rs.statusCode < 400) {
-          return SdkMemIndex(sdk: 'dart', version: version, baseUri: uri);
-        }
-      }
-    } finally {
-      client.close();
-    }
     return SdkMemIndex(
       sdk: 'dart',
       version: runtimeSdkVersion,
-      baseUri: _dartSdkBaseUri(runtimeSdkVersion),
+      baseUri: Uri.parse('https://api.dart.dev/stable/latest/'),
     );
-  }
-
-  static Uri _dartSdkBaseUri(String version) {
-    var branch = 'stable';
-    if (version.contains('beta')) {
-      branch = 'beta';
-    } else if (version.contains('dev')) {
-      branch = 'dev';
-    }
-    return Uri.parse('https://api.dart.dev/$branch/$version/');
   }
 
   factory SdkMemIndex.flutter() {
@@ -77,7 +50,7 @@ class SdkMemIndex {
     );
   }
 
-  Uri get baseUri => _baseUri;
+  late final indexJsonUri = _baseUri.resolve('index.json');
 
   Future<void> addDartdocIndex(
     DartdocIndex index, {

--- a/app/test/search/backend_test.dart
+++ b/app/test/search/backend_test.dart
@@ -14,10 +14,8 @@ void main() {
   group('search backend', () {
     testWithProfile('fetch SDK library description', fn: () async {
       final index = await SdkMemIndex.dart();
-      final content = await searchBackend.fetchSdkIndexContentAsString(
-        baseUri: index.baseUri,
-        relativePath: 'index.json',
-      );
+      final content = await searchBackend
+          .loadOrFetchSdkIndexJsonAsString(index.indexJsonUri);
       await index.addDartdocIndex(DartdocIndex.parseJsonText(content));
       expect(
         index.getLibraryDescription('dart:async'),

--- a/tool/download-sdk-index-jsons.sh
+++ b/tool/download-sdk-index-jsons.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+cd "$SCRIPT_DIR/../app/"
+mkdir -p .dart_tool/pub-search-data
+cd .dart_tool/pub-search-data
+
+echo "Downloading Dart SDK index.json"
+curl -o https-api.dart.dev-stable-latest-index.json https://api.dart.dev/stable/latest/index.json
+
+echo "Downloading Flutter SDK index.json"
+curl -o https-api.flutter.dev-flutter-index.json https://api.flutter.dev/flutter/index.json


### PR DESCRIPTION
- #8670
- The cache location is reused from the test, but instead of hand-provided filename, I've opted to use the URL as the template.
- The TTL is there only for the test to re-download the files periodically, so that we catch regressions. (TBD: should we download the beta channel instead in tests?)
- The docker build will download the files, or will fail during the build. However, if #8680 lands, we could also assert the presence of the files and not fall back to downloading them.