### PR TITLE
Remove SdkMemIndex.getLibraryDescription

### DIFF
--- a/app/lib/search/sdk_mem_index.dart
+++ b/app/lib/search/sdk_mem_index.dart
@@ -6,7 +6,6 @@ import 'dart:math';
 
 import 'package:gcloud/service_scope.dart' as ss;
 import 'package:logging/logging.dart';
-import 'package:meta/meta.dart';
 // ignore: implementation_imports
 import 'package:pana/src/dartdoc/dartdoc_index.dart';
 import 'package:path/path.dart' as p;
@@ -188,10 +187,6 @@ class SdkMemIndex {
             ))
         .toList();
   }
-
-  @visibleForTesting
-  String? getLibraryDescription(String library) =>
-      _libraries[library]?.description;
 }
 
 class _Hit {

--- a/app/test/search/backend_test.dart
+++ b/app/test/search/backend_test.dart
@@ -19,8 +19,9 @@ void main() {
         dartIndex: DartdocIndex.parseJsonText(content),
         flutterIndex: DartdocIndex([]),
       );
+      final rs = index.search('dart:async');
       expect(
-        index.getLibraryDescription('dart:async'),
+        rs.first.description,
         'Support for asynchronous programming, with classes such as Future and Stream.',
       );
     });


### PR DESCRIPTION
- Since the dartdoc `index.json` has the description, this method is no longer needed. Kept the test that checks for the correct value.