### PR TITLE
Like button in is:liked-by-me search results.

### DIFF
--- a/app/lib/account/like_backend.dart
+++ b/app/lib/account/like_backend.dart
@@ -75,6 +75,7 @@ class LikeBackend {
       tx.queueMutations(inserts: [p, newLike]);
       return newLike;
     });
+    await cache.packageView(package).purge();
     await purgeAccountCache(userId: user.userId);
     return res;
   }
@@ -100,6 +101,7 @@ class LikeBackend {
       p.likes--;
       tx.queueMutations(inserts: [p], deletes: [likeKey]);
     });
+    await cache.packageView(package).purge();
     await cache.userPackageLikes(user.userId).purge();
   }
 }

--- a/app/lib/frontend/templates/views/pkg/liked_package_list.dart
+++ b/app/lib/frontend/templates/views/pkg/liked_package_list.dart
@@ -72,22 +72,20 @@ d.Node renderLikeButtonAndLabel(
   return d.div(
     classes: ['like-button-and-label'],
     children: [
-      _renderLikeButton(package, isLiked),
+      renderLikeButton(package, likeCount: likeCount, isLiked: isLiked),
       d.span(
         classes: ['like-button-and-label--count-wrapper'],
         child: d.span(
           classes: ['like-button-and-label--count'],
           text: _formatPackageLikes(likeCount),
-          attributes: {
-            'data-value': likeCount.toString(),
-          },
         ),
       ),
     ],
   );
 }
 
