### PR TITLE
Allow regional Google Analytics and GTM domains in CSP connect-src

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Important changes to data models, configuration, and migrations between each
 AppEngine version, listed here to ease deployment and troubleshooting.
 
 ## Next Release (replace with git tag when deployed)
+ * Allow regional Google Analytics and GTM domains in CSP `connect-src`.
 
 ## `20260730t085500-all`
  * Bump runtimeVersion to `2026.07.28`.

--- a/app/lib/service/csp/default_csp.dart
+++ b/app/lib/service/csp/default_csp.dart
@@ -64,8 +64,10 @@ final _defaultContentSecurityPolicyMap = <String, List<String>>{
   ],
   'connect-src': <String>[
     "'self'",
-    'https://www.google-analytics.com/',
-    'https://stats.g.doubleclick.net/',
+    'https://*.google-analytics.com',
+    'https://*.analytics.google.com',
+    'https://*.googletagmanager.com',
+    'https://*.g.doubleclick.net',
   ],
   'frame-ancestors': _none,
   'base-uri': <String>["'self'"],

--- a/app/test/service/csp/csp_test.dart
+++ b/app/test/service/csp/csp_test.dart
@@ -22,7 +22,7 @@ void main() {
     expect(
       csp,
       contains(
-        "connect-src 'self' https://www.google-analytics.com/ https://stats.g.doubleclick.net/",
+        "connect-src 'self' https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://*.g.doubleclick.net",
       ),
     );
 


### PR DESCRIPTION
Google Analytics 4 (GA4) uses regional collection endpoints such as `region1.google-analytics.com` and `analytics.google.com` to process events and measurement data.

When CSP was tightened to restrict `connect-src` to only `https://www.google-analytics.com/` and `https://stats.g.doubleclick.net/` in https://github.com/dart-lang/pub-dev/pull/9221, modern GA4 traffic dispatched to regional endpoints was blocked by browsers.

This PR updates `connect-src` to include wildcard domains for GA4, GTM, and DoubleClick (`*.google-analytics.com`, `*.analytics.google.com`, `*.googletagmanager.com`, `*.g.doubleclick.net`).

Detailed in https://developers.google.com/tag-platform/security/guides/csp

For validation of our CSP rules we could consider using https://www.w3.org/TR/CSP3/#directive-report-to . But that would be a separate project.