### PR TITLE
Refactor search isolate control + minimal test.

### DIFF
--- a/app/bin/tools/search_benchmark.dart
+++ b/app/bin/tools/search_benchmark.dart
@@ -16,7 +16,7 @@ Future<void> main(List<String> args) async {
     'max memory: ${ProcessInfo.maxRss ~/ 1024} KiB',
   );
   // Assumes that the first argument is a search snapshot file.
-  final index = await loadInMemoryPackageIndexFromFile(args.first);
+  final index = await loadInMemoryPackageIndexFromUrl(args.first);
   print(
     'Loaded. Current memory: ${ProcessInfo.currentRss ~/ 1024} KiB,  '
     'max memory: ${ProcessInfo.maxRss ~/ 1024} KiB',

--- a/app/lib/search/models.dart
+++ b/app/lib/search/models.dart
@@ -19,6 +19,14 @@ class SearchSnapshot {
 
   factory SearchSnapshot() => SearchSnapshot._(clock.now().toUtc(), {});
 
+  factory SearchSnapshot.fromDocuments(Iterable<PackageDocument> documents) {
+    final snapshot = SearchSnapshot();
+    for (final doc in documents) {
+      snapshot.add(doc);
+    }
+    return snapshot;
+  }
+
   factory SearchSnapshot.fromJson(Map<String, dynamic> json) =>
       _$SearchSnapshotFromJson(json);
 

--- a/app/lib/service/entrypoint/search_index.dart
+++ b/app/lib/service/entrypoint/search_index.dart
@@ -49,7 +49,7 @@ Future<void> main(List<String> args, var message) async {
       if (snapshot == null) {
         await indexUpdater.init();
       } else {
-        updatePackageIndex(await loadInMemoryPackageIndexFromFile(snapshot));
+        updatePackageIndex(await loadInMemoryPackageIndexFromUrl(snapshot));
       }
 
       await runIsolateFunctions(

--- a/app/lib/shared/handler_helpers.dart
+++ b/app/lib/shared/handler_helpers.dart
@@ -38,6 +38,7 @@ Future<void> runHandler(
   shelf.Handler handler, {
   bool sanitize = false,
   int port = 8080,
+  Future<void> Function()? processTerminationSignal,
 }) async {
   handler = wrapHandler(logger, handler, sanitize: sanitize);
   if (envConfig.isRunningInAppengine) {
@@ -60,7 +61,8 @@ Future<void> runHandler(
       port,
       shared: true,
     );
-    await waitForProcessSignalTermination();
+    processTerminationSignal ??= waitForProcessSignalTermination;
+    await processTerminationSignal();
     await server.close();
   }
 }

--- a/app/test/service/entrypoint/search_test.dart
+++ b/app/test/service/entrypoint/search_test.dart
@@ -1,0 +1,59 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:pub_dev/fake/server/fake_search_service.dart';
+import 'package:pub_dev/service/entrypoint/search.dart';
+import 'package:shelf/shelf_io.dart';
+import 'package:test/test.dart';
+
+import '../../shared/test_services.dart';
+
+void main() {
+  group('Main search isolate controller', () {
+    testWithProfile(
+      'update the package index isolate',
+      fn: () async {
+        final snapshotServer = await setupLocalSnapshotServer();
+        final renewController = StreamController<Completer>.broadcast();
+        final processTerminationCompleter = Completer();
+        final handlerStartedCompleter = Completer();
+        try {
+          final port = await _detectFreePort();
+          final doneFuture = runSearchInstanceController(
+            port: port,
+            renewPackageIndex: renewController.stream,
+            processTerminationSignal: () async {
+              handlerStartedCompleter.complete();
+              return await processTerminationCompleter.future;
+            },
+            renewWait: Duration.zero,
+            snapshot: 'http://localhost:${snapshotServer.server.port}/',
+          );
+          await handlerStartedCompleter.future;
+
+          // force renew
+          final c = Completer();
+          renewController.add(c);
+          await c.future;
+
+          processTerminationCompleter.complete();
+          await doneFuture;
+        } finally {
+          await snapshotServer.close();
+          await renewController.close();
+        }
+      },
+      timeout: Timeout.factor(8),
+    );
+  });
+}
+
+Future<int> _detectFreePort() async {
+  final server = await IOServer.bind('localhost', 0);
+  final port = server.server.port;
+  await server.close();
+  return port;
+}

--- a/pkg/pub_integration/lib/src/fake_pub_server_process.dart
+++ b/pkg/pub_integration/lib/src/fake_pub_server_process.dart
@@ -151,13 +151,13 @@ class FakePubServerProcess {
   Future<void> get started => _startedCompleter.future;
 
   Future<void> kill() async {
-    // First try SIGINT, and after 10 seconds do SIGTERM.
+    // First try SIGINT, and after 10 seconds do SIGKILL.
     print('Sending INT signal to ${_process.pid}...');
     _process.kill(ProcessSignal.sigint);
     await _coverageConfig?.waitForCollect();
     final timer = Timer(Duration(seconds: 10), () {
       print('Sending TERM signal to ${_process.pid}...');
-      _process.kill();
+      _process.kill(ProcessSignal.sigkill);
     });
     final exitCode = await _process.exitCode;
     print('Exit code: $exitCode');


### PR DESCRIPTION
- Part of #8891. Started using it in fake_server, seems to work, but tests are very flaky with the current code, so submitting only the stable parts and will continue working on the full end-to-end testing in subsequent PRs.
- Updated the local snapshot loading from an arbitrary URL + created a simple web server for it. While the previous file could have been used too, this reduces the complexity of on-demand updates for search.
- In the search entrypoint, the new `runSearchInstanceController` will use a Stream for triggering index reloads. This allows better control than the previous scheduling, and also provides an easy feedback through the completer.
