### PR TITLE
Refactor like button template.

### DIFF
--- a/app/lib/frontend/templates/views/pkg/liked_package_list.dart
+++ b/app/lib/frontend/templates/views/pkg/liked_package_list.dart
@@ -72,39 +72,43 @@ d.Node renderLikeButtonAndLabel(
   return d.div(
     classes: ['like-button-and-label'],
     children: [
-      material.iconButton(
-        classes: ['like-button-and-label--button'],
-        isOn: isLiked,
-        onIcon: d.Image(
-          src: staticUrls.getAssetUrl('/static/img/like-active.svg'),
-          alt: 'liked status: active',
-          width: 18,
-          height: 18,
-        ),
-        offIcon: d.Image(
-          src: staticUrls.getAssetUrl('/static/img/like-inactive.svg'),
-          alt: 'liked status: inactive',
-          width: 18,
-          height: 18,
-        ),
-        title: isLiked ? 'Unlike this package' : 'Like this package',
-        attributes: {
-          'data-ga-click-event': 'toggle-like',
-          'aria-pressed': isLiked ? 'true' : 'false',
-        },
-      ),
+      _renderLikeButton(package, isLiked),
       d.span(
         classes: ['like-button-and-label--count-wrapper'],
         child: d.span(
           classes: ['like-button-and-label--count'],
           text: _formatPackageLikes(likeCount),
           attributes: {
-            'data-package': package,
             'data-value': likeCount.toString(),
           },
         ),
       ),
     ],
+  );
+}
+
+d.Node _renderLikeButton(String package, bool isLiked) {
+  return material.iconButton(
+    classes: ['like-button-and-label--button'],
+    isOn: isLiked,
+    onIcon: d.Image(
+      src: staticUrls.getAssetUrl('/static/img/like-active.svg'),
+      alt: 'liked status: active',
+      width: 18,
+      height: 18,
+    ),
+    offIcon: d.Image(
+      src: staticUrls.getAssetUrl('/static/img/like-inactive.svg'),
+      alt: 'liked status: inactive',
+      width: 18,
+      height: 18,
+    ),
+    title: isLiked ? 'Unlike this package' : 'Like this package',
+    attributes: {
+      'data-ga-click-event': 'toggle-like',
+      'aria-pressed': isLiked ? 'true' : 'false',
+      'data-package': package,
+    },
   );
 }
 

--- a/app/test/frontend/golden/pkg_activity_log_page.html
+++ b/app/test/frontend/golden/pkg_activity_log_page.html
@@ -186,12 +186,12 @@
                     </div>
                   </div>
                   <div class="like-button-and-label">
-                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" title="Like this package">
+                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="oxygen" title="Like this package">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="liked status: inactive" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="liked status: active" width="18" height="18"/>
                     </button>
                     <span class="like-button-and-label--count-wrapper">
-                      <span class="like-button-and-label--count" data-package="oxygen" data-value="0">0</span>
+                      <span class="like-button-and-label--count" data-value="0">0</span>
                     </span>
                   </div>
                 </div>

--- a/app/test/frontend/golden/pkg_admin_page.html
+++ b/app/test/frontend/golden/pkg_admin_page.html
@@ -186,12 +186,12 @@
                     </div>
                   </div>
                   <div class="like-button-and-label">
-                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" title="Like this package">
+                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="oxygen" title="Like this package">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="liked status: inactive" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="liked status: active" width="18" height="18"/>
                     </button>
                     <span class="like-button-and-label--count-wrapper">
-                      <span class="like-button-and-label--count" data-package="oxygen" data-value="0">0</span>
+                      <span class="like-button-and-label--count" data-value="0">0</span>
                     </span>
                   </div>
                 </div>

--- a/app/test/frontend/golden/pkg_changelog_page.html
+++ b/app/test/frontend/golden/pkg_changelog_page.html
@@ -161,12 +161,12 @@
                     </div>
                   </div>
                   <div class="like-button-and-label">
-                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" title="Like this package">
+                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="oxygen" title="Like this package">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="liked status: inactive" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="liked status: active" width="18" height="18"/>
                     </button>
                     <span class="like-button-and-label--count-wrapper">
-                      <span class="like-button-and-label--count" data-package="oxygen" data-value="0">0</span>
+                      <span class="like-button-and-label--count" data-value="0">0</span>
                     </span>
                   </div>
                 </div>

