### PR TITLE
Refactor caching of publishers list page: cache only the inner DOM content.

### DIFF
--- a/app/lib/frontend/handlers/publisher.dart
+++ b/app/lib/frontend/handlers/publisher.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 
 import 'package:_pub_shared/search/search_form.dart';
 import 'package:_pub_shared/search/tags.dart';
+import 'package:pub_dev/frontend/templates/views/publisher/publisher_list.dart';
 import 'package:shelf/shelf.dart' as shelf;
 
 import '../../account/auth_provider.dart';
@@ -40,18 +41,14 @@ Future<shelf.Response> createPublisherPageHandler(shelf.Request request) async {
 
 /// Handles requests for GET /publishers
 Future<shelf.Response> publisherListHandler(shelf.Request request) async {
-  if (requestContext.uiCacheEnabled) {
-    final content = await cache.uiPublisherListPage().get(() async {
-      final page = await publisherBackend.listPublishers();
-      return renderPublisherListPage(page.publishers!);
-    });
-    return htmlResponse(content!);
-  }
-
-  // no caching for logged-in user
-  final page = await publisherBackend.listPublishers();
-  final content = renderPublisherListPage(page.publishers!);
-  return htmlResponse(content);
+  final content = await cache.uiPublisherListPageContent().get(() async {
+    final page = await publisherBackend.listPublishers();
+    return publisherListNode(
+      publishers: page.publishers ?? <PublisherSummary>[],
+      isGlobal: true,
+    );
+  });
+  return htmlResponse(renderPublisherListPage(content!));
 }
 
 /// Handles requests for `GET /publishers/<publisherId>`.

--- a/app/lib/frontend/templates/publisher.dart
+++ b/app/lib/frontend/templates/publisher.dart
@@ -19,7 +19,6 @@ import 'listing.dart';
 import 'views/publisher/admin_page.dart';
 import 'views/publisher/create_page.dart';
 import 'views/publisher/header_metadata.dart';
-import 'views/publisher/publisher_list.dart';
 
 /// Renders the create publisher page.
 String renderCreatePublisherPage({required String? domain}) {
@@ -32,8 +31,7 @@ String renderCreatePublisherPage({required String? domain}) {
 }
 
 /// Renders the global publisher list page.
-String renderPublisherListPage(List<PublisherSummary> publishers) {
-  final content = publisherListNode(publishers: publishers, isGlobal: true);
+String renderPublisherListPage(d.Node content) {
   return renderLayoutPage(
     PageType.listing,
     content,

--- a/app/lib/publisher/backend.dart
+++ b/app/lib/publisher/backend.dart
@@ -674,7 +674,7 @@ Future purgePublisherCache({String? publisherId}) async {
     if (publisherId != null)
       cache.uiPublisherPackagesPage(publisherId).purgeAndRepeat(),
     if (publisherId != null) cache.publisherVisible(publisherId).purge(),
-    cache.uiPublisherListPage().purge(),
+    cache.uiPublisherListPageContent().purge(),
   ]);
 }
 

--- a/app/lib/shared/redis_cache.dart
+++ b/app/lib/shared/redis_cache.dart
@@ -111,10 +111,10 @@ class CachePatterns {
       .withTTL(Duration(minutes: 60))
       .withCodec(_domNodeCodec)['/'];
 
-  Entry<String> uiPublisherListPage() => _cache
-      .withPrefix('ui-publisherpage/')
+  Entry<d.Node> uiPublisherListPageContent() => _cache
+      .withPrefix('ui-publisherlist-page-content/')
       .withTTL(Duration(minutes: 60))
-      .withCodec(utf8)['/publishers'];
+      .withCodec(_domNodeCodec)['/'];
 
   /// The first, non-search page for publisher's packages.
   Entry<String> uiPublisherPackagesPage(String publisherId) => _cache

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -28,6 +28,7 @@ import 'package:pub_dev/frontend/templates/publisher.dart';
 import 'package:pub_dev/frontend/templates/report.dart';
 import 'package:pub_dev/frontend/templates/views/landing/page.dart';
 import 'package:pub_dev/frontend/templates/views/pkg/score_tab.dart';
+import 'package:pub_dev/frontend/templates/views/publisher/publisher_list.dart';
 import 'package:pub_dev/package/backend.dart';
 import 'package:pub_dev/package/models.dart';
 import 'package:pub_dev/package/search_adapter.dart';
@@ -681,16 +682,21 @@ void main() {
     testWithProfile(
       'publisher list page',
       fn: () async {
-        final html = renderPublisherListPage([
-          PublisherSummary(
-            publisherId: 'example.com',
-            created: DateTime(2019, 09, 13),
+        final html = renderPublisherListPage(
+          publisherListNode(
+            publishers: [
+              PublisherSummary(
+                publisherId: 'example.com',
+                created: DateTime(2019, 09, 13),
+              ),
+              PublisherSummary(
+                publisherId: 'other-domain.com',
+                created: DateTime(2019, 09, 19),
+              ),
+            ],
+            isGlobal: true,
           ),
-          PublisherSummary(
-            publisherId: 'other-domain.com',
-            created: DateTime(2019, 09, 19),
-          ),
-        ]);
+        );
         expectGoldenFile(
           html,
           'publisher_list_page.html',


### PR DESCRIPTION
- Following the direction of #9215.
- Cache logic is unconditional for the inner content, simpler rendering code.