### PR TITLE
Cached list of owned packages

### DIFF
--- a/app/lib/account/backend.dart
+++ b/app/lib/account/backend.dart
@@ -662,6 +662,7 @@ Future<void> purgeAccountCache({required String userId}) async {
   await Future.wait([
     cache.userPackageLikes(userId).purgeAndRepeat(),
     cache.publisherPage(userId).purgeAndRepeat(),
+    cache.userUploaderOfPackages(userId).purgeAndRepeat(),
   ]);
 }
 

--- a/app/lib/shared/redis_cache.dart
+++ b/app/lib/shared/redis_cache.dart
@@ -298,6 +298,18 @@ class CachePatterns {
         ),
       )[userId];
 
+  Entry<List<String>> userUploaderOfPackages(String userId) => _cache
+      .withPrefix('user-uploader-of-packages/')
+      .withTTL(Duration(minutes: 60))
+      .withCodec(utf8)
+      .withCodec(json)
+      .withCodec(
+        wrapAsCodec(
+          encode: (List<String> l) => l,
+          decode: (d) => (d as List).cast<String>(),
+        ),
+      )[userId];
+
   Entry<String> secretValue(String secretId) => _cache
       .withPrefix('secret-value/')
       .withTTL(Duration(minutes: 60))


### PR DESCRIPTION
- part of #8980
- the owned list of packages then can be (later) passed to the search endpoint similar with the my liked packages