### PR TITLE
Render-blocking dark-theme initialization for dartdoc pages.

### DIFF
--- a/app/lib/dartdoc/dartdoc_page.dart
+++ b/app/lib/dartdoc/dartdoc_page.dart
@@ -301,6 +301,9 @@ extension DartDocPageRender on DartDocPage {
             'width': '0',
             'style': 'display:none;visibility:hidden',
           })),
+      // NOTE: dartdoc's own initialization will still run, but it is not in conflict
+      //       with the current script.
+      d.script(src: staticUrls.getAssetUrl('/static/js/dark-init.js')),
       d.div(id: 'overlay-under-drawer'),
       _renderHeader(options),
       _renderMain(options),

--- a/app/test/dartdoc/dartdoc_page_test.dart
+++ b/app/test/dartdoc/dartdoc_page_test.dart
@@ -185,6 +185,14 @@ void main() {
                 contains('https://www.googletagmanager.com/'));
             firstNoScript.remove();
 
+            // removing extra dark-theme initializer script
+            renderedXmlDoc.descendantElements
+                .where((e) =>
+                    e.localName == 'script' &&
+                    e.getAttribute('src')!.endsWith('/dark-init.js'))
+                .single
+                .remove();
+
             // removing extra logo
             final firstLogo = renderedXmlDoc.descendantElements.firstWhere(
                 (e) =>

--- a/app/test/task/testdata/goldens/documentation/oxygen/1.0.0/index.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/1.0.0/index.html
@@ -20,6 +20,7 @@
   </head>
   <body class="light-theme" data-base-href="" data-using-base-href="false">
     <noscript>&lt;iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MX6DBN9" height="0" width="0" style="display:none;visibility:hidden">&lt;/iframe></noscript>
+    <script src="/static/hash-%%etag%%/js/dark-init.js"></script>
     <div id="overlay-under-drawer"></div>
     <header id="title">
       <span id="sidenav-left-toggle" class="material-symbols-outlined" role="button" tabindex="0">menu</span>

--- a/app/test/task/testdata/goldens/documentation/oxygen/1.0.0/oxygen/MainClass-class.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/1.0.0/oxygen/MainClass-class.html
@@ -20,6 +20,7 @@
   </head>
   <body class="light-theme" data-base-href="../" data-using-base-href="false">
     <noscript>&lt;iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MX6DBN9" height="0" width="0" style="display:none;visibility:hidden">&lt;/iframe></noscript>
+    <script src="/static/hash-%%etag%%/js/dark-init.js"></script>
     <div id="overlay-under-drawer"></div>
     <header id="title">
       <span id="sidenav-left-toggle" class="material-symbols-outlined" role="button" tabindex="0">menu</span>

--- a/app/test/task/testdata/goldens/documentation/oxygen/1.0.0/oxygen/MainClass/MainClass.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/1.0.0/oxygen/MainClass/MainClass.html
@@ -20,6 +20,7 @@
   </head>
   <body class="light-theme" data-base-href="../../" data-using-base-href="false">
     <noscript>&lt;iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MX6DBN9" height="0" width="0" style="display:none;visibility:hidden">&lt;/iframe></noscript>
+    <script src="/static/hash-%%etag%%/js/dark-init.js"></script>
     <div id="overlay-under-drawer"></div>
     <header id="title">
       <span id="sidenav-left-toggle" class="material-symbols-outlined" role="button" tabindex="0">menu</span>

--- a/app/test/task/testdata/goldens/documentation/oxygen/1.0.0/oxygen/MainClass/text.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/1.0.0/oxygen/MainClass/text.html
@@ -20,6 +20,7 @@
   </head>
   <body class="light-theme" data-base-href="../../" data-using-base-href="false">
     <noscript>&lt;iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MX6DBN9" height="0" width="0" style="display:none;visibility:hidden">&lt;/iframe></noscript>
+    <script src="/static/hash-%%etag%%/js/dark-init.js"></script>
     <div id="overlay-under-drawer"></div>
     <header id="title">
       <span id="sidenav-left-toggle" class="material-symbols-outlined" role="button" tabindex="0">menu</span>

--- a/app/test/task/testdata/goldens/documentation/oxygen/1.0.0/oxygen/MainClass/toLowerCase.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/1.0.0/oxygen/MainClass/toLowerCase.html
@@ -20,6 +20,7 @@
   </head>
   <body class="light-theme" data-base-href="../../" data-using-base-href="false">
     <noscript>&lt;iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MX6DBN9" height="0" width="0" style="display:none;visibility:hidden">&lt;/iframe></noscript>
+    <script src="/static/hash-%%etag%%/js/dark-init.js"></script>
     <div id="overlay-under-drawer"></div>
     <header id="title">
       <span id="sidenav-left-toggle" class="material-symbols-outlined" role="button" tabindex="0">menu</span>

--- a/app/test/task/testdata/goldens/documentation/oxygen/1.0.0/oxygen/MainClass/toString.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/1.0.0/oxygen/MainClass/toString.html
@@ -20,6 +20,7 @@
   </head>
   <body class="light-theme" data-base-href="../../" data-using-base-href="false">
     <noscript>&lt;iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MX6DBN9" height="0" width="0" style="display:none;visibility:hidden">&lt;/iframe></noscript>
+    <script src="/static/hash-%%etag%%/js/dark-init.js"></script>
     <div id="overlay-under-drawer"></div>
     <header id="title">
       <span id="sidenav-left-toggle" class="material-symbols-outlined" role="button" tabindex="0">menu</span>

--- a/app/test/task/testdata/goldens/documentation/oxygen/1.0.0/oxygen/TypeEnum.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/1.0.0/oxygen/TypeEnum.html
@@ -20,6 +20,7 @@
   </head>
   <body class="light-theme" data-base-href="../" data-using-base-href="false">
     <noscript>&lt;iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MX6DBN9" height="0" width="0" style="display:none;visibility:hidden">&lt;/iframe></noscript>
+    <script src="/static/hash-%%etag%%/js/dark-init.js"></script>
     <div id="overlay-under-drawer"></div>
     <header id="title">
       <span id="sidenav-left-toggle" class="material-symbols-outlined" role="button" tabindex="0">menu</span>

--- a/app/test/task/testdata/goldens/documentation/oxygen/1.0.0/oxygen/TypeEnum/values-constant.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/1.0.0/oxygen/TypeEnum/values-constant.html
@@ -20,6 +20,7 @@
   </head>
   <body class="light-theme" data-base-href="../../" data-using-base-href="false">
     <noscript>&lt;iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MX6DBN9" height="0" width="0" style="display:none;visibility:hidden">&lt;/iframe></noscript>
+    <script src="/static/hash-%%etag%%/js/dark-init.js"></script>
     <div id="overlay-under-drawer"></div>
     <header id="title">
       <span id="sidenav-left-toggle" class="material-symbols-outlined" role="button" tabindex="0">menu</span>

--- a/app/test/task/testdata/goldens/documentation/oxygen/1.0.0/oxygen/index.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/1.0.0/oxygen/index.html
@@ -20,6 +20,7 @@
   </head>
   <body class="light-theme" data-base-href="../" data-using-base-href="false">
     <noscript>&lt;iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MX6DBN9" height="0" width="0" style="display:none;visibility:hidden">&lt;/iframe></noscript>
+    <script src="/static/hash-%%etag%%/js/dark-init.js"></script>
     <div id="overlay-under-drawer"></div>
     <header id="title">
       <span id="sidenav-left-toggle" class="material-symbols-outlined" role="button" tabindex="0">menu</span>

--- a/app/test/task/testdata/goldens/documentation/oxygen/1.0.0/oxygen/main.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/1.0.0/oxygen/main.html
@@ -20,6 +20,7 @@
   </head>
   <body class="light-theme" data-base-href="../" data-using-base-href="false">
     <noscript>&lt;iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MX6DBN9" height="0" width="0" style="display:none;visibility:hidden">&lt;/iframe></noscript>
+    <script src="/static/hash-%%etag%%/js/dark-init.js"></script>
     <div id="overlay-under-drawer"></div>
     <header id="title">
       <span id="sidenav-left-toggle" class="material-symbols-outlined" role="button" tabindex="0">menu</span>

--- a/app/test/task/testdata/goldens/documentation/oxygen/2.0.0/index.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/2.0.0/index.html
@@ -20,6 +20,7 @@
   </head>
   <body class="light-theme" data-base-href="" data-using-base-href="false">
     <noscript>&lt;iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MX6DBN9" height="0" width="0" style="display:none;visibility:hidden">&lt;/iframe></noscript>
+    <script src="/static/hash-%%etag%%/js/dark-init.js"></script>
     <div id="overlay-under-drawer"></div>
     <header id="title">
       <span id="sidenav-left-toggle" class="material-symbols-outlined" role="button" tabindex="0">menu</span>

--- a/app/test/task/testdata/goldens/documentation/oxygen/2.0.0/oxygen/MainClass-class.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/2.0.0/oxygen/MainClass-class.html
@@ -20,6 +20,7 @@
   </head>
   <body class="light-theme" data-base-href="../" data-using-base-href="false">
     <noscript>&lt;iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MX6DBN9" height="0" width="0" style="display:none;visibility:hidden">&lt;/iframe></noscript>
+    <script src="/static/hash-%%etag%%/js/dark-init.js"></script>
     <div id="overlay-under-drawer"></div>
     <header id="title">
       <span id="sidenav-left-toggle" class="material-symbols-outlined" role="button" tabindex="0">menu</span>

--- a/app/test/task/testdata/goldens/documentation/oxygen/2.0.0/oxygen/MainClass/MainClass.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/2.0.0/oxygen/MainClass/MainClass.html
@@ -20,6 +20,7 @@
   </head>
   <body class="light-theme" data-base-href="../../" data-using-base-href="false">
     <noscript>&lt;iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MX6DBN9" height="0" width="0" style="display:none;visibility:hidden">&lt;/iframe></noscript>
+    <script src="/static/hash-%%etag%%/js/dark-init.js"></script>
     <div id="overlay-under-drawer"></div>
     <header id="title">
       <span id="sidenav-left-toggle" class="material-symbols-outlined" role="button" tabindex="0">menu</span>

--- a/app/test/task/testdata/goldens/documentation/oxygen/2.0.0/oxygen/MainClass/text.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/2.0.0/oxygen/MainClass/text.html
@@ -20,6 +20,7 @@
   </head>
   <body class="light-theme" data-base-href="../../" data-using-base-href="false">
     <noscript>&lt;iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MX6DBN9" height="0" width="0" style="display:none;visibility:hidden">&lt;/iframe></noscript>
+    <script src="/static/hash-%%etag%%/js/dark-init.js"></script>
     <div id="overlay-under-drawer"></div>
     <header id="title">
       <span id="sidenav-left-toggle" class="material-symbols-outlined" role="button" tabindex="0">menu</span>

--- a/app/test/task/testdata/goldens/documentation/oxygen/2.0.0/oxygen/MainClass/toLowerCase.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/2.0.0/oxygen/MainClass/toLowerCase.html
@@ -20,6 +20,7 @@
   </head>
   <body class="light-theme" data-base-href="../../" data-using-base-href="false">
     <noscript>&lt;iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MX6DBN9" height="0" width="0" style="display:none;visibility:hidden">&lt;/iframe></noscript>
+    <script src="/static/hash-%%etag%%/js/dark-init.js"></script>
     <div id="overlay-under-drawer"></div>
     <header id="title">
       <span id="sidenav-left-toggle" class="material-symbols-outlined" role="button" tabindex="0">menu</span>

--- a/app/test/task/testdata/goldens/documentation/oxygen/2.0.0/oxygen/MainClass/toString.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/2.0.0/oxygen/MainClass/toString.html
@@ -20,6 +20,7 @@
   </head>
   <body class="light-theme" data-base-href="../../" data-using-base-href="false">
     <noscript>&lt;iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MX6DBN9" height="0" width="0" style="display:none;visibility:hidden">&lt;/iframe></noscript>
+    <script src="/static/hash-%%etag%%/js/dark-init.js"></script>
     <div id="overlay-under-drawer"></div>
     <header id="title">
       <span id="sidenav-left-toggle" class="material-symbols-outlined" role="button" tabindex="0">menu</span>

--- a/app/test/task/testdata/goldens/documentation/oxygen/2.0.0/oxygen/TypeEnum.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/2.0.0/oxygen/TypeEnum.html
@@ -20,6 +20,7 @@
   </head>
   <body class="light-theme" data-base-href="../" data-using-base-href="false">
     <noscript>&lt;iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MX6DBN9" height="0" width="0" style="display:none;visibility:hidden">&lt;/iframe></noscript>
+    <script src="/static/hash-%%etag%%/js/dark-init.js"></script>
     <div id="overlay-under-drawer"></div>
     <header id="title">
       <span id="sidenav-left-toggle" class="material-symbols-outlined" role="button" tabindex="0">menu</span>

--- a/app/test/task/testdata/goldens/documentation/oxygen/2.0.0/oxygen/TypeEnum/values-constant.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/2.0.0/oxygen/TypeEnum/values-constant.html
@@ -20,6 +20,7 @@
   </head>
   <body class="light-theme" data-base-href="../../" data-using-base-href="false">
     <noscript>&lt;iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MX6DBN9" height="0" width="0" style="display:none;visibility:hidden">&lt;/iframe></noscript>
+    <script src="/static/hash-%%etag%%/js/dark-init.js"></script>
     <div id="overlay-under-drawer"></div>
     <header id="title">
       <span id="sidenav-left-toggle" class="material-symbols-outlined" role="button" tabindex="0">menu</span>

--- a/app/test/task/testdata/goldens/documentation/oxygen/2.0.0/oxygen/index.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/2.0.0/oxygen/index.html
@@ -20,6 +20,7 @@
   </head>
   <body class="light-theme" data-base-href="../" data-using-base-href="false">
     <noscript>&lt;iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MX6DBN9" height="0" width="0" style="display:none;visibility:hidden">&lt;/iframe></noscript>
+    <script src="/static/hash-%%etag%%/js/dark-init.js"></script>
     <div id="overlay-under-drawer"></div>
     <header id="title">
       <span id="sidenav-left-toggle" class="material-symbols-outlined" role="button" tabindex="0">menu</span>

--- a/app/test/task/testdata/goldens/documentation/oxygen/2.0.0/oxygen/main.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/2.0.0/oxygen/main.html
@@ -20,6 +20,7 @@
   </head>
   <body class="light-theme" data-base-href="../" data-using-base-href="false">
     <noscript>&lt;iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MX6DBN9" height="0" width="0" style="display:none;visibility:hidden">&lt;/iframe></noscript>
+    <script src="/static/hash-%%etag%%/js/dark-init.js"></script>
     <div id="overlay-under-drawer"></div>
     <header id="title">
       <span id="sidenav-left-toggle" class="material-symbols-outlined" role="button" tabindex="0">menu</span>

--- a/app/test/task/testdata/goldens/documentation/oxygen/latest/index.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/latest/index.html
@@ -18,6 +18,7 @@
   </head>
   <body class="light-theme" data-base-href="" data-using-base-href="false">
     <noscript>&lt;iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MX6DBN9" height="0" width="0" style="display:none;visibility:hidden">&lt;/iframe></noscript>
+    <script src="/static/hash-%%etag%%/js/dark-init.js"></script>
     <div id="overlay-under-drawer"></div>
     <header id="title">
       <span id="sidenav-left-toggle" class="material-symbols-outlined" role="button" tabindex="0">menu</span>

--- a/app/test/task/testdata/goldens/documentation/oxygen/latest/oxygen/MainClass-class.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/latest/oxygen/MainClass-class.html
@@ -18,6 +18,7 @@
   </head>
   <body class="light-theme" data-base-href="../" data-using-base-href="false">
     <noscript>&lt;iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MX6DBN9" height="0" width="0" style="display:none;visibility:hidden">&lt;/iframe></noscript>
+    <script src="/static/hash-%%etag%%/js/dark-init.js"></script>
     <div id="overlay-under-drawer"></div>
     <header id="title">
       <span id="sidenav-left-toggle" class="material-symbols-outlined" role="button" tabindex="0">menu</span>

--- a/app/test/task/testdata/goldens/documentation/oxygen/latest/oxygen/MainClass/MainClass.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/latest/oxygen/MainClass/MainClass.html
@@ -19,6 +19,7 @@
   </head>
   <body class="light-theme" data-base-href="../../" data-using-base-href="false">
     <noscript>&lt;iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MX6DBN9" height="0" width="0" style="display:none;visibility:hidden">&lt;/iframe></noscript>
+    <script src="/static/hash-%%etag%%/js/dark-init.js"></script>
     <div id="overlay-under-drawer"></div>
     <header id="title">
       <span id="sidenav-left-toggle" class="material-symbols-outlined" role="button" tabindex="0">menu</span>

--- a/app/test/task/testdata/goldens/documentation/oxygen/latest/oxygen/MainClass/text.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/latest/oxygen/MainClass/text.html
@@ -19,6 +19,7 @@
   </head>
   <body class="light-theme" data-base-href="../../" data-using-base-href="false">
     <noscript>&lt;iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MX6DBN9" height="0" width="0" style="display:none;visibility:hidden">&lt;/iframe></noscript>
+    <script src="/static/hash-%%etag%%/js/dark-init.js"></script>
     <div id="overlay-under-drawer"></div>
     <header id="title">
       <span id="sidenav-left-toggle" class="material-symbols-outlined" role="button" tabindex="0">menu</span>

--- a/app/test/task/testdata/goldens/documentation/oxygen/latest/oxygen/MainClass/toLowerCase.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/latest/oxygen/MainClass/toLowerCase.html
@@ -19,6 +19,7 @@
   </head>
   <body class="light-theme" data-base-href="../../" data-using-base-href="false">
     <noscript>&lt;iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MX6DBN9" height="0" width="0" style="display:none;visibility:hidden">&lt;/iframe></noscript>
+    <script src="/static/hash-%%etag%%/js/dark-init.js"></script>
     <div id="overlay-under-drawer"></div>
     <header id="title">
       <span id="sidenav-left-toggle" class="material-symbols-outlined" role="button" tabindex="0">menu</span>

--- a/app/test/task/testdata/goldens/documentation/oxygen/latest/oxygen/MainClass/toString.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/latest/oxygen/MainClass/toString.html
@@ -19,6 +19,7 @@
   </head>
   <body class="light-theme" data-base-href="../../" data-using-base-href="false">
     <noscript>&lt;iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MX6DBN9" height="0" width="0" style="display:none;visibility:hidden">&lt;/iframe></noscript>
+    <script src="/static/hash-%%etag%%/js/dark-init.js"></script>
     <div id="overlay-under-drawer"></div>
     <header id="title">
       <span id="sidenav-left-toggle" class="material-symbols-outlined" role="button" tabindex="0">menu</span>

--- a/app/test/task/testdata/goldens/documentation/oxygen/latest/oxygen/TypeEnum.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/latest/oxygen/TypeEnum.html
@@ -18,6 +18,7 @@
   </head>
   <body class="light-theme" data-base-href="../" data-using-base-href="false">
     <noscript>&lt;iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MX6DBN9" height="0" width="0" style="display:none;visibility:hidden">&lt;/iframe></noscript>
+    <script src="/static/hash-%%etag%%/js/dark-init.js"></script>
     <div id="overlay-under-drawer"></div>
     <header id="title">
       <span id="sidenav-left-toggle" class="material-symbols-outlined" role="button" tabindex="0">menu</span>

--- a/app/test/task/testdata/goldens/documentation/oxygen/latest/oxygen/TypeEnum/values-constant.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/latest/oxygen/TypeEnum/values-constant.html
@@ -19,6 +19,7 @@
   </head>
   <body class="light-theme" data-base-href="../../" data-using-base-href="false">
     <noscript>&lt;iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MX6DBN9" height="0" width="0" style="display:none;visibility:hidden">&lt;/iframe></noscript>
+    <script src="/static/hash-%%etag%%/js/dark-init.js"></script>
     <div id="overlay-under-drawer"></div>
     <header id="title">
       <span id="sidenav-left-toggle" class="material-symbols-outlined" role="button" tabindex="0">menu</span>

--- a/app/test/task/testdata/goldens/documentation/oxygen/latest/oxygen/index.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/latest/oxygen/index.html
@@ -18,6 +18,7 @@
   </head>
   <body class="light-theme" data-base-href="../" data-using-base-href="false">
     <noscript>&lt;iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MX6DBN9" height="0" width="0" style="display:none;visibility:hidden">&lt;/iframe></noscript>
+    <script src="/static/hash-%%etag%%/js/dark-init.js"></script>
     <div id="overlay-under-drawer"></div>
     <header id="title">
       <span id="sidenav-left-toggle" class="material-symbols-outlined" role="button" tabindex="0">menu</span>

--- a/app/test/task/testdata/goldens/documentation/oxygen/latest/oxygen/main.html
+++ b/app/test/task/testdata/goldens/documentation/oxygen/latest/oxygen/main.html
@@ -18,6 +18,7 @@
   </head>
   <body class="light-theme" data-base-href="../" data-using-base-href="false">
     <noscript>&lt;iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MX6DBN9" height="0" width="0" style="display:none;visibility:hidden">&lt;/iframe></noscript>
+    <script src="/static/hash-%%etag%%/js/dark-init.js"></script>
     <div id="overlay-under-drawer"></div>
     <header id="title">
       <span id="sidenav-left-toggle" class="material-symbols-outlined" role="button" tabindex="0">menu</span>

--- a/static/js/dark-init.js
+++ b/static/js/dark-init.js
@@ -14,13 +14,6 @@
     // ignore errors e.g. when media query matching is not supported
   }
 
