### PR TITLE
Use the changelog excerpt in the atom feeds.

### DIFF
--- a/app/lib/shared/redis_cache.dart
+++ b/app/lib/shared/redis_cache.dart
@@ -130,6 +130,13 @@ class CachePatterns {
         decode: (d) => d as bool,
       ))[package];
 
+  Entry<String> changelogReleaseContentAsMarkdown(
+          String package, String version) =>
+      _cache
+          .withPrefix('changelog-release-content-md/')
+          .withTTL(Duration(hours: 1))
+          .withCodec(utf8)['$package-$version'];
+
   Entry<List<int>> packageData(String package) => _cache
       .withPrefix('api-package-data-by-uri/')
       .withTTL(Duration(minutes: 10))['$package'];

--- a/app/test/frontend/handlers/atom_feed_test.dart
+++ b/app/test/frontend/handlers/atom_feed_test.dart
@@ -36,20 +36,22 @@ void main() {
           '  <id>urn:uuid:a6a43bff-e1ef-4633-b5ee-e0516b655be9</id>\n'
           '  <title>v1.2.0 of oxygen</title>\n'
           '  <updated>(.*)</updated>\n'
-          '  <content>oxygen is awesome</content>\n'
+          // Note: pretty format + indenting converts the newlines into spaces.
+          '  <content>oxygen is awesome Changelog excerpt: - updated</content>\n'
           '  <link href="${activeConfiguration.primarySiteUri}/packages/oxygen" rel="alternate" title="oxygen"/>\n'
           '</entry>');
       expect(
         oxygenExpr.hasMatch(entries[1].toXmlString(pretty: true, indent: '  ')),
         isTrue,
-        reason: entries[1].toXmlString(),
+        reason: entries[1].toXmlString(pretty: true, indent: '  '),
       );
 
       final neonExpr = RegExp('<entry>\n'
           '  <id>urn:uuid:5f920595-c067-404a-bb19-2b0918372eb6</id>\n'
           '  <title>v1.0.0 of neon</title>\n'
           '  <updated>(.*)</updated>\n'
-          '  <content>neon is awesome</content>\n'
+          // Note: pretty format + indenting converts the newlines into spaces.
+          '  <content>neon is awesome Changelog excerpt: - updated</content>\n'
           '  <link href="${activeConfiguration.primarySiteUri}/packages/neon" rel="alternate" title="neon"/>\n'
           '</entry>');
       expect(


### PR DESCRIPTION
- Fixes #5183
- Both the all-packages and the package-specific feed is using the relevant changelog excerpt, the later with more content (because it has only 10 versions, vs. the all-packages 100 versions).