### PR TITLE
Fix exact name matching in multi-phrase search queries.

### DIFF
--- a/app/lib/search/mem_index.dart
+++ b/app/lib/search/mem_index.dart
@@ -757,7 +757,11 @@ class PackageNameIndex {
 
   /// Returns the list of package names where the collapsed name matches.
   List<String>? lookupMatchingNames(String text) {
-    return _collapsedNameResolvesToMap[_removeUnderscores(text.toLowerCase())];
+    // convert to lowercase, remove spaces and underscores
+    final collapsedName = _removeUnderscores(
+      text.toLowerCase().replaceAll(' ', ''),
+    );
+    return _collapsedNameResolvesToMap[collapsedName];
   }
 }
 

--- a/app/test/search/mem_index_test.dart
+++ b/app/test/search/mem_index_test.dart
@@ -772,10 +772,11 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         expect(rs.toJson(), {
           'timestamp': isNotEmpty,
           'totalCount': 2,
+          'nameMatches': ['abc_def'],
           'sdkLibraryHits': [],
           'packageHits': [
-            {'package': 'abc_def_xyz', 'score': closeTo(1.0, 0.01)},
             {'package': 'abc_def', 'score': closeTo(0.55, 0.01)},
+            {'package': 'abc_def_xyz', 'score': closeTo(1.0, 0.01)},
           ],
         });
       });


### PR DESCRIPTION
- Fixes #8989.
- Needs to remove spaces from query to get to the proper collapsed name candidate.