-  // NOTE: dartdoc currently does not support externally supported color scheme,
-  //       and we disable that part for the affected URLs.
-  // TODO: remove this part when dartdoc supports the above detection too
-  if (window.location.pathname.startsWith('/documentation/')) {
-    mediaPrefersDarkScheme = false;
-  }
-
   // Detects whether the control widget was set to use a specific theme
   let colorTheme = window.localStorage.getItem('colorTheme');
   let lightThemeIsSet = colorTheme == 'false';

--- a/static/js/dark-init.js
+++ b/static/js/dark-init.js
@@ -14,6 +14,13 @@
     // ignore errors e.g. when media query matching is not supported
   }
 
+  // NOTE: dartdoc currently does not support externally supported color scheme,
+  //       and we disable that part for the affected URLs.
+  // TODO: remove this part when dartdoc supports the above detection too
+  if (window.location.pathname.startsWith('/documentation/')) {
+    mediaPrefersDarkScheme = false;
+  }
+
   // Detects whether the control widget was set to use a specific theme
   let colorTheme = window.localStorage.getItem('colorTheme');
   let lightThemeIsSet = colorTheme == 'false';


### PR DESCRIPTION
- A simpler alternative to #8836 that focuses only on the rendering glitch.
- Uses the same initialization script and the same (blocking) way on dartdoc pages as the rest of pub.dev.
- dartdoc's own initalization does not support the OS-provided theme-preference yet https://github.com/dart-lang/dartdoc/blob/main/web/theme.dart - removing that part from the initialization script. We need to implement that in dartdoc first (https://github.com/dart-lang/dartdoc/issues/4069).