### PR TITLE
Alternative retry wrapper logic.

### DIFF
--- a/app/lib/database/database.dart
+++ b/app/lib/database/database.dart
@@ -41,7 +41,7 @@ class PrimaryDatabase {
 
   late final _adapter = DatabaseAdapter.postgres(_pg);
   late final _dialect = SqlDialect.postgres();
-  late final db = Database<PrimarySchema>(_adapter, _dialect);
+  late final _db = Database<PrimarySchema>(_adapter, _dialect);
 
   /// Gets the connection string either from the environment variable or from
   /// the secret backend, connects to it and registers the primary database
@@ -232,13 +232,15 @@ Future<void> _dropCustomDatabase(String url, String dbName) async {
   await conn.close(force: true);
 }
 
-extension DatabaseExt on Database {
+extension PrimaryDatabaseExt on PrimaryDatabase {
   /// Runs [fn] in a retry block (without wrapping it in a transaction).
   ///
   /// The call is retried only if [DatabaseConnectionException] is throw.
-  Future<K> withRetry<K>(Future<K> Function() fn) async {
+  Future<K> withRetry<K>(
+    Future<K> Function(Database<PrimarySchema> db) fn,
+  ) async {
     return await retry(
-      fn,
+      () => fn(_db),
       maxAttempts: 3,
       retryIf: (e) => e is DatabaseConnectionException,
     );
@@ -251,11 +253,13 @@ extension DatabaseExt on Database {
   ///
   /// However, if inside the transaction an [Error] is thrown, or if the wrapped exception
   /// is [ResponseException], we don't retry [fn].
-  Future<K> transactWithRetry<K>(Future<K> Function() fn) async {
+  Future<K> transactWithRetry<K>(
+    Future<K> Function(Database<PrimarySchema> db) fn,
+  ) async {
     return await retry(
       () async {
         try {
-          return await transact(fn);
+          return await _db.transact(() => fn(_db));
         } on TransactionAbortedException catch (e) {
           final inner = e.reason;
           if (inner is Error || inner is ResponseException) {

--- a/app/test/database/postgresql_ci_test.dart
+++ b/app/test/database/postgresql_ci_test.dart
@@ -51,36 +51,37 @@ void main() {
     testWithProfile(
       'typed schema access',
       fn: () async {
-        final db = primaryDatabase!.db;
-        await db.tasks
-            .insert(
-              runtime_version: runtimeVersion.asExpr,
-              package: 'foo'.asExpr,
-              state: TaskState(
-                versions: {
-                  '1.0.0': PackageVersionStateInfo(
-                    scheduled: clock.now(),
-                    attempts: 0,
-                  ),
-                },
-                abortedTokens: [],
-              ).asExpr,
-              pending_at: clock.now().asExpr,
-              last_dependency_changed: clock.now().asExpr,
-              finished: clock.now().asExpr,
-            )
-            .execute();
+        await primaryDatabase!.withRetry((db) async {
+          await db.tasks
+              .insert(
+                runtime_version: runtimeVersion.asExpr,
+                package: 'foo'.asExpr,
+                state: TaskState(
+                  versions: {
+                    '1.0.0': PackageVersionStateInfo(
+                      scheduled: clock.now(),
+                      attempts: 0,
+                    ),
+                  },
+                  abortedTokens: [],
+                ).asExpr,
+                pending_at: clock.now().asExpr,
+                last_dependency_changed: clock.now().asExpr,
+                finished: clock.now().asExpr,
+              )
+              .execute();
 
-        final rows = await db.tasks
-            .where((b) => b.package.equalsValue('foo'))
-            .select((b) => (b.package, b.runtime_version, b.state))
-            .fetch();
-        expect(rows, hasLength(1));
-        expect(rows.first.$1, 'foo');
-        expect(rows.first.$2, runtimeVersion);
-        expect(rows.first.$3.toJson(), {
-          'versions': {'1.0.0': isNotNull},
-          'abortedTokens': [],
+          final rows = await db.tasks
+              .where((b) => b.package.equalsValue('foo'))
+              .select((b) => (b.package, b.runtime_version, b.state))
+              .fetch();
+          expect(rows, hasLength(1));
+          expect(rows.first.$1, 'foo');
+          expect(rows.first.$2, runtimeVersion);
+          expect(rows.first.$3.toJson(), {
+            'versions': {'1.0.0': isNotNull},
+            'abortedTokens': [],
+          });
         });
       },
     );


### PR DESCRIPTION
I think this is better, because it does not allow direct access to the `Database<PrimarySchema>` object - one can access it as part of a retry block without transaction, or with transaction. This way there is no access without retry block, while otherwise there would have been.