### PR TITLE
Use a Zone variable to indicate that a database retry block has been already started.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Important changes to data models, configuration, and migrations between each
 AppEngine version, listed here to ease deployment and troubleshooting.
 
 ## Next Release (replace with git tag when deployed)
+ * Bump runtimeVersion to `2026.04.14`.
+ * Note: Started to read search snapshots from `.tar.gz` files (with `.json.gz` fallback).
 
 ## `20260409t113000-all`
  * Image proxy is now enabled for all users (again).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Important changes to data models, configuration, and migrations between each
 AppEngine version, listed here to ease deployment and troubleshooting.
 
 ## Next Release (replace with git tag when deployed)
+
+## `20260416t074200-all`
  * Bump runtimeVersion to `2026.04.14`.
  * Note: Started to read search snapshots from `.tar.gz` files (with `.json.gz` fallback).
 

--- a/app/lib/database/database.dart
+++ b/app/lib/database/database.dart
@@ -237,7 +237,13 @@ final _retryKey = #dbRetryKey;
 extension PrimaryDatabaseExt on PrimaryDatabase {
   /// Runs [fn] in a retry block (without wrapping it in a transaction).
   ///
-  /// The call is retried only if [DatabaseConnectionException] is throw.
+  /// The retry block is tracked with a [Zone], and if multiple retries are embeded
+  /// (with or without transaction), only the outermost block will be retried.
+  ///
+  /// The call is retried if the generic [DatabaseException] is throw, which may be a
+  /// connection issue, deadlock, timeout, constraint or any query-related problem.
+  ///
+  /// However, if inside the transaction an [Error] is thrown, or if the wrapped exception
   Future<K> withRetry<K>(
     Future<K> Function(Database<PrimarySchema> db) fn,
   ) async {
@@ -245,6 +251,9 @@ extension PrimaryDatabaseExt on PrimaryDatabase {
   }
 
   /// Runs [fn] in a transaction with retry block.
+  ///
+  /// The retry block is tracked with a [Zone], and if multiple retries are embeded
+  /// (with or without transaction), only the outermost block will be retried.
   ///
   /// The call is retried if the generic [DatabaseException] is throw, which may be a
   /// connection issue, deadlock, timeout, constraint or any query-related problem.

--- a/app/lib/database/database.dart
+++ b/app/lib/database/database.dart
@@ -244,6 +244,7 @@ extension PrimaryDatabaseExt on PrimaryDatabase {
   /// connection issue, deadlock, timeout, constraint or any query-related problem.
   ///
   /// However, if inside the transaction an [Error] is thrown, or if the wrapped exception
+  /// is [ResponseException], we don't retry [fn].
   Future<K> withRetry<K>(
     Future<K> Function(Database<PrimarySchema> db) fn,
   ) async {

--- a/app/lib/database/database.dart
+++ b/app/lib/database/database.dart
@@ -232,6 +232,8 @@ Future<void> _dropCustomDatabase(String url, String dbName) async {
   await conn.close(force: true);
 }
 
+final _retryKey = #dbRetryKey;
+
 extension PrimaryDatabaseExt on PrimaryDatabase {
   /// Runs [fn] in a retry block (without wrapping it in a transaction).
   ///
@@ -239,11 +241,7 @@ extension PrimaryDatabaseExt on PrimaryDatabase {
   Future<K> withRetry<K>(
     Future<K> Function(Database<PrimarySchema> db) fn,
   ) async {
-    return await retry(
-      () => fn(_db),
-      maxAttempts: 3,
-      retryIf: (e) => e is DatabaseConnectionException,
-    );
+    return await _withRetryZone(fn);
   }
 
   /// Runs [fn] in a transaction with retry block.
@@ -256,21 +254,33 @@ extension PrimaryDatabaseExt on PrimaryDatabase {
   Future<K> transactWithRetry<K>(
     Future<K> Function(Database<PrimarySchema> db) fn,
   ) async {
-    return await retry(
-      () async {
-        try {
-          return await _db.transact(() => fn(_db));
-        } on TransactionAbortedException catch (e) {
-          final inner = e.reason;
-          if (inner is Error || inner is ResponseException) {
-            // TODO: we should keep and use the original stacktrace in typed_sql's exception
-            throw inner;
-          }
-          rethrow;
-        }
-      },
-      maxAttempts: 3,
-      retryIf: (e) => e is DatabaseException,
-    );
+    return await _withRetryZone((db) => db.transact(() => fn(db)));
+  }
+
+  Future<K> _withRetryZone<K>(
+    Future<K> Function(Database<PrimarySchema> db) fn,
+  ) async {
+    if (Zone.current[_retryKey] == null) {
+      return await Zone.current.fork(zoneValues: {_retryKey: true}).run(() async {
+        return await retry(
+          () async {
+            try {
+              return await fn(_db);
+            } on TransactionAbortedException catch (e) {
+              final inner = e.reason;
+              if (inner is Error || inner is ResponseException) {
+                // TODO: we should keep and use the original stacktrace in typed_sql's exception
+                throw inner;
+              }
+              rethrow;
+            }
+          },
+          maxAttempts: 3,
+          retryIf: (e) => e is DatabaseException,
+        );
+      });
+    } else {
+      return await fn(_db);
+    }
   }
 }

--- a/app/lib/search/backend.dart
+++ b/app/lib/search/backend.dart
@@ -13,6 +13,7 @@ import 'package:clock/clock.dart';
 import 'package:collection/collection.dart';
 import 'package:gcloud/service_scope.dart' as ss;
 import 'package:gcloud/storage.dart';
+import 'package:googleapis/storage/v1.dart' show DetailedApiRequestError;
 import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
 // ignore: implementation_imports
@@ -450,7 +451,19 @@ class SearchBackend {
 
   Future<List<PackageDocument>?> fetchSnapshotDocuments() async {
     try {
-      final map = await _snapshotStorage.getContentAsJsonMap();
+      Map<String, dynamic>? map;
+      try {
+        map = await _snapshotStorage.getContentAsJsonMapFromTarGz();
+      } on DetailedApiRequestError catch (e) {
+        if (e.status == 404) {
+          // ignore and log
+          _logger.warning('Snapshot tar.gz archive file not found.');
+        } else {
+          rethrow;
+        }
+      }
+
+      map ??= await _snapshotStorage.getContentAsJsonMap();
       if (map == null) {
         _logger.info('No snapshot to fetch.');
         return null;

--- a/app/lib/shared/versions.dart
+++ b/app/lib/shared/versions.dart
@@ -24,10 +24,10 @@ final RegExp runtimeVersionPattern = RegExp(r'^\d{4}\.\d{2}\.\d{2}$');
 /// when the version switch happens.
 const _acceptedRuntimeVersions = <String>[
   // The current [runtimeVersion].
-  '2026.04.07',
+  '2026.04.14',
   // Fallback runtime versions.
+  '2026.04.07',
   '2026.03.27',
-  '2026.03.26',
 ];
 
 /// Sets the current runtime versions.

--- a/app/test/database/retry_zone_test.dart
+++ b/app/test/database/retry_zone_test.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/app/test/database/retry_zone_test.dart
+++ b/app/test/database/retry_zone_test.dart
@@ -1,0 +1,194 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:clock/clock.dart';
+import 'package:postgres/postgres.dart';
+import 'package:pub_dev/admin/actions/actions.dart';
+import 'package:pub_dev/database/database.dart';
+import 'package:pub_dev/database/schema.dart';
+import 'package:pub_dev/shared/env_config.dart';
+import 'package:pub_dev/shared/versions.dart';
+import 'package:pub_dev/task/models.dart';
+import 'package:test/test.dart';
+import 'package:typed_sql/typed_sql.dart';
+
+import '../shared/test_services.dart';
+
+void main() {
+  group('Retry zone - without transaction', () {
+    testWithProfile(
+      'retry returns value',
+      fn: () async {
+        int count = 0;
+        final rs = await primaryDatabase!.withRetry((db) async {
+          count++;
+          return 2;
+        });
+        expect(count, 1);
+        expect(rs, 2);
+      },
+    );
+
+    testWithProfile(
+      'ResponseException is not retried',
+      fn: () async {
+        int count = 0;
+
+        await expectLater(
+          () async => await primaryDatabase!.withRetry((db) async {
+            count++;
+            throw NotFoundException('');
+          }),
+          throwsA(isA<NotFoundException>()),
+        );
+        expect(count, 1);
+      },
+    );
+
+    testWithProfile(
+      'retried 3 times',
+      fn: () async {
+        int count = 0;
+
+        await expectLater(
+          () async => await primaryDatabase!.withRetry((db) async {
+            count++;
+            await db.insertBadData();
+          }),
+          throwsA(isA<DatabaseException>()),
+        );
+        expect(count, 3);
+      },
+    );
+
+    testWithProfile(
+      'embedded exception is retried only 3 times',
+      fn: () async {
+        int count = 0;
+
+        await expectLater(
+          () async => await primaryDatabase!.withRetry((db) async {
+            await primaryDatabase!.withRetry((db) async {
+              count++;
+              await db.insertBadData();
+            });
+          }),
+          throwsA(isA<DatabaseException>()),
+        );
+        expect(count, 3);
+      },
+    );
+
+    testWithProfile(
+      'embedded transaction is retried only 3 times',
+      fn: () async {
+        int count = 0;
+
+        await expectLater(
+          () async => await primaryDatabase!.withRetry((db) async {
+            await primaryDatabase!.transactWithRetry((db) async {
+              count++;
+              await db.insertBadData();
+            });
+          }),
+          throwsA(isA<DatabaseException>()),
+        );
+        expect(count, 3);
+      },
+    );
+  });
+
+  group('Retry zone - with transaction', () {
+    testWithProfile(
+      'transactWithRetry returns value',
+      fn: () async {
+        int count = 0;
+        final rs = await primaryDatabase!.transactWithRetry((db) async {
+          count++;
+          return 2;
+        });
+        expect(count, 1);
+        expect(rs, 2);
+      },
+    );
+
+    testWithProfile(
+      'ResponseException is not retried',
+      fn: () async {
+        int count = 0;
+
+        await expectLater(
+          () async => await primaryDatabase!.transactWithRetry((db) async {
+            count++;
+            throw NotFoundException('');
+          }),
+          throwsA(isA<NotFoundException>()),
+        );
+        expect(count, 1);
+      },
+    );
+
+    testWithProfile(
+      'retried 3 times',
+      fn: () async {
+        int count = 0;
+
+        await expectLater(
+          () async => await primaryDatabase!.transactWithRetry((db) async {
+            count++;
+            await db.insertBadData();
+          }),
+          throwsA(isA<DatabaseException>()),
+        );
+        expect(count, 3);
+      },
+    );
+
+    testWithProfile(
+      'embedded exception is retried only 3 times',
+      fn: () async {
+        int count = 0;
+
+        await expectLater(
+          () async => await primaryDatabase!.transactWithRetry((db) async {
+            await primaryDatabase!.transactWithRetry((db) async {
+              count++;
+              await db.insertBadData();
+            });
+          }),
+          throwsA(isA<DatabaseException>()),
+        );
+        expect(count, 3);
+      },
+    );
+
+    testWithProfile(
+      'embedded non-transaction is retried only 3 times',
+      fn: () async {
+        int count = 0;
+
+        await expectLater(
+          () async => await primaryDatabase!.transactWithRetry((db) async {
+            await primaryDatabase!.withRetry((db) async {
+              count++;
+              await db.insertBadData();
+            });
+          }),
+          throwsA(isA<DatabaseException>()),
+        );
+        expect(count, 3);
+      },
+    );
+  });
+}
+
+extension on Database<PrimarySchema> {
+  Future<void> insertBadData() => task_dependencies
+      .insert(
+        runtime_version: 'x'.asExpr,
+        package: 'pkg'.asExpr,
+        dependency: 'dep'.asExpr,
+      )
+      .execute();
+}

--- a/app/test/database/retry_zone_test.dart
+++ b/app/test/database/retry_zone_test.dart
@@ -2,14 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:clock/clock.dart';
-import 'package:postgres/postgres.dart';
 import 'package:pub_dev/admin/actions/actions.dart';
 import 'package:pub_dev/database/database.dart';
 import 'package:pub_dev/database/schema.dart';
-import 'package:pub_dev/shared/env_config.dart';
-import 'package:pub_dev/shared/versions.dart';
-import 'package:pub_dev/task/models.dart';
 import 'package:test/test.dart';
 import 'package:typed_sql/typed_sql.dart';
 


### PR DESCRIPTION
- Follow-up to #9336.
- I was updating the task migration (#9126), and while the callbacks introduced some friction, I think the complexity was manageable, with the exception of the loop calls, where it was not clear where we were (e.g. 3x repeat vs 3x3 repeat). Adding the zone tracking should mitigate that.
- This also handles the case where `withRetry()` is called, and then internally these is a `schema.transact()` call which could throw an exception that needs to be unboxed.