### PR TITLE
Closing AsyncQueue at scope exit, accepting tasks while doing so, fixing test.

### DIFF
--- a/app/lib/service/services.dart
+++ b/app/lib/service/services.dart
@@ -339,6 +339,7 @@ Future<R> _withPubServices<R>(FutureOr<R> Function() fn) async {
         registerScopeExitCallback(topPackages.close);
         registerScopeExitCallback(youtubeBackend.close);
         registerScopeExitCallback(downloadCountsBackend.close);
+        registerScopeExitCallback(asyncQueue.close);
 
         // Create a zone-local flag to indicate that services setup has been completed.
         return await fork(

--- a/app/test/package/retracted_test.dart
+++ b/app/test/package/retracted_test.dart
@@ -7,6 +7,7 @@ import 'dart:convert';
 import 'package:_pub_shared/data/package_api.dart';
 import 'package:pub_dev/fake/backend/fake_auth_provider.dart';
 import 'package:pub_dev/package/backend.dart';
+import 'package:pub_dev/service/async_queue/async_queue.dart';
 import 'package:pub_dev/shared/datastore.dart';
 import 'package:pub_dev/tool/test_profile/models.dart';
 import 'package:test/test.dart';
@@ -229,6 +230,7 @@ void main() {
           retractable: ['1.0.0', '1.2.0', '2.0.0-dev'],
           recentlyRetracted: [],
         );
+        await asyncQueue.ongoingProcessing;
         final p3Info = PackageData.fromJson(
           json.decode(utf8.decode(await client.listVersions('oxygen')))
               as Map<String, dynamic>,


### PR DESCRIPTION
- This PR handles one issue uncovered in #9069: the test is only passing because the async tasks (package export + cache invalidation) completed before the test's next client call requested the data.
- It also fixes the oversight that the `AsyncQueue` is left running (`close` was never called) when the test completed.
- Since the async functions may trigger further async functions, we should be lenient on rejecting such tasks while the processing is still ongoing after closing queue (and the context).