### PR TITLE
Quantized score collection

### DIFF
--- a/app/lib/search/mem_index.dart
+++ b/app/lib/search/mem_index.dart
@@ -22,6 +22,9 @@ import 'token_index.dart';
 final _logger = Logger('search.mem_index');
 final _textSearchTimeout = Duration(milliseconds: 500);
 
+// Quantized equivalent of the `0.01` score.
+const _apiScoreCutoff = scoreQuantization ~/ 100;
+
 class InMemoryPackageIndex {
   final List<PackageDocument> _documents;
   final _nameToIndex = <String, int>{};
@@ -37,8 +40,8 @@ class InMemoryPackageIndex {
   final _tagBitArrays = <String, BitArray>{};
 
   /// Adjusted score takes the overall score and transforms
-  /// it linearly into the [0.4-1.0] range.
-  late final List<double> _adjustedOverallScores;
+  /// it linearly into the [0.4-1.0] range, stored with [scoreQuantization].
+  late final List<int> _adjustedOverallScores;
   late final List<IndexedPackageHit> _overallOrderedHits;
   late final List<IndexedPackageHit> _createdOrderedHits;
   late final List<IndexedPackageHit> _updatedOrderedHits;
@@ -294,7 +297,7 @@ class InMemoryPackageIndex {
         }
         // Check whether the best name match will increase the total item count.
         if (bestNameIndex != null &&
-            packageScores.getValue(bestNameIndex) <= 0.0) {
+            packageScores.isNotPositive(bestNameIndex)) {
           totalCount++;
         }
         indexedHits = _rankWithValues(
@@ -333,7 +336,7 @@ class InMemoryPackageIndex {
       packageHits = indexedHits.map((ps) {
         final apiPages = textResults!.topApiPages?[ps.index]
             // TODO(https://github.com/dart-lang/pub-dev/issues/7106): extract title for the page
-            ?.map((MapEntry<String, double> e) => ApiPageRef(path: e.key))
+            ?.map((MapEntry<String, int> e) => ApiPageRef(path: e.key))
             .toList();
         return ps.hit.change(apiPages: apiPages);
       }).toList();
@@ -418,8 +421,8 @@ class InMemoryPackageIndex {
 
       final overall = popularityScore * 0.5 + pointScore * 0.5;
       doc.overallScore = overall;
-      // adding a base score prevents later multiplication with zero
-      return 0.4 + 0.6 * overall;
+      // adding a base score prevents later multiplication with zero (quantized)
+      return ((0.4 + 0.6 * overall) * scoreQuantization).round();
     }).toList();
   }
 
@@ -445,7 +448,7 @@ class InMemoryPackageIndex {
 
     for (final index in packages.asIntIterable()) {
       if (index >= _documents.length) break;
-      packageScores.setValue(index, 1.0);
+      packageScores.setValue(index, scoreQuantization);
     }
 
     bool aborted = false;
@@ -479,7 +482,7 @@ class InMemoryPackageIndex {
       );
     }
 
-    final topApiPages = List<List<MapEntry<String, double>>?>.filled(
+    final topApiPages = List<List<MapEntry<String, int>>?>.filled(
       _documents.length,
       null,
     );
@@ -492,14 +495,13 @@ class InMemoryPackageIndex {
         ) async {
           for (var i = 0; i < symbolPages.length; i++) {
             final value = symbolPages.getValue(i);
-            if (value < 0.01) continue;
+            if (value < _apiScoreCutoff) continue;
 
             final doc = _apiDocPageKeys[i];
             if (!packages[doc.index]) continue;
 
             // skip if the previously found pages are better than the current one
-            final pages = topApiPages[doc.index] ??=
-                <MapEntry<String, double>>[];
+            final pages = topApiPages[doc.index] ??= <MapEntry<String, int>>[];
             if (pages.length >= maxApiPageCount && pages.last.value > value) {
               continue;
             }
@@ -564,7 +566,7 @@ class InMemoryPackageIndex {
     });
     for (var i = 0; i < score.length; i++) {
       final value = score.getValue(i);
-      if (value <= 0.0 && i != bestNameIndex) continue;
+      if (value <= 0 && i != bestNameIndex) continue;
       heap.collect(i);
     }
     return heap
@@ -574,7 +576,7 @@ class InMemoryPackageIndex {
             i,
             PackageHit(
               package: _documents[i].package,
-              score: score.getValue(i),
+              score: score.getValue(i) / scoreQuantization,
             ),
           ),
         );
@@ -640,7 +642,7 @@ class InMemoryPackageIndex {
 
 class _TextResults {
   final bool hasNoMatch;
-  final List<List<MapEntry<String, double>>?>? topApiPages;
+  final List<List<MapEntry<String, int>>?>? topApiPages;
   final String? errorMessage;
 
   factory _TextResults.empty({String? errorMessage}) {
@@ -710,12 +712,13 @@ class PackageNameIndex {
   }
 
   /// Score assigned when the query n-gram(s) occur in the original (underscored)
-  /// package name.
-  static const _originalNameScore = 1.0;
+  /// package name (1.0 quantized).
+  static const _originalNameScore = scoreQuantization;
 
   /// Score assigned when the query n-gram(s) occur only in the collapsed name,
-  /// i.e. the match spans a removed underscore.
-  static const _collapsedNameScore = _collapsedNameWeight / _originalNameWeight;
+  /// i.e. the match spans a removed underscore (0.99 quantized).
+  static final _collapsedNameScore =
+      (_collapsedNameWeight * scoreQuantization / _originalNameWeight).round();
 
   /// Posting weight bytes: the match score scaled by 100. Storing them as small
   /// integers lets the trigram counter sum the weights and recognize a perfect
@@ -742,7 +745,9 @@ class PackageNameIndex {
     final result = <String, double>{};
     for (var i = 0; i < _packageNames.length; i++) {
       final v = score.getValue(i);
-      if (v > 0.0) result[_packageNames[i]] = v;
+      if (v > 0) {
+        result[_packageNames[i]] = v / scoreQuantization;
+      }
     }
     return result;
   }
@@ -786,7 +791,9 @@ class PackageNameIndex {
         for (final part in parts) {
           final postings = _ngramPostings[part];
           if (postings == null) continue;
-          postings.forEach((i, weight) => counts.add(i, weight));
+          postings.forEach((i, weight) {
+            counts.add(i, weight);
+          });
         }
 
         final n = parts.length;
@@ -804,7 +811,7 @@ class PackageNameIndex {
             score.setValue(i, _originalNameScore);
           } else {
             // Partial match: fractional relevance score in [0.5, 1.0).
-            score.setValue(i, sum / fullMatchSum);
+            score.setValue(i, sum * scoreQuantization ~/ fullMatchSum);
           }
         }
       },

--- a/app/lib/search/sdk_mem_index.dart
+++ b/app/lib/search/sdk_mem_index.dart
@@ -59,6 +59,7 @@ const _flutterLibraryAllowlist = {
 final _logger = Logger('search.dart_sdk_mem_index');
 final _dartUri = Uri.parse('https://api.dart.dev/stable/latest/');
 final _flutterUri = Uri.parse('https://api.flutter.dev/flutter/');
+final _top3ApiScoreCutoff = (0.05 * scoreQuantization).round();
 
 /// Tries to load Dart and Flutter SDK's dartdoc `index.json` and build
 /// a search index from it.
@@ -198,9 +199,12 @@ class SdkMemIndex implements SdkIndex {
         words,
         (score) async => Map.fromEntries(
           score
-              .topIndices(3, minValue: 0.05)
+              .topIndices(3, minValue: _top3ApiScoreCutoff)
               .map(
-                (i) => MapEntry(library.tokenIndexKeys[i], score.getValue(i)),
+                (i) => MapEntry(
+                  library.tokenIndexKeys[i],
+                  score.getValue(i) / scoreQuantization,
+                ),
               ),
         ),
       );

--- a/app/lib/search/token_index.dart
+++ b/app/lib/search/token_index.dart
@@ -329,8 +329,14 @@ class TokenIndex {
     for (final entry in tokenMatch.entries) {
       final matchWeight = entry.value;
       final posting = _postings[entry.key]!;
+      // Quantized weights:
+      // - match weight is between 0-256 (0 <= matchWeight * weight <= 1)
+      // - posting weight is between 0-255
+      //
+      // Their multiplication is between 0 and [scoreQuantization].
+      final weightQ = (matchWeight * weight * 256).round();
       posting.forEach((docIndex, w) {
-        score.setValueMaxOf(docIndex, matchWeight * (w + 1) / 256 * weight);
+        score.setValueMaxOf(docIndex, (w + 1) * weightQ);
       });
     }
   }
@@ -413,11 +419,7 @@ abstract class _AllocationPool<T> {
 /// A reusable pool for [IndexedScore] instances to spare some memory allocation.
 class ScorePool extends _AllocationPool<IndexedScore> {
   ScorePool(int length)
-    : super(
-        () => IndexedScore(length),
-        // sets all values to 0.0
-        (score) => score._values.fillRange(0, score.length, 0.0),
-      );
+    : super(() => IndexedScore(length), (score) => score.reset());
 }
 
 /// A reusable pool for [BitArray] instances to spare some memory allocation.
@@ -440,14 +442,24 @@ class IndexedCounterPool extends _AllocationPool<IndexedCounter> {
       );
 }
 
-/// Mutable score list that can accessed via integer index.
-class IndexedScore {
-  final List<double> _values;
+/// Fixed-point scale used by [IndexedScore] to indicate the maximum of its
+/// quantized value.
+const scoreQuantization = 65536;
 
-  IndexedScore(int length, [double value = 0.0])
-    : _values = List<double>.filled(length, value);
+/// Mutable score list that can accessed via integer index.
+///
+/// Values are stored as fixed-point integers at the [scoreQuantization] scale.
+class IndexedScore {
+  final List<int> _values;
+
+  IndexedScore(int length, [int value = 0])
+    : _values = List<int>.filled(length, value);
 
   late final length = _values.length;
+
+  void reset() {
+    _values.fillRange(0, length, 0);
+  }
 
   int positiveCount() {
     var count = 0;
@@ -458,48 +470,43 @@ class IndexedScore {
   }
 
   bool isPositive(int index) {
-    return _values[index] > 0.0;
+    return _values[index] > 0;
   }
 
   bool isNotPositive(int index) {
-    return _values[index] <= 0.0;
+    return _values[index] <= 0;
   }
 
-  double getValue(int index) {
+  int getValue(int index) {
     return _values[index];
   }
 
-  void setValue(int index, double value) {
+  void setValue(int index, int value) {
     _values[index] = value;
   }
 
-  void setValueMaxOf(int index, double value) {
+  void setValueMaxOf(int index, int value) {
     _values[index] = math.max(_values[index], value);
-  }
-
-  /// Sets the positions greater than or equal to [start] and less than [end],
-  /// to [fillValue].
-  void fillRange(int start, int end, double fillValue) {
-    assert(start <= end);
-    if (start == end) return;
-    _values.fillRange(start, end, fillValue);
   }
 
   void multiplyAllFrom(IndexedScore other) {
     multiplyAllFromValues(other._values);
   }
 
-  void multiplyAllFromValues(List<double> values) {
+  /// Multiplies each value with the quantized value at the same index in
+  /// [values], keeping the result at the [scoreQuantization] scale.
+  void multiplyAllFromValues(List<int> values) {
     assert(_values.length == values.length);
     for (var i = 0; i < _values.length; i++) {
-      if (_values[i] == 0.0) continue;
-      final v = values[i];
-      _values[i] = v == 0.0 ? 0.0 : _values[i] * v;
+      final a = _values[i];
+      if (a == 0) continue;
+      final b = values[i];
+      _values[i] = b == 0 ? 0 : (a * b) ~/ scoreQuantization;
     }
   }
 
-  List<int> topIndices(int count, {double? minValue}) {
-    minValue ??= 0.0;
+  List<int> topIndices(int count, {int? minValue}) {
+    minValue ??= 0;
     final heap = Heap<int>((a, b) => -_values[a].compareTo(_values[b]));
     for (var i = 0; i < length; i++) {
       final v = _values[i];

--- a/app/test/search/api_doc_page_test.dart
+++ b/app/test/search/api_doc_page_test.dart
@@ -61,7 +61,7 @@ void main() {
           {'package': 'foo', 'score': 1.0}, // finds package name
           {
             'package': 'other_with_api',
-            'score': closeTo(0.695, 0.001), // finds foo method
+            'score': closeTo(0.694, 0.002), // finds foo method
             'apiPages': [
               {'path': 'main.html'},
             ],

--- a/app/test/search/package_name_index_test.dart
+++ b/app/test/search/package_name_index_test.dart
@@ -83,7 +83,7 @@ void main() {
     test('substring: entu', () {
       expect(index.search('entu'), {
         'fluent': 0.5,
-        'fluent_ui': 0.995, // not 1.0
+        'fluent_ui': closeTo(0.995, 0.001), // not 1.0
       });
     });
   });

--- a/app/test/search/stack_trace_test.dart
+++ b/app/test/search/stack_trace_test.dart
@@ -38,7 +38,7 @@ void main() {
         'totalCount': 1,
         'sdkLibraryHits': [],
         'packageHits': [
-          {'package': 'stack_trace', 'score': 0.9975},
+          {'package': 'stack_trace', 'score': closeTo(0.9975, 0.001)},
         ],
       });
     });

--- a/app/test/search/token_index_test.dart
+++ b/app/test/search/token_index_test.dart
@@ -15,7 +15,7 @@ Future<Map<String, double>> _search(
     final result = <String, double>{};
     for (var i = 0; i < score.length; i++) {
       final v = score.getValue(i);
-      if (v > 0.0) result[keys[i]] = v;
+      if (v > 0) result[keys[i]] = v / scoreQuantization;
     }
     return result;
   });
@@ -126,9 +126,9 @@ void main() {
   group('IndexedScore', () {
     const keys = ['a', 'b', 'c'];
     final score = IndexedScore(3)
-      ..setValue(0, 100.0)
-      ..setValue(1, 30.0)
-      ..setValue(2, 55.0);
+      ..setValue(0, 100)
+      ..setValue(1, 30)
+      ..setValue(2, 55);
 
     test('topIndices', () {
       expect(score.topIndices(1).map((i) => keys[i]), ['a']);


### PR DESCRIPTION
- Using int (2^16) quantization in query score collection.
- Measured 15+% improvement in latency in local benchmark.
- Note: there is further improvement in using a candidate list index while doing the collection (at least in name search), but doing it in a way that doesn't trigger random memory allocation is a bit more complex, I'm doing it in a follow-up PR.