--- a/app/test/frontend/golden/pkg_example_page.html
+++ b/app/test/frontend/golden/pkg_example_page.html
@@ -161,12 +161,12 @@
                     </div>
                   </div>
                   <div class="like-button-and-label">
-                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" title="Like this package">
+                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="oxygen" title="Like this package">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="liked status: inactive" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="liked status: active" width="18" height="18"/>
                     </button>
                     <span class="like-button-and-label--count-wrapper">
-                      <span class="like-button-and-label--count" data-package="oxygen" data-value="0">0</span>
+                      <span class="like-button-and-label--count" data-value="0">0</span>
                     </span>
                   </div>
                 </div>

--- a/app/test/frontend/golden/pkg_install_page.html
+++ b/app/test/frontend/golden/pkg_install_page.html
@@ -161,12 +161,12 @@
                     </div>
                   </div>
                   <div class="like-button-and-label">
-                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" title="Like this package">
+                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="oxygen" title="Like this package">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="liked status: inactive" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="liked status: active" width="18" height="18"/>
                     </button>
                     <span class="like-button-and-label--count-wrapper">
-                      <span class="like-button-and-label--count" data-package="oxygen" data-value="0">0</span>
+                      <span class="like-button-and-label--count" data-value="0">0</span>
                     </span>
                   </div>
                 </div>

--- a/app/test/frontend/golden/pkg_score_page.html
+++ b/app/test/frontend/golden/pkg_score_page.html
@@ -161,12 +161,12 @@
                     </div>
                   </div>
                   <div class="like-button-and-label">
-                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" title="Like this package">
+                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="oxygen" title="Like this package">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="liked status: inactive" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="liked status: active" width="18" height="18"/>
                     </button>
                     <span class="like-button-and-label--count-wrapper">
-                      <span class="like-button-and-label--count" data-package="oxygen" data-value="0">0</span>
+                      <span class="like-button-and-label--count" data-value="0">0</span>
                     </span>
                   </div>
                 </div>

--- a/app/test/frontend/golden/pkg_score_page_with_downloads_chart.html
+++ b/app/test/frontend/golden/pkg_score_page_with_downloads_chart.html
@@ -161,12 +161,12 @@
                     </div>
                   </div>
                   <div class="like-button-and-label">
-                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" title="Like this package">
+                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="oxygen" title="Like this package">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="liked status: inactive" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="liked status: active" width="18" height="18"/>
                     </button>
                     <span class="like-button-and-label--count-wrapper">
-                      <span class="like-button-and-label--count" data-package="oxygen" data-value="0">0</span>
+                      <span class="like-button-and-label--count" data-value="0">0</span>
                     </span>
                   </div>
                 </div>

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -152,12 +152,12 @@
                     </div>
                   </div>
                   <div class="like-button-and-label">
-                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" title="Like this package">
+                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="oxygen" title="Like this package">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="liked status: inactive" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="liked status: active" width="18" height="18"/>
                     </button>
                     <span class="like-button-and-label--count-wrapper">
-                      <span class="like-button-and-label--count" data-package="oxygen" data-value="0">0</span>
+                      <span class="like-button-and-label--count" data-value="0">0</span>
                     </span>
                   </div>
                 </div>

--- a/app/test/frontend/golden/pkg_show_page_discontinued.html
+++ b/app/test/frontend/golden/pkg_show_page_discontinued.html
@@ -160,12 +160,12 @@
                     </div>
                   </div>
                   <div class="like-button-and-label">
-                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" title="Like this package">
+                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="pkg" title="Like this package">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="liked status: inactive" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="liked status: active" width="18" height="18"/>
                     </button>
                     <span class="like-button-and-label--count-wrapper">
-                      <span class="like-button-and-label--count" data-package="pkg" data-value="0">0</span>
+                      <span class="like-button-and-label--count" data-value="0">0</span>
                     </span>
                   </div>
                 </div>

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -150,12 +150,12 @@
                     </div>
                   </div>
                   <div class="like-button-and-label">
-                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" title="Like this package">
+                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="flutter_titanium" title="Like this package">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="liked status: inactive" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="liked status: active" width="18" height="18"/>
                     </button>
                     <span class="like-button-and-label--count-wrapper">
-                      <span class="like-button-and-label--count" data-package="flutter_titanium" data-value="0">0</span>
+                      <span class="like-button-and-label--count" data-value="0">0</span>
                     </span>
                   </div>
                 </div>

