### PR TITLE
Trigger post-update events for Package updates.

### DIFF
--- a/app/lib/admin/actions/merge_moderated_package_into_existing.dart
+++ b/app/lib/admin/actions/merge_moderated_package_into_existing.dart
@@ -62,7 +62,7 @@ Fails if that package has no existing Package entity.
       tx.insert(p!);
       tx.delete(mpKey);
     });
-    await purgePackageCache(packageName);
+    await triggerPackagePostUpdates(packageName).future;
 
     return {
       'package': packageName,

--- a/app/lib/admin/actions/moderate_package_versions.dart
+++ b/app/lib/admin/actions/moderate_package_versions.dart
@@ -5,13 +5,11 @@
 import 'package:_pub_shared/utils/sdk_version_cache.dart';
 import 'package:clock/clock.dart';
 
-import '../../package/api_export/api_exporter.dart';
 import '../../package/backend.dart';
 import '../../package/models.dart';
 import '../../scorecard/backend.dart';
 import '../../shared/datastore.dart';
 import '../../shared/versions.dart';
-import '../../task/backend.dart';
 
 import '../backend.dart';
 import '../models.dart';
@@ -144,11 +142,7 @@ Future<Map<String, dynamic>> adminMarkPackageVersionVisibility(
       return v;
     });
 
-    // make sure visibility cache is updated immediately
-    await purgePackageCache(package);
-
-    // sync exported API(s)
-    await apiExporter.synchronizePackage(package, forceDelete: true);
+    await triggerPackagePostUpdates(package, exportForceDelete: true).future;
 
     // retract or re-populate public archive files
     await packageBackend.tarballStorage.updatePublicArchiveBucket(
@@ -157,8 +151,6 @@ Future<Map<String, dynamic>> adminMarkPackageVersionVisibility(
       deleteIfOlder: Duration.zero,
     );
 
-    await taskBackend.trackPackage(package);
-    await purgePackageCache(package);
     await purgeScorecardData(package, version, isLatest: true);
   }
 

--- a/app/lib/admin/actions/package_version_retraction.dart
+++ b/app/lib/admin/actions/package_version_retraction.dart
@@ -88,7 +88,7 @@ value of `set-retracted`, which should either be `true` or `false`.
           'isRetracted': pv.isRetracted,
         };
       });
-      await purgePackageCache(packageName);
+      triggerPackagePostUpdates(packageName);
 
       return {
         'before': before,

--- a/app/lib/admin/actions/publisher_package_remove.dart
+++ b/app/lib/admin/actions/publisher_package_remove.dart
@@ -59,7 +59,8 @@ If the publisher has no members, the package will end up without uploaders.
           ),
         );
       });
-      await purgePackageCache(packageName);
+      triggerPackagePostUpdates(packageName,
+          skipTask: true, skipVersionsExport: true);
       await purgePublisherCache(publisherId: currentPublisherId);
       return {
         'previousPublisher': currentPublisherId,

--- a/app/lib/admin/tools/package_publisher.dart
+++ b/app/lib/admin/tools/package_publisher.dart
@@ -42,7 +42,8 @@ Future<String> executeSetPackagePublisher(List<String> args) async {
     tx.insert(pkg);
   });
   await purgePublisherCache(publisherId: publisherId);
-  await purgePackageCache(packageName);
+  triggerPackagePostUpdates(packageName,
+      skipTask: true, skipVersionsExport: true);
   if (currentPublisherId != null) {
     await purgePublisherCache(publisherId: currentPublisherId);
   }

--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -381,7 +381,11 @@ class PackageBackend {
       return true;
     });
     if (updated) {
-      await purgePackageCache(package);
+      triggerPackagePostUpdates(
+        package,
+        skipTask: true,
+        skipExport: true,
+      );
     }
     return updated;
   }
@@ -480,9 +484,7 @@ class PackageBackend {
         options: optionsChanges,
       ));
     });
-    await purgePackageCache(package);
-    await taskBackend.trackPackage(package);
-    await apiExporter.synchronizePackage(package);
+    triggerPackagePostUpdates(package, skipVersionsExport: true);
   }
 
   /// Updates [options] on [package]/[version], assuming the current user
@@ -520,10 +522,9 @@ class PackageBackend {
             authenticatedUser, tx, p, pv, options.isRetracted!);
       }
     });
-    await purgePackageCache(package);
     await purgeScorecardData(package, version,
         isLatest: pkg.latestVersion == version);
-    await apiExporter.synchronizePackage(package);
+    triggerPackagePostUpdates(package);
   }
 
   /// Verifies an update to the credential-less publishing settings and
