### PR TITLE
Exporting the per-package RSS/atom feed with the rest of exported APIs.

### DIFF
--- a/app/lib/admin/actions/moderate_package.dart
+++ b/app/lib/admin/actions/moderate_package.dart
@@ -79,6 +79,9 @@ Note: the action may take a longer time to complete as the public archive bucket
         return pkg;
       });
 
+      // make sure visibility cache is updated immediately
+      await purgePackageCache(package);
+
       // sync exported API(s)
       await apiExporter?.synchronizePackage(package, forceDelete: true);
 

--- a/app/lib/admin/actions/moderate_package_versions.dart
+++ b/app/lib/admin/actions/moderate_package_versions.dart
@@ -112,6 +112,9 @@ Set the moderated flag on a package version (updating the flag and the timestamp
         return v;
       });
 
+      // make sure visibility cache is updated immediately
+      await purgePackageCache(package);
+
       // sync exported API(s)
       await apiExporter?.synchronizePackage(package, forceDelete: true);
 

--- a/app/lib/frontend/handlers/atom_feed.dart
+++ b/app/lib/frontend/handlers/atom_feed.dart
@@ -32,7 +32,7 @@ Future<shelf.Response> allPackagesAtomFeedhandler(shelf.Request request) async {
   );
 }
 
-/// Handles requests for `/packages/<package>/feed.atom`
+/// Handles requests for `/api/packages/<package>/feed.atom`
 Future<shelf.Response> packageAtomFeedhandler(
   shelf.Request request,
   String package,

--- a/app/lib/frontend/handlers/pubapi.client.dart
+++ b/app/lib/frontend/handlers/pubapi.client.dart
@@ -132,6 +132,13 @@ class PubApiClient {
     ));
   }
 
