### PR TITLE
htmlResponse updates: separate method for HEAD response, updated status codes...

### DIFF
--- a/app/lib/frontend/handlers/package.dart
+++ b/app/lib/frontend/handlers/package.dart
@@ -396,7 +396,7 @@ Future<shelf.Response> packageAdminHandler(
         return unauthenticatedRs;
       }
       if (!data.isAdmin) {
-        return htmlResponse(renderUnauthorizedPage());
+        return htmlResponse(renderUnauthorizedPage(), status: 403);
       }
       final page = await publisherBackend.listPublishersForUser(
         requestContext.authenticatedUserId!,
@@ -437,7 +437,7 @@ Future<shelf.Response> packageActivityLogHandler(
         return unauthenticatedRs;
       }
       if (!data.isAdmin) {
-        return htmlResponse(renderUnauthorizedPage());
+        return htmlResponse(renderUnauthorizedPage(), status: 403);
       }
       final before = auditBackend.parseBeforeQueryParameter(
         request.requestedUri.queryParameters['before'],

--- a/app/lib/frontend/handlers/publisher.dart
+++ b/app/lib/frontend/handlers/publisher.dart
@@ -172,7 +172,7 @@ Future<shelf.Response> publisherAdminPageHandler(
     requestContext.authenticatedUserId,
   );
   if (!isAdmin) {
-    return htmlResponse(renderUnauthorizedPage());
+    return htmlResponse(renderUnauthorizedPage(), status: 403);
   }
 
   return htmlResponse(
@@ -204,7 +204,7 @@ Future<shelf.Response> publisherActivityLogPageHandler(
     requestContext.authenticatedUserId,
   );
   if (!isAdmin) {
-    return htmlResponse(renderUnauthorizedPage());
+    return htmlResponse(renderUnauthorizedPage(), status: 403);
   }
 
   final before = auditBackend.parseBeforeQueryParameter(

--- a/app/lib/search/handlers.dart
+++ b/app/lib/search/handlers.dart
@@ -51,10 +51,9 @@ Future<shelf.Response> _debugHandler(shelf.Request request) async {
 Future<shelf.Response> _searchHandler(shelf.Request request) async {
   final info = await searchIndex.indexInfo();
   if (!info.isReady) {
-    return htmlResponse(
-      searchIndexNotReadyText,
-      status: searchIndexNotReadyCode,
-    );
+    return jsonResponse({
+      'error': searchIndexNotReadyText,
+    }, status: searchIndexNotReadyCode);
   }
   final Stopwatch sw = Stopwatch()..start();
   final query = request.method == 'POST'

--- a/app/lib/shared/handlers.dart
+++ b/app/lib/shared/handlers.dart
@@ -91,6 +91,11 @@ shelf.Response htmlBytesResponse(
   );
 }
 
+/// Response give to HTTP HEAD requests (contains metadata headers).
+shelf.Response headHtmlResponse({Map<String, String>? headers}) {
+  return htmlResponse('', headers: headers);
+}
+
 final _healthCheckHeaders = {
   ...CacheControl.explicitlyPrivate.headers,
   HttpHeaders.contentTypeHeader: 'text/plain; charset="utf-8"',

--- a/app/lib/task/handlers.dart
+++ b/app/lib/task/handlers.dart
@@ -243,7 +243,7 @@ Future<shelf.Response> handleDartDoc(
   }
 
   if (request.method.toUpperCase() == 'HEAD') {
-    return htmlResponse('', headers: CacheControl.documentationPage.headers);
+    return headHtmlResponse(headers: CacheControl.documentationPage.headers);
   }
 
   final acceptsGzip = request.acceptsGzipEncoding();
@@ -316,7 +316,7 @@ Future<shelf.Response> handleTaskResource(
   }
 
   if (request.method.toUpperCase() == 'HEAD') {
-    return htmlResponse('');
+    return headHtmlResponse();
   }
 
   final acceptsGzip = request.acceptsGzipEncoding();


### PR DESCRIPTION
The remaining use of the method is now regular content rendering - which we want to refactor to have a cached content + on-the-fly rendering block.