### PR TITLE
Remove the SDK version from SDK hits and index.

### DIFF
--- a/app/lib/frontend/templates/views/pkg/package_list.dart
+++ b/app/lib/frontend/templates/views/pkg/package_list.dart
@@ -47,10 +47,6 @@ d.Node listOfPackagesNode({
 
 d.Node _sdkLibraryItem(SdkLibraryHit hit) {
   final sdkDict = getSdkDict(hit.sdk!);
-  final metadataText = [
-    if (hit.version != null) 'v ${hit.version}',
-    sdkDict.libraryTypeLabel,
-  ].join(' • ');
 
   return _item(
     url: hit.url!,
@@ -60,7 +56,8 @@ d.Node _sdkLibraryItem(SdkLibraryHit hit) {
     labeledScoresNode: null,
     description: hit.description ?? '',
     metadataNode: d.fragment([
-      d.span(classes: ['packages-metadata-block'], text: metadataText),
+      d.span(
+          classes: ['packages-metadata-block'], text: sdkDict.libraryTypeLabel),
       coreLibraryBadgeNode,
       nullSafeBadgeNode(),
     ]),

--- a/app/lib/search/sdk_mem_index.dart
+++ b/app/lib/search/sdk_mem_index.dart
@@ -10,7 +10,6 @@ import 'package:pana/src/dartdoc/dartdoc_index.dart';
 import 'package:path/path.dart' as p;
 import 'package:pub_dev/search/flutter_sdk_mem_index.dart';
 
-import '../shared/versions.dart';
 import 'search_service.dart';
 import 'token_index.dart';
 
@@ -34,7 +33,6 @@ const _defaultApiPageDirWeights = {
 /// In-memory index for SDK library search queries.
 class SdkMemIndex {
   final String _sdk;
-  final String? _version;
   final Uri _baseUri;
   final _tokensPerLibrary = <String, TokenIndex<String>>{};
   final _baseUriPerLibrary = <String, String>{};
@@ -43,13 +41,11 @@ class SdkMemIndex {
 
   SdkMemIndex({
     required String sdk,
-    required String? version,
     required Uri baseUri,
     required DartdocIndex index,
     Set<String>? allowedLibraries,
     Map<String, double>? apiPageDirWeights,
   })  : _sdk = sdk,
-        _version = version,
         _baseUri = baseUri,
         _apiPageDirWeights = apiPageDirWeights ?? _defaultApiPageDirWeights {
     _addDartdocIndex(index, allowedLibraries);
@@ -58,7 +54,6 @@ class SdkMemIndex {
   static SdkMemIndex dart({required DartdocIndex index}) {
     return SdkMemIndex(
       sdk: 'dart',
-      version: runtimeSdkVersion,
       baseUri: Uri.parse('https://api.dart.dev/stable/latest/'),
       index: index,
     );
@@ -67,7 +62,6 @@ class SdkMemIndex {
   factory SdkMemIndex.flutter({required DartdocIndex index}) {
     return SdkMemIndex(
       sdk: 'flutter',
-      version: null,
       baseUri: Uri.parse('https://api.flutter.dev/flutter/'),
       index: index,
       allowedLibraries: flutterSdkAllowedLibraries,
@@ -159,7 +153,6 @@ class SdkMemIndex {
         .where((h) => h.score >= minScore)
         .map((hit) => SdkLibraryHit(
               sdk: _sdk,
-              version: _version,
               library: hit.library,
               description: _descriptionPerLibrary[hit.library],
               url: _baseUriPerLibrary[hit.library] ?? _baseUri.toString(),

--- a/app/lib/search/search_service.dart
+++ b/app/lib/search/search_service.dart
@@ -427,7 +427,6 @@ class PackageSearchResult {
 @JsonSerializable(includeIfNull: false, explicitToJson: true)
 class SdkLibraryHit {
   final String? sdk;
-  final String? version;
   final String? library;
   final String? description;
   final String? url;
@@ -436,7 +435,6 @@ class SdkLibraryHit {
 
   SdkLibraryHit({
     required this.sdk,
-    required this.version,
     required this.library,
     required this.description,
     required this.url,

--- a/app/lib/search/search_service.g.dart
+++ b/app/lib/search/search_service.g.dart
@@ -109,7 +109,6 @@ Map<String, dynamic> _$PackageSearchResultToJson(
 SdkLibraryHit _$SdkLibraryHitFromJson(Map<String, dynamic> json) =>
     SdkLibraryHit(
       sdk: json['sdk'] as String?,
-      version: json['version'] as String?,
       library: json['library'] as String?,
       description: json['description'] as String?,
       url: json['url'] as String?,
@@ -122,7 +121,6 @@ SdkLibraryHit _$SdkLibraryHitFromJson(Map<String, dynamic> json) =>
 Map<String, dynamic> _$SdkLibraryHitToJson(SdkLibraryHit instance) =>
     <String, dynamic>{
       if (instance.sdk case final value?) 'sdk': value,
-      if (instance.version case final value?) 'version': value,
       if (instance.library case final value?) 'library': value,
       if (instance.description case final value?) 'description': value,
       if (instance.url case final value?) 'url': value,

--- a/app/test/frontend/golden/pkg_index_page.html
+++ b/app/test/frontend/golden/pkg_index_page.html
@@ -443,7 +443,7 @@
                     <span>core description</span>
                   </div>
                   <p class="packages-metadata">
-                    <span class="packages-metadata-block">v 2.14.0 • Dart SDK library</span>
+                    <span class="packages-metadata-block">Dart SDK library</span>
                     <span class="package-badge">Core library</span>
                     <span class="package-badge" title="Supports the null safety language feature.">Null safety</span>
                   </p>

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -469,7 +469,6 @@ void main() {
             sdkLibraryHits: [
               SdkLibraryHit(
                 sdk: 'dart',
-                version: '2.14.0',
                 library: 'dart:core',
                 description: 'core description',
                 url: 'https://api.dart.dev/library-page.html',

--- a/app/test/search/result_combiner_test.dart
+++ b/app/test/search/result_combiner_test.dart
@@ -32,7 +32,6 @@ void main() {
       primaryIndex: primaryIndex,
       dartSdkMemIndex: SdkMemIndex(
         sdk: 'dart',
-        version: runtimeSdkVersion,
         baseUri: Uri.parse('https://api.dart.dev/stable/$runtimeSdkVersion/'),
         index: DartdocIndex.fromJsonList([
           {

--- a/app/test/search/result_combiner_test.dart
+++ b/app/test/search/result_combiner_test.dart
@@ -110,7 +110,6 @@ void main() {
         'sdkLibraryHits': [
           {
             'sdk': 'dart',
-            'version': isNotEmpty,
             'library': 'dart:core',
             'url': contains('dart-core-library.html'),
             'score': closeTo(0.98, 0.01),

--- a/app/test/search/sdk_mem_index_test.dart
+++ b/app/test/search/sdk_mem_index_test.dart
@@ -90,7 +90,6 @@ void main() {
         [
           {
             'sdk': 'dart',
-            'version': '',
             'library': 'dart:async',
             'description': 'async description',
             'url': 'https://api.dart.dev/x/dart-async/dart-async-library.html',
@@ -123,7 +122,6 @@ void main() {
         [
           {
             'sdk': 'dart',
-            'version': '',
             'library': 'dart:async',
             'description': 'async description',
             'url': 'https://api.dart.dev/x/dart-async/dart-async-library.html',
@@ -147,7 +145,6 @@ void main() {
         [
           {
             'sdk': 'dart',
-            'version': '',
             'library': 'dart:async',
             'description': 'async description',
             'url': 'https://api.dart.dev/x/dart-async/dart-async-library.html',

--- a/app/test/search/sdk_mem_index_test.dart
+++ b/app/test/search/sdk_mem_index_test.dart
@@ -14,7 +14,6 @@ void main() {
     setUpAll(() async {
       index = SdkMemIndex(
         sdk: 'dart',
-        version: '',
         baseUri: Uri.parse('https://api.dart.dev/x/'),
         index: DartdocIndex.fromJsonList([
           {


### PR DESCRIPTION
- part of #8670 (merging the two separate SDK index) follow up to #8761
- the field is no longer used in practice, the downloaded index is now always unversioned (the latest)
- also removing it from the API and the UI
