### PR TITLE
Upgrade Container Optimized OS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ AppEngine version, listed here to ease deployment and troubleshooting.
 
 ## Next Release (replace with git tag when deployed)
 
+ * Upgraded _Container Optimized OS_ to [Milestone 125](https://docs.cloud.google.com/container-optimized-os/docs/release-notes/m125)
+
 ## `20260206t131300-all`
  * Bump runtimeVersion to `2026.02.04`.
  * Upgraded pana to `0.23.9`.

--- a/app/config/dartlang-pub-dev.yaml
+++ b/app/config/dartlang-pub-dev.yaml
@@ -15,7 +15,7 @@ taskResultBucketName: dartlang-pub-dev-task-output
 taskWorkerImage: us-central1-docker.pkg.dev/dartlang-pub-tasks/{{GOOGLE_CLOUD_PROJECT}}-worker-images/task-worker:{{GAE_VERSION}}
 taskWorkerProject: dartlang-pub-tasks
 taskWorkerNetwork: pub-workers
-cosImage: projects/cos-cloud/global/images/family/cos-121-lts
+cosImage: projects/cos-cloud/global/images/family/cos-125-lts
 taskWorkerServiceAccount: task-worker-dev@dartlang-pub-tasks.iam.gserviceaccount.com
 imageBucketName: dartlang-pub-dev--pub-images
 reportsBucketName: dartlang-pub-dev-reports

--- a/app/config/dartlang-pub.yaml
+++ b/app/config/dartlang-pub.yaml
@@ -18,7 +18,7 @@ taskResultBucketName: dartlang-pub-task-output
 taskWorkerImage: us-central1-docker.pkg.dev/dartlang-pub-tasks/{{GOOGLE_CLOUD_PROJECT}}-worker-images/task-worker:{{GAE_VERSION}}
 taskWorkerProject: dartlang-pub-tasks
 taskWorkerNetwork: pub-workers
-cosImage: projects/cos-cloud/global/images/family/cos-121-lts
+cosImage: projects/cos-cloud/global/images/family/cos-125-lts
 taskWorkerServiceAccount: task-worker@dartlang-pub-tasks.iam.gserviceaccount.com
 imageBucketName: dartlang-pub--pub-images
 reportsBucketName: dartlang-pub-reports


### PR DESCRIPTION
Bump COS image as m121 is EOL not that far in the future:
<img width="910" height="522" alt="image" src="https://github.com/user-attachments/assets/285e633f-9bd1-43d0-a789-b2ba512d7b3c" />

This change will upgrade to m125 which is EOL September 2027.
And I've setup calendar event to bump COS again in August 2027, ahead of next EOL deadline.


See also: https://docs.cloud.google.com/container-optimized-os/docs/concepts/versioning