### PR TITLE
Remove _ids from TokenIndex

### DIFF
--- a/app/lib/search/mem_index.dart
+++ b/app/lib/search/mem_index.dart
@@ -26,9 +26,10 @@ class InMemoryPackageIndex {
   final List<PackageDocument> _documents;
   final _nameToIndex = <String, int>{};
   late final PackageNameIndex _packageNameIndex;
-  late final TokenIndex<String> _descrIndex;
-  late final TokenIndex<String> _readmeIndex;
-  late final TokenIndex<IndexedApiDocPage> _apiSymbolIndex;
+  late final TokenIndex _descrIndex;
+  late final TokenIndex _readmeIndex;
+  late final List<IndexedApiDocPage> _apiDocPageKeys;
+  late final TokenIndex _apiSymbolIndex;
   late final _bitArrayPool = BitArrayPool(_documents.length);
   late final _scorePool = ScorePool(_documents.length);
 
@@ -78,15 +79,12 @@ class InMemoryPackageIndex {
     final packageKeys = _documents.map((d) => d.package).toList();
     _packageNameIndex = PackageNameIndex(packageKeys);
     _descrIndex = TokenIndex(
-      packageKeys,
       _documents.map((d) => d.description).toList(),
       skipDocumentWeight: true,
     );
-    _readmeIndex = TokenIndex(
-      packageKeys,
-      _documents.map((d) => d.readme).toList(),
-    );
-    _apiSymbolIndex = TokenIndex.fromValues(apiDocPageKeys, apiDocPageValues);
+    _readmeIndex = TokenIndex(_documents.map((d) => d.readme).toList());
+    _apiDocPageKeys = apiDocPageKeys;
+    _apiSymbolIndex = TokenIndex.fromValues(apiDocPageValues);
 
     // update download scores only if they were not set (should happen on old runtime's snapshot and local tests)
     if (_documents.any((e) => e.downloadScore == null)) {
@@ -501,7 +499,7 @@ class InMemoryPackageIndex {
             final value = symbolPages.getValue(i);
             if (value < 0.01) continue;
 
-            final doc = _apiSymbolIndex.keys[i];
+            final doc = _apiDocPageKeys[i];
             if (!packages[doc.index]) continue;
 
             // skip if the previously found pages are better than the current one

--- a/app/lib/search/sdk_mem_index.dart
+++ b/app/lib/search/sdk_mem_index.dart
@@ -170,7 +170,8 @@ class SdkMemIndex implements SdkIndex {
         name: e.key,
         libraryUrl: (baseUris[e.key] ?? baseUri).toString(),
         description: descriptions[e.key],
-        tokenIndex: TokenIndex.fromMap(e.value),
+        tokenIndexKeys: e.value.keys.toList(),
+        tokenIndex: TokenIndex(e.value.values.toList()),
       );
     }
   }
@@ -199,7 +200,7 @@ class SdkMemIndex implements SdkIndex {
           score
               .topIndices(3, minValue: 0.05)
               .map(
-                (i) => MapEntry(library.tokenIndex.keys[i], score.getValue(i)),
+                (i) => MapEntry(library.tokenIndexKeys[i], score.getValue(i)),
               ),
         ),
       );
@@ -262,7 +263,8 @@ class _Library {
   final String name;
   final String libraryUrl;
   final String? description;
-  final TokenIndex<String> tokenIndex;
+  final List<String> tokenIndexKeys;
+  final TokenIndex tokenIndex;
 
   _Library({
     required this.sdk,
@@ -270,6 +272,7 @@ class _Library {
     required this.name,
     required this.libraryUrl,
     required this.description,
+    required this.tokenIndexKeys,
     required this.tokenIndex,
   });
 

--- a/app/lib/search/token_index.dart
+++ b/app/lib/search/token_index.dart
@@ -40,48 +40,29 @@ class _WeightedDoc {
 }
 
 /// Stores a token -> documentId inverted index with weights.
-class TokenIndex<K> {
-  final List<K> _ids;
+class TokenIndex {
+  final int _length;
 
   /// Maps token Strings to a weighted documents (addressed via indexes).
   final _inverseIds = <String, List<_WeightedDoc>>{};
+  late final _scorePool = ScorePool(_length);
 
-  late final _length = _ids.length;
-
-  late final _scorePool = ScorePool(_ids.length);
-
-  List<K> get keys => _ids;
-
-  TokenIndex(
-    List<K> ids,
-    List<String?> values, {
-    bool skipDocumentWeight = false,
-  }) : _ids = ids {
-    assert(ids.length == values.length);
-    final length = values.length;
-    for (var i = 0; i < length; i++) {
+  TokenIndex(List<String?> values, {bool skipDocumentWeight = false})
+    : _length = values.length {
+    for (var i = 0; i < _length; i++) {
       final text = values[i];
-
-      if (text == null) {
-        continue;
-      }
+      if (text == null) continue;
       _build(i, text, skipDocumentWeight);
     }
   }
 
   TokenIndex.fromValues(
-    List<K> ids,
     List<List<String>?> values, {
     bool skipDocumentWeight = false,
-  }) : _ids = ids {
-    assert(ids.length == values.length);
-    final length = values.length;
-    for (var i = 0; i < length; i++) {
+  }) : _length = values.length {
+    for (var i = 0; i < _length; i++) {
       final parts = values[i];
-
-      if (parts == null || parts.isEmpty) {
-        continue;
-      }
+      if (parts == null || parts.isEmpty) continue;
       for (final text in parts) {
         _build(i, text, skipDocumentWeight);
       }
@@ -108,12 +89,6 @@ class TokenIndex<K> {
         weights.add(_WeightedDoc(i, weight));
       }
     }
-  }
-
-  factory TokenIndex.fromMap(Map<K, String> map) {
-    final keys = map.keys.toList();
-    final values = map.values.toList();
-    return TokenIndex(keys, values);
   }
 
   /// Match the text against the corpus and return the tokens or
@@ -189,22 +164,6 @@ class TokenIndex<K> {
         score.setValueMaxOf(e.index, matchWeight * e.weight * weight);
       }
     }
-  }
-}
-
-extension StringTokenIndexExt on TokenIndex<String> {
-  /// Search the index for [text], with a (term-match / document coverage percent)
-  /// scoring.
-  @visibleForTesting
-  Map<String, double> search(String text) {
-    return withSearchWords(splitForQuery(text), (score) {
-      final result = <String, double>{};
-      for (var i = 0; i < score.length; i++) {
-        final v = score.getValue(i);
-        if (v > 0.0) result[keys[i]] = v;
-      }
-      return result;
-    });
   }
 }
 

--- a/app/test/search/token_index_test.dart
+++ b/app/test/search/token_index_test.dart
@@ -2,13 +2,25 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:pub_dev/search/text_utils.dart';
 import 'package:pub_dev/search/token_index.dart';
 import 'package:test/test.dart';
+
+Map<String, double> _search(TokenIndex index, List<String> keys, String text) {
+  return index.withSearchWords(splitForQuery(text), (score) {
+    final result = <String, double>{};
+    for (var i = 0; i < score.length; i++) {
+      final v = score.getValue(i);
+      if (v > 0.0) result[keys[i]] = v;
+    }
+    return result;
+  });
+}
 
 void main() {
   group('TokenIndex', () {
     test('partial token lookup', () {
-      final index = TokenIndex.fromMap({'x': 'SomeCamelCasedWord and others'});
+      final index = TokenIndex(['SomeCamelCasedWord and others']);
       expect(index.lookupTokens('word').tokenWeights, {'word': 1.0});
       expect(index.lookupTokens('OtherCased').tokenWeights, {
         'cased': closeTo(0.70, 0.01),
@@ -19,23 +31,19 @@ void main() {
     });
 
     test('No match', () {
-      final index = TokenIndex.fromMap({
-        'uri://http': 'http',
-        'uri://http_magic': 'http_magic',
-      });
+      final keys = ['uri://http', 'uri://http_magic'];
+      final index = TokenIndex(['http', 'http_magic']);
 
-      expect(index.search('xml'), {
+      expect(_search(index, keys, 'xml'), {
         // no match for http
         // no match for http_magic
       });
     });
 
     test('Scoring exact and partial matches', () {
-      final index = TokenIndex.fromMap({
-        'uri://http': 'http',
-        'uri://http_magic': 'http_magic',
-      });
-      expect(index.search('http'), {
+      final keys = ['uri://http', 'uri://http_magic'];
+      final index = TokenIndex(['http', 'http_magic']);
+      expect(_search(index, keys, 'http'), {
         'uri://http': closeTo(0.993, 0.001),
         'uri://http_magic': closeTo(0.989, 0.001),
       });
@@ -43,37 +51,35 @@ void main() {
 
     test('CamelCase indexing', () {
       final String queueText = '.DoubleLinkedQueue()';
-      final index = TokenIndex.fromMap({
-        'queue': queueText,
-        'queue_lower': queueText.toLowerCase(),
-        'unmodifiable': 'CustomUnmodifiableMapBase',
-      });
-      expect(index.search('queue'), {'queue': closeTo(0.53, 0.01)});
-      expect(index.search('unmodifiabl'), {}); // no partial matches
-      expect(index.search('unmodifiable'), {
+      final keys = ['queue', 'queue_lower', 'unmodifiable'];
+      final index = TokenIndex([
+        queueText,
+        queueText.toLowerCase(),
+        'CustomUnmodifiableMapBase',
+      ]);
+      expect(_search(index, keys, 'queue'), {'queue': closeTo(0.53, 0.01)});
+      expect(_search(index, keys, 'unmodifiabl'), {}); // no partial matches
+      expect(_search(index, keys, 'unmodifiable'), {
         'unmodifiable': closeTo(0.68, 0.01),
       });
     });
 
     test('Wierd cases: riak client', () {
-      final index = TokenIndex.fromMap({
-        'uri://cli': 'cli',
-        'uri://riak_client': 'riak_client',
-        'uri://teamspeak': 'teamspeak',
+      final keys = ['uri://cli', 'uri://riak_client', 'uri://teamspeak'];
+      final index = TokenIndex(['cli', 'riak_client', 'teamspeak']);
+
+      expect(_search(index, keys, 'riak'), {
+        'uri://riak_client': closeTo(0.99, 0.01),
       });
-
-      expect(index.search('riak'), {'uri://riak_client': closeTo(0.99, 0.01)});
-
-      expect(index.search('riak client'), {
+      expect(_search(index, keys, 'riak client'), {
         'uri://riak_client': closeTo(0.98, 0.01),
       });
     });
 
     test('Do not overweight partial matches', () {
-      final index = TokenIndex.fromMap({
-        'flutter_qr_reader': 'flutter_qr_reader',
-      });
-      final data = index.search('ByteDataReader');
+      final keys = ['flutter_qr_reader'];
+      final index = TokenIndex(['flutter_qr_reader']);
+      final data = _search(index, keys, 'ByteDataReader');
       // The partial match should not return more than 0.65 as score.
       expect(data, {'flutter_qr_reader': lessThan(0.65)});
     });
@@ -91,8 +97,8 @@ void main() {
         'location_picker',
         'background_location_updates',
       ];
-      final index = TokenIndex.fromMap(Map.fromIterables(names, names));
-      final match = index.search('location');
+      final index = TokenIndex(names);
+      final match = _search(index, names, 'location');
       // location should be the top value, everything else should be lower
       final locationValue = match['location'];
       expect(


### PR DESCRIPTION
- Continuing #9343 by separating the id list from the token index, storing the list separately.