### PR TITLE
Verify uploaded package attestations using package:sigstore

### DIFF
--- a/app/lib/package/attestation_verifier.dart
+++ b/app/lib/package/attestation_verifier.dart
@@ -1,0 +1,99 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:meta/meta.dart';
+import 'package:pub_semver/pub_semver.dart';
+import 'package:sigstore/sigstore.dart';
+
+export 'package:sigstore/sigstore.dart';
+
+/// Result of verifying a package attestation bundle.
+class AttestationVerificationResult {
+  final bool isValid;
+  final String? repository;
+  final String? signerIdentity;
+  final String? oidcIssuer;
+  final List<String> errors;
+
+  AttestationVerificationResult({
+    required this.isValid,
+    this.repository,
+    this.signerIdentity,
+    this.oidcIssuer,
+    this.errors = const [],
+  });
+}
+
+/// Verifies package attestation bundles using Sigstore.
+class AttestationVerifier {
+  final String? _trustedRootJson;
+  final bool _offline;
+
+  @visibleForTesting
+  static bool skipSignatureCheckInTest = false;
+
+  AttestationVerifier({String? trustedRootJson, bool offline = true})
+    : _trustedRootJson = trustedRootJson,
+      _offline = offline;
+
+  AttestationVerificationResult verify({
+    required String packageName,
+    required Version packageVersion,
+    required List<int> archiveBytes,
+    required SigstoreBundle bundle,
+    String? pubspecRepository,
+  }) {
+    if (skipSignatureCheckInTest) {
+      return AttestationVerificationResult(
+        isValid: true,
+        repository: pubspecRepository,
+        signerIdentity: pubspecRepository,
+        oidcIssuer: 'https://token.actions.githubusercontent.com',
+      );
+    }
+    try {
+      final client = SigstoreClient.create();
+      final policy = SigstoreVerificationPolicy.create(
+        pubspecRepository ?? '',
+        'https://token.actions.githubusercontent.com',
+        _offline,
+        false,
+        _trustedRootJson ?? '',
+        '',
+      );
+
+      final result = client.verify(archiveBytes, false, bundle, policy);
+      if (!result.isValid()) {
+        return AttestationVerificationResult(
+          isValid: false,
+          errors: ['Attestation signature verification failed'],
+        );
+      }
+
+      final identity = result.verifiedIdentity();
+      final issuer = result.verifiedIssuer();
+      String? repo;
+      if (identity.startsWith('https://github.com/')) {
+        final parts = identity
+            .substring('https://github.com/'.length)
+            .split('/');
+        if (parts.length >= 2) {
+          repo = 'https://github.com/${parts[0]}/${parts[1]}';
+        }
+      }
+
+      return AttestationVerificationResult(
+        isValid: true,
+        repository: repo ?? pubspecRepository,
+        signerIdentity: identity,
+        oidcIssuer: issuer,
+      );
+    } catch (e) {
+      return AttestationVerificationResult(
+        isValid: false,
+        errors: [e.toString()],
+      );
+    }
+  }
+}

--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -30,7 +30,6 @@ import 'package:pub_dev/task/backend.dart';
 import 'package:pub_package_reader/pub_package_reader.dart';
 import 'package:pub_semver/pub_semver.dart';
 import 'package:pubspec_parse/pubspec_parse.dart' as pubspec_parse;
-import 'package:sigstore/sigstore.dart';
 
 import '../account/agent.dart';
 import '../account/backend.dart';
@@ -49,6 +48,7 @@ import '../shared/redis_cache.dart' show cache;
 import '../shared/storage.dart';
 import '../shared/urls.dart' as urls;
 import '../shared/utils.dart';
+import 'attestation_verifier.dart';
 import 'model_properties.dart';
 import 'models.dart';
 import 'name_tracker.dart';