--- a/app/test/frontend/golden/pkg_show_page_publisher.html
+++ b/app/test/frontend/golden/pkg_show_page_publisher.html
@@ -155,12 +155,12 @@
                     </div>
                   </div>
                   <div class="like-button-and-label">
-                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" title="Like this package">
+                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="neon" title="Like this package">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="liked status: inactive" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="liked status: active" width="18" height="18"/>
                     </button>
                     <span class="like-button-and-label--count-wrapper">
-                      <span class="like-button-and-label--count" data-package="neon" data-value="0">0</span>
+                      <span class="like-button-and-label--count" data-value="0">0</span>
                     </span>
                   </div>
                 </div>

--- a/app/test/frontend/golden/pkg_show_page_retracted.html
+++ b/app/test/frontend/golden/pkg_show_page_retracted.html
@@ -143,12 +143,12 @@
                     <span class="package-tag retracted" title="This version was retracted.">retracted</span>
                   </div>
                   <div class="like-button-and-label">
-                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" title="Like this package">
+                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="pkg" title="Like this package">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="liked status: inactive" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="liked status: active" width="18" height="18"/>
                     </button>
                     <span class="like-button-and-label--count-wrapper">
-                      <span class="like-button-and-label--count" data-package="pkg" data-value="0">0</span>
+                      <span class="like-button-and-label--count" data-value="0">0</span>
                     </span>
                   </div>
                 </div>

--- a/app/test/frontend/golden/pkg_show_page_retracted_non_retracted_version.html
+++ b/app/test/frontend/golden/pkg_show_page_retracted_non_retracted_version.html
@@ -151,12 +151,12 @@
                     </div>
                   </div>
                   <div class="like-button-and-label">
-                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" title="Like this package">
+                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="pkg" title="Like this package">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="liked status: inactive" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="liked status: active" width="18" height="18"/>
                     </button>
                     <span class="like-button-and-label--count-wrapper">
-                      <span class="like-button-and-label--count" data-package="pkg" data-value="0">0</span>
+                      <span class="like-button-and-label--count" data-value="0">0</span>
                     </span>
                   </div>
                 </div>

--- a/app/test/frontend/golden/pkg_show_version_page.html
+++ b/app/test/frontend/golden/pkg_show_version_page.html
@@ -161,12 +161,12 @@
                     </div>
                   </div>
                   <div class="like-button-and-label">
-                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" title="Like this package">
+                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="oxygen" title="Like this package">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="liked status: inactive" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="liked status: active" width="18" height="18"/>
                     </button>
                     <span class="like-button-and-label--count-wrapper">
-                      <span class="like-button-and-label--count" data-package="oxygen" data-value="0">0</span>
+                      <span class="like-button-and-label--count" data-value="0">0</span>
                     </span>
                   </div>
                 </div>

--- a/app/test/frontend/golden/pkg_versions_page.html
+++ b/app/test/frontend/golden/pkg_versions_page.html
@@ -160,12 +160,12 @@
                     </div>
                   </div>
                   <div class="like-button-and-label">
-                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" title="Like this package">
+                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="oxygen" title="Like this package">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="liked status: inactive" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="liked status: active" width="18" height="18"/>
                     </button>
                     <span class="like-button-and-label--count-wrapper">
-                      <span class="like-button-and-label--count" data-package="oxygen" data-value="0">0</span>
+                      <span class="like-button-and-label--count" data-value="0">0</span>
                     </span>
                   </div>
                 </div>

--- a/app/test/task/testdata/goldens/packages/oxygen.html
+++ b/app/test/task/testdata/goldens/packages/oxygen.html
@@ -153,12 +153,12 @@
                     </div>
                   </div>
                   <div class="like-button-and-label">
-                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" title="Like this package">
+                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="oxygen" title="Like this package">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="liked status: inactive" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="liked status: active" width="18" height="18"/>
                     </button>
                     <span class="like-button-and-label--count-wrapper">
-                      <span class="like-button-and-label--count" data-package="oxygen" data-value="0">0</span>
+                      <span class="like-button-and-label--count" data-value="0">0</span>
                     </span>
                   </div>
                 </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/changelog.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/changelog.html
@@ -153,12 +153,12 @@
                     </div>
                   </div>
                   <div class="like-button-and-label">
