### PR TITLE
Export more package API endpoints.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ AppEngine version, listed here to ease deployment and troubleshooting.
 ## Next Release (replace with git tag when deployed)
  * Bump runtimeVersion to `2025.06.20`.
  * Upgraded stable Flutter analysis SDK to `3.32.4`.
+ * Note: started to export `/api/packages/<package>/[likes|options|publisher|score]` endpoints.
 
 ## `20250619t085100-all`
  * Bump runtimeVersion to `2025.06.03`.

--- a/app/lib/package/api_export/api_exporter.dart
+++ b/app/lib/package/api_export/api_exporter.dart
@@ -10,6 +10,7 @@ import 'package:gcloud/service_scope.dart' as ss;
 import 'package:gcloud/storage.dart';
 import 'package:logging/logging.dart';
 import 'package:pub_dev/frontend/handlers/atom_feed.dart';
+import 'package:pub_dev/scorecard/backend.dart';
 import 'package:pub_dev/service/security_advisories/backend.dart';
 import 'package:pub_dev/shared/exceptions.dart';
 import 'package:pub_dev/shared/parallel_foreach.dart';
@@ -243,6 +244,22 @@ final class ApiExporter {
         );
     await _api.package(package).versions.write(
           versionListing,
+          forceWrite: forceWrite,
+        );
+    await _api.package(package).likes.write(
+          await packageBackend.getPackageLikesCount(package),
+          forceWrite: forceWrite,
+        );
+    await _api.package(package).options.write(
+          await packageBackend.getPackageOptions(package),
+          forceWrite: forceWrite,
+        );
+    await _api.package(package).publisher.write(
+          await packageBackend.getPublisherInfo(package),
+          forceWrite: forceWrite,
+        );
+    await _api.package(package).score.write(
+          await scoreCardBackend.getVersionScore(package),
           forceWrite: forceWrite,
         );
     await _api.package(package).feedAtomFile.write(

--- a/app/lib/package/api_export/exported_api.dart
+++ b/app/lib/package/api_export/exported_api.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:_pub_shared/data/account_api.dart';
 import 'package:_pub_shared/data/advisories_api.dart';
 import 'package:_pub_shared/data/package_api.dart';
 import 'package:clock/clock.dart';
@@ -273,6 +274,20 @@ final class ExportedPackage {
   ExportedJsonFile<ListAdvisoriesResponse> get advisories =>
       _suffix<ListAdvisoriesResponse>('/advisories');
 
+  /// Interface for writing `/api/packages/<package>/likes`.
+  ExportedJsonFile<PackageLikesCount> get likes =>
+      _suffix<PackageLikesCount>('/likes');
+
+  /// Interface for writing `/api/packages/<package>/options`.
+  ExportedJsonFile<PkgOptions> get options => _suffix<PkgOptions>('/options');
+
+  /// Interface for writing `/api/packages/<package>/publisher`.
+  ExportedJsonFile<PackagePublisherInfo> get publisher =>
+      _suffix<PackagePublisherInfo>('/publisher');
+
+  /// Interface for writing `/api/packages/<package>/score`.
+  ExportedJsonFile<VersionScore> get score => _suffix<VersionScore>('/score');
+
   /// Interface for writing `/api/packages/<package>/feed.atom`
   ExportedAtomFeedFile get feedAtomFile => ExportedAtomFeedFile._(
         _owner,
@@ -406,6 +421,10 @@ final class ExportedPackage {
     await Future.wait([
       _owner._pool.withResource(() async => await versions.delete()),
       _owner._pool.withResource(() async => await advisories.delete()),
+      _owner._pool.withResource(() async => await likes.delete()),
+      _owner._pool.withResource(() async => await options.delete()),
+      _owner._pool.withResource(() async => await publisher.delete()),
+      _owner._pool.withResource(() async => await score.delete()),
       _owner._pool.withResource(() async => await feedAtomFile.delete()),
       ..._owner._prefixes.map((prefix) async {
         await _owner._listBucket(

--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -482,7 +482,7 @@ class PackageBackend {
     });
     await purgePackageCache(package);
     await taskBackend.trackPackage(package);
-    await apiExporter!.synchronizePackage(package);
+    await apiExporter.synchronizePackage(package);
   }
 
   /// Updates [options] on [package]/[version], assuming the current user
@@ -523,7 +523,7 @@ class PackageBackend {
     await purgePackageCache(package);
     await purgeScorecardData(package, version,
         isLatest: pkg.latestVersion == version);
-    await apiExporter!.synchronizePackage(package);
+    await apiExporter.synchronizePackage(package);
   }
 
   /// Verifies an update to the credential-less publishing settings and
@@ -788,7 +788,7 @@ class PackageBackend {
     if (currentPublisherId != null) {
       await purgePublisherCache(publisherId: currentPublisherId);
     }
-    await apiExporter!.synchronizePackage(packageName);
+    await apiExporter.synchronizePackage(packageName);
     return rs;
   }
 

--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -18,6 +18,7 @@ import 'package:meta/meta.dart';
 import 'package:pool/pool.dart';
 import 'package:pub_dev/package/api_export/api_exporter.dart';
 import 'package:pub_dev/package/tarball_storage.dart';
+import 'package:pub_dev/scorecard/backend.dart';
 import 'package:pub_dev/service/async_queue/async_queue.dart';
 import 'package:pub_dev/service/rate_limit/rate_limit.dart';
 import 'package:pub_dev/shared/versions.dart';
@@ -481,6 +482,7 @@ class PackageBackend {
     });
     await purgePackageCache(package);
     await taskBackend.trackPackage(package);
+    await apiExporter!.synchronizePackage(package);
   }
 
   /// Updates [options] on [package]/[version], assuming the current user
@@ -519,6 +521,9 @@ class PackageBackend {
       }
     });
     await purgePackageCache(package);
+    await purgeScorecardData(package, version,
+        isLatest: pkg.latestVersion == version);
+    await apiExporter!.synchronizePackage(package);
   }
 
   /// Verifies an update to the credential-less publishing settings and
@@ -783,7 +788,7 @@ class PackageBackend {
     if (currentPublisherId != null) {
       await purgePublisherCache(publisherId: currentPublisherId);
     }
-
+    await apiExporter!.synchronizePackage(packageName);
     return rs;
   }
 

--- a/app/lib/task/backend.dart
+++ b/app/lib/task/backend.dart
@@ -18,6 +18,7 @@ import 'package:indexed_blob/indexed_blob.dart' show BlobIndex, FileRange;
 import 'package:logging/logging.dart' show Logger;
 import 'package:pana/models.dart' show Summary;
 import 'package:pool/pool.dart' show Pool;
+import 'package:pub_dev/package/api_export/api_exporter.dart';
 import 'package:pub_dev/package/backend.dart';
 import 'package:pub_dev/package/models.dart';
 import 'package:pub_dev/package/upload_signer_service.dart';
@@ -723,6 +724,7 @@ class TaskBackend {
 
     // Clearing the state cache after the update.
     await _purgeCache(package, version);
+    await apiExporter!.synchronizePackage(package);
 
     // If nothing else is running on the instance, delete it!
     // We do this in a microtask after returning, so that it doesn't slow down

--- a/app/lib/task/backend.dart
+++ b/app/lib/task/backend.dart
@@ -724,7 +724,7 @@ class TaskBackend {
 
     // Clearing the state cache after the update.
     await _purgeCache(package, version);
-    await apiExporter!.synchronizePackage(package);
+    await apiExporter.synchronizePackage(package);
 
     // If nothing else is running on the instance, delete it!
     // We do this in a microtask after returning, so that it doesn't slow down

--- a/app/test/admin/exported_api_sync_test.dart
+++ b/app/test/admin/exported_api_sync_test.dart
@@ -71,8 +71,8 @@ void main() {
     testWithProfile('baseline checks', fn: () async {
       await syncExportedApi();
       final data = await listExportedApi();
-      expect(data.keys, hasLength(greaterThan(20)));
-      expect(data.keys, hasLength(lessThan(40)));
+      expect(data.keys, hasLength(greaterThan(50)));
+      expect(data.keys, hasLength(lessThan(70)));
 
       final oxygenFiles = data.keys.where((k) => k.contains('oxygen')).toSet();
       expect(oxygenFiles, hasLength(greaterThan(5)));
@@ -82,12 +82,20 @@ void main() {
         '$runtimeVersion/api/archives/oxygen-2.0.0-dev.tar.gz',
         '$runtimeVersion/api/packages/oxygen',
         '$runtimeVersion/api/packages/oxygen/advisories',
+        '$runtimeVersion/api/packages/oxygen/likes',
+        '$runtimeVersion/api/packages/oxygen/options',
+        '$runtimeVersion/api/packages/oxygen/publisher',
+        '$runtimeVersion/api/packages/oxygen/score',
         '$runtimeVersion/api/packages/oxygen/feed.atom',
         'latest/api/archives/oxygen-1.0.0.tar.gz',
         'latest/api/archives/oxygen-1.2.0.tar.gz',
         'latest/api/archives/oxygen-2.0.0-dev.tar.gz',
         'latest/api/packages/oxygen',
         'latest/api/packages/oxygen/advisories',
+        'latest/api/packages/oxygen/likes',
+        'latest/api/packages/oxygen/options',
+        'latest/api/packages/oxygen/publisher',
+        'latest/api/packages/oxygen/score',
         'latest/api/packages/oxygen/feed.atom',
       });
 

--- a/app/test/package/api_export/api_exporter_test.dart
+++ b/app/test/package/api_export/api_exporter_test.dart
@@ -128,8 +128,36 @@ Future<void> _testExportedApiSynchronization(
       isNotNull,
     );
     expect(
-      await bucket.readBytes('$runtimeVersion/api/packages/foo/feed.atom'),
-      isNotNull,
+      await bucket.readGzippedJson('$runtimeVersion/api/packages/foo/likes'),
+      {
+        'package': 'foo',
+        'likes': 0,
+      },
+    );
+    expect(
+      await bucket.readGzippedJson('$runtimeVersion/api/packages/foo/options'),
+      {
+        'isDiscontinued': false,
+        'replacedBy': null,
+        'isUnlisted': false,
+      },
+    );
+    expect(
+      await bucket
+          .readGzippedJson('$runtimeVersion/api/packages/foo/publisher'),
+      {
+        'publisherId': null,
+      },
+    );
+    expect(
+      await bucket.readGzippedJson('$runtimeVersion/api/packages/foo/score'),
+      {
+        'grantedPoints': isNotNull,
+        'maxPoints': isNotNull,
+        'likeCount': isNotNull,
+        'tags': isNotEmpty,
+        'lastUpdated': isNotNull,
+      },
     );
     expect(
       await bucket.readGzippedJson('$runtimeVersion/api/packages/foo'),
@@ -138,6 +166,10 @@ Future<void> _testExportedApiSynchronization(
         'latest': isNotEmpty,
         'versions': hasLength(1),
       },
+    );
+    expect(
+      await bucket.readString('$runtimeVersion/api/packages/foo/feed.atom'),
+      contains('v1.0.0 of foo'),
     );
     expect(
       await bucket
@@ -150,10 +182,6 @@ Future<void> _testExportedApiSynchronization(
     );
     expect(
       await bucket.readString('$runtimeVersion/feed.atom'),
-      contains('v1.0.0 of foo'),
-    );
-    expect(
-      await bucket.readString('$runtimeVersion/api/packages/foo/feed.atom'),
       contains('v1.0.0 of foo'),
     );
   }
@@ -192,6 +220,22 @@ Future<void> _testExportedApiSynchronization(
     expect(
       await bucket.readString('latest/api/packages/foo/feed.atom'),
       contains('v1.0.0 of foo'),
+    );
+    expect(
+      await bucket.readGzippedJson('latest/api/packages/foo/likes'),
+      isNotNull,
+    );
+    expect(
+      await bucket.readGzippedJson('latest/api/packages/foo/options'),
+      isNotNull,
+    );
+    expect(
+      await bucket.readGzippedJson('latest/api/packages/foo/publisher'),
+      isNotNull,
+    );
+    expect(
+      await bucket.readGzippedJson('latest/api/packages/foo/score'),
+      isNotNull,
     );
     // Note. that name completion data won't be updated until search caches
     //       are purged, so we won't test that it is updated.
@@ -441,6 +485,10 @@ Future<void> _testExportedApiSynchronization(
       isNull,
     );
     expect(
+      await bucket.readGzippedJson('latest/api/packages/bar/options'),
+      isNull,
+    );
+    expect(
       await bucket.readGzippedJson('latest/api/packages/feed.atom'),
       isNull,
     );
@@ -479,6 +527,10 @@ Future<void> _testExportedApiSynchronization(
         'latest': isNotEmpty,
         'versions': hasLength(2),
       },
+    );
+    expect(
+      await bucket.readGzippedJson('latest/api/packages/bar/options'),
+      isNotNull,
     );
     expect(
       await bucket.readBytes('latest/api/archives/bar-2.0.0.tar.gz'),

--- a/app/test/task/task_test.dart
+++ b/app/test/task/task_test.dart
@@ -176,7 +176,9 @@ void main() {
     await clockControl.elapse(minutes: 10);
   });
 
-  testWithProfile('failing instances will be retried', fn: () async {
+  testWithProfile('failing instances will be retried', expectedLogMessages: [
+    'SHOUT [pub-notice:cached_value] Updating cached `thirtyDaysTotalDownloadCounts` value failed.',
+  ], fn: () async {
     await taskBackend.backfillTrackingState();
     await clockControl.elapse(minutes: 1);
 


### PR DESCRIPTION
- exporting `/likes`, `/options`, `/publisher` and `/score` endpoints 
- extracted `getPackageOptions` method + fixed the missing `replacedBy` field
- extracted `getVersionScore` method
- updated triggers on cache invalidation and API export
- #8752