### PR TITLE
Configure CSP report-to directive, Reporting-Endpoints header, and reporting endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Important changes to data models, configuration, and migrations between each
 AppEngine version, listed here to ease deployment and troubleshooting.
 
 ## Next Release (replace with git tag when deployed)
+ * Configure CSP `report-to` directive, `Reporting-Endpoints` response header, and `/api/csp-report` reporting endpoint.
 
 ## `20260730t085500-all`
  * Bump runtimeVersion to `2026.07.28`.

--- a/app/lib/frontend/handlers/misc.dart
+++ b/app/lib/frontend/handlers/misc.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:clock/clock.dart';
@@ -323,4 +324,25 @@ shelf.Response formattedNotFoundHandler(shelf.Request request) {
     ),
     status: 404,
   );
+}
+
+final _cspReportLog = Logger('pub.csp_report');
+
+/// Handles requests for `/api/csp-report`.
+///
+/// Receives and logs Content Security Policy violation reports sent by browsers
+/// via the Reporting API (`report-to`) or legacy `report-uri`.
+Future<shelf.Response> cspReportHandler(shelf.Request request) async {
+  final body = await request.readAsString();
+  if (body.isEmpty) {
+    return shelf.Response(204);
+  }
+  try {
+    json.decode(body);
+    _cspReportLog.warning('CSP violation report received: $body');
+  } on FormatException catch (e) {
+    _cspReportLog.info('Invalid CSP report payload received: $e');
+    return shelf.Response(400);
+  }
+  return shelf.Response(204);
 }

