### PR TITLE
New isolate for the SDK index in the search instance.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Important changes to data models, configuration, and migrations between each
 AppEngine version, listed here to ease deployment and troubleshooting.
 
 ## Next Release (replace with git tag when deployed)
+ * Note: search instance uses separate isolate for the SDK index.
 
 ## `20250522t102600-all`
  * Bump runtimeVersion to `2025.05.21`.

--- a/app/lib/fake/server/fake_search_service.dart
+++ b/app/lib/fake/server/fake_search_service.dart
@@ -39,7 +39,7 @@ class FakeSearchService {
         storage: _storage,
         cloudCompute: _cloudCompute,
         fn: () async {
-          registerSdkMemIndex(await createSdkMemIndex());
+          registerSdkIndex(await createSdkMemIndex());
           final handler = wrapHandler(_logger, searchServiceHandler);
           final server = await IOServer.bind('localhost', port);
           serveRequests(server.server, (request) async {

--- a/app/lib/search/backend.dart
+++ b/app/lib/search/backend.dart
@@ -619,18 +619,34 @@ class _CombinedSearchIndex implements SearchIndex {
   IndexInfo indexInfo() => _packageIndexHolder._index.indexInfo();
 
   @override
-  PackageSearchResult search(ServiceSearchQuery query) {
+  Future<PackageSearchResult> search(ServiceSearchQuery query) async {
     final combiner = SearchResultCombiner(
-      primaryIndex: _packageIndexHolder._index,
-      sdkMemIndex: sdkMemIndex,
+      primaryIndex: _packageIndexHolder,
+      sdkIndex: sdkIndex,
     );
-    return combiner.search(query);
+    return await combiner.search(query);
   }
 }
 
 /// Holds an immutable [InMemoryPackageIndex] that is the actual active search index.
-class PackageIndexHolder {
+class PackageIndexHolder implements SearchIndex {
   var _index = InMemoryPackageIndex(documents: const []);
+
+  @override
+  bool isReady() => indexInfo().isReady;
+
+  @override
+  IndexInfo indexInfo() => _index.indexInfo();
+
+  @override
+  PackageSearchResult search(ServiceSearchQuery query) {
+    return _index.search(query);
+  }
+
+  /// Updates the active package index with [newIndex].
+  void updatePackageIndex(InMemoryPackageIndex newIndex) {
+    _index = newIndex;
+  }
 }
 
 /// Updates the active package index with [newIndex].

--- a/app/lib/search/result_combiner.dart
+++ b/app/lib/search/result_combiner.dart
@@ -2,36 +2,51 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:async';
+
 import 'package:_pub_shared/search/tags.dart';
 import 'package:collection/collection.dart';
 
-import 'mem_index.dart';
 import 'sdk_mem_index.dart';
 import 'search_service.dart';
 
 /// Combines the results from the primary package index and the optional Dart
 /// SDK index.
-class SearchResultCombiner {
-  final InMemoryPackageIndex primaryIndex;
-  final SdkMemIndex? sdkMemIndex;
+class SearchResultCombiner implements SearchIndex {
+  final SearchIndex primaryIndex;
+  final SdkIndex? sdkIndex;
 
   SearchResultCombiner({
     required this.primaryIndex,
-    required this.sdkMemIndex,
+    required this.sdkIndex,
   });
 
-  PackageSearchResult search(ServiceSearchQuery query) {
-    final primaryResult = primaryIndex.search(query);
-    if (!query.includeSdkResults) {
-      return primaryResult;
+  @override
+  FutureOr<IndexInfo> indexInfo() async {
+    return await primaryIndex.indexInfo();
+  }
+
+  @override
+  FutureOr<bool> isReady() async {
+    return await primaryIndex.isReady();
+  }
+
+  @override
+  Future<PackageSearchResult> search(ServiceSearchQuery query) async {
+    if (sdkIndex == null || !query.includeSdkResults) {
+      return await primaryIndex.search(query);
     }
 
     final queryFlutterSdk = query.tagsPredicate.hasNoTagPrefix('sdk:') ||
         query.tagsPredicate.hasTag(SdkTag.sdkFlutter);
-    final sdkLibraryHits = sdkMemIndex
-            ?.search(query.query!, limit: 2, skipFlutter: !queryFlutterSdk)
-            .toList() ??
-        <SdkLibraryHit>[];
+    final results = await Future.wait([
+      Future(() => primaryIndex.search(query)),
+      Future(() => sdkIndex!
+          .search(query.query!, limit: 2, skipFlutter: !queryFlutterSdk)),
+    ]);
+    final primaryResult = results[0] as PackageSearchResult;
+    final sdkLibraryHits = results[1] as List<SdkLibraryHit>;
+
     if (sdkLibraryHits.isNotEmpty) {
       // Do not display low SDK scores if the package hits are more relevant on the page.
       //

--- a/app/lib/search/sdk_mem_index.dart
+++ b/app/lib/search/sdk_mem_index.dart
@@ -17,15 +17,15 @@ import 'token_index.dart';
 
 export 'package:pana/src/dartdoc/dartdoc_index.dart';
 
-/// Sets the SDK in-memory index.
-void registerSdkMemIndex(SdkMemIndex? index) {
+/// Sets the SDK index.
+void registerSdkIndex(SdkIndex? index) {
   if (index != null) {
-    ss.register(#_sdkMemIndex, index);
+    ss.register(#_sdkIndex, index);
   }
 }
 
 /// The active SDK in-memory index.
-SdkMemIndex? get sdkMemIndex => ss.lookup(#_sdkMemIndex) as SdkMemIndex?;
+SdkIndex? get sdkIndex => ss.lookup(#_sdkIndex) as SdkIndex?;
 
 /// Results from these libraries are ranked with lower score and
 /// will be displayed only if the query has the library name, or

--- a/app/lib/service/entrypoint/_isolate.dart
+++ b/app/lib/service/entrypoint/_isolate.dart
@@ -176,10 +176,11 @@ Future<IsolateRunner> startWorkerIsolate({
 Future<IsolateRunner> startQueryIsolate({
   required Logger logger,
   required Uri spawnUri,
+  required String kind,
 }) async {
   final worker = IsolateRunner.uri(
     logger: logger,
-    kind: 'query',
+    kind: kind,
     spawnUri: spawnUri,
   );
   await worker.start(1);

--- a/app/lib/service/entrypoint/search_index.dart
+++ b/app/lib/service/entrypoint/search_index.dart
@@ -8,7 +8,6 @@ import 'dart:convert';
 import 'package:gcloud/service_scope.dart';
 import 'package:logging/logging.dart';
 import 'package:pub_dev/search/backend.dart';
-import 'package:pub_dev/search/sdk_mem_index.dart';
 import 'package:pub_dev/search/search_service.dart';
 import 'package:pub_dev/search/updater.dart';
 import 'package:pub_dev/service/entrypoint/_isolate.dart';
@@ -35,7 +34,6 @@ Future<void> main(List<String> args, var message) async {
   }
   await fork(() async {
     await servicesWrapperFn(() async {
-      registerSdkMemIndex(await createSdkMemIndex());
       await indexUpdater.init();
 
       await runIsolateFunctions(

--- a/app/test/service/entrypoint/search_index_test.dart
+++ b/app/test/service/entrypoint/search_index_test.dart
@@ -34,7 +34,7 @@ void main() {
       final rs =
           await searchIndex.search(ServiceSearchQuery.parse(query: 'json'));
       expect(rs.errorMessage, isNull);
-      expect(rs.sdkLibraryHits, isNotEmpty);
+      expect(rs.sdkLibraryHits, isEmpty);
       expect(rs.packageHits, isEmpty);
     }, timeout: Timeout(Duration(minutes: 5)));
   });


### PR DESCRIPTION
- part of #8670
- on a local benchmark, this removed about 5-8% of the overall wall-clock latency with a single thread load, I think the effect may be more with the real traffic which will have higher concurrency
- This PR refactored `PackageIndexHolder` and `SearchResultCombiner`, but mostly kept them in place. I think we should probably merge those, and make other parts simpler (planned in a follow-up PR).
- note: we (still) lack the test coverage for the `entrypoint/search.dart` file, will address that in a follow-up PR
