### PR TITLE
Fix theme switcher reset when platform filters are applied

### DIFF
--- a/pkg/web_app/lib/script.dart
+++ b/pkg/web_app/lib/script.dart
@@ -27,7 +27,6 @@ void main() {
   EventStreamProviders.pageShowEvent.forTarget(window).listen((_) {
     adjustQueryTextAfterPageShow();
   });
-  _setupDarkThemeButton();
 }
 
 void _setupAllEvents() {
@@ -40,6 +39,7 @@ void _setupAllEvents() {
   setupLikesList();
   setupScreenshotCarousel();
   setupWidgets();
+  _setupDarkThemeButton();
 }
 
 void _setupDarkThemeButton() {


### PR DESCRIPTION
**Description**

This PR fixes the issue where the Theme Switcher would fail when a user applied a platform filter (e.g., selecting "Android", "Web", etc.). The _setupDarkThemeButton() function was called only once in main(), outside of _setupAllEvents(). When setupPageUpdater() re-executed _setupAllEvents() during page navigation or updates, the dark theme button's event listeners were not re-attached, causing the button to become non-functional.

Fixes https://github.com/dart-lang/pub-dev/issues/9143