--- a/app/lib/frontend/handlers/misc.dart
+++ b/app/lib/frontend/handlers/misc.dart
@@ -328,21 +328,105 @@ shelf.Response formattedNotFoundHandler(shelf.Request request) {
 
 final _cspReportLog = Logger('pub.csp_report');
 
+final _ignoredCspSchemes = <String>[
+  'chrome-extension:',
+  'moz-extension:',
+  'safari-extension:',
+  'safari-web-extension:',
+  'ms-browser-extension:',
+  'resource:',
+  'about:',
+];
+
+bool _isIgnoredCspUri(String? uri) {
+  if (uri == null || uri.isEmpty) return false;
+  final lower = uri.toLowerCase();
+  return _ignoredCspSchemes.any((scheme) => lower.startsWith(scheme));
+}
+
+bool _isAllowedDocumentOrigin(String? documentUrl) {
+  if (documentUrl == null || documentUrl.isEmpty) return true;
+  final uri = Uri.tryParse(documentUrl);
+  if (uri == null || !uri.hasScheme) return true;
+  final host = uri.host.toLowerCase();
+  return host == 'pub.dev' ||
+      host == 'pub.dartlang.org' ||
+      host == 'localhost' ||
+      host.endsWith('.pub.dev');
+}
+
 /// Handles requests for `/api/csp-report`.
 ///
 /// Receives and logs Content Security Policy violation reports sent by browsers
 /// via the Reporting API (`report-to`) or legacy `report-uri`.
 Future<shelf.Response> cspReportHandler(shelf.Request request) async {
+  // Guard against oversized payloads (max 64 KB).
+  if (request.contentLength != null && request.contentLength! > 65536) {
+    return shelf.Response(413);
+  }
+
   final body = await request.readAsString();
   if (body.isEmpty) {
     return shelf.Response(204);
   }
+  if (body.length > 65536) {
+    return shelf.Response(413);
+  }
+
   try {
-    json.decode(body);
-    _cspReportLog.warning('CSP violation report received: $body');
+    final parsed = json.decode(body);
+    if (parsed is List) {
+      // Reporting API payload: array of reports
+      for (final item in parsed) {
+        if (item is Map<String, dynamic>) {
+          final reportBody = item['body'];
+          if (reportBody is Map<String, dynamic>) {
+            _processCspReport(
+              effectiveDirective: reportBody['effectiveDirective'] as String?,
+              blockedUrl: reportBody['blockedURL'] as String?,
+              documentUrl: reportBody['documentURL'] as String?,
+              disposition: reportBody['disposition'] as String?,
+            );
+          }
+        }
+      }
+    } else if (parsed is Map<String, dynamic>) {
+      // Legacy report-uri payload: {"csp-report": {...}}
+      final report = parsed['csp-report'];
+      if (report is Map<String, dynamic>) {
+        _processCspReport(
+          effectiveDirective:
+              (report['effective-directive'] ?? report['violated-directive'])
+                  as String?,
+          blockedUrl:
+              (report['blocked-uri'] ?? report['blockedURL']) as String?,
+          documentUrl:
+              (report['document-uri'] ?? report['documentURL']) as String?,
+          disposition: report['disposition'] as String?,
+        );
+      }
+    }
   } on FormatException catch (e) {
-    _cspReportLog.info('Invalid CSP report payload received: $e');
+    _cspReportLog.fine('Invalid CSP report payload received: $e');
     return shelf.Response(400);
   }
   return shelf.Response(204);
+}
+
+void _processCspReport({
+  String? effectiveDirective,
+  String? blockedUrl,
+  String? documentUrl,
+  String? disposition,
+}) {
+  if (_isIgnoredCspUri(blockedUrl) || _isIgnoredCspUri(documentUrl)) {
+    return;
+  }
+  if (!_isAllowedDocumentOrigin(documentUrl)) {
+    return;
+  }
+  _cspReportLog.info(
+    'CSP violation: effectiveDirective="$effectiveDirective" '
+    'blockedURL="$blockedUrl" documentURL="$documentUrl" disposition="$disposition"',
+  );
 }

--- a/app/lib/frontend/handlers/routes.dart
+++ b/app/lib/frontend/handlers/routes.dart
@@ -393,6 +393,11 @@ class PubSiteService {
   Future<Response> reportPage(Request request) async =>
       reportPageHandler(request);
 
+  /// Receives Content Security Policy violation reports.
+  @Route.post('/api/csp-report')
+  Future<Response> cspReport(Request request) async =>
+      cspReportHandler(request);
+
   // ****
   // **** Experimental task end-points
   // ****

--- a/app/lib/frontend/handlers/routes.g.dart
+++ b/app/lib/frontend/handlers/routes.g.dart
@@ -147,6 +147,7 @@ Router _$PubSiteServiceRouter(PubSiteService service) {
   router.add('GET', r'/authorized', service.authorizationConfirmed);
   router.add('GET', r'/consent', service.consentPage);
   router.add('GET', r'/report', service.reportPage);
+  router.add('POST', r'/api/csp-report', service.cspReport);
   router.add(
     'GET',
     r'/experimental/task-summary/<package>/<version>/',

--- a/app/lib/service/csp/default_csp.dart
+++ b/app/lib/service/csp/default_csp.dart
@@ -72,6 +72,7 @@ final _defaultContentSecurityPolicyMap = <String, List<String>>{
   'form-action': <String>["'self'"],
   'upgrade-insecure-requests': <String>[],
   'report-to': <String>['csp-endpoint'],
+  'report-uri': <String>['/api/csp-report'],
 };
 
 /// Returns the serialized string of the CSP header.

--- a/app/lib/service/csp/default_csp.dart
+++ b/app/lib/service/csp/default_csp.dart
@@ -71,6 +71,7 @@ final _defaultContentSecurityPolicyMap = <String, List<String>>{
   'base-uri': <String>["'self'"],
   'form-action': <String>["'self'"],
   'upgrade-insecure-requests': <String>[],
+  'report-to': <String>['csp-endpoint'],
 };
 
 /// Returns the serialized string of the CSP header.

--- a/app/lib/shared/handler_helpers.dart
+++ b/app/lib/shared/handler_helpers.dart
@@ -163,6 +163,7 @@ shelf.Handler _cspHeaderWrapper(shelf.Handler handler) {
           'x-content-type-options': 'nosniff',
           'x-frame-options': 'deny',
           'content-security-policy': defaultContentSecurityPolicySerialized,
+          'reporting-endpoints': 'csp-endpoint="/api/csp-report"',
         },
       );
     } else {

--- a/app/test/frontend/handlers/misc_test.dart
+++ b/app/test/frontend/handlers/misc_test.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:pub_dev/tool/test_profile/models.dart';
 import 'package:test/test.dart';
 
 import '../../shared/test_services.dart';
@@ -61,8 +62,14 @@ void main() {
   });
 
   group('CSP reporting', () {
+    final emptyProfile = TestProfile(
+      users: [TestUser(email: 'admin@pub.dev', likes: [])],
+      defaultUser: 'admin@pub.dev',
+    );
+
     testWithProfile(
       'HTML response contains reporting-endpoints, report-to, and report-uri in CSP',
+      testProfile: emptyProfile,
       fn: () async {
         final rs = await issueGet('/');
         expect(rs.statusCode, 200);
@@ -83,6 +90,7 @@ void main() {
 
     testWithProfile(
       'Receives valid Reporting API report',
+      testProfile: emptyProfile,
       fn: () async {
         final rs = await issueHttp(
           'POST',
@@ -97,6 +105,7 @@ void main() {
 
     testWithProfile(
       'Receives valid legacy CSP report',
+      testProfile: emptyProfile,
       fn: () async {
         final rs = await issueHttp(
           'POST',
@@ -111,6 +120,7 @@ void main() {
 
     testWithProfile(
       'Ignores browser extension CSP report cleanly',
+      testProfile: emptyProfile,
       fn: () async {
         final rs = await issueHttp(
           'POST',
@@ -125,6 +135,7 @@ void main() {
 
     testWithProfile(
       'Receives empty CSP report',
+      testProfile: emptyProfile,
       fn: () async {
         final rs = await issueHttp('POST', '/api/csp-report', body: '');
         expect(rs.statusCode, 204);
@@ -133,6 +144,7 @@ void main() {
 
     testWithProfile(
       'Rejects malformed CSP report payload',
+      testProfile: emptyProfile,
       fn: () async {
         final rs = await issueHttp(
           'POST',
@@ -145,6 +157,7 @@ void main() {
 
     testWithProfile(
       'Rejects oversized CSP report payload',
+      testProfile: emptyProfile,
       fn: () async {
         final hugeBody = 'x' * 70000;
         final rs = await issueHttp('POST', '/api/csp-report', body: hugeBody);

--- a/app/test/frontend/handlers/misc_test.dart
+++ b/app/test/frontend/handlers/misc_test.dart
@@ -59,4 +59,70 @@ void main() {
       },
     );
   });
+
+  group('CSP reporting', () {
+    testWithProfile(
+      'HTML response contains reporting-endpoints and report-to in CSP',
+      fn: () async {
+        final rs = await issueGet('/');
+        expect(rs.statusCode, 200);
+        expect(
+          rs.headers['reporting-endpoints'],
+          'csp-endpoint="/api/csp-report"',
+        );
+        expect(
+          rs.headers['content-security-policy'],
+          contains('report-to csp-endpoint'),
+        );
+      },
+    );
+
+    testWithProfile(
+      'Receives valid Reporting API report',
+      fn: () async {
+        final rs = await issueHttp(
+          'POST',
+          '/api/csp-report',
+          headers: {'content-type': 'application/reports+json'},
+          body:
+              '[{"type":"csp-violation","body":{"effectiveDirective":"connect-src","blockedURL":"https://example.com"}}]',
+        );
+        expect(rs.statusCode, 204);
+      },
+    );
+
+    testWithProfile(
+      'Receives valid legacy CSP report',
+      fn: () async {
+        final rs = await issueHttp(
+          'POST',
+          '/api/csp-report',
+          headers: {'content-type': 'application/csp-report'},
+          body:
+              '{"csp-report":{"effective-directive":"connect-src","blocked-uri":"https://example.com"}}',
+        );
+        expect(rs.statusCode, 204);
+      },
+    );
+
+    testWithProfile(
+      'Receives empty CSP report',
+      fn: () async {
+        final rs = await issueHttp('POST', '/api/csp-report', body: '');
+        expect(rs.statusCode, 204);
+      },
+    );
+
+    testWithProfile(
+      'Rejects malformed CSP report payload',
+      fn: () async {
+        final rs = await issueHttp(
+          'POST',
+          '/api/csp-report',
+          body: 'not a json',
+        );
+        expect(rs.statusCode, 400);
+      },
+    );
+  });
 }

--- a/app/test/frontend/handlers/misc_test.dart
+++ b/app/test/frontend/handlers/misc_test.dart
@@ -62,7 +62,7 @@ void main() {
 
   group('CSP reporting', () {
     testWithProfile(
-      'HTML response contains reporting-endpoints and report-to in CSP',
+      'HTML response contains reporting-endpoints, report-to, and report-uri in CSP',
       fn: () async {
         final rs = await issueGet('/');
         expect(rs.statusCode, 200);
@@ -73,6 +73,10 @@ void main() {
         expect(
           rs.headers['content-security-policy'],
           contains('report-to csp-endpoint'),
+        );
+        expect(
+          rs.headers['content-security-policy'],
+          contains('report-uri /api/csp-report'),
         );
       },
     );
@@ -85,7 +89,7 @@ void main() {
           '/api/csp-report',
           headers: {'content-type': 'application/reports+json'},
           body:
-              '[{"type":"csp-violation","body":{"effectiveDirective":"connect-src","blockedURL":"https://example.com"}}]',
+              '[{"type":"csp-violation","body":{"effectiveDirective":"connect-src","blockedURL":"https://example.com","documentURL":"https://pub.dev/packages/foo"}}]',
         );
         expect(rs.statusCode, 204);
       },
@@ -99,7 +103,21 @@ void main() {
           '/api/csp-report',
           headers: {'content-type': 'application/csp-report'},
           body:
-              '{"csp-report":{"effective-directive":"connect-src","blocked-uri":"https://example.com"}}',
+              '{"csp-report":{"effective-directive":"connect-src","blocked-uri":"https://example.com","document-uri":"https://pub.dev/packages/foo"}}',
+        );
+        expect(rs.statusCode, 204);
+      },
+    );
+
+    testWithProfile(
+      'Ignores browser extension CSP report cleanly',
+      fn: () async {
+        final rs = await issueHttp(
+          'POST',
+          '/api/csp-report',
+          headers: {'content-type': 'application/reports+json'},
+          body:
+              '[{"type":"csp-violation","body":{"effectiveDirective":"script-src","blockedURL":"chrome-extension://abcdef/content.js"}}]',
         );
         expect(rs.statusCode, 204);
       },
@@ -122,6 +140,15 @@ void main() {
           body: 'not a json',
         );
         expect(rs.statusCode, 400);
+      },
+    );
+
+    testWithProfile(
+      'Rejects oversized CSP report payload',
+      fn: () async {
+        final hugeBody = 'x' * 70000;
+        final rs = await issueHttp('POST', '/api/csp-report', body: hugeBody);
+        expect(rs.statusCode, 413);
       },
     );
   });

--- a/app/test/service/csp/csp_test.dart
+++ b/app/test/service/csp/csp_test.dart
@@ -10,6 +10,7 @@ void main() {
     final csp = defaultContentSecurityPolicySerialized;
     expect(csp, contains("default-src 'self'"));
     expect(csp, contains('upgrade-insecure-requests'));
+    expect(csp, contains('report-to csp-endpoint'));
     expect(csp, contains("frame-ancestors 'none'"));
     expect(csp, contains("base-uri 'self'"));
     expect(csp, contains("form-action 'self'"));

--- a/app/test/service/csp/csp_test.dart
+++ b/app/test/service/csp/csp_test.dart
@@ -11,6 +11,7 @@ void main() {
     expect(csp, contains("default-src 'self'"));
     expect(csp, contains('upgrade-insecure-requests'));
     expect(csp, contains('report-to csp-endpoint'));
+    expect(csp, contains('report-uri /api/csp-report'));
     expect(csp, contains("frame-ancestors 'none'"));
     expect(csp, contains("base-uri 'self'"));
     expect(csp, contains("form-action 'self'"));


### PR DESCRIPTION
Configure CSP violation reporting using modern Reporting API and legacy fallbacks:
- Add `report-to csp-endpoint` and `report-uri /api/csp-report` directives to `Content-Security-Policy`.
- Add `Reporting-Endpoints: csp-endpoint="/api/csp-report"` response header on HTML responses.
- Implement `/api/csp-report` endpoint to receive, parse, and log reports at `info` level.
- Filter out noise from browser extension schemes (`chrome-extension:`, `moz-extension:`, etc.) and off-origin document URLs.
- Guard against oversized payloads (>64 KB).
- Update unit tests for CSP serialization and frontend reporting handlers.