### PR TITLE
Replace material design select widget to plain HTML <select>.

### DIFF
--- a/app/lib/frontend/dom/material.dart
+++ b/app/lib/frontend/dom/material.dart
@@ -285,9 +285,9 @@ d.Node checkbox({
   );
 }
 
-/// Renders a material dropdown / select component.
+/// Renders a plain HTML dropdown / select component.
 ///
-/// [options] must be a list of `<li>` elements from [option].
+/// [options] must be a list of `<option>` elements from [option].
 d.Node dropdown({
   required String id,
   required String label,
@@ -295,74 +295,30 @@ d.Node dropdown({
   Iterable<String>? classes,
 }) {
   return d.div(
-    id: id,
-    classes: ['mdc-select', 'mdc-select--filled', ...?classes],
-    attributes: {'data-mdc-auto-init': 'MDCSelect'},
+    classes: ['pub-select', ...?classes],
     children: [
-      d.div(
-        classes: ['mdc-select__anchor'],
-        children: [
-          d.span(classes: ['mdc-select__ripple']),
-          d.span(classes: ['mdc-select__selected-text']),
-          d.span(
-            classes: ['mdc-select__dropdown-icon'],
-            child: d.element(
-              'svg',
-              classes: ['mdc-select__dropdown-icon-graphic'],
-              attributes: {'viewBox': '7 10 10 5'},
-              children: [
-                d.element(
-                  'polygon',
-                  classes: ['mdc-select__dropdown-icon-inactive'],
-                  attributes: {
-                    'stroke': 'none',
-                    'fill-rule': 'evenodd',
-                    'points': '7 10 12 15 17 10',
-                  },
-                ),
-                d.element(
-                  'polygon',
-                  classes: ['mdc-select__dropdown-icon-active'],
-                  attributes: {
-                    'stroke': 'none',
-                    'fill-rule': 'evenodd',
-                    'points': '7 15 12 10 17 15',
-                  },
-                ),
-              ],
-            ),
-          ),
-          d.span(classes: ['mdc-floating-label'], text: label),
-          d.span(classes: ['mdc-line-ripple']),
-        ],
+      d.label(
+        classes: ['pub-select-label'],
+        attributes: {'for': id},
+        text: label,
       ),
-      d.div(
-        classes: [
-          'mdc-select__menu',
-          'mdc-menu',
-          'mdc-menu-surface',
-          'mdc-menu-surface--fullwidth',
-        ],
-        child: d.ul(classes: ['mdc-list'], children: options),
-      ),
+      d.select(id: id, classes: ['pub-select-input'], children: options),
     ],
   );
 }
 
-/// Renders an option item for material dropdown / select component.
+/// Renders an `<option>` item for the [dropdown] / select component.
 d.Node option({
   required String value,
   required String text,
   bool selected = false,
   bool disabled = false,
 }) {
-  return d.li(
-    classes: ['mdc-list-item', if (selected) 'mdc-list-item--selected'],
-    attributes: {'data-value': value},
-    children: [
-      d.span(classes: ['mdc-list-item__ripple']),
-      d.span(classes: ['mdc-list-item__text'], text: text),
-    ],
+  return d.option(
+    value: value,
+    text: text,
+    selected: selected,
+    disabled: disabled,
   );
 }
 

--- a/app/lib/frontend/templates/views/pkg/admin_page.dart
+++ b/app/lib/frontend/templates/views/pkg/admin_page.dart
@@ -258,6 +258,12 @@ d.Node packageAdminPageNode({
             label: 'Select a version',
             classes: ['-admin-dropdown'],
             options: [
+              material.option(
+                value: '',
+                text: '',
+                disabled: true,
+                selected: true,
+              ),
               ...retractableVersions.map(
                 (v) => material.option(value: v, text: v),
               ),
@@ -285,6 +291,12 @@ d.Node packageAdminPageNode({
             label: 'Select a version',
             classes: ['-admin-dropdown'],
             options: [
+              material.option(
+                value: '',
+                text: '',
+                disabled: true,
+                selected: true,
+              ),
               ...retractedVersions.map(
                 (v) => material.option(value: v, text: v),
               ),

--- a/app/test/frontend/golden/pkg_admin_page.html
+++ b/app/test/frontend/golden/pkg_admin_page.html
@@ -289,31 +289,12 @@
                       <strong>Upgrading to verified publishers is an irreversible operation.</strong>
                       Packages can be transferred between publishers, but they can't be converted back to legacy uploader ownership.
                     </p>
-                    <div id="-admin-set-publisher-input" class="mdc-select mdc-select--filled -admin-dropdown" data-mdc-auto-init="MDCSelect">
-                      <div class="mdc-select__anchor">
-                        <span class="mdc-select__ripple"></span>
-                        <span class="mdc-select__selected-text"></span>
-                        <span class="mdc-select__dropdown-icon">
-                          <svg class="mdc-select__dropdown-icon-graphic" viewBox="7 10 10 5">
-                            <polygon class="mdc-select__dropdown-icon-inactive" stroke="none" fill-rule="evenodd" points="7 10 12 15 17 10"></polygon>
-                            <polygon class="mdc-select__dropdown-icon-active" stroke="none" fill-rule="evenodd" points="7 15 12 10 17 15"></polygon>
-                          </svg>
-                        </span>
-                        <span class="mdc-floating-label">Select a publisher</span>
-                        <span class="mdc-line-ripple"></span>
-                      </div>
-                      <div class="mdc-select__menu mdc-menu mdc-menu-surface mdc-menu-surface--fullwidth">
-                        <ul class="mdc-list">
-                          <li class="mdc-list-item mdc-list-item--selected" data-value="">
-                            <span class="mdc-list-item__ripple"></span>
-                            <span class="mdc-list-item__text"></span>
-                          </li>
-                          <li class="mdc-list-item" data-value="example.com">
-                            <span class="mdc-list-item__ripple"></span>
-                            <span class="mdc-list-item__text">example.com</span>
-                          </li>
-                        </ul>
-                      </div>
+                    <div class="pub-select -admin-dropdown">
+                      <label class="pub-select-label" for="-admin-set-publisher-input">Select a publisher</label>
+                      <select id="-admin-set-publisher-input" class="pub-select-input">
+                        <option value="" disabled="disabled" selected="selected"></option>
+                        <option value="example.com">example.com</option>
+                      </select>
                     </div>
                     <p>
                       <button id="-admin-set-publisher-button" class="mdc-button mdc-button--raised pub-button-danger" data-mdc-auto-init="MDCRipple">Transfer to publisher</button>
@@ -618,27 +599,12 @@
                     <p>This will not remove the package version, but warn developers using it and stop new applications from taking dependency on it without a dependency override.</p>
                     <p>You can restore a retracted package version if the version was retracted within the last 7 days.</p>
                     <h3>Retract package version</h3>
-                    <div id="-admin-retract-package-version-input" class="mdc-select mdc-select--filled -admin-dropdown" data-mdc-auto-init="MDCSelect">
-                      <div class="mdc-select__anchor">
-                        <span class="mdc-select__ripple"></span>
-                        <span class="mdc-select__selected-text"></span>
-                        <span class="mdc-select__dropdown-icon">
-                          <svg class="mdc-select__dropdown-icon-graphic" viewBox="7 10 10 5">
-                            <polygon class="mdc-select__dropdown-icon-inactive" stroke="none" fill-rule="evenodd" points="7 10 12 15 17 10"></polygon>
-                            <polygon class="mdc-select__dropdown-icon-active" stroke="none" fill-rule="evenodd" points="7 15 12 10 17 15"></polygon>
-                          </svg>
-                        </span>
-                        <span class="mdc-floating-label">Select a version</span>
-                        <span class="mdc-line-ripple"></span>
-                      </div>
-                      <div class="mdc-select__menu mdc-menu mdc-menu-surface mdc-menu-surface--fullwidth">
-                        <ul class="mdc-list">
-                          <li class="mdc-list-item" data-value="2.0.0">
-                            <span class="mdc-list-item__ripple"></span>
-                            <span class="mdc-list-item__text">2.0.0</span>
-                          </li>
-                        </ul>
-                      </div>
+                    <div class="pub-select -admin-dropdown">
+                      <label class="pub-select-label" for="-admin-retract-package-version-input">Select a version</label>
+                      <select id="-admin-retract-package-version-input" class="pub-select-input">
+                        <option value="" disabled="disabled" selected="selected"></option>
+                        <option value="2.0.0">2.0.0</option>
+                      </select>
                     </div>
                     <p>
                       <button id="-admin-retract-package-version-button" class="mdc-button mdc-button--raised pub-button-danger" data-mdc-auto-init="MDCRipple">Retract Package Version</button>
@@ -646,27 +612,12 @@
                   </div>
                   <h3>Restore retracted package version</h3>
                   <div>
-                    <div id="-admin-restore-retract-package-version-input" class="mdc-select mdc-select--filled -admin-dropdown" data-mdc-auto-init="MDCSelect">
-                      <div class="mdc-select__anchor">
-                        <span class="mdc-select__ripple"></span>
-                        <span class="mdc-select__selected-text"></span>
-                        <span class="mdc-select__dropdown-icon">
-                          <svg class="mdc-select__dropdown-icon-graphic" viewBox="7 10 10 5">
-                            <polygon class="mdc-select__dropdown-icon-inactive" stroke="none" fill-rule="evenodd" points="7 10 12 15 17 10"></polygon>
-                            <polygon class="mdc-select__dropdown-icon-active" stroke="none" fill-rule="evenodd" points="7 15 12 10 17 15"></polygon>
-                          </svg>
-                        </span>
-                        <span class="mdc-floating-label">Select a version</span>
-                        <span class="mdc-line-ripple"></span>
-                      </div>
-                      <div class="mdc-select__menu mdc-menu mdc-menu-surface mdc-menu-surface--fullwidth">
-                        <ul class="mdc-list">
-                          <li class="mdc-list-item" data-value="1.0.0">
-                            <span class="mdc-list-item__ripple"></span>
-                            <span class="mdc-list-item__text">1.0.0</span>
-                          </li>
-                        </ul>
-                      </div>
+                    <div class="pub-select -admin-dropdown">
+                      <label class="pub-select-label" for="-admin-restore-retract-package-version-input">Select a version</label>
+                      <select id="-admin-restore-retract-package-version-input" class="pub-select-input">
+                        <option value="" disabled="disabled" selected="selected"></option>
+                        <option value="1.0.0">1.0.0</option>
+                      </select>
                     </div>
                     <p>
                       <button id="-admin-restore-retract-package-version-button" class="mdc-button mdc-button--raised pub-button-danger" data-mdc-auto-init="MDCRipple">Restore Retraced Package Version</button>

--- a/pkg/pub_integration/lib/src/pub_puppeteer_helpers.dart
+++ b/pkg/pub_integration/lib/src/pub_puppeteer_helpers.dart
@@ -93,8 +93,7 @@ extension PubPageExt on Page {
     required String publisherId,
   }) async {
     await gotoOrigin('/packages/$package/admin');
-    await waitAndClick('#-admin-set-publisher-input');
-    await waitAndClick('li[data-value="$publisherId"]');
+    await select('#-admin-set-publisher-input', [publisherId]);
     await waitAndClick('#-admin-set-publisher-button');
     await waitAndClickOnDialogOk();
     await _waitForModelHidden();

--- a/pkg/web_app/lib/src/_dom_helper.dart
+++ b/pkg/web_app/lib/src/_dom_helper.dart
@@ -170,10 +170,9 @@ Future<Element> markdown(String text) async {
   return md.markdown(text);
 }
 
-/// Get the value of the material dropdown's selected element
+/// Get the value of the dropdown's selected option
 /// (or null if none is selected).
-String? materialDropdownSelected(Element? elem) {
-  if (elem == null) return null;
-  final item = elem.querySelector('.mdc-list-item--selected');
-  return item?.getAttribute('data-value');
+String? dropdownSelected(Element? elem) {
+  if (elem is HTMLSelectElement) return elem.value;
+  return null;
 }

--- a/pkg/web_app/lib/src/admin_pages.dart
+++ b/pkg/web_app/lib/src/admin_pages.dart
@@ -337,8 +337,7 @@ class _PkgAdminWidget {
   }
 
   Future<void> _setRetracted() async {
-    final version =
-        materialDropdownSelected(_retractPackageVersionInput)?.trim() ?? '';
+    final version = dropdownSelected(_retractPackageVersionInput)?.trim() ?? '';
     if (version.isEmpty) {
       await _validateVersionSelection();
       return;
@@ -361,8 +360,7 @@ class _PkgAdminWidget {
 
   Future<void> _restoreRetracted() async {
     final version =
-        materialDropdownSelected(_restoreRetractPackageVersionInput)?.trim() ??
-        '';
+        dropdownSelected(_restoreRetractPackageVersionInput)?.trim() ?? '';
     if (version.isEmpty) {
       await _validateVersionSelection();
       return;
@@ -389,8 +387,7 @@ class _PkgAdminWidget {
   }
 
   Future<void> _setPublisher() async {
-    final publisherId =
-        materialDropdownSelected(_setPublisherInput)?.trim() ?? '';
+    final publisherId = dropdownSelected(_setPublisherInput)?.trim() ?? '';
     if (publisherId.isEmpty) {
       await modalMessage('Input validation', 'Please specify a publisher.');
       return;

--- a/pkg/web_css/lib/src/_form.scss
+++ b/pkg/web_css/lib/src/_form.scss
@@ -141,26 +141,6 @@
     }
   }
 
-  .mdc-select:not(.mdc-select--disabled) {
-    .mdc-select__dropdown-icon {
-      fill: var(--mdc_pub-select-label-color);
-    }
-
-    .mdc-select__selected-text {
-      color: var(--mdc_pub-select-text-color);
-    }
-
-    .mdc-floating-label {
-      color: var(--mdc_pub-select-label-color);
-    }
-  }
-
-  .mdc-select--filled:not(.mdc-select--disabled) {
-    .mdc-select__anchor {
-      background-color: var(--mdc_pub-select-background-color);
-    }
-  }
-
   .mdc-data-table {
     border-color: var(--mdc_pub-data_table-border-color);
   }
@@ -201,6 +181,39 @@
 
     .-pub-icon-button-icon--off {
       display: none;
+    }
+  }
+}
+
+
+// Plain HTML dropdown / select component (see material.dart `dropdown`).
+.pub-select {
+  display: inline-block;
+
+  .pub-select-label {
+    display: block;
+    margin-bottom: 8px;
+  }
+
+  .pub-select-input {
+    width: 100%;
+    padding: 8px 12px;
+    font-size: 14px;
+    line-height: 1.6;
+    color: var(--pub-neutral-textColor);
+    background-color: var(--pub-neutral-bgColor);
+    border: 2px solid var(--pub-neutral-borderColor);
+    border-radius: 4px;
+    cursor: pointer;
+    transition: border-color 0.3s;
+
+    &:hover {
+      border-color: var(--pub-neutral-textColor);
+    }
+
+    &:focus {
+      outline: none;
+      border-color: var(--pub-link-text-color);
     }
   }
 }

--- a/pkg/web_css/lib/src/_variables.scss
+++ b/pkg/web_css/lib/src/_variables.scss
@@ -232,9 +232,6 @@
 
   // Pub-specific Material Design overrides
   --mdc_pub-data_table-border-color: var(--mdc-checkbox-unchecked-color);
-  --mdc_pub-select-background-color: rgba(255, 255, 255, 0.1);
-  --mdc_pub-select-label-color: var(--pub-link-text-color);
-  --mdc_pub-select-text-color: var(--pub-neutral-textColor);
   --mdc_pub-text_field-background-color: rgba(255, 255, 255, 0.1);
   --mdc_pub-text_field-border-color: var(--mdc-checkbox-unchecked-color);
   --mdc_pub-text_field-text-color: var(--pub-neutral-textColor);


### PR DESCRIPTION
Before:
<img width="346" height="185" alt="image" src="https://github.com/user-attachments/assets/4b767da5-7572-499c-8742-e9aabb36d3cb" />

After:
[Screencast_20260608_162943.webm](https://github.com/user-attachments/assets/38e70afa-d7ec-4058-93bf-aa9fb8f2d2cb)
[Screencast_20260608_163057.webm](https://github.com/user-attachments/assets/e87edd88-9a07-47db-a237-158e0e760d83)

Note: I've kept it in `material.dart`, since it is more closer to the high-level reusable widget category, and the radiobuttons there are not material either.