### PR TITLE
Preserve Stacktrace when extracting inner transaction.

### DIFF
--- a/app/lib/database/database.dart
+++ b/app/lib/database/database.dart
@@ -396,24 +396,25 @@ extension PrimaryDatabaseExt on PrimaryDatabase {
     Future<K> Function(Database<PrimarySchema> db) fn,
   ) async {
     if (Zone.current[_retryKey] == null) {
-      return await Zone.current.fork(zoneValues: {_retryKey: true}).run(() async {
-        return await retry(
-          () async {
-            try {
-              return await fn(_db);
-            } on TransactionAbortedException catch (e) {
-              final inner = e.reason;
-              if (inner is Error || inner is ResponseException) {
-                // TODO: we should keep and use the original stacktrace in typed_sql's exception
-                throw inner;
+      return await Zone.current.fork(zoneValues: {_retryKey: true}).run(
+        () async {
+          return await retry(
+            () async {
+              try {
+                return await fn(_db);
+              } on TransactionAbortedException catch (e, st) {
+                final inner = e.reason;
+                if (inner is Error || inner is ResponseException) {
+                  Error.throwWithStackTrace(inner, st);
+                }
+                rethrow;
               }
-              rethrow;
-            }
-          },
-          maxAttempts: 3,
-          retryIf: (e) => e is DatabaseException,
-        );
-      });
+            },
+            maxAttempts: 3,
+            retryIf: (e) => e is DatabaseException,
+          );
+        },
+      );
     } else {
       return await fn(_db);
     }

--- a/app/lib/task/backend.dart
+++ b/app/lib/task/backend.dart
@@ -290,8 +290,7 @@ class TaskBackend {
     // If we had any error, we rethrow to ensure that any background task
     // calling this method won't register completion as successful.
     if (error != null) {
-      // Hack to rethrow [error] with [stackTrace]
-      await Future.error(error!, stackTrace);
+      Error.throwWithStackTrace(error!, stackTrace!);
     }
   }
 


### PR DESCRIPTION
The main changes are the `Error.throwWithStackTrace` calls, the rest is formatting.

Note: I'm wondering if `TransactionAbortedException` should also keep the original stacktrace it catched.