### PR TITLE
Better pub_worker bounds: limit log size and blob index size with graceful stop conditions.

### DIFF
--- a/app/lib/task/backend.dart
+++ b/app/lib/task/backend.dart
@@ -755,13 +755,14 @@ class TaskBackend {
     String path, {
     int? offset,
     int? length,
+    int? maxSize,
   }) async {
     try {
       return await _bucket.readAsBytes(
         path,
         offset: offset,
         length: length,
-        maxSize: blobContentSizeLimit, // sanity limit
+        maxSize: maxSize ?? blobContentSizeLimit, // sanity limit
       );
     } on DetailedApiRequestError catch (e) {
       if (e.status == 404) {
@@ -817,7 +818,7 @@ class TaskBackend {
   }) async {
     final pathPrefix = '$runtimeVersion/$package/$version';
     final path = '$pathPrefix/index.json';
-    final bytes = await _readFromBucket(path);
+    final bytes = await _readFromBucket(path, maxSize: blobIndexSizeLimit);
     if (bytes == null) {
       return BlobIndex.empty(blobId: '');
     }

--- a/pkg/_pub_shared/lib/worker/limits.dart
+++ b/pkg/_pub_shared/lib/worker/limits.dart
@@ -4,3 +4,6 @@
 
 /// The maximum size of the compressed blob content that we want to store and serve.
 const blobContentSizeLimit = 10 * 1024 * 1024;
+
+/// The maximum size of the blob index file.
+const blobIndexSizeLimit = blobContentSizeLimit;

--- a/pkg/indexed_blob/test/blob_test.dart
+++ b/pkg/indexed_blob/test/blob_test.dart
@@ -97,7 +97,9 @@ void main() {
     await b.addFile('lib/src/test-b.dart', Stream.value([101]));
     await b.addFile('log.txt', Stream.value([0, 0]));
 
+    expect(b.indexUpperLength, 184);
     final index = await b.buildIndex('42');
+    expect(index.asBytes().length, 146);
 
     final files = index.files.toList();
     expect(files, hasLength(5));
@@ -107,16 +109,25 @@ void main() {
     final controller = StreamController<List<int>>();
     final result = controller.stream.toList();
     final b = IndexedBlobBuilder(controller);
-    await b.addFile('a', Stream.value([0, 1]), skipAfterSize: 3);
-    await b.addFile(
-      'b',
-      Stream.fromIterable([
-        [0],
-        [1, 2, 3], // will be removed,
-      ]),
-      skipAfterSize: 3,
+    expect(
+      await b.addFile('a', Stream.value([0, 1]), skipAfterSize: 3),
+      isTrue,
     );
-    await b.addFile('c', Stream.value([8, 9]), skipAfterSize: 3);
+    expect(
+      await b.addFile(
+        'b',
+        Stream.fromIterable([
+          [0],
+          [1, 2, 3], // will be removed,
+        ]),
+        skipAfterSize: 3,
+      ),
+      isFalse,
+    );
+    expect(
+      await b.addFile('c', Stream.value([8, 9]), skipAfterSize: 3),
+      isTrue,
+    );
     final index = await b.buildIndex('1');
     final files = index.files.toList();
     expect(files, hasLength(2));


### PR DESCRIPTION
Fixes #9186.