### PR TITLE
Set DART_VM_OPTIONS for image proxy to adjust GC

### DIFF
--- a/pkg/image_proxy/Dockerfile
+++ b/pkg/image_proxy/Dockerfile
@@ -18,8 +18,7 @@ COPY --from=build /app/server /app/bin/
 
 # Set Dart VM options for container execution:
 # - --old_gen_heap_size=768 caps the old generation heap to trigger GC before container cgroup limits.
-# - --dontneed_on_sweep returns freed heap pages to the OS kernel via madvise(MADV_DONTNEED).
-ENV DART_VM_OPTIONS="--old_gen_heap_size=768,--dontneed_on_sweep"
+ENV DART_VM_OPTIONS="--old_gen_heap_size=768"
 
 # Start server.
 EXPOSE 8080

--- a/pkg/image_proxy/Dockerfile
+++ b/pkg/image_proxy/Dockerfile
@@ -16,6 +16,11 @@ FROM scratch
 COPY --from=build /runtime/ /
 COPY --from=build /app/server /app/bin/
 
+# Set Dart VM options for container execution:
+# - --old_gen_heap_size=768 caps the old generation heap to trigger GC before container cgroup limits.
+# - --dontneed_on_sweep returns freed heap pages to the OS kernel via madvise(MADV_DONTNEED).
+ENV DART_VM_OPTIONS="--old_gen_heap_size=768,--dontneed_on_sweep"
+
 # Start server.
 EXPOSE 8080
 CMD ["/app/bin/server"]

--- a/tool/build_image_proxy.yaml
+++ b/tool/build_image_proxy.yaml
@@ -47,6 +47,7 @@ steps:
       gcloud run deploy image-proxy-server \
         --image="us-central1-docker.pkg.dev/$PROJECT_ID/image-proxy/image-proxy:$TAG_NAME" \
         --region=us-central1 \
+        --update-env-vars="^@^DART_VM_OPTIONS=--old_gen_heap_size=768,--dontneed_on_sweep"
     env:
       - 'PROJECT_ID=$PROJECT_ID'
       - 'TAG_NAME=$TAG_NAME'

--- a/tool/build_image_proxy.yaml
+++ b/tool/build_image_proxy.yaml
@@ -47,7 +47,7 @@ steps:
       gcloud run deploy image-proxy-server \
         --image="us-central1-docker.pkg.dev/$PROJECT_ID/image-proxy/image-proxy:$TAG_NAME" \
         --region=us-central1 \
-        --update-env-vars="^@^DART_VM_OPTIONS=--old_gen_heap_size=768,--dontneed_on_sweep"
+        --update-env-vars="DART_VM_OPTIONS=--old_gen_heap_size=768"
     env:
       - 'PROJECT_ID=$PROJECT_ID'
       - 'TAG_NAME=$TAG_NAME'


### PR DESCRIPTION
Configure `DART_VM_OPTIONS="--old_gen_heap_size=768"` for the image proxy server in both the Dockerfile and Cloud Build deployment step.

- `--old_gen_heap_size=768`: caps old generation heap (75% of the 1 GiB container memory limit) to trigger garbage collection before reaching container memory boundaries, leaving ~256 MB for new-gen heap, thread stacks, TLS/socket buffers, and runtime overhead.

Improves the situation on #9554 (but we should also increase memory).