### PR TITLE
Catch NotFound and Moderated exceptions when processing scorecards in search index and its display.

### DIFF
--- a/app/lib/search/backend.dart
+++ b/app/lib/search/backend.dart
@@ -171,6 +171,8 @@ class SearchBackend {
           snapshot.add(doc);
         } on RemovedPackageException catch (_) {
           snapshot.remove(package);
+        } on NotFoundException catch (_) {
+          snapshot.remove(package);
         }
       });
     }


### PR DESCRIPTION
Note: `ModeratedException extends NotFoundException`  