### PR TITLE
Updated schema.org SearchAction entry

### DIFF
--- a/app/lib/frontend/templates/layout.dart
+++ b/app/lib/frontend/templates/layout.dart
@@ -154,12 +154,15 @@ final String _defaultPageDescription =
     'libraries & packages for Flutter and general Dart programs.';
 
 const _schemaOrgSearchAction = {
-  '@context': 'http://schema.org',
+  '@context': 'https://schema.org',
   '@type': 'WebSite',
   'url': '${urls.siteRoot}/',
   'potentialAction': {
     '@type': 'SearchAction',
-    'target': '${urls.siteRoot}/packages?q={search_term_string}',
+    'target': {
+      '@type': 'EntryPoint',
+      'urlTemplate': '${urls.siteRoot}/packages?q={search_term_string}',
+    },
     'query-input': 'required name=search_term_string',
   },
 };

--- a/app/lib/frontend/templates/views/shared/layout.dart
+++ b/app/lib/frontend/templates/views/shared/layout.dart
@@ -181,6 +181,8 @@ d.Node pageLayoutNode({
                 ),
                 as: 'script',
               ),
+            if (schemaOrgSearchActionJson != null)
+              d.ldJson(schemaOrgSearchActionJson),
           ],
         ),
         d.element(
@@ -291,8 +293,6 @@ d.Node pageLayoutNode({
                   defer: true,
                 ),
               ]),
-            if (schemaOrgSearchActionJson != null)
-              d.ldJson(schemaOrgSearchActionJson),
           ],
         ),
       ],

--- a/app/test/frontend/golden/landing_page.html
+++ b/app/test/frontend/golden/landing_page.html
@@ -33,6 +33,7 @@
     <script src="https://www.gstatic.com/brandstudio/kato/cookie_choice_component/cookie_consent_bar.v3.js" defer="defer" data-autoload-cookie-consent-bar="true"></script>
     <link rel="preload" href="/static/hash-%%etag%%/img/hero-bg-static.svg" as="image"/>
     <link rel="preload" href="/static/hash-%%etag%%/img/square-bg-full-2x.webp" as="image"/>
+    <script type="application/ld+json">{"@context":"https\u003a\u002f\u002fschema.org","@type":"WebSite","url":"https\u003a\u002f\u002fpub.dev\u002f","potentialAction":{"@type":"SearchAction","target":{"@type":"EntryPoint","urlTemplate":"https\u003a\u002f\u002fpub.dev\u002fpackages\u003fq\u003d\u007bsearch\u005fterm\u005fstring\u007d"},"query-input":"required name\u003dsearch\u005fterm\u005fstring"}}</script>
   </head>
   <body class="page-landing light-theme">
     <script src="/static/hash-%%etag%%/js/dark-init.js"></script>
@@ -219,6 +220,5 @@
         <img class="inline-icon" src="/static/hash-%%etag%%/img/bug-report-white-96px.png" alt="bug report" width="20" height="20" title="Report an issue with this site"/>
       </a>
     </footer>
-    <script type="application/ld+json">{"@context":"http\u003a\u002f\u002fschema.org","@type":"WebSite","url":"https\u003a\u002f\u002fpub.dev\u002f","potentialAction":{"@type":"SearchAction","target":"https\u003a\u002f\u002fpub.dev\u002fpackages\u003fq\u003d\u007bsearch\u005fterm\u005fstring\u007d","query-input":"required name\u003dsearch\u005fterm\u005fstring"}}</script>
   </body>
 </html>


### PR DESCRIPTION
This feature (search in chrome's address bar using pub.dev + tab completion) is broken for a long time, these changes are suggested by Gemini:
- moving the definition to the `<head>`
- using the `https` URL
- specifying the target/entrypoint type.