### PR TITLE
Remove CSP rule that includes old site URL.

### DIFF
--- a/app/lib/service/csp/default_csp.dart
+++ b/app/lib/service/csp/default_csp.dart
@@ -48,7 +48,6 @@ final _defaultContentSecurityPolicyMap = <String, List<String>>{
   ],
   'style-src': <String>[
     "'self'",
-    'https://pub.dartlang.org/static/', // older dartdoc content requires it
     "'unsafe-inline'", // package page (esp. analysis tab) required is
     'https://fonts.googleapis.com/',
     'https://gstatic.com',


### PR DESCRIPTION
I'm sure that we no longer depend on this URL.