### PR TITLE
Send changelog excerpt in package uploaded email.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ AppEngine version, listed here to ease deployment and troubleshooting.
 ## Next Release (replace with git tag when deployed)
  * Bump runtimeVersion to `2025.08.25`.
  * Upgraded dependencies (incl. `googleapis` and `googleapis_auth`)
+ * Note: upload emails may contain a changelog excerpt.
 
 ## `20250821t095300-all`
  * Bump runtimeVersion to `2025.08.15`.

--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -1175,7 +1175,7 @@ class PackageBackend {
       versionKey: newVersion.qualifiedVersionKey,
       changelogContent: entities.changelogAsset?.textContent,
     );
-    if (changelogExcerpt != null) {
+    if (changelogExcerpt != null && changelogExcerpt.isNotEmpty) {
       uploadMessages
           .add('Excerpt of the changelog:\n```\n$changelogExcerpt\n```');
     }

--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -9,6 +9,7 @@ import 'package:_pub_shared/data/account_api.dart' as account_api;
 import 'package:_pub_shared/data/package_api.dart' as api;
 import 'package:_pub_shared/utils/sdk_version_cache.dart';
 import 'package:clock/clock.dart';
+import 'package:collection/collection.dart';
 import 'package:convert/convert.dart';
 import 'package:crypto/crypto.dart';
 import 'package:gcloud/service_scope.dart' as ss;
@@ -21,6 +22,8 @@ import 'package:pub_dev/package/tarball_storage.dart';
 import 'package:pub_dev/scorecard/backend.dart';
 import 'package:pub_dev/service/async_queue/async_queue.dart';
 import 'package:pub_dev/service/rate_limit/rate_limit.dart';
+import 'package:pub_dev/shared/changelog.dart';
+import 'package:pub_dev/shared/monitoring.dart';
 import 'package:pub_dev/shared/versions.dart';
 import 'package:pub_dev/task/backend.dart';
 import 'package:pub_package_reader/pub_package_reader.dart';
@@ -1168,6 +1171,15 @@ class PackageBackend {
         .run()
         .toList();
 
+    final changelogExcerpt = _createChangelogExcerpt(
+      versionKey: newVersion.qualifiedVersionKey,
+      changelogContent: entities.changelogAsset?.textContent,
+    );
+    if (changelogExcerpt != null) {
+      uploadMessages
+          .add('Excerpt of the changelog:\n```\n$changelogExcerpt\n```');
+    }
+
     // Add the new package to the repository by storing the tarball and
     // inserting metadata to datastore (which happens atomically).
     final (pv, outgoingEmail) = await withRetryTransaction(db, (tx) async {
@@ -1313,6 +1325,42 @@ class PackageBackend {
 
     _logger.info('Post-upload tasks completed in ${sw.elapsed}.');
     return (pv, uploadMessages);
+  }
+
+  String? _createChangelogExcerpt({
+    required QualifiedVersionKey versionKey,
+    required String? changelogContent,
+  }) {
+    if (changelogContent == null) {
+      return null;
+    }
+    try {
+      final parsed = ChangelogParser().parseMarkdownText(changelogContent);
+      final version = parsed.releases
+          .firstWhereOrNull((r) => r.version == versionKey.version);
+      if (version == null) {
+        return null;
+      }
+      final text = version.content.asMarkdownText;
+
+      /// Limit the changelog to 10 lines, 75 characters each:
+      final lines = text.split('\n');
+      final excerpt = lines
+          // filter empty or decorative lines to maximalize usefulness
+          .where((line) =>
+              line.isNotEmpty &&
+              !line.startsWith('```') && // also removes the need to escape it
+              !line.startsWith('---'))
+          .take(10)
+          .map((line) =>
+              line.length < 76 ? line : '${line.substring(0, 70)}[...]')
+          .join('\n');
+      return excerpt;
+    } catch (e, st) {
+      _logger.pubNoticeShout('changelog-parse-error',
+          'Unable to parse changelog for $versionKey', e, st);
+      return null;
+    }
   }
 
   /// The post-upload tasks are not critical and could fail without any impact on
@@ -1903,6 +1951,9 @@ class _UploadEntities {
     this.packageVersionInfo,
     this.assets,
   );
+
+  late final changelogAsset =
+      assets.firstWhereOrNull((e) => e.kind == AssetKind.changelog);
 }
 
 class DerivedPackageVersionEntities {

--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -1352,6 +1352,8 @@ class PackageBackend {
               !line.startsWith('```') && // also removes the need to escape it
               !line.startsWith('---'))
           .take(10)
+          // prevent accidental HTML-tag creation
+          .map((line) => line.replaceAll('<', '[').replaceAll('>', ']'))
           .map((line) =>
               line.length < 76 ? line : '${line.substring(0, 70)}[...]')
           .join('\n');

--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -1353,7 +1353,10 @@ class PackageBackend {
               !line.startsWith('---'))
           .take(10)
           // prevent accidental HTML-tag creation
-          .map((line) => line.replaceAll('<', '[').replaceAll('>', ']'))
+          .map((line) => line
+              .replaceAll('<', '[')
+              .replaceAll('>', ']')
+              .replaceAll('&', ' '))
           .map((line) =>
               line.length < 76 ? line : '${line.substring(0, 70)}[...]')
           .join('\n');

--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -1346,17 +1346,20 @@ class PackageBackend {
       /// Limit the changelog to 10 lines, 75 characters each:
       final lines = text.split('\n');
       final excerpt = lines
-          // filter empty or decorative lines to maximalize usefulness
-          .where((line) =>
-              line.isNotEmpty &&
-              !line.startsWith('```') && // also removes the need to escape it
-              !line.startsWith('---'))
-          .take(10)
           // prevent accidental HTML-tag creation
           .map((line) => line
               .replaceAll('<', '[')
               .replaceAll('>', ']')
-              .replaceAll('&', ' '))
+              .replaceAll('&', ' ')
+              .trim())
+          // filter empty or decorative lines to maximalize usefulness
+          .where((line) =>
+              line.isNotEmpty &&
+              line != '-' && // empty list item
+              line != '1.' && // empty list item
+              !line.startsWith('```') && // also removes the need to escape it
+              !line.startsWith('---'))
+          .take(10)
           .map((line) =>
               line.length < 76 ? line : '${line.substring(0, 70)}[...]')
           .join('\n');

--- a/app/lib/shared/changelog.dart
+++ b/app/lib/shared/changelog.dart
@@ -257,12 +257,6 @@ class _MarkdownVisitor extends dom_parsing.TreeVisitor {
   @override
   void visitText(html.Text node) {
     _result.write(node.text.normalizeAndTrim());
-    // if (_inlineDepth > 0 &&
-    //     (node.parent?.nodes.indexOf(this) ?? -1) !=
-    //         (node.parent?.nodes.length ?? 0) - 1 &&
-    //     node.text.endsWithWhitespace()) {
-    //   _out.write(' ');
-    // }
   }
 
   @override

--- a/app/lib/shared/changelog.dart
+++ b/app/lib/shared/changelog.dart
@@ -238,7 +238,8 @@ class _MarkdownVisitor extends dom_parsing.TreeVisitor {
         final indent = '  ' * (_listDepth - 1);
         _write(indent);
         if (parent == 'ol') {
-          _write('1. ');
+          final childIndex = (node.parent?.children.indexOf(node) ?? 0) + 1;
+          _write('$childIndex. ');
         } else {
           _write('- ');
         }

--- a/app/test/package/backend_test_utils.dart
+++ b/app/test/package/backend_test_utils.dart
@@ -19,10 +19,13 @@ Future<T> withTempDirectory<T>(Future<T> Function(String temp) func) async {
   }
 }
 
-Future<List<int>> packageArchiveBytes({required String pubspecContent}) async {
+Future<List<int>> packageArchiveBytes({
+  required String pubspecContent,
+  String? changelogContent,
+}) async {
   final builder = ArchiveBuilder();
   builder.addFile('README.md', foobarReadmeContent);
-  builder.addFile('CHANGELOG.md', foobarChangelogContent);
+  builder.addFile('CHANGELOG.md', changelogContent ?? foobarChangelogContent);
   builder.addFile('pubspec.yaml', pubspecContent);
   builder.addFile('LICENSE', 'BSD LICENSE 2.0');
   builder.addFile('lib/test_library.dart', 'hello() => print("hello");');

--- a/app/test/shared/changelog_test.dart
+++ b/app/test/shared/changelog_test.dart
@@ -2,16 +2,11 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:html/parser.dart' as html_parser;
-import 'package:markdown/markdown.dart' as m;
 import 'package:pub_dev/shared/changelog.dart';
 import 'package:test/test.dart';
 
 Changelog _parse(String input) {
-  final nodes = m.Document(extensionSet: m.ExtensionSet.gitHubWeb).parse(input);
-  final rawHtml = m.renderToHtml(nodes);
-  final root = html_parser.parseFragment(rawHtml);
-  return ChangelogParser().parseHtmlNodes(root.nodes);
+  return ChangelogParser().parseMarkdownText(input);
 }
 
 void main() {
@@ -47,6 +42,7 @@ void main() {
       expect(firstRelease.date, equals(DateTime(2025, 7, 10)));
       expect(firstRelease.content.asHtmlText, contains('New feature A'));
       expect(firstRelease.content.asHtmlText, contains('Bug fix 1'));
+      expect(firstRelease.content.asMarkdownText, contains('Bug fix 1'));
 
       final secondRelease = changelog.releases[1];
       expect(secondRelease.version, equals('1.1.0'));
@@ -537,6 +533,74 @@ This is the changelog for the project.
           changelog.description!.asHtmlText, contains('This is the changelog'));
       expect(changelog.releases, hasLength(1));
       expect(changelog.releases[0].version, equals('1.0.0'));
+    });
+
+    test('markdown rendering with different styles', () {
+      const markdown = '''
+# Changelog
+
+## Header 2
+
+Text 2 over
+two lines.
+
+Multiple paragraphs with [link](https://pub.dev), `code`, and *different* **emphasis**.
+
+---
+
+Also:
+- unordered
+  multiline
+- list
+
+And:
+1. order
+1. list
+
+>With multiline quoted
+> `code` and *text*.
+
+### Header 3
+#### Header 4
+##### Header 5
+###### Header 6
+''';
+      final changelog = _parse(markdown);
+      expect(
+          changelog.description?.asMarkdownText,
+          '## Header 2\n'
+          '\n'
+          'Text 2 over two lines.\n'
+          '\n'
+          'Multiple paragraphs with [link](https://pub.dev), `code`, and *different* **emphasis**.\n'
+          '\n'
+          '---\n'
+          'Also:\n'
+          '\n'
+          '- unordered multiline\n'
+          '- list\n'
+          '\n'
+          'And:\n'
+          '\n'
+          '1. order\n'
+          '1. list\n'
+          '\n'
+          '> With multiline quoted `code`and *text*.\n'
+          '\n'
+          '\n'
+          '### Header 3\n'
+          '\n'
+          '#### Header 4\n'
+          '\n'
+          '##### Header 5\n'
+          '\n'
+          '###### Header 6');
+
+      // check stability: another round of the markdown output yields the same result
+      final changelog2 =
+          _parse('# Changelog\n${changelog.description?.asMarkdownText}');
+      expect(changelog2.description?.asMarkdownText,
+          changelog.description?.asMarkdownText);
     });
   });
 }

--- a/app/test/shared/changelog_test.dart
+++ b/app/test/shared/changelog_test.dart
@@ -583,7 +583,7 @@ And:
           'And:\n'
           '\n'
           '1. order\n'
-          '1. list\n'
+          '2. list\n'
           '\n'
           '> With multiline quoted `code`and *text*.\n'
           '\n'


### PR DESCRIPTION
- Fixes #2028.
- Excerpt is generated with the following processing: markdown -> html -> changelog parser -> html content of the release -> markdown-ified version of the release ->  taking only 10 lines, with limited character counts.
