### PR TITLE
Scan tar archive against maxUncompressedSize, not maxArchiveSize

### DIFF
--- a/pkg/pub_package_reader/lib/pub_package_reader.dart
+++ b/pkg/pub_package_reader/lib/pub_package_reader.dart
@@ -122,7 +122,7 @@ Future<PackageSummary> summarizePackageArchive(
     tar = await TarArchive.scan(
       archivePath,
       maxFileCount: maxFileCount,
-      maxTotalLengthBytes: maxArchiveSize,
+      maxTotalLengthBytes: maxUncompressedSize,
     );
   } on TarException catch (e, st) {
     _logger.info('Failed to scan tar archive.', e, st);


### PR DESCRIPTION
I *think* this is an unintended leftover from https://github.com/dart-lang/pub-dev/pull/9085 because `TarArchive.scan` `maxTotalLengthBytes` counts uncompressed bytes.


It prevents package with uncompressed size of 119 MB to be uploaded here: https://github.com/agilord/aws_client/actions/runs/27630763575/job/81704812401

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
