### PR TITLE
Updated tests in preparation for the typed_sql task migration.

### DIFF
--- a/app/test/admin/moderate_package_test.dart
+++ b/app/test/admin/moderate_package_test.dart
@@ -18,6 +18,7 @@ import 'package:pub_dev/fake/backend/fake_pub_worker.dart';
 import 'package:pub_dev/package/backend.dart';
 import 'package:pub_dev/scorecard/backend.dart';
 import 'package:pub_dev/search/backend.dart';
+import 'package:pub_dev/service/async_queue/async_queue.dart';
 import 'package:pub_dev/shared/configuration.dart';
 import 'package:pub_dev/shared/datastore.dart';
 import 'package:pub_dev/shared/versions.dart';
@@ -52,7 +53,7 @@ void main() {
       bool? state,
     }) async {
       final api = createPubApiClient(authToken: siteAdminToken);
-      return await api.adminInvokeAction(
+      final rs = await api.adminInvokeAction(
         'moderate-package',
         AdminInvokeActionArguments(
           arguments: {
@@ -62,6 +63,8 @@ void main() {
           },
         ),
       );
+      await asyncQueue.ongoingProcessing;
+      return rs;
     }
 
     testWithProfile(
@@ -451,6 +454,7 @@ void main() {
         await accountBackend.withBearerToken(siteAdminToken, () async {
           await adminBackend.removePackageVersion('oxygen', '1.0.0');
         });
+        await asyncQueue.ongoingProcessing;
 
         // canonical file is present
         expect(

--- a/app/test/admin/moderate_package_version_test.dart
+++ b/app/test/admin/moderate_package_version_test.dart
@@ -17,6 +17,7 @@ import 'package:pub_dev/fake/backend/fake_pub_worker.dart';
 import 'package:pub_dev/package/backend.dart';
 import 'package:pub_dev/scorecard/backend.dart';
 import 'package:pub_dev/search/backend.dart';
+import 'package:pub_dev/service/async_queue/async_queue.dart';
 import 'package:pub_dev/shared/configuration.dart';
 import 'package:pub_dev/shared/datastore.dart';
 import 'package:pub_dev/shared/exceptions.dart';
@@ -53,7 +54,7 @@ void main() {
       bool? state,
     }) async {
       final api = createPubApiClient(authToken: siteAdminToken);
-      return await api.adminInvokeAction(
+      final rs = await api.adminInvokeAction(
         'moderate-package-version',
         AdminInvokeActionArguments(
           arguments: {
@@ -64,6 +65,8 @@ void main() {
           },
         ),
       );
+      await asyncQueue.ongoingProcessing;
+      return rs;
     }
 
     testWithProfile(

--- a/app/test/dartdoc/doc_url_test.dart
+++ b/app/test/dartdoc/doc_url_test.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:pub_dev/service/async_queue/async_queue.dart';
 import 'package:pub_dev/tool/test_profile/models.dart';
 import 'package:test/test.dart';
 
@@ -123,6 +124,7 @@ void main() {
             pubspecContent: generatePubspecYaml('oxygen', '2.5.0'),
           ),
         );
+        await asyncQueue.ongoingProcessing;
         await expectRedirectResponse(
           await issueGet('/documentation/oxygen/1.0.0/'),
           '/documentation/oxygen/1.1.0/',

--- a/app/test/database/postgresql_ci_test.dart
+++ b/app/test/database/postgresql_ci_test.dart
@@ -72,6 +72,7 @@ void main() {
             .execute();
 
         final rows = await db.tasks
+            .where((b) => b.package.equalsValue('foo'))
             .select((b) => (b.package, b.runtimeVersion, b.state))
             .fetch();
         expect(rows, hasLength(1));

--- a/app/test/package/api_export/api_exporter_test.dart
+++ b/app/test/package/api_export/api_exporter_test.dart
@@ -13,6 +13,7 @@ import 'package:googleapis/storage/v1.dart' show DetailedApiRequestError;
 import 'package:logging/logging.dart';
 import 'package:pub_dev/fake/backend/fake_auth_provider.dart';
 import 'package:pub_dev/package/api_export/api_exporter.dart';
+import 'package:pub_dev/service/async_queue/async_queue.dart';
 import 'package:pub_dev/shared/configuration.dart';
 import 'package:pub_dev/shared/storage.dart';
 import 'package:pub_dev/shared/utils.dart';
@@ -85,10 +86,10 @@ void main() {
 
       await apiExporter.start();
 
-      await _testExportedApiSynchronization(
-        bucket,
-        () async => clockControl.elapse(minutes: 15),
-      );
+      await _testExportedApiSynchronization(bucket, () async {
+        clockControl.elapse(minutes: 15);
+        await asyncQueue.ongoingProcessing;
+      });
 
       await apiExporter.stop();
     },

--- a/app/test/package/upload_test.dart
+++ b/app/test/package/upload_test.dart
@@ -1577,6 +1577,7 @@ void main() {
             'Please contact support@pub.dev',
           ),
         );
+        await asyncQueue.ongoingProcessing;
         expect(
           fakeEmailSender.sentMessages.last.bodyText,
           contains('has 0 versions left before reaching the limit'),


### PR DESCRIPTION
- Most of the tests that are not directly related to the task migration from #9126.
- Filing these separately so that we are sure that the tests are passing before and also after the task migration.

Note: we could probably review the async queue and the awaiting of the ongoing processing automatically, but that can happen separately, let's unblock the tests first.