### PR TITLE
Start reading .tar.gz snapshot file (with .json.gz fallback)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Important changes to data models, configuration, and migrations between each
 AppEngine version, listed here to ease deployment and troubleshooting.
 
 ## Next Release (replace with git tag when deployed)
+ * Bump runtimeVersion to `2026.04.14`.
  * Note: Started to read search snapshots from `.tar.gz` files (with `.json.gz` fallback).
 
 ## `20260409t113000-all`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Important changes to data models, configuration, and migrations between each
 AppEngine version, listed here to ease deployment and troubleshooting.
 
 ## Next Release (replace with git tag when deployed)
+ * Note: Started to read search snapshots from `.tar.gz` files (with `.json.gz` fallback).
 
 ## `20260409t113000-all`
  * Image proxy is now enabled for all users (again).

--- a/app/lib/search/backend.dart
+++ b/app/lib/search/backend.dart
@@ -457,7 +457,7 @@ class SearchBackend {
       } on DetailedApiRequestError catch (e) {
         if (e.status == 404) {
           // ignore and log
-          _logger.warning('Snapshot archive file not found.');
+          _logger.warning('Snapshot tar.gz archive file not found.');
         } else {
           rethrow;
         }

--- a/app/lib/search/backend.dart
+++ b/app/lib/search/backend.dart
@@ -13,6 +13,7 @@ import 'package:clock/clock.dart';
 import 'package:collection/collection.dart';
 import 'package:gcloud/service_scope.dart' as ss;
 import 'package:gcloud/storage.dart';
+import 'package:googleapis/storage/v1.dart' show DetailedApiRequestError;
 import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
 // ignore: implementation_imports
@@ -450,7 +451,19 @@ class SearchBackend {
 
   Future<List<PackageDocument>?> fetchSnapshotDocuments() async {
     try {
-      final map = await _snapshotStorage.getContentAsJsonMap();
+      Map<String, dynamic>? map;
+      try {
+        map = await _snapshotStorage.getContentAsJsonMapFromTarGz();
+      } on DetailedApiRequestError catch (e) {
+        if (e.status == 404) {
+          // ignore and log
+          _logger.warning('Snapshot archive file not found.');
+        } else {
+          rethrow;
+        }
+      }
+
+      map ??= await _snapshotStorage.getContentAsJsonMap();
       if (map == null) {
         _logger.info('No snapshot to fetch.');
         return null;

--- a/app/lib/shared/versions.dart
+++ b/app/lib/shared/versions.dart
@@ -24,10 +24,10 @@ final RegExp runtimeVersionPattern = RegExp(r'^\d{4}\.\d{2}\.\d{2}$');
 /// when the version switch happens.
 const _acceptedRuntimeVersions = <String>[
   // The current [runtimeVersion].
-  '2026.04.07',
+  '2026.04.14',
   // Fallback runtime versions.
+  '2026.04.07',
   '2026.03.27',
-  '2026.03.26',
 ];
 
 /// Sets the current runtime versions.


### PR DESCRIPTION
- Follow-up to #9327
- Starts reading the tar.gz file, logging if it is missing. (If such logs do not show up, it is safe to remove the .json.gz fallback).