### PR TITLE
Explicit test that we catch trailing junk in archive_surface

### DIFF
--- a/pkg/pub_package_reader/lib/src/archive_surface.dart
+++ b/pkg/pub_package_reader/lib/src/archive_surface.dart
@@ -37,6 +37,8 @@ Stream<ArchiveIssue> scanArchiveSurface(
         .transform(gzip.decoder)
         .fold<int>(0, (length, element) => length + element.length);
   } on FormatException catch (e) {
+    // This will among other things catch trailing junk in the gzip stream.
+    // See https://github.com/dart-lang/pub-dev/issues/9247.
     yield ArchiveIssue('gzip decoder failed: $e.');
     return;
   }

--- a/pkg/pub_package_reader/test/archive_surface_test.dart
+++ b/pkg/pub_package_reader/test/archive_surface_test.dart
@@ -2,9 +2,11 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:pub_package_reader/pub_package_reader.dart';
+import 'package:tar/tar.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -50,6 +52,32 @@ void main() {
 
     test('file has garbage bytes', () async {
       await archiveFile.writeAsBytes(<int>[1, 2, 3, 4, 5, 6, 7]);
+      final summary = await summarizePackageArchive(archiveFile.path);
+      expect(summary.issues, isNotEmpty);
+      expect(
+        summary.issues.single.message,
+        'gzip decoder failed: FormatException: Filter error, bad data.',
+      );
+    });
+
+    test('file has trailing junk', () async {
+      final entriesStream = Stream.fromIterable([
+        TarEntry(
+          TarHeader(name: 'pubspec.yaml', mode: int.parse('644', radix: 8)),
+          Stream.fromIterable([utf8.encode('name: foo')]),
+        ),
+      ]);
+      final tarStream = tarWriter.bind(entriesStream);
+      final gzipStream = gzip.encoder.bind(tarStream);
+      final sink = archiveFile.openWrite();
+      await sink.addStream(gzipStream);
+      await sink.addStream(
+        Stream.fromIterable([
+          [0, 0, 0],
+        ]),
+      ); // trailing junk
+      await sink.close();
+
       final summary = await summarizePackageArchive(archiveFile.path);
       expect(summary.issues, isNotEmpty);
       expect(


### PR DESCRIPTION
Following up on #9247 