### PR TITLE
Migrate screenshot carousel + focusability to `package:web`.

### DIFF
--- a/pkg/web_app/lib/src/_dart_html_focusability.dart
+++ b/pkg/web_app/lib/src/_dart_html_focusability.dart
@@ -1,0 +1,89 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// TODO: migrate to package:web
+// ignore: deprecated_member_use
+import 'dart:html';
+
+/// These selectors provide the elements that are focusable through tab or
+/// keyboard navigation.
+const _focusableSelectors = <String>[
+  'a',
+  'audio',
+  'button',
+  'canvas',
+  'details',
+  'iframe',
+  'input',
+  'select',
+  'summary',
+  'textarea',
+  'video',
+  '[accesskey]',
+  '[contenteditable]',
+  '[tabindex]',
+];
+
+/// Disables all focusable elements, except for the elements inside
+/// [allowedComponents]. Returns a [Function] that will restore the
+/// original focusability state of the disabled elements.
+void Function() disableAllFocusability({
+  required List<Element> allowedComponents,
+}) {
+  final focusableElements = document.body!.querySelectorAll(
+    _focusableSelectors.join(', '),
+  );
+  final restoreFocusabilityFns = <void Function()>[];
+  for (final e in focusableElements) {
+    if (allowedComponents.any((content) => _isInsideContent(e, content))) {
+      continue;
+    }
+    restoreFocusabilityFns.add(_disableFocusability(e));
+  }
+  return () {
+    for (final fn in restoreFocusabilityFns) {
+      fn();
+    }
+  };
+}
+
+/// Update [e] to disable focusability and return a [Function] that can be
+/// called to revert its original state.
+void Function() _disableFocusability(Element e) {
+  final isLink = e.tagName.toLowerCase() == 'a';
+  final hasTabindex = e.hasAttribute('tabindex');
+  final attributesToSet = <String, String>{
+    if (isLink || hasTabindex) 'tabindex': '-1',
+    if (!isLink) 'disabled': 'disabled',
+    'aria-hidden': 'true',
+  };
+  final attributesToRestore = attributesToSet.map(
+    (key, _) => MapEntry(key, e.getAttribute(key)),
+  );
+  for (final a in attributesToSet.entries) {
+    e.setAttribute(a.key, a.value);
+  }
+  return () {
+    for (final a in attributesToRestore.entries) {
+      final value = a.value;
+      if (value == null) {
+        e.removeAttribute(a.key);
+      } else {
+        e.setAttribute(a.key, value);
+      }
+    }
+  };
+}
+
+bool _isInsideContent(Element e, Element content) {
+  // check if [e] is under [content].
+  Element? p = e;
+  while (p != null) {
+    if (p == content) {
+      return true;
+    }
+    p = p.parent;
+  }
+  return false;
+}

--- a/pkg/web_app/lib/src/_dom_helper.dart
+++ b/pkg/web_app/lib/src/_dom_helper.dart
@@ -9,7 +9,7 @@ import 'dart:html';
 
 import 'package:mdc_web/mdc_web.dart' show MDCDialog;
 
-import '_focusability.dart';
+import '_dart_html_focusability.dart';
 import 'deferred/markdown.dart' deferred as md;
 
 /// Displays a message via the modal window.

--- a/pkg/web_app/lib/src/_focusability.dart
+++ b/pkg/web_app/lib/src/_focusability.dart
@@ -2,9 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// TODO: migrate to package:web
-// ignore: deprecated_member_use
-import 'dart:html';
+import 'package:web/web.dart';
+import 'package:web_app/src/web_util.dart';
 
 /// These selectors provide the elements that are focusable through tab or
 /// keyboard navigation.
