### PR TITLE
Fix task scan in backfillTrackingState.

### DIFF
--- a/app/lib/task/backend.dart
+++ b/app/lib/task/backend.dart
@@ -262,30 +262,30 @@ class TaskBackend {
     await pool.done;
 
     // Check that all [PackageState] entities have a matching [Package] entity.
+    final packagesToDelete = <String>{};
     await _database.withRetry((db) async {
-      final packagesToDelete = <String>{};
       await for (final state in db.tasksAccess.listAllForCurrentRuntime()) {
         if (packageNames.contains(state.package)) {
           continue;
         }
         // Lookup the package to ensure it really doesn't exist
-        if (!await _datastore.packages.exists(state.package)) {
+        if (await _datastore.packages.exists(state.package)) {
           continue;
         }
         packagesToDelete.add(state.package);
       }
-      for (final package in packagesToDelete) {
-        try {
-          await db.tasksAccess.delete(package);
-        } catch (e, st) {
-          _log.severe('failed to untrack "$package"', e, st);
-          if (error == null) {
-            error = e; // save [e] for later, if this is the first failure
-            stackTrace = st;
-          }
+    });
+    for (final package in packagesToDelete) {
+      try {
+        await _database.withRetry((db) => db.tasksAccess.delete(package));
+      } catch (e, st) {
+        _log.severe('failed to untrack "$package"', e, st);
+        if (error == null) {
+          error = e; // save [e] for later, if this is the first failure
+          stackTrace = st;
         }
       }
-    });
+    }
 
     // If we had any error, we rethrow to ensure that any background task
     // calling this method won't register completion as successful.


### PR DESCRIPTION
- Efficiency fix: decouple the two phase (and the two retry), as otherwise a transient issue while deleting the task would re-start the streaming and processing of all packages.
- Functional fix: existence check was wrong. However, it doesn't affected much in practice, since line 268 mostly prevented existing packages from being deleted. Probably impact: package state was not deleted, while it should have.
