### PR TITLE
fix: resolve race-condition deadlock in parallelForEach using package:pool

### DIFF
--- a/app/lib/shared/parallel_foreach.dart
+++ b/app/lib/shared/parallel_foreach.dart
@@ -8,6 +8,8 @@
 
 import 'dart:async';
 
+import 'package:pool/pool.dart';
+
 /// A [Notifier] allows micro-tasks to [wait] for other micro-tasks to
 /// [notify].
 ///
@@ -98,25 +100,24 @@ extension StreamExtensions<T> on Stream<T> {
     FutureOr<void> Function(T item) each, {
     FutureOr<void> Function(Object e, StackTrace? st) onError = Future.error,
   }) async {
-    // Track the first error, so we rethrow when we're done.
+    final pool = Pool(maxParallel);
     Object? firstError;
     StackTrace? firstStackTrace;
-
-    // Track number of running items.
-    var running = 0;
-    final itemDone = Notifier();
+    var doBreak = false;
 
     try {
-      var doBreak = false;
       await for (final item in this) {
-        // For each item we increment [running] and call [each]
-        running += 1;
+        if (doBreak) break;
+        final resource = await pool.request();
+        if (doBreak) {
+          resource.release();
+          break;
+        }
         unawaited(() async {
           try {
             await each(item);
           } catch (e, st) {
             try {
-              // If [onError] doesn't throw, we'll just continue.
               await onError(e, st);
             } catch (e, st) {
               doBreak = true;
@@ -126,24 +127,12 @@ extension StreamExtensions<T> on Stream<T> {
               }
             }
           } finally {
-            // When [each] is done, we decrement [running] and notify
-            running -= 1;
-            itemDone.notify();
+            resource.release();
           }
         }());
-
-        if (running >= maxParallel) {
-          await itemDone.wait;
-        }
-        if (doBreak) {
-          break;
-        }
       }
     } finally {
-      // Wait for all items to be finished
-      while (running > 0) {
-        await itemDone.wait;
-      }
+      await pool.close();
     }
 
     // If an error happened, then we rethrow the first one.

--- a/app/test/shared/parallel_foreach_test.dart
+++ b/app/test/shared/parallel_foreach_test.dart
@@ -167,5 +167,27 @@ void main() {
       expect(countedTo, greaterThanOrEqualTo(10));
       expect(countedTo, lessThan(20));
     });
+
+    test('fast streaming items stress test does not deadlock', () async {
+      for (var trial = 0; trial < 10; trial++) {
+        Stream<int> entityStream() async* {
+          for (var b = 0; b < 20; b++) {
+            await Future.delayed(Duration(microseconds: 10));
+            for (var i = 0; i < 50; i++) {
+              yield b * 50 + i;
+            }
+          }
+        }
+
+        var processed = 0;
+        await entityStream()
+            .parallelForEach(4, (item) async {
+              await Stream.fromIterable([item]).toList();
+              processed++;
+            })
+            .timeout(Duration(seconds: 5));
+        expect(processed, 1000);
+      }
+    });
   });
 }


### PR DESCRIPTION
## Description

Fixes a race-condition deadlock in `StreamExtensions.parallelForEach` that caused background tasks such as `check-datastore-integrity` and `synchronize-exported-api` to hang indefinitely.

### Root Cause of the Deadlock

The `Notifier` helper class acts as an event broadcaster rather than a counting semaphore:
```dart
final class Notifier {
  var _completer = Completer<void>();

  void notify() {
    if (!_completer.isCompleted) {
      _completer.complete();
    }
  }

  Future<void> get wait {
    if (_completer.isCompleted) {
      _completer = Completer();
    }
    return _completer.future;
  }
}
```

When multiple tasks complete close together:
1. `Notifier.notify()` marks its internal `_completer` as completed.
2. Any subsequent `notify()` calls occurring before `wait` is accessed are dropped (`!_completer.isCompleted` is false).
3. When `await itemDone.wait` is subsequently called, `if (_completer.isCompleted)` resets `_completer = Completer()` and returns an **uncompleted `Future`** from the new completer, waiting for a *subsequent* notification instead of resolving immediately.
4. When `parallelForEach` completes its `await for` stream iteration and enters the `finally` block:
   ```dart
   while (running > 0) {
     await itemDone.wait;
   }
   ```
   If remaining in-flight tasks finish while `wait` is accessed or during a microtask turn, `running` becomes `0`, but `wait` returns a brand new unresolved `Completer`. Because no tasks remain running to call `notify()`, `parallelForEach` **deadlocks indefinitely**.

### Minimal Reproduction Example

```dart
import 'dart:async';
import 'package:pub_dev/shared/parallel_foreach.dart';

void main() async {
  // A stream that yields items with micro-delays (e.g. paginated queries).
  Stream<int> stream() async* {
    for (var i = 0; i < 100; i++) {
      yield i;
    }
  }

  // With fast async tasks, remaining in-flight tasks complete while `wait`
  // is evaluated in `finally`, creating an unresolved Completer that never resolves.
  await stream().parallelForEach(4, (item) async {
    await Stream.fromIterable([item]).toList();
  }); // <-- Deadlocks here indefinitely
}
```

### Fix

- Refactors `parallelForEach` to use `Pool` from `package:pool` (already in `pubspec.yaml`).
- `await pool.request()` cleanly enforces backpressure on the stream when `maxParallel` tasks are in-flight.
- `resource.release()` immediately grants execution to the next waiting request in FIFO order.
- `await pool.close()` safely waits for all in-flight tasks to complete in the `finally` block.
- Adds stress tests in `parallel_foreach_test.dart` to verify no race conditions or deadlocks occur under high-throughput streaming workloads.
