### PR TITLE
Always specify some database connection parameters (when the configured ones are absent)

### DIFF
--- a/app/lib/database/database.dart
+++ b/app/lib/database/database.dart
@@ -97,6 +97,7 @@ class PrimaryDatabase {
       }
     }
 
+    url = _expandConnectionUrl(url);
     final pg = Pool.withUrl(url);
     final adapter = DatabaseAdapter.postgres(pg);
     final db = Database<PrimarySchema>(adapter, SqlDialect.postgres());
@@ -122,6 +123,21 @@ class PrimaryDatabase {
   }
 }
 
+/// Expand the connection URL to override default parameters, unless specified in the provided URL.
+String _expandConnectionUrl(String url) {
+  final uri = Uri.parse(url);
+  return uri
+      .replace(
+        queryParameters: {
+          // replace connections after an hour (value is in seconds)
+          'max_connection_age': '3600',
+          'max_connection_count': '8',
+          ...uri.queryParameters,
+        },
+      )
+      .toString();
+}
+
 Future<(String, String?)> _startOrUseLocalPostgresInDocker() async {
   // sanity check
   if (envConfig.isRunningInAppengine) {
@@ -136,7 +152,6 @@ Future<(String, String?)> _startOrUseLocalPostgresInDocker() async {
     queryParameters: {
       'host': '.dart_tool/postgresql/run/.s.PGSQL.5432',
       'sslmode': 'disable',
-      'max_connection_count': '8',
     },
   ).toString();
 


### PR DESCRIPTION
- Fixes most of the integration test in the current state of #9126, by providing the connection pool size of 8 (which otherwise could be 1), otherwise the code would be in a deadlock at one point.
- Also adds a one-hour period after which a new connection object will be opened (may not be needed, but I think it is better to always rotate and cleanup these objects).