### PR TITLE
Fix exit code interpolation in run-wrapper.sh

### DIFF
--- a/tool/run-wrapper.sh
+++ b/tool/run-wrapper.sh
@@ -11,7 +11,7 @@ if [ "$EXIT_CODE" -eq 0 ]; then
   echo '{"message": "[pub-run-wrapper-exited]", "severity": "NOTICE", "component": "pub-run-wrapper"}' >&2
   sleep 3
 else
-  echo '{"message": "[pub-run-wrapper-failed] exit code $EXIT_CODE", "severity": "CRITICAL", "component": "pub-run-wrapper"}' >&2
+  echo '{"message": "[pub-run-wrapper-failed] exit code '"$EXIT_CODE"'", "severity": "CRITICAL", "component": "pub-run-wrapper"}' >&2
   sleep 10
 fi
 


### PR DESCRIPTION
In `tool/run-wrapper.sh`, single quotes prevented `$EXIT_CODE` from expanding when logging failures to stderr. This changes the quoting so the actual exit code integer is emitted.