+  Future<List<int>> packageAtomFeed(String package) async {
+    return await _client.requestBytes(
+      verb: 'get',
+      path: '/api/packages/$package/feed.atom',
+    );
+  }
+
   Future<_i5.PublisherInfo> createPublisher(String publisherId) async {
     return _i5.PublisherInfo.fromJson(await _client.requestJson(
       verb: 'post',

--- a/app/lib/frontend/handlers/pubapi.dart
+++ b/app/lib/frontend/handlers/pubapi.dart
@@ -9,6 +9,7 @@ import 'package:_pub_shared/data/package_api.dart';
 import 'package:_pub_shared/data/publisher_api.dart';
 import 'package:_pub_shared/data/task_api.dart';
 import 'package:api_builder/api_builder.dart';
+import 'package:pub_dev/frontend/handlers/atom_feed.dart';
 import 'package:shelf/shelf.dart';
 import 'package:shelf_router/shelf_router.dart';
 
@@ -214,6 +215,11 @@ class PubApi {
     InviteUploaderRequest invite,
   ) async =>
       await packageBackend.inviteUploader(package, invite);
+
+  /// Renders the Atom XML feed for the package.
+  @EndPoint.get('/api/packages/<package>/feed.atom')
+  Future<Response> packageAtomFeed(Request request, String package) =>
+      packageAtomFeedhandler(request, package);
 
   // ****
   // **** Publisher API

--- a/app/lib/frontend/handlers/pubapi.g.dart
+++ b/app/lib/frontend/handlers/pubapi.g.dart
@@ -255,6 +255,26 @@ Router _$PubApiRouter(PubApi service) {
     },
   );
   router.add(
+    'GET',
+    r'/api/packages/<package>/feed.atom',
+    (
+      Request request,
+      String package,
+    ) async {
+      try {
+        final _$result = await service.packageAtomFeed(
+          request,
+          package,
+        );
+        return _$result;
+      } on ApiResponseException catch (e) {
+        return e.asApiResponse();
+      } catch (e, st) {
+        return $utilities.unhandledError(e, st);
+      }
+    },
+  );
+  router.add(
     'POST',
     r'/api/publishers/<publisherId>',
     (

--- a/app/lib/frontend/handlers/routes.dart
+++ b/app/lib/frontend/handlers/routes.dart
@@ -176,11 +176,6 @@ class PubSiteService {
   Future<Response> packageVersions(Request request, String package) =>
       packageVersionsListHandler(request, package);
 
-  /// Renders the Atom XML feed for the package.
-  @Route.get('/packages/<package>/feed.atom')
-  Future<Response> packageAtomFeed(Request request, String package) =>
-      packageAtomFeedhandler(request, package);
-
   @Route.get('/packages/<package>')
   Future<Response> package(Request request, String package) =>
       packageVersionHandlerHtml(request, package);

--- a/app/lib/frontend/handlers/routes.g.dart
+++ b/app/lib/frontend/handlers/routes.g.dart
@@ -160,11 +160,6 @@ Router _$PubSiteServiceRouter(PubSiteService service) {
   );
   router.add(
     'GET',
-    r'/packages/<package>/feed.atom',
-    service.packageAtomFeed,
-  );
-  router.add(
-    'GET',
     r'/packages/<package>',
     service.package,
   );

--- a/app/lib/package/api_export/api_exporter.dart
+++ b/app/lib/package/api_export/api_exporter.dart
@@ -244,6 +244,10 @@ final class ApiExporter {
           versionListing,
           forceWrite: forceWrite,
         );
+    await _api.package(package).feedAtomFile.write(
+          await buildPackageAtomFeedContent(package),
+          forceWrite: forceWrite,
+        );
   }
 
   /// Scan for updates from packages until [abort] is resolved, or [claim]

--- a/app/lib/package/api_export/exported_api.dart
+++ b/app/lib/package/api_export/exported_api.dart
@@ -273,6 +273,13 @@ final class ExportedPackage {
   ExportedJsonFile<ListAdvisoriesResponse> get advisories =>
       _suffix<ListAdvisoriesResponse>('/advisories');
 
+  /// Interface for writing `/api/packages/<package>/feed.atom`
+  ExportedAtomFeedFile get feedAtomFile => ExportedAtomFeedFile._(
+        _owner,
+        '/api/packages/$_package/feed.atom',
+        Duration(hours: 12),
+      );
+
   /// Interace for writing `/api/archives/<package>-<version>.tar.gz`.
   ExportedBlob tarball(String version) => ExportedBlob._(
         _owner,
@@ -399,6 +406,7 @@ final class ExportedPackage {
     await Future.wait([
       _owner._pool.withResource(() async => await versions.delete()),
       _owner._pool.withResource(() async => await advisories.delete()),
+      _owner._pool.withResource(() async => await feedAtomFile.delete()),
       ..._owner._prefixes.map((prefix) async {
         await _owner._listBucket(
           prefix: prefix + '/api/archives/$_package-',

--- a/app/lib/shared/urls.dart
+++ b/app/lib/shared/urls.dart
@@ -135,7 +135,7 @@ String pkgArchiveDownloadUrl(String package, String version, {Uri? baseUri}) {
 }
 
 String pkgFeedUrl(String package) {
-  return '/packages/$package/feed.atom';
+  return '/api/packages/$package/feed.atom';
 }
 
 String pkgDocUrl(

--- a/app/test/admin/exported_api_sync_test.dart
+++ b/app/test/admin/exported_api_sync_test.dart
@@ -82,11 +82,13 @@ void main() {
         '$runtimeVersion/api/archives/oxygen-2.0.0-dev.tar.gz',
         '$runtimeVersion/api/packages/oxygen',
         '$runtimeVersion/api/packages/oxygen/advisories',
+        '$runtimeVersion/api/packages/oxygen/feed.atom',
         'latest/api/archives/oxygen-1.0.0.tar.gz',
         'latest/api/archives/oxygen-1.2.0.tar.gz',
         'latest/api/archives/oxygen-2.0.0-dev.tar.gz',
         'latest/api/packages/oxygen',
         'latest/api/packages/oxygen/advisories',
+        'latest/api/packages/oxygen/feed.atom',
       });
 
       final oxygenDataJson = data['latest/api/packages/oxygen'];

--- a/app/test/frontend/handlers/atom_feed_test.dart
+++ b/app/test/frontend/handlers/atom_feed_test.dart
@@ -77,9 +77,9 @@ void main() {
     });
   });
 
-  testWithProfile('/packages/<package>/feed.atom', fn: () async {
+  testWithProfile('/api/packages/<package>/feed.atom', fn: () async {
     final content = await expectAtomXmlResponse(
-        await issueGet('/packages/oxygen/feed.atom'));
+        await issueGet('/api/packages/oxygen/feed.atom'));
     // check if content is valid XML
     final root = XmlDocument.parse(content);
     final feed = root.rootElement;
@@ -110,11 +110,11 @@ void main() {
     entries.forEach((e) => e.parent!.children.remove(e));
 
     final restExp = RegExp('<feed xmlns="http://www.w3.org/2005/Atom">\n'
-        '  <id>${activeConfiguration.primarySiteUri}/packages/oxygen/feed.atom</id>\n'
+        '  <id>${activeConfiguration.primarySiteUri}/api/packages/oxygen/feed.atom</id>\n'
         '  <title>Recently published versions of package oxygen on pub.dev</title>\n'
         '  <updated>(.*)</updated>\n'
         '  <link href="${activeConfiguration.primarySiteUri}/packages/oxygen" rel="alternate"/>\n'
-        '  <link href="${activeConfiguration.primarySiteUri}/packages/oxygen/feed.atom" rel="self"/>\n'
+        '  <link href="${activeConfiguration.primarySiteUri}/api/packages/oxygen/feed.atom" rel="self"/>\n'
         '  <generator version="0.1.0">Pub Feed Generator</generator>\n'
         '  <subtitle>oxygen is awesome</subtitle>\n'
         '(\\s*)'

--- a/app/test/package/api_export/api_exporter_test.dart
+++ b/app/test/package/api_export/api_exporter_test.dart
@@ -132,6 +132,10 @@ Future<void> _testExportedApiSynchronization(
       isNotNull,
     );
     expect(
+      await bucket.readBytes('$runtimeVersion/api/packages/foo/feed.atom'),
+      isNotNull,
+    );
+    expect(
       await bucket.readGzippedJson('$runtimeVersion/api/packages/foo'),
       {
         'name': 'foo',
@@ -150,6 +154,10 @@ Future<void> _testExportedApiSynchronization(
     );
     expect(
       await bucket.readString('$runtimeVersion/feed.atom'),
+      contains('v1.0.0 of foo'),
+    );
+    expect(
+      await bucket.readString('$runtimeVersion/api/packages/foo/feed.atom'),
       contains('v1.0.0 of foo'),
     );
   }
@@ -185,6 +193,10 @@ Future<void> _testExportedApiSynchronization(
       await bucket.readString('latest/feed.atom'),
       contains('v1.0.0 of foo'),
     );
+    expect(
+      await bucket.readString('latest/api/packages/foo/feed.atom'),
+      contains('v1.0.0 of foo'),
+    );
     // Note. that name completion data won't be updated until search caches
     //       are purged, so we won't test that it is updated.
 
@@ -203,6 +215,10 @@ Future<void> _testExportedApiSynchronization(
     );
     expect(
       await bucket.readString('latest/feed.atom'),
+      contains('v2.0.0 of bar'),
+    );
+    expect(
+      await bucket.readString('latest/api/packages/bar/feed.atom'),
       contains('v2.0.0 of bar'),
     );
   }
@@ -245,6 +261,10 @@ Future<void> _testExportedApiSynchronization(
     );
     expect(
       await bucket.readString('$runtimeVersion/feed.atom'),
+      contains('v3.0.0 of bar'),
+    );
+    expect(
+      await bucket.readString('latest/api/packages/bar/feed.atom'),
       contains('v3.0.0 of bar'),
     );
   }
@@ -422,6 +442,10 @@ Future<void> _testExportedApiSynchronization(
 
     expect(
       await bucket.readGzippedJson('latest/api/packages/bar'),
+      isNull,
+    );
+    expect(
+      await bucket.readGzippedJson('latest/api/packages/feed.atom'),
       isNull,
     );
     expect(

--- a/pkg/_pub_shared/lib/src/pubapi.client.dart
+++ b/pkg/_pub_shared/lib/src/pubapi.client.dart
@@ -132,6 +132,13 @@ class PubApiClient {
     ));
   }
 
+  Future<List<int>> packageAtomFeed(String package) async {
+    return await _client.requestBytes(
+      verb: 'get',
+      path: '/api/packages/$package/feed.atom',
+    );
+  }
+
   Future<_i5.PublisherInfo> createPublisher(String publisherId) async {
     return _i5.PublisherInfo.fromJson(await _client.requestJson(
       verb: 'post',


### PR DESCRIPTION
- #1378 and #5267
- Moved the endpoint from `/packages/<package>/feed.atom` to `/api/packages/<package>/feed.atom`. Since it is mostly read by machines, I think it should live under the `/api/` namespace, and it aligns better with the exported API files as well.
- Added extra cache purge on admin actions, as it was simpler to do than to exempt the cache use inside the per-package atom feed creation (specifically the check whether a package is visible).
- Updated and extended tests to verify the successful export.