### PR TITLE
Fix code highlight: remove 'markdown' from automatic language detection.

### DIFF
--- a/third_party/highlight/init.js
+++ b/third_party/highlight/init.js
@@ -1,1 +1,24 @@
+hljs.configure({
+  // The list of languages that may be used in the auto-detection.
+  // NOTE: always derive this list from the `readme.md`.
+  languages: [
+    'bash',
+    'c',
+    'css',
+    'dart',
+    'diff',
+    'java',
+    'javascript',
+    'json',
+    'kotlin',
+    // removal reason: https://github.com/highlightjs/highlight.js/issues/4279#issuecomment-3126165923
+    // 'markdown',
+    'objectivec',
+    'plaintext',
+    'shell',
+    'swift',
+    'xml',
+    'yaml',
+  ]
+});
 hljs.highlightAll();

--- a/third_party/highlight/readme.md
+++ b/third_party/highlight/readme.md
@@ -10,6 +10,8 @@
 4. Verify that the listed language are selected.
 5. Download and extract assets.
 
+**NOTE:** when updating this list, also update the `init.js`.
+
 ```javascript
 var selected = [
   'bash',


### PR DESCRIPTION
- Fixes #8861.
- Verified locally: `highlight.js` will use `markdown` language is the code block is tagged with it, but won't use it in automatic language detection, when there is no language tag on the code block.
- Note: I was also looking for a way to define these two list from a single source, but (1) the list is short, (2) in a single place, (3) rarely updated, so let's just keep it via copy-paste.