-                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" title="Like this package">
+                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="oxygen" title="Like this package">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="liked status: inactive" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="liked status: active" width="18" height="18"/>
                     </button>
                     <span class="like-button-and-label--count-wrapper">
-                      <span class="like-button-and-label--count" data-package="oxygen" data-value="0">0</span>
+                      <span class="like-button-and-label--count" data-value="0">0</span>
                     </span>
                   </div>
                 </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/example.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/example.html
@@ -153,12 +153,12 @@
                     </div>
                   </div>
                   <div class="like-button-and-label">
-                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" title="Like this package">
+                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="oxygen" title="Like this package">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="liked status: inactive" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="liked status: active" width="18" height="18"/>
                     </button>
                     <span class="like-button-and-label--count-wrapper">
-                      <span class="like-button-and-label--count" data-package="oxygen" data-value="0">0</span>
+                      <span class="like-button-and-label--count" data-value="0">0</span>
                     </span>
                   </div>
                 </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/install.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/install.html
@@ -153,12 +153,12 @@
                     </div>
                   </div>
                   <div class="like-button-and-label">
-                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" title="Like this package">
+                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="oxygen" title="Like this package">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="liked status: inactive" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="liked status: active" width="18" height="18"/>
                     </button>
                     <span class="like-button-and-label--count-wrapper">
-                      <span class="like-button-and-label--count" data-package="oxygen" data-value="0">0</span>
+                      <span class="like-button-and-label--count" data-value="0">0</span>
                     </span>
                   </div>
                 </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/license.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/license.html
@@ -153,12 +153,12 @@
                     </div>
                   </div>
                   <div class="like-button-and-label">
-                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" title="Like this package">
+                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="oxygen" title="Like this package">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="liked status: inactive" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="liked status: active" width="18" height="18"/>
                     </button>
                     <span class="like-button-and-label--count-wrapper">
-                      <span class="like-button-and-label--count" data-package="oxygen" data-value="0">0</span>
+                      <span class="like-button-and-label--count" data-value="0">0</span>
                     </span>
                   </div>
                 </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/score.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/score.html
@@ -153,12 +153,12 @@
                     </div>
                   </div>
                   <div class="like-button-and-label">
-                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" title="Like this package">
+                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="oxygen" title="Like this package">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="liked status: inactive" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="liked status: active" width="18" height="18"/>
                     </button>
                     <span class="like-button-and-label--count-wrapper">
-                      <span class="like-button-and-label--count" data-package="oxygen" data-value="0">0</span>
+                      <span class="like-button-and-label--count" data-value="0">0</span>
                     </span>
                   </div>
                 </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions.html
@@ -152,12 +152,12 @@
                     </div>
                   </div>
                   <div class="like-button-and-label">
-                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" title="Like this package">
+                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="oxygen" title="Like this package">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="liked status: inactive" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="liked status: active" width="18" height="18"/>
                     </button>
                     <span class="like-button-and-label--count-wrapper">
-                      <span class="like-button-and-label--count" data-package="oxygen" data-value="0">0</span>
+                      <span class="like-button-and-label--count" data-value="0">0</span>
                     </span>
                   </div>
                 </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0.html
@@ -157,12 +157,12 @@
                     </div>
                   </div>
                   <div class="like-button-and-label">
-                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" title="Like this package">
+                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="oxygen" title="Like this package">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="liked status: inactive" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="liked status: active" width="18" height="18"/>
                     </button>
                     <span class="like-button-and-label--count-wrapper">
-                      <span class="like-button-and-label--count" data-package="oxygen" data-value="0">0</span>
+                      <span class="like-button-and-label--count" data-value="0">0</span>
                     </span>
                   </div>
                 </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/changelog.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/changelog.html
@@ -157,12 +157,12 @@
                     </div>
                   </div>
                   <div class="like-button-and-label">
-                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" title="Like this package">
+                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="oxygen" title="Like this package">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="liked status: inactive" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="liked status: active" width="18" height="18"/>
                     </button>
                     <span class="like-button-and-label--count-wrapper">
-                      <span class="like-button-and-label--count" data-package="oxygen" data-value="0">0</span>
+                      <span class="like-button-and-label--count" data-value="0">0</span>
                     </span>
                   </div>
                 </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/example.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/example.html
@@ -157,12 +157,12 @@
                     </div>
                   </div>
                   <div class="like-button-and-label">
