### PR TITLE
Migrate textfield + textarea from material component to plain HTML + updated style rules.

### DIFF
--- a/app/lib/frontend/dom/material.dart
+++ b/app/lib/frontend/dom/material.dart
@@ -94,7 +94,7 @@ d.Node raisedButton({
   );
 }
 
-/// Renders a material text field.
+/// Renders a plain HTML text field.
 d.Node textField({
   required String id,
   required String? label,
@@ -102,34 +102,26 @@ d.Node textField({
   String? value,
 }) {
   return d.div(
-    classes: ['mdc-form-field'],
+    classes: ['pub-text-field'],
     children: [
-      if (label != null) d.label(attributes: {'for': id}, text: label),
-      d.div(
-        classes: ['mdc-text-field', 'mdc-text-field--outlined'],
-        attributes: {'data-mdc-auto-init': 'MDCTextField'},
-        children: [
-          d.input(
-            type: 'text',
-            id: id,
-            name: name,
-            classes: ['mdc-text-field__input'],
-            value: value,
-          ),
-          d.div(
-            classes: ['mdc-notched-outline'],
-            children: [
-              d.div(classes: ['mdc-notched-outline__leading'], text: ''),
-              d.div(classes: ['mdc-notched-outline__trailing'], text: ''),
-            ],
-          ),
-        ],
+      if (label != null)
+        d.label(
+          classes: ['pub-text-field-label'],
+          attributes: {'for': id},
+          text: label,
+        ),
+      d.input(
+        type: 'text',
+        id: id,
+        name: name,
+        classes: ['pub-text-field-input'],
+        value: value,
       ),
     ],
   );
 }
 
-/// Renders a material text area.
+/// Renders a plain HTML text area.
 d.Node textArea({
   required String id,
   required String label,
@@ -139,38 +131,32 @@ d.Node textArea({
   String? name,
   String? value,
 }) {
-  return d.fragment([
-    d.label(attributes: {'for': id}, text: label),
-    d.div(
-      classes: ['mdc-text-field', 'mdc-text-field--textarea'],
-      attributes: {'data-mdc-auto-init': 'MDCTextField'},
-      children: [
-        d.div(
-          classes: ['mdc-text-field-character-counter'],
-          text: '${value?.length ?? 0} / $maxLength',
-        ),
-        d.element(
-          'textarea',
-          id: id,
-          classes: ['mdc-text-field__input'],
-          attributes: {
-            if (name != null) 'name': name,
-            'rows': '$rows',
-            'cols': '$cols',
-            'maxlength': '$maxLength',
-          },
-          text: value,
-        ),
-        d.div(
-          classes: ['mdc-notched-outline'],
-          children: [
-            d.div(classes: ['mdc-notched-outline__leading'], text: ''),
-            d.div(classes: ['mdc-notched-outline__trailing'], text: ''),
-          ],
-        ),
-      ],
-    ),
-  ]);
+  return d.div(
+    classes: ['pub-text-field', 'pub-text-field--textarea'],
+    children: [
+      d.label(
+        classes: ['pub-text-field-label'],
+        attributes: {'for': id},
+        text: label,
+      ),
+      d.element(
+        'textarea',
+        id: id,
+        classes: ['pub-text-field-input'],
+        attributes: {
+          if (name != null) 'name': name,
+          'rows': '$rows',
+          'cols': '$cols',
+          'maxlength': '$maxLength',
+        },
+        text: value,
+      ),
+      d.div(
+        classes: ['pub-text-field-character-counter'],
+        text: '${value?.length ?? 0} / $maxLength',
+      ),
+    ],
+  );
 }
 
 class DataTableColumn<T> {

--- a/app/test/frontend/golden/create_publisher_page.html
+++ b/app/test/frontend/golden/create_publisher_page.html
@@ -172,15 +172,9 @@
       </ul>
       <p>We strongly recommend you invite other members of your organization as members to the verified publisher. This ensures that your organization retains access to the publisher when you are not available.</p>
       <div class="-pub-form-textfield-row">
-        <div class="mdc-form-field">
-          <label for="-publisher-id">Domain Name</label>
-          <div class="mdc-text-field mdc-text-field--outlined" data-mdc-auto-init="MDCTextField">
-            <input id="-publisher-id" class="mdc-text-field__input" type="text"/>
-            <div class="mdc-notched-outline">
-              <div class="mdc-notched-outline__leading"></div>
-              <div class="mdc-notched-outline__trailing"></div>
-            </div>
-          </div>
+        <div class="pub-text-field">
+          <label class="pub-text-field-label" for="-publisher-id">Domain Name</label>
+          <input id="-publisher-id" class="pub-text-field-input" type="text"/>
         </div>
         <button id="-admin-create-publisher" class="mdc-button mdc-button--raised" data-mdc-auto-init="MDCRipple">Start verification</button>
       </div>

--- a/app/test/frontend/golden/pkg_admin_page.html
+++ b/app/test/frontend/golden/pkg_admin_page.html
@@ -330,15 +330,9 @@
                         <li>Invite and remove uploaders of this package</li>
                       </ul>
                       <div class="-pub-form-textfield-row">
-                        <div class="mdc-form-field">
-                          <label for="-pkg-admin-invite-uploader-input">Email address</label>
-                          <div class="mdc-text-field mdc-text-field--outlined" data-mdc-auto-init="MDCTextField">
-                            <input id="-pkg-admin-invite-uploader-input" class="mdc-text-field__input" type="text"/>
-                            <div class="mdc-notched-outline">
-                              <div class="mdc-notched-outline__leading"></div>
-                              <div class="mdc-notched-outline__trailing"></div>
-                            </div>
-                          </div>
+                        <div class="pub-text-field">
+                          <label class="pub-text-field-label" for="-pkg-admin-invite-uploader-input">Email address</label>
+                          <input id="-pkg-admin-invite-uploader-input" class="pub-text-field-input" type="text"/>
                         </div>
                       </div>
                     </div>
@@ -445,27 +439,15 @@
                   </div>
                   <div class="-pub-form-checkbox-indent -pub-form-block-hidden">
                     <div class="-pub-form-textfield-row">
-                      <div class="mdc-form-field">
-                        <label for="-pkg-admin-automated-github-repository">Repository (&lt;owner>/&lt;repository>)</label>
-                        <div class="mdc-text-field mdc-text-field--outlined" data-mdc-auto-init="MDCTextField">
-                          <input id="-pkg-admin-automated-github-repository" class="mdc-text-field__input" type="text"/>
-                          <div class="mdc-notched-outline">
-                            <div class="mdc-notched-outline__leading"></div>
-                            <div class="mdc-notched-outline__trailing"></div>
-                          </div>
-                        </div>
+                      <div class="pub-text-field">
+                        <label class="pub-text-field-label" for="-pkg-admin-automated-github-repository">Repository (&lt;owner>/&lt;repository>)</label>
+                        <input id="-pkg-admin-automated-github-repository" class="pub-text-field-input" type="text"/>
                       </div>
                     </div>
                     <div class="-pub-form-textfield-row">
-                      <div class="mdc-form-field">
-                        <label for="-pkg-admin-automated-github-tagpattern">Tag pattern</label>
-                        <div class="mdc-text-field mdc-text-field--outlined" data-mdc-auto-init="MDCTextField">
-                          <input id="-pkg-admin-automated-github-tagpattern" class="mdc-text-field__input" type="text" value="v{{version}}"/>
-                          <div class="mdc-notched-outline">
-                            <div class="mdc-notched-outline__leading"></div>
-                            <div class="mdc-notched-outline__trailing"></div>
-                          </div>
-                        </div>
+                      <div class="pub-text-field">
+                        <label class="pub-text-field-label" for="-pkg-admin-automated-github-tagpattern">Tag pattern</label>
+                        <input id="-pkg-admin-automated-github-tagpattern" class="pub-text-field-input" type="text" value="v{{version}}"/>
                       </div>
                       <p>
                         <code>{{version}}</code>
@@ -534,15 +516,9 @@
                       </div>
                     </div>
                     <div class="-pub-form-checkbox-indent -pub-form-textfield-row -pub-form-block-hidden">
-                      <div class="mdc-form-field">
-                        <label for="-pkg-admin-automated-github-environment">Environment</label>
-                        <div class="mdc-text-field mdc-text-field--outlined" data-mdc-auto-init="MDCTextField">
-                          <input id="-pkg-admin-automated-github-environment" class="mdc-text-field__input" type="text"/>
-                          <div class="mdc-notched-outline">
-                            <div class="mdc-notched-outline__leading"></div>
-                            <div class="mdc-notched-outline__trailing"></div>
-                          </div>
-                        </div>
+                      <div class="pub-text-field">
+                        <label class="pub-text-field-label" for="-pkg-admin-automated-github-environment">Environment</label>
+                        <input id="-pkg-admin-automated-github-environment" class="pub-text-field-input" type="text"/>
                       </div>
                     </div>
                   </div>
@@ -573,15 +549,9 @@
                   </div>
                   <div class="-pub-form-checkbox-indent -pub-form-block-hidden">
                     <div class="-pub-form-textfield-row">
-                      <div class="mdc-form-field">
-                        <label for="-pkg-admin-automated-gcp-serviceaccountemail">Service account email</label>
-                        <div class="mdc-text-field mdc-text-field--outlined" data-mdc-auto-init="MDCTextField">
-                          <input id="-pkg-admin-automated-gcp-serviceaccountemail" class="mdc-text-field__input" type="text"/>
-                          <div class="mdc-notched-outline">
-                            <div class="mdc-notched-outline__leading"></div>
-                            <div class="mdc-notched-outline__trailing"></div>
-                          </div>
-                        </div>
+                      <div class="pub-text-field">
+                        <label class="pub-text-field-label" for="-pkg-admin-automated-gcp-serviceaccountemail">Service account email</label>
+                        <input id="-pkg-admin-automated-gcp-serviceaccountemail" class="pub-text-field-input" type="text"/>
                       </div>
                     </div>
                   </div>

--- a/app/test/frontend/golden/publisher_admin_page.html
+++ b/app/test/frontend/golden/publisher_admin_page.html
@@ -163,38 +163,22 @@
                 <section class="tab-content detail-tab-admin-content -active">
                   <h2>Publisher information</h2>
                   <div class="-pub-form-textfield-row">
-                    <label for="-publisher-description">Description</label>
-                    <div class="mdc-text-field mdc-text-field--textarea" data-mdc-auto-init="MDCTextField">
-                      <div class="mdc-text-field-character-counter">0 / 4096</div>
-                      <textarea id="-publisher-description" class="mdc-text-field__input" rows="5" cols="60" maxlength="4096"></textarea>
-                      <div class="mdc-notched-outline">
-                        <div class="mdc-notched-outline__leading"></div>
-                        <div class="mdc-notched-outline__trailing"></div>
-                      </div>
+                    <div class="pub-text-field pub-text-field--textarea">
+                      <label class="pub-text-field-label" for="-publisher-description">Description</label>
+                      <textarea id="-publisher-description" class="pub-text-field-input" rows="5" cols="60" maxlength="4096"></textarea>
+                      <div class="pub-text-field-character-counter">0 / 4096</div>
                     </div>
                   </div>
                   <div class="-pub-form-textfield-row">
-                    <div class="mdc-form-field">
-                      <label for="-publisher-website-url">Website</label>
-                      <div class="mdc-text-field mdc-text-field--outlined" data-mdc-auto-init="MDCTextField">
-                        <input id="-publisher-website-url" class="mdc-text-field__input" type="text" value="https://example.com/"/>
-                        <div class="mdc-notched-outline">
-                          <div class="mdc-notched-outline__leading"></div>
-                          <div class="mdc-notched-outline__trailing"></div>
-                        </div>
-                      </div>
+                    <div class="pub-text-field">
+                      <label class="pub-text-field-label" for="-publisher-website-url">Website</label>
+                      <input id="-publisher-website-url" class="pub-text-field-input" type="text" value="https://example.com/"/>
                     </div>
                   </div>
                   <div class="-pub-form-textfield-row">
-                    <div class="mdc-form-field">
-                      <label for="-publisher-contact-email">Contact email</label>
-                      <div class="mdc-text-field mdc-text-field--outlined" data-mdc-auto-init="MDCTextField">
-                        <input id="-publisher-contact-email" class="mdc-text-field__input" type="text" value="admin@pub.dev"/>
-                        <div class="mdc-notched-outline">
-                          <div class="mdc-notched-outline__leading"></div>
-                          <div class="mdc-notched-outline__trailing"></div>
-                        </div>
-                      </div>
+                    <div class="pub-text-field">
+                      <label class="pub-text-field-label" for="-publisher-contact-email">Contact email</label>
+                      <input id="-publisher-contact-email" class="pub-text-field-input" type="text" value="admin@pub.dev"/>
                     </div>
                   </div>
                   <div class="-pub-form-right-aligned">
@@ -233,15 +217,9 @@
                       <li>Add and remove members of this publisher</li>
                     </ul>
                     <div class="-pub-form-textfield-row">
-                      <div class="mdc-form-field">
-                        <label for="-admin-invite-member-input">Email address</label>
-                        <div class="mdc-text-field mdc-text-field--outlined" data-mdc-auto-init="MDCTextField">
-                          <input id="-admin-invite-member-input" class="mdc-text-field__input" type="text"/>
-                          <div class="mdc-notched-outline">
-                            <div class="mdc-notched-outline__leading"></div>
-                            <div class="mdc-notched-outline__trailing"></div>
-                          </div>
-                        </div>
+                      <div class="pub-text-field">
+                        <label class="pub-text-field-label" for="-admin-invite-member-input">Email address</label>
+                        <input id="-admin-invite-member-input" class="pub-text-field-input" type="text"/>
                       </div>
                     </div>
                   </div>

--- a/app/test/frontend/golden/report_page.html
+++ b/app/test/frontend/golden/report_page.html
@@ -161,25 +161,15 @@
             </div>
             <div class="foldable-content">
               <p>Contact information:</p>
-              <div class="mdc-form-field">
-                <label for="report-email">Email</label>
-                <div class="mdc-text-field mdc-text-field--outlined" data-mdc-auto-init="MDCTextField">
-                  <input id="report-email" class="mdc-text-field__input" type="text" name="email"/>
-                  <div class="mdc-notched-outline">
-                    <div class="mdc-notched-outline__leading"></div>
-                    <div class="mdc-notched-outline__trailing"></div>
-                  </div>
-                </div>
+              <div class="pub-text-field">
+                <label class="pub-text-field-label" for="report-email">Email</label>
+                <input id="report-email" class="pub-text-field-input" type="text" name="email"/>
               </div>
               <p>Please describe the issue you want to report:</p>
-              <label for="report-message">Message</label>
-              <div class="mdc-text-field mdc-text-field--textarea" data-mdc-auto-init="MDCTextField">
-                <div class="mdc-text-field-character-counter">0 / 8192</div>
-                <textarea id="report-message" class="mdc-text-field__input" name="message" rows="10" cols="60" maxlength="8192"></textarea>
-                <div class="mdc-notched-outline">
-                  <div class="mdc-notched-outline__leading"></div>
-                  <div class="mdc-notched-outline__trailing"></div>
-                </div>
+              <div class="pub-text-field pub-text-field--textarea">
+                <label class="pub-text-field-label" for="report-message">Message</label>
+                <textarea id="report-message" class="pub-text-field-input" name="message" rows="10" cols="60" maxlength="8192"></textarea>
+                <div class="pub-text-field-character-counter">0 / 8192</div>
               </div>
               <button id="report-submit" class="mdc-button mdc-button--raised" data-mdc-auto-init="MDCRipple" data-form-api-button="submit">Submit</button>
             </div>

--- a/app/test/frontend/golden/report_page_appeal.html
+++ b/app/test/frontend/golden/report_page_appeal.html
@@ -126,24 +126,14 @@
             <b>You can appeal at most once per case.</b>
           </p>
           <p>Contact information:</p>
-          <div class="mdc-form-field">
-            <label for="report-email">Email</label>
-            <div class="mdc-text-field mdc-text-field--outlined" data-mdc-auto-init="MDCTextField">
-              <input id="report-email" class="mdc-text-field__input" type="text" name="email"/>
-              <div class="mdc-notched-outline">
-                <div class="mdc-notched-outline__leading"></div>
-                <div class="mdc-notched-outline__trailing"></div>
-              </div>
-            </div>
+          <div class="pub-text-field">
+            <label class="pub-text-field-label" for="report-email">Email</label>
+            <input id="report-email" class="pub-text-field-input" type="text" name="email"/>
           </div>
-          <label for="report-message">Message</label>
-          <div class="mdc-text-field mdc-text-field--textarea" data-mdc-auto-init="MDCTextField">
-            <div class="mdc-text-field-character-counter">0 / 8192</div>
-            <textarea id="report-message" class="mdc-text-field__input" name="message" rows="10" cols="60" maxlength="8192"></textarea>
-            <div class="mdc-notched-outline">
-              <div class="mdc-notched-outline__leading"></div>
-              <div class="mdc-notched-outline__trailing"></div>
-            </div>
+          <div class="pub-text-field pub-text-field--textarea">
+            <label class="pub-text-field-label" for="report-message">Message</label>
+            <textarea id="report-message" class="pub-text-field-input" name="message" rows="10" cols="60" maxlength="8192"></textarea>
+            <div class="pub-text-field-character-counter">0 / 8192</div>
           </div>
           <button id="report-submit" class="mdc-button mdc-button--raised" data-mdc-auto-init="MDCRipple" data-form-api-button="submit">Submit</button>
         </div>

--- a/pkg/web_app/lib/script.dart
+++ b/pkg/web_app/lib/script.dart
@@ -14,6 +14,7 @@ import 'src/mobile_nav.dart';
 import 'src/page_updater.dart';
 import 'src/screenshot_carousel.dart';
 import 'src/search.dart';
+import 'src/widget/core/text_area.dart';
 import 'src/widget/widget.dart' show setupWidgets;
 
 void main() {
@@ -39,6 +40,7 @@ void _setupAllEvents() {
   setupLikesList();
   setupScreenshotCarousel();
   setupWidgets();
+  setupTextAreas();
   _setupDarkThemeButton();
 }
 

--- a/pkg/web_app/lib/src/widget/core/text_area.dart
+++ b/pkg/web_app/lib/src/widget/core/text_area.dart
@@ -1,0 +1,29 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:web/web.dart';
+
+import '../../web_util.dart';
+
+/// Keeps the character counter of `.pub-text-field--textarea` components in
+/// sync with the current content of their `<textarea>`.
+void setupTextAreas() {
+  final textAreas = document
+      .querySelectorAll('.pub-text-field--textarea')
+      .toElementList<HTMLElement>();
+  for (final field in textAreas) {
+    final textArea =
+        field.querySelector('.pub-text-field-input') as HTMLTextAreaElement?;
+    final counter = field.querySelector('.pub-text-field-character-counter');
+    if (textArea == null || counter == null) continue;
+
+    final maxLength = textArea.getAttribute('maxlength');
+    void updateCounter() {
+      counter.textContent = '${textArea.value.length} / $maxLength';
+    }
+
+    updateCounter();
+    textArea.onInput.listen((_) => updateCounter());
+  }
+}

--- a/pkg/web_css/lib/src/_form.scss
+++ b/pkg/web_css/lib/src/_form.scss
@@ -32,13 +32,8 @@
 }
 
 .-pub-form-textfield-row {
-  label {
+  .pub-text-field {
     display: block;
-    margin-bottom: 8px;
-  }
-
-  .mdc-text-field {
-    min-width: 100%;
     margin-bottom: 8px;
   }
 }
@@ -113,34 +108,6 @@
 }
 
 .dark-theme {
-  .mdc-text-field-character-counter {
-    color: var(--mdc_pub-text_field-text-color);
-  }
-
-  .mdc-text-field--outlined,
-  .mdc-text-field--textarea {
-    .mdc-text-field__input {
-      color: var(--mdc_pub-text_field-text-color);
-    }
-
-    .mdc-notched-outline__leading {
-      background: var(--mdc_pub-text_field-background-color);
-      border-color: var(--mdc_pub-text_field-border-color);
-    }
-
-    .mdc-notched-outline__trailing {
-      background: var(--mdc_pub-text_field-background-color);
-      border-color: var(--mdc_pub-text_field-border-color);
-    }
-
-    &:hover {
-      .mdc-notched-outline__leading,
-      .mdc-notched-outline__trailing {
-        border-color: var(--pub-neutral-textColor) !important;
-      }
-    }
-  }
-
   .mdc-data-table {
     border-color: var(--mdc_pub-data_table-border-color);
   }
@@ -201,8 +168,8 @@
     font-size: 14px;
     line-height: 1.6;
     color: var(--pub-neutral-textColor);
-    background-color: var(--pub-neutral-bgColor);
-    border: 2px solid var(--pub-neutral-borderColor);
+    background-color: color-mix(in srgb, var(--pub-neutral-borderColor) 40%, transparent);
+    border: 2px solid color-mix(in srgb, var(--pub-neutral-textColor) 40%, transparent);
     border-radius: 4px;
     cursor: pointer;
     transition: border-color 0.3s;
@@ -214,6 +181,53 @@
     &:focus {
       outline: none;
       border-color: var(--pub-link-text-color);
+    }
+  }
+}
+
+// Plain HTML text field / text area component
+// (see material.dart `textField` / `textArea`).
+.pub-text-field {
+  display: inline-block;
+
+  .pub-text-field-label {
+    display: block;
+    margin-bottom: 8px;
+  }
+
+  .pub-text-field-input {
+    width: 100%;
+    box-sizing: border-box;
+    padding: 8px 12px;
+    font-size: 14px;
+    line-height: 1.6;
+    color: var(--pub-neutral-textColor);
+    background-color: color-mix(in srgb, var(--pub-neutral-borderColor) 40%, transparent);
+    border: 2px solid color-mix(in srgb, var(--pub-neutral-textColor) 40%, transparent);
+    border-radius: 4px;
+    transition: border-color 0.3s;
+
+    &:hover {
+      border-color: var(--pub-neutral-textColor);
+    }
+
+    &:focus {
+      outline: none;
+      border-color: var(--pub-link-text-color);
+    }
+  }
+
+  &.pub-text-field--textarea {
+    .pub-text-field-input {
+      font-family: inherit;
+      resize: vertical;
+    }
+
+    .pub-text-field-character-counter {
+      margin-top: 4px;
+      font-size: 12px;
+      text-align: right;
+      color: var(--pub-neutral-textColor);
     }
   }
 }

--- a/pkg/web_css/lib/src/_report.scss
+++ b/pkg/web_css/lib/src/_report.scss
@@ -6,7 +6,8 @@
   max-width: 800px;
   margin: 0px auto;
 
-  .mdc-text-field {
+  .pub-text-field {
+    display: block;
     width: 100%;
     margin-bottom: 12px;
   }

--- a/pkg/web_css/lib/src/_variables.scss
+++ b/pkg/web_css/lib/src/_variables.scss
@@ -232,9 +232,6 @@
 
   // Pub-specific Material Design overrides
   --mdc_pub-data_table-border-color: var(--mdc-checkbox-unchecked-color);
-  --mdc_pub-text_field-background-color: rgba(255, 255, 255, 0.1);
-  --mdc_pub-text_field-border-color: var(--mdc-checkbox-unchecked-color);
-  --mdc_pub-text_field-text-color: var(--pub-neutral-textColor);
 
   // Most of our SVG images are black on transparent background and they
   // are almost invisible in dark mode. Ideally we would have different


### PR DESCRIPTION
- Changed the HTML DOM layout + styles, added a client-side script to update the character counter.
- Removed material-specific styles that are no longer relevant.
- Updated the colors of the input + select widget: it gets a slightly shaded background, and the border has more contrast than before. Kept now as combined percent of the base color, will update the colors in a subsequent review/change.

Before:
<img width="1514" height="484" alt="image" src="https://github.com/user-attachments/assets/5ae7c5a5-438e-4f8b-b701-1ffa76f66c95" />

After:
<img width="1513" height="489" alt="image" src="https://github.com/user-attachments/assets/333cb9c9-f324-42b7-ace3-06c62dcb6680" />
<img width="1507" height="497" alt="image" src="https://github.com/user-attachments/assets/e0d657c2-b732-4bc2-b06f-4c6af6100c73" />
