### PR TITLE
Code cleanup: use available latestVersion field instead of full lookup.

### DIFF
--- a/app/lib/scorecard/backend.dart
+++ b/app/lib/scorecard/backend.dart
@@ -77,8 +77,8 @@ class ScoreCardBackend {
         return null;
       }
 
-      final version = await taskBackend.latestFinishedVersion(package) ??
-          await packageBackend.getLatestVersion(package);
+      final version =
+          await taskBackend.latestFinishedVersion(package) ?? p.latestVersion;
       if (version == null) {
         return null;
       }


### PR DESCRIPTION
Note: it has probably no noticeable effect, but since I've noticed it, couldn't ignore it :)