### PR TITLE
Rewrite GitHub blob image URLs in README to raw.githubusercontent.com

### DIFF
--- a/pkg/pub_package_reader/test/known_templates_test.dart
+++ b/pkg/pub_package_reader/test/known_templates_test.dart
@@ -44,5 +44,12 @@ void main() {
         isNotEmpty,
       );
     });
+
+    test('rewrite Github blob image URLs', (){
+      final input = '![example](https://github.com/org/repo/blob/main/img.png)';
+      final expected = '![example](https://raw.githubusercontent.com/org/repo/main/img.png)';
+      final output = rewriteGithubImagesInMarkdown(input);
+      expect(output, expected);
+    });
   });
 }


### PR DESCRIPTION
This PR addresses issue #9156
 by rewriting GitHub blob image URLs in package README files to use raw.githubusercontent.com, ensuring that images render correctly on `pub.dev`.

**Changes:**
- Added rewriteGithubImagesInMarkdown helper in `known_templates.dart` to convert GitHub blob links to raw URLs.
- Updated `known_templates_test.dart` with a new test to verify that image URLs are rewritten correctly.
- No other functionality was modified.

**Test Plan:**
- Added a unit test for the new helper function.
- All existing tests pass using dart test.

Fixes: #9156

- [✔️] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

