### PR TITLE
Upgrade dependencies.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ AppEngine version, listed here to ease deployment and troubleshooting.
 ## Next Release (replace with git tag when deployed)
  * Bump runtimeVersion to `2025.04.29`.
  * Upgraded stable Dart analysis SDK to `3.7.3`
+ * Upgraded dependencies.
 
 ## `20250424t115200-all`
  * Bump runtimeVersion to `2025.04.24`.

--- a/pkg/api_builder/lib/src/api_router_generator.dart
+++ b/pkg/api_builder/lib/src/api_router_generator.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// ignore_for_file: deprecated_member_use
+
 import 'package:analyzer/dart/element/element.dart' show ClassElement;
 import 'package:analyzer/dart/element/type.dart' show ParameterizedType;
 import 'package:code_builder/code_builder.dart' as code;

--- a/pkg/api_builder/lib/src/client_library_generator.dart
+++ b/pkg/api_builder/lib/src/client_library_generator.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// ignore_for_file: deprecated_member_use
+
 import 'package:analyzer/dart/element/element.dart'
     show ClassElement, ExecutableElement;
 import 'package:analyzer/dart/element/type.dart'

--- a/pkg/api_builder/lib/src/shared.dart
+++ b/pkg/api_builder/lib/src/shared.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// ignore_for_file: deprecated_member_use
+
 import 'package:analyzer/dart/element/element.dart'
     show ClassElement, ExecutableElement, ParameterElement;
 import 'package:analyzer/dart/element/type.dart' show DartType;

--- a/pkg/web_app/lib/script.dart
+++ b/pkg/web_app/lib/script.dart
@@ -48,7 +48,8 @@ void _setupDarkThemeButton() {
     button.onClick.listen((_) {
       final classes = document.body!.classList;
       final isCurrentlyDark = classes.contains('dark-theme');
-      window.localStorage['colorTheme'] = isCurrentlyDark ? 'false' : 'true';
+      window.localStorage
+          .setItem('colorTheme', isCurrentlyDark ? 'false' : 'true');
       classes.toggle('dark-theme');
       classes.toggle('light-theme');
     });

--- a/pkg/web_app/lib/src/hoverable.dart
+++ b/pkg/web_app/lib/src/hoverable.dart
@@ -120,7 +120,7 @@ void _setEventForPreCodeCopyToClipboard() {
 
     final feedback = HTMLDivElement()
       ..classList.add('-pub-pre-copy-feedback')
-      ..text = 'copied to clipboard';
+      ..textContent = 'copied to clipboard';
     container.append(feedback);
 
     _setupCopyAndFeedbackButton(
@@ -176,7 +176,7 @@ void _updateXAgoLabels() {
     final newLabel = formatXAgo(DateTime.now().difference(timestamp));
     final oldLabel = e.textContent;
     if (oldLabel != newLabel) {
-      e.text = newLabel;
+      e.textContent = newLabel;
     }
   });
 }
@@ -188,7 +188,7 @@ void _setEventForXAgo() {
       event.preventDefault();
       event.stopPropagation();
       final text = e.textContent;
-      e.text = e.getAttribute('title') ?? '';
+      e.textContent = e.getAttribute('title') ?? '';
       e.setAttribute('title', text!);
     });
   });

--- a/pkg/web_app/lib/src/widget/downloads_chart/widget.dart
+++ b/pkg/web_app/lib/src/widget/downloads_chart/widget.dart
@@ -303,7 +303,7 @@ void drawChart(
       tickLabel.setAttribute(
           'class', 'downloads-chart-tick-label  downloads-chart-tick-label-x');
     }
-    tickLabel.text = formatAbbrMonthDay(date);
+    tickLabel.textContent = formatAbbrMonthDay(date);
     tickLabel.setAttribute('y', '$tickLabelYCoordinate');
     tickLabel.setAttribute('x', '$x');
 