-                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" title="Like this package">
+                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="oxygen" title="Like this package">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="liked status: inactive" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="liked status: active" width="18" height="18"/>
                     </button>
                     <span class="like-button-and-label--count-wrapper">
-                      <span class="like-button-and-label--count" data-package="oxygen" data-value="0">0</span>
+                      <span class="like-button-and-label--count" data-value="0">0</span>
                     </span>
                   </div>
                 </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/install.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/install.html
@@ -157,12 +157,12 @@
                     </div>
                   </div>
                   <div class="like-button-and-label">
-                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" title="Like this package">
+                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="oxygen" title="Like this package">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="liked status: inactive" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="liked status: active" width="18" height="18"/>
                     </button>
                     <span class="like-button-and-label--count-wrapper">
-                      <span class="like-button-and-label--count" data-package="oxygen" data-value="0">0</span>
+                      <span class="like-button-and-label--count" data-value="0">0</span>
                     </span>
                   </div>
                 </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/license.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/license.html
@@ -157,12 +157,12 @@
                     </div>
                   </div>
                   <div class="like-button-and-label">
-                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" title="Like this package">
+                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="oxygen" title="Like this package">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="liked status: inactive" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="liked status: active" width="18" height="18"/>
                     </button>
                     <span class="like-button-and-label--count-wrapper">
-                      <span class="like-button-and-label--count" data-package="oxygen" data-value="0">0</span>
+                      <span class="like-button-and-label--count" data-value="0">0</span>
                     </span>
                   </div>
                 </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/score.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/score.html
@@ -157,12 +157,12 @@
                     </div>
                   </div>
                   <div class="like-button-and-label">
-                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" title="Like this package">
+                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="oxygen" title="Like this package">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="liked status: inactive" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="liked status: active" width="18" height="18"/>
                     </button>
                     <span class="like-button-and-label--count-wrapper">
-                      <span class="like-button-and-label--count" data-package="oxygen" data-value="0">0</span>
+                      <span class="like-button-and-label--count" data-value="0">0</span>
                     </span>
                   </div>
                 </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/2.0.0.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/2.0.0.html
@@ -153,12 +153,12 @@
                     </div>
                   </div>
                   <div class="like-button-and-label">
-                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" title="Like this package">
+                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="oxygen" title="Like this package">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="liked status: inactive" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="liked status: active" width="18" height="18"/>
                     </button>
                     <span class="like-button-and-label--count-wrapper">
-                      <span class="like-button-and-label--count" data-package="oxygen" data-value="0">0</span>
+                      <span class="like-button-and-label--count" data-value="0">0</span>
                     </span>
                   </div>
                 </div>

--- a/pkg/web_app/lib/src/likes.dart
+++ b/pkg/web_app/lib/src/likes.dart
@@ -45,25 +45,21 @@ void setupLikesList() {
 }
 
 void setupLikes() {
-  for (final buttonAndLabel
-      in document.querySelectorAll('.like-button-and-label')) {
-    final likeButton = buttonAndLabel
-        .querySelector('.like-button-and-label--button') as ButtonElement?;
-    if (likeButton == null) continue;
-
-    final countLabel =
-        buttonAndLabel.querySelector('.like-button-and-label--count');
-    if (countLabel == null) continue;
-
-    final package = countLabel.dataset['package'];
+  for (final likeButton
+      in document.querySelectorAll('.like-button-and-label--button')) {
+    final package = likeButton.dataset['package'];
     if (package == null || package.isEmpty) continue;
 
-    final originalCount = int.tryParse(countLabel.dataset['value'] ?? '');
-    if (originalCount == null) continue;
+    final countLabel =
+        likeButton.parent?.querySelector('.like-button-and-label--count');
+    final originalCount = int.tryParse(countLabel?.dataset['value'] ?? '');
 
     var likesDelta = 0;
 
     void updateLabels() {
+      if (countLabel == null || originalCount == null) {
+        return;
+      }
       final likesCount = originalCount + likesDelta;
       // keep in-sync with app/lib/frontend/templates/views/pkg/liked_package_list.dart
       countLabel.innerText = formatWithSuffix(likesCount);


### PR DESCRIPTION
- #8887
- moves the `data-package` attribute from the label to the button element
- updated script to work on primarily on the button, and optionally on the label (if it is present), allowing a different parent element and styling (TBD in a follow-up PR)