### PR TITLE
Updated integrity and cache handling.

### DIFF
--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -1750,11 +1750,6 @@ class PackageBackend {
     await tarballStorage.deleteArchiveFromAllBuckets(package, version);
   }
 
-  /// Gets the file info of a [package] in the given [version].
-  Future<ObjectInfo?> packageTarballInfo(String package, String version) async {
-    return await tarballStorage.getPublicBucketArchiveInfo(package, version);
-  }
-
   void _updatePackageAutomatedPublishingLock(
       Package package, AuthenticatedAgent agent) {
     final current = package.automatedPublishing;

--- a/app/lib/shared/integrity.dart
+++ b/app/lib/shared/integrity.dart
@@ -1059,8 +1059,8 @@ class TarballIntegrityChecker extends _BaseIntegrityChecker {
         pv.package, pv.version!,
         baseUri: activeConfiguration.primaryApiUri));
 
-    final shouldBeInPublicBucket =
-        await packageBackend.isPackageVisible(pv.package) && pv.isVisible;
+    final isPackageVisible = await packageBackend.isPackageVisible(pv.package);
+    final shouldBeInPublicBucket = isPackageVisible && pv.isVisible;
 
     final canonicalInfo = await packageBackend.tarballStorage
         .getCanonicalBucketArchiveInfo(pv.package, pv.version!);
@@ -1069,11 +1069,12 @@ class TarballIntegrityChecker extends _BaseIntegrityChecker {
       return;
     }
 
-    final info =
-        await packageBackend.packageTarballInfo(pv.package, pv.version!);
+    final info = await packageBackend.tarballStorage
+        .getPublicBucketArchiveInfo(pv.package, pv.version!);
     if (info == null) {
       if (shouldBeInPublicBucket) {
-        yield 'PackageVersion "${pv.qualifiedVersionKey}" has no matching public archive file.';
+        yield 'PackageVersion "${pv.qualifiedVersionKey}" has no matching public archive file '
+            '(Package: $isPackageVisible, PackageVersion: ${pv.isVisible}).';
       }
       return;
     }

--- a/app/lib/shared/redis_cache.dart
+++ b/app/lib/shared/redis_cache.dart
@@ -122,7 +122,7 @@ class CachePatterns {
 
   Entry<bool> packageVisible(String package) => _cache
       .withPrefix('package-visible/')
-      .withTTL(Duration(days: 7))
+      .withTTL(Duration(hours: 12))
       .withCodec(utf8)
       .withCodec(json)
       .withCodec(wrapAsCodec(
@@ -312,7 +312,7 @@ class CachePatterns {
 
   Entry<bool> publisherVisible(String publisherId) => _cache
       .withPrefix('publisher-visible/')
-      .withTTL(Duration(days: 7))
+      .withTTL(Duration(hours: 12))
       .withCodec(utf8)
       .withCodec(json)
       .withCodec(wrapAsCodec(
@@ -337,21 +337,6 @@ class CachePatterns {
   Entry<List<int>> searchInputCompletionDataJsonGz() => _cache
       .withPrefix('search-input-completion-data-json-gz/')
       .withTTL(Duration(hours: 8))['-'];
-
-  /// Stores the flag that latest version of packages have been scanned for job entities.
-  Entry<bool> jobHistoryLatestScanned(String service) =>
-      jobHistoryPackageScanned(service, '');
-
-  /// Stores the flag that a [package]'s versions have been scanned for job entities.
-  Entry<bool> jobHistoryPackageScanned(String service, String package) => _cache
-      .withPrefix('job-history-package-scanned/')
-      .withTTL(Duration(days: 7))
-      .withCodec(utf8)
-      .withCodec(json)
-      .withCodec(wrapAsCodec(
-        encode: (bool value) => value,
-        decode: (d) => d as bool,
-      ))['$service/$package'];
 
   /// Cache for index objects, used by TaskBackend.
   Entry<BlobIndex> taskResultIndex(String package, String version) => _cache


### PR DESCRIPTION
- removed `packageTarballInfo` as calling the `getPublicBucketArchiveInfo` seems to be more readable
- split up parts of `shouldBeInPublicBucket` and exposing them in the integrity message for better debugging
- reduced the cache timeout to 12 hours for visibility cache entries
- removed obsolete cache entries