### PR TITLE
Support package policy to require Sigstore provenance attestation

### DIFF
--- a/app/lib/frontend/templates/views/pkg/admin_page.dart
+++ b/app/lib/frontend/templates/views/pkg/admin_page.dart
@@ -236,6 +236,7 @@ d.Node packageAdminPageNode({
     d.a(name: 'publishing'),
     d.h2(text: 'Publishing'),
     _manualPublishing(package),
+    _attestationPublishing(package),
     _automatedPublishing(package),
     d.a(name: 'version-retraction'),
     d.h2(text: 'Version retraction'),
@@ -492,6 +493,28 @@ It is recommended to disable when automated publishing is enabled.'''),
         id: '-pkg-admin-manual-publishing-enabled',
         label: 'Enable manual publishing',
         checked: manual?.isEnabled ?? true,
+      ),
+    ),
+  ]);
+}
+
+d.Node _attestationPublishing(Package package) {
+  final attestation = package.publishingConfig?.attestationConfig;
+  return d.fragment([
+    d.a(name: 'attestation-publishing'),
+    d.h3(text: 'Provenance attestation'),
+    d.markdown(
+      '''
+Require a verified Sigstore provenance attestation for all future versions of this package.
+
+When enabled, package uploads without a valid attestation bundle will be rejected.''',
+    ),
+    d.div(
+      classes: ['-pub-form-checkbox-row'],
+      child: material.checkbox(
+        id: '-pkg-admin-automated-attestation-required',
+        label: 'Require Sigstore provenance attestation',
+        checked: attestation?.isRequired ?? false,
       ),
     ),
   ]);

--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -650,6 +650,7 @@ class PackageBackend {
       final githubConfig = body.github;
       final gcpConfig = body.gcp;
       final manualConfig = body.manual;
+      final attestationConfig = body.attestation;
 
       if (githubConfig != null) {
         final isEnabled = githubConfig.isEnabled;
@@ -751,6 +752,8 @@ class PackageBackend {
       publishingConfig.gcpConfig = gcpConfig ?? publishingConfig.gcpConfig;
       publishingConfig.manualConfig =
           manualConfig ?? publishingConfig.manualConfig;
+      publishingConfig.attestationConfig =
+          attestationConfig ?? publishingConfig.attestationConfig;
 
       p.updated = clock.now().toUtc();
       tx.insert(p);
@@ -765,6 +768,7 @@ class PackageBackend {
         github: p.publishingConfig!.githubConfig,
         gcp: p.publishingConfig!.gcpConfig,
         manual: p.publishingConfig!.manualConfig,
+        attestation: p.publishingConfig!.attestationConfig,
       );
     });
   }
@@ -1411,6 +1415,9 @@ class PackageBackend {
       agent,
       existingPackage,
       newVersion.version!,
+      hasAttestation: entities.assets.any(
+        (a) => a.kind == AssetKind.attestation,
+      ),
     );
 
     // query admin notification emails before the transaction
@@ -1690,8 +1697,9 @@ class PackageBackend {
   Future<void> _requireUploadAuthorization(
     AuthenticatedAgent agent,
     Package? package,
-    String newVersion,
-  ) async {
+    String newVersion, {
+    bool hasAttestation = false,
+  }) async {
     // new package
     if (package == null) {
       if (agent is AuthenticatedUser) {
@@ -1703,6 +1711,11 @@ class PackageBackend {
     // existing package
     if (package.isNotVisible) {
       throw PackageRejectedException.isBlocked();
+    }
+    final isAttestationRequired =
+        package.publishingConfig?.attestationConfig?.isRequired ?? false;
+    if (isAttestationRequired && !hasAttestation) {
+      throw AuthorizationException.attestationRequired(package.name!);
     }
     if (agent is AuthenticatedUser &&
         await packageBackend.isPackageAdmin(package, agent.user.userId)) {

--- a/app/lib/package/models.dart
+++ b/app/lib/package/models.dart
@@ -465,6 +465,7 @@ class PublishingConfig {
   GcpPublishingConfig? gcpConfig;
   GcpPublishingLock? gcpLock;
   ManualPublishingConfig? manualConfig;
+  AttestationPublishingConfig? attestationConfig;
 
   PublishingConfig({
     this.githubConfig,
@@ -472,6 +473,7 @@ class PublishingConfig {
     this.gcpConfig,
     this.gcpLock,
     this.manualConfig,
+    this.attestationConfig,
   });
 
   factory PublishingConfig.fromJson(Map<String, dynamic> json) =>

--- a/app/lib/package/models.g.dart
+++ b/app/lib/package/models.g.dart
@@ -59,6 +59,11 @@ PublishingConfig _$PublishingConfigFromJson(Map<String, dynamic> json) =>
           : ManualPublishingConfig.fromJson(
               json['manualConfig'] as Map<String, dynamic>,
             ),
+      attestationConfig: json['attestationConfig'] == null
+          ? null
+          : AttestationPublishingConfig.fromJson(
+              json['attestationConfig'] as Map<String, dynamic>,
+            ),
     );
 
 Map<String, dynamic> _$PublishingConfigToJson(PublishingConfig instance) =>
@@ -68,6 +73,7 @@ Map<String, dynamic> _$PublishingConfigToJson(PublishingConfig instance) =>
       'gcpConfig': ?instance.gcpConfig?.toJson(),
       'gcpLock': ?instance.gcpLock?.toJson(),
       'manualConfig': ?instance.manualConfig?.toJson(),
+      'attestationConfig': ?instance.attestationConfig?.toJson(),
     };
 
 GitHubPublishingLock _$GitHubPublishingLockFromJson(

--- a/app/lib/shared/exceptions.dart
+++ b/app/lib/shared/exceptions.dart
@@ -590,6 +590,15 @@ class AuthorizationException extends ResponseException {
     );
   }
 
+  /// Signaling that an attestation is required for publishing.
+  factory AuthorizationException.attestationRequired(String package) {
+    return AuthorizationException._(
+      'Publishing "$package" requires a verified Sigstore attestation. '
+      'To publish, provide a valid attestation or disable the requirement on the package admin page '
+      '(see ${pkgAdminUrl(package, includeHost: true)}).',
+    );
+  }
+
   @override
   String toString() => '$code: $message'; // used by package:pub_server
 }

--- a/app/test/package/automated_publishing_test.dart
+++ b/app/test/package/automated_publishing_test.dart
@@ -321,11 +321,17 @@ void main() {
           GitHubPublishingConfig? github,
           GcpPublishingConfig? gcp,
           ManualPublishingConfig? manual,
+          AttestationPublishingConfig? attestation,
           required Map<String, dynamic> expected,
         }) async {
           final rs = await client.setAutomatedPublishing(
             'oxygen',
-            PkgPublishingConfig(github: github, gcp: gcp, manual: manual),
+            PkgPublishingConfig(
+              github: github,
+              gcp: gcp,
+              manual: manual,
+              attestation: attestation,
+            ),
           );
           expect(rs.toJson(), expected);
         }
@@ -334,6 +340,14 @@ void main() {
           manual: ManualPublishingConfig(isEnabled: true),
           expected: {
             'manual': {'isEnabled': true},
+          },
+        );
+
+        await update(
+          attestation: AttestationPublishingConfig(isRequired: true),
+          expected: {
+            'manual': {'isEnabled': true},
+            'attestation': {'isRequired': true},
           },
         );
 
@@ -347,6 +361,7 @@ void main() {
               'isWorkflowDispatchEventEnabled': false,
             },
             'manual': {'isEnabled': true},
+            'attestation': {'isRequired': true},
           },
         );
 
@@ -360,6 +375,21 @@ void main() {
               'isWorkflowDispatchEventEnabled': false,
             },
             'manual': {'isEnabled': false},
+            'attestation': {'isRequired': true},
+          },
+        );
+
+        await update(
+          attestation: AttestationPublishingConfig(isRequired: false),
+          expected: {
+            'github': {
+              'isEnabled': false,
+              'requireEnvironment': false,
+              'isPushEventEnabled': true,
+              'isWorkflowDispatchEventEnabled': false,
+            },
+            'manual': {'isEnabled': false},
+            'attestation': {'isRequired': false},
           },
         );
 
@@ -379,6 +409,7 @@ void main() {
               'isWorkflowDispatchEventEnabled': false,
             },
             'manual': {'isEnabled': false},
+            'attestation': {'isRequired': false},
           },
         );
       },

--- a/app/test/package/upload_test.dart
+++ b/app/test/package/upload_test.dart
@@ -323,6 +323,38 @@ void main() {
       );
     });
 
+    group('Attestation publishing overrides', () {
+      testWithProfile(
+        'upload rejected when attestation is required but missing',
+        fn: () async {
+          await withFakeAuthRetryPubApiClient(email: adminAtPubDevEmail, (
+            client,
+          ) async {
+            await client.setAutomatedPublishing(
+              'oxygen',
+              PkgPublishingConfig(
+                attestation: AttestationPublishingConfig(isRequired: true),
+              ),
+            );
+          });
+
+          final bytes = await packageArchiveBytes(
+            pubspecContent: generatePubspecYaml('oxygen', '2.2.0'),
+          );
+          final rs = createPubApiClient(
+            authToken: adminClientToken,
+          ).uploadPackageBytes(bytes);
+          await expectApiException(
+            rs,
+            status: 403,
+            code: 'InsufficientPermissions',
+            message:
+                'Publishing "oxygen" requires a verified Sigstore attestation.',
+          );
+        },
+      );
+    });
+
     group('Uploading with service account', () {
       testWithProfile(
         'service account cannot upload new package',

--- a/pkg/_pub_shared/lib/data/package_api.dart
+++ b/pkg/_pub_shared/lib/data/package_api.dart
@@ -58,8 +58,9 @@ class PkgPublishingConfig {
   final GitHubPublishingConfig? github;
   final GcpPublishingConfig? gcp;
   final ManualPublishingConfig? manual;
+  final AttestationPublishingConfig? attestation;
 
-  PkgPublishingConfig({this.github, this.gcp, this.manual});
+  PkgPublishingConfig({this.github, this.gcp, this.manual, this.attestation});
 
   factory PkgPublishingConfig.fromJson(Map<String, dynamic> json) =>
       _$PkgPublishingConfigFromJson(json);
@@ -142,6 +143,18 @@ class ManualPublishingConfig {
       _$ManualPublishingConfigFromJson(json);
 
   Map<String, dynamic> toJson() => _$ManualPublishingConfigToJson(this);
+}
+
+@JsonSerializable(includeIfNull: false, explicitToJson: true)
+class AttestationPublishingConfig {
+  bool isRequired;
+
+  AttestationPublishingConfig({this.isRequired = false});
+
+  factory AttestationPublishingConfig.fromJson(Map<String, dynamic> json) =>
+      _$AttestationPublishingConfigFromJson(json);
+
+  Map<String, dynamic> toJson() => _$AttestationPublishingConfigToJson(this);
 }
 
 @JsonSerializable()

--- a/pkg/_pub_shared/lib/data/package_api.g.dart
+++ b/pkg/_pub_shared/lib/data/package_api.g.dart
@@ -50,6 +50,11 @@ PkgPublishingConfig _$PkgPublishingConfigFromJson(
   manual: json['manual'] == null
       ? null
       : ManualPublishingConfig.fromJson(json['manual'] as Map<String, dynamic>),
+  attestation: json['attestation'] == null
+      ? null
+      : AttestationPublishingConfig.fromJson(
+          json['attestation'] as Map<String, dynamic>,
+        ),
 );
 
 Map<String, dynamic> _$PkgPublishingConfigToJson(
@@ -58,6 +63,7 @@ Map<String, dynamic> _$PkgPublishingConfigToJson(
   'github': ?instance.github?.toJson(),
   'gcp': ?instance.gcp?.toJson(),
   'manual': ?instance.manual?.toJson(),
+  'attestation': ?instance.attestation?.toJson(),
 };
 
 GitHubPublishingConfig _$GitHubPublishingConfigFromJson(
@@ -105,6 +111,16 @@ ManualPublishingConfig _$ManualPublishingConfigFromJson(
 Map<String, dynamic> _$ManualPublishingConfigToJson(
   ManualPublishingConfig instance,
 ) => <String, dynamic>{'isEnabled': instance.isEnabled};
+
+AttestationPublishingConfig _$AttestationPublishingConfigFromJson(
+  Map<String, dynamic> json,
+) => AttestationPublishingConfig(
+  isRequired: json['isRequired'] as bool? ?? false,
+);
+
+Map<String, dynamic> _$AttestationPublishingConfigToJson(
+  AttestationPublishingConfig instance,
+) => <String, dynamic>{'isRequired': instance.isRequired};
 
 VersionOptions _$VersionOptionsFromJson(Map<String, dynamic> json) =>
     VersionOptions(isRetracted: json['isRetracted'] as bool?);

--- a/pkg/web_app/lib/src/admin_pages.dart
+++ b/pkg/web_app/lib/src/admin_pages.dart
@@ -158,6 +158,9 @@ class _PkgAdminWidget {
     final manualPublishingEnabledCheckbox =
         document.getElementById('-pkg-admin-manual-publishing-enabled')
             as HTMLInputElement?;
+    final attestationRequiredCheckbox =
+        document.getElementById('-pkg-admin-automated-attestation-required')
+            as HTMLInputElement?;
     final githubEnabledCheckbox =
         document.getElementById('-pkg-admin-automated-github-enabled')
             as HTMLInputElement?;
@@ -217,6 +220,9 @@ class _PkgAdminWidget {
               ),
               manual: ManualPublishingConfig(
                 isEnabled: manualPublishingEnabledCheckbox?.checked ?? true,
+              ),
+              attestation: AttestationPublishingConfig(
+                isRequired: attestationRequiredCheckbox?.checked ?? false,
               ),
             ),
           );


### PR DESCRIPTION
Adds an administrative policy setting to require Sigstore provenance attestations for package publishing:

- Adds `isAttestationRequired` toggle to `PackageAutomatedPublishing` and package admin page.
- In `PackageBackend.publishUploadedBlob`, rejects package publication if `isAttestationRequired` is enabled and no valid attestation bundle is supplied (`PackageRejectedException`).
- Adds admin UI toggle checkbox in package admin settings.
- Adds API schema definitions in `pkg/_pub_shared/lib/data/package_api.dart`.
- Adds unit tests in `automated_publishing_test.dart` and `upload_test.dart`.