### PR TITLE
Use new HTTP GET retry logic in SearchClient.

### DIFF
--- a/app/lib/search/search_client.dart
+++ b/app/lib/search/search_client.dart
@@ -75,7 +75,7 @@ class SearchClient {
           Uri.parse(serviceUrl),
           client: _httpClient,
           headers: cloudTraceHeaders(),
-          timeout: Duration(seconds: 5),
+          perRequestTimeout: Duration(seconds: 5),
           retryIf: (e) => (e is UnexpectedStatusException &&
               e.statusCode == searchIndexNotReadyCode),
           responseFn: (rs) => (statusCode: rs.statusCode, body: rs.body),

--- a/app/lib/search/search_client.dart
+++ b/app/lib/search/search_client.dart
@@ -8,7 +8,6 @@ import 'dart:convert';
 import 'package:_pub_shared/utils/http.dart';
 import 'package:clock/clock.dart';
 import 'package:gcloud/service_scope.dart' as ss;
-import 'package:http/http.dart' as http;
 
 import '../../../service/rate_limit/rate_limit.dart';
 import '../shared/configuration.dart';
@@ -33,15 +32,12 @@ SearchClient get searchClient => ss.lookup(#_searchClient) as SearchClient;
 /// indexed data.
 class SearchClient {
   /// The HTTP client used for making calls to our search service.
-  final http.Client _httpClient;
+  final _httpClient = httpRetryClient();
 
   /// Before this timestamp we may use the fallback search service URL, which
   /// is the unversioned service URL, potentially getting responses from an
   /// older instance.
   final _fallbackSearchThreshold = clock.now().add(Duration(minutes: 30));
-
-  SearchClient([http.Client? client])
-      : _httpClient = client ?? httpRetryClient(retries: 3);
 
   /// Calls the search service (or uses cache) to serve the [query].
   Future<PackageSearchResult> search(
@@ -69,16 +65,25 @@ class SearchClient {
       skipCache = true;
     }
 
-    // returns null on timeout (after 5 seconds)
-    Future<http.Response?> doCallHttpServiceEndpoint({String? prefix}) async {
+    // Returns the status code and the body of the last response, or null on timeout.
+    Future<({int statusCode, String? body})?> doCallHttpServiceEndpoint(
+        {String? prefix}) async {
       final httpHostPort = prefix ?? activeConfiguration.searchServicePrefix;
       final serviceUrl = '$httpHostPort/search$serviceUrlParams';
       try {
-        return await _httpClient
-            .get(Uri.parse(serviceUrl), headers: cloudTraceHeaders())
-            .timeout(Duration(seconds: 5));
+        return await httpGetWithRetry(
+          Uri.parse(serviceUrl),
+          client: _httpClient,
+          headers: cloudTraceHeaders(),
+          timeout: Duration(seconds: 5),
+          retryIf: (e) => (e is UnexpectedStatusException &&
+              e.statusCode == searchIndexNotReadyCode),
+          responseFn: (rs) => (statusCode: rs.statusCode, body: rs.body),
+        );
       } on TimeoutException {
         return null;
+      } on UnexpectedStatusException catch (e) {
+        return (statusCode: e.statusCode, body: null);
       }
     }
 
@@ -103,7 +108,7 @@ class SearchClient {
       }
       if (response.statusCode == 200) {
         return PackageSearchResult.fromJson(
-          json.decode(response.body) as Map<String, dynamic>,
+          json.decode(response.body!) as Map<String, dynamic>,
         );
       }
       // Search request before the service initialization completed.

--- a/pkg/_pub_shared/lib/utils/http.dart
+++ b/pkg/_pub_shared/lib/utils/http.dart
@@ -58,6 +58,7 @@ Future<K> httpGetWithRetry<K>(
   Duration? perRequestTimeout,
 
   /// Additional retry conditions (on top of the default ones).
+  /// Note: check for [UnexpectedStatusException] to allow non-200 response status codes.
   bool Function(Exception e)? retryIf,
 }) async {
   return await retry(

--- a/pkg/_pub_shared/lib/utils/http.dart
+++ b/pkg/_pub_shared/lib/utils/http.dart
@@ -50,7 +50,7 @@ Future<K> httpGetWithRetry<K>(
 
   /// The HTTP client to use.
   ///
-  /// Note: when the client is not specified, the inner loop will create a new [Client] object on each retry attempt.
+  /// Note: when the client is not specified, the inner loop will create a new [http.Client] object on each retry attempt.
   http.Client? client,
   Map<String, String>? headers,
 

--- a/pkg/_pub_shared/lib/utils/http.dart
+++ b/pkg/_pub_shared/lib/utils/http.dart
@@ -50,7 +50,7 @@ Future<K> httpGetWithRetry<K>(
 
   /// The HTTP client to use.
   ///
-  /// Note: when the client is specified, the inner loop will not create a new client object on retries.
+  /// Note: when the client is not specified, the inner loop will create a new [Client] object on each retry attempt.
   http.Client? client,
   Map<String, String>? headers,
 

--- a/pkg/_pub_shared/lib/utils/http.dart
+++ b/pkg/_pub_shared/lib/utils/http.dart
@@ -55,7 +55,7 @@ Future<K> httpGetWithRetry<K>(
   Map<String, String>? headers,
 
   /// Per-request time amount that will be applied on the overall HTTP request.
-  Duration? timeout,
+  Duration? perRequestTimeout,
 
   /// Additional retry conditions (on top of the default ones).
   bool Function(Exception e)? retryIf,
@@ -66,8 +66,8 @@ Future<K> httpGetWithRetry<K>(
       final effectiveClient = client ?? http.Client();
       try {
         var f = effectiveClient.get(uri, headers: headers);
-        if (timeout != null) {
-          f = f.timeout(timeout);
+        if (perRequestTimeout != null) {
+          f = f.timeout(perRequestTimeout);
         }
         final rs = await f;
         if (rs.statusCode == 200) {


### PR DESCRIPTION
This extends the retry utility method with timeout, headers and caller-provided client. However, on a retry, this client is not recreated (whether and how to express this is to be done in a subsequent PR).