### PR TITLE
New tag to indicate search on the current user's liked packages.

### DIFF
--- a/app/lib/account/like_backend.dart
+++ b/app/lib/account/like_backend.dart
@@ -34,13 +34,14 @@ class LikeBackend {
   }
 
   /// Returns a list with [LikeData] of all the packages that the given
-  ///  [user] likes.
-  Future<List<LikeData>> listPackageLikes(User user) async {
-    return (await cache.userPackageLikes(user.userId).get(() async {
+  ///  user's likes.
+  Future<List<LikeData>> listPackageLikes(String userId) async {
+    return (await cache.userPackageLikes(userId).get(() async {
       // TODO(zarah): Introduce pagination and/or migrate this to search.
-      final query = _db.query<Like>(ancestorKey: user.key)
-        ..order('-created')
-        ..limit(1000);
+      final query =
+          _db.query<Like>(ancestorKey: _db.emptyKey.append(User, id: userId))
+            ..order('-created')
+            ..limit(1000);
       final likes = await query.run().toList();
       return likes.map((Like l) => LikeData.fromModel(l)).toList();
     }))!;

--- a/app/lib/admin/backend.dart
+++ b/app/lib/admin/backend.dart
@@ -178,7 +178,7 @@ class AdminBackend {
   Future<void> _removeAndDecrementLikes(User user) async {
     final pool = Pool(5);
     final futures = <Future>[];
-    for (final like in await likeBackend.listPackageLikes(user)) {
+    for (final like in await likeBackend.listPackageLikes(user.userId)) {
       final f = pool
           .withResource(() => likeBackend.unlikePackage(user, like.package!));
       futures.add(f);

--- a/app/lib/frontend/handlers/account.dart
+++ b/app/lib/frontend/handlers/account.dart
@@ -197,7 +197,7 @@ Future<LikedPackagesResponse> listPackageLikesHandler(
     shelf.Request request) async {
   final authenticatedUser = await requireAuthenticatedWebUser();
   final user = authenticatedUser.user;
-  final packages = await likeBackend.listPackageLikes(user);
+  final packages = await likeBackend.listPackageLikes(user.userId);
   final List<PackageLikeResponse> packageLikes = packages
       .map((like) => PackageLikeResponse(
           liked: true, package: like.package, created: like.created))
@@ -294,7 +294,7 @@ Future<shelf.Response> accountMyLikedPackagesPageHandler(
 
   final user = (await accountBackend
       .lookupUserById(requestContext.authenticatedUserId!))!;
-  final likes = await likeBackend.listPackageLikes(user);
+  final likes = await likeBackend.listPackageLikes(user.userId);
   final html = renderMyLikedPackagesPage(
     user: user,
     userSessionData: requestContext.sessionData!,

--- a/app/lib/frontend/handlers/experimental.dart
+++ b/app/lib/frontend/handlers/experimental.dart
@@ -10,15 +10,11 @@ typedef PublicFlag = ({String name, String description});
 
 const _publicFlags = <PublicFlag>{
   (name: 'example', description: 'Short description'),
-  (
-    name: 'trending-search',
-    description: 'Show trending packages and search by trending scores'
-  ),
 };
 
 final _allFlags = <String>{
   'dark-as-default',
-  'search-post',
+  'my-liked-search',
   ..._publicFlags.map((x) => x.name),
 };
 
@@ -93,7 +89,7 @@ class ExperimentalFlags {
 
   bool get isDarkModeDefault => isEnabled('dark-as-default');
 
-  bool get useSearchPost => isEnabled('search-post');
+  bool get useMyLikedSearch => isEnabled('my-liked-search');
 
   String encodedAsCookie() => _enabled.join(':');
 

--- a/app/lib/search/mem_index.dart
+++ b/app/lib/search/mem_index.dart
@@ -6,6 +6,7 @@ import 'dart:math' as math;
 
 import 'package:_pub_shared/search/search_form.dart';
 import 'package:_pub_shared/search/search_request_data.dart';
+import 'package:_pub_shared/search/tags.dart';
 import 'package:clock/clock.dart';
 import 'package:collection/collection.dart';
 import 'package:logging/logging.dart';
@@ -125,6 +126,13 @@ class InMemoryPackageIndex {
     // prevent any work if offset is outside of the range
     if (query.offset >= _documents.length) {
       return PackageSearchResult.empty();
+    }
+    // Special case for the account-related tag.
+    if (query.parsedQuery.tagsPredicate.hasTag(AccountTag.isLikedByMe)) {
+      return PackageSearchResult.error(
+        statusCode: 400,
+        errorMessage: '`is:liked-by-me` is only for authenticated users.',
+      );
     }
     return _bitArrayPool.withPoolItem(fn: (array) {
       return _scorePool.withItemGetter(

--- a/app/test/admin/user_merger_test.dart
+++ b/app/test/admin/user_merger_test.dart
@@ -150,17 +150,17 @@ void main() {
     final admin = await accountBackend.lookupUserByEmail('admin@pub.dev');
     await likeBackend.likePackage(admin, 'oxygen');
     expect(
-        (await likeBackend.listPackageLikes(admin))
+        (await likeBackend.listPackageLikes(admin.userId))
             .map((e) => e.package)
             .toList(),
         ['oxygen']);
-    expect(await likeBackend.listPackageLikes(user), isEmpty);
+    expect(await likeBackend.listPackageLikes(user.userId), isEmpty);
 
     await _corruptAndFix();
 
-    expect(await likeBackend.listPackageLikes(admin), isEmpty);
+    expect(await likeBackend.listPackageLikes(admin.userId), isEmpty);
     expect(
-        (await likeBackend.listPackageLikes(user))
+        (await likeBackend.listPackageLikes(user.userId))
             .map((e) => e.package)
             .toList(),
         ['oxygen']);

--- a/pkg/_pub_shared/lib/search/search_request_data.dart
+++ b/pkg/_pub_shared/lib/search/search_request_data.dart
@@ -88,6 +88,25 @@ class SearchRequestData {
     map.removeWhere((k, v) => v == null);
     return map;
   }
+
+  /// Creates a new instance with fields being replaced (if provided).
+  SearchRequestData replace({
+    String? query,
+    List<String>? tags,
+    List<String>? packages,
+  }) {
+    return SearchRequestData(
+      query: query ?? this.query,
+      minPoints: minPoints,
+      publisherId: publisherId,
+      tags: tags ?? this.tags,
+      packages: packages ?? this.packages,
+      order: order,
+      offset: offset,
+      limit: limit,
+      textMatchExtent: textMatchExtent,
+    );
+  }
 }
 
 /// The scope (depth) of the text matching.

--- a/pkg/_pub_shared/lib/search/tags.dart
+++ b/pkg/_pub_shared/lib/search/tags.dart
@@ -151,6 +151,11 @@ abstract class PlatformTagValue {
   static const String windows = 'windows';
 }
 
+/// Tags that control account-related search features.
+abstract class AccountTag {
+  static const isLikedByMe = 'is:liked-by-me';
+}
+
 /// Tags that may be relevant in search for packages that have preview or
 /// prerelease version published.
 const _futureVersionTags = <String>{


### PR DESCRIPTION
- #8887
- behind (updated) experimental flag
- the presence of the tag is not propagated to the backend (since there won't be any package with it), it needs to be removed before sending the query to the backend
- when the tag is present, we must not cache the results (or should add a userid to the cache key, TBD)
- updated like backend to work with `userId` instead of `User` object