### PR TITLE
Increase search instance's memory (and core count).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ AppEngine version, listed here to ease deployment and troubleshooting.
  * Upgraded stable Flutter analysis SDK to `3.32.4`.
  * Note: started to export `/api/packages/<package>/[likes|options|publisher|score]` endpoints.
  * Note: search instance uses separate isolate for predicate-only queries.
+ * Note: increased search instance's CPU core count to 4, memory to 25GB.
 
 ## `20250619t085100-all`
  * Bump runtimeVersion to `2025.06.03`.

--- a/search.yaml
+++ b/search.yaml
@@ -7,10 +7,10 @@ env: flex
 service: search
 
 resources:
-  cpu: 2
+  cpu: 4
   # This is the max memory we can request for 2 cpus.
   # https://cloud.google.com/appengine/docs/flexible/reference/app-yaml?tab=python
-  memory_gb: 12.6
+  memory_gb: 25.6
   disk_size_gb: 25
 
 #manual_scaling:


### PR DESCRIPTION
The production search instances report about 6.5-7 GB memory being used, and about 12 GB maximum memory usage, which is happening when the new search isolate is being loaded while the old one is still active. This is very close to the 12.6 GB limit, and the new search isolate also adds a nontrivial amount of memory.

I think we should increase the memory, which can only be done if we also increase the CPU count. This is a must if we must keep the current experiment with the fast-lane search isolate, but even if we roll that back, I think we should increase the memory as we are close to the allocated threshold.

Note: I'll spend some time on the memory usage later, I think we have a few things to optimize (or remove) there.