### PR TITLE
Remove topics match experiment.

### DIFF
--- a/app/lib/frontend/handlers/experimental.dart
+++ b/app/lib/frontend/handlers/experimental.dart
@@ -9,7 +9,7 @@ import '../../shared/cookie_utils.dart';
 typedef PublicFlag = ({String name, String description});
 
 const _publicFlags = <PublicFlag>{
-  (name: 'search-topics', description: 'Show matching topics when searching'),
+  (name: 'example', description: 'Short description'),
 };
 
 final _allFlags = <String>{
@@ -85,8 +85,6 @@ class ExperimentalFlags {
     }
     return params;
   }
-
-  bool get isSearchTopicsEnabled => isEnabled('search-topics');
 
   bool get isDarkModeDefault => isEnabled('dark-as-default');
 

--- a/app/lib/frontend/templates/listing.dart
+++ b/app/lib/frontend/templates/listing.dart
@@ -6,7 +6,6 @@ import 'dart:math';
 
 import 'package:_pub_shared/search/search_form.dart';
 import 'package:collection/collection.dart';
-import 'package:pub_dev/frontend/request_context.dart';
 
 import '../../package/search_adapter.dart';
 import '../../search/search_service.dart';
@@ -52,9 +51,6 @@ String renderPkgIndexPage(
       messageFromBackend: searchResultPage.errorMessage,
     ),
     nameMatches: _nameMatches(searchForm, searchResultPage.nameMatches),
-    topicMatches: requestContext.experimentalFlags.isSearchTopicsEnabled
-        ? _topicMatches(searchForm, searchResultPage.topicMatches)
-        : null,
     packageList: packageList(searchResultPage),
     pagination: searchResultPage.hasHit ? paginationNode(links) : null,
     openSections: openSections,
@@ -147,27 +143,6 @@ d.Node? _nameMatches(SearchForm form, List<String>? matches) {
           href: urls.pkgPageUrl(name),
           child: d.b(text: name),
         ),
