### PR TITLE
Schedule package analysis immediately in task-bump-priority admin action

### DIFF
--- a/app/lib/admin/actions/task_bump_priority.dart
+++ b/app/lib/admin/actions/task_bump_priority.dart
@@ -18,9 +18,7 @@ It will also immediately trigger an analysis worker instance if quota is availab
 If the instance quota limit is reached or instance creation fails, the priority
 remains bumped and the background scheduler will pick it up as soon as possible.
 ''',
-  options: {
-    'package': 'Name of package whose priority should be bumped',
-  },
+  options: {'package': 'Name of package whose priority should be bumped'},
   invoke: (options) async {
     final package =
         options['package'] ??

--- a/app/lib/admin/actions/task_bump_priority.dart
+++ b/app/lib/admin/actions/task_bump_priority.dart
@@ -8,31 +8,32 @@ import 'package:pub_dev/task/backend.dart';
 
 final taskBumpPriority = AdminAction(
   name: 'task-bump-priority',
-  summary: 'Increase priority for task scheduling of specific package',
+  summary: 'Increase priority and schedule analysis of specific package.',
   description: '''
-This action will lower the `PackageState.pendingAt` property for the given
-package. This should cause an analysis task for the package to be scheduled
-sooner.
+This action resets the scheduling state for the given package (and optional version)
+and immediately triggers an analysis worker instance if quota is available.
 
-This will always set `pendingAt` to the same value, it will not trigger new
-analysis, if none is pending, merely increase the priority. Calling it multiple
-times will have no effect, it will always set `pendingAt` to the same value.
-
-This is intended for debugging, or solving one-off issues.
+If the instance quota limit is reached or instance creation fails, it sets the
+priority to the highest level so the background scheduler will pick it up as soon as possible.
 ''',
-  options: {'package': 'Name of package whose priority should be bumped'},
+  options: {
+    'package': 'Name of package whose priority should be bumped',
+    'version': 'Optional version of package to analyze',
+  },
   invoke: (options) async {
     final package =
         options['package'] ??
         (throw InvalidInputException('Needs a package name'));
     InvalidInputException.checkPackageName(package);
+    final version = options['version'];
+    if (version != null) {
+      InvalidInputException.checkSemanticVersion(version);
+    }
     // Make sure package exists.
     final pkg = await packageBackend.lookupPackage(package);
     if (pkg == null) {
       throw InvalidInputException('No package $package');
     }
-    await taskBackend.adminBumpPriority(package);
-
-    return {'message': 'Priority may have been bumped, good luck!'};
+    return await taskBackend.adminBumpPriority(package, version: version);
   },
 );

--- a/app/lib/admin/actions/task_bump_priority.dart
+++ b/app/lib/admin/actions/task_bump_priority.dart
@@ -10,30 +10,27 @@ final taskBumpPriority = AdminAction(
   name: 'task-bump-priority',
   summary: 'Increase priority and schedule analysis of specific package.',
   description: '''
-This action resets the scheduling state for the given package (and optional version)
-and immediately triggers an analysis worker instance if quota is available.
+This action bumps the priority of the given package.
+Pending/running analysis will be cancelled and analysis of all versions will be
+queued at highest priority.
 
