### PR TITLE
sparse zoneBannedUntil in instance creation

### DIFF
--- a/app/lib/task/scheduler.dart
+++ b/app/lib/task/scheduler.dart
@@ -70,7 +70,10 @@ Future<(CreateInstancesState, Duration)> runOneCreateInstancesCycle(
   // Determine which zones are not banned
   final allowedZones =
       compute.zones
-          .where((zone) => (zoneBannedUntil[zone] ?? DateTime(0)).isBefore(now))
+          .where(
+            (zone) =>
+                (zoneBannedUntil[zone] ?? DateTime(0)).isBefore(clock.now()),
+          )
           .toList()
         ..shuffle(rng);
   var nextZoneIndex = 0;


### PR DESCRIPTION
Note: this will remove the timed-out bans, and uses the compute's zone list to check currently available zones, but removes the extra check for zone names.