### PR TITLE
Add build.yaml file for the image proxy

### DIFF
--- a/tool/build_image_proxy.yaml
+++ b/tool/build_image_proxy.yaml
@@ -6,6 +6,7 @@
 #   <project-id>@cloudbuild.gserviceaccount.com
 #
 # Reference: https://cloud.google.com/cloud-build/docs/build-config
+# https://docs.cloud.google.com/build/docs/deploying-builds/deploy-cloud-run
 steps:
   - name: 'gcr.io/cloud-builders/docker'
     script: |


### PR DESCRIPTION
This is intended to be triggered by tagging this repo with tags on the form `image_proxy-<version>` and will build and push a docker image for the image_proxy, and deploy on cloud run.
