### PR TITLE
Refactor task backend's low-level data access.

### DIFF
--- a/app/lib/shared/datastore.dart
+++ b/app/lib/shared/datastore.dart
@@ -21,10 +21,13 @@ final Logger _logger = Logger('pub.datastore_helper');
 /// Wrap [Transaction] to avoid exposing [Transaction.commit] and
 /// [Transaction.rollback].
 class TransactionWrapper {
+  final DatastoreDB _db;
   final Transaction _tx;
   bool _mutated = false;
 
-  TransactionWrapper._(this._tx);
+  TransactionWrapper._(this._db, this._tx);
+
+  Key get emptyKey => _db.emptyKey;
 
   /// See [Transaction.lookup].
   Future<List<T?>> lookup<T extends Model>(List<Key> keys) =>
@@ -111,7 +114,7 @@ Future<T> _withTransaction<T>(
     return await db.withTransaction<T>((tx) async {
       bool commitAttempted = false;
       try {
-        final wrapper = TransactionWrapper._(tx);
+        final wrapper = TransactionWrapper._(db, tx);
         final retval = await fn(wrapper);
         if (wrapper._mutated) {
           commitAttempted = true;

--- a/app/lib/task/models.dart
+++ b/app/lib/task/models.dart
@@ -73,13 +73,13 @@ Duration taskRetryDelay(int attempts) =>
 ///  * `PackageState` entities never have a parent.
 @db.Kind(name: 'PackageState', idType: db.IdType.String)
 class PackageState extends db.ExpandoModel<String> {
-  /// Create a key for [runtimeVersion] and [packageName] in [ddb].
+  /// Create a key for [runtimeVersion] and [packageName] using the Datastore's empty key.
   static db.Key<String> createKey(
-    db.DatastoreDB ddb,
+    db.Key emptyKey,
     String runtimeVersion,
     String packageName,
   ) =>
-      ddb.emptyKey.append<String>(
+      emptyKey.append<String>(
         PackageState,
         id: '$runtimeVersion/$packageName',
       );


### PR DESCRIPTION
- An iteration over #8705.
- Uses extensions methods to create a short-lived wrapper object that allows `DatastoreDB.tasks.lookupOrNull('pkg')` calls, which should be easy to reason about and also replace with their SQL counterparts.
- Some transactional update methods (e.g. `updateDependencyChanged` or `bumpPriority`) are easy to refactor enclosing the transaction logic, but others (e.g. the `trackPackage` method) is not that easy, and kept it as-is for now.
- Separated the `insert`/`update` methods, not really sure if it is helpful, but at least we have a quick overview where we are updating/inserting the entities.