### PR TITLE
Migrate to package:web: search update handling + api client library

### DIFF
--- a/pkg/web_app/lib/src/api_client/api_client.dart
+++ b/pkg/web_app/lib/src/api_client/api_client.dart
@@ -2,12 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// TODO: migrate to package:web
-// ignore: deprecated_member_use
-import 'dart:html';
-
 import 'package:_pub_shared/pubapi.dart';
-import 'package:api_builder/_client_utils.dart';
+import 'package:api_builder/_client_utils.dart' as api_utils;
+import 'package:web/web.dart';
 
 import '../deferred/http.dart' as http;
 
@@ -42,7 +39,7 @@ Future<Map<String, Object?>> sendJson({
 }) async {
   final client = http.createClientWithCsrf();
   try {
-    final c = Client(_baseUrl, client: client);
+    final c = api_utils.Client(_baseUrl, client: client);
     return await c.requestJson(verb: verb, path: path, body: body);
   } finally {
     client.close();


### PR DESCRIPTION
- Note: I've noticed that we have started our `package:web` migration in `pub-dev/pkg/web_app`, but for some reason it got abandoned/forgotten.
- The `dataset` access is replaced with `getAttribute('data-<property>'`), since it provided better consistency (as opposed to the `JSAny?` return value, which returns a `null` value wrapped inside a non-null object).
