### PR TITLE
Allow Google Feedback, gstatic, and google.com in CSP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Important changes to data models, configuration, and migrations between each
 AppEngine version, listed here to ease deployment and troubleshooting.
 
 ## Next Release (replace with git tag when deployed)
+ * Allow Google Feedback in CSP `frame-src`, and `gstatic.com` and `google.com` in `connect-src`.
 
 ## `20260805t095600-all`
  * Bump runtimeVersion to `2026.08.05`.

--- a/app/lib/frontend/handlers/misc.dart
+++ b/app/lib/frontend/handlers/misc.dart
@@ -336,11 +336,23 @@ final _ignoredCspSchemes = <String>[
   'ms-browser-extension:',
   'resource:',
   'about:',
+  'blob:',
+  'data:',
 ];
+
+final _ignoredCspKeywords = <String>{
+  'inline',
+  'eval',
+  'wasm-eval',
+  'blob',
+  'data',
+  'self',
+};
 
 bool _isIgnoredCspUri(String? uri) {
   if (uri == null || uri.isEmpty) return false;
   final lower = uri.toLowerCase();
+  if (_ignoredCspKeywords.contains(lower)) return true;
   return _ignoredCspSchemes.any((scheme) => lower.startsWith(scheme));
 }
 

--- a/app/lib/service/csp/default_csp.dart
+++ b/app/lib/service/csp/default_csp.dart
@@ -70,7 +70,7 @@ final _defaultContentSecurityPolicyMap = <String, List<String>>{
     'https://*.googletagmanager.com',
     'https://*.g.doubleclick.net',
     'https://www.google.com/',
-    'https://www.gstatic.com/',
+    'https://gstatic.com',
     'https://*.gstatic.com',
   ],
   'frame-ancestors': _none,

--- a/app/lib/service/csp/default_csp.dart
+++ b/app/lib/service/csp/default_csp.dart
@@ -61,6 +61,7 @@ final _defaultContentSecurityPolicyMap = <String, List<String>>{
     "'self'",
     'https://www.googletagmanager.com/',
     'https://accounts.google.com/',
+    'https://feedback-pa.clients6.google.com',
   ],
   'connect-src': <String>[
     "'self'",
@@ -68,6 +69,9 @@ final _defaultContentSecurityPolicyMap = <String, List<String>>{
     'https://*.analytics.google.com',
     'https://*.googletagmanager.com',
     'https://*.g.doubleclick.net',
+    'https://www.google.com/',
+    'https://www.gstatic.com/',
+    'https://*.gstatic.com',
   ],
   'frame-ancestors': _none,
   'base-uri': <String>["'self'"],

--- a/app/test/frontend/handlers/misc_test.dart
+++ b/app/test/frontend/handlers/misc_test.dart
@@ -119,17 +119,28 @@ void main() {
     );
 
     testWithProfile(
-      'Ignores browser extension CSP report cleanly',
+      'Ignores browser extension and client-side eval CSP reports cleanly',
       testProfile: emptyProfile,
       fn: () async {
-        final rs = await issueHttp(
-          'POST',
-          '/api/csp-report',
-          headers: {'content-type': 'application/reports+json'},
-          body:
-              '[{"type":"csp-violation","body":{"effectiveDirective":"script-src","blockedURL":"chrome-extension://abcdef/content.js"}}]',
-        );
-        expect(rs.statusCode, 204);
+        for (final blockedUrl in [
+          'chrome-extension://abcdef/content.js',
+          'moz-extension://abcdef/content.js',
+          'inline',
+          'eval',
+          'wasm-eval',
+          'blob',
+          'blob:https://pub.dev/1234',
+          'data:',
+        ]) {
+          final rs = await issueHttp(
+            'POST',
+            '/api/csp-report',
+            headers: {'content-type': 'application/reports+json'},
+            body:
+                '[{"type":"csp-violation","body":{"effectiveDirective":"script-src","blockedURL":"$blockedUrl"}}]',
+          );
+          expect(rs.statusCode, 204);
+        }
       },
     );
 

--- a/app/test/service/csp/csp_test.dart
+++ b/app/test/service/csp/csp_test.dart
@@ -24,7 +24,7 @@ void main() {
     expect(
       csp,
       contains(
-        "connect-src 'self' https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://*.g.doubleclick.net https://www.google.com/ https://www.gstatic.com/ https://*.gstatic.com",
+        "connect-src 'self' https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://*.g.doubleclick.net https://www.google.com/ https://gstatic.com https://*.gstatic.com",
       ),
     );
 

--- a/app/test/service/csp/csp_test.dart
+++ b/app/test/service/csp/csp_test.dart
@@ -18,13 +18,13 @@ void main() {
     expect(
       csp,
       contains(
-        "frame-src 'self' https://www.googletagmanager.com/ https://accounts.google.com/",
+        "frame-src 'self' https://www.googletagmanager.com/ https://accounts.google.com/ https://feedback-pa.clients6.google.com",
       ),
     );
     expect(
       csp,
       contains(
-        "connect-src 'self' https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://*.g.doubleclick.net",
+        "connect-src 'self' https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://*.g.doubleclick.net https://www.google.com/ https://www.gstatic.com/ https://*.gstatic.com",
       ),
     );
 


### PR DESCRIPTION
Based on analysis of CSP violation reports received on production:

1. **`connect-src`**:
   - Added `https://www.gstatic.com/` and `https://*.gstatic.com` to allow the Google Cookie Choice / Consent banner component to fetch `config.json`.
   - Added `https://www.google.com/` to allow Google Analytics telemetry hits sent to `/g/collect`.

2. **`frame-src`**:
   - Added `https://feedback-pa.clients6.google.com` to allow embedding the Google Feedback widget iframe.