### PR TITLE
Test updates: await on async queue, check for no dart:html use.

### DIFF
--- a/app/test/shared/test_services.dart
+++ b/app/test/shared/test_services.dart
@@ -149,6 +149,7 @@ final class FakeAppengineEnv {
                 await fork(() async {
                   await fn();
                 });
+                await asyncQueue.ongoingProcessing;
                 await _postTestVerification(integrityProblem: integrityProblem);
               },
             );

--- a/pkg/web_app/test/no_dart_html_test.dart
+++ b/pkg/web_app/test/no_dart_html_test.dart
@@ -1,0 +1,19 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+void main() {
+  test('no dart:html use in pkg/web_app', () async {
+    final dir = Directory('lib');
+    await for (final f in dir.list(recursive: true)) {
+      if (f is File && f.path.endsWith('.dart')) {
+        final content = await f.readAsString();
+        expect(content, isNot(contains('dart:html')), reason: f.path);
+      }
+    }
+  });
+}


### PR DESCRIPTION
I think the await is beneficial to fix a very small fraction of flaky tests.