@@ -35,7 +34,7 @@ void Function() disableAllFocusability({
     _focusableSelectors.join(', '),
   );
   final restoreFocusabilityFns = <void Function()>[];
-  for (final e in focusableElements) {
+  for (final e in focusableElements.toElementList()) {
     if (allowedComponents.any((content) => _isInsideContent(e, content))) {
       continue;
     }
@@ -83,7 +82,7 @@ bool _isInsideContent(Element e, Element content) {
     if (p == content) {
       return true;
     }
-    p = p.parent;
+    p = p.parentElement;
   }
   return false;
 }

--- a/pkg/web_app/lib/src/screenshot_carousel.dart
+++ b/pkg/web_app/lib/src/screenshot_carousel.dart
@@ -7,7 +7,7 @@ import 'dart:convert';
 // ignore: deprecated_member_use
 import 'dart:html';
 
-import '_focusability.dart';
+import '_dart_html_focusability.dart';
 
 void setupScreenshotCarousel() {
   _setEventForScreenshot();

--- a/pkg/web_app/lib/src/screenshot_carousel.dart
+++ b/pkg/web_app/lib/src/screenshot_carousel.dart
@@ -3,57 +3,59 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:convert';
-// TODO: migrate to package:web
-// ignore: deprecated_member_use
-import 'dart:html';
+import 'dart:js_interop';
 
-import '_dart_html_focusability.dart';
+import 'package:web/web.dart';
+import 'package:web_app/src/web_util.dart';
+
+import '_focusability.dart';
 
 void setupScreenshotCarousel() {
   _setEventForScreenshot();
 }
 
 void _setEventForScreenshot() {
-  final carousel = document.getElementById('-screenshot-carousel');
+  final carousel =
+      document.getElementById('-screenshot-carousel') as HTMLElement?;
   if (carousel == null) {
     return;
   }
   final thumbnails = document.querySelectorAll('div[data-thumbnail]');
   final imageContainer = document.getElementById('-image-container')!;
-  final prev = document.getElementById('-carousel-prev')!;
-  final next = document.getElementById('-carousel-next')!;
+  final prev = document.getElementById('-carousel-prev') as HTMLElement;
+  final next = document.getElementById('-carousel-next') as HTMLElement;
   final description =
-      document.getElementById('-screenshot-description') as ParagraphElement;
+      document.getElementById('-screenshot-description') as HTMLElement;
   final existingImageElement =
-      document.getElementById('-carousel-image') as ImageElement?;
-  final ImageElement imageElement;
+      document.getElementById('-carousel-image') as HTMLElement?;
+  final HTMLElement imageElement;
   if (existingImageElement != null) {
     imageElement = existingImageElement;
   } else {
-    imageElement = ImageElement();
+    imageElement = document.createElement('img') as HTMLElement;
     imageElement.id = '-carousel-image';
     imageContainer.append(imageElement);
     imageElement.className = 'carousel-image';
   }
 
-  Element? focusedTriggerSourceElement;
+  HTMLElement? focusedTriggerSourceElement;
   void Function()? restoreFocusabilityFn;
   var images = <String>[];
   var descriptions = <String>[];
 
-  void hideElement(Element element) {
+  void hideElement(HTMLElement element) {
     element.style.display = 'none';
   }
 
-  void showElement(Element element) {
+  void showElement(HTMLElement element) {
     element.style.display = 'flex';
   }
 
   void showImage(int index) {
     hideElement(description);
     hideElement(imageElement);
-    imageElement.src = images[index];
-    description.text = descriptions[index];
+    imageElement.setAttribute('src', images[index]);
+    description.innerText = descriptions[index];
 
     if (index == images.length - 1) {
       hideElement(next);
@@ -75,14 +77,14 @@ void _setEventForScreenshot() {
   }
 
   var screenshotIndex = 0;
-  for (final thumbnail in thumbnails) {
+  for (final thumbnail in thumbnails.toElementList()) {
     void setup() {
       restoreFocusabilityFn = disableAllFocusability(
         allowedComponents: [prev, next],
       );
-      focusedTriggerSourceElement = thumbnail;
+      focusedTriggerSourceElement = thumbnail as HTMLElement;
       showElement(carousel);
-      document.body!.classes
+      document.body!.classList
         ..remove('overflow-auto')
         ..add('overflow-hidden');
       images = thumbnail.dataset['thumbnail']!.split(',');
@@ -91,7 +93,7 @@ void _setEventForScreenshot() {
       showImage(screenshotIndex);
     }
 
-    thumbnail.parent!.onClick.listen((event) {
+    thumbnail.parentElement!.onClick.listen((event) {
       event.stopPropagation();
       setup();
     });
@@ -108,7 +110,7 @@ void _setEventForScreenshot() {
     hideElement(next);
     hideElement(prev);
     hideElement(description);
-    document.body!.classes
+    document.body!.classList
       ..remove('overflow-hidden')
       ..add('overflow-auto');
     screenshotIndex = 0;
@@ -158,26 +160,29 @@ void _setEventForScreenshot() {
     closeCarousel();
   });
 
-  document.onKeyDown.listen((event) {
-    if (carousel.style.display == 'none') {
-      return;
-    }
+  document.addEventListener(
+    'keydown',
+    (KeyboardEvent event) {
+      if (carousel.style.display == 'none') {
+        return;
+      }
 
-    if (event.key == 'Escape') {
-      event.stopPropagation();
-      closeCarousel();
-    }
-    if (event.key == 'ArrowLeft') {
-      if (screenshotIndex > 0) {
+      if (event.key == 'Escape') {
         event.stopPropagation();
-        gotoPrev();
+        closeCarousel();
       }
-    }
-    if (event.key == 'ArrowRight') {
-      if (screenshotIndex < images.length - 1) {
-        event.stopPropagation();
-        gotoNext();
+      if (event.key == 'ArrowLeft') {
+        if (screenshotIndex > 0) {
+          event.stopPropagation();
+          gotoPrev();
+        }
       }
-    }
-  });
+      if (event.key == 'ArrowRight') {
+        if (screenshotIndex < images.length - 1) {
+          event.stopPropagation();
+          gotoNext();
+        }
+      }
+    }.toJS,
+  );
 }

--- a/pkg/web_app/lib/src/screenshot_carousel.dart
+++ b/pkg/web_app/lib/src/screenshot_carousel.dart
@@ -87,8 +87,10 @@ void _setEventForScreenshot() {
       document.body!.classList
         ..remove('overflow-auto')
         ..add('overflow-hidden');
-      images = thumbnail.dataset['thumbnail']!.split(',');
-      final raw = jsonDecode(thumbnail.dataset['thumbnail-descriptions-json']!);
+      images = thumbnail.getAttribute('data-thumbnail')!.split(',');
+      final raw = jsonDecode(
+        thumbnail.getAttribute('data-thumbnail-descriptions-json')!,
+      );
       descriptions = (raw as List).cast<String>();
       showImage(screenshotIndex);
     }


### PR DESCRIPTION
- Copied/split `focusability.dart` to have a `dart:html` and a `package:web` version, since the modal window code depends on it too.
- Migrated screenshot carousel + its version of focusability to `package:web`.