### PR TITLE
Migrate material checkbox to plain HTML.

### DIFF
--- a/app/lib/frontend/dom/material.dart
+++ b/app/lib/frontend/dom/material.dart
@@ -219,7 +219,7 @@ d.Node dataTable<T>({
   );
 }
 
-/// Renders a material checkbox component.
+/// Renders a plain HTML checkbox component.
 d.Node checkbox({
   required String id,
   required String label,
@@ -229,44 +229,23 @@ d.Node checkbox({
 }) {
   labelNodeContent ??= d.text;
   return d.div(
-    classes: ['mdc-form-field'],
+    classes: ['pub-checkbox'],
     children: [
-      d.div(
-        classes: ['mdc-checkbox'],
-        children: [
-          d.input(
-            type: 'checkbox',
-            classes: ['mdc-checkbox__native-control'],
-            id: id,
-            attributes: {
-              if (checked) 'checked': 'checked',
-              if (indeterminate) 'data-indeterminate': 'true',
-              if (indeterminate) 'aria-checked': 'mixed',
-            },
-          ),
-          d.div(
-            classes: ['mdc-checkbox__background'],
-            children: [
-              d.element(
-                'svg',
-                classes: ['mdc-checkbox__checkmark'],
-                attributes: {'viewBox': '0 0 24 24'},
-                child: d.element(
-                  'path',
-                  classes: ['mdc-checkbox__checkmark-path'],
-                  attributes: {
-                    'fill': 'none',
-                    'd': 'M1.73,12.91 8.1,19.28 22.79,4.59',
-                  },
-                ),
-              ),
-              d.div(classes: ['mdc-checkbox__mixedmark']),
-            ],
-          ),
-          d.div(classes: ['mdc-checkbox__ripple']),
-        ],
+      d.input(
+        type: 'checkbox',
+        id: id,
+        classes: ['pub-checkbox-input'],
+        attributes: {
+          if (checked) 'checked': 'checked',
+          if (indeterminate) 'data-indeterminate': 'true',
+          if (indeterminate) 'aria-checked': 'mixed',
+        },
       ),
-      d.label(attributes: {'for': id}, child: labelNodeContent(label)),
+      d.label(
+        classes: ['pub-checkbox-label'],
+        attributes: {'for': id},
+        child: labelNodeContent(label),
+      ),
     ],
   );
 }

--- a/app/test/frontend/golden/pkg_admin_page.html
+++ b/app/test/frontend/golden/pkg_admin_page.html
@@ -349,18 +349,9 @@
                     remain available to package users, but they don't appear in search results on pub.dev unless the user specifies advanced search options.
                   </p>
                   <div class="-pub-form-checkbox-row">
-                    <div class="mdc-form-field">
-                      <div class="mdc-checkbox">
-                        <input id="-admin-is-discontinued-checkbox" class="mdc-checkbox__native-control" type="checkbox"/>
-                        <div class="mdc-checkbox__background">
-                          <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
-                            <path class="mdc-checkbox__checkmark-path" fill="none" d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
-                          </svg>
-                          <div class="mdc-checkbox__mixedmark"></div>
-                        </div>
-                        <div class="mdc-checkbox__ripple"></div>
-                      </div>
-                      <label for="-admin-is-discontinued-checkbox">Mark "discontinued"</label>
+                    <div class="pub-checkbox">
+                      <input id="-admin-is-discontinued-checkbox" class="pub-checkbox-input" type="checkbox"/>
+                      <label class="pub-checkbox-label" for="-admin-is-discontinued-checkbox">Mark "discontinued"</label>
                     </div>
                   </div>
                   <a name="unlisted"></a>
@@ -371,18 +362,9 @@
                     doesn't normally appear in search results on pub.dev. Unlisted packages remain publicly available, and users can search for them using advanced search options.
                   </p>
                   <div class="-pub-form-checkbox-row">
-                    <div class="mdc-form-field">
-                      <div class="mdc-checkbox">
-                        <input id="-admin-is-unlisted-checkbox" class="mdc-checkbox__native-control" type="checkbox"/>
-                        <div class="mdc-checkbox__background">
-                          <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
-                            <path class="mdc-checkbox__checkmark-path" fill="none" d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
-                          </svg>
-                          <div class="mdc-checkbox__mixedmark"></div>
-                        </div>
-                        <div class="mdc-checkbox__ripple"></div>
-                      </div>
-                      <label for="-admin-is-unlisted-checkbox">Mark "unlisted"</label>
+                    <div class="pub-checkbox">
+                      <input id="-admin-is-unlisted-checkbox" class="pub-checkbox-input" type="checkbox"/>
+                      <label class="pub-checkbox-label" for="-admin-is-unlisted-checkbox">Mark "unlisted"</label>
                     </div>
                   </div>
                   <a name="publishing"></a>
@@ -399,18 +381,9 @@
                   <p>Disable to prevent accidental publication from the command line.</p>
                   <p>It is recommended to disable when automated publishing is enabled.</p>
                   <div class="-pub-form-checkbox-row">
-                    <div class="mdc-form-field">
-                      <div class="mdc-checkbox">
-                        <input id="-pkg-admin-manual-publishing-enabled" class="mdc-checkbox__native-control" type="checkbox" checked="checked"/>
-                        <div class="mdc-checkbox__background">
-                          <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
-                            <path class="mdc-checkbox__checkmark-path" fill="none" d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
-                          </svg>
-                          <div class="mdc-checkbox__mixedmark"></div>
-                        </div>
-                        <div class="mdc-checkbox__ripple"></div>
-                      </div>
-                      <label for="-pkg-admin-manual-publishing-enabled">Enable manual publishing</label>
+                    <div class="pub-checkbox">
+                      <input id="-pkg-admin-manual-publishing-enabled" class="pub-checkbox-input" type="checkbox" checked="checked"/>
+                      <label class="pub-checkbox-label" for="-pkg-admin-manual-publishing-enabled">Enable manual publishing</label>
                     </div>
                   </div>
                   <a name="automated-publishing"></a>
@@ -423,18 +396,9 @@
                   <a name="github-actions"></a>
                   <h3>Publishing from GitHub Actions</h3>
                   <div class="-pub-form-checkbox-row -pub-form-checkbox-toggle-next-sibling">
-                    <div class="mdc-form-field">
-                      <div class="mdc-checkbox">
-                        <input id="-pkg-admin-automated-github-enabled" class="mdc-checkbox__native-control" type="checkbox"/>
-                        <div class="mdc-checkbox__background">
-                          <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
-                            <path class="mdc-checkbox__checkmark-path" fill="none" d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
-                          </svg>
-                          <div class="mdc-checkbox__mixedmark"></div>
-                        </div>
-                        <div class="mdc-checkbox__ripple"></div>
-                      </div>
-                      <label for="-pkg-admin-automated-github-enabled">Enable publishing from GitHub Actions</label>
+                    <div class="pub-checkbox">
+                      <input id="-pkg-admin-automated-github-enabled" class="pub-checkbox-input" type="checkbox"/>
+                      <label class="pub-checkbox-label" for="-pkg-admin-automated-github-enabled">Enable publishing from GitHub Actions</label>
                     </div>
                   </div>
                   <div class="-pub-form-checkbox-indent -pub-form-block-hidden">
@@ -463,18 +427,9 @@
                       </p>
                     </div>
                     <div class="-pub-form-checkbox-row">
-                      <div class="mdc-form-field">
-                        <div class="mdc-checkbox">
-                          <input id="-pkg-admin-automated-github-push-events" class="mdc-checkbox__native-control" type="checkbox" checked="checked"/>
-                          <div class="mdc-checkbox__background">
-                            <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
-                              <path class="mdc-checkbox__checkmark-path" fill="none" d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
-                            </svg>
-                            <div class="mdc-checkbox__mixedmark"></div>
-                          </div>
-                          <div class="mdc-checkbox__ripple"></div>
-                        </div>
-                        <label for="-pkg-admin-automated-github-push-events">
+                      <div class="pub-checkbox">
+                        <input id="-pkg-admin-automated-github-push-events" class="pub-checkbox-input" type="checkbox" checked="checked"/>
+                        <label class="pub-checkbox-label" for="-pkg-admin-automated-github-push-events">
                           Enable publishing from
                           <code>push</code>
                           events
@@ -482,18 +437,9 @@
                       </div>
                     </div>
                     <div class="-pub-form-checkbox-row">
-                      <div class="mdc-form-field">
-                        <div class="mdc-checkbox">
-                          <input id="-pkg-admin-automated-github-workflowdispatch-events" class="mdc-checkbox__native-control" type="checkbox"/>
-                          <div class="mdc-checkbox__background">
-                            <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
-                              <path class="mdc-checkbox__checkmark-path" fill="none" d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
-                            </svg>
-                            <div class="mdc-checkbox__mixedmark"></div>
-                          </div>
-                          <div class="mdc-checkbox__ripple"></div>
-                        </div>
-                        <label for="-pkg-admin-automated-github-workflowdispatch-events">
+                      <div class="pub-checkbox">
+                        <input id="-pkg-admin-automated-github-workflowdispatch-events" class="pub-checkbox-input" type="checkbox"/>
+                        <label class="pub-checkbox-label" for="-pkg-admin-automated-github-workflowdispatch-events">
                           Enable publishing from
                           <code>workflow_dispatch</code>
                           events
@@ -501,18 +447,9 @@
                       </div>
                     </div>
                     <div class="-pub-form-checkbox-row -pub-form-checkbox-toggle-next-sibling">
-                      <div class="mdc-form-field">
-                        <div class="mdc-checkbox">
-                          <input id="-pkg-admin-automated-github-requireenv" class="mdc-checkbox__native-control" type="checkbox"/>
-                          <div class="mdc-checkbox__background">
-                            <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
-                              <path class="mdc-checkbox__checkmark-path" fill="none" d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
-                            </svg>
-                            <div class="mdc-checkbox__mixedmark"></div>
-                          </div>
-                          <div class="mdc-checkbox__ripple"></div>
-                        </div>
-                        <label for="-pkg-admin-automated-github-requireenv">Require GitHub Actions environment</label>
+                      <div class="pub-checkbox">
+                        <input id="-pkg-admin-automated-github-requireenv" class="pub-checkbox-input" type="checkbox"/>
+                        <label class="pub-checkbox-label" for="-pkg-admin-automated-github-requireenv">Require GitHub Actions environment</label>
                       </div>
                     </div>
                     <div class="-pub-form-checkbox-indent -pub-form-textfield-row -pub-form-block-hidden">
@@ -533,18 +470,9 @@
                     <a href="https://dart.dev/go/automated-publishing">dart.dev/go/automated-publishing</a>
                   </p>
                   <div class="-pub-form-checkbox-row -pub-form-checkbox-toggle-next-sibling">
-                    <div class="mdc-form-field">
-                      <div class="mdc-checkbox">
-                        <input id="-pkg-admin-automated-gcp-enabled" class="mdc-checkbox__native-control" type="checkbox"/>
-                        <div class="mdc-checkbox__background">
-                          <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
-                            <path class="mdc-checkbox__checkmark-path" fill="none" d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
-                          </svg>
-                          <div class="mdc-checkbox__mixedmark"></div>
-                        </div>
-                        <div class="mdc-checkbox__ripple"></div>
-                      </div>
-                      <label for="-pkg-admin-automated-gcp-enabled">Enable publishing with Google Cloud Service account</label>
+                    <div class="pub-checkbox">
+                      <input id="-pkg-admin-automated-gcp-enabled" class="pub-checkbox-input" type="checkbox"/>
+                      <label class="pub-checkbox-label" for="-pkg-admin-automated-gcp-enabled">Enable publishing with Google Cloud Service account</label>
                     </div>
                   </div>
                   <div class="-pub-form-checkbox-indent -pub-form-block-hidden">

--- a/app/test/frontend/golden/pkg_index_page.html
+++ b/app/test/frontend/golden/pkg_index_page.html
@@ -126,103 +126,49 @@
             </h3>
             <div class="foldable-content">
               <div class="search-form-linked-checkbox" title="Show only packages that support the Android platform.">
-                <div class="mdc-form-field">
-                  <div class="mdc-checkbox">
-                    <input id="search-form-checkbox-platform-android" class="mdc-checkbox__native-control" type="checkbox"/>
-                    <div class="mdc-checkbox__background">
-                      <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
-                        <path class="mdc-checkbox__checkmark-path" fill="none" d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
-                      </svg>
-                      <div class="mdc-checkbox__mixedmark"></div>
-                    </div>
-                    <div class="mdc-checkbox__ripple"></div>
-                  </div>
-                  <label for="search-form-checkbox-platform-android">
+                <div class="pub-checkbox">
+                  <input id="search-form-checkbox-platform-android" class="pub-checkbox-input" type="checkbox"/>
+                  <label class="pub-checkbox-label" for="search-form-checkbox-platform-android">
                     <a class="link-tag" href="/packages?q=sdk%3Adart+platform%3Aandroid" rel="nofollow" data-action="filter-platform-android" data-tag="platform:android">Android</a>
                   </label>
                 </div>
               </div>
               <div class="search-form-linked-checkbox" title="Show only packages that support the iOS platform.">
-                <div class="mdc-form-field">
-                  <div class="mdc-checkbox">
-                    <input id="search-form-checkbox-platform-ios" class="mdc-checkbox__native-control" type="checkbox"/>
-                    <div class="mdc-checkbox__background">
-                      <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
-                        <path class="mdc-checkbox__checkmark-path" fill="none" d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
-                      </svg>
-                      <div class="mdc-checkbox__mixedmark"></div>
-                    </div>
-                    <div class="mdc-checkbox__ripple"></div>
-                  </div>
-                  <label for="search-form-checkbox-platform-ios">
+                <div class="pub-checkbox">
+                  <input id="search-form-checkbox-platform-ios" class="pub-checkbox-input" type="checkbox"/>
+                  <label class="pub-checkbox-label" for="search-form-checkbox-platform-ios">
                     <a class="link-tag" href="/packages?q=sdk%3Adart+platform%3Aios" rel="nofollow" data-action="filter-platform-ios" data-tag="platform:ios">iOS</a>
                   </label>
                 </div>
               </div>
               <div class="search-form-linked-checkbox" title="Show only packages that support the Linux platform.">
-                <div class="mdc-form-field">
-                  <div class="mdc-checkbox">
-                    <input id="search-form-checkbox-platform-linux" class="mdc-checkbox__native-control" type="checkbox"/>
-                    <div class="mdc-checkbox__background">
-                      <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
-                        <path class="mdc-checkbox__checkmark-path" fill="none" d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
-                      </svg>
-                      <div class="mdc-checkbox__mixedmark"></div>
-                    </div>
-                    <div class="mdc-checkbox__ripple"></div>
-                  </div>
-                  <label for="search-form-checkbox-platform-linux">
+                <div class="pub-checkbox">
+                  <input id="search-form-checkbox-platform-linux" class="pub-checkbox-input" type="checkbox"/>
+                  <label class="pub-checkbox-label" for="search-form-checkbox-platform-linux">
                     <a class="link-tag" href="/packages?q=sdk%3Adart+platform%3Alinux" rel="nofollow" data-action="filter-platform-linux" data-tag="platform:linux">Linux</a>
                   </label>
                 </div>
               </div>
               <div class="search-form-linked-checkbox" title="Show only packages that support the macOS platform.">
-                <div class="mdc-form-field">
-                  <div class="mdc-checkbox">
-                    <input id="search-form-checkbox-platform-macos" class="mdc-checkbox__native-control" type="checkbox"/>
-                    <div class="mdc-checkbox__background">
-                      <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
-                        <path class="mdc-checkbox__checkmark-path" fill="none" d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
-                      </svg>
-                      <div class="mdc-checkbox__mixedmark"></div>
-                    </div>
-                    <div class="mdc-checkbox__ripple"></div>
-                  </div>
-                  <label for="search-form-checkbox-platform-macos">
+                <div class="pub-checkbox">
+                  <input id="search-form-checkbox-platform-macos" class="pub-checkbox-input" type="checkbox"/>
+                  <label class="pub-checkbox-label" for="search-form-checkbox-platform-macos">
                     <a class="link-tag" href="/packages?q=sdk%3Adart+platform%3Amacos" rel="nofollow" data-action="filter-platform-macos" data-tag="platform:macos">macOS</a>
                   </label>
                 </div>
               </div>
               <div class="search-form-linked-checkbox" title="Show only packages that support the Web platform.">
-                <div class="mdc-form-field">
-                  <div class="mdc-checkbox">
-                    <input id="search-form-checkbox-platform-web" class="mdc-checkbox__native-control" type="checkbox"/>
-                    <div class="mdc-checkbox__background">
-                      <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
-                        <path class="mdc-checkbox__checkmark-path" fill="none" d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
-                      </svg>
-                      <div class="mdc-checkbox__mixedmark"></div>
-                    </div>
-                    <div class="mdc-checkbox__ripple"></div>
-                  </div>
-                  <label for="search-form-checkbox-platform-web">
+                <div class="pub-checkbox">
+                  <input id="search-form-checkbox-platform-web" class="pub-checkbox-input" type="checkbox"/>
+                  <label class="pub-checkbox-label" for="search-form-checkbox-platform-web">
                     <a class="link-tag" href="/packages?q=sdk%3Adart+platform%3Aweb" rel="nofollow" data-action="filter-platform-web" data-tag="platform:web">Web</a>
                   </label>
                 </div>
               </div>
               <div class="search-form-linked-checkbox" title="Show only packages that support the Windows platform.">
-                <div class="mdc-form-field">
-                  <div class="mdc-checkbox">
-                    <input id="search-form-checkbox-platform-windows" class="mdc-checkbox__native-control" type="checkbox"/>
-                    <div class="mdc-checkbox__background">
-                      <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
-                        <path class="mdc-checkbox__checkmark-path" fill="none" d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
-                      </svg>
-                      <div class="mdc-checkbox__mixedmark"></div>
-                    </div>
-                    <div class="mdc-checkbox__ripple"></div>
-                  </div>
-                  <label for="search-form-checkbox-platform-windows">
+                <div class="pub-checkbox">
+                  <input id="search-form-checkbox-platform-windows" class="pub-checkbox-input" type="checkbox"/>
+                  <label class="pub-checkbox-label" for="search-form-checkbox-platform-windows">
                     <a class="link-tag" href="/packages?q=sdk%3Adart+platform%3Awindows" rel="nofollow" data-action="filter-platform-windows" data-tag="platform:windows">Windows</a>
                   </label>
                 </div>
@@ -236,35 +182,17 @@
             </h3>
             <div class="foldable-content">
               <div class="search-form-linked-checkbox" title="Show only packages that support the Dart SDK.">
-                <div class="mdc-form-field">
-                  <div class="mdc-checkbox">
-                    <input id="search-form-checkbox-sdk-dart" class="mdc-checkbox__native-control" type="checkbox" checked="checked"/>
-                    <div class="mdc-checkbox__background">
-                      <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
-                        <path class="mdc-checkbox__checkmark-path" fill="none" d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
-                      </svg>
-                      <div class="mdc-checkbox__mixedmark"></div>
-                    </div>
-                    <div class="mdc-checkbox__ripple"></div>
-                  </div>
-                  <label for="search-form-checkbox-sdk-dart">
+                <div class="pub-checkbox">
+                  <input id="search-form-checkbox-sdk-dart" class="pub-checkbox-input" type="checkbox" checked="checked"/>
+                  <label class="pub-checkbox-label" for="search-form-checkbox-sdk-dart">
                     <a class="link-tag" href="/packages" rel="nofollow" data-action="filter-sdk-dart" data-tag="sdk:dart">Dart</a>
                   </label>
                 </div>
               </div>
               <div class="search-form-linked-checkbox" title="Show only packages that support the Flutter SDK.">
-                <div class="mdc-form-field">
-                  <div class="mdc-checkbox">
-                    <input id="search-form-checkbox-sdk-flutter" class="mdc-checkbox__native-control" type="checkbox"/>
-                    <div class="mdc-checkbox__background">
-                      <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
-                        <path class="mdc-checkbox__checkmark-path" fill="none" d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
-                      </svg>
-                      <div class="mdc-checkbox__mixedmark"></div>
-                    </div>
-                    <div class="mdc-checkbox__ripple"></div>
-                  </div>
-                  <label for="search-form-checkbox-sdk-flutter">
+                <div class="pub-checkbox">
+                  <input id="search-form-checkbox-sdk-flutter" class="pub-checkbox-input" type="checkbox"/>
+                  <label class="pub-checkbox-label" for="search-form-checkbox-sdk-flutter">
                     <a class="link-tag" href="/packages?q=sdk%3Adart+sdk%3Aflutter" rel="nofollow" data-action="filter-sdk-flutter" data-tag="sdk:flutter">Flutter</a>
                   </label>
                 </div>
@@ -278,18 +206,9 @@
             </h3>
             <div class="foldable-content">
               <div class="search-form-linked-checkbox" title="Show only packages with OSI approved license.">
-                <div class="mdc-form-field">
-                  <div class="mdc-checkbox">
-                    <input id="search-form-checkbox-license-osi-approved" class="mdc-checkbox__native-control" type="checkbox"/>
-                    <div class="mdc-checkbox__background">
-                      <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
-                        <path class="mdc-checkbox__checkmark-path" fill="none" d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
-                      </svg>
-                      <div class="mdc-checkbox__mixedmark"></div>
-                    </div>
-                    <div class="mdc-checkbox__ripple"></div>
-                  </div>
-                  <label for="search-form-checkbox-license-osi-approved">
+                <div class="pub-checkbox">
+                  <input id="search-form-checkbox-license-osi-approved" class="pub-checkbox-input" type="checkbox"/>
+                  <label class="pub-checkbox-label" for="search-form-checkbox-license-osi-approved">
                     <a class="link-tag" href="/packages?q=sdk%3Adart+license%3Aosi-approved" rel="nofollow" data-action="filter-license-osi-approved" data-tag="license:osi-approved">OSI approved</a>
                   </label>
                 </div>
@@ -303,86 +222,41 @@
             </h3>
             <div class="foldable-content">
               <div class="search-form-linked-checkbox" title="Show only Flutter Favorite packages.">
-                <div class="mdc-form-field">
-                  <div class="mdc-checkbox">
-                    <input id="search-form-checkbox-is-flutter-favorite" class="mdc-checkbox__native-control" type="checkbox"/>
-                    <div class="mdc-checkbox__background">
-                      <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
-                        <path class="mdc-checkbox__checkmark-path" fill="none" d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
-                      </svg>
-                      <div class="mdc-checkbox__mixedmark"></div>
-                    </div>
-                    <div class="mdc-checkbox__ripple"></div>
-                  </div>
-                  <label for="search-form-checkbox-is-flutter-favorite">
+                <div class="pub-checkbox">
+                  <input id="search-form-checkbox-is-flutter-favorite" class="pub-checkbox-input" type="checkbox"/>
+                  <label class="pub-checkbox-label" for="search-form-checkbox-is-flutter-favorite">
                     <a class="link-tag" href="/packages?q=sdk%3Adart+is%3Aflutter-favorite" rel="nofollow" data-action="filter-is-flutter-favorite" data-tag="is:flutter-favorite">Flutter Favorite</a>
                   </label>
                 </div>
               </div>
               <div class="search-form-linked-checkbox" title="Show only packages with screenshots.">
-                <div class="mdc-form-field">
-                  <div class="mdc-checkbox">
-                    <input id="search-form-checkbox-has-screenshot" class="mdc-checkbox__native-control" type="checkbox"/>
-                    <div class="mdc-checkbox__background">
-                      <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
-                        <path class="mdc-checkbox__checkmark-path" fill="none" d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
-                      </svg>
-                      <div class="mdc-checkbox__mixedmark"></div>
-                    </div>
-                    <div class="mdc-checkbox__ripple"></div>
-                  </div>
-                  <label for="search-form-checkbox-has-screenshot">
+                <div class="pub-checkbox">
+                  <input id="search-form-checkbox-has-screenshot" class="pub-checkbox-input" type="checkbox"/>
+                  <label class="pub-checkbox-label" for="search-form-checkbox-has-screenshot">
                     <a class="link-tag" href="/packages?q=sdk%3Adart+has%3Ascreenshot" rel="nofollow" data-action="filter-has-screenshot" data-tag="has:screenshot">Has screenshot</a>
                   </label>
                 </div>
               </div>
               <div class="search-form-linked-checkbox" title="Show unlisted, discontinued and legacy Dart 1.x packages.">
-                <div class="mdc-form-field">
-                  <div class="mdc-checkbox">
-                    <input id="search-form-checkbox-show-unlisted" class="mdc-checkbox__native-control" type="checkbox"/>
-                    <div class="mdc-checkbox__background">
-                      <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
-                        <path class="mdc-checkbox__checkmark-path" fill="none" d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
-                      </svg>
-                      <div class="mdc-checkbox__mixedmark"></div>
-                    </div>
-                    <div class="mdc-checkbox__ripple"></div>
-                  </div>
-                  <label for="search-form-checkbox-show-unlisted">
+                <div class="pub-checkbox">
+                  <input id="search-form-checkbox-show-unlisted" class="pub-checkbox-input" type="checkbox"/>
+                  <label class="pub-checkbox-label" for="search-form-checkbox-show-unlisted">
                     <a class="link-tag" href="/packages?q=sdk%3Adart+show%3Aunlisted" rel="nofollow" data-action="filter-show-unlisted" data-tag="show:unlisted">Include unlisted</a>
                   </label>
                 </div>
               </div>
               <div class="search-form-linked-checkbox" title="Show only Flutter plugins.">
-                <div class="mdc-form-field">
-                  <div class="mdc-checkbox">
-                    <input id="search-form-checkbox-is-plugin" class="mdc-checkbox__native-control" type="checkbox"/>
-                    <div class="mdc-checkbox__background">
-                      <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
-                        <path class="mdc-checkbox__checkmark-path" fill="none" d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
-                      </svg>
-                      <div class="mdc-checkbox__mixedmark"></div>
-                    </div>
-                    <div class="mdc-checkbox__ripple"></div>
-                  </div>
-                  <label for="search-form-checkbox-is-plugin">
+                <div class="pub-checkbox">
+                  <input id="search-form-checkbox-is-plugin" class="pub-checkbox-input" type="checkbox"/>
+                  <label class="pub-checkbox-label" for="search-form-checkbox-is-plugin">
                     <a class="link-tag" href="/packages?q=sdk%3Adart+is%3Aplugin" rel="nofollow" data-action="filter-is-plugin" data-tag="is:plugin">Flutter plugin</a>
                   </label>
                 </div>
               </div>
               <div class="search-form-linked-checkbox" title="Show only packages with SwiftPM plugins.">
-                <div class="mdc-form-field">
-                  <div class="mdc-checkbox">
-                    <input id="search-form-checkbox-is-swiftpm-plugin" class="mdc-checkbox__native-control" type="checkbox"/>
-                    <div class="mdc-checkbox__background">
-                      <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
-                        <path class="mdc-checkbox__checkmark-path" fill="none" d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
-                      </svg>
-                      <div class="mdc-checkbox__mixedmark"></div>
-                    </div>
-                    <div class="mdc-checkbox__ripple"></div>
-                  </div>
-                  <label for="search-form-checkbox-is-swiftpm-plugin">
+                <div class="pub-checkbox">
+                  <input id="search-form-checkbox-is-swiftpm-plugin" class="pub-checkbox-input" type="checkbox"/>
+                  <label class="pub-checkbox-label" for="search-form-checkbox-is-swiftpm-plugin">
                     <a class="link-tag" href="/packages?q=sdk%3Adart+is%3Aswiftpm-plugin" rel="nofollow" data-action="filter-is-swiftpm-plugin" data-tag="is:swiftpm-plugin">SwiftPM plugin</a>
                     <a class="link-more" href="https://docs.flutter.dev/packages-and-plugins/swift-package-manager/for-app-developers" rel="nofollow noopener" target="_blank">
                       <sup>(?)</sup>
@@ -391,18 +265,9 @@
                 </div>
               </div>
               <div class="search-form-linked-checkbox" title="Show only WASM ready packages.">
-                <div class="mdc-form-field">
-                  <div class="mdc-checkbox">
-                    <input id="search-form-checkbox-is-wasm-ready" class="mdc-checkbox__native-control" type="checkbox"/>
-                    <div class="mdc-checkbox__background">
-                      <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
-                        <path class="mdc-checkbox__checkmark-path" fill="none" d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
-                      </svg>
-                      <div class="mdc-checkbox__mixedmark"></div>
-                    </div>
-                    <div class="mdc-checkbox__ripple"></div>
-                  </div>
-                  <label for="search-form-checkbox-is-wasm-ready">
+                <div class="pub-checkbox">
+                  <input id="search-form-checkbox-is-wasm-ready" class="pub-checkbox-input" type="checkbox"/>
+                  <label class="pub-checkbox-label" for="search-form-checkbox-is-wasm-ready">
                     <a class="link-tag" href="/packages?q=sdk%3Adart+is%3Awasm-ready" rel="nofollow" data-action="filter-is-wasm-ready" data-tag="is:wasm-ready">WASM ready</a>
                     <a class="link-more" href="https://dart.dev/interop/js-interop/package-web" rel="nofollow noopener" target="_blank">
                       <sup>(?)</sup>

--- a/app/test/frontend/golden/search_page.html
+++ b/app/test/frontend/golden/search_page.html
@@ -127,103 +127,49 @@
             </h3>
             <div class="foldable-content">
               <div class="search-form-linked-checkbox" title="Show only packages that support the Android platform.">
-                <div class="mdc-form-field">
-                  <div class="mdc-checkbox">
-                    <input id="search-form-checkbox-platform-android" class="mdc-checkbox__native-control" type="checkbox"/>
-                    <div class="mdc-checkbox__background">
-                      <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
-                        <path class="mdc-checkbox__checkmark-path" fill="none" d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
-                      </svg>
-                      <div class="mdc-checkbox__mixedmark"></div>
-                    </div>
-                    <div class="mdc-checkbox__ripple"></div>
-                  </div>
-                  <label for="search-form-checkbox-platform-android">
+                <div class="pub-checkbox">
+                  <input id="search-form-checkbox-platform-android" class="pub-checkbox-input" type="checkbox"/>
+                  <label class="pub-checkbox-label" for="search-form-checkbox-platform-android">
                     <a class="link-tag" href="/packages?q=platform%3Aandroid+foobar&amp;sort=top" rel="nofollow" data-action="filter-platform-android" data-tag="platform:android">Android</a>
                   </label>
                 </div>
               </div>
               <div class="search-form-linked-checkbox" title="Show only packages that support the iOS platform.">
-                <div class="mdc-form-field">
-                  <div class="mdc-checkbox">
-                    <input id="search-form-checkbox-platform-ios" class="mdc-checkbox__native-control" type="checkbox"/>
-                    <div class="mdc-checkbox__background">
-                      <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
-                        <path class="mdc-checkbox__checkmark-path" fill="none" d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
-                      </svg>
-                      <div class="mdc-checkbox__mixedmark"></div>
-                    </div>
-                    <div class="mdc-checkbox__ripple"></div>
-                  </div>
-                  <label for="search-form-checkbox-platform-ios">
+                <div class="pub-checkbox">
+                  <input id="search-form-checkbox-platform-ios" class="pub-checkbox-input" type="checkbox"/>
+                  <label class="pub-checkbox-label" for="search-form-checkbox-platform-ios">
                     <a class="link-tag" href="/packages?q=platform%3Aios+foobar&amp;sort=top" rel="nofollow" data-action="filter-platform-ios" data-tag="platform:ios">iOS</a>
                   </label>
                 </div>
               </div>
               <div class="search-form-linked-checkbox" title="Show only packages that support the Linux platform.">
-                <div class="mdc-form-field">
-                  <div class="mdc-checkbox">
-                    <input id="search-form-checkbox-platform-linux" class="mdc-checkbox__native-control" type="checkbox"/>
-                    <div class="mdc-checkbox__background">
-                      <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
-                        <path class="mdc-checkbox__checkmark-path" fill="none" d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
-                      </svg>
-                      <div class="mdc-checkbox__mixedmark"></div>
-                    </div>
-                    <div class="mdc-checkbox__ripple"></div>
-                  </div>
-                  <label for="search-form-checkbox-platform-linux">
+                <div class="pub-checkbox">
+                  <input id="search-form-checkbox-platform-linux" class="pub-checkbox-input" type="checkbox"/>
+                  <label class="pub-checkbox-label" for="search-form-checkbox-platform-linux">
                     <a class="link-tag" href="/packages?q=platform%3Alinux+foobar&amp;sort=top" rel="nofollow" data-action="filter-platform-linux" data-tag="platform:linux">Linux</a>
                   </label>
                 </div>
               </div>
               <div class="search-form-linked-checkbox" title="Show only packages that support the macOS platform.">
-                <div class="mdc-form-field">
-                  <div class="mdc-checkbox">
-                    <input id="search-form-checkbox-platform-macos" class="mdc-checkbox__native-control" type="checkbox"/>
-                    <div class="mdc-checkbox__background">
-                      <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
-                        <path class="mdc-checkbox__checkmark-path" fill="none" d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
-                      </svg>
-                      <div class="mdc-checkbox__mixedmark"></div>
-                    </div>
-                    <div class="mdc-checkbox__ripple"></div>
-                  </div>
-                  <label for="search-form-checkbox-platform-macos">
+                <div class="pub-checkbox">
+                  <input id="search-form-checkbox-platform-macos" class="pub-checkbox-input" type="checkbox"/>
+                  <label class="pub-checkbox-label" for="search-form-checkbox-platform-macos">
                     <a class="link-tag" href="/packages?q=platform%3Amacos+foobar&amp;sort=top" rel="nofollow" data-action="filter-platform-macos" data-tag="platform:macos">macOS</a>
                   </label>
                 </div>
               </div>
               <div class="search-form-linked-checkbox" title="Show only packages that support the Web platform.">
-                <div class="mdc-form-field">
-                  <div class="mdc-checkbox">
-                    <input id="search-form-checkbox-platform-web" class="mdc-checkbox__native-control" type="checkbox"/>
-                    <div class="mdc-checkbox__background">
-                      <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
-                        <path class="mdc-checkbox__checkmark-path" fill="none" d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
-                      </svg>
-                      <div class="mdc-checkbox__mixedmark"></div>
-                    </div>
-                    <div class="mdc-checkbox__ripple"></div>
-                  </div>
-                  <label for="search-form-checkbox-platform-web">
+                <div class="pub-checkbox">
+                  <input id="search-form-checkbox-platform-web" class="pub-checkbox-input" type="checkbox"/>
+                  <label class="pub-checkbox-label" for="search-form-checkbox-platform-web">
                     <a class="link-tag" href="/packages?q=platform%3Aweb+foobar&amp;sort=top" rel="nofollow" data-action="filter-platform-web" data-tag="platform:web">Web</a>
                   </label>
                 </div>
               </div>
               <div class="search-form-linked-checkbox" title="Show only packages that support the Windows platform.">
-                <div class="mdc-form-field">
-                  <div class="mdc-checkbox">
-                    <input id="search-form-checkbox-platform-windows" class="mdc-checkbox__native-control" type="checkbox"/>
-                    <div class="mdc-checkbox__background">
-                      <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
-                        <path class="mdc-checkbox__checkmark-path" fill="none" d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
-                      </svg>
-                      <div class="mdc-checkbox__mixedmark"></div>
-                    </div>
-                    <div class="mdc-checkbox__ripple"></div>
-                  </div>
-                  <label for="search-form-checkbox-platform-windows">
+                <div class="pub-checkbox">
+                  <input id="search-form-checkbox-platform-windows" class="pub-checkbox-input" type="checkbox"/>
+                  <label class="pub-checkbox-label" for="search-form-checkbox-platform-windows">
                     <a class="link-tag" href="/packages?q=platform%3Awindows+foobar&amp;sort=top" rel="nofollow" data-action="filter-platform-windows" data-tag="platform:windows">Windows</a>
                   </label>
                 </div>
@@ -237,35 +183,17 @@
             </h3>
             <div class="foldable-content">
               <div class="search-form-linked-checkbox" title="Show only packages that support the Dart SDK.">
-                <div class="mdc-form-field">
-                  <div class="mdc-checkbox">
-                    <input id="search-form-checkbox-sdk-dart" class="mdc-checkbox__native-control" type="checkbox"/>
-                    <div class="mdc-checkbox__background">
-                      <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
-                        <path class="mdc-checkbox__checkmark-path" fill="none" d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
-                      </svg>
-                      <div class="mdc-checkbox__mixedmark"></div>
-                    </div>
-                    <div class="mdc-checkbox__ripple"></div>
-                  </div>
-                  <label for="search-form-checkbox-sdk-dart">
+                <div class="pub-checkbox">
+                  <input id="search-form-checkbox-sdk-dart" class="pub-checkbox-input" type="checkbox"/>
+                  <label class="pub-checkbox-label" for="search-form-checkbox-sdk-dart">
                     <a class="link-tag" href="/packages?q=sdk%3Adart+foobar&amp;sort=top" rel="nofollow" data-action="filter-sdk-dart" data-tag="sdk:dart">Dart</a>
                   </label>
                 </div>
               </div>
               <div class="search-form-linked-checkbox" title="Show only packages that support the Flutter SDK.">
-                <div class="mdc-form-field">
-                  <div class="mdc-checkbox">
-                    <input id="search-form-checkbox-sdk-flutter" class="mdc-checkbox__native-control" type="checkbox"/>
-                    <div class="mdc-checkbox__background">
-                      <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
-                        <path class="mdc-checkbox__checkmark-path" fill="none" d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
-                      </svg>
-                      <div class="mdc-checkbox__mixedmark"></div>
-                    </div>
-                    <div class="mdc-checkbox__ripple"></div>
-                  </div>
-                  <label for="search-form-checkbox-sdk-flutter">
+                <div class="pub-checkbox">
+                  <input id="search-form-checkbox-sdk-flutter" class="pub-checkbox-input" type="checkbox"/>
+                  <label class="pub-checkbox-label" for="search-form-checkbox-sdk-flutter">
                     <a class="link-tag" href="/packages?q=sdk%3Aflutter+foobar&amp;sort=top" rel="nofollow" data-action="filter-sdk-flutter" data-tag="sdk:flutter">Flutter</a>
                   </label>
                 </div>
@@ -279,18 +207,9 @@
             </h3>
             <div class="foldable-content">
               <div class="search-form-linked-checkbox" title="Show only packages with OSI approved license.">
-                <div class="mdc-form-field">
-                  <div class="mdc-checkbox">
-                    <input id="search-form-checkbox-license-osi-approved" class="mdc-checkbox__native-control" type="checkbox"/>
-                    <div class="mdc-checkbox__background">
-                      <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
-                        <path class="mdc-checkbox__checkmark-path" fill="none" d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
-                      </svg>
-                      <div class="mdc-checkbox__mixedmark"></div>
-                    </div>
-                    <div class="mdc-checkbox__ripple"></div>
-                  </div>
-                  <label for="search-form-checkbox-license-osi-approved">
+                <div class="pub-checkbox">
+                  <input id="search-form-checkbox-license-osi-approved" class="pub-checkbox-input" type="checkbox"/>
+                  <label class="pub-checkbox-label" for="search-form-checkbox-license-osi-approved">
                     <a class="link-tag" href="/packages?q=license%3Aosi-approved+foobar&amp;sort=top" rel="nofollow" data-action="filter-license-osi-approved" data-tag="license:osi-approved">OSI approved</a>
                   </label>
                 </div>
@@ -304,86 +223,41 @@
             </h3>
             <div class="foldable-content">
               <div class="search-form-linked-checkbox" title="Show only Flutter Favorite packages.">
-                <div class="mdc-form-field">
-                  <div class="mdc-checkbox">
-                    <input id="search-form-checkbox-is-flutter-favorite" class="mdc-checkbox__native-control" type="checkbox"/>
-                    <div class="mdc-checkbox__background">
-                      <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
-                        <path class="mdc-checkbox__checkmark-path" fill="none" d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
-                      </svg>
-                      <div class="mdc-checkbox__mixedmark"></div>
-                    </div>
-                    <div class="mdc-checkbox__ripple"></div>
-                  </div>
-                  <label for="search-form-checkbox-is-flutter-favorite">
+                <div class="pub-checkbox">
+                  <input id="search-form-checkbox-is-flutter-favorite" class="pub-checkbox-input" type="checkbox"/>
+                  <label class="pub-checkbox-label" for="search-form-checkbox-is-flutter-favorite">
                     <a class="link-tag" href="/packages?q=is%3Aflutter-favorite+foobar&amp;sort=top" rel="nofollow" data-action="filter-is-flutter-favorite" data-tag="is:flutter-favorite">Flutter Favorite</a>
                   </label>
                 </div>
               </div>
               <div class="search-form-linked-checkbox" title="Show only packages with screenshots.">
-                <div class="mdc-form-field">
-                  <div class="mdc-checkbox">
-                    <input id="search-form-checkbox-has-screenshot" class="mdc-checkbox__native-control" type="checkbox"/>
-                    <div class="mdc-checkbox__background">
-                      <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
-                        <path class="mdc-checkbox__checkmark-path" fill="none" d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
-                      </svg>
-                      <div class="mdc-checkbox__mixedmark"></div>
-                    </div>
-                    <div class="mdc-checkbox__ripple"></div>
-                  </div>
-                  <label for="search-form-checkbox-has-screenshot">
+                <div class="pub-checkbox">
+                  <input id="search-form-checkbox-has-screenshot" class="pub-checkbox-input" type="checkbox"/>
+                  <label class="pub-checkbox-label" for="search-form-checkbox-has-screenshot">
                     <a class="link-tag" href="/packages?q=has%3Ascreenshot+foobar&amp;sort=top" rel="nofollow" data-action="filter-has-screenshot" data-tag="has:screenshot">Has screenshot</a>
                   </label>
                 </div>
               </div>
               <div class="search-form-linked-checkbox" title="Show unlisted, discontinued and legacy Dart 1.x packages.">
-                <div class="mdc-form-field">
-                  <div class="mdc-checkbox">
-                    <input id="search-form-checkbox-show-unlisted" class="mdc-checkbox__native-control" type="checkbox"/>
-                    <div class="mdc-checkbox__background">
-                      <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
-                        <path class="mdc-checkbox__checkmark-path" fill="none" d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
-                      </svg>
-                      <div class="mdc-checkbox__mixedmark"></div>
-                    </div>
-                    <div class="mdc-checkbox__ripple"></div>
-                  </div>
-                  <label for="search-form-checkbox-show-unlisted">
+                <div class="pub-checkbox">
+                  <input id="search-form-checkbox-show-unlisted" class="pub-checkbox-input" type="checkbox"/>
+                  <label class="pub-checkbox-label" for="search-form-checkbox-show-unlisted">
                     <a class="link-tag" href="/packages?q=show%3Aunlisted+foobar&amp;sort=top" rel="nofollow" data-action="filter-show-unlisted" data-tag="show:unlisted">Include unlisted</a>
                   </label>
                 </div>
               </div>
               <div class="search-form-linked-checkbox" title="Show only Flutter plugins.">
-                <div class="mdc-form-field">
-                  <div class="mdc-checkbox">
-                    <input id="search-form-checkbox-is-plugin" class="mdc-checkbox__native-control" type="checkbox"/>
-                    <div class="mdc-checkbox__background">
-                      <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
-                        <path class="mdc-checkbox__checkmark-path" fill="none" d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
-                      </svg>
-                      <div class="mdc-checkbox__mixedmark"></div>
-                    </div>
-                    <div class="mdc-checkbox__ripple"></div>
-                  </div>
-                  <label for="search-form-checkbox-is-plugin">
+                <div class="pub-checkbox">
+                  <input id="search-form-checkbox-is-plugin" class="pub-checkbox-input" type="checkbox"/>
+                  <label class="pub-checkbox-label" for="search-form-checkbox-is-plugin">
                     <a class="link-tag" href="/packages?q=is%3Aplugin+foobar&amp;sort=top" rel="nofollow" data-action="filter-is-plugin" data-tag="is:plugin">Flutter plugin</a>
                   </label>
                 </div>
               </div>
               <div class="search-form-linked-checkbox" title="Show only packages with SwiftPM plugins.">
-                <div class="mdc-form-field">
-                  <div class="mdc-checkbox">
-                    <input id="search-form-checkbox-is-swiftpm-plugin" class="mdc-checkbox__native-control" type="checkbox"/>
-                    <div class="mdc-checkbox__background">
-                      <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
-                        <path class="mdc-checkbox__checkmark-path" fill="none" d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
-                      </svg>
-                      <div class="mdc-checkbox__mixedmark"></div>
-                    </div>
-                    <div class="mdc-checkbox__ripple"></div>
-                  </div>
-                  <label for="search-form-checkbox-is-swiftpm-plugin">
+                <div class="pub-checkbox">
+                  <input id="search-form-checkbox-is-swiftpm-plugin" class="pub-checkbox-input" type="checkbox"/>
+                  <label class="pub-checkbox-label" for="search-form-checkbox-is-swiftpm-plugin">
                     <a class="link-tag" href="/packages?q=is%3Aswiftpm-plugin+foobar&amp;sort=top" rel="nofollow" data-action="filter-is-swiftpm-plugin" data-tag="is:swiftpm-plugin">SwiftPM plugin</a>
                     <a class="link-more" href="https://docs.flutter.dev/packages-and-plugins/swift-package-manager/for-app-developers" rel="nofollow noopener" target="_blank">
                       <sup>(?)</sup>
@@ -392,18 +266,9 @@
                 </div>
               </div>
               <div class="search-form-linked-checkbox" title="Show only WASM ready packages.">
-                <div class="mdc-form-field">
-                  <div class="mdc-checkbox">
-                    <input id="search-form-checkbox-is-wasm-ready" class="mdc-checkbox__native-control" type="checkbox"/>
-                    <div class="mdc-checkbox__background">
-                      <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
-                        <path class="mdc-checkbox__checkmark-path" fill="none" d="M1.73,12.91 8.1,19.28 22.79,4.59"/>
-                      </svg>
-                      <div class="mdc-checkbox__mixedmark"></div>
-                    </div>
-                    <div class="mdc-checkbox__ripple"></div>
-                  </div>
-                  <label for="search-form-checkbox-is-wasm-ready">
+                <div class="pub-checkbox">
+                  <input id="search-form-checkbox-is-wasm-ready" class="pub-checkbox-input" type="checkbox"/>
+                  <label class="pub-checkbox-label" for="search-form-checkbox-is-wasm-ready">
                     <a class="link-tag" href="/packages?q=is%3Awasm-ready+foobar&amp;sort=top" rel="nofollow" data-action="filter-is-wasm-ready" data-tag="is:wasm-ready">WASM ready</a>
                     <a class="link-more" href="https://dart.dev/interop/js-interop/package-web" rel="nofollow noopener" target="_blank">
                       <sup>(?)</sup>

--- a/pkg/pub_integration/test/search_update_test.dart
+++ b/pkg/pub_integration/test/search_update_test.dart
@@ -131,7 +131,7 @@ void main() {
 
         // unclick Flutter
         final flutterCB4 = await page.$('#search-form-checkbox-sdk-flutter');
-        final flutterLink = await flutterCB4.$x('../following-sibling::*');
+        final flutterLink = await flutterCB4.$x('following-sibling::*');
         await flutterLink.single.clickAndWaitOneResponse();
         await _waitOneSecond();
         final i4 = await listingPageInfo(page);
@@ -169,7 +169,7 @@ void main() {
         expect(await flutterCB5.attributeValue('data-indeterminate'), 'true');
 
         // clear Flutter with a row-level click
-        final flutterRow = await flutterCB5.$x('../../..');
+        final flutterRow = await flutterCB5.$x('../..');
         await flutterRow.single.clickAndWaitOneResponse();
         await _waitOneSecond();
         final i6 = await listingPageInfo(page);

--- a/pkg/web_app/lib/script.dart
+++ b/pkg/web_app/lib/script.dart
@@ -14,6 +14,7 @@ import 'src/mobile_nav.dart';
 import 'src/page_updater.dart';
 import 'src/screenshot_carousel.dart';
 import 'src/search.dart';
+import 'src/widget/core/checkbox.dart';
 import 'src/widget/core/text_area.dart';
 import 'src/widget/widget.dart' show setupWidgets;
 
@@ -40,6 +41,7 @@ void _setupAllEvents() {
   setupLikesList();
   setupScreenshotCarousel();
   setupWidgets();
+  setupCheckboxes();
   setupTextAreas();
   _setupDarkThemeButton();
 }

--- a/pkg/web_app/lib/src/widget/core/checkbox.dart
+++ b/pkg/web_app/lib/src/widget/core/checkbox.dart
@@ -1,0 +1,19 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:web/web.dart';
+
+import '../../web_util.dart';
+
+/// Reflects the `data-indeterminate` attribute of `.pub-checkbox-input`
+/// elements onto the native `indeterminate` property, as the indeterminate
+/// state of a checkbox cannot be expressed through HTML markup alone.
+void setupCheckboxes() {
+  final inputs = document
+      .querySelectorAll('.pub-checkbox-input')
+      .toElementList<HTMLInputElement>();
+  for (final input in inputs) {
+    input.indeterminate = input.getAttribute('data-indeterminate') == 'true';
+  }
+}

--- a/pkg/web_css/lib/src/_form.scss
+++ b/pkg/web_css/lib/src/_form.scss
@@ -224,7 +224,7 @@
         content: '';
         width: 4px;
         height: 8px;
-        border: solid #fff;
+        border: solid var(--pub-color-white);
         border-width: 0 2px 2px 0;
         // Nudge up to offset the checkmark's lower-hanging heel.
         transform: translateY(-1px) rotate(45deg);
@@ -240,7 +240,7 @@
         content: '';
         width: 8px;
         height: 2px;
-        background-color: #fff;
+        background-color: var(--pub-color-white);
       }
     }
   }

--- a/pkg/web_css/lib/src/_form.scss
+++ b/pkg/web_css/lib/src/_form.scss
@@ -188,6 +188,7 @@
 .pub-checkbox {
   display: flex;
   align-items: center;
+  padding: 2px 2px;
 
   .pub-checkbox-input {
     appearance: none;
@@ -199,10 +200,10 @@
     box-sizing: border-box;
     width: 18px;
     height: 18px;
-    margin: 0 8px 0 0;
+    margin: 0 5px 0 8px;
     background-color: color-mix(in srgb, var(--pub-neutral-borderColor) 40%, transparent);
-    border: 2px solid color-mix(in srgb, var(--pub-neutral-textColor) 40%, transparent);
-    border-radius: 4px;
+    border: 2px solid color-mix(in srgb, var(--pub-neutral-textColor) 60%, transparent);
+    border-radius: 1px;
     cursor: pointer;
     transition: border-color 0.3s, background-color 0.3s;
 
@@ -246,7 +247,7 @@
   }
 
   .pub-checkbox-label {
-    padding: 4px 8px;
+    padding: 6px 8px 4px;
     cursor: pointer;
   }
 }

--- a/pkg/web_css/lib/src/_form.scss
+++ b/pkg/web_css/lib/src/_form.scss
@@ -185,6 +185,72 @@
   }
 }
 
