### PR TITLE
Rename daily task and file for trend scores

### DIFF
--- a/app/lib/service/download_counts/computations.dart
+++ b/app/lib/service/download_counts/computations.dart
@@ -36,7 +36,7 @@ Future<Map<String, double>> computeTrend() async {
   return res;
 }
 
-final trendScoreFileName = 'trend-scores.json';
+final trendScoreFileName = 'trend-scores-v2.json';
 
 Future<void> uploadTrendScores(Map<String, double> trends) async {
   final reportsBucket =

--- a/app/lib/tool/neat_task/pub_dev_tasks.dart
+++ b/app/lib/tool/neat_task/pub_dev_tasks.dart
@@ -212,7 +212,7 @@ List<NeatPeriodicTaskScheduler> createPeriodicTaskSchedulers({
     ),
 
     _daily(
-      name: 'compute-trend-scores',
+      name: 'compute-trend-scores-v2',
       isRuntimeVersioned: false,
       task: computeTrendScoreTask,
     ),


### PR DESCRIPTION
Renaming, to be sure we read the newest data after next deployment.