### PR TITLE
Reduce memory usage during index construction.

### DIFF
--- a/app/bin/tools/isolate_search_benchmark.dart
+++ b/app/bin/tools/isolate_search_benchmark.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:io';
 import 'dart:math';
 
 import 'package:_pub_shared/search/search_form.dart';
@@ -23,13 +24,15 @@ final queries = [
 ];
 
 Future<void> main(List<String> args) async {
-  print('Loading...');
+  print('Started. Current memory: ${ProcessInfo.currentRss ~/ 1024} KiB,  '
+      'max memory: ${ProcessInfo.maxRss ~/ 1024} KiB');
   final primaryRunner = await startSearchIsolate(snapshot: args.first);
   final reducedRunner = await startSearchIsolate(
     snapshot: args.first,
     removeTextContent: true,
   );
-  print('Loaded.');
+  print('Loaded. Current memory: ${ProcessInfo.currentRss ~/ 1024} KiB,  '
+      'max memory: ${ProcessInfo.maxRss ~/ 1024} KiB');
 
   for (var i = 0; i < 5; i++) {
     await _benchmark(primaryRunner, primaryRunner);
@@ -39,6 +42,8 @@ Future<void> main(List<String> args) async {
 
   await primaryRunner.close();
   await reducedRunner.close();
+  print('Done. Current memory: ${ProcessInfo.currentRss ~/ 1024} KiB,  '
+      'max memory: ${ProcessInfo.maxRss ~/ 1024} KiB');
 }
 
 Future<void> _benchmark(IsolateRunner primary, IsolateRunner reduced) async {

--- a/app/bin/tools/sdk_search_benchmark.dart
+++ b/app/bin/tools/sdk_search_benchmark.dart
@@ -2,11 +2,17 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:io';
+
 import 'package:pub_dev/search/sdk_mem_index.dart';
 
 /// Loads a Dart SDK search snapshot and executes queries on it, benchmarking their total time to complete.
 Future<void> main() async {
+  print('Started. Current memory: ${ProcessInfo.currentRss ~/ 1024} KiB,  '
+      'max memory: ${ProcessInfo.maxRss ~/ 1024} KiB');
   final index = await createSdkMemIndex();
+  print('Loaded. Current memory: ${ProcessInfo.currentRss ~/ 1024} KiB,  '
+      'max memory: ${ProcessInfo.maxRss ~/ 1024} KiB');
 
   // NOTE: please add more queries to this list, especially if there is a performance bottleneck.
   final queries = [
@@ -25,4 +31,6 @@ Future<void> main() async {
   }
   sw.stop();
   print('${(sw.elapsedMilliseconds / count).toStringAsFixed(2)} ms/request');
+  print('Done. Current memory: ${ProcessInfo.currentRss ~/ 1024} KiB,  '
+      'max memory: ${ProcessInfo.maxRss ~/ 1024} KiB');
 }

--- a/app/bin/tools/search_benchmark.dart
+++ b/app/bin/tools/search_benchmark.dart
@@ -2,14 +2,21 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:async';
+import 'dart:io';
+
 import 'package:_pub_shared/search/search_form.dart';
 import 'package:pub_dev/search/search_service.dart';
 import 'package:pub_dev/search/updater.dart';
 
 /// Loads a search snapshot and executes queries on it, benchmarking their total time to complete.
 Future<void> main(List<String> args) async {
+  print('Started. Current memory: ${ProcessInfo.currentRss ~/ 1024} KiB,  '
+      'max memory: ${ProcessInfo.maxRss ~/ 1024} KiB');
   // Assumes that the first argument is a search snapshot file.
   final index = await loadInMemoryPackageIndexFromFile(args.first);
+  print('Loaded. Current memory: ${ProcessInfo.currentRss ~/ 1024} KiB,  '
+      'max memory: ${ProcessInfo.maxRss ~/ 1024} KiB');
 
   // NOTE: please add more queries to this list, especially if there is a performance bottleneck.
   final queries = [
@@ -34,4 +41,6 @@ Future<void> main(List<String> args) async {
   }
   sw.stop();
   print('${(sw.elapsedMilliseconds / count).toStringAsFixed(2)} ms/request');
+  print('Done. Current memory: ${ProcessInfo.currentRss ~/ 1024} KiB,  '
+      'max memory: ${ProcessInfo.maxRss ~/ 1024} KiB');
 }

--- a/app/lib/search/token_index.dart
+++ b/app/lib/search/token_index.dart
@@ -51,18 +51,40 @@ class TokenIndex<K> {
       if (text == null) {
         continue;
       }
-      final tokens = tokenize(text);
-      if (tokens == null || tokens.isEmpty) {
+      _build(i, text, skipDocumentWeight);
+    }
+  }
+
+  TokenIndex.fromValues(
+    List<K> ids,
+    List<List<String>?> values, {
+    bool skipDocumentWeight = false,
+  }) : _ids = ids {
+    assert(ids.length == values.length);
+    final length = values.length;
+    for (var i = 0; i < length; i++) {
+      final parts = values[i];
+
+      if (parts == null || parts.isEmpty) {
         continue;
       }
-      // Document weight is a highly scaled-down proxy of the length.
-      final dw =
-          skipDocumentWeight ? 1.0 : 1 + math.log(1 + tokens.length) / 100;
-      for (final e in tokens.entries) {
-        final token = e.key;
-        final weights = _inverseIds.putIfAbsent(token, () => {});
-        weights[i] = math.max(weights[i] ?? 0.0, e.value / dw);
+      for (final text in parts) {
+        _build(i, text, skipDocumentWeight);
       }
+    }
+  }
+
+  void _build(int i, String text, bool skipDocumentWeight) {
+    final tokens = tokenize(text);
+    if (tokens == null || tokens.isEmpty) {
+      return;
+    }
+    // Document weight is a highly scaled-down proxy of the length.
+    final dw = skipDocumentWeight ? 1.0 : 1 + math.log(1 + tokens.length) / 100;
+    for (final e in tokens.entries) {
+      final token = e.key;
+      final weights = _inverseIds.putIfAbsent(token, () => {});
+      weights[i] = math.max(weights[i] ?? 0.0, e.value / dw);
     }
   }
 


### PR DESCRIPTION
- The removal of `_documentsByName` (little use) and `_topics` (unused) is mostly symbolic, there isn't much memory overhead there.
- The change in API doc page index construction (using separate strings instead of concatenating and the splitting the same string) reduces index building time, but more importantly reduces memory usage by several hundred megabytes.