@@ -780,7 +781,6 @@ class PackageBackend {
       return _asPackagePublisherInfo(package);
     });
     await purgePublisherCache(publisherId: request.publisherId);
-    await purgePackageCache(packageName);
 
     if (email != null) {
       await emailBackend.trySendOutgoingEmail(email!);
@@ -788,7 +788,11 @@ class PackageBackend {
     if (currentPublisherId != null) {
       await purgePublisherCache(publisherId: currentPublisherId);
     }
-    await apiExporter.synchronizePackage(packageName);
+    triggerPackagePostUpdates(
+      packageName,
+      skipTask: true,
+      skipVersionsExport: true,
+    );
     return rs;
   }
 
@@ -1299,7 +1303,7 @@ class PackageBackend {
     sw.reset();
 
     _logger.info('Invalidating cache for package ${newVersion.package}.');
-    await purgePackageCache(newVersion.package);
+    triggerPackagePostUpdates(newVersion.package, taskUpdateDependents: true);
 
     // Let's not block the upload response on these post-upload tasks.
     // The operations should either be non-critical, or should be retried
@@ -1324,12 +1328,10 @@ class PackageBackend {
       await Future.wait([
         if (activeConfiguration.isPublishedEmailNotificationEnabled)
           emailBackend.trySendOutgoingEmail(outgoingEmail),
-        taskBackend.trackPackage(newVersion.package, updateDependents: true),
-        apiExporter.synchronizePackage(newVersion.package),
         apiExporter.synchronizeAllPackagesAtomFeed(),
+        tarballStorage.updateContentDispositionOnPublicBucket(
+            newVersion.package, newVersion.version!),
       ]);
-      await tarballStorage.updateContentDispositionOnPublicBucket(
-          newVersion.package, newVersion.version!);
     } catch (e, st) {
       final v = newVersion.qualifiedVersionKey;
       _logger.severe('Error post-processing package upload $v', e, st);
@@ -1581,7 +1583,7 @@ class PackageBackend {
         package: packageName,
       ));
     });
-    await purgePackageCache(packageName);
+    triggerPackagePostUpdates(packageName, skipTask: true, skipExport: true);
   }
 
   Future<void> _validatePackageUploader(
@@ -1657,7 +1659,7 @@ class PackageBackend {
         uploaderUser: uploader,
       ));
     });
-    await purgePackageCache(packageName);
+    triggerPackagePostUpdates(packageName, skipTask: true, skipExport: true);
     return api.SuccessMessage(
         success: api.Message(
             message:
@@ -2095,4 +2097,50 @@ class _VersionTransactionDataAcccess {
     final pkgKey = _tx.emptyKey.append(Package, id: name);
     return await _tx.query<PackageVersion>(pkgKey).run().toList();
   }
+}
+
+/// Triggers post-update event processing after a [Package] object is part of
+/// a transaction.
+///
+/// Returns a record with an optionally awaitable [Future] in case the caller needs
+/// wait the updates before yielding its response.
+({Future future}) triggerPackagePostUpdates(
+  String package, {
+  /// Skip trigger a new analysis on the package.
+  bool skipTask = false,
+
+  /// Skip triggering a new export to the CDN bucket.
+  bool skipExport = false,
+
+  /// Skip only the version-related exports to the CDN bucket, keeps the
+  /// package-related operations.
+  /// TODO: implement this in API exporter.
+  bool skipVersionsExport = false,
+
+  /// Pass the force-deletion flag to the package export operation.
+  bool exportForceDelete = false,
+
+  /// Pass the update-dependents flag to the task update operation.
+  bool taskUpdateDependents = false,
+}) {
+  Future add(Future Function() fn) {
+    return asyncQueue.addAsyncFn(fn).future;
+  }
+
+  final futures = [
+    add(() => purgePackageCache(package)),
+    if (!skipTask)
+      add(() => taskBackend.trackPackage(
+            package,
+            updateDependents: taskUpdateDependents,
+          )),
+    if (!skipExport)
+      add(() => apiExporter.synchronizePackage(
+            package,
+            forceDelete: exportForceDelete,
+            // TODO: implement and use [skipVersionsExport]
+          )),
+  ];
+
+  return (future: Future.wait(futures));
 }


### PR DESCRIPTION
- Single and explicit method call for all potential post-update events.
- Cache is always purged, task update and API export can be skipped.
- API export partial skip is indicated with a new flag (`skipVersionsExport`), but it is not implemented yet.
- Updated all but one uses of `purgePackageCache` (TBD later if/how that should be changed).
- The trigger method and also the `AsyncQueue` update returns an optional `Future` that can be awaited, but doesn't cause linter issues when not awaited.
- If we like this pattern, I would also implement it for the other entities too.