### PR TITLE
Updated score API: emit null when value is not present, remove updated timestamp.

### DIFF
--- a/app/lib/scorecard/backend.dart
+++ b/app/lib/scorecard/backend.dart
@@ -210,12 +210,7 @@ class ScoreCardBackend {
       throw NotFoundException.resource('package "$package" version "$version"');
     }
 
-    var updated = pkg.updated;
     final card = await scoreCardBackend.getScoreCardData(package, v);
-    if (updated == null || card.updated?.isAfter(updated) == true) {
-      updated = card.updated;
-    }
-
     final tags = <String>{
       ...pkg.getTags(),
       ...pv.getTags(),
@@ -229,7 +224,6 @@ class ScoreCardBackend {
       downloadCount30Days:
           downloadCountsBackend.lookup30DaysTotalCounts(package),
       tags: tags.toList(),
-      lastUpdated: updated,
     );
   }
 }

--- a/app/test/frontend/handlers/custom_api_test.dart
+++ b/app/test/frontend/handlers/custom_api_test.dart
@@ -180,8 +180,8 @@ void main() {
           'grantedPoints': greaterThan(10),
           'maxPoints': greaterThan(50),
           'likeCount': 0,
+          'downloadCount30Days': null,
           'tags': contains('sdk:dart'),
-          'lastUpdated': isNotEmpty,
         });
       },
     );

--- a/app/test/package/api_export/api_exporter_test.dart
+++ b/app/test/package/api_export/api_exporter_test.dart
@@ -155,8 +155,8 @@ Future<void> _testExportedApiSynchronization(
         'grantedPoints': isNotNull,
         'maxPoints': isNotNull,
         'likeCount': isNotNull,
+        'downloadCount30Days': null,
         'tags': isNotEmpty,
-        'lastUpdated': isNotNull,
       },
     );
     expect(

--- a/pkg/_pub_shared/lib/data/package_api.dart
+++ b/pkg/_pub_shared/lib/data/package_api.dart
@@ -274,14 +274,13 @@ class VersionInfo {
   Map<String, dynamic> toJson() => _$VersionInfoToJson(this);
 }
 
-@JsonSerializable(includeIfNull: false)
+@JsonSerializable(includeIfNull: true)
 class VersionScore {
   final int? grantedPoints;
   final int? maxPoints;
   final int? likeCount;
   final int? downloadCount30Days;
   final List<String>? tags;
-  final DateTime? lastUpdated;
 
   VersionScore({
     required this.grantedPoints,
@@ -289,7 +288,6 @@ class VersionScore {
     required this.likeCount,
     required this.downloadCount30Days,
     required this.tags,
-    required this.lastUpdated,
   });
 
   factory VersionScore.fromJson(Map<String, dynamic> json) =>

--- a/pkg/_pub_shared/lib/data/package_api.g.dart
+++ b/pkg/_pub_shared/lib/data/package_api.g.dart
@@ -182,21 +182,15 @@ VersionScore _$VersionScoreFromJson(Map<String, dynamic> json) => VersionScore(
       likeCount: (json['likeCount'] as num?)?.toInt(),
       downloadCount30Days: (json['downloadCount30Days'] as num?)?.toInt(),
       tags: (json['tags'] as List<dynamic>?)?.map((e) => e as String).toList(),
-      lastUpdated: json['lastUpdated'] == null
-          ? null
-          : DateTime.parse(json['lastUpdated'] as String),
     );
 
 Map<String, dynamic> _$VersionScoreToJson(VersionScore instance) =>
     <String, dynamic>{
-      if (instance.grantedPoints case final value?) 'grantedPoints': value,
-      if (instance.maxPoints case final value?) 'maxPoints': value,
-      if (instance.likeCount case final value?) 'likeCount': value,
-      if (instance.downloadCount30Days case final value?)
-        'downloadCount30Days': value,
-      if (instance.tags case final value?) 'tags': value,
-      if (instance.lastUpdated?.toIso8601String() case final value?)
-        'lastUpdated': value,
+      'grantedPoints': instance.grantedPoints,
+      'maxPoints': instance.maxPoints,
+      'likeCount': instance.likeCount,
+      'downloadCount30Days': instance.downloadCount30Days,
+      'tags': instance.tags,
     };
 
 RemoveUploaderRequest _$RemoveUploaderRequestFromJson(


### PR DESCRIPTION
Fixes #8920.