### PR TITLE
Refactor caching of publisher packages page: cache only the inner DOM content of the tab.

### DIFF
--- a/app/lib/frontend/templates/publisher.dart
+++ b/app/lib/frontend/templates/publisher.dart
@@ -40,23 +40,21 @@ String renderPublisherListPage(d.Node content) {
   );
 }
 
-/// Renders the search results on the publisher's packages page.
-String renderPublisherPackagesPage({
-  required Publisher publisher,
+/// The tab content of the search results on the publisher's packages page.
+d.Node publisherPackagesListTabContentNode({
+  required String publisherId,
   required PublisherPackagesPageKind kind,
   required SearchResultPage searchResultPage,
-  required bool isAdmin,
 }) {
   final pageLinks = PageLinks(
     searchResultPage.form,
     searchResultPage.totalCount,
   );
-
-  final tabContent = d.fragment([
+  return d.fragment([
     listingInfo(
       searchForm: searchResultPage.form,
       totalCount: searchResultPage.totalCount,
-      ownedBy: publisher.publisherId,
+      ownedBy: publisherId,
       messageFromBackend: searchResultPage.errorMessage,
     ),
     if (kind == PublisherPackagesPageKind.unlisted)
@@ -68,7 +66,17 @@ String renderPublisherPackagesPage({
     if (searchResultPage.hasHit) packageList(searchResultPage),
     paginationNode(pageLinks),
   ]);
+}
 
+/// Renders the search results on the publisher's packages page.
+String renderPublisherPackagesPage({
+  required Publisher publisher,
+  required PublisherPackagesPageKind kind,
+  required SearchForm searchForm,
+  required d.Node tabContent,
+  required int totalCount,
+  required bool isAdmin,
+}) {
   List<Tab> packagesTabs;
   switch (kind) {
     case PublisherPackagesPageKind.listed:
@@ -123,13 +131,13 @@ String renderPublisherPackagesPage({
     pageData: PageData(
       publisher: PublisherData(publisherId: publisher.publisherId),
     ),
-    searchForm: searchResultPage.form,
+    searchForm: searchForm,
     canonicalUrl: canonicalUrl,
     noIndex:
         isAdmin ||
         publisher.isUnlisted ||
         kind == PublisherPackagesPageKind.unlisted ||
-        searchResultPage.hasNoHit,
+        totalCount == 0,
     mainClasses: [wideHeaderDetailPageClassName],
   );
 }

--- a/app/lib/publisher/backend.dart
+++ b/app/lib/publisher/backend.dart
@@ -671,7 +671,8 @@ Future<Publisher> requirePublisherAdmin(
 /// Purge [cache] entries for given [publisherId].
 Future purgePublisherCache(String publisherId) async {
   await Future.wait([
-    cache.uiPublisherPackagesPage(publisherId).purgeAndRepeat(),
+    cache.publisherPackagesTabContent(publisherId, .listed).purgeAndRepeat(),
+    cache.publisherPackagesTabContent(publisherId, .unlisted).purgeAndRepeat(),
     cache.publisherStatus(publisherId).purge(),
     cache.uiPublisherListPageContent().purge(),
   ]);

--- a/app/lib/shared/redis_cache.dart
+++ b/app/lib/shared/redis_cache.dart
@@ -24,7 +24,8 @@ import '../../shared/env_config.dart';
 import '../account/models.dart' show Consent, LikeData, SessionData;
 import '../frontend/dom/dom.dart' as d;
 import '../package/models.dart' show PackageView;
-import '../publisher/models.dart' show PublisherPage, PublisherStatus;
+import '../publisher/models.dart'
+    show PublisherPackagesPageKind, PublisherPage, PublisherStatus;
 import '../scorecard/models.dart' show ScoreCardData;
 import '../search/search_service.dart' show PackageSearchResult;
 import '../service/openid/openid_models.dart' show OpenIdData;
@@ -118,10 +119,24 @@ class CachePatterns {
       .withCodec(_domNodeCodec)['/'];
 
   /// The first, non-search page for publisher's packages.
-  Entry<String> uiPublisherPackagesPage(String publisherId) => _cache
-      .withPrefix('ui-publisherpage/')
+  Entry<(d.Node tabContent, int totalCount)> publisherPackagesTabContent(
+    String publisherId,
+    PublisherPackagesPageKind kind,
+  ) => _cache
+      .withPrefix('publisher-packages-tab-content/')
       .withTTL(Duration(minutes: 60))
-      .withCodec(utf8)[publisherId];
+      .withCodec(utf8)
+      .withCodec(
+        wrapAsCodec(
+          encode: ((d.Node tabContent, int totalCount) e) {
+            return json.encode([e.$1.toString(), e.$2]);
+          },
+          decode: (v) {
+            final x = json.decode(v) as List;
+            return (d.unsafeRawHtml(x[0] as String), x[1] as int);
+          },
+        ),
+      )['$publisherId/${kind.name}'];
 
   Entry<bool> packageVisible(String package) => _cache
       .withPrefix('package-visible/')

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -720,14 +720,21 @@ void main() {
         final titanium = (await scoreCardBackend.getPackageView(
           'flutter_titanium',
         ))!;
+        final searchResult = SearchResultPage(
+          searchForm,
+          2,
+          packageHits: [neon, titanium],
+        );
         final html = renderPublisherPackagesPage(
           publisher: publisher,
           kind: PublisherPackagesPageKind.listed,
-          searchResultPage: SearchResultPage(
-            searchForm,
-            2,
-            packageHits: [neon, titanium],
+          searchForm: searchForm,
+          tabContent: publisherPackagesListTabContentNode(
+            publisherId: publisher.publisherId,
+            kind: .listed,
+            searchResultPage: searchResult,
           ),
+          totalCount: searchResult.totalCount,
           isAdmin: true,
         );
         expectGoldenFile(
@@ -755,14 +762,21 @@ void main() {
         final titanium = (await scoreCardBackend.getPackageView(
           'flutter_titanium',
         ))!;
+        final searchResult = SearchResultPage(
+          searchForm,
+          2,
+          packageHits: [neon, titanium],
+        );
         final html = renderPublisherPackagesPage(
           publisher: publisher,
           kind: PublisherPackagesPageKind.unlisted,
-          searchResultPage: SearchResultPage(
-            searchForm,
-            2,
-            packageHits: [neon, titanium],
+          searchForm: searchForm,
+          tabContent: publisherPackagesListTabContentNode(
+            publisherId: publisher.publisherId,
+            kind: .unlisted,
+            searchResultPage: searchResult,
           ),
+          totalCount: searchResult.totalCount,
           isAdmin: true,
         );
         expectGoldenFile(


### PR DESCRIPTION
Following the direction of https://github.com/dart-lang/pub-dev/pull/9215.