### PR TITLE
Updated admin removal for package versions: using the flag on the action

### DIFF
--- a/app/lib/admin/actions/package_version_delete.dart
+++ b/app/lib/admin/actions/package_version_delete.dart
@@ -4,47 +4,38 @@
 
 import '../../account/backend.dart';
 import '../../shared/configuration.dart';
-import '../backend.dart';
 import 'actions.dart';
+import 'moderate_package_versions.dart';
 
 final packageVersionDelete = AdminAction(
-    name: 'package-version-delete',
-    options: {
-      'package': 'name of package to delete',
-      'version': 'version of package',
-    },
-    summary: 'Deletes package <package> version <version>.',
-    description: '''
-Deletes package <package> version <version>.
-
-Deletes all associated resources:
-
-* PackageVersions
-* PackageVersionAsset
-* archives (might be retrievable from backup)
-
-The package version will be "tombstoned" and same version cannot be published
-later.
+  name: 'package-version-delete',
+  summary:
+      'Set the admin-deleted flag on a package version (making it not visible).',
+  description: '''
+Set the admin-deleted flag on a package version (updating the flag and the timestamp).
 ''',
-    invoke: (args) async {
-      await requireAuthenticatedAdmin(AdminPermission.removePackage);
-      final packageName = args['package'];
-      if (packageName == null) {
-        throw InvalidInputException('Missing `package` argument');
-      }
-      final version = args['version'];
-      if (version == null) {
-        throw InvalidInputException('Missing `version` argument');
-      }
-      final result =
-          await adminBackend.removePackageVersion(packageName, version);
-
-      return {
-        'message': 'Package version and all associated resources deleted.',
-        'package': packageName,
-        'version': version,
-        'deletedPackageVersions': result.deletedPackageVersions,
-        'deletedPackageVersionInfos': result.deletedPackageVersionInfos,
-        'deletedPackageVersionAssets': result.deletedPackageVersionAssets,
-      };
-    });
+  options: {
+    'package': 'The package name to be deleted',
+    'version': 'The version to be deleted',
+    'state':
+        'Set admin-deleted state true / false. Returns current state if omitted.',
+  },
+  invoke: (args) async {
+    await requireAuthenticatedAdmin(AdminPermission.removePackage);
+    final package = args['package'];
+    final version = args['version'];
+    final state = args['state'];
+    return await adminMarkPackageVersionVisibility(
+      package,
+      version,
+      state: state,
+      whenUpdating: (tx, v, valueToSet) async {
+        v.updateIsAdminDeleted(isAdminDeleted: valueToSet);
+      },
+      valueFn: (v) => {
+        'isAdminDeleted': v.isAdminDeleted,
+        'adminDeletedAt': v.adminDeletedAt?.toIso8601String(),
+      },
+    );
+  },
+);

--- a/app/lib/admin/actions/package_version_delete.dart
+++ b/app/lib/admin/actions/package_version_delete.dart
@@ -12,7 +12,7 @@ final packageVersionDelete = AdminAction(
   summary:
       'Set the admin-deleted flag on a package version (making it not visible).',
   description: '''
-Set the admin-deleted flag on a package version (updating the flag and the timestamp).
+Set the admin-deleted flag on a package version (updating the flag and the timestamp). After 2 months it will be fully deleted.
 ''',
   options: {
     'package': 'The package name to be deleted',

--- a/app/lib/admin/backend.dart
+++ b/app/lib/admin/backend.dart
@@ -804,7 +804,6 @@ class AdminBackend {
     }
 
     // delete package versions
-    // TODO: merge this with the removePackageVersion method.
     final pvQuery = _db.query<PackageVersion>()
       ..filter('moderatedAt <', before)
       ..order('moderatedAt');

--- a/app/lib/admin/backend.dart
+++ b/app/lib/admin/backend.dart
@@ -455,6 +455,7 @@ class AdminBackend {
   /// Removes the specific package version from the Datastore and updates other
   /// related entities. It is safe to call [removePackageVersion] on an already
   /// removed version, as the call is idempotent.
+  @visibleForTesting
   Future<
       ({
         int deletedPackageVersions,
@@ -466,6 +467,20 @@ class AdminBackend {
         lastKnownStable: toolStableDartSdkVersion);
     final currentFlutterSdk = await getCachedFlutterSdkVersion(
         lastKnownStable: toolStableFlutterSdkVersion);
+
+    _logger.info('Removing GCS objects ...');
+    await packageBackend.removePackageTarball(packageName, version);
+
+    final deletedPackageVersionInfos = await _db.deleteWithQuery(
+      _db.query<PackageVersionInfo>()..filter('package =', packageName),
+      where: (PackageVersionInfo info) => info.version == version,
+    );
+
+    final deletedPackageVersionAssets = await _db.deleteWithQuery(
+      _db.query<PackageVersionAsset>()..filter('package =', packageName),
+      where: (PackageVersionAsset asset) => asset.version == version,
+    );
+
     await withRetryTransaction(_db, (tx) async {
       final packageKey = _db.emptyKey.append(Package, id: packageName);
       final package = await tx.lookupOrNull<Package>(packageKey);
@@ -501,19 +516,6 @@ class AdminBackend {
 
       tx.insert(package);
     });
-
-    _logger.info('Removing GCS objects ...');
-    await packageBackend.removePackageTarball(packageName, version);
-
-    final deletedPackageVersionInfos = await _db.deleteWithQuery(
-      _db.query<PackageVersionInfo>()..filter('package =', packageName),
-      where: (PackageVersionInfo info) => info.version == version,
-    );
-
-    final deletedPackageVersionAssets = await _db.deleteWithQuery(
-      _db.query<PackageVersionAsset>()..filter('package =', packageName),
-      where: (PackageVersionAsset asset) => asset.version == version,
-    );
 
     await purgePackageCache(packageName);
     await purgeScorecardData(packageName, version, isLatest: true);
@@ -802,6 +804,7 @@ class AdminBackend {
     }
 
     // delete package versions
+    // TODO: merge this with the removePackageVersion method.
     final pvQuery = _db.query<PackageVersion>()
       ..filter('moderatedAt <', before)
       ..order('moderatedAt');
@@ -813,48 +816,7 @@ class AdminBackend {
 
       _logger.info(
           'Deleting moderated package version: ${version.qualifiedVersionKey}');
-
-      // deleting from canonical bucket
-      await packageBackend.tarballStorage
-          .deleteArchiveFromCanonicalBucket(version.package, version.version!);
-
-      // deleting from datastore
-      await withRetryTransaction(_db, (tx) async {
-        final pv = await tx.lookupOrNull<PackageVersion>(version.key);
-        if (pv == null) {
-          return null;
-        }
-        final p = await tx.lookupOrNull<Package>(version.packageKey!);
-        if (p == null) {
-          return;
-        }
-        final pvi = await tx.lookupOrNull<PackageVersionInfo>(_db.emptyKey
-            .append(PackageVersionInfo,
-                id: version.qualifiedVersionKey.qualifiedVersion));
-
-        p.deletedVersions ??= [];
-        p.deletedVersions!.add(version.version!);
-        p.deletedVersions!.sort();
-        p.updated = clock.now().toUtc();
-        tx.insert(p);
-
-        // delete version + info + assets
-        tx.delete(pv.key);
-        if (pvi != null) {
-          tx.delete(pvi.key);
-
-          for (final assetKind in pvi.assets) {
-            tx.delete(
-              _db.emptyKey.append(PackageVersionAsset,
-                  id: Uri(pathSegments: [
-                    version.package,
-                    version.version!,
-                    assetKind
-                  ]).path),
-            );
-          }
-        }
-      });
+      await removePackageVersion(version.package, version.version!);
       _logger.info(
           'Deleted moderated package version: ${version.qualifiedVersionKey}');
     }
@@ -910,6 +872,31 @@ class AdminBackend {
       _logger.info('Deleting moderated user: ${user.userId}');
       await _removeUser(user);
       _logger.info('Deleting moderated user: ${user.userId}');
+    }
+  }
+
+  /// Scans datastore and deletes admin-deleted entities where the last action
+  /// was more than 2 months ago.
+  Future<void> deleteAdminDeletedEntities({
+    @visibleForTesting DateTime? before,
+  }) async {
+    before ??= clock.ago(days: 62).toUtc(); // extra buffer days
+
+    // delete package versions
+    final pvQuery = _db.query<PackageVersion>()
+      ..filter('adminDeletedAt <', before)
+      ..order('adminDeletedAt');
+    await for (final version in pvQuery.run()) {
+      // sanity check
+      if (!(version.isAdminDeleted ?? false)) {
+        continue;
+      }
+
+      _logger.info(
+          'Deleting admin-deleted package version: ${version.qualifiedVersionKey}');
+      await removePackageVersion(version.package, version.version!);
+      _logger.info(
+          'Deleted moderated package version: ${version.qualifiedVersionKey}');
     }
   }
 

--- a/app/lib/package/models.dart
+++ b/app/lib/package/models.dart
@@ -412,6 +412,14 @@ class Package extends db.ExpandoModel<String> {
     moderatedAt = isModerated ? clock.now().toUtc() : null;
     updated = clock.now().toUtc();
   }
+
+  void updateIsAdminDeleted({
+    required bool isAdminDeleted,
+  }) {
+    this.isAdminDeleted = isAdminDeleted;
+    adminDeletedAt = isAdminDeleted ? clock.now().toUtc() : null;
+    updated = clock.now().toUtc();
+  }
 }
 
 /// Describes the various categories of latest releases.
@@ -675,6 +683,13 @@ class PackageVersion extends db.ExpandoModel<String> {
   }) {
     this.isModerated = isModerated;
     moderatedAt = isModerated ? clock.now().toUtc() : null;
+  }
+
+  void updateIsAdminDeleted({
+    required bool isAdminDeleted,
+  }) {
+    this.isAdminDeleted = isAdminDeleted;
+    adminDeletedAt = isAdminDeleted ? clock.now().toUtc() : null;
   }
 }
 

--- a/app/lib/tool/neat_task/pub_dev_tasks.dart
+++ b/app/lib/tool/neat_task/pub_dev_tasks.dart
@@ -136,6 +136,13 @@ List<NeatPeriodicTaskScheduler> createPeriodicTaskSchedulers({
       task: () async => await apiExporter.synchronizeExportedApi(),
     ),
 
+    // Deletes admin-deleted entities.
+    _weekly(
+      name: 'delete-admin-deleted-entities',
+      isRuntimeVersioned: false,
+      task: () async => adminBackend.deleteAdminDeletedEntities(),
+    ),
+
     // Deletes moderated packages, versions, publishers and users.
     _weekly(
       name: 'delete-moderated-subjects',


### PR DESCRIPTION
- part of #8730
- only changes the deletion of a version and not the package (yet, to be done in a follow-up PR)
- follows the same admin action pattern as the moderate actions
- reuses most of the update code with moderating and deleting a package version
- updated tests with only a few relevant bits, we won't need to duplicate everything, as the main code will be already tested with the moderation action
- does the actual deletion after 2 months
