### PR TITLE
Fix like button CSS.

### DIFF
--- a/pkg/web_css/lib/src/_detail_page.scss
+++ b/pkg/web_css/lib/src/_detail_page.scss
@@ -183,14 +183,24 @@ $detail-tabs-tablet-width: calc(100% - 240px);
   text-transform: uppercase;
   white-space: nowrap;
   display: flex;
-  margin-top: -4px;
   border: 1px solid transparent;
   padding: 2px;
+  gap: 4px;
+  align-items: start;
 
   .like-button-and-label--count-wrapper {
     display: inline-block;
-    padding-top: 6px;
     min-width: 12px;
+  }
+
+  .like-button-and-label--button {
+    width: 18px;
+    padding: 0;
+  }
+
+  .like-button-and-label--button img {
+    width: 18px;
+    height: 18px;
   }
 
   &:focus-within {

--- a/pkg/web_css/lib/src/_list.scss
+++ b/pkg/web_css/lib/src/_list.scss
@@ -234,11 +234,6 @@
     font-weight: 500;
     margin: 0;
     overflow-wrap: anywhere;
-
-    .like-button-and-label--button img {
-      width: 18px;
-      height: 18px;
-    }
   }
 
   .packages-recent {


### PR DESCRIPTION
- Fixes #9347
- The key fix is the `padding: 0` part, that was part of the material icon button and was missed with the migration.