-      ];
-    }),
-  ]);
-}
-
-d.Node? _topicMatches(SearchForm form, List<String>? matches) {
-  if (matches == null || matches.isEmpty) {
-    return null;
-  }
-  final singular = matches.length == 1;
-  final isExactNameMatch = singular && form.parsedQuery.text == matches.single;
-  final nameMatchLabel = isExactNameMatch
-      ? 'Exact topic match: '
-      : 'Matching ${singular ? 'topic' : 'topics'}: ';
-
-  return d.p(children: [
-    d.text(nameMatchLabel),
-    ...matches.expandIndexed((i, name) {
-      return [
-        if (i > 0) d.text(', '),
-        d.a(href: urls.searchUrl(q: 'topic:$name'), text: '#$name'),
       ];
     }),
   ]);

--- a/app/lib/frontend/templates/views/pkg/index.dart
+++ b/app/lib/frontend/templates/views/pkg/index.dart
@@ -14,21 +14,16 @@ d.Node packageListingNode({
   required SearchForm searchForm,
   required d.Node listingInfo,
   required d.Node? nameMatches,
-  required d.Node? topicMatches,
   required d.Node packageList,
   required d.Node? pagination,
   required Set<String>? openSections,
 }) {
-  final matchHighlights = [
-    if (nameMatches != null) nameMatches,
-    if (topicMatches != null) topicMatches,
-  ];
   final innerContent = d.fragment([
     listingInfo,
-    if (matchHighlights.isNotEmpty)
+    if (nameMatches != null)
       d.div(
         classes: ['listing-highlight-block'],
-        children: matchHighlights,
+        child: nameMatches,
       ),
     packageList,
     if (pagination != null) pagination,

--- a/app/lib/package/search_adapter.dart
+++ b/app/lib/package/search_adapter.dart
@@ -45,7 +45,6 @@ class SearchAdapter {
       form,
       result.totalCount,
       nameMatches: result.nameMatches,
-      topicMatches: result.topicMatches,
       sdkLibraryHits: result.sdkLibraryHits,
       packageHits:
           result.packageHits.map((h) => views[h.package]).nonNulls.toList(),
@@ -149,9 +148,6 @@ class SearchResultPage {
   /// would be considered as blocker for publishing).
   final List<String>? nameMatches;
 
-  /// Topic names that are exact name matches or are close to a known topic.
-  final List<String>? topicMatches;
-
   /// The hits from the SDK libraries.
   final List<SdkLibraryHit> sdkLibraryHits;
 
@@ -169,7 +165,6 @@ class SearchResultPage {
     this.form,
     this.totalCount, {
     this.nameMatches,
-    this.topicMatches,
     List<SdkLibraryHit>? sdkLibraryHits,
     List<PackageView>? packageHits,
     this.errorMessage,

--- a/app/lib/search/mem_index.dart
+++ b/app/lib/search/mem_index.dart
@@ -230,19 +230,6 @@ class InMemoryPackageIndex {
     );
 
     final nameMatches = textResults?.nameMatches;
-    List<String>? topicMatches;
-
-    if (parsedQueryText != null) {
-      final parts = parsedQueryText
-          .split(' ')
-          .map((t) => canonicalTopics.aliasToCanonicalMap[t] ?? t)
-          .toSet()
-          .where(_topics.contains)
-          .toList();
-      if (parts.isNotEmpty) {
-        topicMatches = parts;
-      }
-    }
 
     List<IndexedPackageHit> indexedHits;
     switch (query.effectiveOrder ?? SearchOrder.top) {
@@ -306,7 +293,6 @@ class InMemoryPackageIndex {
       timestamp: clock.now().toUtc(),
       totalCount: totalCount,
       nameMatches: nameMatches,
-      topicMatches: topicMatches,
       packageHits: packageHits,
       errorMessage: textResults?.errorMessage,
     );

--- a/app/lib/search/search_service.dart
+++ b/app/lib/search/search_service.dart
@@ -361,8 +361,6 @@ class PackageSearchResult {
   /// would be considered as blocker for publishing).
   final List<String>? nameMatches;
 
-  /// Topic names that are exact name matches or close to the queried text.
-  final List<String>? topicMatches;
   final List<SdkLibraryHit> sdkLibraryHits;
   final List<PackageHit> packageHits;
 
@@ -376,7 +374,6 @@ class PackageSearchResult {
     required this.timestamp,
     required this.totalCount,
     this.nameMatches,
-    this.topicMatches,
     List<SdkLibraryHit>? sdkLibraryHits,
     List<PackageHit>? packageHits,
     this.errorMessage,
@@ -396,7 +393,6 @@ class PackageSearchResult {
   })  : timestamp = clock.now().toUtc(),
         totalCount = 0,
         nameMatches = null,
-        topicMatches = null,
         sdkLibraryHits = <SdkLibraryHit>[],
         packageHits = <PackageHit>[];
 
@@ -416,7 +412,6 @@ class PackageSearchResult {
       timestamp: timestamp,
       totalCount: totalCount,
       nameMatches: nameMatches,
-      topicMatches: topicMatches,
       sdkLibraryHits: sdkLibraryHits ?? this.sdkLibraryHits,
       packageHits: packageHits,
       errorMessage: errorMessage,

--- a/app/lib/search/search_service.g.dart
+++ b/app/lib/search/search_service.g.dart
@@ -82,9 +82,6 @@ PackageSearchResult _$PackageSearchResultFromJson(Map<String, dynamic> json) =>
       nameMatches: (json['nameMatches'] as List<dynamic>?)
           ?.map((e) => e as String)
           .toList(),
-      topicMatches: (json['topicMatches'] as List<dynamic>?)
-          ?.map((e) => e as String)
-          .toList(),
       sdkLibraryHits: (json['sdkLibraryHits'] as List<dynamic>?)
           ?.map((e) => SdkLibraryHit.fromJson(e as Map<String, dynamic>))
           .toList(),
@@ -101,7 +98,6 @@ Map<String, dynamic> _$PackageSearchResultToJson(
       'timestamp': instance.timestamp.toIso8601String(),
       'totalCount': instance.totalCount,
       if (instance.nameMatches case final value?) 'nameMatches': value,
-      if (instance.topicMatches case final value?) 'topicMatches': value,
       'sdkLibraryHits': instance.sdkLibraryHits.map((e) => e.toJson()).toList(),
       'packageHits': instance.packageHits.map((e) => e.toJson()).toList(),
       if (instance.errorMessage case final value?) 'errorMessage': value,


### PR DESCRIPTION
The experiment was never gaining any interest, especially since we've added the topics text to the index. With the different UI for name matches, we should just remove this.