### PR TITLE
Fix and improve test_profile import.

### DIFF
--- a/app/lib/tool/test_profile/import_source.dart
+++ b/app/lib/tool/test_profile/import_source.dart
@@ -183,28 +183,22 @@ class ArchiveBuilder {
   final _entries = <TarEntry>[];
 
   void addFile(String path, String content) {
-    final bytes = utf8.encode(content);
-    _entries.add(
-      TarEntry(
-        TarHeader(
-          name: path,
-          size: bytes.length,
-          mode: 420, // 644₈
-        ),
-        Stream<List<int>>.fromIterable([bytes]),
-      ),
-    );
+    addFileBytes(path, utf8.encode(content));
   }
 
   void addFileBytes(String path, List<int> bytes) {
+    addFileByteChunks(path, [bytes]);
+  }
+
+  void addFileByteChunks(String path, List<List<int>> chunks) {
     _entries.add(
       TarEntry(
         TarHeader(
           name: path,
-          size: bytes.length,
+          size: chunks.fold<int>(0, (a, b) => a + b.length),
           mode: 420, // 644₈
         ),
-        Stream<List<int>>.fromIterable([bytes]),
+        Stream<List<int>>.fromIterable(chunks),
       ),
     );
   }


### PR DESCRIPTION
During the local test_profile import I've encountered the following strange issue:
```
FINE: Created /home/isoos/work/tmp/pub-cache/_temp/dirLXTOFI/test from stream.
IO  : Deleting directory pub-cache/_temp/dirLXTOFI.
IO  : Deleting directory /home/isoos/work/tmp/pub_CEOGVT.
FINE: Downloading lua 0.2.0 to `target/lua-0.2.0` finished (0.070s).
ERR : Creation failed, path = '/home/isoos/work/tmp/pub-cache/_temp/dirLXTOFI/test' (OS Error: Not a directory, errno = 20)
```

Tracked down to the test_profile importer code where we wanted to enforce certain file permissions, which were working for older archives, but recent archives seems to have additional flags. And for some reason the tar archive now has entries for directories, which we have re-created as files. (Note: this is only in the scope of local test_profile importing a recent archive, does not affect the pub site.)

Also updated the archive builder to not create a merged bytes blob unless it is needed (should give a little bit better test latencies).
