### PR TITLE
Escape changelog excerpt HTML to fix formatting in email

### DIFF
--- a/app/lib/service/email/email_templates.dart
+++ b/app/lib/service/email/email_templates.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:convert';
 import 'dart:io';
 
 import '../../shared/urls.dart';
@@ -43,7 +44,7 @@ String _changeLogDiv(String excerpt) =>
     '''
 Excerpt of the changelog:<br/>
 <div style="background-color: #f6f8fa; border-radius: 0.25rem; padding: 1rem; overflow: auto; border: 1px solid #d0d7de; margin: 1rem 0;">
-  <pre style="margin: 0; font-family: 'Courier New', Courier, monospace; font-size: 1rem; line-height: 1.5; color: #24292f;"><code>$excerpt</code></pre>
+  <pre style="margin: 0; font-family: 'Courier New', Courier, monospace; font-size: 0.85em; line-height: 1.5; color: #24292f;"><code>${htmlEscape.convert(excerpt)}</code></pre>
 </div>''';
 
 /// Represents a parsed email address.

--- a/app/test/service/email/email_templates_test.dart
+++ b/app/test/service/email/email_templates_test.dart
@@ -210,15 +210,15 @@ void main() {
           EmailAddress('uploader@example.com'),
         ],
         uploadMessages: [],
-        changelogExcerpt: 'changelog content',
+        changelogExcerpt: 'changelog <content>',
       );
       expect(
         message.bodyText,
-        contains('Excerpt of the changelog:\n```\nchangelog content\n```'),
+        contains('Excerpt of the changelog:\n```\nchangelog <content>\n```'),
       );
       expect(message.bodyHtml, contains('Excerpt of the changelog:<br/>\n'));
       final codeRegexp = RegExp(
-        '<div style=".*?">\n  <pre style=".*?"><code>.*</code></pre>\n</div>',
+        '<div style=".*?">\n  <pre style=".*?"><code>changelog &lt;content&gt;</code></pre>\n</div>',
       );
       expect(
         message.bodyHtml.contains(codeRegexp),


### PR DESCRIPTION
Fixes an issue where \'<1\', \'\'>=\', etc. would be mangled in email clients due to incorrect HTML parsing

Also shrink the changelog font size to 0.85em to better match GitHub's styling
