### PR TITLE
Set auto image height in markdown content.

### DIFF
--- a/pkg/web_css/lib/src/_base.scss
+++ b/pkg/web_css/lib/src/_base.scss
@@ -278,6 +278,10 @@ pre {
       background-color: inherit; /* overrides github-markdown.css */
     }
   }
+
+  img {
+    height: auto; /* Preserves aspect ratio when img has height and a wider width attribute set. */
+  }
 }
 
 ._banner-bg {


### PR DESCRIPTION
Fixes #9257.