### PR TITLE
Image proxy inherit configuration from existing deployment

### DIFF
--- a/tool/build_image_proxy.yaml
+++ b/tool/build_image_proxy.yaml
@@ -44,7 +44,7 @@ steps:
     script: |
       #!/usr/bin/env bash
       set -x
-      gcloud run deploy image-proxy-server \
+      gcloud run deploy image_proxy_server \
         --image="us-central1-docker.pkg.dev/$PROJECT_ID/image-proxy/image-proxy:$TAG_NAME" \
     env:
       - 'PROJECT_ID=$PROJECT_ID'


### PR DESCRIPTION
This makes the code here much more generic, and moves deployment details into google3 (or whereever one would configure this from).

Also rename the service name to use _ instead of -.