### PR TITLE
Check the saved file length + md5 hash at upload processing.

### DIFF
--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -918,7 +918,7 @@ class PackageBackend {
       final fileLength = await file.length();
       if (fileLength != info.length) {
         _logger.warning(
-            'Saved file length missmatch ($fileLength != ${info.length}).');
+            'Saved file length mismatch ($fileLength != ${info.length}).');
         throw InvalidInputException(
             'Failed to save uploaded file: length mismatch.');
       }

--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -926,7 +926,7 @@ class PackageBackend {
       if (!md5Hash.byteToByteEquals(info.md5Hash)) {
         _logger.warning('Saved file md5 missmatch.');
         throw InvalidInputException(
-            'Failed to save uploaded file: md5 missmatch.');
+            'Failed to save uploaded file: md5 mismatch.');
       }
       final sha256Hash = (await file.openRead().transform(sha256).single).bytes;
       final archive = await summarizePackageArchive(

--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -915,6 +915,19 @@ class PackageBackend {
       _logger.info('Examining tarball content ($guid).');
       final sw = Stopwatch()..start();
       final file = File(filename);
+      final fileLength = await file.length();
+      if (fileLength != info.length) {
+        _logger.warning(
+            'Saved file length missmatch ($fileLength != ${info.length}).');
+        throw InvalidInputException(
+            'Failed to save uploaded file: length missmatch.');
+      }
+      final md5Hash = (await file.openRead().transform(md5).single).bytes;
+      if (!md5Hash.byteToByteEquals(info.md5Hash)) {
+        _logger.warning('Saved file md5 missmatch.');
+        throw InvalidInputException(
+            'Failed to save uploaded file: md5 missmatch.');
+      }
       final sha256Hash = (await file.openRead().transform(sha256).single).bytes;
       final archive = await summarizePackageArchive(
         filename,

--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -920,7 +920,7 @@ class PackageBackend {
         _logger.warning(
             'Saved file length missmatch ($fileLength != ${info.length}).');
         throw InvalidInputException(
-            'Failed to save uploaded file: length missmatch.');
+            'Failed to save uploaded file: length mismatch.');
       }
       final md5Hash = (await file.openRead().transform(md5).single).bytes;
       if (!md5Hash.byteToByteEquals(info.md5Hash)) {

--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -924,7 +924,7 @@ class PackageBackend {
       }
       final md5Hash = (await file.openRead().transform(md5).single).bytes;
       if (!md5Hash.byteToByteEquals(info.md5Hash)) {
-        _logger.warning('Saved file md5 missmatch.');
+        _logger.warning('Saved file md5 mismatch.');
         throw InvalidInputException(
             'Failed to save uploaded file: md5 mismatch.');
       }


### PR DESCRIPTION
- The length check is cheap and catches trivial issues.
- The md5 check seems to be better than the CRC32, and should provide more confidence.