### PR TITLE
Do not try to update local built files in regular frontend startup.

### DIFF
--- a/app/lib/service/entrypoint/frontend.dart
+++ b/app/lib/service/entrypoint/frontend.dart
@@ -41,12 +41,11 @@ class DefaultCommand extends Command {
 }
 
 Future _main() async {
-  await updateLocalBuiltFilesIfNeeded();
-  final appHandler = createAppHandler();
-
   if (envConfig.isRunningLocally) {
+    await updateLocalBuiltFilesIfNeeded();
     await watchForResourceChanges();
   }
+  final appHandler = createAppHandler();
   await nameTracker.startTracking();
   await announcementBackend.start();
   await topPackages.start();


### PR DESCRIPTION
- Fixes https://github.com/dart-lang/pub-dev/issues/8673.
- As discussed on #8680 we don't want the startup to fail if such files are not present, instead, they will be served with `404 Not found`.