+.pub-checkbox {
+  display: flex;
+  align-items: center;
+
+  .pub-checkbox-input {
+    appearance: none;
+    -webkit-appearance: none;
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    box-sizing: border-box;
+    width: 18px;
+    height: 18px;
+    margin: 0 8px 0 0;
+    background-color: color-mix(in srgb, var(--pub-neutral-borderColor) 40%, transparent);
+    border: 2px solid color-mix(in srgb, var(--pub-neutral-textColor) 40%, transparent);
+    border-radius: 4px;
+    cursor: pointer;
+    transition: border-color 0.3s, background-color 0.3s;
+
+    &:hover {
+      border-color: var(--pub-neutral-textColor);
+    }
+
+    &:focus-visible {
+      outline: none;
+      border-color: var(--pub-link-text-color);
+    }
+
+    // Checkmark, drawn with two borders of a rotated rectangle.
+    &:checked {
+      background-color: var(--pub-link-text-color);
+      border-color: var(--pub-link-text-color);
+
+      &::after {
+        content: '';
+        width: 4px;
+        height: 8px;
+        border: solid #fff;
+        border-width: 0 2px 2px 0;
+        // Nudge up to offset the checkmark's lower-hanging heel.
+        transform: translateY(-1px) rotate(45deg);
+      }
+    }
+
+    // Indeterminate state, drawn as a single horizontal bar.
+    &:indeterminate {
+      background-color: var(--pub-link-text-color);
+      border-color: var(--pub-link-text-color);
+
+      &::after {
+        content: '';
+        width: 8px;
+        height: 2px;
+        background-color: #fff;
+      }
+    }
+  }
+
+  .pub-checkbox-label {
+    padding: 4px 8px;
+    cursor: pointer;
+  }
+}
+
 // Plain HTML text field / text area component
 // (see material.dart `textField` / `textArea`).
 .pub-text-field {

--- a/pkg/web_css/lib/src/_list.scss
+++ b/pkg/web_css/lib/src/_list.scss
@@ -420,10 +420,5 @@
       color: var(--pub-neutral-textColor);
       text-decoration: none;
     }