-d.Node _renderLikeButton(String package, bool isLiked) {
+d.Node renderLikeButton(String package,
+    {required int likeCount, required bool isLiked}) {
   return material.iconButton(
     classes: ['like-button-and-label--button'],
     isOn: isLiked,
@@ -108,6 +106,7 @@ d.Node _renderLikeButton(String package, bool isLiked) {
       'data-ga-click-event': 'toggle-like',
       'aria-pressed': isLiked ? 'true' : 'false',
       'data-package': package,
+      'data-value': likeCount.toString(),
     },
   );
 }

--- a/app/test/frontend/golden/pkg_activity_log_page.html
+++ b/app/test/frontend/golden/pkg_activity_log_page.html
@@ -186,12 +186,12 @@
                     </div>
                   </div>
                   <div class="like-button-and-label">
-                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="oxygen" title="Like this package">
+                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="oxygen" data-value="0" title="Like this package">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="liked status: inactive" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="liked status: active" width="18" height="18"/>
                     </button>
                     <span class="like-button-and-label--count-wrapper">
-                      <span class="like-button-and-label--count" data-value="0">0</span>
+                      <span class="like-button-and-label--count">0</span>
                     </span>
                   </div>
                 </div>

--- a/app/test/frontend/golden/pkg_admin_page.html
+++ b/app/test/frontend/golden/pkg_admin_page.html
@@ -186,12 +186,12 @@
                     </div>
                   </div>
                   <div class="like-button-and-label">
-                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="oxygen" title="Like this package">
+                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="oxygen" data-value="0" title="Like this package">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="liked status: inactive" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="liked status: active" width="18" height="18"/>
                     </button>
                     <span class="like-button-and-label--count-wrapper">
-                      <span class="like-button-and-label--count" data-value="0">0</span>
+                      <span class="like-button-and-label--count">0</span>
                     </span>
                   </div>
                 </div>

--- a/app/test/frontend/golden/pkg_changelog_page.html
+++ b/app/test/frontend/golden/pkg_changelog_page.html
@@ -161,12 +161,12 @@
                     </div>
                   </div>
                   <div class="like-button-and-label">
-                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="oxygen" title="Like this package">
+                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="oxygen" data-value="0" title="Like this package">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="liked status: inactive" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="liked status: active" width="18" height="18"/>
                     </button>
                     <span class="like-button-and-label--count-wrapper">
-                      <span class="like-button-and-label--count" data-value="0">0</span>
+                      <span class="like-button-and-label--count">0</span>
                     </span>
                   </div>
                 </div>

--- a/app/test/frontend/golden/pkg_example_page.html
+++ b/app/test/frontend/golden/pkg_example_page.html
@@ -161,12 +161,12 @@
                     </div>
                   </div>
                   <div class="like-button-and-label">
-                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="oxygen" title="Like this package">
+                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="oxygen" data-value="0" title="Like this package">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="liked status: inactive" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="liked status: active" width="18" height="18"/>
                     </button>
                     <span class="like-button-and-label--count-wrapper">
-                      <span class="like-button-and-label--count" data-value="0">0</span>
+                      <span class="like-button-and-label--count">0</span>
                     </span>
                   </div>
                 </div>

--- a/app/test/frontend/golden/pkg_install_page.html
+++ b/app/test/frontend/golden/pkg_install_page.html
@@ -161,12 +161,12 @@
                     </div>
                   </div>
                   <div class="like-button-and-label">
-                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="oxygen" title="Like this package">
+                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="oxygen" data-value="0" title="Like this package">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="liked status: inactive" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="liked status: active" width="18" height="18"/>
                     </button>
                     <span class="like-button-and-label--count-wrapper">
-                      <span class="like-button-and-label--count" data-value="0">0</span>
+                      <span class="like-button-and-label--count">0</span>
                     </span>
                   </div>
                 </div>

--- a/app/test/frontend/golden/pkg_score_page.html
+++ b/app/test/frontend/golden/pkg_score_page.html
@@ -161,12 +161,12 @@
                     </div>
                   </div>
                   <div class="like-button-and-label">
-                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="oxygen" title="Like this package">
+                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="oxygen" data-value="0" title="Like this package">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="liked status: inactive" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="liked status: active" width="18" height="18"/>
                     </button>
                     <span class="like-button-and-label--count-wrapper">
-                      <span class="like-button-and-label--count" data-value="0">0</span>
+                      <span class="like-button-and-label--count">0</span>
                     </span>
                   </div>
                 </div>

--- a/app/test/frontend/golden/pkg_score_page_with_downloads_chart.html
+++ b/app/test/frontend/golden/pkg_score_page_with_downloads_chart.html
@@ -161,12 +161,12 @@
                     </div>
                   </div>
                   <div class="like-button-and-label">
-                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="oxygen" title="Like this package">
+                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="oxygen" data-value="0" title="Like this package">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="liked status: inactive" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="liked status: active" width="18" height="18"/>
                     </button>
                     <span class="like-button-and-label--count-wrapper">
-                      <span class="like-button-and-label--count" data-value="0">0</span>
+                      <span class="like-button-and-label--count">0</span>
                     </span>
                   </div>
                 </div>

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -152,12 +152,12 @@
                     </div>
                   </div>
                   <div class="like-button-and-label">
-                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="oxygen" title="Like this package">
+                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="oxygen" data-value="0" title="Like this package">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="liked status: inactive" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="liked status: active" width="18" height="18"/>
                     </button>
                     <span class="like-button-and-label--count-wrapper">
-                      <span class="like-button-and-label--count" data-value="0">0</span>
+                      <span class="like-button-and-label--count">0</span>
                     </span>
                   </div>
                 </div>

--- a/app/test/frontend/golden/pkg_show_page_discontinued.html
+++ b/app/test/frontend/golden/pkg_show_page_discontinued.html
@@ -160,12 +160,12 @@
                     </div>
                   </div>
                   <div class="like-button-and-label">
-                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="pkg" title="Like this package">
+                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="pkg" data-value="0" title="Like this package">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="liked status: inactive" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="liked status: active" width="18" height="18"/>
                     </button>
                     <span class="like-button-and-label--count-wrapper">
-                      <span class="like-button-and-label--count" data-value="0">0</span>
+                      <span class="like-button-and-label--count">0</span>
                     </span>
                   </div>
                 </div>

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -150,12 +150,12 @@
                     </div>
                   </div>
                   <div class="like-button-and-label">
-                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="flutter_titanium" title="Like this package">
+                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="flutter_titanium" data-value="0" title="Like this package">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="liked status: inactive" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="liked status: active" width="18" height="18"/>
                     </button>
                     <span class="like-button-and-label--count-wrapper">
-                      <span class="like-button-and-label--count" data-value="0">0</span>
+                      <span class="like-button-and-label--count">0</span>
                     </span>
                   </div>
                 </div>

--- a/app/test/frontend/golden/pkg_show_page_publisher.html
+++ b/app/test/frontend/golden/pkg_show_page_publisher.html
@@ -155,12 +155,12 @@
                     </div>
                   </div>
                   <div class="like-button-and-label">
-                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="neon" title="Like this package">
+                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="neon" data-value="0" title="Like this package">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="liked status: inactive" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="liked status: active" width="18" height="18"/>
                     </button>
                     <span class="like-button-and-label--count-wrapper">
-                      <span class="like-button-and-label--count" data-value="0">0</span>
+                      <span class="like-button-and-label--count">0</span>
                     </span>
                   </div>
                 </div>

--- a/app/test/frontend/golden/pkg_show_page_retracted.html
+++ b/app/test/frontend/golden/pkg_show_page_retracted.html
@@ -143,12 +143,12 @@
                     <span class="package-tag retracted" title="This version was retracted.">retracted</span>
                   </div>
                   <div class="like-button-and-label">
-                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="pkg" title="Like this package">
+                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="pkg" data-value="0" title="Like this package">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="liked status: inactive" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="liked status: active" width="18" height="18"/>
                     </button>
                     <span class="like-button-and-label--count-wrapper">
-                      <span class="like-button-and-label--count" data-value="0">0</span>
+                      <span class="like-button-and-label--count">0</span>
                     </span>
                   </div>
                 </div>

--- a/app/test/frontend/golden/pkg_show_page_retracted_non_retracted_version.html
+++ b/app/test/frontend/golden/pkg_show_page_retracted_non_retracted_version.html
@@ -151,12 +151,12 @@
                     </div>
                   </div>
                   <div class="like-button-and-label">
-                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="pkg" title="Like this package">
+                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="pkg" data-value="0" title="Like this package">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="liked status: inactive" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="liked status: active" width="18" height="18"/>
                     </button>
                     <span class="like-button-and-label--count-wrapper">
-                      <span class="like-button-and-label--count" data-value="0">0</span>
+                      <span class="like-button-and-label--count">0</span>
                     </span>
                   </div>
                 </div>

--- a/app/test/frontend/golden/pkg_show_version_page.html
+++ b/app/test/frontend/golden/pkg_show_version_page.html
@@ -161,12 +161,12 @@
                     </div>
                   </div>
                   <div class="like-button-and-label">
-                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="oxygen" title="Like this package">
+                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="oxygen" data-value="0" title="Like this package">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="liked status: inactive" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="liked status: active" width="18" height="18"/>
                     </button>
                     <span class="like-button-and-label--count-wrapper">
-                      <span class="like-button-and-label--count" data-value="0">0</span>
+                      <span class="like-button-and-label--count">0</span>
                     </span>
                   </div>
                 </div>

--- a/app/test/frontend/golden/pkg_versions_page.html
+++ b/app/test/frontend/golden/pkg_versions_page.html
@@ -160,12 +160,12 @@
                     </div>
                   </div>
                   <div class="like-button-and-label">
-                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="oxygen" title="Like this package">
+                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="oxygen" data-value="0" title="Like this package">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="liked status: inactive" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="liked status: active" width="18" height="18"/>
                     </button>
                     <span class="like-button-and-label--count-wrapper">
-                      <span class="like-button-and-label--count" data-value="0">0</span>
+                      <span class="like-button-and-label--count">0</span>
                     </span>
                   </div>
                 </div>

--- a/app/test/task/testdata/goldens/packages/oxygen.html
+++ b/app/test/task/testdata/goldens/packages/oxygen.html
@@ -153,12 +153,12 @@
                     </div>
                   </div>
                   <div class="like-button-and-label">
-                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="oxygen" title="Like this package">
+                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="oxygen" data-value="0" title="Like this package">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="liked status: inactive" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="liked status: active" width="18" height="18"/>
                     </button>
                     <span class="like-button-and-label--count-wrapper">
-                      <span class="like-button-and-label--count" data-value="0">0</span>
+                      <span class="like-button-and-label--count">0</span>
                     </span>
                   </div>
                 </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/changelog.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/changelog.html
@@ -153,12 +153,12 @@
                     </div>
                   </div>
                   <div class="like-button-and-label">
-                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="oxygen" title="Like this package">
+                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="oxygen" data-value="0" title="Like this package">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="liked status: inactive" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="liked status: active" width="18" height="18"/>
                     </button>
                     <span class="like-button-and-label--count-wrapper">
-                      <span class="like-button-and-label--count" data-value="0">0</span>
+                      <span class="like-button-and-label--count">0</span>
                     </span>
                   </div>
                 </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/example.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/example.html
@@ -153,12 +153,12 @@
                     </div>
                   </div>
                   <div class="like-button-and-label">
-                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="oxygen" title="Like this package">
+                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="oxygen" data-value="0" title="Like this package">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="liked status: inactive" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="liked status: active" width="18" height="18"/>
                     </button>
                     <span class="like-button-and-label--count-wrapper">
-                      <span class="like-button-and-label--count" data-value="0">0</span>
+                      <span class="like-button-and-label--count">0</span>
                     </span>
                   </div>
                 </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/install.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/install.html
@@ -153,12 +153,12 @@
                     </div>
                   </div>
                   <div class="like-button-and-label">
-                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="oxygen" title="Like this package">
+                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="oxygen" data-value="0" title="Like this package">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="liked status: inactive" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="liked status: active" width="18" height="18"/>
                     </button>
                     <span class="like-button-and-label--count-wrapper">
-                      <span class="like-button-and-label--count" data-value="0">0</span>
+                      <span class="like-button-and-label--count">0</span>
                     </span>
                   </div>
                 </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/license.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/license.html
@@ -153,12 +153,12 @@
                     </div>
                   </div>
                   <div class="like-button-and-label">
-                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="oxygen" title="Like this package">
+                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="oxygen" data-value="0" title="Like this package">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="liked status: inactive" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="liked status: active" width="18" height="18"/>
                     </button>
                     <span class="like-button-and-label--count-wrapper">
-                      <span class="like-button-and-label--count" data-value="0">0</span>
+                      <span class="like-button-and-label--count">0</span>
                     </span>
                   </div>
                 </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/score.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/score.html
@@ -153,12 +153,12 @@
                     </div>
                   </div>
                   <div class="like-button-and-label">
-                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="oxygen" title="Like this package">
+                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="oxygen" data-value="0" title="Like this package">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="liked status: inactive" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="liked status: active" width="18" height="18"/>
                     </button>
                     <span class="like-button-and-label--count-wrapper">
-                      <span class="like-button-and-label--count" data-value="0">0</span>
+                      <span class="like-button-and-label--count">0</span>
                     </span>
                   </div>
                 </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions.html
@@ -152,12 +152,12 @@
                     </div>
                   </div>
                   <div class="like-button-and-label">
-                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="oxygen" title="Like this package">
+                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="oxygen" data-value="0" title="Like this package">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="liked status: inactive" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="liked status: active" width="18" height="18"/>
                     </button>
                     <span class="like-button-and-label--count-wrapper">
-                      <span class="like-button-and-label--count" data-value="0">0</span>
+                      <span class="like-button-and-label--count">0</span>
                     </span>
                   </div>
                 </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0.html
@@ -157,12 +157,12 @@
                     </div>
                   </div>
                   <div class="like-button-and-label">
-                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="oxygen" title="Like this package">
+                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="oxygen" data-value="0" title="Like this package">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="liked status: inactive" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="liked status: active" width="18" height="18"/>
                     </button>
                     <span class="like-button-and-label--count-wrapper">
-                      <span class="like-button-and-label--count" data-value="0">0</span>
+                      <span class="like-button-and-label--count">0</span>
                     </span>
                   </div>
                 </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/changelog.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/changelog.html
@@ -157,12 +157,12 @@
                     </div>
                   </div>
                   <div class="like-button-and-label">
-                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="oxygen" title="Like this package">
+                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="oxygen" data-value="0" title="Like this package">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="liked status: inactive" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="liked status: active" width="18" height="18"/>
                     </button>
                     <span class="like-button-and-label--count-wrapper">
-                      <span class="like-button-and-label--count" data-value="0">0</span>
+                      <span class="like-button-and-label--count">0</span>
                     </span>
                   </div>
                 </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/example.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/example.html
@@ -157,12 +157,12 @@
                     </div>
                   </div>
                   <div class="like-button-and-label">
-                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="oxygen" title="Like this package">
+                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="oxygen" data-value="0" title="Like this package">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="liked status: inactive" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="liked status: active" width="18" height="18"/>
                     </button>
                     <span class="like-button-and-label--count-wrapper">
-                      <span class="like-button-and-label--count" data-value="0">0</span>
+                      <span class="like-button-and-label--count">0</span>
                     </span>
                   </div>
                 </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/install.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/install.html
@@ -157,12 +157,12 @@
                     </div>
                   </div>
                   <div class="like-button-and-label">
-                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="oxygen" title="Like this package">
+                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="oxygen" data-value="0" title="Like this package">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="liked status: inactive" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="liked status: active" width="18" height="18"/>
                     </button>
                     <span class="like-button-and-label--count-wrapper">
-                      <span class="like-button-and-label--count" data-value="0">0</span>
+                      <span class="like-button-and-label--count">0</span>
                     </span>
                   </div>
                 </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/license.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/license.html
@@ -157,12 +157,12 @@
                     </div>
                   </div>
                   <div class="like-button-and-label">
-                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="oxygen" title="Like this package">
+                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="oxygen" data-value="0" title="Like this package">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="liked status: inactive" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="liked status: active" width="18" height="18"/>
                     </button>
                     <span class="like-button-and-label--count-wrapper">
-                      <span class="like-button-and-label--count" data-value="0">0</span>
+                      <span class="like-button-and-label--count">0</span>
                     </span>
                   </div>
                 </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/score.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/score.html
@@ -157,12 +157,12 @@
                     </div>
                   </div>
                   <div class="like-button-and-label">
-                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="oxygen" title="Like this package">
+                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="oxygen" data-value="0" title="Like this package">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="liked status: inactive" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="liked status: active" width="18" height="18"/>
                     </button>
                     <span class="like-button-and-label--count-wrapper">
-                      <span class="like-button-and-label--count" data-value="0">0</span>
+                      <span class="like-button-and-label--count">0</span>
                     </span>
                   </div>
                 </div>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/2.0.0.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/2.0.0.html
@@ -153,12 +153,12 @@
                     </div>
                   </div>
                   <div class="like-button-and-label">
-                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="oxygen" title="Like this package">
+                    <button class="mdc-icon-button like-button-and-label--button" data-ga-click-event="toggle-like" aria-pressed="false" data-package="oxygen" data-value="0" title="Like this package">
                       <img class="mdc-icon-button__icon" src="/static/hash-%%etag%%/img/like-inactive.svg" alt="liked status: inactive" width="18" height="18"/>
                       <img class="mdc-icon-button__icon mdc-icon-button__icon--on" src="/static/hash-%%etag%%/img/like-active.svg" alt="liked status: active" width="18" height="18"/>
                     </button>
                     <span class="like-button-and-label--count-wrapper">
-                      <span class="like-button-and-label--count" data-value="0">0</span>
+                      <span class="like-button-and-label--count">0</span>
                     </span>
                   </div>
                 </div>

--- a/pkg/web_app/lib/src/likes.dart
+++ b/pkg/web_app/lib/src/likes.dart
@@ -48,21 +48,22 @@ void setupLikes() {
   for (final likeButton
       in document.querySelectorAll('.like-button-and-label--button')) {
     final package = likeButton.dataset['package'];
-    if (package == null || package.isEmpty) continue;
+    final originalCount = int.tryParse(likeButton.dataset['value'] ?? '');
 
-    final countLabel =
-        likeButton.parent?.querySelector('.like-button-and-label--count');
-    final originalCount = int.tryParse(countLabel?.dataset['value'] ?? '');
+    if (package == null || package.isEmpty || originalCount == null) {
+      continue;
+    }
 
     var likesDelta = 0;
 
     void updateLabels() {
-      if (countLabel == null || originalCount == null) {
-        return;
-      }
       final likesCount = originalCount + likesDelta;
-      // keep in-sync with app/lib/frontend/templates/views/pkg/liked_package_list.dart
-      countLabel.innerText = formatWithSuffix(likesCount);
+      final countLabel =
+          likeButton.parent?.querySelector('.like-button-and-label--count');
+      if (countLabel != null) {
+        // keep in-sync with app/lib/frontend/templates/views/pkg/liked_package_list.dart
+        countLabel.innerText = formatWithSuffix(likesCount);
+      }
 
       // keep in-sync with app/lib/frontend/templates/views/pkg/labeled_scores.dart
       final formatted = compactFormat(likesCount);

--- a/pkg/web_css/lib/src/_list.scss
+++ b/pkg/web_css/lib/src/_list.scss
@@ -234,6 +234,11 @@
     font-weight: 500;
     margin: 0;
     overflow-wrap: anywhere;
+
+    .like-button-and-label--button img {
+      width: 18px;
+      height: 18px;
+    }
   }
 
   .packages-recent {


### PR DESCRIPTION
- #8887
- Updated like button template: moved the count to the button to make it easier to update labels on page.
- Updated like event handling: works if the like button has no label.
- Updated cache purge when like/unlike happens.
- The like button is only displayed behind experiment and when the search query has `is:liked-by-me` predicate. Extending it to be a generic button in all listing may be possible, but it may not be needed at all (the button is now a substitute for the unlike button in the /my-liked-packages page).

<img width="667" height="200" alt="image" src="https://github.com/user-attachments/assets/564e7d9c-a1df-4bad-86c6-ba75e3f29dfc" />
