### PR TITLE
More robust analysis download.

### DIFF
--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -2585,20 +2585,20 @@ class _VersionTransactionDataAcccess {
 
   final futures = [
     add(() => purgePackageCache(package)),
-    if (!skipReanalysis)
-      add(
-        () => taskBackend.trackPackage(
-          package,
-          updateDependents: taskUpdateDependents,
-          refreshVersionsCache: true,
-        ),
-      ),
     if (!skipExport)
       add(
         () => apiExporter.synchronizePackage(
           package,
           forceDelete: exportForceDelete,
           skipArchives: skipArchiveExport,
+        ),
+      ),
+    if (!skipReanalysis)
+      add(
+        () => taskBackend.trackPackage(
+          package,
+          updateDependents: taskUpdateDependents,
+          refreshVersionsCache: true,
         ),
       ),
   ];

--- a/app/test/package/upload_test.dart
+++ b/app/test/package/upload_test.dart
@@ -1608,6 +1608,8 @@ void main() {
           authToken: adminClientToken,
         ).uploadPackageBytes(bytes);
         expect(message.success.message, contains('Successfully uploaded'));
+
+        await asyncQueue.ongoingProcessing;
         await nameTracker.reloadFromDatastore();
 
         await accountBackend.withBearerToken(

--- a/pkg/pub_worker/bin/pub_worker_subprocess.dart
+++ b/pkg/pub_worker/bin/pub_worker_subprocess.dart
@@ -106,7 +106,12 @@ Future<void> main(List<String> args) async {
       'SANDBOX_NETWORK_ENABLED': 'true',
     },
     throwOnError: true,
-    retryOptions: RetryOptions(maxAttempts: 3),
+    retryOptions: RetryOptions(
+      maxAttempts: 5,
+      delayFactor: Duration(seconds: 15),
+      maxDelay: Duration(minutes: 4),
+    ),
+    retryIf: (_) => true,
     workingDirectory: rawDartdocOutputFolder.path,
   );
   await unpackPubCacheDir.delete(recursive: true);


### PR DESCRIPTION
- The post-upload async task starts with the `synchronizePackage` call and updates the tracking state afterwards.
- The initial download of the package is retried more, with extended delays, up to 8 minutes total.