### PR TITLE
Extract most UserSession DatastoreDB access methods.

### DIFF
--- a/app/lib/frontend/handlers/account.dart
+++ b/app/lib/frontend/handlers/account.dart
@@ -138,12 +138,7 @@ Future<shelf.Response> invalidateSessionHandler(shelf.Request request) async {
   final userId = requestContext.authenticatedUserId;
   // Invalidate the server-side session object, in case the user signed out because
   // the local cookie store was compromised.
-  if (sessionId != null) {
-    await accountBackend.invalidateUserSession(sessionId);
-  }
-  if (userId != null) {
-    await accountBackend.invalidateAllUserSessions(userId);
-  }
+  await accountBackend.deleteUserSessions(userId: userId, sessionId: sessionId);
   return jsonResponse(
     {},
     // Clear cookie, so we don't have to lookup an invalid sessionId.


### PR DESCRIPTION
- #8652
- Note: `createOrUpdateClientSession` could be also moved to the data access parts, but it felt it has more direct and transactional logic and we should rather keep it there. However, during the SQL migration we will migrate it alongside the data access methods.