### PR TITLE
Use top-k sorted list builder instead of full-list sorts in search indexes.

### DIFF
--- a/app/lib/search/token_index.dart
+++ b/app/lib/search/token_index.dart
@@ -5,6 +5,7 @@
 import 'dart:math' as math;
 
 import 'package:meta/meta.dart';
+import 'package:pub_dev/shared/utils.dart';
 import 'package:pub_dev/third_party/bit_array/bit_array.dart';
 
 import 'text_utils.dart';
@@ -313,21 +314,16 @@ class IndexedScore<K> {
   }
 
   Map<K, double> top(int count, {double? minValue}) {
-    final list = <int>[];
-    double? lastValue;
+    minValue ??= 0.0;
+    final builder = TopKSortedListBuilder<int>(
+        count, (a, b) => -_values[a].compareTo(_values[b]));
     for (var i = 0; i < length; i++) {
       final v = _values[i];
-      if (minValue != null && v < minValue) continue;
-      if (list.length == count) {
-        if (lastValue != null && lastValue >= v) continue;
-        list[count - 1] = i;
-      } else {
-        list.add(i);
-      }
-      list.sort((a, b) => -_values[a].compareTo(_values[b]));
-      lastValue = _values[list.last];
+      if (v < minValue) continue;
+      builder.add(i);
     }
-    return Map.fromEntries(list.map((i) => MapEntry(_keys[i], _values[i])));
+    return Map.fromEntries(
+        builder.getTopK().map((i) => MapEntry(_keys[i], _values[i])));
   }
 
   Map<K, double> toMap() {

--- a/app/lib/shared/utils.dart
+++ b/app/lib/shared/utils.dart
@@ -148,6 +148,50 @@ class DurationTracker extends LastNTracker<Duration> {
       };
 }
 
+/// Builds a sorted list of the top-k items using the provided comparator.
+///
+/// The algorithm uses a binary tree insertion, resulting in O(N * log(K)) comparison.
+class TopKSortedListBuilder<T> {
+  final int _k;
+  final Comparator<T> _compare;
+  final _list = <T>[];
+
+  TopKSortedListBuilder(this._k, this._compare);
+
+  void addAll(Iterable<T> items) {
+    for (final item in items) {
+      add(item);
+    }
+  }
+
+  void add(T item) {
+    if (_list.length >= _k && _compare(_list.last, item) <= 0) {
+      return;
+    }
+    var start = 0, end = _list.length;
+    while (start < end) {
+      final mid = (start + end) >> 1;
+      if (_compare(_list[mid], item) <= 0) {
+        start = mid + 1;
+      } else {
+        end = mid;
+      }
+    }
+    if (_list.length < _k) {
+      _list.insert(start, item);
+      return;
+    }
+    for (var i = _list.length - 1; i > start; i--) {
+      _list[i] = _list[i - 1];
+    }
+    _list[start] = item;
+  }
+
+  Iterable<T> getTopK() {
+    return _list;
+  }
+}
+
 /// Returns the MIME content type based on the name of the file.
 String contentType(String name) {
   final ext = p.extension(name).replaceAll('.', '');

--- a/app/test/shared/utils_test.dart
+++ b/app/test/shared/utils_test.dart
@@ -73,4 +73,37 @@ void main() {
       expect(tracker.getLatency().inMilliseconds, greaterThan(15000));
     });
   });
+
+  group('top-k sorted list', () {
+    int compare(int a, int b) => -a.compareTo(b);
+
+    test('no items', () {
+      final builder = TopKSortedListBuilder(5, compare);
+      expect(builder.getTopK().toList(), []);
+    });
+
+    test('single item', () {
+      final builder = TopKSortedListBuilder(5, compare);
+      builder.add(1);
+      expect(builder.getTopK().toList(), [1]);
+    });
+
+    test('three items ascending', () {
+      final builder = TopKSortedListBuilder(5, compare);
+      builder.addAll([1, 2, 3]);
+      expect(builder.getTopK().toList(), [3, 2, 1]);
+    });
+
+    test('three items descending', () {
+      final builder = TopKSortedListBuilder(5, compare);
+      builder.addAll([3, 2, 1]);
+      expect(builder.getTopK().toList(), [3, 2, 1]);
+    });
+
+    test('10 items + repeated', () {
+      final builder = TopKSortedListBuilder(5, compare);
+      builder.addAll([1, 10, 2, 9, 3, 8, 4, 7, 6, 5, 9]);
+      expect(builder.getTopK().toList(), [10, 9, 9, 8, 7]);
+    });
+  });
 }


### PR DESCRIPTION
- #8670 and #8671
- updated `_rankWithValues` to not build a full list and initialize the result objects lazily
- local benchmark showed 3-5% latency improvements in the most common queries (offset=0, limit=10 for packages), which somewhat linearly disappeared as offset increased to the total item counts (as expected)
- added another check that prevents sorted list building if offset is larger than the maximum expected result count
 