### PR TITLE
Separate weekly tasks for tarball-integrity checks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ AppEngine version, listed here to ease deployment and troubleshooting.
 ## Next Release (replace with git tag when deployed)
  * Bump runtimeVersion to `2025.07.14`.
  * Note: Updated worker base image to use Debian 12.
+ * Note: Tarball-related integrity checks are run in a separate weekly task (`check-tarball-integrity`).
 
 ## `20250708t090800-all`
  * Bump runtimeVersion to `2025.07.04`.

--- a/app/lib/package/tarball_storage.dart
+++ b/app/lib/package/tarball_storage.dart
@@ -61,6 +61,19 @@ class TarballStorage {
   String getCanonicalBucketAbsoluteObjectName(String package, String version) =>
       _canonicalBucket.absoluteObjectName(tarballObjectName(package, version));
 
+  /// Get a list of package names in the canonical bucket.
+  Future<List<String>> listPackagesInCanonicalBucket() async {
+    final items = await _canonicalBucket.listAllItemsWithRetry(
+        prefix: 'packages/', delimiter: '-');
+    final packages = items
+        .where((i) => i.isDirectory)
+        .map((i) => i.name)
+        .map((name) => name.substring(9).split('-').first)
+        .toSet()
+        .toList();
+    return packages;
+  }
+
   /// Get map from `version` to [SourceObjectInfo] for each version of [package] in
   /// canonical bucket.
   Future<Map<String, SourceObjectInfo>> listVersionsInCanonicalBucket(

--- a/app/lib/tool/neat_task/pub_dev_tasks.dart
+++ b/app/lib/tool/neat_task/pub_dev_tasks.dart
@@ -248,6 +248,16 @@ List<NeatPeriodicTaskScheduler> createPeriodicTaskSchedulers({
           .verifyAndLogIssues(),
       timeout: Duration(days: 1),
     ),
+
+    // Checks the tarball storage integrity of the archive files.
+    _weekly(
+      name: 'check-tarball-integrity',
+      isRuntimeVersioned: true,
+      task: () async => await TarballIntegrityChecker(dbService, concurrency: 4)
+          .verifyAndLogIssues(),
+      timeout: Duration(days: 1),
+    ),
+
     // Deletes the old search snapshots
     _weekly(
       name: 'delete-old-search-snapshots',

--- a/app/test/shared/test_services.dart
+++ b/app/test/shared/test_services.dart
@@ -136,7 +136,7 @@ final class FakeAppengineEnv {
 Future<void> _postTestVerification({
   required Pattern? integrityProblem,
 }) async {
-  final problems = await IntegrityChecker(dbService).findProblems().toList();
+  final problems = await findAllIntegrityProblems().toList();
   if (problems.isNotEmpty &&
       (integrityProblem == null ||
           integrityProblem.matchAsPrefix(problems.first) == null)) {
@@ -153,8 +153,7 @@ Future<void> _postTestVerification({
   }
 
   // re-run integrity checks on the updated state
-  final laterProblems =
-      await IntegrityChecker(dbService).findProblems().toList();
+  final laterProblems = await findAllIntegrityProblems().toList();
   expect(laterProblems, problems);
 }
 


### PR DESCRIPTION
- #8848
- Refactored the IntegrityChecker to have a base functionality and split out tarballStorage-related checks. This reduces the time it takes to run the regular integrity checks, and it is also a natural split point for the future SQL migration.
- Also added further cross-reference in the other direction: that each file in the canonical storage should have a matching database entry.
- Note: I think the canonical bucket's cross-reference is a good test, but I'm not sure if and how many stale uploads we had that left an archive there. At least this will get us some insight about that through the logs.
- We could also consider a similar scan for the public bucket, though it seems to be not critical, since the update of that bucket is always predicated on the canonical one.