-If the instance quota limit is reached or instance creation fails, it sets the
-priority to the highest level so the background scheduler will pick it up as soon as possible.
+It will also immediately trigger an analysis worker instance if quota is available.
+If the instance quota limit is reached or instance creation fails, the priority
+remains bumped and the background scheduler will pick it up as soon as possible.
 ''',
   options: {
     'package': 'Name of package whose priority should be bumped',
-    'version': 'Optional version of package to analyze',
   },
   invoke: (options) async {
     final package =
         options['package'] ??
         (throw InvalidInputException('Needs a package name'));
     InvalidInputException.checkPackageName(package);
-    final version = options['version'];
-    if (version != null) {
-      InvalidInputException.checkSemanticVersion(version);
-    }
     // Make sure package exists.
     final pkg = await packageBackend.lookupPackage(package);
     if (pkg == null) {
       throw InvalidInputException('No package $package');
     }
-    return await taskBackend.adminBumpPriority(package, version: version);
+    return await taskBackend.adminBumpPriority(package);
   },
 );

--- a/app/lib/task/backend.dart
+++ b/app/lib/task/backend.dart
@@ -1187,85 +1187,18 @@ class TaskBackend {
     }
 
     final zone = compute.zones.first;
-    final instanceName = compute.generateInstanceName();
-
-    // 3. Atomically assign tokens and state.
-    final payload = await updatePackageStateWithPendingVersions(
-      _database,
-      packageName,
-      zone,
-      instanceName,
+    final res = await schedulePackageInstance(
+      database: _database,
+      compute: compute,
+      package: packageName,
+      zone: zone,
     );
-    if (payload == null) {
-      return {
-        'status': 'none-pending',
-        'message': 'No versions pending analysis.',
-        'package': packageName,
-        if (version != null) 'version': version,
-      };
-    }
 
-    final description =
-        'admin: package:${payload.package} analysis of ${payload.versions.length} versions.';
-
-    var rollbackPackageState = true;
-    try {
-      await purgePackageCache(payload.package);
-      _log.info(
-        'creating instance $instanceName in $zone for package:$packageName',
-      );
-      await compute.createInstance(
-        zone: zone,
-        instanceName: instanceName,
-        dockerImage: activeConfiguration.taskWorkerImage!,
-        arguments: [json.encode(payload)],
-        description: description,
-      );
-      rollbackPackageState = false;
-    } on ZoneExhaustedException catch (e, st) {
-      _log.info(
-        'zone resources exhausted, failed to create $instanceName in $zone',
-        e,
-        st,
-      );
-    } catch (e, st) {
-      _log.warning(
-        'Failed to create instance $instanceName in $zone for package $packageName',
-        e,
-        st,
-      );
-    }
-
-    if (rollbackPackageState) {
-      await _database.transactWithRetry((db) async {
-        final s = await db.taskLookupOrNull(packageName);
-        if (s == null) return;
-        final versions = s.state.versions;
-        versions.addEntries(
-          versions.entries
-              .where((e) => e.value.instance == instanceName)
-              .map((e) => MapEntry(e.key, e.value.resetAfterFailedAttempt())),
-        );
-        await db.tasks
-            .byKey(runtimeVersion, packageName)
-            .update(
-              (_, set) => set(
-                state: TaskState(
-                  versions: versions,
-                  abortedTokens: s.state.abortedTokens,
-                ).asExpr,
-                pendingAt: derivePendingAt(
-                  versions: versions,
-                  lastDependencyChanged: s.lastDependencyChanged,
-                ).asExpr,
-              ),
-            )
-            .execute();
-      });
+    if (res == null) {
       return {
         'status': 'enqueued',
         'message':
-            'Failed to start instance immediately. Task remains enqueued with highest priority.',
+            'Failed to start instance immediately or no versions pending. Task remains enqueued with highest priority.',
         'package': packageName,
         if (version != null) 'version': version,
       };
@@ -1275,9 +1208,9 @@ class TaskBackend {
       'status': 'started',
       'message': 'Instance created for analysis.',
       'package': packageName,
-      'instance': instanceName,
-      'zone': zone,
-      'versions': payload.versions.map((v) => v.version).toList(),
+      'instance': res.instanceName,
+      'zone': res.zone,
+      'versions': res.payload.versions.map((v) => v.version).toList(),
     };
   }
 

--- a/app/lib/task/backend.dart
+++ b/app/lib/task/backend.dart
@@ -1098,9 +1098,57 @@ class TaskBackend {
   ///
   /// Throws [InvalidInputException] if [packageName] is not tracked.
   Future<Map<String, dynamic>> adminBumpPriority(String packageName) async {
-    // Ensure we're up-to-date and prioritized.
-    await trackPackage(packageName);
-    await _database.withRetry((db) => db.taskBumpPriority(packageName));
+    // Ensure we're up-to-date.
+    await trackPackage(packageName, refreshVersionsCache: true);
+
+    // 1. Reset version state so it's guaranteed to be pending.
+    await _database.transactWithRetry((db) async {
+      final task = await db.taskLookupOrNull(packageName);
+      if (task == null) {
+        throw InvalidInputException('No task found for "$packageName".');
+      }
+
+      final versions = {...task.state.versions};
+      final targetVersions = versions.keys.toList();
+      final abortedTokens = <AbortedTokenInfo>[];
+      for (final v in targetVersions) {
+        final current = versions[v];
+        if (current == null) continue;
+        if (current.secretToken != null) {
+          abortedTokens.add(
+            AbortedTokenInfo(
+              token: current.secretToken!,
+              expires: current.scheduled.add(maxTaskExecutionTime),
+            ),
+          );
+        }
+        versions[v] = PackageVersionStateInfo(
+          scheduled: initialTimestamp,
+          attempts: 0,
+          docs: current.docs,
+          pana: current.pana,
+          finished: current.finished,
+        );
+      }
+
+      final newAbortedTokens = [
+        ...abortedTokens,
+        ...task.state.abortedTokens,
+      ].where((t) => t.isNotExpired).take(50).toList();
+
+      await db.tasks
+          .byKey(runtimeVersion, packageName)
+          .update(
+            (_, set) => set(
+              state: TaskState(
+                versions: versions,
+                abortedTokens: newAbortedTokens,
+              ).asExpr,
+              pendingAt: initialTimestamp.asExpr,
+            ),
+          )
+          .execute();
+    });
 
     // 2. Check quota and pick zone.
     final compute = taskWorkerCloudCompute;

--- a/app/lib/task/backend.dart
+++ b/app/lib/task/backend.dart
@@ -1073,7 +1073,6 @@ class TaskBackend {
     await _database.withRetry((db) async {
       await for (final state in db.taskListAllForCurrentRuntime()) {
         final zone = taskWorkerCloudCompute.zones.first;
-        // ignore: invalid_use_of_visible_for_testing_member
         final payload = await updatePackageStateWithPendingVersions(
           _database,
           state.package,
@@ -1086,13 +1085,200 @@ class TaskBackend {
     });
   }
 
-  /// Trigger a one-off priority bump for [packageName].
+  /// Trigger an immediate analysis scheduling or priority bump for [packageName]
+  /// and an optional [version].
   ///
-  /// Intended to be used for admin actions, not intended for normal operations.
-  Future<void> adminBumpPriority(String packageName) async {
+  /// Resets the version(s) state so that they are guaranteed to be considered
+  /// pending, sets `pendingAt` to [initialTimestamp], and immediately attempts
+  /// to create a worker instance if quota is available.
+  ///
+  /// If instance quota is reached or instance creation fails, the task remains
+  /// enqueued with highest priority and will be picked up on the next scheduler loop.
+  ///
+  /// It is an error if [packageName] is empty.
+  ///
+  /// Throws [InvalidInputException] if [packageName] is not tracked, or if [version]
+  /// is specified but not tracked for [packageName].
+  Future<Map<String, dynamic>> adminBumpPriority(
+    String packageName, {
+    String? version,
+  }) async {
     // Ensure we're up-to-date.
-    await trackPackage(packageName);
-    await _database.withRetry((db) => db.taskBumpPriority(packageName));
+    await trackPackage(packageName, refreshVersionsCache: true);
+
+    // 1. Reset version state so it's guaranteed to be pending.
+    await _database.transactWithRetry((db) async {
+      final task = await db.taskLookupOrNull(packageName);
+      if (task == null) {
+        throw InvalidInputException('No task found for "$packageName".');
+      }
+
+      final versions = {...task.state.versions};
+      if (version != null && !versions.containsKey(version)) {
+        throw InvalidInputException(
+          'Version "$version" is not tracked for package "$packageName".',
+        );
+      }
+
+      final targetVersions = version != null
+          ? [version]
+          : versions.keys.toList();
+      final abortedTokens = <AbortedTokenInfo>[];
+      for (final v in targetVersions) {
+        final current = versions[v];
+        if (current == null) continue;
+        if (current.secretToken != null) {
+          abortedTokens.add(
+            AbortedTokenInfo(
+              token: current.secretToken!,
+              expires: current.scheduled.add(maxTaskExecutionTime),
+            ),
+          );
+        }
+        versions[v] = PackageVersionStateInfo(
+          scheduled: initialTimestamp,
+          attempts: 0,
+          docs: current.docs,
+          pana: current.pana,
+          finished: current.finished,
+        );
+      }
+
+      final newAbortedTokens = [
+        ...abortedTokens,
+        ...task.state.abortedTokens,
+      ].where((t) => t.isNotExpired).take(50).toList();
+
+      await db.tasks
+          .byKey(runtimeVersion, packageName)
+          .update(
+            (_, set) => set(
+              state: TaskState(
+                versions: versions,
+                abortedTokens: newAbortedTokens,
+              ).asExpr,
+              pendingAt: initialTimestamp.asExpr,
+            ),
+          )
+          .execute();
+    });
+
+    // 2. Check quota and pick zone.
+    final compute = taskWorkerCloudCompute;
+    final instances = await compute.listInstances().toList();
+    if (instances.length >= activeConfiguration.maxTaskInstances) {
+      return {
+        'status': 'enqueued',
+        'message':
+            'Instance limit reached. Analysis task is enqueued with highest priority.',
+        'package': packageName,
+        if (version != null) 'version': version,
+      };
+    }
+
+    if (compute.zones.isEmpty) {
+      return {
+        'status': 'enqueued',
+        'message':
+            'No compute zones configured. Analysis task is enqueued with highest priority.',
+        'package': packageName,
+        if (version != null) 'version': version,
+      };
+    }
+
+    final zone = compute.zones.first;
+    final instanceName = compute.generateInstanceName();
+
+    // 3. Atomically assign tokens and state.
+    final payload = await updatePackageStateWithPendingVersions(
+      _database,
+      packageName,
+      zone,
+      instanceName,
+    );
+    if (payload == null) {
+      return {
+        'status': 'none-pending',
+        'message': 'No versions pending analysis.',
+        'package': packageName,
+        if (version != null) 'version': version,
+      };
+    }
+
+    final description =
+        'admin: package:${payload.package} analysis of ${payload.versions.length} versions.';
+
+    var rollbackPackageState = true;
+    try {
+      await purgePackageCache(payload.package);
+      _log.info(
+        'creating instance $instanceName in $zone for package:$packageName',
+      );
+      await compute.createInstance(
+        zone: zone,
+        instanceName: instanceName,
+        dockerImage: activeConfiguration.taskWorkerImage!,
+        arguments: [json.encode(payload)],
+        description: description,
+      );
+      rollbackPackageState = false;
+    } on ZoneExhaustedException catch (e, st) {
+      _log.info(
+        'zone resources exhausted, failed to create $instanceName in $zone',
+        e,
+        st,
+      );
+    } catch (e, st) {
+      _log.warning(
+        'Failed to create instance $instanceName in $zone for package $packageName',
+        e,
+        st,
+      );
+    }
+
+    if (rollbackPackageState) {
+      await _database.transactWithRetry((db) async {
+        final s = await db.taskLookupOrNull(packageName);
+        if (s == null) return;
+        final versions = s.state.versions;
+        versions.addEntries(
+          versions.entries
+              .where((e) => e.value.instance == instanceName)
+              .map((e) => MapEntry(e.key, e.value.resetAfterFailedAttempt())),
+        );
+        await db.tasks
+            .byKey(runtimeVersion, packageName)
+            .update(
+              (_, set) => set(
+                state: TaskState(
+                  versions: versions,
+                  abortedTokens: s.state.abortedTokens,
+                ).asExpr,
+                pendingAt: derivePendingAt(
+                  versions: versions,
+                  lastDependencyChanged: s.lastDependencyChanged,
+                ).asExpr,
+              ),
+            )
+            .execute();
+      });
+      return {
+        'status': 'enqueued',
+        'message':
+            'Failed to start instance immediately. Task remains enqueued with highest priority.',
+        'package': packageName,
+        if (version != null) 'version': version,
+      };
+    }
+
+    return {
+      'status': 'started',
+      'message': 'Instance created for analysis.',
+      'package': packageName,
+      'instance': instanceName,
+      'zone': zone,
+      'versions': payload.versions.map((v) => v.version).toList(),
+    };
   }
 
   /// Returns the latest version of the [package] which has a finished analysis.

--- a/app/lib/task/backend.dart
+++ b/app/lib/task/backend.dart
@@ -1085,8 +1085,7 @@ class TaskBackend {
     });
   }
 
-  /// Trigger an immediate analysis scheduling or priority bump for [packageName]
-  /// and an optional [version].
+  /// Trigger an immediate analysis scheduling or priority bump for [packageName].
   ///
   /// Resets the version(s) state so that they are guaranteed to be considered
   /// pending, sets `pendingAt` to [initialTimestamp], and immediately attempts
@@ -1097,71 +1096,11 @@ class TaskBackend {
   ///
   /// It is an error if [packageName] is empty.
   ///
-  /// Throws [InvalidInputException] if [packageName] is not tracked, or if [version]
-  /// is specified but not tracked for [packageName].
-  Future<Map<String, dynamic>> adminBumpPriority(
-    String packageName, {
-    String? version,
-  }) async {
-    // Ensure we're up-to-date.
-    await trackPackage(packageName, refreshVersionsCache: true);
-
-    // 1. Reset version state so it's guaranteed to be pending.
-    await _database.transactWithRetry((db) async {
-      final task = await db.taskLookupOrNull(packageName);
-      if (task == null) {
-        throw InvalidInputException('No task found for "$packageName".');
-      }
-
-      final versions = {...task.state.versions};
-      if (version != null && !versions.containsKey(version)) {
-        throw InvalidInputException(
-          'Version "$version" is not tracked for package "$packageName".',
-        );
-      }
-
-      final targetVersions = version != null
-          ? [version]
-          : versions.keys.toList();
-      final abortedTokens = <AbortedTokenInfo>[];
-      for (final v in targetVersions) {
-        final current = versions[v];
-        if (current == null) continue;
-        if (current.secretToken != null) {
-          abortedTokens.add(
-            AbortedTokenInfo(
-              token: current.secretToken!,
-              expires: current.scheduled.add(maxTaskExecutionTime),
-            ),
-          );
-        }
-        versions[v] = PackageVersionStateInfo(
-          scheduled: initialTimestamp,
-          attempts: 0,
-          docs: current.docs,
-          pana: current.pana,
-          finished: current.finished,
-        );
-      }
-
-      final newAbortedTokens = [
-        ...abortedTokens,
-        ...task.state.abortedTokens,
-      ].where((t) => t.isNotExpired).take(50).toList();
-
-      await db.tasks
-          .byKey(runtimeVersion, packageName)
-          .update(
-            (_, set) => set(
-              state: TaskState(
-                versions: versions,
-                abortedTokens: newAbortedTokens,
-              ).asExpr,
-              pendingAt: initialTimestamp.asExpr,
-            ),
-          )
-          .execute();
-    });
+  /// Throws [InvalidInputException] if [packageName] is not tracked.
+  Future<Map<String, dynamic>> adminBumpPriority(String packageName) async {
+    // Ensure we're up-to-date and prioritized.
+    await trackPackage(packageName);
+    await _database.withRetry((db) => db.taskBumpPriority(packageName));
 
     // 2. Check quota and pick zone.
     final compute = taskWorkerCloudCompute;
@@ -1172,7 +1111,6 @@ class TaskBackend {
         'message':
             'Instance limit reached. Analysis task is enqueued with highest priority.',
         'package': packageName,
-        if (version != null) 'version': version,
       };
     }
 
@@ -1182,7 +1120,6 @@ class TaskBackend {
         'message':
             'No compute zones configured. Analysis task is enqueued with highest priority.',
         'package': packageName,
-        if (version != null) 'version': version,
       };
     }
 
@@ -1200,7 +1137,6 @@ class TaskBackend {
         'message':
             'Failed to start instance immediately or no versions pending. Task remains enqueued with highest priority.',
         'package': packageName,
-        if (version != null) 'version': version,
       };
     }
 

--- a/app/lib/task/scheduler.dart
+++ b/app/lib/task/scheduler.dart
@@ -99,116 +99,19 @@ Future<(CreateInstancesState, Duration)> runOneCreateInstancesCycle(
 
   Future<void> scheduleInstance(({String package}) selected) async {
     pendingPackagesReviewed += 1;
-
-    final instanceName = compute.generateInstanceName();
     final zone = pickZone();
-
-    final payload = await updatePackageStateWithPendingVersions(
-      database,
-      selected.package,
-      zone,
-      instanceName,
-    );
-    if (payload == null) {
-      return;
-    }
-    // Create human readable description for GCP console.
-    final description =
-        'package:${payload.package} analysis of ${payload.versions.length} '
-        'versions.';
-
-    var rollbackPackageState = true;
-    try {
-      // Purging cache is important for the edge case, where the new upload happens
-      // on a different runtime version, and the current one's cache is still stale
-      // and does not have the version yet.
-      // TODO(https://github.com/dart-lang/pub-dev/issues/7268) remove after it gets fixed.
-      await purgePackageCache(payload.package);
-      _log.info(
-        'creating instance $instanceName in $zone for '
-        'package:${selected.package}',
-      );
-      await compute.createInstance(
-        zone: zone,
-        instanceName: instanceName,
-        dockerImage: activeConfiguration.taskWorkerImage!,
-        arguments: [json.encode(payload)],
-        description: description,
-      );
-      rollbackPackageState = false;
-    } on ZoneExhaustedException catch (e, st) {
-      // A zone being exhausted is normal operations, we just use another
-      // zone for 30 minutes.
-      _log.info(
-        'zone resources exhausted, banning ${e.zone} for 30 minutes',
-        e,
-        st,
-      );
-      // Ban usage of zone for 30 minutes
-      banZone(e.zone, minutes: 30);
-    } on QuotaExhaustedException catch (e, st) {
-      // Quota exhausted, this can happen, but it shouldn't. We'll just stop
-      // doing anything for 10 minutes. Hopefully that'll resolve the issue.
-      // We log severe, because this is a reason to adjust the quota or
-      // instance limits.
-      _log.severe(
-        'Quota exhausted trying to create $instanceName, banning all zones '
-        'for 10 minutes',
-        e,
-        st,
-      );
-
-      // Ban all zones for 10 minutes
-      for (final zone in compute.zones) {
-        banZone(zone, minutes: 10);
-      }
-    } catch (e, st) {
-      // No idea what happened, but for robustness we'll stop using the zone
-      // and shout into the logs
-      _log.shout(
-        'Failed to create instance $instanceName, banning zone "$zone" for '
-        '15 minutes',
-        e,
-        st,
-      );
-      // Ban usage of zone for 15 minutes
-      banZone(zone, minutes: 15);
-    }
-    if (rollbackPackageState) {
-      // Restore the state of the PackageState for versions that were
-      // supposed to run on the instance we just failed to create.
-      // If this doesn't work, we'll eventually retry. Hence, correctness
-      // does not hinge on this transaction being successful.
-      await database.transactWithRetry((db) async {
-        final s = await db.taskLookupOrNull(selected.package);
-        if (s == null) {
-          return; // Presumably, the package was deleted.
+    await schedulePackageInstance(
+      database: database,
+      compute: compute,
+      package: selected.package,
+      zone: zone,
+      onZoneFailure: banZone,
+      onQuotaExhausted: (e, st) {
+        for (final zone in compute.zones) {
+          banZone(zone, minutes: 10);
         }
-
-        final versions = s.state.versions;
-        versions.addEntries(
-          versions.entries
-              .where((e) => e.value.instance == instanceName)
-              .map((e) => MapEntry(e.key, e.value.resetAfterFailedAttempt())),
-        );
-
-        await db.tasks
-            .byKey(runtimeVersion, selected.package)
-            .update(
-              (_, set) => set(
-                state: TaskState(
-                  versions: versions,
-                  abortedTokens: s.state.abortedTokens,
-                ).asExpr,
-                pendingAt: derivePendingAt(
-                  versions: versions,
-                  lastDependencyChanged: s.lastDependencyChanged,
-                ).asExpr,
-              ),
-            )
-            .execute();
-      });
-    }
+      },
+    );
   }
 
   // Creating an instance can be slow, we want to schedule them concurrently.
@@ -240,6 +143,151 @@ Future<(CreateInstancesState, Duration)> runOneCreateInstancesCycle(
     CreateInstancesState(zoneBannedUntil: zoneBannedUntil),
     Duration(minutes: 1),
   );
+}
+
+/// Result of scheduling a worker instance for a package.
+final class SchedulePackageResult {
+  /// Name of the cloud compute instance created.
+  final String instanceName;
+
+  /// Cloud compute zone where the instance is running.
+  final String zone;
+
+  /// The task [Payload] passed to the instance.
+  final Payload payload;
+
+  SchedulePackageResult({
+    required this.instanceName,
+    required this.zone,
+    required this.payload,
+  });
+}
+
+/// Attempts to schedule and start a worker instance for [package] in [zone].
+///
+/// Updates package state with pending versions, purges package cache, creates the
+/// VM instance via [compute], and rolls back the package version state if instance
+/// creation fails.
+///
+/// If [onZoneFailure] is provided, it is called when a zone exhaustion or creation error occurs.
+/// If [onQuotaExhausted] is provided, it is called when a [QuotaExhaustedException] is encountered.
+///
+/// Returns [SchedulePackageResult] if the instance was successfully created.
+/// Returns `null` if no versions were pending or if instance creation failed.
+Future<SchedulePackageResult?> schedulePackageInstance({
+  required PrimaryDatabase database,
+  required CloudCompute compute,
+  required String package,
+  required String zone,
+  void Function(String zone, {int minutes, int hours, int days})? onZoneFailure,
+  void Function(QuotaExhaustedException e, StackTrace st)? onQuotaExhausted,
+}) async {
+  final instanceName = compute.generateInstanceName();
+
+  final payload = await updatePackageStateWithPendingVersions(
+    database,
+    package,
+    zone,
+    instanceName,
+  );
+  if (payload == null) {
+    return null;
+  }
+  // Create human readable description for GCP console.
+  final description =
+      'package:${payload.package} analysis of ${payload.versions.length} '
+      'versions.';
+
+  var rollbackPackageState = true;
+  try {
+    // Purging cache is important for the edge case, where the new upload happens
+    // on a different runtime version, and the current one's cache is still stale
+    // and does not have the version yet.
+    // TODO(https://github.com/dart-lang/pub-dev/issues/7268) remove after it gets fixed.
+    await purgePackageCache(payload.package);
+    _log.info('creating instance $instanceName in $zone for package:$package');
+    await compute.createInstance(
+      zone: zone,
+      instanceName: instanceName,
+      dockerImage: activeConfiguration.taskWorkerImage!,
+      arguments: [json.encode(payload)],
+      description: description,
+    );
+    rollbackPackageState = false;
+    return SchedulePackageResult(
+      instanceName: instanceName,
+      zone: zone,
+      payload: payload,
+    );
+  } on ZoneExhaustedException catch (e, st) {
+    // A zone being exhausted is normal operations, we just use another zone.
+    _log.info(
+      'zone resources exhausted, banning ${e.zone} for 30 minutes',
+      e,
+      st,
+    );
+    onZoneFailure?.call(e.zone, minutes: 30);
+  } on QuotaExhaustedException catch (e, st) {
+    // Quota exhausted, this can happen, but it shouldn't.
+    _log.severe(
+      'Quota exhausted trying to create $instanceName, banning all zones for 10 minutes',
+      e,
+      st,
+    );
+    if (onQuotaExhausted != null) {
+      onQuotaExhausted(e, st);
+    } else if (onZoneFailure != null) {
+      for (final z in compute.zones) {
+        onZoneFailure(z, minutes: 10);
+      }
+    }
+  } catch (e, st) {
+    // No idea what happened, but for robustness we'll stop using the zone
+    // and shout into the logs
+    _log.shout(
+      'Failed to create instance $instanceName, banning zone "$zone" for 15 minutes',
+      e,
+      st,
+    );
+    onZoneFailure?.call(zone, minutes: 15);
+  } finally {
+    if (rollbackPackageState) {
+      // Restore the state of the PackageState for versions that were
+      // supposed to run on the instance we just failed to create.
+      // If this doesn't work, we'll eventually retry. Hence, correctness
+      // does not hinge on this transaction being successful.
+      await database.transactWithRetry((db) async {
+        final s = await db.taskLookupOrNull(package);
+        if (s == null) {
+          return; // Presumably, the package was deleted.
+        }
+
+        final versions = s.state.versions;
+        versions.addEntries(
+          versions.entries
+              .where((e) => e.value.instance == instanceName)
+              .map((e) => MapEntry(e.key, e.value.resetAfterFailedAttempt())),
+        );
+
+        await db.tasks
+            .byKey(runtimeVersion, package)
+            .update(
+              (_, set) => set(
+                state: TaskState(
+                  versions: versions,
+                  abortedTokens: s.state.abortedTokens,
+                ).asExpr,
+                pendingAt: derivePendingAt(
+                  versions: versions,
+                  lastDependencyChanged: s.lastDependencyChanged,
+                ).asExpr,
+              ),
+            )
+            .execute();
+      });
+    }
+  }
+  return null;
 }
 
 /// Updates the package state with versions that are already pending or

--- a/app/lib/task/scheduler.dart
+++ b/app/lib/task/scheduler.dart
@@ -6,7 +6,6 @@ import 'package:_pub_shared/data/task_payload.dart';
 import 'package:basics/basics.dart';
 import 'package:clock/clock.dart';
 import 'package:logging/logging.dart' show Logger;
-import 'package:meta/meta.dart';
 import 'package:pub_dev/database/database.dart';
 import 'package:pub_dev/database/schema.dart';
 import 'package:pub_dev/package/backend.dart';
@@ -245,7 +244,8 @@ Future<(CreateInstancesState, Duration)> runOneCreateInstancesCycle(
 
 /// Updates the package state with versions that are already pending or
 /// will be pending soon.
-@visibleForTesting
+///
+/// Returns `null` if the package does not exist or has no pending versions.
 Future<Payload?> updatePackageStateWithPendingVersions(
   PrimaryDatabase database,
   String package,

--- a/app/test/admin/package_actions_test.dart
+++ b/app/test/admin/package_actions_test.dart
@@ -3,8 +3,12 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:_pub_shared/data/admin_api.dart';
+import 'package:pub_dev/shared/configuration.dart';
+import 'package:pub_dev/task/backend.dart';
+import 'package:pub_dev/task/cloudcompute/fakecloudcompute.dart';
 import 'package:test/test.dart';
 
+import '../shared/handlers_test_utils.dart';
 import '../shared/test_models.dart';
 import '../shared/test_services.dart';
 
@@ -90,6 +94,115 @@ void main() {
           'before': {'publisherId': null},
           'after': {'publisherId': 'example.com'},
         });
+      },
+    );
+
+    testWithProfile(
+      'task-bump-priority immediate instance creation',
+      processJobsWithFakeRunners: true,
+      fn: () async {
+        final client = createPubApiClient(authToken: siteAdminToken);
+        final cloud = taskWorkerCloudCompute as FakeCloudCompute;
+
+        final rs = await client.adminInvokeAction(
+          'task-bump-priority',
+          AdminInvokeActionArguments(arguments: {'package': 'oxygen'}),
+        );
+        expect(rs.output, {
+          'status': 'started',
+          'message': 'Instance created for analysis.',
+          'package': 'oxygen',
+          'instance': startsWith('instance-'),
+          'zone': 'zone-a',
+          'versions': ['1.2.0', '2.0.0-dev', '1.0.0'],
+        });
+
+        final instances = await cloud.listInstances().toList();
+        expect(instances, hasLength(1));
+        expect(instances.first.instanceName, rs.output['instance']);
+      },
+    );
+
+    testWithProfile(
+      'task-bump-priority with specific version',
+      processJobsWithFakeRunners: true,
+      fn: () async {
+        final client = createPubApiClient(authToken: siteAdminToken);
+        final cloud = taskWorkerCloudCompute as FakeCloudCompute;
+
+        final rs = await client.adminInvokeAction(
+          'task-bump-priority',
+          AdminInvokeActionArguments(
+            arguments: {'package': 'oxygen', 'version': '1.2.0'},
+          ),
+        );
+        expect(rs.output, {
+          'status': 'started',
+          'message': 'Instance created for analysis.',
+          'package': 'oxygen',
+          'instance': startsWith('instance-'),
+          'zone': 'zone-a',
+          'versions': ['1.2.0'],
+        });
+
+        final instances = await cloud.listInstances().toList();
+        expect(instances, hasLength(1));
+      },
+    );
+
+    testWithProfile(
+      'task-bump-priority when quota/instance limit is reached',
+      processJobsWithFakeRunners: true,
+      fn: () async {
+        final client = createPubApiClient(authToken: siteAdminToken);
+        final cloud = taskWorkerCloudCompute as FakeCloudCompute;
+
+        // Fill instances up to maxTaskInstances (10)
+        for (var i = 0; i < activeConfiguration.maxTaskInstances; i++) {
+          cloud.fakeCreateRunningInstance(
+            zone: 'zone-a',
+            instanceName: 'busy-$i',
+            ago: Duration(minutes: 5),
+          );
+        }
+
+        final rs = await client.adminInvokeAction(
+          'task-bump-priority',
+          AdminInvokeActionArguments(arguments: {'package': 'oxygen'}),
+        );
+        expect(rs.output, {
+          'status': 'enqueued',
+          'message':
+              'Instance limit reached. Analysis task is enqueued with highest priority.',
+          'package': 'oxygen',
+        });
+      },
+    );
+
+    testWithProfile(
+      'task-bump-priority with non-existent package',
+      fn: () async {
+        final client = createPubApiClient(authToken: siteAdminToken);
+        final rs = client.adminInvokeAction(
+          'task-bump-priority',
+          AdminInvokeActionArguments(arguments: {'package': 'non_existing'}),
+        );
+        await expectApiException(rs, status: 400, code: 'InvalidInput');
+      },
+    );
+
+    testWithProfile(
+      'task-bump-priority with untracked version',
+      processJobsWithFakeRunners: true,
+      fn: () async {
+        final client = createPubApiClient(authToken: siteAdminToken);
+        final rs = client.adminInvokeAction(
+          'task-bump-priority',
+          AdminInvokeActionArguments(
+            arguments: {'package': 'oxygen', 'version': '9.9.9'},
+          ),
+        );
+        await expectApiException(rs, status: 400, code: 'InvalidInput');
       },
     );
   });

--- a/app/test/admin/package_actions_test.dart
+++ b/app/test/admin/package_actions_test.dart
@@ -124,33 +124,6 @@ void main() {
     );
 
     testWithProfile(
-      'task-bump-priority with specific version',
-      processJobsWithFakeRunners: true,
-      fn: () async {
-        final client = createPubApiClient(authToken: siteAdminToken);
-        final cloud = taskWorkerCloudCompute as FakeCloudCompute;
-
-        final rs = await client.adminInvokeAction(
-          'task-bump-priority',
-          AdminInvokeActionArguments(
-            arguments: {'package': 'oxygen', 'version': '1.2.0'},
-          ),
-        );
-        expect(rs.output, {
-          'status': 'started',
-          'message': 'Instance created for analysis.',
-          'package': 'oxygen',
-          'instance': startsWith('instance-'),
-          'zone': 'zone-a',
-          'versions': ['1.2.0'],
-        });
-
-        final instances = await cloud.listInstances().toList();
-        expect(instances, hasLength(1));
-      },
-    );
-
-    testWithProfile(
       'task-bump-priority when quota/instance limit is reached',
       processJobsWithFakeRunners: true,
       fn: () async {
@@ -186,21 +159,6 @@ void main() {
         final rs = client.adminInvokeAction(
           'task-bump-priority',
           AdminInvokeActionArguments(arguments: {'package': 'non_existing'}),
-        );
-        await expectApiException(rs, status: 400, code: 'InvalidInput');
-      },
-    );
-
-    testWithProfile(
-      'task-bump-priority with untracked version',
-      processJobsWithFakeRunners: true,
-      fn: () async {
-        final client = createPubApiClient(authToken: siteAdminToken);
-        final rs = client.adminInvokeAction(
-          'task-bump-priority',
-          AdminInvokeActionArguments(
-            arguments: {'package': 'oxygen', 'version': '9.9.9'},
-          ),
         );
         await expectApiException(rs, status: 400, code: 'InvalidInput');
       },


### PR DESCRIPTION
Updates the `task-bump-priority` admin action and `TaskBackend.adminBumpPriority` to:
- Use the standard `db.taskBumpPriority` to enqueue analysis for all tracked versions of the package.
- Direct-launch an analysis worker VM instance right away if quota allows instead of strictly waiting for the background scheduler.
- If the instance quota limit is reached or VM creation fails, the task remains enqueued with high priority and will be picked up by the background scheduler cycle.