### PR TITLE
Allow <a name=""></a> elements in the markdown.

### DIFF
--- a/app/lib/shared/markdown.dart
+++ b/app/lib/shared/markdown.dart
@@ -220,7 +220,13 @@ class _RelativeUrlRewriter extends html_parsing.TreeVisitor {
     super.visitElement(element);
 
     // check current element
-    if (element.localName == 'a') {
+    if (element.localName == 'a' &&
+        element.attributes.length == 1 &&
+        element.attributes.containsKey('name') &&
+        element.attributes['name']!.isNotEmpty &&
+        element.nodes.isEmpty) {
+      // allow name anchor without any other attribute or content
+    } else if (element.localName == 'a') {
       _updateUrlAttributes(element, 'href');
     } else if (element.localName == 'img') {
       _updateUrlAttributes(element, 'src', raw: true);

--- a/app/test/shared/markdown_test.dart
+++ b/app/test/shared/markdown_test.dart
@@ -27,6 +27,16 @@ void main() {
         '</ul>\n',
       );
     });
+
+    test('named anchor', () {
+      expect(
+          markdownToHtml('<a name="abc"></a>'), '<p><a name="abc"></a></p>\n');
+    });
+
+    test('named anchor with other content', () {
+      expect(markdownToHtml('<a name="abc" other="1"></a>'), '<p></p>\n');
+      expect(markdownToHtml('<a name="abc">x</a>'), '<p>x</p>\n');
+    });
   });
 
   group('Valid custom base URL', () {


### PR DESCRIPTION
Fixes #8794.