### PR TITLE
Fix SSRF signing oracle in sign-in complete and filter private destinations in image proxy

### DIFF
--- a/app/lib/frontend/handlers/account.dart
+++ b/app/lib/frontend/handlers/account.dart
@@ -8,7 +8,6 @@ import 'package:_pub_shared/search/tags.dart';
 import 'package:clock/clock.dart';
 import 'package:pub_dev/frontend/handlers/cache_control.dart';
 import 'package:pub_dev/package/search_adapter.dart';
-import 'package:pub_dev/shared/markdown.dart';
 import 'package:shelf/shelf.dart' as shelf;
 
 import '../../account/backend.dart';
@@ -28,8 +27,10 @@ import '../../shared/exceptions.dart';
 import '../../shared/handlers.dart';
 import '../../shared/urls.dart' as urls;
 
+import '../dom/dom.dart' as d;
 import '../templates/admin.dart';
 import '../templates/consent.dart';
+import '../templates/layout.dart';
 import '../templates/misc.dart' show renderUnauthenticatedPage;
 
 /// Handles requests for /authorized
@@ -76,7 +77,16 @@ Future<shelf.Response> signInCompleteHandler(shelf.Request request) async {
   final error = params['error'];
   if (error != null && error.isNotEmpty) {
     return htmlResponse(
-      markdownToHtml('There was an error:\n\n```\n$error\n```\n'),
+      renderLayoutPage(
+        PageType.standalone,
+        d.fragment([
+          d.h1(text: 'Sign-in error'),
+          d.p(text: 'There was an error during sign-in:'),
+          d.pre(classes: ['highlight'], text: error),
+        ]),
+        title: 'Sign-in error',
+        noIndex: true,
+      ),
       status: 401,
     );
   }

--- a/app/test/frontend/handlers/account_test.dart
+++ b/app/test/frontend/handlers/account_test.dart
@@ -52,6 +52,20 @@ void main() {
     // TODO: add test for PUT /api/account/consent/<consentId> API calls
 
     testWithProfile(
+      '/sign-in/complete?error=... does not render markdown or SSRF image links',
+      fn: () async {
+        await expectHtmlResponse(
+          await issueGet(
+            '/sign-in/complete?error=x%0A%60%60%60%0A%21%5Bi%5D%28http%3A%2F%2Fmetadata.google.internal%2F%3Fvv%3D1%29%0A',
+          ),
+          status: 401,
+          present: ['metadata.google.internal'],
+          absent: ['external-images.pub.dev'],
+        );
+      },
+    );
+
+    testWithProfile(
       '/my-packages',
       fn: () async {
         final cookies = await acquireSessionCookies('admin@pub.dev');

--- a/pkg/image_proxy/lib/image_proxy_service.dart
+++ b/pkg/image_proxy/lib/image_proxy_service.dart
@@ -464,7 +464,7 @@ Future<bool> _isAllowedDestination(Uri url) async {
         }
       }
     }
-  } catch (_) {
+  } on SocketException {
     // If DNS lookup fails, allow through so client.getUrl throws expected DNS error
   }
   return true;

--- a/pkg/image_proxy/lib/image_proxy_service.dart
+++ b/pkg/image_proxy/lib/image_proxy_service.dart
@@ -16,6 +16,8 @@ import 'package:retry/retry.dart';
 import 'package:shelf/shelf.dart' as shelf;
 import 'package:shelf/shelf_io.dart';
 
+import 'prohibited_addresses.dart';
+
 enum Severity {
   notice,
   info,
@@ -410,48 +412,6 @@ Future<Uint8List> readAllBytes(Stream<List<int>> stream, int maxBytes) async {
   return builder.takeBytes();
 }
 
-/// Checks whether [address] belongs to a private, loopback, link-local, multicast,
-/// or reserved network address range to prevent Server-Side Request Forgery (SSRF).
-///
-/// Checks the following address spaces:
-/// - Loopback, link-local, or multicast addresses (`InternetAddress` properties).
-/// - RFC 1122 current network (`0.0.0.0/8`) and loopback (`127.0.0.0/8`).
-/// - RFC 1918 private IPv4 networks (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`).
-/// - RFC 3927 link-local IPv4 (`169.254.0.0/16`, which includes cloud metadata servers like `169.254.169.254`).
-/// - RFC 6598 carrier-grade NAT / shared address space (`100.64.0.0/10`).
-/// - RFC 4193 IPv6 unique local addresses (`fc00::/7`).
-/// - RFC 3513 IPv6 site-local addresses (`fec0::/10`).
-///
-/// Returns `true` if [address] is within any prohibited network range.
-bool _isProhibitedAddress(InternetAddress address) {
-  if (address.isLoopback || address.isLinkLocal || address.isMulticast) {
-    return true;
-  }
-  final raw = address.rawAddress;
-  if (address.type == InternetAddressType.IPv4 && raw.length == 4) {
-    if (raw[0] == 0 || // 0.0.0.0/8 (RFC 1122)
-        raw[0] == 10 || // 10.0.0.0/8 (RFC 1918)
-        raw[0] == 127 || // 127.0.0.0/8 (RFC 1122)
-        (raw[0] == 169 &&
-            raw[1] == 254) || // 169.254.0.0/16 (RFC 3927 metadata)
-        (raw[0] == 172 &&
-            raw[1] >= 16 &&
-            raw[1] <= 31) || // 172.16.0.0/12 (RFC 1918)
-        (raw[0] == 192 && raw[1] == 168) || // 192.168.0.0/16 (RFC 1918)
-        (raw[0] == 100 && raw[1] >= 64 && raw[1] <= 127)) {
-      // 100.64.0.0/10 (RFC 6598)
-      return true;
-    }
-  } else if (address.type == InternetAddressType.IPv6 && raw.length == 16) {
-    // Unique local (fc00::/7) or site-local (fec0::/10)
-    if ((raw[0] & 0xfe) == 0xfc ||
-        (raw[0] == 0xfe && (raw[1] & 0xc0) == 0xc0)) {
-      return true;
-    }
-  }
-  return false;
-}
-
 /// Verifies whether [url] is a safe destination for proxying.
 ///
 /// Preconditions:
@@ -462,7 +422,7 @@ bool _isProhibitedAddress(InternetAddress address) {
 ///    `.local` suffixes (mDNS), and cloud metadata IP string `169.254.169.254`.
 /// 2. Rejects `localhost` and `.localhost` hostnames unless isTesting is enabled.
 /// 3. Resolves the host of [url] via DNS and rejects the destination if any resolved IP address
-///    matches [_isProhibitedAddress]. When isTesting is `true`, loopback IP addresses
+///    matches [isProhibitedAddress]. When isTesting is `true`, loopback IP addresses
 ///    are permitted so unit tests can run against local test servers.
 ///
 /// If DNS resolution throws a [SocketException], this function returns `true` so that
@@ -489,7 +449,7 @@ Future<bool> _isAllowedDestination(Uri url) async {
   try {
     final addresses = await InternetAddress.lookup(host);
     for (final address in addresses) {
-      if (_isProhibitedAddress(address)) {
+      if (isProhibitedAddress(address)) {
         if (isTesting && address.isLoopback) {
           // Allow loopback in unit tests
         } else {

--- a/pkg/image_proxy/lib/image_proxy_service.dart
+++ b/pkg/image_proxy/lib/image_proxy_service.dart
@@ -258,7 +258,7 @@ Future<shelf.Response> handler(shelf.Request request) async {
           if (location == null) {
             throw RedirectException('No location header in redirect.');
           }
-          final redirectUrl = parsedImageUrl.resolve(location);
+          final redirectUrl = url.resolve(location);
           if (!(await _isAllowedDestination(redirectUrl))) {
             throw RedirectException('Prohibited redirect destination url.');
           }

--- a/pkg/image_proxy/lib/image_proxy_service.dart
+++ b/pkg/image_proxy/lib/image_proxy_service.dart
@@ -410,22 +410,40 @@ Future<Uint8List> readAllBytes(Stream<List<int>> stream, int maxBytes) async {
   return builder.takeBytes();
 }
 
+/// Checks whether [address] belongs to a private, loopback, link-local, multicast,
+/// or reserved network address range to prevent Server-Side Request Forgery (SSRF).
+///
+/// Checks the following address spaces:
+/// - Loopback, link-local, or multicast addresses (`InternetAddress` properties).
+/// - RFC 1122 current network (`0.0.0.0/8`) and loopback (`127.0.0.0/8`).
+/// - RFC 1918 private IPv4 networks (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`).
+/// - RFC 3927 link-local IPv4 (`169.254.0.0/16`, which includes cloud metadata servers like `169.254.169.254`).
+/// - RFC 6598 carrier-grade NAT / shared address space (`100.64.0.0/10`).
+/// - RFC 4193 IPv6 unique local addresses (`fc00::/7`).
+/// - RFC 3513 IPv6 site-local addresses (`fec0::/10`).
+///
+/// Returns `true` if [address] is within any prohibited network range.
 bool _isProhibitedAddress(InternetAddress address) {
   if (address.isLoopback || address.isLinkLocal || address.isMulticast) {
     return true;
   }
   final raw = address.rawAddress;
   if (address.type == InternetAddressType.IPv4 && raw.length == 4) {
-    if (raw[0] == 0 ||
-        raw[0] == 10 ||
-        raw[0] == 127 ||
-        (raw[0] == 169 && raw[1] == 254) ||
-        (raw[0] == 172 && raw[1] >= 16 && raw[1] <= 31) ||
-        (raw[0] == 192 && raw[1] == 168) ||
+    if (raw[0] == 0 || // 0.0.0.0/8 (RFC 1122)
+        raw[0] == 10 || // 10.0.0.0/8 (RFC 1918)
+        raw[0] == 127 || // 127.0.0.0/8 (RFC 1122)
+        (raw[0] == 169 &&
+            raw[1] == 254) || // 169.254.0.0/16 (RFC 3927 metadata)
+        (raw[0] == 172 &&
+            raw[1] >= 16 &&
+            raw[1] <= 31) || // 172.16.0.0/12 (RFC 1918)
+        (raw[0] == 192 && raw[1] == 168) || // 192.168.0.0/16 (RFC 1918)
         (raw[0] == 100 && raw[1] >= 64 && raw[1] <= 127)) {
+      // 100.64.0.0/10 (RFC 6598)
       return true;
     }
   } else if (address.type == InternetAddressType.IPv6 && raw.length == 16) {
+    // Unique local (fc00::/7) or site-local (fec0::/10)
     if ((raw[0] & 0xfe) == 0xfc ||
         (raw[0] == 0xfe && (raw[1] & 0xc0) == 0xc0)) {
       return true;
@@ -434,6 +452,21 @@ bool _isProhibitedAddress(InternetAddress address) {
   return false;
 }
 
+/// Verifies whether [url] is a safe destination for proxying.
+///
+/// Preconditions:
+/// - [url] must be an absolute HTTP or HTTPS URI.
+///
+/// Checks performed:
+/// 1. Rejects internal hostnames such as `metadata.google.internal`, `.internal` suffixes,
+///    `.local` suffixes (mDNS), and cloud metadata IP string `169.254.169.254`.
+/// 2. Rejects `localhost` and `.localhost` hostnames unless isTesting is enabled.
+/// 3. Resolves the host of [url] via DNS and rejects the destination if any resolved IP address
+///    matches [_isProhibitedAddress]. When isTesting is `true`, loopback IP addresses
+///    are permitted so unit tests can run against local test servers.
+///
+/// If DNS resolution throws a [SocketException], this function returns `true` so that
+/// the caller's HTTP client can attempt connection and throw its expected DNS error.
 Future<bool> _isAllowedDestination(Uri url) async {
   if (!(url.isScheme('http') || url.isScheme('https'))) {
     return false;

--- a/pkg/image_proxy/lib/image_proxy_service.dart
+++ b/pkg/image_proxy/lib/image_proxy_service.dart
@@ -218,6 +218,12 @@ Future<shelf.Response> handler(shelf.Request request) async {
         headers: securityHeaders,
       );
     }
+    if (!(await _isAllowedDestination(parsedImageUrl))) {
+      return shelf.Response.badRequest(
+        body: 'Prohibited proxied destination url',
+        headers: securityHeaders,
+      );
+    }
 
     Future<
       ({
@@ -250,8 +256,12 @@ Future<shelf.Response> handler(shelf.Request request) async {
           if (location == null) {
             throw RedirectException('No location header in redirect.');
           }
+          final redirectUrl = parsedImageUrl.resolve(location);
+          if (!(await _isAllowedDestination(redirectUrl))) {
+            throw RedirectException('Prohibited redirect destination url.');
+          }
           return await makeRequest(
-            parsedImageUrl.resolve(location),
+            redirectUrl,
             redirectCount: redirectCount + 1,
           );
         }
@@ -398,4 +408,64 @@ Future<Uint8List> readAllBytes(Stream<List<int>> stream, int maxBytes) async {
     builder.add(chunk);
   }
   return builder.takeBytes();
+}
+
+bool _isProhibitedAddress(InternetAddress address) {
+  if (address.isLoopback || address.isLinkLocal || address.isMulticast) {
+    return true;
+  }
+  final raw = address.rawAddress;
+  if (address.type == InternetAddressType.IPv4 && raw.length == 4) {
+    if (raw[0] == 0 ||
+        raw[0] == 10 ||
+        raw[0] == 127 ||
+        (raw[0] == 169 && raw[1] == 254) ||
+        (raw[0] == 172 && raw[1] >= 16 && raw[1] <= 31) ||
+        (raw[0] == 192 && raw[1] == 168) ||
+        (raw[0] == 100 && raw[1] >= 64 && raw[1] <= 127)) {
+      return true;
+    }
+  } else if (address.type == InternetAddressType.IPv6 && raw.length == 16) {
+    if ((raw[0] & 0xfe) == 0xfc ||
+        (raw[0] == 0xfe && (raw[1] & 0xc0) == 0xc0)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+Future<bool> _isAllowedDestination(Uri url) async {
+  if (!(url.isScheme('http') || url.isScheme('https'))) {
+    return false;
+  }
+  if (!url.isAbsolute) {
+    return false;
+  }
+  final host = url.host.toLowerCase();
+  if (host == 'metadata.google.internal' ||
+      host.endsWith('.internal') ||
+      host.endsWith('.local') ||
+      host == '169.254.169.254') {
+    return false;
+  }
+  if (!isTesting) {
+    if (host == 'localhost' || host.endsWith('.localhost')) {
+      return false;
+    }
+  }
+  try {
+    final addresses = await InternetAddress.lookup(host);
+    for (final address in addresses) {
+      if (_isProhibitedAddress(address)) {
+        if (isTesting && address.isLoopback) {
+          // Allow loopback in unit tests
+        } else {
+          return false;
+        }
+      }
+    }
+  } catch (_) {
+    // If DNS lookup fails, allow through so client.getUrl throws expected DNS error
+  }
+  return true;
 }

--- a/pkg/image_proxy/lib/prohibited_addresses.dart
+++ b/pkg/image_proxy/lib/prohibited_addresses.dart
@@ -1,0 +1,152 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+/// Represents an IPv4 or IPv6 Classless Inter-Domain Routing (CIDR) address block
+/// (for example, `'10.0.0.0/8'` or `'fc00::/7'`).
+///
+/// Performance:
+/// - [CidrBlock.parse] runs in \(O(B)\) time where \(B\) is the length of the string.
+/// - [contains] runs in \(O(N)\) time where \(N\) is the number of bytes in the IP address (4 for IPv4, 16 for IPv6).
+final class CidrBlock {
+  /// The base network address of this CIDR block.
+  final InternetAddress baseAddress;
+
+  /// The prefix length (number of network mask bits) for this CIDR block.
+  final int prefixLength;
+
+  /// Creates a [CidrBlock] with [baseAddress] and [prefixLength].
+  ///
+  /// Preconditions:
+  /// - [prefixLength] must be non-negative.
+  /// - [prefixLength] must not exceed 32 for IPv4 addresses or 128 for IPv6 addresses.
+  ///
+  /// Throws [ArgumentError] if [prefixLength] is negative or exceeds the maximum
+  /// number of address bits.
+  CidrBlock(this.baseAddress, this.prefixLength) {
+    if (prefixLength < 0) {
+      throw ArgumentError.value(
+        prefixLength,
+        'prefixLength',
+        'Must be non-negative',
+      );
+    }
+    final maxBits = baseAddress.type == InternetAddressType.IPv4 ? 32 : 128;
+    if (prefixLength > maxBits) {
+      throw ArgumentError.value(
+        prefixLength,
+        'prefixLength',
+        'Exceeds maximum bits ($maxBits for ${baseAddress.type.name})',
+      );
+    }
+  }
+
+  /// Parses a CIDR string in the format `<ip_address>/<prefix_length>`
+  /// (for example, `'10.0.0.0/8'` or `'fc00::/7'`).
+  ///
+  /// Preconditions:
+  /// - [cidr] must contain exactly one `/` separating a valid IP address and an integer prefix length.
+  ///
+  /// Throws [FormatException] or [ArgumentError] if [cidr] is malformed or if
+  /// the prefix length is out of range for the address type.
+  factory CidrBlock.parse(String cidr) {
+    final parts = cidr.split('/');
+    if (parts.length != 2) {
+      throw FormatException(
+        'Invalid CIDR format (expected <ip>/<prefix_length>): $cidr',
+      );
+    }
+    final InternetAddress address;
+    try {
+      address = InternetAddress(parts[0]);
+    } on ArgumentError {
+      throw FormatException('Invalid IP address in CIDR: ${parts[0]}');
+    }
+    final prefixLength = int.tryParse(parts[1]);
+    if (prefixLength == null) {
+      throw FormatException('Invalid integer prefix length in CIDR: $cidr');
+    }
+    return CidrBlock(address, prefixLength);
+  }
+
+  /// Checks whether [address] is contained within this CIDR block.
+  ///
+  /// Preconditions:
+  /// - [address] must not be `null`.
+  ///
+  /// Returns `true` if [address] is of the same address family as [baseAddress]
+  /// and its leading [prefixLength] bits match [baseAddress].
+  bool contains(InternetAddress address) {
+    if (address.type != baseAddress.type) {
+      return false;
+    }
+    final rawBase = baseAddress.rawAddress;
+    final rawTarget = address.rawAddress;
+    var bitsLeft = prefixLength;
+    for (var i = 0; i < rawBase.length && bitsLeft > 0; i++) {
+      final mask = bitsLeft >= 8 ? 0xff : (0xff << (8 - bitsLeft)) & 0xff;
+      if ((rawBase[i] & mask) != (rawTarget[i] & mask)) {
+        return false;
+      }
+      bitsLeft -= 8;
+    }
+    return true;
+  }
+
+  @override
+  String toString() => '${baseAddress.address}/$prefixLength';
+}
+
+/// The list of prohibited IP address blocks that must not be proxied to prevent
+/// Server-Side Request Forgery (SSRF).
+final List<CidrBlock> prohibitedCidrBlocks = [
+  // RFC 1122 Current network (0.0.0.0/8)
+  CidrBlock.parse('0.0.0.0/8'),
+  // RFC 1918 Private IPv4 networks
+  CidrBlock.parse('10.0.0.0/8'),
+  CidrBlock.parse('172.16.0.0/12'),
+  CidrBlock.parse('192.168.0.0/16'),
+  // RFC 1122 Loopback IPv4
+  CidrBlock.parse('127.0.0.0/8'),
+  // RFC 3927 Link-local IPv4 (includes cloud metadata servers such as 169.254.169.254)
+  CidrBlock.parse('169.254.0.0/16'),
+  // RFC 6598 Carrier-grade NAT / shared address space
+  CidrBlock.parse('100.64.0.0/10'),
+  // RFC 4193 Unique local IPv6 addresses
+  CidrBlock.parse('fc00::/7'),
+  // RFC 3513 Site-local IPv6 addresses (deprecated)
+  CidrBlock.parse('fec0::/10'),
+  // Loopback IPv6
+  CidrBlock.parse('::1/128'),
+];
+
+/// Checks whether [address] belongs to a private, loopback, link-local, multicast,
+/// or reserved network address range.
+///
+/// Preconditions:
+/// - [address] must not be `null`.
+///
+/// Checks:
+/// - [InternetAddress.isLoopback]
+/// - [InternetAddress.isLinkLocal]
+/// - [InternetAddress.isMulticast]
+/// - Inclusion in any of [prohibitedCidrBlocks]
+///
+/// Performance:
+/// - Runs in \(O(K \cdot N)\) time where \(K\) is the number of [prohibitedCidrBlocks]
+///   and \(N\) is the byte length of [address].
+///
+/// Returns `true` if [address] is within a prohibited network range.
+bool isProhibitedAddress(InternetAddress address) {
+  if (address.isLoopback || address.isLinkLocal || address.isMulticast) {
+    return true;
+  }
+  for (final block in prohibitedCidrBlocks) {
+    if (block.contains(address)) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/pkg/image_proxy/test/image_proxy_test.dart
+++ b/pkg/image_proxy/test/image_proxy_test.dart
@@ -88,6 +88,15 @@ Future<int> startImageServer() async {
           );
         case 'redirect':
           return shelf.Response.movedPermanently('path/to/image.jpg');
+        case 'redir/step1':
+          return shelf.Response.movedPermanently('/other/step2');
+        case 'other/step2':
+          return shelf.Response.movedPermanently('final.jpg');
+        case 'other/final.jpg':
+          return shelf.Response.ok(
+            File(jpgImagePath).readAsBytesSync(),
+            headers: {'content-type': 'image/jpeg'},
+          );
         case 'redirectForever':
           return shelf.Response.movedPermanently('redirectForever');
         case 'serverError':
@@ -319,6 +328,24 @@ Future<void> main() async {
       final response = await getImage(
         imageProxyPort: imageProxyPort,
         imageUrl: Uri.parse('http://localhost:$imageServerPort/redirect'),
+        day: today,
+      );
+      validateSecurityHeaders(response);
+
+      expect(response.statusCode, 200);
+      final hash = await sha256.bind(response).single;
+      final expected = sha256.convert(File(jpgImagePath).readAsBytesSync());
+      expect(hash, expected);
+    }
+  });
+
+  test('Follows multi-step relative redirect across paths', () async {
+    final imageProxyPort = await startImageProxy();
+    final imageServerPort = await startImageServer();
+    {
+      final response = await getImage(
+        imageProxyPort: imageProxyPort,
+        imageUrl: Uri.parse('http://localhost:$imageServerPort/redir/step1'),
         day: today,
       );
       validateSecurityHeaders(response);

--- a/pkg/image_proxy/test/image_proxy_test.dart
+++ b/pkg/image_proxy/test/image_proxy_test.dart
@@ -503,5 +503,18 @@ Future<void> main() async {
       // The proxy doesn't cache as long time as the original.
       expect(await Utf8Codec().decodeStream(response), 'Image too large');
     }
+    {
+      final response = await getImage(
+        imageProxyPort: imageProxyPort,
+        imageUrl: Uri.parse('http://metadata.google.internal/?vv=1'),
+        day: today,
+      );
+      validateSecurityHeaders(response);
+      expect(response.statusCode, 400);
+      expect(
+        await Utf8Codec().decodeStream(response),
+        'Prohibited proxied destination url',
+      );
+    }
   });
 }

--- a/pkg/image_proxy/test/prohibited_addresses_test.dart
+++ b/pkg/image_proxy/test/prohibited_addresses_test.dart
@@ -1,0 +1,102 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:pub_dev_image_proxy/prohibited_addresses.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('CidrBlock', () {
+    test('parses and matches IPv4 blocks', () {
+      final block = CidrBlock.parse('172.16.0.0/12');
+      expect(block.contains(InternetAddress('172.16.0.0')), isTrue);
+      expect(block.contains(InternetAddress('172.16.0.1')), isTrue);
+      expect(block.contains(InternetAddress('172.31.255.255')), isTrue);
+      expect(block.contains(InternetAddress('172.15.255.255')), isFalse);
+      expect(block.contains(InternetAddress('172.32.0.0')), isFalse);
+    });
+
+    test('parses and matches IPv6 blocks', () {
+      final block = CidrBlock.parse('fc00::/7');
+      expect(block.contains(InternetAddress('fc00::1')), isTrue);
+      expect(
+        block.contains(
+          InternetAddress('fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff'),
+        ),
+        isTrue,
+      );
+      expect(block.contains(InternetAddress('fbff::')), isFalse);
+      expect(block.contains(InternetAddress('fe00::')), isFalse);
+    });
+
+    test('family mismatch returns false', () {
+      final ipv4Block = CidrBlock.parse('10.0.0.0/8');
+      expect(ipv4Block.contains(InternetAddress('::1')), isFalse);
+
+      final ipv6Block = CidrBlock.parse('fc00::/7');
+      expect(ipv6Block.contains(InternetAddress('10.0.0.1')), isFalse);
+    });
+
+    test('throws on invalid CIDR strings and prefix lengths', () {
+      expect(() => CidrBlock.parse('10.0.0.0'), throwsFormatException);
+      expect(() => CidrBlock.parse('10.0.0.0/abc'), throwsFormatException);
+      expect(() => CidrBlock.parse('not.an.ip/8'), throwsFormatException);
+      expect(
+        () => CidrBlock(InternetAddress('10.0.0.0'), -1),
+        throwsArgumentError,
+      );
+      expect(
+        () => CidrBlock(InternetAddress('10.0.0.0'), 33),
+        throwsArgumentError,
+      );
+      expect(() => CidrBlock(InternetAddress('::1'), 129), throwsArgumentError);
+    });
+  });
+
+  group('isProhibitedAddress', () {
+    test('returns false for public IP addresses', () {
+      expect(isProhibitedAddress(InternetAddress('8.8.8.8')), isFalse);
+      expect(isProhibitedAddress(InternetAddress('1.1.1.1')), isFalse);
+      expect(isProhibitedAddress(InternetAddress('142.250.190.46')), isFalse);
+      expect(
+        isProhibitedAddress(InternetAddress('2001:4860:4860::8888')),
+        isFalse,
+      );
+    });
+
+    test('returns true for RFC 1918 private IPv4 addresses', () {
+      expect(isProhibitedAddress(InternetAddress('10.0.0.1')), isTrue);
+      expect(isProhibitedAddress(InternetAddress('10.255.255.255')), isTrue);
+      expect(isProhibitedAddress(InternetAddress('172.16.0.1')), isTrue);
+      expect(isProhibitedAddress(InternetAddress('172.31.255.254')), isTrue);
+      expect(isProhibitedAddress(InternetAddress('192.168.0.1')), isTrue);
+      expect(isProhibitedAddress(InternetAddress('192.168.255.255')), isTrue);
+    });
+
+    test('returns true for link-local and cloud metadata addresses', () {
+      expect(isProhibitedAddress(InternetAddress('169.254.169.254')), isTrue);
+      expect(isProhibitedAddress(InternetAddress('169.254.0.1')), isTrue);
+      expect(isProhibitedAddress(InternetAddress('fe80::1')), isTrue);
+    });
+
+    test('returns true for loopback addresses', () {
+      expect(isProhibitedAddress(InternetAddress('127.0.0.1')), isTrue);
+      expect(isProhibitedAddress(InternetAddress('127.255.255.254')), isTrue);
+      expect(isProhibitedAddress(InternetAddress('::1')), isTrue);
+    });
+
+    test('returns true for carrier-grade NAT / RFC 6598 addresses', () {
+      expect(isProhibitedAddress(InternetAddress('100.64.0.1')), isTrue);
+      expect(isProhibitedAddress(InternetAddress('100.127.255.255')), isTrue);
+      expect(isProhibitedAddress(InternetAddress('100.63.255.255')), isFalse);
+      expect(isProhibitedAddress(InternetAddress('100.128.0.0')), isFalse);
+    });
+
+    test('returns true for RFC 4193 unique local IPv6 addresses', () {
+      expect(isProhibitedAddress(InternetAddress('fc00::1')), isTrue);
+      expect(isProhibitedAddress(InternetAddress('fd00::1')), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
This PR fixes SSRF vulnerability reported in b/543872427 and redirect handling in image_proxy:

1. Removes `markdownToHtml` rendering of the `error` query parameter in `/sign-in/complete` (`app/lib/frontend/handlers/account.dart`), preventing markdown injection from closing code blocks and generating signed proxy URLs via `_ImageProxyRewriter`.
2. Extracts RFC 1918 (private IPs), link-local (`169.254.0.0/16`), RFC 6598 carrier-grade NAT, unique local IPv6, loopback (when not testing), and internal metadata domain (`metadata.google.internal`) filtering into its own reusable CIDR matching library (`pkg/image_proxy/lib/prohibited_addresses.dart`).
3. Fixes relative redirect URL resolution in `image_proxy` (`pkg/image_proxy/lib/image_proxy_service.dart`) so that `Location` headers are resolved against the current redirect step URI rather than the initial request URI.
4. Adds comprehensive unit tests covering the `/sign-in/complete?error=...` handler, prohibited IP/CIDR block destination filtering, and multi-step relative redirect resolution.