@@ -321,7 +321,7 @@ void drawChart(
     final suffix = displayMode == DisplayMode.percentage
         ? '%'
         : compactFormat(i * interval).suffix;
-    tickLabel.text = '${compactFormat(i * interval).value}$suffix';
+    tickLabel.textContent = '${compactFormat(i * interval).value}$suffix';
     tickLabel.setAttribute('x', '${xMax + marginPadding}');
     tickLabel.setAttribute('y', '$y');
     chart.append(tickLabel);
@@ -439,7 +439,7 @@ void drawChart(
 
     final legendLabel = SVGTextElement();
     legendLabel.setAttribute('class', 'downloads-chart-tick-label');
-    legendLabel.text = ranges[i];
+    legendLabel.textContent = ranges[i];
     chart.append(legendLabel);
     chart.append(legend);
     legends.add((legend, legendLabel));
@@ -629,7 +629,7 @@ void drawChart(
         'top:${e.y + toolTipOffsetFromMouse + document.scrollingElement!.scrollTop}px;$horizontalPosition');
     toolTip.replaceChildren(HTMLDivElement()
       ..setAttribute('class', 'downloads-chart-tooltip-date')
-      ..text =
+      ..textContent =
           '${formatAbbrMonthDay(startDay)} - ${formatAbbrMonthDay(selectedDay)}');
 
     final downloads = values[nearestIndex];
@@ -641,14 +641,14 @@ void drawChart(
         final square = HTMLDivElement()
           ..setAttribute('class',
               'downloads-chart-tooltip-square ${squareColorClass(colorIndex(i))}');
-        final rangeText = HTMLSpanElement()..text = '${ranges[i]}: ';
+        final rangeText = HTMLSpanElement()..textContent = '${ranges[i]}: ';
         final suffix = (displayMode == DisplayMode.percentage)
             ? ' (${(downloads[i] * 100 / totals[nearestIndex]).toStringAsPrecision(2)}%)'
             : '';
         final text = '${formatWithThousandSeperators(downloads[i])}$suffix';
         final downloadsText = HTMLSpanElement()
           ..setAttribute('class', 'downloads-chart-tooltip-downloads')
-          ..text = text;
+          ..textContent = text;
 
         final tooltipRange = HTMLDivElement()
           ..setAttribute('class', 'downloads-chart-tooltip-row')

--- a/pkg/web_app/lib/src/widget/weekly_sparkline/widget.dart
+++ b/pkg/web_app/lib/src/widget/weekly_sparkline/widget.dart
@@ -95,7 +95,8 @@ void drawChart(Element svg, HTMLDivElement toolTip, HTMLDivElement chartSubText,
 
   // Render chart
 
-  chartSubText.text = '${formatDate(firstDay)} - ${formatDate(lastDate)}';
+  chartSubText.textContent =
+      '${formatDate(firstDay)} - ${formatDate(lastDate)}';
   final chart = SVGGElement();
 
   final sparklineBar = SVGLineElement();
@@ -158,10 +159,11 @@ void drawChart(Element svg, HTMLDivElement toolTip, HTMLDivElement chartSubText,
     final coords = computeCoordinates(selectedDay.date, selectedDay.downloads);
     sparklineSpot.setAttribute('cy', '${coords.$2}');
     sparklineCursor.setAttribute('transform', 'translate(${coords.$1}, 0)');
-    toolTip.text = '${formatWithThousandSeperators(selectedDay.downloads)}';
+    toolTip.textContent =
+        '${formatWithThousandSeperators(selectedDay.downloads)}';
 
     final startDay = selectedDay.date.subtract(Duration(days: 7));
-    chartSubText.text =
+    chartSubText.textContent =
         '${formatDate(startDay)} - ${formatDate(selectedDay.date)}';
 
     lastSelectedDay = selectedDay.date;
@@ -170,7 +172,8 @@ void drawChart(Element svg, HTMLDivElement toolTip, HTMLDivElement chartSubText,
   void hideSparklineCursor(_) {
     sparklineCursor.setAttribute('style', 'opacity:0');
     toolTip.setAttribute('style', 'opacity:0;position:absolute;');
-    chartSubText.text = '${formatDate(firstDay)} - ${formatDate(lastDate)}';
+    chartSubText.textContent =
+        '${formatDate(firstDay)} - ${formatDate(lastDate)}';
     lastSelectedDay = null;
   }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -13,31 +13,26 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "88399e291da5f7e889359681a8f64b18c5123e03576b01f32a6a276611e511c3"
+      sha256: e55636ed79578b9abca5fecf9437947798f5ef7456308b5cb85720b793eac92f
       url: "https://pub.dev"
     source: hosted
-    version: "78.0.0"
-  _macros:
-    dependency: transitive
-    description: dart
-    source: sdk
-    version: "0.3.3"
+    version: "82.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "62899ef43d0b962b056ed2ebac6b47ec76ffd003d5f7c4e4dc870afe63188e33"
+      sha256: "13c1e6c6fd460522ea840abec3f677cc226f5fec7872c04ad7b425517ccf54f7"
       url: "https://pub.dev"
     source: hosted
-    version: "7.1.0"
+    version: "7.4.4"
   appengine:
     dependency: transitive
     description:
       name: appengine
-      sha256: "488e3018c3954387e6ac5c8d8dca1604de92391a2de5ec284068cdc98fb49efd"
+      sha256: "5b092678bc159c229fbab751afd0c0574eb7f8ec9079101c577e5790f01938c9"
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.9"
+    version: "0.13.10"
   archive:
     dependency: transitive
     description:
@@ -50,18 +45,18 @@ packages:
     dependency: transitive
     description:
       name: args
-      sha256: bf9f5caeea8d8fe6721a9c358dd8a5c1947b27f1cfaa18b39c301273594919e6
+      sha256: d0481093c50b1da8910eb0bb301626d4d8eb7284aa739614d2b394ee09e3ea04
       url: "https://pub.dev"
     source: hosted
-    version: "2.6.0"
+    version: "2.7.0"
   async:
     dependency: transitive
     description:
       name: async
-      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
+      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
       url: "https://pub.dev"
     source: hosted
-    version: "2.12.0"
+    version: "2.13.0"
   basics:
     dependency: transitive
     description:
@@ -98,26 +93,26 @@ packages:
     dependency: transitive
     description:
       name: build_daemon
-      sha256: "294a2edaf4814a378725bfe6358210196f5ea37af89ecd81bfa32960113d4948"
+      sha256: "8e928697a82be082206edb0b9c99c5a4ad6bc31c9e9b8b2f291ae65cd4a25daa"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.3"
+    version: "4.0.4"
   build_resolvers:
     dependency: transitive
     description:
       name: build_resolvers
-      sha256: "99d3980049739a985cf9b21f30881f46db3ebc62c5b8d5e60e27440876b1ba1e"
+      sha256: b9e4fda21d846e192628e7a4f6deda6888c36b5b69ba02ff291a01fd529140f0
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.3"
+    version: "2.4.4"
   build_runner:
     dependency: transitive
     description:
       name: build_runner
-      sha256: "74691599a5bc750dc96a6b4bfd48f7d9d66453eab04c7f4063134800d6a5c573"
+      sha256: "058fe9dce1de7d69c4b84fada934df3e0153dd000758c4d65964d0166779aa99"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.14"
+    version: "2.4.15"
   build_runner_core:
     dependency: transitive
     description:
@@ -146,10 +141,10 @@ packages:
     dependency: transitive
     description:
       name: built_value
-      sha256: "28a712df2576b63c6c005c465989a348604960c0958d28be5303ba9baa841ac2"
+      sha256: ea90e81dc4a25a043d9bee692d20ed6d1c4a1662a28c03a96417446c093ed6b4
       url: "https://pub.dev"
     source: hosted
-    version: "8.9.3"
+    version: "8.9.5"
   characters:
     dependency: transitive
     description:
@@ -182,14 +177,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.2"
+  cli_config:
+    dependency: transitive
+    description:
+      name: cli_config
+      sha256: ac20a183a07002b700f0c25e61b7ee46b23c309d76ab7b7640a028f18e4d99ec
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
   cli_pkg:
     dependency: transitive
     description:
       name: cli_pkg
-      sha256: f07db5590796444efdfdc7549e596949b74ce2b707c6a2dfd1f9d841d8337dd4
+      sha256: eeeea1e0773c5d53fb80a179f82f12c96c50487a37b3cf0174499eb9884c55b2
       url: "https://pub.dev"
     source: hosted
-    version: "2.11.0"
+    version: "2.12.0"
   cli_repl:
     dependency: transitive
     description:
@@ -242,10 +245,10 @@ packages:
     dependency: transitive
     description:
       name: coverage
-      sha256: e3493833ea012784c740e341952298f1cc77f1f01b1bbc3eb4eecf6984fb7f43
+      sha256: "802bd084fb82e55df091ec8ad1553a7331b61c08251eef19a508b6f3f3a9858d"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.1"
+    version: "1.13.1"
   crypto:
     dependency: transitive
     description:
@@ -274,18 +277,18 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.3.3"
   ffi:
     dependency: transitive
     description:
       name: ffi
-      sha256: "16ed7b077ef01ad6170a3d0c57caa4a112a38d7a2ed5602e0aca9ca6f3d98da6"
+      sha256: "289279317b4b16eb2bb7e271abccd4bf84ec9bdcbe999e278a94b804f5630418"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.3"
+    version: "2.1.4"
   file:
     dependency: transitive
     description:
@@ -322,18 +325,18 @@ packages:
     dependency: transitive
     description:
       name: glob
-      sha256: "0e7014b3b7d4dac1ca4d6114f82bf1782ee86745b9b42a92c9289c23d8a0ab63"
+      sha256: c3f1ee72c96f8f78935e18aa8cecced9ab132419e8625dc187e1c2408efc20de
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.3"
   google_identity_services_web:
     dependency: transitive
     description:
       name: google_identity_services_web
-      sha256: "55580f436822d64c8ff9a77e37d61f5fb1e6c7ec9d632a43ee324e2a05c3c6c9"
+      sha256: "5d187c46dc59e02646e10fe82665fc3884a9b71bc1c90c2b8b749316d33ee454"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.3"
+    version: "0.3.3+1"
   googleapis:
     dependency: transitive
     description:
@@ -370,26 +373,26 @@ packages:
     dependency: transitive
     description:
       name: grpc
-      sha256: e93ee3bce45c134bf44e9728119102358c7cd69de7832d9a874e2e74eb8cab40
+      sha256: "30e1edae6846b163a64f6d8716e3443980fe1f7d2d1f086f011d24ea186f2582"
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.4"
+    version: "4.0.4"
   html:
     dependency: transitive
     description:
       name: html
-      sha256: "1fc58edeaec4307368c60d59b7e15b9d658b57d7f3125098b6294153c75337ec"
+      sha256: "6d1264f2dffa1b1101c25a91dff0dc2daee4c18e87cd8538729773c073dbf602"
       url: "https://pub.dev"
     source: hosted
-    version: "0.15.5"
+    version: "0.15.6"
   http:
     dependency: transitive
     description:
       name: http
-      sha256: b9c29a161230ee03d3ccf545097fccd9b87a5264228c5d348202e0f0c28f9010
+      sha256: fe7ab022b76f3034adc518fb6ea04a82387620e19977665ea18d30a1cf43442f
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.2"
+    version: "1.3.0"
   http2:
     dependency: transitive
     description:
@@ -458,10 +461,10 @@ packages:
     dependency: transitive
     description:
       name: json_serializable
-      sha256: "8f52361c07497a7f2c16c13aac159f9be6fb12b1d67719eac98a21d9a205d571"
+      sha256: c50ef5fc083d5b5e12eef489503ba3bf5ccc899e487d691584699b4bdefeea8c
       url: "https://pub.dev"
     source: hosted
-    version: "6.9.2"
+    version: "6.9.5"
   jsontool:
     dependency: transitive
     description:
@@ -494,14 +497,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
-  macros:
-    dependency: transitive
-    description:
-      name: macros
-      sha256: "1d9e801cd66f7ea3663c45fc708450db1fa57f988142c64289142c9b7ee80656"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.3-main.0"
   mailer:
     dependency: transitive
     description:
@@ -554,10 +549,10 @@ packages:
     dependency: "direct dev"
     description:
       name: mono_repo
-      sha256: "6f72e60b59366ccbd5b7ee5184cff31ad1a9e733491c3de2722dbc598824f3e3"
+      sha256: "442806126e36d053bf4a305f65fb8f51990bb96115d76522237ac9e7feecf214"
       url: "https://pub.dev"
     source: hosted
-    version: "6.6.2"
+    version: "6.6.3"
   native_stack_traces:
     dependency: transitive
     description:
@@ -594,10 +589,10 @@ packages:
     dependency: transitive
     description:
       name: node_interop
-      sha256: "3af2420c728173806f4378cf89c53ba9f27f7f67792b898561bff9d390deb98e"
+      sha256: "4848ac408c0cdd0f70136b755df816a8e4c96c244e5377a3fb3b8f8950666150"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.2.0"
   node_preamble:
     dependency: transitive
     description:
@@ -618,10 +613,10 @@ packages:
     dependency: transitive
     description:
       name: package_config
-      sha256: "92d4488434b520a62570293fbd33bb556c7d49230791c1b4bbd973baf6d2dc67"
+      sha256: f096c55ebb7deb7e384101542bfba8c52696c1b56fca2eb62827989ef2353bbc
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.2.0"
   pana:
     dependency: transitive
     description:
@@ -674,10 +669,10 @@ packages:
     dependency: transitive
     description:
       name: pub_semver
-      sha256: "7b3cfbf654f3edd0c6298ecd5be782ce997ddf0e00531b9464b55245185bbbbd"
+      sha256: "5bfcf68ca79ef689f8990d1160781b4bad40a3bd5e5218ad4076ddb7f4081585"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.5"
+    version: "2.2.0"
   pubspec_parse:
     dependency: transitive
     description:
@@ -722,10 +717,10 @@ packages:
     dependency: transitive
     description:
       name: sass
-      sha256: c6abff6269edf6dc6767fde2ead064cbf939b8982656bd6a2097eda5d9c8f42b
+      sha256: "8d7b1a1fd61e843667208ea3e05e35f3e1a8958e850638afd518e2b785e82a73"
       url: "https://pub.dev"
     source: hosted
-    version: "1.83.1"
+    version: "1.87.0"
   shelf:
     dependency: transitive
     description:
@@ -770,10 +765,10 @@ packages:
     dependency: transitive
     description:
       name: shelf_web_socket
-      sha256: cc36c297b52866d203dbf9332263c94becc2fe0ceaa9681d07b6ef9807023b67
+      sha256: "3632775c8e90d6c9712f883e633716432a27758216dfb61bd86a8321c0580925"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.0"
   slugid:
     dependency: transitive
     description:
@@ -882,10 +877,10 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "8391fbe68d520daf2314121764d38e37f934c02fd7301ad18307bd93bd6b725d"
+      sha256: "301b213cd241ca982e9ba50266bd3f5bd1ea33f1455554c5abb85d1be0e2d87e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.25.14"
+    version: "1.25.15"
   test_api:
     dependency: transitive
     description:
@@ -962,26 +957,26 @@ packages:
     dependency: transitive
     description:
       name: web
-      sha256: cd3543bd5798f6ad290ea73d210f423502e71900302dde696f8bff84bf89a1cb
+      sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   web_socket:
     dependency: transitive
     description:
       name: web_socket
-      sha256: "3c12d96c0c9a4eec095246debcea7b86c0324f22df69893d538fcc6f1b8cce83"
+      sha256: bfe6f435f6ec49cb6c01da1e275ae4228719e59a6b067048c51e72d9d63bcc4b
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.6"
+    version: "1.0.0"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
-      sha256: "9f187088ed104edd8662ca07af4b124465893caf063ba29758f97af57e61da8f"
+      sha256: d645757fb0f4773d602444000a8131ff5d48c9e47adfe9772652dd1a4f2d45c8
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.3"
   webkit_inspection_protocol:
     dependency: transitive
     description:
@@ -1015,4 +1010,4 @@ packages:
     source: hosted
     version: "2.2.2"
 sdks:
-  dart: ">=3.6.0 <4.0.0"
+  dart: ">=3.7.0 <4.0.0"


### PR DESCRIPTION
- `pkg/api_generator` is updated with `ignore_for_file: deprecated_member_use` for now, as the analyzer API deprecations require non-trivial changes that could be made in a follow-up PR.
- the other (mostly `package:web`) deprecations are straightforward