### PR TITLE
Remove keys from IndexedScore.

### DIFF
--- a/app/lib/search/mem_index.dart
+++ b/app/lib/search/mem_index.dart
@@ -30,7 +30,7 @@ class InMemoryPackageIndex {
   late final TokenIndex<String> _readmeIndex;
   late final TokenIndex<IndexedApiDocPage> _apiSymbolIndex;
   late final _bitArrayPool = BitArrayPool(_documents.length);
-  late final _scorePool = ScorePool(_packageNameIndex._packageNames);
+  late final _scorePool = ScorePool(_documents.length);
 
   /// Maps the tag strings to a list of document index values using bit arrays.
   /// - (`PackageDocument doc.tags -> BitArray(List<_documents.indexOf(doc)>)`).
@@ -225,7 +225,7 @@ class InMemoryPackageIndex {
   PackageSearchResult _search(
     ServiceSearchQuery query,
     BitArray packages,
-    IndexedScore<String> Function() scoreFn,
+    IndexedScore Function() scoreFn,
   ) {
     _resetBitArray(packages, query.packages);
     final predicateFilterCount = _filterOnPredicates(query, packages);
@@ -240,7 +240,7 @@ class InMemoryPackageIndex {
     // do text matching
     final parsedQueryText = query.parsedQuery.text;
     _TextResults? textResults;
-    IndexedScore<String>? packageScores;
+    IndexedScore? packageScores;
 
     if (parsedQueryText != null && parsedQueryText.isNotEmpty) {
       packageScores = scoreFn();
@@ -425,7 +425,7 @@ class InMemoryPackageIndex {
   }
 
   _TextResults _searchText(
-    IndexedScore<String> packageScores,
+    IndexedScore packageScores,
     BitArray packages,
     String text, {
     required TextMatchExtent textMatchExtent,
@@ -501,7 +501,7 @@ class InMemoryPackageIndex {
             final value = symbolPages.getValue(i);
             if (value < 0.01) continue;
 
-            final doc = symbolPages.keys[i];
+            final doc = _apiSymbolIndex.keys[i];
             if (!packages[doc.index]) continue;
 
             // skip if the previously found pages are better than the current one
@@ -551,7 +551,7 @@ class InMemoryPackageIndex {
   }
 
   Iterable<IndexedPackageHit> _rankWithValues(
-    IndexedScore<String> score, {
+    IndexedScore score, {
 
     /// When no best name match is applied, this parameter will be `-1`
     required int bestNameIndex,
@@ -579,7 +579,10 @@ class InMemoryPackageIndex {
         .map(
           (i) => IndexedPackageHit(
             i,
-            PackageHit(package: score.keys[i], score: score.getValue(i)),
+            PackageHit(
+              package: _documents[i].package,
+              score: score.getValue(i),
+            ),
           ),
         );
   }
@@ -682,9 +685,9 @@ class PackageNameIndex {
   /// Search [text] and return the matching packages with scores.
   @visibleForTesting
   Map<String, double> search(String text) {
-    IndexedScore<String>? score;
+    IndexedScore? score;
     for (final w in splitForQuery(text)) {
-      final s = IndexedScore(_packageNames);
+      final s = IndexedScore(_packageNames.length);
       searchWord(w, score: s, filterOnNonZeros: score);
       if (score == null) {
         score = s;
@@ -692,7 +695,13 @@ class PackageNameIndex {
         score.multiplyAllFrom(s);
       }
     }
-    return score?.toMap() ?? {};
+    if (score == null) return {};
+    final result = <String, double>{};
+    for (var i = 0; i < _packageNames.length; i++) {
+      final v = score.getValue(i);
+      if (v > 0.0) result[_packageNames[i]] = v;
+    }
+    return result;
   }
 
   /// Search using the parsed [word] and return the matching packages with scores
@@ -702,10 +711,10 @@ class PackageNameIndex {
   /// non-zero value are evaluated.
   void searchWord(
     String word, {
-    required IndexedScore<String> score,
-    IndexedScore<String>? filterOnNonZeros,
+    required IndexedScore score,
+    IndexedScore? filterOnNonZeros,
   }) {
-    assert(score.keys.length == _packageNames.length);
+    assert(score.length == _packageNames.length);
     final lowercasedWord = word.toLowerCase();
     final collapsedWord = _removeUnderscores(lowercasedWord);
     final parts = collapsedWord.length <= 3

--- a/app/lib/search/sdk_mem_index.dart
+++ b/app/lib/search/sdk_mem_index.dart
@@ -195,7 +195,13 @@ class SdkMemIndex implements SdkIndex {
 
       final plainResults = library.tokenIndex.withSearchWords(
         words,
-        (score) => score.top(3, minValue: 0.05),
+        (score) => Map.fromEntries(
+          score
+              .topIndices(3, minValue: 0.05)
+              .map(
+                (i) => MapEntry(library.tokenIndex.keys[i], score.getValue(i)),
+              ),
+        ),
       );
       if (plainResults.isEmpty) continue;
 

--- a/app/lib/search/token_index.dart
+++ b/app/lib/search/token_index.dart
@@ -48,7 +48,9 @@ class TokenIndex<K> {
 
   late final _length = _ids.length;
 
-  late final _scorePool = ScorePool(_ids);
+  late final _scorePool = ScorePool(_ids.length);
+
+  List<K> get keys => _ids;
 
   TokenIndex(
     List<K> ids,
@@ -148,10 +150,10 @@ class TokenIndex<K> {
   /// in the [fn] callback, reusing the score buffers between calls.
   R withSearchWords<R>(
     List<String> words,
-    R Function(IndexedScore<K> score) fn, {
+    R Function(IndexedScore score) fn, {
     double weight = 1.0,
   }) {
-    IndexedScore<K>? score;
+    IndexedScore? score;
 
     weight = math.pow(weight, 1 / words.length).toDouble();
     for (final w in words) {
@@ -195,7 +197,14 @@ extension StringTokenIndexExt on TokenIndex<String> {
   /// scoring.
   @visibleForTesting
   Map<String, double> search(String text) {
-    return withSearchWords(splitForQuery(text), (score) => score.toMap());
+    return withSearchWords(splitForQuery(text), (score) {
+      final result = <String, double>{};
+      for (var i = 0; i < score.length; i++) {
+        final v = score.getValue(i);
+        if (v > 0.0) result[keys[i]] = v;
+      }
+      return result;
+    });
   }
 }
 
@@ -258,10 +267,10 @@ abstract class _AllocationPool<T> {
 }
 
 /// A reusable pool for [IndexedScore] instances to spare some memory allocation.
-class ScorePool<K> extends _AllocationPool<IndexedScore<K>> {
-  ScorePool(List<K> keys)
+class ScorePool extends _AllocationPool<IndexedScore> {
+  ScorePool(int length)
     : super(
-        () => IndexedScore(keys),
+        () => IndexedScore(length),
         // sets all values to 0.0
         (score) => score._values.setAll(
           0,
@@ -282,19 +291,12 @@ class BitArrayPool extends _AllocationPool<BitArray> {
 }
 
 /// Mutable score list that can accessed via integer index.
-class IndexedScore<K> {
-  final List<K> _keys;
+class IndexedScore {
   final List<double> _values;
 
-  IndexedScore._(this._keys, this._values);
+  IndexedScore(int length, [double value = 0.0])
+    : _values = List<double>.filled(length, value);
 
-  factory IndexedScore(List<K> keys, [double value = 0.0]) =>
-      IndexedScore._(keys, List<double>.filled(keys.length, value));
-
-  factory IndexedScore.fromMap(Map<K, double> values) =>
-      IndexedScore._(values.keys.toList(), values.values.toList());
-
-  List<K> get keys => _keys;
   late final length = _values.length;
 
   int positiveCount() {
@@ -360,7 +362,7 @@ class IndexedScore<K> {
     return list;
   }
 
-  Map<K, double> top(int count, {double? minValue}) {
+  List<int> topIndices(int count, {double? minValue}) {
     minValue ??= 0.0;
     final heap = Heap<int>((a, b) => -_values[a].compareTo(_values[b]));
     for (var i = 0; i < length; i++) {
@@ -368,19 +370,6 @@ class IndexedScore<K> {
       if (v < minValue) continue;
       heap.collect(i);
     }
-    return Map.fromEntries(
-      heap.getAndRemoveTopK(count).map((i) => MapEntry(_keys[i], _values[i])),
-    );
-  }
-
-  Map<K, double> toMap() {
-    final map = <K, double>{};
-    for (var i = 0; i < _values.length; i++) {
-      final v = _values[i];
-      if (v > 0.0) {
-        map[_keys[i]] = v;
-      }
-    }
-    return map;
+    return heap.getAndRemoveTopK(count).toList();
   }
 }

--- a/app/test/search/token_index_test.dart
+++ b/app/test/search/token_index_test.dart
@@ -106,12 +106,16 @@ void main() {
   });
 
   group('IndexedScore', () {
-    final score = IndexedScore.fromMap({'a': 100.0, 'b': 30.0, 'c': 55.0});
+    const keys = ['a', 'b', 'c'];
+    final score = IndexedScore(3)
+      ..setValue(0, 100.0)
+      ..setValue(1, 30.0)
+      ..setValue(2, 55.0);
 
-    test('top', () {
-      expect(score.top(1), {'a': 100.0});
-      expect(score.top(2), {'a': 100.0, 'c': 55.0});
-      expect(score.top(2, minValue: 60), {'a': 100.0});
+    test('topIndices', () {
+      expect(score.topIndices(1).map((i) => keys[i]), ['a']);
+      expect(score.topIndices(2).map((i) => keys[i]), ['a', 'c']);
+      expect(score.topIndices(2, minValue: 60).map((i) => keys[i]), ['a']);
     });
   });
 }


### PR DESCRIPTION
Part of the refactor wrt. `TokenIndex`, decoupling the keys from the stored values (for now in the score accumulation part).