### PR TITLE
Throw TaskAbortedException when the task state entry is missing or the token has been replaced or expired.

### DIFF
--- a/app/lib/task/backend.dart
+++ b/app/lib/task/backend.dart
@@ -1153,11 +1153,11 @@ PackageVersionStateInfo _authorizeWorkerCallback(
 
   final versionState = state.versions![version];
   if (versionState == null) {
-    throw NotFoundException.resource('$package/$version');
+    throw TaskAbortedException('The provided token is invalid or expired.');
   }
   // Check the secret token
   if (!versionState.isAuthorized(token)) {
-    throw AuthenticationException.authenticationRequired();
+    throw TaskAbortedException('The provided token is invalid or expired.');
   }
   assert(versionState.scheduled != initialTimestamp);
   assert(versionState.instance != null);

--- a/app/test/task/task_test.dart
+++ b/app/test/task/task_test.dart
@@ -784,9 +784,9 @@ void main() {
         final api = createPubApiClient(authToken: v.token);
         await expectApiException(
           api.taskUploadFinished('neon', v.version),
-          status: 404,
-          code: 'NotFound',
-          message: 'Could not find `neon/1.0.0`.',
+          status: 400,
+          code: 'TaskAborted',
+          message: 'The provided token is invalid or expired.',
         );
       }
 


### PR DESCRIPTION
- Fixes #8799.
- Updated the test in one commit, overlayed with the fix in another.
- I was considering to update the worker to handle not found or the 401 better, but eventually decided to just emit `TaskAborted` in all of these cases. Handling the other cases wouldn't really improve the log suppression, and exposing this message wouldn't compromise us in any way against a malicious attacker (they would know that it is about expired tokens anyway).
