### PR TITLE
Restrict Flutter SDK libraries in the search index.

### DIFF
--- a/app/lib/search/sdk_mem_index.dart
+++ b/app/lib/search/sdk_mem_index.dart
@@ -108,7 +108,7 @@ class SdkMemIndex implements SdkIndex {
       'flutter',
       _flutterUri,
       flutterIndex,
-      libraryFn: (library) =>
+      includeLibraryFn: (library) =>
           library.startsWith('flutter_') ||
           _flutterLibraryAllowlist.contains(library),
     );
@@ -123,7 +123,9 @@ class SdkMemIndex implements SdkIndex {
     String sdk,
     Uri baseUri,
     DartdocIndex index, {
-    bool Function(String library)? libraryFn,
+    /// If specified, the index building will call this function for
+    /// each library, and will include only the ones that return `true`.
+    bool Function(String library)? includeLibraryFn,
   }) {
     final textsPerLibrary = <String, Map<String, String>>{};
     final baseUris = <String, Uri>{};
@@ -140,7 +142,7 @@ class SdkMemIndex implements SdkIndex {
         continue;
       }
       // Skips libraries that are not explicitly allowed.
-      if (libraryFn != null && !libraryFn(library)) {
+      if (includeLibraryFn != null && !includeLibraryFn(library)) {
         continue;
       }
       if (f.isLibrary) {

--- a/app/lib/search/sdk_mem_index.dart
+++ b/app/lib/search/sdk_mem_index.dart
@@ -42,6 +42,22 @@ const _defaultApiPageDirWeights = {
   'material/Icons': 0.25,
 };
 
+/// The list of libraries that are to be exposed as part of the Flutter SDK index.
+const _flutterLibraryAllowlist = {
+  'animation',
+  'cupertino',
+  'foundation',
+  'gestures',
+  'material',
+  'painting',
+  'physics',
+  'rendering',
+  'scheduler',
+  'semantics',
+  'services',
+  'widgets',
+};
+
 final _logger = Logger('search.dart_sdk_mem_index');
 final _dartUri = Uri.parse('https://api.dart.dev/stable/latest/');
 final _flutterUri = Uri.parse('https://api.flutter.dev/flutter/');
@@ -88,7 +104,14 @@ class SdkMemIndex implements SdkIndex {
     Map<String, double>? apiPageDirWeights,
   }) : _apiPageDirWeights = apiPageDirWeights ?? _defaultApiPageDirWeights {
     _addDartdocIndex('dart', _dartUri, dartIndex);
-    _addDartdocIndex('flutter', _flutterUri, flutterIndex);
+    _addDartdocIndex(
+      'flutter',
+      _flutterUri,
+      flutterIndex,
+      libraryFn: (library) =>
+          library.startsWith('flutter_') ||
+          _flutterLibraryAllowlist.contains(library),
+    );
   }
 
   static final dartSdkIndexJsonUri =
@@ -99,8 +122,9 @@ class SdkMemIndex implements SdkIndex {
   void _addDartdocIndex(
     String sdk,
     Uri baseUri,
-    DartdocIndex index,
-  ) {
+    DartdocIndex index, {
+    bool Function(String library)? libraryFn,
+  }) {
     final textsPerLibrary = <String, Map<String, String>>{};
     final baseUris = <String, Uri>{};
     final descriptions = <String, String>{};
@@ -109,7 +133,16 @@ class SdkMemIndex implements SdkIndex {
       final library = f.qualifiedName?.split('.').first;
       if (library == null) continue;
       if (f.href == null) continue;
-      if (_libraries.containsKey(library)) continue;
+      // Skips libraries that were added in a previous call of this method,
+      // e.g. Dart SDK libraries are kept as-is and Flutter SDK libraries
+      // are not overriding them here.
+      if (_libraries.containsKey(library)) {
+        continue;
+      }
+      // Skips libraries that are not explicitly allowed.
+      if (libraryFn != null && !libraryFn(library)) {
+        continue;
+      }
       if (f.isLibrary) {
         baseUris[library] = baseUri.resolve(f.href!);
 


### PR DESCRIPTION
Searching for `intl` or `meta` is confusing, as it will expose the SDK-included package link and the regular package as results. Restricting the SDK packages to the list defined explicitly (the first section on `api.flutter.io`) and also packages that start with `flutter_` in the index json, right now the following:

```
flutter_driver
flutter_driver_extension
flutter_gpu
flutter_localizations
flutter_test
flutter_web_plugins
```

In the long term we should probably use some kind of additional field in the `index.json` that `dartdoc` generates so that we can have this decision automatically, without any external list.