### PR TITLE
Runtime version bump for task SQL migration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Important changes to data models, configuration, and migrations between each
 AppEngine version, listed here to ease deployment and troubleshooting.
 
 ## Next Release (replace with git tag when deployed)
+ * Bump runtimeVersion to `2026.06.01`.
+ * Note: switched to Postgres-backed task backend.
 
 ## `20260528t110400-all`
  * Bump runtimeVersion to `2026.05.22`.

--- a/app/lib/shared/versions.dart
+++ b/app/lib/shared/versions.dart
@@ -24,10 +24,9 @@ final RegExp runtimeVersionPattern = RegExp(r'^\d{4}\.\d{2}\.\d{2}$');
 /// when the version switch happens.
 const _acceptedRuntimeVersions = <String>[
   // The current [runtimeVersion].
-  '2026.05.22',
+  '2026.06.01',
   // Fallback runtime versions.
-  '2026.05.19',
-  '2026.05.05',
+  '2026.05.12',
 ];
 
 /// Sets the current runtime versions.


### PR DESCRIPTION
- `2026.05.12` was the previous attempt, so most packages will already start with a fallback analysis.
- This is to be merged only if #9410 gets merged.