### PR TITLE
Migrate document weight map to simple list to lower memory use.

### DIFF
--- a/app/bin/tools/search_benchmark.dart
+++ b/app/bin/tools/search_benchmark.dart
@@ -15,10 +15,11 @@ Future<void> main(List<String> args) async {
     'Started. Current memory: ${ProcessInfo.currentRss ~/ 1024} KiB,  '
     'max memory: ${ProcessInfo.maxRss ~/ 1024} KiB',
   );
+  final loadWatch = Stopwatch()..start();
   // Assumes that the first argument is a search snapshot file.
   final index = await loadInMemoryPackageIndexFromUrl(args.first);
   print(
-    'Loaded. Current memory: ${ProcessInfo.currentRss ~/ 1024} KiB,  '
+    'Loaded in ${loadWatch.elapsed}. Current memory: ${ProcessInfo.currentRss ~/ 1024} KiB,  '
     'max memory: ${ProcessInfo.maxRss ~/ 1024} KiB',
   );
 


### PR DESCRIPTION
- In the local benchmark this has reduced the memory use by 10% and the initial load time of the index by 20%.
- I've also tried this using record types, but it didn't yield any memory benefit (it was about the same as the current memory needed).
- Note: this is efficient only because the documents are added only once and only in order. We should probably refactor this initialization so that it is clearly not getting documents in a non-incremental order, but I would do it in a separate PR.