### PR TITLE
fix: preserve angle brackets in changelog notification excerpts

### DIFF
--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -1562,14 +1562,7 @@ class PackageBackend {
       /// Limit the changelog to 10 lines, 75 characters each:
       final lines = text.split('\n');
       final excerpt = lines
-          // prevent accidental HTML-tag creation
-          .map(
-            (line) => line
-                .replaceAll('<', '[')
-                .replaceAll('>', ']')
-                .replaceAll('&', ' ')
-                .trim(),
-          )
+          .map((line) => line.trim())
           // filter empty or decorative lines to maximalize usefulness
           .where(
             (line) =>

--- a/app/lib/shared/model_properties.dart
+++ b/app/lib/shared/model_properties.dart
@@ -58,6 +58,6 @@ class CompatibleListProperty<T> extends Property {
 /// Similar to [StringListProperty] but one which is fully compatible with
 /// python's 'db' implementation.
 class CompatibleStringListProperty extends CompatibleListProperty<String> {
-  const CompatibleStringListProperty({super.propertyName, super.indexed})
+  const CompatibleStringListProperty({super.propertyName, super.indexed = true})
     : super(const StringProperty(required: true));
 }

--- a/app/lib/shared/model_properties.dart
+++ b/app/lib/shared/model_properties.dart
@@ -58,12 +58,6 @@ class CompatibleListProperty<T> extends Property {
 /// Similar to [StringListProperty] but one which is fully compatible with
 /// python's 'db' implementation.
 class CompatibleStringListProperty extends CompatibleListProperty<String> {
-  const CompatibleStringListProperty({
-    String? propertyName,
-    bool indexed = true,
-  }) : super(
-         const StringProperty(required: true),
-         propertyName: propertyName,
-         indexed: indexed,
-       );
+  const CompatibleStringListProperty({super.propertyName, super.indexed})
+    : super(const StringProperty(required: true));
 }

--- a/app/test/package/upload_test.dart
+++ b/app/test/package/upload_test.dart
@@ -1481,7 +1481,7 @@ void main() {
           final tarball = await packageArchiveBytes(
             pubspecContent: generatePubspecYaml('oxygen', '3.0.0'),
             changelogContent:
-                '# Changelog\n\n## v3.0.0\n\nSome bug fixes:\n- one,\n- two\n\n',
+                '# Changelog\n\n## v3.0.0\n\nSome bug fixes:\n- one,\n- Require `analyzer: \'>=10.0.0 <14.0.0\'`\n\n',
           );
           final message = await createPubApiClient(
             authToken: adminClientToken,
@@ -1510,7 +1510,7 @@ void main() {
               '```\n'
               'Some bug fixes:\n'
               '- one,\n'
-              '- two\n'
+              '- Require `analyzer: \'>=10.0.0 <14.0.0\'`\n'
               '```\n\n',
             ),
           );


### PR DESCRIPTION
Removes the explicit conversion of '<' and '>' into '[' and ']' inside
the changelog excerpt generation. This restores accurate rendering for
version constraint statements (e.g., `>=10.0.0 <14.0.0`) in published
package notification emails.

Html output remains completely secure as excerpts continue to be safely
processed via `htmlEscape.convert()` in the underlying template.

(also fixed new lint for super params!)
