### PR TITLE
Implement bitarray pool in package search index.

### DIFF
--- a/app/lib/search/token_index.dart
+++ b/app/lib/search/token_index.dart
@@ -204,9 +204,9 @@ class BitArrayPool<K> {
   R withBitArrayAllSet<R>({
     required R Function(BitArray array) fn,
   }) {
-    final score = _acquireAllSet();
-    final r = fn(score);
-    _release(score);
+    final array = _acquireAllSet();
+    final r = fn(array);
+    _release(array);
     return r;
   }
 }

--- a/app/lib/search/token_index.dart
+++ b/app/lib/search/token_index.dart
@@ -5,6 +5,7 @@
 import 'dart:math' as math;
 
 import 'package:meta/meta.dart';
+import 'package:pub_dev/third_party/bit_array/bit_array.dart';
 
 import 'text_utils.dart';
 
@@ -177,6 +178,33 @@ class ScorePool<K> {
     required R Function(IndexedScore<K> score) fn,
   }) {
     final score = _acquire(value);
+    final r = fn(score);
+    _release(score);
+    return r;
+  }
+}
+
+/// A reusable pool for [BitArray] instances to spare some memory allocation.
+class BitArrayPool<K> {
+  final int _length;
+  final _pool = <BitArray>[];
+
+  BitArrayPool(this._length);
+
+  BitArray _acquireAllSet() {
+    final array = _pool.isNotEmpty ? _pool.removeLast() : BitArray(_length);
+    array.setRange(0, _length);
+    return array;
+  }
+
+  void _release(BitArray array) {
+    _pool.add(array);
+  }
+
+  R withBitArrayAllSet<R>({
+    required R Function(BitArray array) fn,
+  }) {
+    final score = _acquireAllSet();
     final r = fn(score);
     _release(score);
     return r;


### PR DESCRIPTION
- Provides a consistent 1-2% latency improvement.
- Note: I've also investigated how to reduce the use of `IndexedScore`, but seems to be a bit more involved, postponing it for now (with a follow-up PR that may prepare it).