### PR TITLE
Fix DB connection string parameter trimming.

### DIFF
--- a/app/lib/database/database.dart
+++ b/app/lib/database/database.dart
@@ -285,16 +285,13 @@ String _expandConnectionUrl(String url) {
   final uri = Uri.parse(url.trim());
   return uri
       .replace(
-        queryParameters: uri.queryParameters.map(
-          (k, v) => MapEntry(k, v.toString().trim()),
-        ),
-      )
-      .replace(
         queryParameters: {
           // replace connections after an hour (value is in seconds)
           'max_connection_age': '3600',
           'max_connection_count': '8',
-          ...uri.queryParameters,
+          ...uri.queryParameters.map(
+            (k, v) => MapEntry(k, v.toString().trim()),
+          ),
         },
       )
       .toString();


### PR DESCRIPTION
It turns out the code was a no-op in practice, since it (a) first created the trimmed values, but then (b) override it with the originals from `uri.queryParameters`.

Since it was a no-op, and since both staging and prod is working now, we may consider to remove it altogether.