### PR TITLE
Refactor search + better early return when there are no hits.

### DIFF
--- a/app/lib/search/search_service.dart
+++ b/app/lib/search/search_service.dart
@@ -167,8 +167,8 @@ class ServiceSearchQuery {
 
   /// The value of the `sort` URL query parameter.
   final SearchOrder? order;
-  final int? offset;
-  final int? limit;
+  final int offset;
+  final int limit;
 
   /// The scope/depth of text matching.
   final TextMatchExtent? textMatchExtent;
@@ -179,10 +179,12 @@ class ServiceSearchQuery {
     String? publisherId,
     required this.minPoints,
     this.order,
-    this.offset,
-    this.limit,
+    int? offset,
+    int? limit,
     this.textMatchExtent,
-  })  : parsedQuery = ParsedQueryText.parse(query),
+  })  : offset = max(0, offset ?? 0),
+        limit = max(_minSearchLimit, limit ?? 10),
+        parsedQuery = ParsedQueryText.parse(query),
         tagsPredicate = tagsPredicate ?? TagsPredicate(),
         publisherId = publisherId?.trimToNull();
 
@@ -232,8 +234,8 @@ class ServiceSearchQuery {
       publisherId: publisherId,
       order: order,
       minPoints: minPoints,
-      offset: max(0, offset),
-      limit: max(_minSearchLimit, limit),
+      offset: offset,
+      limit: limit,
       textMatchExtent: textMatchExtent,
     );
   }
@@ -264,10 +266,10 @@ class ServiceSearchQuery {
       'q': query,
       'tags': tagsPredicate.toQueryParameters(),
       'publisherId': publisherId,
-      'offset': offset?.toString(),
+      'offset': offset.toString(),
       if (minPoints != null && minPoints! > 0)
         'minPoints': minPoints.toString(),
-      'limit': limit?.toString(),
+      'limit': limit.toString(),
       'order': order?.name,
       if (textMatchExtent != null) 'textMatchExtent': textMatchExtent!.name,
     };

--- a/app/lib/shared/utils.dart
+++ b/app/lib/shared/utils.dart
@@ -155,16 +155,16 @@ String contentType(String name) {
 }
 
 /// Returns a subset of the list, bounded by [offset] and [limit].
-List<T> boundedList<T>(List<T> list, {int? offset, int? limit}) {
+List<T> boundedList<T>(List<T> list, {int offset = 0, int limit = 0}) {
   Iterable<T> iterable = list;
-  if (offset != null && offset > 0) {
+  if (offset > 0) {
     if (offset >= list.length) {
       return <T>[];
     } else {
       iterable = iterable.skip(offset);
     }
   }
-  if (limit != null && limit > 0) {
+  if (limit > 0) {
     iterable = iterable.take(limit);
   }
   return iterable.toList();


### PR DESCRIPTION
- updated `offset` and `limit` to be non-nullable and moved range sanitization to the innermost constructor
- extracted best name match into its own method, because it is easily separable from the rest
- extracted predicate filtering in preparation of providing a fast-track to queries without text
- the extracted predicate filtering also allows for an early return check where the offset of query is larger than the available item count
- local benchmark shows no difference in performance