### PR TITLE
Isolate-based access to the SDK index (but not used yet).

### DIFF
--- a/app/lib/search/sdk_mem_index.dart
+++ b/app/lib/search/sdk_mem_index.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:async';
 import 'dart:math';
 
 import 'package:gcloud/service_scope.dart' as ss;
@@ -66,8 +67,18 @@ Future<SdkMemIndex?> createSdkMemIndex() async {
   }
 }
 
+/// Defines the general interface for the SDK index.
+// ignore: one_member_abstracts
+abstract class SdkIndex {
+  FutureOr<List<SdkLibraryHit>> search(
+    String query, {
+    int? limit,
+    bool skipFlutter = false,
+  });
+}
+
 /// In-memory index for SDK library search queries.
-class SdkMemIndex {
+class SdkMemIndex implements SdkIndex {
   final _libraries = <String, _Library>{};
   final Map<String, double> _apiPageDirWeights;
 
@@ -126,6 +137,7 @@ class SdkMemIndex {
     }
   }
 
+  @override
   List<SdkLibraryHit> search(
     String query, {
     int? limit,

--- a/app/lib/service/entrypoint/sdk_isolate_index.dart
+++ b/app/lib/service/entrypoint/sdk_isolate_index.dart
@@ -1,0 +1,81 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:gcloud/service_scope.dart';
+import 'package:logging/logging.dart';
+import 'package:pub_dev/service/entrypoint/logging.dart';
+import 'package:pub_dev/service/services.dart';
+import 'package:pub_dev/shared/env_config.dart';
+import 'package:pub_dev/shared/logging.dart';
+
+import '../../../service/entrypoint/_isolate.dart';
+
+import '../../search/sdk_mem_index.dart';
+import '../../search/search_service.dart';
+
+final _logger = Logger('sdk_search_index');
+
+/// Entry point for the SDK search index isolate.
+Future<void> main(List<String> args, var message) async {
+  final timer = Timer.periodic(Duration(milliseconds: 250), (_) {});
+
+  final ServicesWrapperFn servicesWrapperFn;
+  if (envConfig.isRunningInAppengine) {
+    servicesWrapperFn = withServices;
+    setupAppEngineLogging();
+  } else {
+    servicesWrapperFn = (fn) => withFakeServices(fn: fn);
+    setupDebugEnvBasedLogging();
+  }
+
+  await fork(() async {
+    await servicesWrapperFn(() async {
+      final sdkMemIndex = await createSdkMemIndex();
+      await runIsolateFunctions(
+          message: message,
+          logger: _logger,
+          fn: (payload) async {
+            final args = payload as List;
+            final rs = sdkMemIndex!.search(
+              args[0] as String,
+              limit: args[1] as int?,
+              skipFlutter: args[2] as bool,
+            );
+            return ReplyMessage.result(rs.map((e) => e.toJson()).toList());
+          });
+    });
+  });
+
+  timer.cancel();
+}
+
+/// Implementation of [SdkMemIndex] that uses [RequestMessage]s to send requests
+/// across isolate boundaries. The instance should be registered inside the
+/// `frontend` isolate, and it calls the `sdk-index` isolate as a delegate.
+class SdkIsolateIndex implements SdkIndex {
+  final IsolateRunner _runner;
+  SdkIsolateIndex(this._runner);
+
+  @override
+  Future<List<SdkLibraryHit>> search(
+    String query, {
+    int? limit,
+    bool skipFlutter = false,
+  }) async {
+    try {
+      final rs = await _runner.sendRequest(
+        [query, limit, skipFlutter],
+        timeout: Duration(seconds: 2),
+      );
+      return (rs as List)
+          .map((v) => SdkLibraryHit.fromJson(v as Map<String, dynamic>))
+          .toList();
+    } catch (e, st) {
+      _logger.warning('Failed to search SDK index.', e, st);
+      return <SdkLibraryHit>[];
+    }
+  }
+}

--- a/app/test/service/entrypoint/sdk_isolate_index_test.dart
+++ b/app/test/service/entrypoint/sdk_isolate_index_test.dart
@@ -1,0 +1,44 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:logging/logging.dart';
+import 'package:pub_dev/service/entrypoint/_isolate.dart';
+import 'package:pub_dev/service/entrypoint/sdk_isolate_index.dart';
+import 'package:test/test.dart';
+
+final _logger = Logger('sdk_isolate_index_test');
+
+void main() {
+  group('SDK index inside an isolate', () {
+    final indexRunner = IsolateRunner.uri(
+      kind: 'index',
+      logger: _logger,
+      spawnUri: Uri.parse(
+          'package:pub_dev/service/entrypoint/sdk_isolate_index.dart'),
+    );
+
+    tearDownAll(() async {
+      await indexRunner.close();
+    });
+
+    test('start and work with index', () async {
+      await indexRunner.start(1);
+
+      final sdkIndex = SdkIsolateIndex(indexRunner);
+
+      final rs = await sdkIndex.search('json');
+      expect(rs.map((e) => e.toJson()).toList(), [
+        {
+          'sdk': 'dart',
+          'library': 'dart:convert',
+          'description': isNotNull,
+          'url': 'https://api.dart.dev/stable/latest/dart-convert/',
+          'score': isNotNull,
+          'apiPages': isNotEmpty,
+        },
+        isA<Map>(), // second hit from `package:flutter_driver`
+      ]);
+    }, timeout: Timeout(Duration(minutes: 5)));
+  });
+}

--- a/app/test/shared/timer_import_test.dart
+++ b/app/test/shared/timer_import_test.dart
@@ -44,6 +44,9 @@ void main() {
     // Uses timer to prevent GC compaction.
     'lib/service/entrypoint/search_index.dart',
 
+    // Uses timer to prevent GC compaction.
+    'lib/service/entrypoint/sdk_isolate_index.dart',
+
     // Uses timer to timeout GlobalLock claim acquisition.
     'lib/tool/neat_task/pub_dev_tasks.dart',
 


### PR DESCRIPTION
- #8670
- refactored and reused the package index's code into a bit more generic `runIsolateFunctions` to handle the initialization and message passing on the service isolate side
- added a test that runs the SDK index in an isolate, will update the search service to use it in a subsequent PR