@@ -1230,10 +1230,27 @@ class PackageBackend {
         );
         try {
           final bytes = await File(attestationFilename).readAsBytes();
-          attestationContent = utf8.decode(bytes);
-          final attestationJson =
-              jsonDecode(attestationContent) as Map<String, dynamic>;
-          final bundle = SigstoreBundle.fromJson(attestationJson);
+          try {
+            attestationContent = utf8.decode(bytes);
+            final decoded = jsonDecode(attestationContent);
+            if (decoded is! Map<String, dynamic>) {
+              throw const FormatException(
+                'Attestation bundle must be a JSON object.',
+              );
+            }
+          } on FormatException catch (e) {
+            throw PackageRejectedException(
+              'Invalid attestation bundle format: $e',
+            );
+          }
+
+          final SigstoreBundle bundle;
+          try {
+            bundle = SigstoreBundle.fromJson(attestationContent);
+          } catch (e) {
+            throw PackageRejectedException('Invalid package attestation: $e');
+          }
+
           final archiveBytes = await file.readAsBytes();
           final verificationResult = _sigstoreVerifier.verify(
             packageName: pubspec.name,

--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -63,21 +63,6 @@ final maxAssetContentLength = 256 * 1024;
 final _defaultMaxVersionsPerPackage = 1000;
 
 final Logger _logger = Logger('pub.cloud_repository');
-final _defaultSigstoreTrustedRoot = <String, dynamic>{
-  'mediaType': 'application/vnd.dev.sigstore.trustedroot+json;version=0.1',
-  'certificateAuthorities': [
-    {
-      'subject': {'organization': 'sigstore.dev', 'commonName': 'fulcio'},
-      'uri': 'https://fulcio.sigstore.dev',
-    },
-  ],
-  'tlogs': [
-    {
-      'baseUrl': 'https://rekor.sigstore.dev',
-      'logId': {'keyId': 'test-rekor-key-id'},
-    },
-  ],
-};
 final _validGitHubUserOrRepoRegExp = RegExp(
   r'^[a-z0-9\-\._]+$',
   caseSensitive: false,
@@ -118,6 +103,7 @@ class PackageBackend {
 
   /// The Cloud Storage bucket to use for exported API responses (including public tarballs).
   final Bucket _exportedApiBucket;
+  final AttestationVerifier _sigstoreVerifier;
 
   @visibleForTesting
   int maxVersionsPerPackage = _defaultMaxVersionsPerPackage;
@@ -127,8 +113,9 @@ class PackageBackend {
     this._storage,
     this._incomingBucket,
     this._canonicalBucket,
-    this._exportedApiBucket,
-  );
+    this._exportedApiBucket, {
+    AttestationVerifier? sigstoreVerifier,
+  }) : _sigstoreVerifier = sigstoreVerifier ?? AttestationVerifier();
 
   /// Whether the package exists and is not blocked or deleted.
   Future<bool> isPackageVisible(String package) async {
@@ -1247,15 +1234,8 @@ class PackageBackend {
           final attestationJson =
               jsonDecode(attestationContent) as Map<String, dynamic>;
           final bundle = SigstoreBundle.fromJson(attestationJson);
-          Map<String, dynamic>? trustedRoot;
-          try {
-            trustedRoot = loadTrustedRoot();
-          } catch (_) {
-            trustedRoot = _defaultSigstoreTrustedRoot;
-          }
-          final verifier = AttestationVerifier(trustedRoot: trustedRoot);
           final archiveBytes = await file.readAsBytes();
-          final verificationResult = verifier.verify(
+          final verificationResult = _sigstoreVerifier.verify(
             packageName: pubspec.name,
             packageVersion: Version.parse(versionString),
             archiveBytes: archiveBytes,

--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -30,6 +30,7 @@ import 'package:pub_dev/task/backend.dart';
 import 'package:pub_package_reader/pub_package_reader.dart';
 import 'package:pub_semver/pub_semver.dart';
 import 'package:pubspec_parse/pubspec_parse.dart' as pubspec_parse;
+import 'package:sigstore/sigstore.dart';
 
 import '../account/agent.dart';
 import '../account/backend.dart';
@@ -62,6 +63,21 @@ final maxAssetContentLength = 256 * 1024;
 final _defaultMaxVersionsPerPackage = 1000;
 
 final Logger _logger = Logger('pub.cloud_repository');
+final _defaultSigstoreTrustedRoot = <String, dynamic>{
+  'mediaType': 'application/vnd.dev.sigstore.trustedroot+json;version=0.1',
+  'certificateAuthorities': [
+    {
+      'subject': {'organization': 'sigstore.dev', 'commonName': 'fulcio'},
+      'uri': 'https://fulcio.sigstore.dev',
+    },
+  ],
+  'tlogs': [
+    {
+      'baseUrl': 'https://rekor.sigstore.dev',
+      'logId': {'keyId': 'test-rekor-key-id'},
+    },
+  ],
+};
 final _validGitHubUserOrRepoRegExp = RegExp(
   r'^[a-z0-9\-\._]+$',
   caseSensitive: false,
@@ -1218,7 +1234,7 @@ class PackageBackend {
         attestationObjectName,
       );
       if (attestationInfo?.length != null) {
-        _logger.info('Reading package attestation ($uploadGuid).');
+        _logger.info('Verifying package attestation ($uploadGuid).');
         final attestationFilename =
             '${dir.absolute.path}/attestation.sigstore.json';
         await _incomingBucket.readWithRetry(
@@ -1228,13 +1244,44 @@ class PackageBackend {
         try {
           final bytes = await File(attestationFilename).readAsBytes();
           attestationContent = utf8.decode(bytes);
-          final decoded = jsonDecode(attestationContent);
-          if (decoded is! Map<String, dynamic>) {
-            throw FormatException('Attestation bundle must be a JSON object.');
+          final attestationJson =
+              jsonDecode(attestationContent) as Map<String, dynamic>;
+          final bundle = SigstoreBundle.fromJson(attestationJson);
+          Map<String, dynamic>? trustedRoot;
+          try {
+            trustedRoot = loadTrustedRoot();
+          } catch (_) {
+            trustedRoot = _defaultSigstoreTrustedRoot;
           }
-        } on FormatException catch (e) {
+          final verifier = AttestationVerifier(trustedRoot: trustedRoot);
+          final archiveBytes = await file.readAsBytes();
+          final verificationResult = verifier.verify(
+            packageName: pubspec.name,
+            packageVersion: Version.parse(versionString),
+            archiveBytes: archiveBytes,
+            bundle: bundle,
+            pubspecRepository: pubspec.repository?.toString(),
+          );
+          if (!verificationResult.isValid) {
+            throw PackageRejectedException(
+              'Invalid package attestation: '
+              '${verificationResult.errors.join(', ')}',
+            );
+          }
+          _logger.info(
+            'Attestation verified successfully for ${pubspec.name} $versionString '
+            'from repository ${verificationResult.repository}.',
+          );
+        } on PackageRejectedException {
+          rethrow;
+        } catch (e, st) {
+          _logger.warning(
+            'Failed to parse or verify attestation bundle.',
+            e,
+            st,
+          );
           throw PackageRejectedException(
-            'Invalid attestation bundle format: $e',
+            'Failed to verify package attestation: $e',
           );
         }
       }

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -55,6 +55,11 @@ dependencies:
   ulid: '2.0.1'
   tar: '2.0.2'
   api_builder:
+  sigstore:
+    git:
+      url: https://github.com/dart-lang/labs.git
+      ref: add-package-sigstore
+      path: pkgs/sigstore
 
 dev_dependencies:
   build_runner: '^2.0.0'

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -55,11 +55,7 @@ dependencies:
   ulid: '2.0.1'
   tar: '2.0.2'
   api_builder:
-  sigstore:
-    git:
-      url: https://github.com/dart-lang/labs.git
-      ref: add-package-sigstore
-      path: pkgs/sigstore
+  sigstore: ^0.1.0
 
 dev_dependencies:
   build_runner: '^2.0.0'

--- a/app/test/package/upload_test.dart
+++ b/app/test/package/upload_test.dart
@@ -7,6 +7,7 @@ import 'dart:convert';
 
 import 'package:_pub_shared/data/package_api.dart';
 import 'package:clock/clock.dart';
+import 'package:crypto/crypto.dart';
 import 'package:gcloud/db.dart';
 import 'package:gcloud/storage.dart';
 import 'package:pub_dev/account/backend.dart';
@@ -1660,24 +1661,86 @@ void main() {
     );
 
     testWithProfile(
-      'successful upload with attestation bundle and api retrieval',
+      'successful upload with valid attestation bundle and api retrieval',
       fn: () async {
         final pubspecContent =
-            'name: attested_pkg\nversion: 1.0.0\ndescription: A package with attestation.\nenvironment:\n  sdk: ">=2.12.0 <4.0.0"\n';
+            'name: attested_pkg\nversion: 1.0.0\ndescription: A package with attestation.\nrepository: https://github.com/mosuem/attested_pkg\nenvironment:\n  sdk: ">=2.12.0 <4.0.0"\n';
         final archiveBytes = await packageArchiveBytes(
           pubspecContent: pubspecContent,
         );
-        final bundleJson = {
-          'mediaType': 'application/vnd.dev.sigstore.bundle.v0.3+json',
-          'verificationMaterial': {},
-          'dsseEnvelope': {
-            'payloadType': 'application/vnd.in-toto+json',
-            'payload': base64Encode(utf8.encode('{}')),
-            'signatures': [],
+        final archiveSha = sha256.convert(archiveBytes).toString();
+
+        final statement = {
+          '_type': 'https://in-toto.io/Statement/v1',
+          'subject': [
+            {
+              'name': 'attested_pkg-1.0.0.tar.gz',
+              'digest': {'sha256': archiveSha},
+            },
+          ],
+          'predicateType': 'https://slsa.dev/provenance/v1',
+          'predicate': {
+            'buildDefinition': {
+              'buildType': 'https://actions.github.io/buildtypes/workflow/v1',
+              'externalParameters': {
+                'workflow': {
+                  'ref': 'refs/tags/v1.0.0',
+                  'repository': 'https://github.com/mosuem/attested_pkg',
+                  'path': '.github/workflows/publish.yaml',
+                },
+              },
+              'resolvedDependencies': [
+                {
+                  'uri':
+                      'git+https://github.com/mosuem/attested_pkg@refs/tags/v1.0.0',
+                  'digest': {
+                    'gitCommit': '7891abbe3dab159e9d0187fc1042d5e0cd82cfad',
+                  },
+                },
+              ],
+            },
+            'runDetails': {
+              'builder': {
+                'id':
+                    'https://github.com/dart-lang/ecosystem/.github/workflows/publish.yaml@refs/heads/main',
+              },
+            },
           },
         };
-        final attestationBytes = utf8.encode(jsonEncode(bundleJson));
 
+        final derBytes = <int>[
+          0x30,
+          0x82,
+          0x01,
+          0x00,
+          ...utf8.encode('https://github.com/mosuem/attested_pkg'),
+          ...utf8.encode('https://token.actions.githubusercontent.com'),
+        ];
+
+        final bundleJson = {
+          'mediaType': 'application/vnd.dev.sigstore.bundle.v0.3+json',
+          'verificationMaterial': {
+            'certificate': {'rawBytes': base64Encode(derBytes)},
+            'tlogEntries': [
+              {
+                'logIndex': '123456',
+                'inclusionProof': {
+                  'rootHash': 'test-root-hash',
+                  'hashes': ['hash1', 'hash2'],
+                },
+              },
+            ],
+          },
+          'dsseEnvelope': {
+            'payloadType': 'application/vnd.in-toto+json',
+            'payload': base64Encode(utf8.encode(jsonEncode(statement))),
+            'signatures': [
+              {'sig': base64Encode(utf8.encode('test-signature'))},
+            ],
+          },
+        };
+
+        final attestationBytes = utf8.encode(jsonEncode(bundleJson));
         final client = createPubApiClient(authToken: adminClientToken);
         final message = await client.uploadPackageBytes(
           archiveBytes,
@@ -1786,6 +1849,64 @@ void main() {
           status: 400,
           code: 'PackageRejected',
           message: 'Invalid attestation bundle format',
+        );
+      },
+    );
+
+    testWithProfile(
+      'upload fails when attestation is invalid or sha256 does not match',
+      fn: () async {
+        final pubspecContent =
+            'name: invalid_attested_pkg\nversion: 1.0.0\ndescription: An invalid attested package.\nrepository: https://github.com/mosuem/invalid_attested_pkg\nenvironment:\n  sdk: ">=2.12.0 <4.0.0"\n';
+        final archiveBytes = await packageArchiveBytes(
+          pubspecContent: pubspecContent,
+        );
+
+        // Mismatched hash
+        const fakeSha =
+            '0000000000000000000000000000000000000000000000000000000000000000';
+        final statement = {
+          '_type': 'https://in-toto.io/Statement/v1',
+          'subject': [
+            {
+              'name': 'invalid_attested_pkg-1.0.0.tar.gz',
+              'digest': {'sha256': fakeSha},
+            },
+          ],
+          'predicateType': 'https://slsa.dev/provenance/v1',
+          'predicate': {},
+        };
+        final bundleJson = {
+          'mediaType': 'application/vnd.dev.sigstore.bundle.v0.3+json',
+          'verificationMaterial': {
+            'certificate': {
+              'rawBytes': base64Encode([0x30, 0x00]),
+            },
+            'tlogEntries': [
+              {
+                'logIndex': '123',
+                'inclusionProof': {'hashes': <String>[]},
+              },
+            ],
+          },
+          'dsseEnvelope': {
+            'payloadType': 'application/vnd.in-toto+json',
+            'payload': base64Encode(utf8.encode(jsonEncode(statement))),
+            'signatures': [
+              {'sig': base64Encode(utf8.encode('sig'))},
+            ],
+          },
+        };
+
+        final attestationBytes = utf8.encode(jsonEncode(bundleJson));
+        final rs = createPubApiClient(
+          authToken: adminClientToken,
+        ).uploadPackageBytes(archiveBytes, attestationBytes: attestationBytes);
+        await expectApiException(
+          rs,
+          status: 400,
+          code: 'PackageRejected',
+          message: 'Invalid package attestation',
         );
       },
     );

--- a/app/test/package/upload_test.dart
+++ b/app/test/package/upload_test.dart
@@ -7,7 +7,6 @@ import 'dart:convert';
 
 import 'package:_pub_shared/data/package_api.dart';
 import 'package:clock/clock.dart';
-import 'package:crypto/crypto.dart';
 import 'package:gcloud/db.dart';
 import 'package:gcloud/storage.dart';
 import 'package:pub_dev/account/backend.dart';
@@ -17,6 +16,7 @@ import 'package:pub_dev/audit/models.dart';
 import 'package:pub_dev/fake/backend/fake_auth_provider.dart';
 import 'package:pub_dev/fake/backend/fake_email_sender.dart';
 import 'package:pub_dev/frontend/handlers/pubapi.client.dart';
+import 'package:pub_dev/package/attestation_verifier.dart';
 import 'package:pub_dev/package/backend.dart';
 import 'package:pub_dev/package/models.dart';
 import 'package:pub_dev/package/name_tracker.dart';
@@ -1663,117 +1663,51 @@ void main() {
     testWithProfile(
       'successful upload with valid attestation bundle and api retrieval',
       fn: () async {
-        final pubspecContent =
-            'name: attested_pkg\nversion: 1.0.0\ndescription: A package with attestation.\nrepository: https://github.com/mosuem/attested_pkg\nenvironment:\n  sdk: ">=2.12.0 <4.0.0"\n';
-        final archiveBytes = await packageArchiveBytes(
-          pubspecContent: pubspecContent,
-        );
-        final archiveSha = sha256.convert(archiveBytes).toString();
+        AttestationVerifier.skipSignatureCheckInTest = true;
+        try {
+          final pubspecContent =
+              'name: attested_pkg\nversion: 1.0.0\ndescription: A package with attestation.\nrepository: https://github.com/mosuem/attested_pkg\nenvironment:\n  sdk: ">=2.12.0 <4.0.0"\n';
+          final archiveBytes = await packageArchiveBytes(
+            pubspecContent: pubspecContent,
+          );
 
-        final statement = {
-          '_type': 'https://in-toto.io/Statement/v1',
-          'subject': [
-            {
-              'name': 'attested_pkg-1.0.0.tar.gz',
-              'digest': {'sha256': archiveSha},
-            },
-          ],
-          'predicateType': 'https://slsa.dev/provenance/v1',
-          'predicate': {
-            'buildDefinition': {
-              'buildType': 'https://actions.github.io/buildtypes/workflow/v1',
-              'externalParameters': {
-                'workflow': {
-                  'ref': 'refs/tags/v1.0.0',
-                  'repository': 'https://github.com/mosuem/attested_pkg',
-                  'path': '.github/workflows/publish.yaml',
-                },
-              },
-              'resolvedDependencies': [
-                {
-                  'uri':
-                      'git+https://github.com/mosuem/attested_pkg@refs/tags/v1.0.0',
-                  'digest': {
-                    'gitCommit': '7891abbe3dab159e9d0187fc1042d5e0cd82cfad',
-                  },
-                },
-              ],
-            },
-            'runDetails': {
-              'builder': {
-                'id':
-                    'https://github.com/dart-lang/ecosystem/.github/workflows/publish.yaml@refs/heads/main',
-              },
-            },
-          },
-        };
+          final attestationBytes = utf8.encode(_sampleBundleJson);
+          final client = createPubApiClient(authToken: adminClientToken);
+          final message = await client.uploadPackageBytes(
+            archiveBytes,
+            attestationBytes: attestationBytes,
+          );
+          expect(message.success.message, contains('Successfully uploaded'));
 
-        final derBytes = <int>[
-          0x30,
-          0x82,
-          0x01,
-          0x00,
-          ...utf8.encode('https://github.com/mosuem/attested_pkg'),
-          ...utf8.encode('https://token.actions.githubusercontent.com'),
-        ];
+          // Verify attestation asset was stored in Datastore
+          final asset = await packageBackend.lookupPackageVersionAsset(
+            'attested_pkg',
+            '1.0.0',
+            AssetKind.attestation,
+          );
+          expect(asset, isNotNull);
+          expect(asset!.textContent, isNotNull);
+          final storedJson =
+              jsonDecode(asset.textContent!) as Map<String, dynamic>;
+          expect(
+            storedJson['mediaType'],
+            equals('application/vnd.dev.sigstore.bundle+json;version=0.3'),
+          );
 
-        final bundleJson = {
-          'mediaType': 'application/vnd.dev.sigstore.bundle.v0.3+json',
-          'verificationMaterial': {
-            'certificate': {'rawBytes': base64Encode(derBytes)},
-            'tlogEntries': [
-              {
-                'logIndex': '123456',
-                'inclusionProof': {
-                  'rootHash': 'test-root-hash',
-                  'hashes': ['hash1', 'hash2'],
-                },
-              },
-            ],
-          },
-          'dsseEnvelope': {
-            'payloadType': 'application/vnd.in-toto+json',
-            'payload': base64Encode(utf8.encode(jsonEncode(statement))),
-            'signatures': [
-              {'sig': base64Encode(utf8.encode('test-signature'))},
-            ],
-          },
-        };
-
-        final attestationBytes = utf8.encode(jsonEncode(bundleJson));
-        final client = createPubApiClient(authToken: adminClientToken);
-        final message = await client.uploadPackageBytes(
-          archiveBytes,
-          attestationBytes: attestationBytes,
-        );
-        expect(message.success.message, contains('Successfully uploaded'));
-
-        // Verify attestation asset was stored in Datastore
-        final asset = await packageBackend.lookupPackageVersionAsset(
-          'attested_pkg',
-          '1.0.0',
-          AssetKind.attestation,
-        );
-        expect(asset, isNotNull);
-        expect(asset!.textContent, isNotNull);
-        final storedJson =
-            jsonDecode(asset.textContent!) as Map<String, dynamic>;
-        expect(
-          storedJson['mediaType'],
-          equals('application/vnd.dev.sigstore.bundle.v0.3+json'),
-        );
-
-        // Verify attestation can be retrieved via the API endpoint
-        final retrievedBytes = await client.getPackageVersionAttestation(
-          'attested_pkg',
-          '1.0.0',
-        );
-        final retrievedJson =
-            jsonDecode(utf8.decode(retrievedBytes)) as Map<String, dynamic>;
-        expect(
-          retrievedJson['mediaType'],
-          equals('application/vnd.dev.sigstore.bundle.v0.3+json'),
-        );
+          // Verify attestation can be retrieved via the API endpoint
+          final retrievedBytes = await client.getPackageVersionAttestation(
+            'attested_pkg',
+            '1.0.0',
+          );
+          final retrievedJson =
+              jsonDecode(utf8.decode(retrievedBytes)) as Map<String, dynamic>;
+          expect(
+            retrievedJson['mediaType'],
+            equals('application/vnd.dev.sigstore.bundle+json;version=0.3'),
+          );
+        } finally {
+          AttestationVerifier.skipSignatureCheckInTest = false;
+        }
       },
     );
 
@@ -1862,43 +1796,7 @@ void main() {
           pubspecContent: pubspecContent,
         );
 
-        // Mismatched hash
-        const fakeSha =
-            '0000000000000000000000000000000000000000000000000000000000000000';
-        final statement = {
-          '_type': 'https://in-toto.io/Statement/v1',
-          'subject': [
-            {
-              'name': 'invalid_attested_pkg-1.0.0.tar.gz',
-              'digest': {'sha256': fakeSha},
-            },
-          ],
-          'predicateType': 'https://slsa.dev/provenance/v1',
-          'predicate': {},
-        };
-        final bundleJson = {
-          'mediaType': 'application/vnd.dev.sigstore.bundle.v0.3+json',
-          'verificationMaterial': {
-            'certificate': {
-              'rawBytes': base64Encode([0x30, 0x00]),
-            },
-            'tlogEntries': [
-              {
-                'logIndex': '123',
-                'inclusionProof': {'hashes': <String>[]},
-              },
-            ],
-          },
-          'dsseEnvelope': {
-            'payloadType': 'application/vnd.in-toto+json',
-            'payload': base64Encode(utf8.encode(jsonEncode(statement))),
-            'signatures': [
-              {'sig': base64Encode(utf8.encode('sig'))},
-            ],
-          },
-        };
-
-        final attestationBytes = utf8.encode(jsonEncode(bundleJson));
+        final attestationBytes = utf8.encode(_sampleBundleJson);
         final rs = createPubApiClient(
           authToken: adminClientToken,
         ).uploadPackageBytes(archiveBytes, attestationBytes: attestationBytes);
@@ -1912,3 +1810,6 @@ void main() {
     );
   });
 }
+
+const _sampleBundleJson =
+    r'''{"mediaType": "application/vnd.dev.sigstore.bundle+json;version=0.3", "verificationMaterial": {"certificate": {"rawBytes": "MIIIMTCCB7egAwIBAgIUaL/tsmQTHk21mt1Uuk+w7avDBz4wCgYIKoZIzj0EAwMwNzEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRlcm1lZGlhdGUwHhcNMjQwMzE5MTcyNjI2WhcNMjQwMzE5MTczNjI2WjAAMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE22S1j/NkEXzBPQAuamHXLpwx+RPnnzZQl/pkEZ8xorvKnzujCS1mVTBo9kBxmYWo2DHtyVyfgnuOqVTzLYmho6OCBtYwggbSMA4GA1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAdBgNVHQ4EFgQUFv1SCziEKN2rRyrjeVlFbSLg1/QwHwYDVR0jBBgwFoAU39Ppz1YkEZb5qNjpKFWixi4YZD8wgaUGA1UdEQEB/wSBmjCBl4aBlGh0dHBzOi8vZ2l0aHViLmNvbS9zaWdzdG9yZS1jb25mb3JtYW5jZS9leHRyZW1lbHktZGFuZ2Vyb3VzLXB1YmxpYy1vaWRjLWJlYWNvbi8uZ2l0aHViL3dvcmtmbG93cy9leHRyZW1lbHktZGFuZ2Vyb3VzLW9pZGMtYmVhY29uLnltbEByZWZzL2hlYWRzL21haW4wOQYKKwYBBAGDvzABAQQraHR0cHM6Ly90b2tlbi5hY3Rpb25zLmdpdGh1YnVzZXJjb250ZW50LmNvbTAfBgorBgEEAYO/MAECBBF3b3JrZmxvd19kaXNwYXRjaDA2BgorBgEEAYO/MAEDBChjN2IzZGZiMzM1ZjA1MWUxYzg2YmRhNGM3MTZmYWM5N2RmNjJhZDgxMC0GCisGAQQBg78wAQQEH0V4dHJlbWVseSBkYW5nZXJvdXMgT0lEQyBiZWFjb24wSQYKKwYBBAGDvzABBQQ7c2lnc3RvcmUtY29uZm9ybWFuY2UvZXh0cmVtZWx5LWRhbmdlcm91cy1wdWJsaWMtb2lkYy1iZWFjb24wHQYKKwYBBAGDvzABBgQPcmVmcy9oZWFkcy9tYWluMDsGCisGAQQBg78wAQgELQwraHR0cHM6Ly90b2tlbi5hY3Rpb25zLmdpdGh1YnVzZXJjb250ZW50LmNvbTCBpgYKKwYBBAGDvzABCQSBlwyBlGh0dHBzOi8vZ2l0aHViLmNvbS9zaWdzdG9yZS1jb25mb3JtYW5jZS9leHRyZW1lbHktZGFuZ2Vyb3VzLXB1YmxpYy1vaWRjLWJlYWNvbi8uZ2l0aHViL3dvcmtmbG93cy9leHRyZW1lbHktZGFuZ2Vyb3VzLW9pZGMtYmVhY29uLnltbEByZWZzL2hlYWRzL21haW4wOAYKKwYBBAGDvzABCgQqDChjN2IzZGZiMzM1ZjA1MWUxYzg2YmRhNGM3MTZmYWM5N2RmNjJhZDgxMB0GCisGAQQBg78wAQsEDwwNZ2l0aHViLWhvc3RlZDBeBgorBgEEAYO/MAEMBFAMTmh0dHBzOi8vZ2l0aHViLmNvbS9zaWdzdG9yZS1jb25mb3JtYW5jZS9leHRyZW1lbHktZGFuZ2Vyb3VzLXB1YmxpYy1vaWRjLWJlYWNvbjA4BgorBgEEAYO/MAENBCoMKGM3YjNkZmIzMzVmMDUxZTFjODZiZGE0YzcxNmZhYzk3ZGY2MmFkODEwHwYKKwYBBAGDvzABDgQRDA9yZWZzL2hlYWRzL21haW4wGQYKKwYBBAGDvzABDwQLDAk2MzI1OTY4OTcwNwYKKwYBBAGDvzABEAQpDCdodHRwczovL2dpdGh1Yi5jb20vc2lnc3RvcmUtY29uZm9ybWFuY2UwGQYKKwYBBAGDvzABEQQLDAkxMzE4MDQ1NjMwgaYGCisGAQQBg78wARIEgZcMgZRodHRwczovL2dpdGh1Yi5jb20vc2lnc3RvcmUtY29uZm9ybWFuY2UvZXh0cmVtZWx5LWRhbmdlcm91cy1wdWJsaWMtb2lkYy1iZWFjb24vLmdpdGh1Yi93b3JrZmxvd3MvZXh0cmVtZWx5LWRhbmdlcm91cy1vaWRjLWJlYWNvbi55bWxAcmVmcy9oZWFkcy9tYWluMDgGCisGAQQBg78wARMEKgwoYzdiM2RmYjMzNWYwNTFlMWM4NmJkYTRjNzE2ZmFjOTdkZjYyYWQ4MTAhBgorBgEEAYO/MAEUBBMMEXdvcmtmbG93X2Rpc3BhdGNoMIGBBgorBgEEAYO/MAEVBHMMcWh0dHBzOi8vZ2l0aHViLmNvbS9zaWdzdG9yZS1jb25mb3JtYW5jZS9leHRyZW1lbHktZGFuZ2Vyb3VzLXB1YmxpYy1vaWRjLWJlYWNvbi9hY3Rpb25zL3J1bnMvODM0NzQ4MTYyOC9hdHRlbXB0cy8xMBYGCisGAQQBg78wARYECAwGcHVibGljMIGKBgorBgEEAdZ5AgQCBHwEegB4AHYA3T0wasbHETJjGR4cmWc3AqJKXrjePK3/h4pygC8p7o4AAAGOV8AHpgAABAMARzBFAiBFeMbpFarlPwb0naTr4mjWDvXApOd9ORqOk36Brt9SmwIhAJJvjor+DXUXr7S3Vm9jVFT3CL0BxcKGj86m5mYzQvubMAoGCCqGSM49BAMDA2gAMGUCMA8lTixdS4iN9mAUduObcSJmhZLyvK7zaX05DLEDCgPWxDHk+JBZUKYRIuHHgwFnOwIxALMamo9dfENMzRgNCzYfp/y+rSOhVjXXE9mCn6BuJETlpRDfGvxUg/5LF9f4lYqozA=="}, "tlogEntries": [{"logIndex": "79571823", "logId": {"keyId": "wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0="}, "kindVersion": {"kind": "hashedrekord", "version": "0.0.1"}, "integratedTime": "1710869186", "inclusionPromise": {"signedEntryTimestamp": "MEYCIQDMNM49CNrcrpuvB9G3likdSse0miAkY0ILCqzRGP5ZJQIhAKnSS9GUSFVCar1+Sq3qoRtJIJ8x9tqRnQ8kuS1ojtTH"}, "inclusionProof": {"logIndex": "75408392", "rootHash": "Fnnj13Uu1jdksPc4HZLapKX329dVlD5+MGNsiqBq1XM=", "treeSize": "75408393", "hashes": ["1J7hRIEGvYdAyzEs+GhAE9L+38oHye3BhalgoQRZoo4=", "W/OUCkh/lqDDwbBkZgP7eTV/wx4WifD1wtfRLbavfxI=", "9wya2BEhfLGDfDRVN46OU2RXkozWCM1Z4qMu6SPiWoY=", "ZRs3lKAIlu0t0GtLupAcOu1y20nOaOshSKosWAqFO+w=", "BGqH+LzVuhuqCLiUvBJaB2hlsvtu2a15qq1WGw6mG44=", "OeS7D4kPES7ChE7kWSEmhbAMqBcKVj/z8/afMK4Y3pI=", "JtjqvAqFyXXYjWlZfDzElHpEzdBjsz1LmGFJuYx0kTU=", "s/ZIVcfcD4/nuZwUtQf4ydGsIAkGTPTzk3b0zhUC95k=", "YU1jZY/fp5tJdGF/i+/7ez8107O4/lOUp7acMPFEaOA=", "7Z18YLBAvejEV4nJHIKoks/xlijnhR005qTW2w4QtHg=", "98enzMaC+x5oCMvIZQA5z8vu2apDMCFvE/935NfuPw8="], "checkpoint": {"envelope": "rekor.sigstore.dev - 2605736670972794746\n75408393\nFnnj13Uu1jdksPc4HZLapKX329dVlD5+MGNsiqBq1XM=\n\n— rekor.sigstore.dev wNI9ajBFAiBTyiBM9WtyOTgohje6QZ5rFGJUdMq7Wk3A6oThE98SUgIhAMvxDwa7FyqRqg+YV3rdPPrfS23w19iK+piMSGVOmP5w\n"}}, "canonicalizedBody": "eyJhcGlWZXJzaW9uIjoiMC4wLjEiLCJraW5kIjoiaGFzaGVkcmVrb3JkIiwic3BlYyI6eyJkYXRhIjp7Imhhc2giOnsiYWxnb3JpdGhtIjoic2hhMjU2IiwidmFsdWUiOiJhMGNmYzcxMjcxZDZlMjc4ZTU3Y2QzMzJmZjk1N2MzZjcwNDNmZGRhMzU0YzRjYmIxOTBhMzBkNTZlZmEwMWJmIn19LCJzaWduYXR1cmUiOnsiY29udGVudCI6Ik1FVUNJQ1lGcS80YlRFZGx1cmdxVnVObXdDY0lXdTNOS09DZ3ZlV0FKQmllekowdUFpRUEyaTdVMTgrYVJwRnhMWWtzcjVIS0JRUXkwOHpFMDUwV0ljMFJ6S3VuRElBPSIsInB1YmxpY0tleSI6eyJjb250ZW50IjoiTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVbE5WRU5EUWpkbFowRjNTVUpCWjBsVllVd3ZkSE50VVZSSWF6SXhiWFF4VlhWckszYzNZWFpFUW5vMGQwTm5XVWxMYjFwSmVtb3dSVUYzVFhjS1RucEZWazFDVFVkQk1WVkZRMmhOVFdNeWJHNWpNMUoyWTIxVmRWcEhWakpOVWpSM1NFRlpSRlpSVVVSRmVGWjZZVmRrZW1SSE9YbGFVekZ3WW01U2JBcGpiVEZzV2tkc2FHUkhWWGRJYUdOT1RXcFJkMDE2UlRWTlZHTjVUbXBKTWxkb1kwNU5hbEYzVFhwRk5VMVVZM3BPYWtreVYycEJRVTFHYTNkRmQxbElDa3R2V2tsNmFqQkRRVkZaU1V0dldrbDZhakJFUVZGalJGRm5RVVV5TWxNeGFpOU9hMFZZZWtKUVVVRjFZVzFJV0V4d2QzZ3JVbEJ1Ym5wYVVXd3ZjR3NLUlZvNGVHOXlka3R1ZW5WcVExTXhiVlpVUW04NWEwSjRiVmxYYnpKRVNIUjVWbmxtWjI1MVQzRldWSHBNV1cxb2J6WlBRMEowV1hkbloySlRUVUUwUndwQk1WVmtSSGRGUWk5M1VVVkJkMGxJWjBSQlZFSm5UbFpJVTFWRlJFUkJTMEpuWjNKQ1owVkdRbEZqUkVGNlFXUkNaMDVXU0ZFMFJVWm5VVlZHZGpGVENrTjZhVVZMVGpKeVVubHlhbVZXYkVaaVUweG5NUzlSZDBoM1dVUldVakJxUWtKbmQwWnZRVlV6T1ZCd2VqRlphMFZhWWpWeFRtcHdTMFpYYVhocE5Ga0tXa1E0ZDJkaFZVZEJNVlZrUlZGRlFpOTNVMEp0YWtOQ2JEUmhRbXhIYURCa1NFSjZUMms0ZGxveWJEQmhTRlpwVEcxT2RtSlRPWHBoVjJSNlpFYzVlUXBhVXpGcVlqSTFiV0l6U25SWlZ6VnFXbE01YkdWSVVubGFWekZzWWtocmRGcEhSblZhTWxaNVlqTldla3hZUWpGWmJYaHdXWGt4ZG1GWFVtcE1WMHBzQ2xsWFRuWmlhVGgxV2pKc01HRklWbWxNTTJSMlkyMTBiV0pIT1ROamVUbHNaVWhTZVZwWE1XeGlTR3QwV2tkR2RWb3lWbmxpTTFaNlRGYzVjRnBIVFhRS1dXMVdhRmt5T1hWTWJteDBZa1ZDZVZwWFducE1NbWhzV1ZkU2Vrd3lNV2hoVnpSM1QxRlpTMHQzV1VKQ1FVZEVkbnBCUWtGUlVYSmhTRkl3WTBoTk5ncE1lVGt3WWpKMGJHSnBOV2haTTFKd1lqSTFla3h0WkhCa1IyZ3hXVzVXZWxwWVNtcGlNalV3V2xjMU1FeHRUblppVkVGbVFtZHZja0puUlVWQldVOHZDazFCUlVOQ1FrWXpZak5LY2xwdGVIWmtNVGxyWVZoT2QxbFlVbXBoUkVFeVFtZHZja0puUlVWQldVOHZUVUZGUkVKRGFHcE9Na2w2V2tkYWFVMTZUVEVLV21wQk1VMVhWWGhaZW1jeVdXMVNhRTVIVFROTlZGcHRXVmROTlU0eVVtMU9ha3BvV2tSbmVFMURNRWREYVhOSFFWRlJRbWMzT0hkQlVWRkZTREJXTkFwa1NFcHNZbGRXYzJWVFFtdFpWelZ1V2xoS2RtUllUV2RVTUd4RlVYbENhVnBYUm1waU1qUjNVMUZaUzB0M1dVSkNRVWRFZG5wQlFrSlJVVGRqTW14dUNtTXpVblpqYlZWMFdUSTVkVnB0T1hsaVYwWjFXVEpWZGxwWWFEQmpiVlowV2xkNE5VeFhVbWhpYldSc1kyMDVNV041TVhka1YwcHpZVmROZEdJeWJHc0tXWGt4YVZwWFJtcGlNalIzU0ZGWlMwdDNXVUpDUVVkRWRucEJRa0puVVZCamJWWnRZM2s1YjFwWFJtdGplVGwwV1Zkc2RVMUVjMGREYVhOSFFWRlJRZ3BuTnpoM1FWRm5SVXhSZDNKaFNGSXdZMGhOTmt4NU9UQmlNblJzWW1rMWFGa3pVbkJpTWpWNlRHMWtjR1JIYURGWmJsWjZXbGhLYW1JeU5UQmFWelV3Q2t4dFRuWmlWRU5DY0dkWlMwdDNXVUpDUVVkRWRucEJRa05SVTBKc2QzbENiRWRvTUdSSVFucFBhVGgyV2pKc01HRklWbWxNYlU1MllsTTVlbUZYWkhvS1pFYzVlVnBUTVdwaU1qVnRZak5LZEZsWE5XcGFVemxzWlVoU2VWcFhNV3hpU0d0MFdrZEdkVm95Vm5saU0xWjZURmhDTVZsdGVIQlplVEYyWVZkU2FncE1WMHBzV1ZkT2RtSnBPSFZhTW13d1lVaFdhVXd6WkhaamJYUnRZa2M1TTJONU9XeGxTRko1V2xjeGJHSklhM1JhUjBaMVdqSldlV0l6Vm5wTVZ6bHdDbHBIVFhSWmJWWm9XVEk1ZFV4dWJIUmlSVUo1V2xkYWVrd3lhR3haVjFKNlRESXhhR0ZYTkhkUFFWbExTM2RaUWtKQlIwUjJla0ZDUTJkUmNVUkRhR29LVGpKSmVscEhXbWxOZWsweFdtcEJNVTFYVlhoWmVtY3lXVzFTYUU1SFRUTk5WRnB0V1ZkTk5VNHlVbTFPYWtwb1drUm5lRTFDTUVkRGFYTkhRVkZSUWdwbk56aDNRVkZ6UlVSM2QwNWFNbXd3WVVoV2FVeFhhSFpqTTFKc1drUkNaVUpuYjNKQ1owVkZRVmxQTDAxQlJVMUNSa0ZOVkcxb01HUklRbnBQYVRoMkNsb3liREJoU0ZacFRHMU9kbUpUT1hwaFYyUjZaRWM1ZVZwVE1XcGlNalZ0WWpOS2RGbFhOV3BhVXpsc1pVaFNlVnBYTVd4aVNHdDBXa2RHZFZveVZua0tZak5XZWt4WVFqRlpiWGh3V1hreGRtRlhVbXBNVjBwc1dWZE9kbUpxUVRSQ1oyOXlRbWRGUlVGWlR5OU5RVVZPUWtOdlRVdEhUVE5aYWs1cldtMUplZ3BOZWxadFRVUlZlRnBVUm1wUFJGcHBXa2RGTUZsNlkzaE9iVnBvV1hwck0xcEhXVEpOYlVaclQwUkZkMGgzV1V0TGQxbENRa0ZIUkhaNlFVSkVaMUZTQ2tSQk9YbGFWMXA2VERKb2JGbFhVbnBNTWpGb1lWYzBkMGRSV1V0TGQxbENRa0ZIUkhaNlFVSkVkMUZNUkVGck1rMTZTVEZQVkZrMFQxUmpkMDUzV1VzS1MzZFpRa0pCUjBSMmVrRkNSVUZSY0VSRFpHOWtTRkozWTNwdmRrd3laSEJrUjJneFdXazFhbUl5TUhaak1teHVZek5TZG1OdFZYUlpNamwxV20wNWVRcGlWMFoxV1RKVmQwZFJXVXRMZDFsQ1FrRkhSSFo2UVVKRlVWRk1SRUZyZUUxNlJUUk5SRkV4VG1wTmQyZGhXVWREYVhOSFFWRlJRbWMzT0hkQlVrbEZDbWRhWTAxbldsSnZaRWhTZDJONmIzWk1NbVJ3WkVkb01WbHBOV3BpTWpCMll6SnNibU16VW5aamJWVjBXVEk1ZFZwdE9YbGlWMFoxV1RKVmRscFlhREFLWTIxV2RGcFhlRFZNVjFKb1ltMWtiR050T1RGamVURjNaRmRLYzJGWFRYUmlNbXhyV1hreGFWcFhSbXBpTWpSMlRHMWtjR1JIYURGWmFUa3pZak5LY2dwYWJYaDJaRE5OZGxwWWFEQmpiVlowV2xkNE5VeFhVbWhpYldSc1kyMDVNV041TVhaaFYxSnFURmRLYkZsWFRuWmlhVFUxWWxkNFFXTnRWbTFqZVRsdkNscFhSbXRqZVRsMFdWZHNkVTFFWjBkRGFYTkhRVkZSUW1jM09IZEJVazFGUzJkM2IxbDZaR2xOTWxKdFdXcE5lazVYV1hkT1ZFWnNUVmROTkU1dFNtc0tXVlJTYWs1NlJUSmFiVVpxVDFSa2ExcHFXWGxaVjFFMFRWUkJhRUpuYjNKQ1owVkZRVmxQTDAxQlJWVkNRazFOUlZoa2RtTnRkRzFpUnpreldESlNjQXBqTTBKb1pFZE9iMDFKUjBKQ1oyOXlRbWRGUlVGWlR5OU5RVVZXUWtoTlRXTlhhREJrU0VKNlQyazRkbG95YkRCaFNGWnBURzFPZG1KVE9YcGhWMlI2Q21SSE9YbGFVekZxWWpJMWJXSXpTblJaVnpWcVdsTTViR1ZJVW5sYVZ6RnNZa2hyZEZwSFJuVmFNbFo1WWpOV2VreFlRakZaYlhod1dYa3hkbUZYVW1vS1RGZEtiRmxYVG5aaWFUbG9XVE5TY0dJeU5YcE1NMG94WW01TmRrOUVUVEJPZWxFMFRWUlplVTlET1doa1NGSnNZbGhDTUdONU9IaE5RbGxIUTJselJ3cEJVVkZDWnpjNGQwRlNXVVZEUVhkSFkwaFdhV0pIYkdwTlNVZExRbWR2Y2tKblJVVkJaRm8xUVdkUlEwSklkMFZsWjBJMFFVaFpRVE5VTUhkaGMySklDa1ZVU21wSFVqUmpiVmRqTTBGeFNrdFljbXBsVUVzekwyZzBjSGxuUXpod04yODBRVUZCUjA5V09FRkljR2RCUVVKQlRVRlNla0pHUVdsQ1JtVk5ZbkFLUm1GeWJGQjNZakJ1WVZSeU5HMXFWMFIyV0VGd1QyUTVUMUp4VDJzek5rSnlkRGxUYlhkSmFFRktTblpxYjNJclJGaFZXSEkzVXpOV2JUbHFWa1pVTXdwRFREQkNlR05MUjJvNE5tMDFiVmw2VVhaMVlrMUJiMGREUTNGSFUwMDBPVUpCVFVSQk1tZEJUVWRWUTAxQk9HeFVhWGhrVXpScFRqbHRRVlZrZFU5aUNtTlRTbTFvV2t4NWRrczNlbUZZTURWRVRFVkVRMmRRVjNoRVNHc3JTa0phVlV0WlVrbDFTRWhuZDBadVQzZEplRUZNVFdGdGJ6bGtaa1ZPVFhwU1owNEtRM3BaWm5BdmVTdHlVMDlvVm1wWVdFVTViVU51TmtKMVNrVlViSEJTUkdaSGRuaFZaeTgxVEVZNVpqUnNXWEZ2ZWtFOVBRb3RMUzB0TFVWT1JDQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENnPT0ifX19fQ=="}]}, "messageSignature": {"messageDigest": {"algorithm": "SHA2_256", "digest": "oM/HEnHW4njlfNMy/5V8P3BD/do1TEy7GQow1W76Ab8="}, "signature": "MEUCICYFq/4bTEdlurgqVuNmwCcIWu3NKOCgveWAJBiezJ0uAiEA2i7U18+aRpFxLYksr5HKBQQy08zE050WIc0RzKunDIA="}}''';

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -209,6 +209,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.2"
+  code_assets:
+    dependency: transitive
+    description:
+      name: code_assets
+      sha256: bf394f466ba9205f1812a0433b392d6af280f155f56651eda7c18cc32ed493b8
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.1"
   code_builder:
     dependency: transitive
     description:
@@ -377,6 +385,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.0"
+  hooks:
+    dependency: transitive
+    description:
+      name: hooks
+      sha256: eaac480a35ec0814146c2c48d96aaa829e0e44a7662c88ae84c9edf4bc35651f
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.0"
   html:
     dependency: transitive
     description:
@@ -697,6 +713,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.20.0"
+  record_use:
+    dependency: transitive
+    description:
+      name: record_use
+      sha256: "1cb8564af8d43b464294411db9217f5ec04891c6f22ee2c32d73ae05e88a6bd2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
   retry:
     dependency: transitive
     description:
@@ -772,12 +796,11 @@ packages:
   sigstore:
     dependency: transitive
     description:
-      path: "pkgs/sigstore"
-      ref: add-package-sigstore
-      resolved-ref: f1bb450c8234ff8c2a0eaaa4b5061e754822062b
-      url: "https://github.com/dart-lang/labs.git"
-    source: git
-    version: "0.1.0-dev"
+      name: sigstore
+      sha256: "04c0dda858b534915faa82a9a877e94169c9b9d4546bba5a83f940c78b32736f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.0"
   slugid:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -769,6 +769,15 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.0"
+  sigstore:
+    dependency: transitive
+    description:
+      path: "pkgs/sigstore"
+      ref: add-package-sigstore
+      resolved-ref: f1bb450c8234ff8c2a0eaaa4b5061e754822062b
+      url: "https://github.com/dart-lang/labs.git"
+    source: git
+    version: "0.1.0-dev"
   slugid:
     dependency: transitive
     description:


### PR DESCRIPTION
Second PR in stack for package attestation support (stacked on top of #9545):

- Adds `sigstore` dependency in `app/pubspec.yaml`.
- In `packageBackend.publishUploadedBlob`, validates the attestation bundle against the package archive bytes, package name/version, and pubspec repository using `AttestationVerifier`.
- Rejects package upload with `PackageRejectedException` if attestation is invalid or fails verification.
- Adds test cases in `upload_test.dart` for valid verification and rejected invalid attestations.