### PR TITLE
Use DateTime.utc() for sanity

### DIFF
--- a/app/lib/service/download_counts/download_counts.dart
+++ b/app/lib/service/download_counts/download_counts.dart
@@ -79,7 +79,7 @@ class CountData {
   /// Process and store download counts given in [dayCounts] on the form
   /// {version: #downloads} for a date given by [dateTime].
   void addDownloadCounts(Map<String, int> dayCounts, DateTime dateTime) {
-    final date = DateTime(dateTime.year, dateTime.month, dateTime.day);
+    final date = DateTime.utc(dateTime.year, dateTime.month, dateTime.day);
     newestDate ??= date.addCalendarDays(-1);
 
     final nextNewestDate = date.isAfter(newestDate!) ? date : newestDate!;

--- a/app/test/service/download_counts/computations_test.dart
+++ b/app/test/service/download_counts/computations_test.dart
@@ -30,7 +30,7 @@ void main() {
         '4.0.0-0': 2,
         '6.1.0': 2,
       };
-      final date = DateTime.parse('1986-02-16');
+      final date = DateTime.parse('1986-02-16T00:00:00Z');
       var downloadCounts1 = await downloadCountsBackend.updateDownloadCounts(
           pkg, versionsCounts, date);
       for (var i = 1; i < 5; i++) {
@@ -128,7 +128,7 @@ void main() {
   group('weekly download counts', () {
     testWithProfile('compute weekly', fn: () async {
       final pkg = 'foo';
-      final date = DateTime.parse('1986-02-16');
+      final date = DateTime.parse('1986-02-16T00:00:00Z');
       final versionsCounts = {
         '1.0.1': 2,
         '2.0.0-alpha': 2,
@@ -172,7 +172,7 @@ void main() {
 
     testWithProfile('compute weekly for all verion ranges', fn: () async {
       final pkg = 'foo';
-      final date = DateTime.parse('1986-02-16');
+      final date = DateTime.parse('1986-02-16T00:00:00Z');
       final versions = [
         '1.1.0',
         '2.0.0-alpha',

--- a/app/test/service/download_counts/download_counts_major_test.dart
+++ b/app/test/service/download_counts/download_counts_major_test.dart
@@ -46,7 +46,7 @@ void main() {
   }
 
   test('Add counts on following date', () async {
-    final initialLastDate = DateTime.parse('1986-02-16');
+    final initialLastDate = DateTime.parse('1986-02-16T00:00:00Z');
     final countData = setupInitialCounts(initialLastDate);
 
     // Extend existing counts and expel the lowest range.
@@ -84,7 +84,7 @@ void main() {
   });
 
   test('Add counts for two days later', () async {
-    final initialLastDate = DateTime.parse('1986-02-16');
+    final initialLastDate = DateTime.parse('1986-02-16T00:00:00Z');
     final countData = setupInitialCounts(initialLastDate);
 
     // Extend existing counts and expel the lowest range.
@@ -186,7 +186,7 @@ void main() {
   });
 
   test('Add counts on older date', () async {
-    final initialLastDate = DateTime.parse('1986-02-16');
+    final initialLastDate = DateTime.parse('1986-02-16T00:00:00Z');
     final countData = setupInitialCounts(initialLastDate);
 
     final versionsCounts = {
@@ -223,7 +223,7 @@ void main() {
   });
 
   test('Add counts not affecting range', () async {
-    final initialLastDate = DateTime.parse('1986-02-16');
+    final initialLastDate = DateTime.parse('1986-02-16T00:00:00Z');
     final countData = setupInitialCounts(initialLastDate);
 
     final versionsCounts = {
@@ -257,7 +257,7 @@ void main() {
   });
 
   test('Add counts on missing range in the middle', () async {
-    final initialLastDate = DateTime.parse('1986-02-16');
+    final initialLastDate = DateTime.parse('1986-02-16T00:00:00Z');
     final countData = setupInitialCounts(initialLastDate);
 
     final versionCounts = {
@@ -296,7 +296,7 @@ void main() {
   });
 
   test('Add counts on missing range in the end', () async {
-    final initialLastDate = DateTime.parse('1986-02-16');
+    final initialLastDate = DateTime.parse('1986-02-16T00:00:00Z');
 
     final countData = CountData.empty();
     final versionsCounts = {
@@ -342,7 +342,7 @@ void main() {
   });
 
   test('More than maxAge dates', () async {
-    final initialLastDate = DateTime.parse('1986-02-16');
+    final initialLastDate = DateTime.parse('1986-02-16T00:00:00Z');
     final countData = CountData.empty();
     final versionsCounts = {
       '1.0.0': 2,

--- a/app/test/service/download_counts/download_counts_minor_test.dart
+++ b/app/test/service/download_counts/download_counts_minor_test.dart
@@ -51,7 +51,7 @@ void main() {
   }
 
   test('Add counts on following date', () async {
-    final initialLastDate = DateTime.parse('1986-02-16');
+    final initialLastDate = DateTime.parse('1986-02-16T00:00:00Z');
     final countData = setupInitialCounts(initialLastDate);
 
     // Extend existing counts and expel the lowest range.
@@ -94,7 +94,7 @@ void main() {
   });
 
   test('Add counts for two days later', () async {
-    final initialLastDate = DateTime.parse('1986-02-16');
+    final initialLastDate = DateTime.parse('1986-02-16T00:00:00Z');
     final countData = setupInitialCounts(initialLastDate);
 
     // Extend existing counts and expel the lowest range.
@@ -211,7 +211,7 @@ void main() {
   });
 
   test('Add counts on older date', () async {
-    final initialLastDate = DateTime.parse('1986-02-16');
+    final initialLastDate = DateTime.parse('1986-02-16T00:00:00Z');
     final countData = setupInitialCounts(initialLastDate);
 
     final versionsCounts = {
@@ -253,7 +253,7 @@ void main() {
   });
 
   test('Add counts not affecting minor ranges', () async {
-    final initialLastDate = DateTime.parse('1986-02-16');
+    final initialLastDate = DateTime.parse('1986-02-16T00:00:00Z');
     final countData = setupInitialCounts(initialLastDate);
 
     final versionsCounts = {
@@ -297,7 +297,7 @@ void main() {
   });
 
   test('Add counts on missing minor range in the middle', () async {
-    final initialLastDate = DateTime.parse('1986-02-16');
+    final initialLastDate = DateTime.parse('1986-02-16T00:00:00Z');
     final countData = setupInitialCounts(initialLastDate);
 
     final versionCounts = {
@@ -341,7 +341,7 @@ void main() {
   });
 
   test('Add counts on missing minor range in the end', () async {
-    final initialLastDate = DateTime.parse('1986-02-16');
+    final initialLastDate = DateTime.parse('1986-02-16T00:00:00Z');
 
     final countData = CountData.empty();
     final versionsCounts = {
@@ -392,7 +392,7 @@ void main() {
   });
 
   test('More than maxAge dates', () async {
-    final initialLastDate = DateTime.parse('1986-02-16');
+    final initialLastDate = DateTime.parse('1986-02-16T00:00:00Z');
     final countData = CountData.empty();
     final versionsCounts = {
       '1.1.0': 2,

--- a/app/test/service/download_counts/download_counts_patch_test.dart
+++ b/app/test/service/download_counts/download_counts_patch_test.dart
@@ -58,7 +58,7 @@ void main() {
   }
 
   test('Add counts on following date', () async {
-    final initialLastDate = DateTime.parse('1986-02-16');
+    final initialLastDate = DateTime.parse('1986-02-16T00:00:00Z');
     final countData = setupInitialCounts(initialLastDate);
 
     // Extend existing counts and expel the lowest range.
@@ -108,7 +108,7 @@ void main() {
   });
 
   test('Add counts for two days later', () async {
-    final initialLastDate = DateTime.parse('1986-02-16');
+    final initialLastDate = DateTime.parse('1986-02-16T00:00:00Z');
     final countData = setupInitialCounts(initialLastDate);
 
     // Extend existing counts and expel the lowest range.
@@ -246,7 +246,7 @@ void main() {
   });
 
   test('Add counts on older date', () async {
-    final initialLastDate = DateTime.parse('1986-02-16');
+    final initialLastDate = DateTime.parse('1986-02-16T00:00:00Z');
     final countData = setupInitialCounts(initialLastDate);
 
     final versionsCounts = {
@@ -295,7 +295,7 @@ void main() {
   });
 
   test('Add counts not affecting ranges', () async {
-    final initialLastDate = DateTime.parse('1986-02-16');
+    final initialLastDate = DateTime.parse('1986-02-16T00:00:00Z');
     final countData = setupInitialCounts(initialLastDate);
 
     final versionsCounts = {
@@ -351,7 +351,7 @@ void main() {
   });
 
   test('Add counts on missing patch range in the middle', () async {
-    final initialLastDate = DateTime.parse('1986-02-16');
+    final initialLastDate = DateTime.parse('1986-02-16T00:00:00Z');
     final countData = setupInitialCounts(initialLastDate);
 
     final versionCounts = {
@@ -402,7 +402,7 @@ void main() {
   });
 
   test('Add counts on missing patch range in the end', () async {
-    final initialLastDate = DateTime.parse('1986-02-16');
+    final initialLastDate = DateTime.parse('1986-02-16T00:00:00Z');
 
     final countData = CountData.empty();
     final versionsCounts = {
@@ -470,7 +470,7 @@ void main() {
   });
 
   test('More than maxAge dates', () async {
-    final initialLastDate = DateTime.parse('1986-02-16');
+    final initialLastDate = DateTime.parse('1986-02-16T00:00:00Z');
     final countData = CountData.empty();
     final versionsCounts = {
       '1.1.0': 2,

--- a/app/test/service/download_counts/download_counts_test.dart
+++ b/app/test/service/download_counts/download_counts_test.dart
@@ -31,7 +31,7 @@ void main() {
         '4.0.0-0': 2,
         '6.1.0': 2,
       };
-      final date = DateTime.parse('1986-02-16');
+      final date = DateTime.parse('1986-02-16T00:00:00Z');
       final updatedDownloadCounts = await downloadCountsBackend
           .updateDownloadCounts(pkg, versionsCounts, date);
       expect(updatedDownloadCounts, isNotNull);
@@ -48,7 +48,7 @@ void main() {
     });
 
     testWithProfile('process download counts', fn: () async {
-      final date = DateTime.parse('2024-01-05');
+      final date = DateTime.parse('2024-01-05T00:00:00Z');
       final downloadCountsJsonFileName =
           'daily_download_counts/2024-01-05T00:00:00Z/data-000000000000.jsonl';
       await uploadFakeDownloadCountsToBucket(
@@ -69,7 +69,7 @@ void main() {
     testWithProfile(
         'Process download counts - 0 count for unmentioned packages',
         fn: () async {
-      final date = DateTime.parse('2024-01-05');
+      final date = DateTime.parse('2024-01-05T00:00:00Z');
       final downloadCountsJsonFileNameJan5 =
           'daily_download_counts/2024-01-05T00:00:00Z/data-000000000000.jsonl';
       await uploadFakeDownloadCountsToBucket(
@@ -78,7 +78,7 @@ void main() {
               'download_counts', 'fake_download_counts_data.jsonl'));
       await processDownloadCounts(date);
 
-      final nextDate = DateTime.parse('2024-01-06');
+      final nextDate = DateTime.parse('2024-01-06T00:00:00Z');
       final downloadCountsJsonFileNameJan6 =
           'daily_download_counts/2024-01-06T00:00:00Z/data-000000000000.jsonl';
       await uploadFakeDownloadCountsToBucket(
@@ -110,7 +110,7 @@ void main() {
     });
 
     testWithProfile('with faulty line', fn: () async {
-      final nextDate = DateTime.parse('2024-01-06');
+      final nextDate = DateTime.parse('2024-01-06T00:00:00Z');
       final downloadCountsJsonFileNameJan6 =
           'daily_download_counts/2024-01-06T00:00:00Z/data-000000000000.jsonl';
       await uploadFakeDownloadCountsToBucket(
@@ -147,7 +147,7 @@ void main() {
     });
 
     testWithProfile('with non-existing package', fn: () async {
-      final nextDate = DateTime.parse('2024-01-06');
+      final nextDate = DateTime.parse('2024-01-06T00:00:00Z');
       final downloadCountsJsonFileNameJan6 =
           'daily_download_counts/2024-01-06T00:00:00Z/data-000000000000.jsonl';
       await uploadFakeDownloadCountsToBucket(
@@ -182,7 +182,7 @@ void main() {
     });
 
     testWithProfile('file not present', fn: () async {
-      final nextDate = DateTime.parse('2024-01-06');
+      final nextDate = DateTime.parse('2024-01-06T00:00:00Z');
       Set<String> failedFiles;
       final messages = <String>[];
       final subscription = Logger.root.onRecord.listen((event) {
@@ -199,7 +199,7 @@ void main() {
     });
 
     testWithProfile('empty file', fn: () async {
-      final nextDate = DateTime.parse('2024-01-06');
+      final nextDate = DateTime.parse('2024-01-06T00:00:00Z');
       final downloadCountsJsonFileNameJan6 =
           'daily_download_counts/2024-01-06T00:00:00Z/data-000000000000.jsonl';
       await uploadFakeDownloadCountsToBucket(


### PR DESCRIPTION
I'm not entirely sure why this fails when using local time, but not using local time is probably a good idea.

I suspect that if we wanted to make the logic more robust, we should convert `DateTime` objects to milliseconds, and do a floating point division with `24 * 60 * 60 * 1000` (ms per day), and then round to nearest count of days.

I suspect the problem with `Duration.inDays` is that it doesn't round up, it'll always round down.

That may be a better fix.