### PR TITLE
Improve name search by changing Set.contains into counting.

### DIFF
--- a/app/bin/tools/search_benchmark.dart
+++ b/app/bin/tools/search_benchmark.dart
@@ -25,19 +25,30 @@ Future<void> main(List<String> args) async {
 
   // NOTE: please add more queries to this list, especially if there is a performance bottleneck.
   final queries = [
+    // tag only
     'sdk:dart',
     'sdk:flutter platform:android',
     'is:flutter-favorite',
+    // frequent substring
+    'a',
+    'er',
+    // frequently searched for
     'chart',
     'json',
     'camera',
+    // frequent words of different length
+    'dart',
+    'flutter',
+    'development',
+    // multi-word expressions
     'android camera',
     'sql database',
+    'to help speed up',
   ];
 
   final sw = Stopwatch()..start();
   var count = 0;
-  for (var i = 0; i < 100; i++) {
+  for (var i = 0; i < 100 || sw.elapsed.inMinutes < 2; i++) {
     await index.search(
       ServiceSearchQuery.parse(
         query: queries[i % queries.length],

--- a/app/lib/search/mem_index.dart
+++ b/app/lib/search/mem_index.dart
@@ -663,7 +663,7 @@ class PackageNameIndex {
   /// whose collapsed name contains that trigram.
   late final Map<String, List<int>> _trigramPostings;
 
-  // TODO: consider int-based counter implementation
+  // TODO(https://github.com/dart-lang/pub-dev/issues/9462): consider int-based counter implementation
   late final _counterPool = ScorePool(_packageNames.length);
 
   PackageNameIndex(this._packageNames) {
@@ -679,7 +679,7 @@ class PackageNameIndex {
           .putIfAbsent(_data[i].collapsed, () => [])
           .add(_packageNames[i]);
       // Register only a single trigram -> document index posting.
-      // TODO: consider posting weights
+      // TODO(https://github.com/dart-lang/pub-dev/issues/9462): consider posting weights
       for (final trigram in trigrams(_data[i].collapsed).toSet()) {
         _trigramPostings.putIfAbsent(trigram, () => <int>[]).add(i);
       }
@@ -742,7 +742,7 @@ class PackageNameIndex {
 
     // Note: short strings (less than a trigram) are not indexed separately,
     //       we need to do full substring check, evaluating every package.
-    // TODO: consider updating the index + the evaluation algorithm
+    // TODO(https://github.com/dart-lang/pub-dev/issues/9462): consider updating the index + the evaluation algorithm
     if (collapsedWord.length < 3) {
       for (var i = 0; i < _data.length; i++) {
         if (filterOnNonZeros?.isNotPositive(i) ?? false) continue;

--- a/app/lib/search/mem_index.dart
+++ b/app/lib/search/mem_index.dart
@@ -465,7 +465,7 @@ class InMemoryPackageIndex {
     for (final word in words) {
       await _scorePool.withPoolItem(
         fn: (wordScore) async {
-          _packageNameIndex.searchWord(
+          _packageNameIndex._searchWord(
             word,
             score: wordScore,
             filterOnNonZeros: packageScores,
@@ -659,17 +659,30 @@ class PackageNameIndex {
   /// Maps the collapsed name to all the original names (e.g. `asyncmap`=> [`async_map`, `as_y_n_cmaP`]).
   late final Map<String, List<String>> _collapsedNameResolvesToMap;
 
+  /// Inverted trigram index: maps each trigram to the package indexes (ascending),
+  /// whose collapsed name contains that trigram.
+  late final Map<String, List<int>> _trigramPostings;
+
+  // TODO: consider int-based counter implementation
+  late final _counterPool = ScorePool(_packageNames.length);
+
   PackageNameIndex(this._packageNames) {
     _data = _packageNames.map((package) {
       final lowercased = package.toLowerCase();
       final collapsed = _removeUnderscores(lowercased);
-      return _PkgNameData(lowercased, collapsed, trigrams(collapsed).toSet());
+      return _PkgNameData(lowercased, collapsed);
     }).toList();
     _collapsedNameResolvesToMap = {};
+    _trigramPostings = {};
     for (var i = 0; i < _data.length; i++) {
       _collapsedNameResolvesToMap
           .putIfAbsent(_data[i].collapsed, () => [])
           .add(_packageNames[i]);
+      // Register only a single trigram -> document index posting.
+      // TODO: consider posting weights
+      for (final trigram in trigrams(_data[i].collapsed).toSet()) {
+        _trigramPostings.putIfAbsent(trigram, () => <int>[]).add(i);
+      }
     }
   }
 
@@ -681,7 +694,7 @@ class PackageNameIndex {
     IndexedScore? score;
     for (final w in splitForQuery(text)) {
       final s = IndexedScore(_packageNames.length);
-      searchWord(w, score: s, filterOnNonZeros: score);
+      _searchWord(w, score: s, filterOnNonZeros: score);
       if (score == null) {
         score = s;
       } else {
@@ -702,7 +715,7 @@ class PackageNameIndex {
   ///
   /// When [filterOnNonZeros] is present, only the indexes with an already
   /// non-zero value are evaluated.
-  void searchWord(
+  void _searchWord(
     String word, {
     required IndexedScore score,
     IndexedScore? filterOnNonZeros,
@@ -710,51 +723,65 @@ class PackageNameIndex {
     assert(score.length == _packageNames.length);
     final lowercasedWord = word.toLowerCase();
     final collapsedWord = _removeUnderscores(lowercasedWord);
-    final parts = collapsedWord.length <= 3
-        ? [collapsedWord]
-        : trigrams(collapsedWord);
-    for (var i = 0; i < _data.length; i++) {
-      if (filterOnNonZeros?.isNotPositive(i) ?? false) {
-        continue;
-      }
 
-      final entry = _data[i];
+    bool tryScoreWithSubstringMatch(int index) {
+      final entry = _data[index];
       if (entry.collapsed.length >= collapsedWord.length &&
           entry.collapsed.contains(collapsedWord)) {
         // also check for non-collapsed match
         if (entry.lowercased.length >= lowercasedWord.length &&
             entry.lowercased.contains(lowercasedWord)) {
-          score.setValue(i, 1.0);
-          continue;
-        }
-
-        score.setValue(i, 0.99);
-        continue;
-      }
-      var matched = 0;
-      var unmatched = 0;
-      final acceptThreshold = parts.length ~/ 2;
-      final rejectThreshold = parts.length - acceptThreshold;
-      for (final part in parts) {
-        if (entry.trigrams.contains(part)) {
-          matched++;
+          score.setValue(index, 1.0);
         } else {
-          unmatched++;
-          if (unmatched > rejectThreshold) {
-            // we have no chance to accept this hit
-            break;
+          score.setValue(index, 0.99);
+        }
+        return true;
+      }
+      return false;
+    }
+
+    // Note: short strings (less than a trigram) are not indexed separately,
+    //       we need to do full substring check, evaluating every package.
+    // TODO: consider updating the index + the evaluation algorithm
+    if (collapsedWord.length < 3) {
+      for (var i = 0; i < _data.length; i++) {
+        if (filterOnNonZeros?.isNotPositive(i) ?? false) continue;
+        tryScoreWithSubstringMatch(i);
+      }
+      return;
+    }
+
+    _counterPool.withPoolItemSync(
+      fn: (countScore) {
+        assert(countScore.length == _packageNames.length);
+
+        // count the trigrams for each package
+        final parts = trigrams(collapsedWord);
+        for (final part in parts) {
+          final postings = _trigramPostings[part];
+          if (postings == null) continue;
+          for (final i in postings) {
+            final count = countScore.getValue(i);
+            countScore.setValue(i, count + 1.0);
           }
         }
-      }
 
-      if (matched >= acceptThreshold) {
-        // making sure that match score is minimum 0.5
-        final v = matched / parts.length;
-        if (v >= 0.5) {
-          score.setValue(i, v);
+        final acceptThreshold = parts.length ~/ 2;
+        for (var i = 0; i < _packageNames.length; i++) {
+          if (filterOnNonZeros?.isNotPositive(i) ?? false) continue;
+          if (countScore.isNotPositive(i)) continue;
+          if (tryScoreWithSubstringMatch(i)) continue;
+          final matched = countScore.getValue(i);
+          if (matched >= acceptThreshold) {
+            // making sure that match score is minimum 0.5
+            final v = matched / parts.length;
+            if (v >= 0.5) {
+              score.setValue(i, v);
+            }
+          }
         }
-      }
-    }
+      },
+    );
   }
 
   /// Returns the list of package names where the collapsed name matches.
@@ -770,9 +797,8 @@ class PackageNameIndex {
 class _PkgNameData {
   final String lowercased;
   final String collapsed;
-  final Set<String> trigrams;
 
-  _PkgNameData(this.lowercased, this.collapsed, this.trigrams);
+  _PkgNameData(this.lowercased, this.collapsed);
 }
 
 extension on List<IndexedPackageHit> {

--- a/app/lib/search/token_index.dart
+++ b/app/lib/search/token_index.dart
@@ -374,6 +374,17 @@ abstract class _AllocationPool<T> {
     }
   }
 
+  /// Executes synchronous [fn] and provides a pool item in the callback.
+  /// The item will be released to the pool after [fn] completes.
+  R withPoolItemSync<R>({required R Function(T array) fn}) {
+    final item = _acquire();
+    try {
+      return fn(item);
+    } finally {
+      _release(item);
+    }
+  }
+
   /// Executes [fn] and provides a getter function that can be used to
   /// acquire new pool items while the [fn] is being executed. The
   /// acquired items will be released back to the pool after [fn] completes.


### PR DESCRIPTION
This replaces the Set of trigrams and their contains operation with posting of package index numbers, and counting them.

Note: local benchmark showed a significant improvement (30%+) but I think I should probably update the benchmark script before concluding it is a good representation.

Note: I've been also experimenting with additional optimizations, but eventually reduced the PR to the minimum (and I think where the most gain is coming from). Further benchmarks will be done (left TODOs for them). It is also possible we can slightly alter the matching algorithm for 1- and 2-character search expressions.