### PR TITLE
Use int-based counter in search name matching.

### DIFF
--- a/app/lib/search/mem_index.dart
+++ b/app/lib/search/mem_index.dart
@@ -663,8 +663,7 @@ class PackageNameIndex {
   /// whose collapsed name contains that trigram.
   late final Map<String, List<int>> _trigramPostings;
 
-  // TODO(https://github.com/dart-lang/pub-dev/issues/9462): consider int-based counter implementation
-  late final _counterPool = ScorePool(_packageNames.length);
+  late final _counterPool = IndexedCounterPool(_packageNames.length);
 
   PackageNameIndex(this._packageNames) {
     _data = _packageNames.map((package) {
@@ -752,26 +751,23 @@ class PackageNameIndex {
     }
 
     _counterPool.withPoolItemSync(
-      fn: (countScore) {
-        assert(countScore.length == _packageNames.length);
-
+      fn: (counts) {
         // count the trigrams for each package
         final parts = trigrams(collapsedWord);
         for (final part in parts) {
           final postings = _trigramPostings[part];
           if (postings == null) continue;
           for (final i in postings) {
-            final count = countScore.getValue(i);
-            countScore.setValue(i, count + 1.0);
+            counts.increment(i);
           }
         }
 
         final acceptThreshold = parts.length ~/ 2;
         for (var i = 0; i < _packageNames.length; i++) {
+          final matched = counts.getValue(i);
+          if (matched == 0) continue;
           if (filterOnNonZeros?.isNotPositive(i) ?? false) continue;
-          if (countScore.isNotPositive(i)) continue;
           if (tryScoreWithSubstringMatch(i)) continue;
-          final matched = countScore.getValue(i);
           if (matched >= acceptThreshold) {
             // making sure that match score is minimum 0.5
             final v = matched / parts.length;

--- a/app/lib/search/token_index.dart
+++ b/app/lib/search/token_index.dart
@@ -435,7 +435,10 @@ class BitArrayPool extends _AllocationPool<BitArray> {
 /// A reusable pool for [IndexedCounter] instances to spare some memory allocation.
 class IndexedCounterPool extends _AllocationPool<IndexedCounter> {
   IndexedCounterPool(int length)
-    : super(() => IndexedCounter(length), (counter) => counter.reset());
+    : super(
+        () => IndexedCounter(List.filled(length, 0)),
+        (counter) => counter.reset(),
+      );
 }
 
 /// Mutable score list that can accessed via integer index.
@@ -509,18 +512,14 @@ class IndexedScore {
 }
 
 /// Integer counter that can be accessed via index.
-class IndexedCounter {
-  final List<int> _values;
-
-  IndexedCounter(int length) : _values = List<int>.filled(length, 0);
-
+extension type IndexedCounter(List<int> values) {
   void reset() {
-    _values.fillRange(0, _values.length, 0);
+    values.fillRange(0, values.length, 0);
   }
 
-  int getValue(int index) => _values[index];
+  int getValue(int index) => values[index];
 
   void increment(int index) {
-    _values[index]++;
+    values[index]++;
   }
 }

--- a/app/lib/search/token_index.dart
+++ b/app/lib/search/token_index.dart
@@ -432,6 +432,15 @@ class BitArrayPool extends _AllocationPool<BitArray> {
       );
 }
 
+/// A reusable pool for [IndexedCounter] instances to spare some memory allocation.
+class IndexedCounterPool extends _AllocationPool<IndexedCounter> {
+  IndexedCounterPool(int length)
+    : super(
+        () => IndexedCounter(length),
+        (counter) => counter.reset(),
+      );
+}
+
 /// Mutable score list that can accessed via integer index.
 class IndexedScore {
   final List<double> _values;
@@ -499,5 +508,22 @@ class IndexedScore {
       heap.collect(i);
     }
     return heap.getAndRemoveTopK(count).toList();
+  }
+}
+
+/// Integer counter that can be accessed via index.
+class IndexedCounter {
+  final List<int> _values;
+
+  IndexedCounter(int length) : _values = List<int>.filled(length, 0);
+
+  void reset() {
+    _values.fillRange(0, _values.length, 0);
+  }
+
+  int getValue(int index) => _values[index];
+
+  void increment(int index) {
+    _values[index]++;
   }
 }

--- a/app/lib/search/token_index.dart
+++ b/app/lib/search/token_index.dart
@@ -435,10 +435,7 @@ class BitArrayPool extends _AllocationPool<BitArray> {
 /// A reusable pool for [IndexedCounter] instances to spare some memory allocation.
 class IndexedCounterPool extends _AllocationPool<IndexedCounter> {
   IndexedCounterPool(int length)
-    : super(
-        () => IndexedCounter(length),
-        (counter) => counter.reset(),
-      );
+    : super(() => IndexedCounter(length), (counter) => counter.reset());
 }
 
 /// Mutable score list that can accessed via integer index.


### PR DESCRIPTION
- #9462
- very small (1-4%) but mostly consistent improvement over the double-based counter
- interestingly 8, 16 or 64-bit `UintXXList` instances weren't faster, in fact, most of the time they performed slower than the int-based list