### PR TITLE
Report advisoriesUpdated: null if there are no advisories

### DIFF
--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -977,7 +977,7 @@ class PackageBackend {
       replacedBy: pkg.replacedBy,
       latest: latest.toApiVersionInfo(),
       versions: packageVersions.map((pv) => pv.toApiVersionInfo()).toList(),
-      advisoriesUpdated: pkg.latestAdvisory,
+      advisoriesUpdated: pkg.hasAdvisories ? pkg.latestAdvisory : null,
     );
   }
 

--- a/app/lib/package/models.dart
+++ b/app/lib/package/models.dart
@@ -169,6 +169,10 @@ class Package extends db.ExpandoModel<String> {
   @db.DateTimeProperty()
   DateTime? latestAdvisory;
 
+  /// Whether the package is affected by any active security advisories.
+  @db.BoolProperty(required: true)
+  bool hasAdvisories = false;
+
   Package();
 
   /// Creates a new [Package] and populates all of its fields from [version].

--- a/app/lib/service/security_advisories/backend.dart
+++ b/app/lib/service/security_advisories/backend.dart
@@ -69,10 +69,6 @@ class SecurityAdvisoryBackend {
       skipCache: skipCache,
     );
 
-    if (advisories.isEmpty) {
-      return ListAdvisoriesResponse(advisories: [], advisoriesUpdated: null);
-    }
-
     final p = await packageBackend.lookupPackage(package);
     final latestAdvisory =
         p?.latestAdvisory ?? DateTime.fromMillisecondsSinceEpoch(0);
@@ -166,6 +162,7 @@ class SecurityAdvisoryBackend {
         final packages = await _lookupAffectedPackages(newAdvisory, tx);
         for (final pkg in packages) {
           pkg.latestAdvisory = syncTime;
+          pkg.hasAdvisories = true;
           pkg.updated = clock.now().toUtc();
           updatedPackages.add(pkg.name!);
         }
@@ -231,6 +228,10 @@ class SecurityAdvisoryBackend {
         final packages = await _lookupAffectedPackages(advisory, tx);
         for (final pkg in packages) {
           pkg.latestAdvisory = syncTime;
+          final otherAdvisoriesQuery = tx.query<SecurityAdvisory>(tx.emptyKey)
+            ..filter('affectedPackages =', pkg.name!);
+          final list = await otherAdvisoriesQuery.run().toList();
+          pkg.hasAdvisories = list.any((a) => a.id != advisory.id);
           pkg.updated = clock.now().toUtc();
           updatedPackages.add(pkg.name!);
         }

--- a/app/lib/service/security_advisories/backend.dart
+++ b/app/lib/service/security_advisories/backend.dart
@@ -69,6 +69,10 @@ class SecurityAdvisoryBackend {
       skipCache: skipCache,
     );
 
+    if (advisories.isEmpty) {
+      return ListAdvisoriesResponse(advisories: [], advisoriesUpdated: null);
+    }
+
     final p = await packageBackend.lookupPackage(package);
     final latestAdvisory =
         p?.latestAdvisory ?? DateTime.fromMillisecondsSinceEpoch(0);

--- a/app/test/service/security_advisory/security_advisory_test.dart
+++ b/app/test/service/security_advisory/security_advisory_test.dart
@@ -12,6 +12,8 @@ import 'package:path/path.dart' as path;
 import 'package:pub_dev/fake/backend/fake_auth_provider.dart';
 import 'package:pub_dev/package/backend.dart';
 import 'package:pub_dev/service/security_advisories/backend.dart';
+import 'package:pub_dev/shared/datastore.dart';
+import 'package:pub_dev/shared/redis_cache.dart';
 import 'package:pub_dev/shared/utils.dart';
 import 'package:test/test.dart';
 
@@ -504,7 +506,9 @@ void main() {
       neonPkg = await packageBackend.lookupPackage('neon');
 
       expect(oxygenPkg!.latestAdvisory, syncTime);
+      expect(oxygenPkg.hasAdvisories, isTrue);
       expect(neonPkg!.latestAdvisory, isNull);
+      expect(neonPkg.hasAdvisories, isFalse);
 
       final client = await createFakeAuthPubApiClient(
         email: adminAtPubDevEmail,
@@ -522,6 +526,35 @@ void main() {
       );
       expect(neonPkgInfo.advisoriesUpdated, isNull);
 
+      // When latestAdvisory is a valid timestamp but hasAdvisories is false
+      neonPkg.latestAdvisory = syncTime;
+      neonPkg.hasAdvisories = false;
+      await dbService.commit(inserts: [neonPkg]);
+      await cache.packageDataGz('neon').purge();
+
+      final neonPkgInfo2 = PackageData.fromJson(
+        json.decode(utf8.decode(await client.listVersions('neon')))
+            as Map<String, dynamic>,
+      );
+      expect(neonPkgInfo2.advisoriesUpdated, isNull);
+
+      // When hasAdvisories is true
+      neonPkg.hasAdvisories = true;
+      await dbService.commit(inserts: [neonPkg]);
+      await cache.packageDataGz('neon').purge();
+
+      final neonPkgInfo3 = PackageData.fromJson(
+        json.decode(utf8.decode(await client.listVersions('neon')))
+            as Map<String, dynamic>,
+      );
+      expect(neonPkgInfo3.advisoriesUpdated, syncTime);
+
+      // Reset neonPkg back to default
+      neonPkg.latestAdvisory = null;
+      neonPkg.hasAdvisories = false;
+      await dbService.commit(inserts: [neonPkg]);
+      await cache.packageDataGz('neon').purge();
+
       final oxygenRes = await client.getPackageAdvisories('oxygen');
       expect(oxygenRes.advisories.length, 1);
       expect(oxygenRes.advisories.first.id, '123');
@@ -529,7 +562,7 @@ void main() {
 
       final neonRes = await client.getPackageAdvisories('neon');
       expect(neonRes.advisories, isEmpty);
-      expect(neonRes.advisoriesUpdated, isNull);
+      expect(neonRes.advisoriesUpdated, DateTime.fromMillisecondsSinceEpoch(0));
     },
   );
 

--- a/app/test/service/security_advisory/security_advisory_test.dart
+++ b/app/test/service/security_advisory/security_advisory_test.dart
@@ -529,7 +529,7 @@ void main() {
 
       final neonRes = await client.getPackageAdvisories('neon');
       expect(neonRes.advisories, isEmpty);
-      expect(neonRes.advisoriesUpdated, DateTime.fromMillisecondsSinceEpoch(0));
+      expect(neonRes.advisoriesUpdated, isNull);
     },
   );
 


### PR DESCRIPTION
This should fix: https://github.com/dart-lang/pub/issues/4818

We should also have the client fetch advisories in parallel.