-
-    label {
-      position: relative;
-      top: -6px;
-    }
   }
 }

--- a/pkg/web_css/lib/src/_variables.scss
+++ b/pkg/web_css/lib/src/_variables.scss
@@ -223,8 +223,6 @@
   --mdc-theme-on-primary: var(--pub-neutral-textColor);
   --mdc-theme-on-secondary: var(--pub-neutral-textColor);
   --mdc-theme-on-surface: var(--pub-neutral-textColor);
-  --mdc-checkbox-unchecked-color: #777777;
-  --mdc-checkbox-disabled-color: #666666;
   --mdc-filled-button-container-color: rgba(255, 255, 255, 0.1);
   --mdc-filled-button-label-text-color: var(--pub-neutral-textColor);
   --mdc-protected-button-disabled-container-color: rgba(255, 255, 255, 0.1);

--- a/pkg/web_css/test/expression_test.dart
+++ b/pkg/web_css/test/expression_test.dart
@@ -38,6 +38,7 @@ void main() {
       // CSS functions
       expressions.removeAll(<String>[
         'first-child',
+        'focus-visible',
         'focus-within',
         'keyframes',
         'last-child',


### PR DESCRIPTION
- Continuing the migration of material components to plain HTML versions. The checkbox styling was a bit harder to crack, and there may be edge cases I haven't tried or covered.
- The CSS implementation of the checkmarks was created from a mix of LLM-suggested styles and online templates. It looks closer to the material design and much better than the default checkbox implementation.
- I've struggled to align the label with the bottom part of box border, the current one is a good-enough for first attempt, may fine-tune it later.
- Followed the same styling as the textfields.

Before:

<img width="198" height="378" alt="image" src="https://github.com/user-attachments/assets/5f27c01c-9b71-477e-83f5-b06ea155136b" />
<img width="198" height="378" alt="image" src="https://github.com/user-attachments/assets/796d7b48-e8c4-4175-9ab9-b86d3a66d9af" />

After:

<img width="198" height="458" alt="image" src="https://github.com/user-attachments/assets/08102692-96be-451d-84a4-57ca3f68dd9f" />
<img width="244" height="428" alt="image" src="https://github.com/user-attachments/assets/5c2ef559-18fc-4844-99fa-a6838401128a" />
