### PR TITLE
Migrate the material floating action button to plain HTML.

### DIFF
--- a/app/lib/frontend/dom/material.dart
+++ b/app/lib/frontend/dom/material.dart
@@ -51,8 +51,8 @@ d.Node button({
   );
 }
 
-/// Renders a material floating action button (FAB) element.
-/// The FAB is 48x48px by default. If [fabMini] is `true` the FAB will be
+/// Renders a plain HTML floating action button (FAB) element.
+/// The FAB is 56x56px by default. If [fabMini] is `true` the FAB will be
 /// 40x40px.
 d.Node floatingActionButton({
   String? id,
@@ -62,15 +62,14 @@ d.Node floatingActionButton({
   d.Image? icon,
 }) {
   return d.element(
-    'fab',
+    'button',
     id: id,
-    classes: ['mdc-fab', if (fabMini) 'mdc-fab--mini', ...?classes],
-    attributes: {'data-mdc-auto-init': 'MDCRipple', ...?attributes},
+    classes: ['pub-fab', if (fabMini) 'pub-fab--mini', ...?classes],
+    attributes: attributes,
     children: [
-      d.div(classes: ['mdc-fab__ripple']),
       if (icon != null)
         d.img(
-          classes: ['mdc-fab__icon'],
+          classes: ['pub-fab-icon'],
           image: icon,
           attributes: {'aria-hidden': 'true'},
         ),

--- a/app/test/frontend/golden/my_activity_log_page.html
+++ b/app/test/frontend/golden/my_activity_log_page.html
@@ -384,15 +384,13 @@
         </div>
       </div>
       <div id="-screenshot-carousel" class="carousel">
-        <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
-          <div class="mdc-fab__ripple"></div>
-          <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
-        </fab>
+        <button id="-carousel-prev" class="pub-fab carousel-prev carousel-nav" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
+          <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
+        </button>
         <div id="-image-container" class="image-container"></div>
-        <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
-          <div class="mdc-fab__ripple"></div>
-          <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
-        </fab>
+        <button id="-carousel-next" class="pub-fab carousel-next carousel-nav" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
+          <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
+        </button>
         <p id="-screenshot-description" class="screenshot-description"></p>
       </div>
     </main>

--- a/app/test/frontend/golden/my_liked_packages.html
+++ b/app/test/frontend/golden/my_liked_packages.html
@@ -346,15 +346,13 @@
                       </div>
                     </div>
                     <div id="-screenshot-carousel" class="carousel">
-                      <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
-                        <div class="mdc-fab__ripple"></div>
-                        <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
-                      </fab>
+                      <button id="-carousel-prev" class="pub-fab carousel-prev carousel-nav" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
+                        <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
+                      </button>
                       <div id="-image-container" class="image-container"></div>
-                      <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
-                        <div class="mdc-fab__ripple"></div>
-                        <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
-                      </fab>
+                      <button id="-carousel-next" class="pub-fab carousel-next carousel-nav" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
+                        <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
+                      </button>
                       <p id="-screenshot-description" class="screenshot-description"></p>
                     </div>
                   </div>
@@ -382,15 +380,13 @@
         </div>
       </div>
       <div id="-screenshot-carousel" class="carousel">
-        <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
-          <div class="mdc-fab__ripple"></div>
-          <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
-        </fab>
+        <button id="-carousel-prev" class="pub-fab carousel-prev carousel-nav" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
+          <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
+        </button>
         <div id="-image-container" class="image-container"></div>
-        <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
-          <div class="mdc-fab__ripple"></div>
-          <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
-        </fab>
+        <button id="-carousel-next" class="pub-fab carousel-next carousel-nav" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
+          <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
+        </button>
         <p id="-screenshot-description" class="screenshot-description"></p>
       </div>
     </main>

--- a/app/test/frontend/golden/my_packages.html
+++ b/app/test/frontend/golden/my_packages.html
@@ -348,15 +348,13 @@
                       </div>
                     </div>
                     <div id="-screenshot-carousel" class="carousel">
-                      <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
-                        <div class="mdc-fab__ripple"></div>
-                        <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
-                      </fab>
+                      <button id="-carousel-prev" class="pub-fab carousel-prev carousel-nav" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
+                        <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
+                      </button>
                       <div id="-image-container" class="image-container"></div>
-                      <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
-                        <div class="mdc-fab__ripple"></div>
-                        <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
-                      </fab>
+                      <button id="-carousel-next" class="pub-fab carousel-next carousel-nav" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
+                        <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
+                      </button>
                       <p id="-screenshot-description" class="screenshot-description"></p>
                     </div>
                   </div>
@@ -370,15 +368,13 @@
         </div>
       </div>
       <div id="-screenshot-carousel" class="carousel">
-        <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
-          <div class="mdc-fab__ripple"></div>
-          <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
-        </fab>
+        <button id="-carousel-prev" class="pub-fab carousel-prev carousel-nav" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
+          <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
+        </button>
         <div id="-image-container" class="image-container"></div>
-        <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
-          <div class="mdc-fab__ripple"></div>
-          <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
-        </fab>
+        <button id="-carousel-next" class="pub-fab carousel-next carousel-nav" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
+          <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
+        </button>
         <p id="-screenshot-description" class="screenshot-description"></p>
       </div>
     </main>

--- a/app/test/frontend/golden/my_publishers.html
+++ b/app/test/frontend/golden/my_publishers.html
@@ -202,15 +202,13 @@
         </div>
       </div>
       <div id="-screenshot-carousel" class="carousel">
-        <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
-          <div class="mdc-fab__ripple"></div>
-          <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
-        </fab>
+        <button id="-carousel-prev" class="pub-fab carousel-prev carousel-nav" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
+          <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
+        </button>
         <div id="-image-container" class="image-container"></div>
-        <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
-          <div class="mdc-fab__ripple"></div>
-          <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
-        </fab>
+        <button id="-carousel-next" class="pub-fab carousel-next carousel-nav" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
+          <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
+        </button>
         <p id="-screenshot-description" class="screenshot-description"></p>
       </div>
     </main>

--- a/app/test/frontend/golden/pkg_activity_log_page.html
+++ b/app/test/frontend/golden/pkg_activity_log_page.html
@@ -507,15 +507,13 @@
         </p>
       </div>
       <div id="-screenshot-carousel" class="carousel">
-        <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
-          <div class="mdc-fab__ripple"></div>
-          <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
-        </fab>
+        <button id="-carousel-prev" class="pub-fab carousel-prev carousel-nav" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
+          <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
+        </button>
         <div id="-image-container" class="image-container"></div>
-        <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
-          <div class="mdc-fab__ripple"></div>
-          <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
-        </fab>
+        <button id="-carousel-next" class="pub-fab carousel-next carousel-nav" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
+          <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
+        </button>
         <p id="-screenshot-description" class="screenshot-description"></p>
       </div>
     </main>

--- a/app/test/frontend/golden/pkg_admin_page.html
+++ b/app/test/frontend/golden/pkg_admin_page.html
@@ -675,15 +675,13 @@
         </p>
       </div>
       <div id="-screenshot-carousel" class="carousel">
-        <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
-          <div class="mdc-fab__ripple"></div>
-          <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
-        </fab>
+        <button id="-carousel-prev" class="pub-fab carousel-prev carousel-nav" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
+          <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
+        </button>
         <div id="-image-container" class="image-container"></div>
-        <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
-          <div class="mdc-fab__ripple"></div>
-          <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
-        </fab>
+        <button id="-carousel-next" class="pub-fab carousel-next carousel-nav" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
+          <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
+        </button>
         <p id="-screenshot-description" class="screenshot-description"></p>
       </div>
     </main>

--- a/app/test/frontend/golden/pkg_changelog_page.html
+++ b/app/test/frontend/golden/pkg_changelog_page.html
@@ -379,15 +379,13 @@
         </p>
       </div>
       <div id="-screenshot-carousel" class="carousel">
-        <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
-          <div class="mdc-fab__ripple"></div>
-          <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
-        </fab>
+        <button id="-carousel-prev" class="pub-fab carousel-prev carousel-nav" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
+          <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
+        </button>
         <div id="-image-container" class="image-container"></div>
-        <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
-          <div class="mdc-fab__ripple"></div>
-          <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
-        </fab>
+        <button id="-carousel-next" class="pub-fab carousel-next carousel-nav" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
+          <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
+        </button>
         <p id="-screenshot-description" class="screenshot-description"></p>
       </div>
     </main>

--- a/app/test/frontend/golden/pkg_example_page.html
+++ b/app/test/frontend/golden/pkg_example_page.html
@@ -376,15 +376,13 @@
         </p>
       </div>
       <div id="-screenshot-carousel" class="carousel">
-        <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
-          <div class="mdc-fab__ripple"></div>
-          <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
-        </fab>
+        <button id="-carousel-prev" class="pub-fab carousel-prev carousel-nav" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
+          <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
+        </button>
         <div id="-image-container" class="image-container"></div>
-        <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
-          <div class="mdc-fab__ripple"></div>
-          <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
-        </fab>
+        <button id="-carousel-next" class="pub-fab carousel-next carousel-nav" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
+          <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
+        </button>
         <p id="-screenshot-description" class="screenshot-description"></p>
       </div>
     </main>

--- a/app/test/frontend/golden/pkg_index_page.html
+++ b/app/test/frontend/golden/pkg_index_page.html
@@ -482,15 +482,13 @@
               </div>
             </div>
             <div id="-screenshot-carousel" class="carousel">
-              <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
-                <div class="mdc-fab__ripple"></div>
-                <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
-              </fab>
+              <button id="-carousel-prev" class="pub-fab carousel-prev carousel-nav" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
+                <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
+              </button>
               <div id="-image-container" class="image-container"></div>
-              <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
-                <div class="mdc-fab__ripple"></div>
-                <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
-              </fab>
+              <button id="-carousel-next" class="pub-fab carousel-next carousel-nav" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
+                <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
+              </button>
               <p id="-screenshot-description" class="screenshot-description"></p>
             </div>
           </div>

--- a/app/test/frontend/golden/pkg_install_page.html
+++ b/app/test/frontend/golden/pkg_install_page.html
@@ -402,15 +402,13 @@
         </p>
       </div>
       <div id="-screenshot-carousel" class="carousel">
-        <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
-          <div class="mdc-fab__ripple"></div>
-          <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
-        </fab>
+        <button id="-carousel-prev" class="pub-fab carousel-prev carousel-nav" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
+          <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
+        </button>
         <div id="-image-container" class="image-container"></div>
-        <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
-          <div class="mdc-fab__ripple"></div>
-          <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
-        </fab>
+        <button id="-carousel-next" class="pub-fab carousel-next carousel-nav" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
+          <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
+        </button>
         <p id="-screenshot-description" class="screenshot-description"></p>
       </div>
     </main>

--- a/app/test/frontend/golden/pkg_score_page.html
+++ b/app/test/frontend/golden/pkg_score_page.html
@@ -500,15 +500,13 @@
         </p>
       </div>
       <div id="-screenshot-carousel" class="carousel">
-        <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
-          <div class="mdc-fab__ripple"></div>
-          <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
-        </fab>
+        <button id="-carousel-prev" class="pub-fab carousel-prev carousel-nav" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
+          <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
+        </button>
         <div id="-image-container" class="image-container"></div>
-        <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
-          <div class="mdc-fab__ripple"></div>
-          <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
-        </fab>
+        <button id="-carousel-next" class="pub-fab carousel-next carousel-nav" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
+          <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
+        </button>
         <p id="-screenshot-description" class="screenshot-description"></p>
       </div>
     </main>

--- a/app/test/frontend/golden/pkg_score_page_with_downloads_chart.html
+++ b/app/test/frontend/golden/pkg_score_page_with_downloads_chart.html
@@ -500,15 +500,13 @@
         </p>
       </div>
       <div id="-screenshot-carousel" class="carousel">
-        <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
-          <div class="mdc-fab__ripple"></div>
-          <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
-        </fab>
+        <button id="-carousel-prev" class="pub-fab carousel-prev carousel-nav" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
+          <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
+        </button>
         <div id="-image-container" class="image-container"></div>
-        <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
-          <div class="mdc-fab__ripple"></div>
-          <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
-        </fab>
+        <button id="-carousel-next" class="pub-fab carousel-next carousel-nav" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
+          <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
+        </button>
         <p id="-screenshot-description" class="screenshot-description"></p>
       </div>
     </main>

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -454,15 +454,13 @@
         </p>
       </div>
       <div id="-screenshot-carousel" class="carousel">
-        <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
-          <div class="mdc-fab__ripple"></div>
-          <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
-        </fab>
+        <button id="-carousel-prev" class="pub-fab carousel-prev carousel-nav" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
+          <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
+        </button>
         <div id="-image-container" class="image-container"></div>
-        <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
-          <div class="mdc-fab__ripple"></div>
-          <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
-        </fab>
+        <button id="-carousel-next" class="pub-fab carousel-next carousel-nav" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
+          <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
+        </button>
         <p id="-screenshot-description" class="screenshot-description"></p>
       </div>
     </main>

--- a/app/test/frontend/golden/pkg_show_page_discontinued.html
+++ b/app/test/frontend/golden/pkg_show_page_discontinued.html
@@ -368,15 +368,13 @@
         </p>
       </div>
       <div id="-screenshot-carousel" class="carousel">
-        <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
-          <div class="mdc-fab__ripple"></div>
-          <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
-        </fab>
+        <button id="-carousel-prev" class="pub-fab carousel-prev carousel-nav" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
+          <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
+        </button>
         <div id="-image-container" class="image-container"></div>
-        <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
-          <div class="mdc-fab__ripple"></div>
-          <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
-        </fab>
+        <button id="-carousel-next" class="pub-fab carousel-next carousel-nav" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
+          <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
+        </button>
         <p id="-screenshot-description" class="screenshot-description"></p>
       </div>
     </main>

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -376,15 +376,13 @@
         </p>
       </div>
       <div id="-screenshot-carousel" class="carousel">
-        <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
-          <div class="mdc-fab__ripple"></div>
-          <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
-        </fab>
+        <button id="-carousel-prev" class="pub-fab carousel-prev carousel-nav" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
+          <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
+        </button>
         <div id="-image-container" class="image-container"></div>
-        <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
-          <div class="mdc-fab__ripple"></div>
-          <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
-        </fab>
+        <button id="-carousel-next" class="pub-fab carousel-next carousel-nav" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
+          <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
+        </button>
         <p id="-screenshot-description" class="screenshot-description"></p>
       </div>
     </main>

--- a/app/test/frontend/golden/pkg_show_page_publisher.html
+++ b/app/test/frontend/golden/pkg_show_page_publisher.html
@@ -357,15 +357,13 @@
         </p>
       </div>
       <div id="-screenshot-carousel" class="carousel">
-        <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
-          <div class="mdc-fab__ripple"></div>
-          <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
-        </fab>
+        <button id="-carousel-prev" class="pub-fab carousel-prev carousel-nav" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
+          <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
+        </button>
         <div id="-image-container" class="image-container"></div>
-        <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
-          <div class="mdc-fab__ripple"></div>
-          <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
-        </fab>
+        <button id="-carousel-next" class="pub-fab carousel-next carousel-nav" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
+          <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
+        </button>
         <p id="-screenshot-description" class="screenshot-description"></p>
       </div>
     </main>

--- a/app/test/frontend/golden/pkg_show_page_retracted.html
+++ b/app/test/frontend/golden/pkg_show_page_retracted.html
@@ -345,15 +345,13 @@
         </p>
       </div>
       <div id="-screenshot-carousel" class="carousel">
-        <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
-          <div class="mdc-fab__ripple"></div>
-          <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
-        </fab>
+        <button id="-carousel-prev" class="pub-fab carousel-prev carousel-nav" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
+          <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
+        </button>
         <div id="-image-container" class="image-container"></div>
-        <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
-          <div class="mdc-fab__ripple"></div>
-          <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
-        </fab>
+        <button id="-carousel-next" class="pub-fab carousel-next carousel-nav" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
+          <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
+        </button>
         <p id="-screenshot-description" class="screenshot-description"></p>
       </div>
     </main>

--- a/app/test/frontend/golden/pkg_show_page_retracted_non_retracted_version.html
+++ b/app/test/frontend/golden/pkg_show_page_retracted_non_retracted_version.html
@@ -359,15 +359,13 @@
         </p>
       </div>
       <div id="-screenshot-carousel" class="carousel">
-        <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
-          <div class="mdc-fab__ripple"></div>
-          <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
-        </fab>
+        <button id="-carousel-prev" class="pub-fab carousel-prev carousel-nav" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
+          <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
+        </button>
         <div id="-image-container" class="image-container"></div>
-        <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
-          <div class="mdc-fab__ripple"></div>
-          <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
-        </fab>
+        <button id="-carousel-next" class="pub-fab carousel-next carousel-nav" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
+          <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
+        </button>
         <p id="-screenshot-description" class="screenshot-description"></p>
       </div>
     </main>

--- a/app/test/frontend/golden/pkg_show_version_page.html
+++ b/app/test/frontend/golden/pkg_show_version_page.html
@@ -373,15 +373,13 @@
         </p>
       </div>
       <div id="-screenshot-carousel" class="carousel">
-        <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
-          <div class="mdc-fab__ripple"></div>
-          <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
-        </fab>
+        <button id="-carousel-prev" class="pub-fab carousel-prev carousel-nav" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
+          <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
+        </button>
         <div id="-image-container" class="image-container"></div>
-        <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
-          <div class="mdc-fab__ripple"></div>
-          <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
-        </fab>
+        <button id="-carousel-next" class="pub-fab carousel-next carousel-nav" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
+          <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
+        </button>
         <p id="-screenshot-description" class="screenshot-description"></p>
       </div>
     </main>

--- a/app/test/frontend/golden/pkg_versions_page.html
+++ b/app/test/frontend/golden/pkg_versions_page.html
@@ -485,15 +485,13 @@
         </p>
       </div>
       <div id="-screenshot-carousel" class="carousel">
-        <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
-          <div class="mdc-fab__ripple"></div>
-          <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
-        </fab>
+        <button id="-carousel-prev" class="pub-fab carousel-prev carousel-nav" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
+          <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
+        </button>
         <div id="-image-container" class="image-container"></div>
-        <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
-          <div class="mdc-fab__ripple"></div>
-          <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
-        </fab>
+        <button id="-carousel-next" class="pub-fab carousel-next carousel-nav" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
+          <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
+        </button>
         <p id="-screenshot-description" class="screenshot-description"></p>
       </div>
     </main>

--- a/app/test/frontend/golden/publisher_activity_log_page.html
+++ b/app/test/frontend/golden/publisher_activity_log_page.html
@@ -216,15 +216,13 @@
         </div>
       </div>
       <div id="-screenshot-carousel" class="carousel">
-        <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
-          <div class="mdc-fab__ripple"></div>
-          <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
-        </fab>
+        <button id="-carousel-prev" class="pub-fab carousel-prev carousel-nav" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
+          <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
+        </button>
         <div id="-image-container" class="image-container"></div>
-        <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
-          <div class="mdc-fab__ripple"></div>
-          <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
-        </fab>
+        <button id="-carousel-next" class="pub-fab carousel-next carousel-nav" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
+          <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
+        </button>
         <p id="-screenshot-description" class="screenshot-description"></p>
       </div>
     </main>

--- a/app/test/frontend/golden/publisher_admin_page.html
+++ b/app/test/frontend/golden/publisher_admin_page.html
@@ -230,15 +230,13 @@
         </div>
       </div>
       <div id="-screenshot-carousel" class="carousel">
-        <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
-          <div class="mdc-fab__ripple"></div>
-          <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
-        </fab>
+        <button id="-carousel-prev" class="pub-fab carousel-prev carousel-nav" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
+          <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
+        </button>
         <div id="-image-container" class="image-container"></div>
-        <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
-          <div class="mdc-fab__ripple"></div>
-          <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
-        </fab>
+        <button id="-carousel-next" class="pub-fab carousel-next carousel-nav" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
+          <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
+        </button>
         <p id="-screenshot-description" class="screenshot-description"></p>
       </div>
     </main>

--- a/app/test/frontend/golden/publisher_packages_page.html
+++ b/app/test/frontend/golden/publisher_packages_page.html
@@ -345,15 +345,13 @@
                       </div>
                     </div>
                     <div id="-screenshot-carousel" class="carousel">
-                      <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
-                        <div class="mdc-fab__ripple"></div>
-                        <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
-                      </fab>
+                      <button id="-carousel-prev" class="pub-fab carousel-prev carousel-nav" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
+                        <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
+                      </button>
                       <div id="-image-container" class="image-container"></div>
-                      <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
-                        <div class="mdc-fab__ripple"></div>
-                        <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
-                      </fab>
+                      <button id="-carousel-next" class="pub-fab carousel-next carousel-nav" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
+                        <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
+                      </button>
                       <p id="-screenshot-description" class="screenshot-description"></p>
                     </div>
                   </div>
@@ -381,15 +379,13 @@
         </div>
       </div>
       <div id="-screenshot-carousel" class="carousel">
-        <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
-          <div class="mdc-fab__ripple"></div>
-          <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
-        </fab>
+        <button id="-carousel-prev" class="pub-fab carousel-prev carousel-nav" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
+          <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
+        </button>
         <div id="-image-container" class="image-container"></div>
-        <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
-          <div class="mdc-fab__ripple"></div>
-          <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
-        </fab>
+        <button id="-carousel-next" class="pub-fab carousel-next carousel-nav" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
+          <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
+        </button>
         <p id="-screenshot-description" class="screenshot-description"></p>
       </div>
     </main>

--- a/app/test/frontend/golden/publisher_unlisted_packages_page.html
+++ b/app/test/frontend/golden/publisher_unlisted_packages_page.html
@@ -351,15 +351,13 @@
                       </div>
                     </div>
                     <div id="-screenshot-carousel" class="carousel">
-                      <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
-                        <div class="mdc-fab__ripple"></div>
-                        <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
-                      </fab>
+                      <button id="-carousel-prev" class="pub-fab carousel-prev carousel-nav" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
+                        <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
+                      </button>
                       <div id="-image-container" class="image-container"></div>
-                      <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
-                        <div class="mdc-fab__ripple"></div>
-                        <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
-                      </fab>
+                      <button id="-carousel-next" class="pub-fab carousel-next carousel-nav" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
+                        <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
+                      </button>
                       <p id="-screenshot-description" class="screenshot-description"></p>
                     </div>
                   </div>
@@ -387,15 +385,13 @@
         </div>
       </div>
       <div id="-screenshot-carousel" class="carousel">
-        <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
-          <div class="mdc-fab__ripple"></div>
-          <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
-        </fab>
+        <button id="-carousel-prev" class="pub-fab carousel-prev carousel-nav" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
+          <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
+        </button>
         <div id="-image-container" class="image-container"></div>
-        <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
-          <div class="mdc-fab__ripple"></div>
-          <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
-        </fab>
+        <button id="-carousel-next" class="pub-fab carousel-next carousel-nav" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
+          <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
+        </button>
         <p id="-screenshot-description" class="screenshot-description"></p>
       </div>
     </main>

--- a/app/test/frontend/golden/search_page.html
+++ b/app/test/frontend/golden/search_page.html
@@ -476,15 +476,13 @@
               </div>
             </div>
             <div id="-screenshot-carousel" class="carousel">
-              <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
-                <div class="mdc-fab__ripple"></div>
-                <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
-              </fab>
+              <button id="-carousel-prev" class="pub-fab carousel-prev carousel-nav" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
+                <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
+              </button>
               <div id="-image-container" class="image-container"></div>
-              <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
-                <div class="mdc-fab__ripple"></div>
-                <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
-              </fab>
+              <button id="-carousel-next" class="pub-fab carousel-next carousel-nav" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
+                <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
+              </button>
               <p id="-screenshot-description" class="screenshot-description"></p>
             </div>
           </div>

--- a/app/test/task/testdata/goldens/packages/oxygen.html
+++ b/app/test/task/testdata/goldens/packages/oxygen.html
@@ -368,15 +368,13 @@
         </p>
       </div>
       <div id="-screenshot-carousel" class="carousel">
-        <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
-          <div class="mdc-fab__ripple"></div>
-          <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
-        </fab>
+        <button id="-carousel-prev" class="pub-fab carousel-prev carousel-nav" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
+          <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
+        </button>
         <div id="-image-container" class="image-container"></div>
-        <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
-          <div class="mdc-fab__ripple"></div>
-          <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
-        </fab>
+        <button id="-carousel-next" class="pub-fab carousel-next carousel-nav" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
+          <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
+        </button>
         <p id="-screenshot-description" class="screenshot-description"></p>
       </div>
     </main>

--- a/app/test/task/testdata/goldens/packages/oxygen/changelog.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/changelog.html
@@ -374,15 +374,13 @@
         </p>
       </div>
       <div id="-screenshot-carousel" class="carousel">
-        <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
-          <div class="mdc-fab__ripple"></div>
-          <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
-        </fab>
+        <button id="-carousel-prev" class="pub-fab carousel-prev carousel-nav" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
+          <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
+        </button>
         <div id="-image-container" class="image-container"></div>
-        <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
-          <div class="mdc-fab__ripple"></div>
-          <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
-        </fab>
+        <button id="-carousel-next" class="pub-fab carousel-next carousel-nav" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
+          <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
+        </button>
         <p id="-screenshot-description" class="screenshot-description"></p>
       </div>
     </main>

--- a/app/test/task/testdata/goldens/packages/oxygen/example.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/example.html
@@ -369,15 +369,13 @@
         </p>
       </div>
       <div id="-screenshot-carousel" class="carousel">
-        <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
-          <div class="mdc-fab__ripple"></div>
-          <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
-        </fab>
+        <button id="-carousel-prev" class="pub-fab carousel-prev carousel-nav" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
+          <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
+        </button>
         <div id="-image-container" class="image-container"></div>
-        <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
-          <div class="mdc-fab__ripple"></div>
-          <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
-        </fab>
+        <button id="-carousel-next" class="pub-fab carousel-next carousel-nav" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
+          <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
+        </button>
         <p id="-screenshot-description" class="screenshot-description"></p>
       </div>
     </main>

--- a/app/test/task/testdata/goldens/packages/oxygen/install.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/install.html
@@ -397,15 +397,13 @@
         </p>
       </div>
       <div id="-screenshot-carousel" class="carousel">
-        <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
-          <div class="mdc-fab__ripple"></div>
-          <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
-        </fab>
+        <button id="-carousel-prev" class="pub-fab carousel-prev carousel-nav" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
+          <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
+        </button>
         <div id="-image-container" class="image-container"></div>
-        <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
-          <div class="mdc-fab__ripple"></div>
-          <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
-        </fab>
+        <button id="-carousel-next" class="pub-fab carousel-next carousel-nav" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
+          <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
+        </button>
         <p id="-screenshot-description" class="screenshot-description"></p>
       </div>
     </main>

--- a/app/test/task/testdata/goldens/packages/oxygen/license.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/license.html
@@ -370,15 +370,13 @@
         </p>
       </div>
       <div id="-screenshot-carousel" class="carousel">
-        <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
-          <div class="mdc-fab__ripple"></div>
-          <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
-        </fab>
+        <button id="-carousel-prev" class="pub-fab carousel-prev carousel-nav" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
+          <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
+        </button>
         <div id="-image-container" class="image-container"></div>
-        <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
-          <div class="mdc-fab__ripple"></div>
-          <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
-        </fab>
+        <button id="-carousel-next" class="pub-fab carousel-next carousel-nav" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
+          <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
+        </button>
         <p id="-screenshot-description" class="screenshot-description"></p>
       </div>
     </main>

--- a/app/test/task/testdata/goldens/packages/oxygen/score.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/score.html
@@ -672,15 +672,13 @@
         </p>
       </div>
       <div id="-screenshot-carousel" class="carousel">
-        <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
-          <div class="mdc-fab__ripple"></div>
-          <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
-        </fab>
+        <button id="-carousel-prev" class="pub-fab carousel-prev carousel-nav" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
+          <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
+        </button>
         <div id="-image-container" class="image-container"></div>
-        <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
-          <div class="mdc-fab__ripple"></div>
-          <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
-        </fab>
+        <button id="-carousel-next" class="pub-fab carousel-next carousel-nav" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
+          <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
+        </button>
         <p id="-screenshot-description" class="screenshot-description"></p>
       </div>
     </main>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions.html
@@ -431,15 +431,13 @@
         </p>
       </div>
       <div id="-screenshot-carousel" class="carousel">
-        <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
-          <div class="mdc-fab__ripple"></div>
-          <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
-        </fab>
+        <button id="-carousel-prev" class="pub-fab carousel-prev carousel-nav" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
+          <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
+        </button>
         <div id="-image-container" class="image-container"></div>
-        <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
-          <div class="mdc-fab__ripple"></div>
-          <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
-        </fab>
+        <button id="-carousel-next" class="pub-fab carousel-next carousel-nav" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
+          <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
+        </button>
         <p id="-screenshot-description" class="screenshot-description"></p>
       </div>
     </main>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0.html
@@ -372,15 +372,13 @@
         </p>
       </div>
       <div id="-screenshot-carousel" class="carousel">
-        <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
-          <div class="mdc-fab__ripple"></div>
-          <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
-        </fab>
+        <button id="-carousel-prev" class="pub-fab carousel-prev carousel-nav" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
+          <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
+        </button>
         <div id="-image-container" class="image-container"></div>
-        <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
-          <div class="mdc-fab__ripple"></div>
-          <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
-        </fab>
+        <button id="-carousel-next" class="pub-fab carousel-next carousel-nav" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
+          <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
+        </button>
         <p id="-screenshot-description" class="screenshot-description"></p>
       </div>
     </main>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/changelog.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/changelog.html
@@ -378,15 +378,13 @@
         </p>
       </div>
       <div id="-screenshot-carousel" class="carousel">
-        <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
-          <div class="mdc-fab__ripple"></div>
-          <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
-        </fab>
+        <button id="-carousel-prev" class="pub-fab carousel-prev carousel-nav" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
+          <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
+        </button>
         <div id="-image-container" class="image-container"></div>
-        <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
-          <div class="mdc-fab__ripple"></div>
-          <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
-        </fab>
+        <button id="-carousel-next" class="pub-fab carousel-next carousel-nav" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
+          <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
+        </button>
         <p id="-screenshot-description" class="screenshot-description"></p>
       </div>
     </main>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/example.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/example.html
@@ -373,15 +373,13 @@
         </p>
       </div>
       <div id="-screenshot-carousel" class="carousel">
-        <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
-          <div class="mdc-fab__ripple"></div>
-          <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
-        </fab>
+        <button id="-carousel-prev" class="pub-fab carousel-prev carousel-nav" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
+          <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
+        </button>
         <div id="-image-container" class="image-container"></div>
-        <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
-          <div class="mdc-fab__ripple"></div>
-          <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
-        </fab>
+        <button id="-carousel-next" class="pub-fab carousel-next carousel-nav" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
+          <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
+        </button>
         <p id="-screenshot-description" class="screenshot-description"></p>
       </div>
     </main>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/install.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/install.html
@@ -401,15 +401,13 @@
         </p>
       </div>
       <div id="-screenshot-carousel" class="carousel">
-        <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
-          <div class="mdc-fab__ripple"></div>
-          <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
-        </fab>
+        <button id="-carousel-prev" class="pub-fab carousel-prev carousel-nav" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
+          <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
+        </button>
         <div id="-image-container" class="image-container"></div>
-        <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
-          <div class="mdc-fab__ripple"></div>
-          <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
-        </fab>
+        <button id="-carousel-next" class="pub-fab carousel-next carousel-nav" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
+          <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
+        </button>
         <p id="-screenshot-description" class="screenshot-description"></p>
       </div>
     </main>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/license.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/license.html
@@ -374,15 +374,13 @@
         </p>
       </div>
       <div id="-screenshot-carousel" class="carousel">
-        <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
-          <div class="mdc-fab__ripple"></div>
-          <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
-        </fab>
+        <button id="-carousel-prev" class="pub-fab carousel-prev carousel-nav" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
+          <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
+        </button>
         <div id="-image-container" class="image-container"></div>
-        <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
-          <div class="mdc-fab__ripple"></div>
-          <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
-        </fab>
+        <button id="-carousel-next" class="pub-fab carousel-next carousel-nav" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
+          <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
+        </button>
         <p id="-screenshot-description" class="screenshot-description"></p>
       </div>
     </main>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/score.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/1.0.0/score.html
@@ -676,15 +676,13 @@
         </p>
       </div>
       <div id="-screenshot-carousel" class="carousel">
-        <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
-          <div class="mdc-fab__ripple"></div>
-          <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
-        </fab>
+        <button id="-carousel-prev" class="pub-fab carousel-prev carousel-nav" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
+          <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
+        </button>
         <div id="-image-container" class="image-container"></div>
-        <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
-          <div class="mdc-fab__ripple"></div>
-          <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
-        </fab>
+        <button id="-carousel-next" class="pub-fab carousel-next carousel-nav" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
+          <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
+        </button>
         <p id="-screenshot-description" class="screenshot-description"></p>
       </div>
     </main>

--- a/app/test/task/testdata/goldens/packages/oxygen/versions/2.0.0.html
+++ b/app/test/task/testdata/goldens/packages/oxygen/versions/2.0.0.html
@@ -368,15 +368,13 @@
         </p>
       </div>
       <div id="-screenshot-carousel" class="carousel">
-        <fab id="-carousel-prev" class="mdc-fab carousel-prev carousel-nav" data-mdc-auto-init="MDCRipple" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
-          <div class="mdc-fab__ripple"></div>
-          <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
-        </fab>
+        <button id="-carousel-prev" class="pub-fab carousel-prev carousel-nav" title="Previous" data-ga-click-event="screenshot-carousel-prev-click" tabindex="0">
+          <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_left.svg" alt="previous" width="24" height="24" aria-hidden="true"/>
+        </button>
         <div id="-image-container" class="image-container"></div>
-        <fab id="-carousel-next" class="mdc-fab carousel-next carousel-nav" data-mdc-auto-init="MDCRipple" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
-          <div class="mdc-fab__ripple"></div>
-          <img class="mdc-fab__icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
-        </fab>
+        <button id="-carousel-next" class="pub-fab carousel-next carousel-nav" title="Next" data-ga-click-event="screenshot-carousel-next-click" tabindex="0">
+          <img class="pub-fab-icon" src="/static/hash-%%etag%%/img/keyboard_arrow_right.svg" alt="next" width="24" height="24" aria-hidden="true"/>
+        </button>
         <p id="-screenshot-description" class="screenshot-description"></p>
       </div>
     </main>

--- a/pkg/web_css/lib/src/_form.scss
+++ b/pkg/web_css/lib/src/_form.scss
@@ -140,6 +140,44 @@
   }
 }
 
+.pub-fab {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
+  width: 56px;
+  height: 56px;
+  padding: 0;
+  border: none;
+  border-radius: 50%;
+  background-color: var(--pub-link-text-color);
+  color: var(--pub-color-white);
+  fill: currentColor;
+  cursor: pointer;
+  user-select: none;
+  box-shadow: 0 3px 5px -1px rgba(0, 0, 0, 0.2),
+    0 6px 10px 0 rgba(0, 0, 0, 0.14), 0 1px 18px 0 rgba(0, 0, 0, 0.12);
+  transition: box-shadow 0.28s cubic-bezier(0.4, 0, 0.2, 1);
+
+  &.pub-fab--mini {
+    width: 40px;
+    height: 40px;
+  }
+
+  &:hover {
+    box-shadow: 0 5px 5px -3px rgba(0, 0, 0, 0.2),
+      0 8px 10px 1px rgba(0, 0, 0, 0.14), 0 3px 14px 2px rgba(0, 0, 0, 0.12);
+  }
+
+  &:focus {
+    outline: none;
+  }
+
+  .pub-fab-icon {
+    width: 24px;
+    height: 24px;
+  }
+}
 
 // Plain HTML dropdown / select component (see material.dart `dropdown`).
 .pub-select {


### PR DESCRIPTION
- Mostly copy of the material style rules.
- Available on staging (eg. win32 screenshots).