### PR TITLE
Tool for local SDK search index benchmark

### DIFF
--- a/app/bin/tools/sdk_search_benchmark.dart
+++ b/app/bin/tools/sdk_search_benchmark.dart
@@ -1,0 +1,28 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:pub_dev/search/flutter_sdk_mem_index.dart';
+
+/// Loads a Dart SDK search snapshot and executes queries on it, benchmarking their total time to complete.
+Future<void> main() async {
+  final index = await createFlutterSdkMemIndex();
+
+  // NOTE: please add more queries to this list, especially if there is a performance bottleneck.
+  final queries = [
+    'chart',
+    'json',
+    'camera',
+    'android camera',
+    'sql database',
+  ];
+
+  final sw = Stopwatch()..start();
+  var count = 0;
+  for (var i = 0; i < 100; i++) {
+    index!.search(queries[i % queries.length]);
+    count++;
+  }
+  sw.stop();
+  print('${(sw.elapsedMilliseconds / count).toStringAsFixed(2)} ms/request');
+}


### PR DESCRIPTION
- #8670
- This tool is similar to https://github.com/dart-lang/pub-dev/blob/master/app/bin/tools/search_benchmark.dart only for SDK indexes, using the Flutter index by default, as it is larger.
- The local profiling showed that most time is spent in the top-k (top-3) result selection. I didn't see any trivial changes there that improved the outcome.
- The overall time spent in the SDK search method is less than 2 ms on my localhost - it is likely not a big contributor to search latencies (which were in the 30-40 ms range last time I've checked). Still, it may be worth to look into top-k selection, as the regular search index also uses it when sorting/selecting the results.