### PR TITLE
New /my-liked-packages page (behind experimental).

### DIFF
--- a/app/lib/frontend/handlers/experimental.dart
+++ b/app/lib/frontend/handlers/experimental.dart
@@ -10,11 +10,14 @@ typedef PublicFlag = ({String name, String description});
 
 const _publicFlags = <PublicFlag>{
   (name: 'example', description: 'Short description'),
+  (
+    name: 'my-liked-search',
+    description: 'New "My liked packages" page and search.',
+  ),
 };
 
 final _allFlags = <String>{
   'dark-as-default',
-  'my-liked-search',
   ..._publicFlags.map((x) => x.name),
 };
 

--- a/app/lib/frontend/templates/layout.dart
+++ b/app/lib/frontend/templates/layout.dart
@@ -35,8 +35,8 @@ enum PageType {
 
 /// Whether to show a wide/tall search banner at the top of the page,
 /// otherwise only show a top-navigation search input.
-bool showSearchBanner(PageType type) =>
-    type != PageType.account &&
+bool showSearchBanner(PageType type, SearchForm? searchForm) =>
+    (type != PageType.account || searchForm != null) &&
     type != PageType.package &&
     type != PageType.standalone;
 
@@ -99,7 +99,11 @@ String renderLayoutPage(
         ? null
         : pageDataJsonCodec.encode(pageData.toJson()),
     bodyClasses: bodyClasses,
-    siteHeader: siteHeaderNode(pageType: type, userSession: session),
+    siteHeader: siteHeaderNode(
+      pageType: type,
+      userSession: session,
+      searchForm: searchForm,
+    ),
     announcementBanner: announcementBannerHtml == null
         ? null
         : d.unsafeRawHtml(announcementBannerHtml),
@@ -108,7 +112,7 @@ String renderLayoutPage(
         : hex
               .encode(sha1.convert(utf8.encode(announcementBannerHtml)).bytes)
               .substring(0, 16),
-    searchBanner: showSearchBanner(type)
+    searchBanner: showSearchBanner(type, searchForm)
         ? _renderSearchBanner(type: type, searchForm: searchForm)
         : null,
     isLanding: type == PageType.landing,

--- a/app/lib/frontend/templates/views/shared/site_header.dart
+++ b/app/lib/frontend/templates/views/shared/site_header.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:_pub_shared/search/search_form.dart';
+
 import '../../../../account/models.dart' show SessionData;
 import '../../../../shared/urls.dart' as urls;
 import '../../../dom/dom.dart' as d;
@@ -10,7 +12,11 @@ import '../../_consts.dart';
 import '../../layout.dart' show PageType, showSearchBanner;
 
 /// Creates the site header and navigation node.
-d.Node siteHeaderNode({required PageType pageType, SessionData? userSession}) {
+d.Node siteHeaderNode({
+  required PageType pageType,
+  required SessionData? userSession,
+  required SearchForm? searchForm,
+}) {
   return d.div(
     classes: ['site-header'],
     children: [
@@ -31,7 +37,7 @@ d.Node siteHeaderNode({required PageType pageType, SessionData? userSession}) {
         ),
       d.div(classes: ['site-header-space']),
       d.div(classes: ['site-header-mask']),
-      if (!showSearchBanner(pageType))
+      if (!showSearchBanner(pageType, searchForm))
         d.div(
           classes: ['site-header-search'],
           child: d.form(

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -880,6 +880,8 @@ void main() {
               LikeData(package: 'super_package', created: liked1),
               LikeData(package: 'another_package', created: liked2),
             ],
+            searchForm: null,
+            searchResult: null,
           );
           expectGoldenFile(
             html,

--- a/pkg/pub_integration/test/like_test.dart
+++ b/pkg/pub_integration/test/like_test.dart
@@ -88,6 +88,11 @@ void main() {
         await Future.delayed(Duration(milliseconds: 200));
         expect(await getCountLabels(), ['1', '1', '']);
 
+        // checking /my-liked-packages - with the one liked package
+        await page.gotoOrigin('/my-liked-packages');
+        final info = await listingPageInfo(page);
+        expect(info.packageNames.toSet(), {'test_pkg'});
+
         // checking search with my-liked packages - with the one liked package
         await page.gotoOrigin('/packages?q=pkg+is:liked-by-me');
         final info2 = await listingPageInfo(page);


### PR DESCRIPTION
- #8887
- the like button is only displayed when the `is:liked-by-me` predicate is active on the search, and its status is always assumed to be active (more fine-grained listing TBD)
- updated layout logic to display search form and also handles the sort control

<img width="871" height="320" alt="image" src="https://github.com/user-attachments/assets/442fb177-fbb2-402c-83c3-9360e22f7495" />
