### PR TITLE
Use exported-api bucket for pub_get_offline script

### DIFF
--- a/tool/pub_get_offline.dart
+++ b/tool/pub_get_offline.dart
@@ -96,7 +96,7 @@ Map<String, String> _parsePubspecLockSync(File file) {
 Future<void> _downloadInto(
     String package, String version, String? pubCachePath) async {
   final rq = await _client.getUrl(Uri.parse(
-      'https://storage.googleapis.com/dartlang-pub-public-packages/packages/${Uri.encodeComponent(package)}-${Uri.encodeComponent(version)}.tar.gz'));
+      'https://storage.googleapis.com/dartlang-pub-exported-api/latest/api/archives/${Uri.encodeComponent(package)}-${Uri.encodeComponent(version)}.tar.gz'));
   final rs = await rq.close();
   if (rs.statusCode != 200) {
     throw Exception('Unable to access archive of $package-$version.');


### PR DESCRIPTION
Towards https://github.com/dart-lang/pub-dev/issues/9248