### PR TITLE
Include GitHub Actions repository, commit, and run links in publish emails

### DIFF
--- a/app/lib/audit/models.dart
+++ b/app/lib/audit/models.dart
@@ -12,6 +12,7 @@ import 'package:pub_dev/service/rate_limit/rate_limit.dart';
 
 import '../account/models.dart';
 import '../shared/datastore.dart' as db;
+import '../shared/urls.dart';
 import '../shared/utils.dart' show createUuid;
 
 @visibleForTesting
@@ -264,13 +265,18 @@ class AuditLogRecord extends db.ExpandoModel<String> {
       final repository = uploader.payload.repository;
       final runId = uploader.payload.runId;
       final sha = uploader.payload.sha;
+      final runUri = runId != null
+          ? githubWorkflowRunUrl(repository: repository, runId: runId)
+          : null;
+      final commitUri = sha != null
+          ? githubCommitUrl(repository: repository, commit: sha)
+          : null;
       return [
         ...prefix,
         ' was published from GitHub Actions',
-        if (runId != null)
-          ' (`run_id`: [`$runId`](https://github.com/$repository/actions/runs/$runId))',
+        if (runId != null) ' (`run_id`: [`$runId`]($runUri))',
         ' triggered by pushing',
-        if (sha != null) ' revision `$sha`',
+        if (sha != null) ' revision [`$sha`]($commitUri)',
         ' to the `$repository` repository.',
       ].join();
     } else if (uploader is AuthenticatedGcpServiceAccount) {

--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -1483,6 +1483,15 @@ class PackageBackend {
             .toList(),
         uploadMessages: uploadMessages,
         changelogExcerpt: changelogExcerpt,
+        githubRepository: agent is AuthenticatedGitHubAction
+            ? agent.payload.repository
+            : null,
+        githubCommitSha: agent is AuthenticatedGitHubAction
+            ? agent.payload.sha
+            : null,
+        githubRunId: agent is AuthenticatedGitHubAction
+            ? agent.payload.runId
+            : null,
       );
       final outgoingEmail = emailBackend.prepareEntity(email);
 

--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -1474,6 +1474,9 @@ class PackageBackend {
         );
       }
 
+      final ghPayload = agent is AuthenticatedGitHubAction
+          ? agent.payload
+          : null;
       final email = createPackageUploadedEmail(
         packageName: newVersion.package,
         packageVersion: newVersion.version!,
@@ -1483,15 +1486,9 @@ class PackageBackend {
             .toList(),
         uploadMessages: uploadMessages,
         changelogExcerpt: changelogExcerpt,
-        githubRepository: agent is AuthenticatedGitHubAction
-            ? agent.payload.repository
-            : null,
-        githubCommitSha: agent is AuthenticatedGitHubAction
-            ? agent.payload.sha
-            : null,
-        githubRunId: agent is AuthenticatedGitHubAction
-            ? agent.payload.runId
-            : null,
+        githubRepository: ghPayload?.repository,
+        githubCommitSha: ghPayload?.sha,
+        githubRunId: ghPayload?.runId,
       );
       final outgoingEmail = emailBackend.prepareEntity(email);
 

--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -1489,6 +1489,9 @@ class PackageBackend {
         githubRepository: ghPayload?.repository,
         githubCommitSha: ghPayload?.sha,
         githubRunId: ghPayload?.runId,
+        githubRef: ghPayload?.ref,
+        githubRefType: ghPayload?.refType,
+        githubActor: ghPayload?.actor,
       );
       final outgoingEmail = emailBackend.prepareEntity(email);
 

--- a/app/lib/service/email/email_templates.dart
+++ b/app/lib/service/email/email_templates.dart
@@ -223,6 +223,9 @@ EmailMessage createPackageUploadedEmail({
   required List<EmailAddress> authorizedUploaders,
   required List<String> uploadMessages,
   String? changelogExcerpt,
+  String? githubRepository,
+  String? githubCommitSha,
+  String? githubRunId,
 }) {
   final url = pkgPageUrl(
     packageName,
@@ -230,9 +233,41 @@ EmailMessage createPackageUploadedEmail({
     includeHost: true,
   );
   final subject = 'Package uploaded: $packageName $packageVersion';
+
+  String? githubInfoText;
+  String? githubInfoHtml;
+  if (githubRepository != null) {
+    final repoUri = githubRepositoryUrl(githubRepository);
+    final commitUri = githubCommitSha != null
+        ? githubCommitUrl(repository: githubRepository, commit: githubCommitSha)
+        : null;
+    final runUri = githubRunId != null
+        ? githubWorkflowRunUrl(repository: githubRepository, runId: githubRunId)
+        : null;
+
+    final textLines = <String>[
+      'GitHub Actions details:',
+      '- Repository: $repoUri',
+      if (commitUri != null) '- Commit: $commitUri',
+      if (runUri != null) '- Action run: $runUri',
+    ];
+    githubInfoText = textLines.join('\n');
+
+    final htmlLines = <String>[
+      'GitHub Actions details:',
+      '- Repository: <a href="$repoUri">${htmlEscape.convert(githubRepository)}</a>',
+      if (commitUri != null)
+        '- Commit: <a href="$commitUri"><code>${htmlEscape.convert(githubCommitSha!)}</code></a>',
+      if (runUri != null)
+        '- Action run: <a href="$runUri">#${htmlEscape.convert(githubRunId!)}</a>',
+    ];
+    githubInfoHtml = htmlLines.join('<br/>\n');
+  }
+
   final paragraphs = [
     'Dear package maintainer,',
     '$displayId has published a new version ($packageVersion) of the $packageName package to the Dart package site ($primaryHost).',
+    if (githubInfoText != null) githubInfoText,
     'For details, go to $url',
     ...uploadMessages,
     if (changelogExcerpt != null)
@@ -243,6 +278,7 @@ EmailMessage createPackageUploadedEmail({
   final htmlParagraphs = [
     'Dear package maintainer,',
     '$displayId has published a new version ($packageVersion) of the $packageName package to the Dart package site ($primaryHost).',
+    if (githubInfoHtml != null) githubInfoHtml,
     'For details, go to <a href="$url">$url</a>',
     ...uploadMessages,
   ];

--- a/app/lib/service/email/email_templates.dart
+++ b/app/lib/service/email/email_templates.dart
@@ -226,6 +226,9 @@ EmailMessage createPackageUploadedEmail({
   String? githubRepository,
   String? githubCommitSha,
   String? githubRunId,
+  String? githubRef,
+  String? githubRefType,
+  String? githubActor,
 }) {
   final url = pkgPageUrl(
     packageName,
@@ -246,22 +249,57 @@ EmailMessage createPackageUploadedEmail({
     final runUri = runId != null
         ? githubWorkflowRunUrl(repository: githubRepository, runId: runId)
         : null;
+    final ref = githubRef;
+    String? refLabel;
+    String? refValue;
+    Uri? refUri;
+    if (ref != null) {
+      if (ref.startsWith('refs/tags/')) {
+        refLabel = 'Tag';
+        refValue = ref.substring('refs/tags/'.length);
+      } else if (ref.startsWith('refs/heads/')) {
+        refLabel = 'Branch';
+        refValue = ref.substring('refs/heads/'.length);
+      } else if (githubRefType == 'tag') {
+        refLabel = 'Tag';
+        refValue = ref;
+      } else if (githubRefType == 'branch') {
+        refLabel = 'Branch';
+        refValue = ref;
+      } else {
+        refLabel = 'Ref';
+        refValue = ref;
+      }
+      refUri = githubRefUrl(
+        repository: githubRepository,
+        ref: ref,
+        refType: githubRefType,
+      );
+    }
+    final actor = githubActor;
+    final actorUri = actor != null ? githubUserUrl(actor) : null;
 
     final textLines = <String>[
       'GitHub Actions details:',
       '- Repository: $repoUri',
+      if (refLabel != null && refUri != null) '- $refLabel: $refUri',
       if (commitUri != null) '- Commit: $commitUri',
       if (runUri != null) '- Action run: $runUri',
+      if (actor != null && actorUri != null) '- Triggered by: $actorUri',
     ];
     githubInfoText = textLines.join('\n');
 
     final htmlLines = <String>[
       'GitHub Actions details:',
       '- Repository: <a href="$repoUri">${htmlEscape.convert(githubRepository)}</a>',
+      if (refLabel != null && refValue != null && refUri != null)
+        '- $refLabel: <a href="$refUri"><code>${htmlEscape.convert(refValue)}</code></a>',
       if (commitUri != null && commitSha != null)
         '- Commit: <a href="$commitUri"><code>${htmlEscape.convert(commitSha)}</code></a>',
       if (runUri != null && runId != null)
         '- Action run: <a href="$runUri">#${htmlEscape.convert(runId)}</a>',
+      if (actor != null && actorUri != null)
+        '- Triggered by: <a href="$actorUri">@${htmlEscape.convert(actor)}</a>',
     ];
     githubInfoHtml = htmlLines.join('<br/>\n');
   }

--- a/app/lib/service/email/email_templates.dart
+++ b/app/lib/service/email/email_templates.dart
@@ -237,12 +237,14 @@ EmailMessage createPackageUploadedEmail({
   String? githubInfoText;
   String? githubInfoHtml;
   if (githubRepository != null) {
+    final commitSha = githubCommitSha;
+    final runId = githubRunId;
     final repoUri = githubRepositoryUrl(githubRepository);
-    final commitUri = githubCommitSha != null
-        ? githubCommitUrl(repository: githubRepository, commit: githubCommitSha)
+    final commitUri = commitSha != null
+        ? githubCommitUrl(repository: githubRepository, commit: commitSha)
         : null;
-    final runUri = githubRunId != null
-        ? githubWorkflowRunUrl(repository: githubRepository, runId: githubRunId)
+    final runUri = runId != null
+        ? githubWorkflowRunUrl(repository: githubRepository, runId: runId)
         : null;
 
     final textLines = <String>[
@@ -256,10 +258,10 @@ EmailMessage createPackageUploadedEmail({
     final htmlLines = <String>[
       'GitHub Actions details:',
       '- Repository: <a href="$repoUri">${htmlEscape.convert(githubRepository)}</a>',
-      if (commitUri != null)
-        '- Commit: <a href="$commitUri"><code>${htmlEscape.convert(githubCommitSha!)}</code></a>',
-      if (runUri != null)
-        '- Action run: <a href="$runUri">#${htmlEscape.convert(githubRunId!)}</a>',
+      if (commitUri != null && commitSha != null)
+        '- Commit: <a href="$commitUri"><code>${htmlEscape.convert(commitSha)}</code></a>',
+      if (runUri != null && runId != null)
+        '- Action run: <a href="$runUri">#${htmlEscape.convert(runId)}</a>',
     ];
     githubInfoHtml = htmlLines.join('<br/>\n');
   }

--- a/app/lib/shared/urls.dart
+++ b/app/lib/shared/urls.dart
@@ -304,6 +304,66 @@ Uri githubWorkflowRunUrl({required String repository, required String runId}) =>
       pathSegments: [...repository.split('/'), 'actions', 'runs', runId],
     );
 
+/// Returns the GitHub URL for a given Git reference or tag/branch.
+///
+/// Preconditions:
+/// - [repository] must be a non-empty GitHub repository name formatted as `owner/repo`.
+/// - [ref] must be a non-empty Git reference (e.g. `refs/tags/v1.0.0`, `refs/heads/main`, or a tag name).
+///
+/// When [ref] starts with `refs/tags/` or [refType] is `'tag'`, links to the release tag
+/// (`https://github.com/<owner>/<repo>/releases/tag/<tag>`).
+/// Otherwise, links to the tree view (`https://github.com/<owner>/<repo>/tree/<branch>`).
+///
+/// Performance considerations: Runs in O(N) where N is the combined length of [repository] and [ref].
+Uri githubRefUrl({
+  required String repository,
+  required String ref,
+  String? refType,
+}) {
+  if (ref.startsWith('refs/tags/')) {
+    final tag = ref.substring('refs/tags/'.length);
+    return Uri(
+      scheme: 'https',
+      host: 'github.com',
+      pathSegments: [
+        ...repository.split('/'),
+        'releases',
+        'tag',
+        ...tag.split('/'),
+      ],
+    );
+  }
+  if (refType == 'tag') {
+    return Uri(
+      scheme: 'https',
+      host: 'github.com',
+      pathSegments: [
+        ...repository.split('/'),
+        'releases',
+        'tag',
+        ...ref.split('/'),
+      ],
+    );
+  }
+  final target = ref.startsWith('refs/heads/')
+      ? ref.substring('refs/heads/'.length)
+      : ref;
+  return Uri(
+    scheme: 'https',
+    host: 'github.com',
+    pathSegments: [...repository.split('/'), 'tree', ...target.split('/')],
+  );
+}
+
+/// Returns the GitHub user profile URL for a given GitHub username.
+///
+/// Preconditions:
+/// - [actor] must be a non-empty GitHub username.
+///
+/// Performance considerations: Runs in O(N) where N is the length of [actor].
+Uri githubUserUrl(String actor) =>
+    Uri(scheme: 'https', host: 'github.com', pathSegments: [actor]);
+
 /// Returns the consent URL that will be sent to the invited user.
 String consentUrl(String consentId) => '$siteRoot/consent?id=$consentId';
 

--- a/app/lib/shared/urls.dart
+++ b/app/lib/shared/urls.dart
@@ -305,16 +305,6 @@ Uri githubWorkflowRunUrl({required String repository, required String runId}) =>
     );
 
 /// Returns the GitHub URL for a given Git reference or tag/branch.
-///
-/// Preconditions:
-/// - [repository] must be a non-empty GitHub repository name formatted as `owner/repo`.
-/// - [ref] must be a non-empty Git reference (e.g. `refs/tags/v1.0.0`, `refs/heads/main`, or a tag name).
-///
-/// When [ref] starts with `refs/tags/` or [refType] is `'tag'`, links to the release tag
-/// (`https://github.com/<owner>/<repo>/releases/tag/<tag>`).
-/// Otherwise, links to the tree view (`https://github.com/<owner>/<repo>/tree/<branch>`).
-///
-/// Performance considerations: Runs in O(N) where N is the combined length of [repository] and [ref].
 Uri githubRefUrl({
   required String repository,
   required String ref,
@@ -356,11 +346,6 @@ Uri githubRefUrl({
 }
 
 /// Returns the GitHub user profile URL for a given GitHub username.
-///
-/// Preconditions:
-/// - [actor] must be a non-empty GitHub username.
-///
-/// Performance considerations: Runs in O(N) where N is the length of [actor].
 Uri githubUserUrl(String actor) =>
     Uri(scheme: 'https', host: 'github.com', pathSegments: [actor]);
 

--- a/app/lib/shared/urls.dart
+++ b/app/lib/shared/urls.dart
@@ -281,6 +281,29 @@ String? inferServiceProviderName(String? url) {
   return null;
 }
 
+/// Returns the GitHub repository URL.
+Uri githubRepositoryUrl(String repository) => Uri(
+  scheme: 'https',
+  host: 'github.com',
+  pathSegments: repository.split('/'),
+);
+
+/// Returns the GitHub commit URL for a given repository and commit SHA.
+Uri githubCommitUrl({required String repository, required String commit}) =>
+    Uri(
+      scheme: 'https',
+      host: 'github.com',
+      pathSegments: [...repository.split('/'), 'commit', commit],
+    );
+
+/// Returns the GitHub Actions workflow run URL for a given repository and run ID.
+Uri githubWorkflowRunUrl({required String repository, required String runId}) =>
+    Uri(
+      scheme: 'https',
+      host: 'github.com',
+      pathSegments: [...repository.split('/'), 'actions', 'runs', runId],
+    );
+
 /// Returns the consent URL that will be sent to the invited user.
 String consentUrl(String consentId) => '$siteRoot/consent?id=$consentId';
 

--- a/app/test/audit/backend_test.dart
+++ b/app/test/audit/backend_test.dart
@@ -96,7 +96,8 @@ void main() {
         r.summary,
         'Package `pkg` version `1.2.0` was published from GitHub Actions '
         '(`run_id`: [`example-run-id`](https://github.com/abcd/efgh/actions/runs/example-run-id)) '
-        'triggered by pushing revision `some-hash-value` to the `abcd/efgh` repository.',
+        'triggered by pushing revision [`some-hash-value`](https://github.com/abcd/efgh/commit/some-hash-value) '
+        'to the `abcd/efgh` repository.',
       );
       expect(r.data, {
         'package': 'pkg',

--- a/app/test/package/upload_test.dart
+++ b/app/test/package/upload_test.dart
@@ -932,7 +932,7 @@ void main() {
             email.bodyHtml,
             contains(
               'GitHub Actions details:<br/>\n'
-              '- Repository: <a href="https://github.com/a/b">a/b</a><br/>\n'
+              '- Repository: <a href="https://github.com/a/b">a&#47;b</a><br/>\n'
               '- Commit: <a href="https://github.com/a/b/commit/11223344556677889900aabbccddeeff11223344"><code>11223344556677889900aabbccddeeff11223344</code></a><br/>\n'
               '- Action run: <a href="https://github.com/a/b/actions/runs/',
             ),

--- a/app/test/package/upload_test.dart
+++ b/app/test/package/upload_test.dart
@@ -924,6 +924,7 @@ void main() {
             contains(
               'GitHub Actions details:\n'
               '- Repository: https://github.com/a/b\n'
+              '- Tag: https://github.com/a/b/releases/tag/2.2.0\n'
               '- Commit: https://github.com/a/b/commit/11223344556677889900aabbccddeeff11223344\n'
               '- Action run: https://github.com/a/b/actions/runs/',
             ),
@@ -933,6 +934,7 @@ void main() {
             contains(
               'GitHub Actions details:<br/>\n'
               '- Repository: <a href="https://github.com/a/b">a&#47;b</a><br/>\n'
+              '- Tag: <a href="https://github.com/a/b/releases/tag/2.2.0"><code>2.2.0</code></a><br/>\n'
               '- Commit: <a href="https://github.com/a/b/commit/11223344556677889900aabbccddeeff11223344"><code>11223344556677889900aabbccddeeff11223344</code></a><br/>\n'
               '- Action run: <a href="https://github.com/a/b/actions/runs/',
             ),

--- a/app/test/package/upload_test.dart
+++ b/app/test/package/upload_test.dart
@@ -891,6 +891,7 @@ void main() {
             ref: 'refs/tags/2.2.0',
             repositoryId: 'repo-id-1',
             repositoryOwnerId: 'owner-id-234',
+            sha: '11223344556677889900aabbccddeeff11223344',
           );
           final pubspecContent = generatePubspecYaml('_dummy_pkg', '2.2.0');
           final bytes = await packageArchiveBytes(
@@ -918,6 +919,24 @@ void main() {
               'service:github-actions has published a new version (2.2.0)',
             ),
           );
+          expect(
+            email.bodyText,
+            contains(
+              'GitHub Actions details:\n'
+              '- Repository: https://github.com/a/b\n'
+              '- Commit: https://github.com/a/b/commit/11223344556677889900aabbccddeeff11223344\n'
+              '- Action run: https://github.com/a/b/actions/runs/',
+            ),
+          );
+          expect(
+            email.bodyHtml,
+            contains(
+              'GitHub Actions details:<br/>\n'
+              '- Repository: <a href="https://github.com/a/b">a/b</a><br/>\n'
+              '- Commit: <a href="https://github.com/a/b/commit/11223344556677889900aabbccddeeff11223344"><code>11223344556677889900aabbccddeeff11223344</code></a><br/>\n'
+              '- Action run: <a href="https://github.com/a/b/actions/runs/',
+            ),
+          );
 
           final audits = await auditBackend.listRecordsForPackageVersion(
             '_dummy_pkg',
@@ -943,13 +962,16 @@ void main() {
           );
           expect(
             publishedAudit.summary,
-            contains('triggered by pushing to the `a/b` repository.'),
+            contains(
+              'triggered by pushing revision [`11223344556677889900aabbccddeeff11223344`](https://github.com/a/b/commit/11223344556677889900aabbccddeeff11223344) to the `a/b` repository.',
+            ),
           );
           expect(publishedAudit.data, {
             'package': '_dummy_pkg',
             'version': '2.2.0',
             'repository': 'a/b',
             'run_id': isNotEmpty,
+            'sha': '11223344556677889900aabbccddeeff11223344',
           });
         },
       );

--- a/app/test/service/email/email_templates_test.dart
+++ b/app/test/service/email/email_templates_test.dart
@@ -228,5 +228,36 @@ void main() {
       expect(message.bodyHtml, isNot(contains('<p><div')));
       expect(message.bodyHtml, isNot(matches(RegExp(r'<p>\s*<div'))));
     });
+
+    test('with GitHub Actions details', () {
+      final message = createPackageUploadedEmail(
+        packageName: 'pkg_foo',
+        packageVersion: '1.0.0',
+        displayId: 'service:github-actions',
+        authorizedUploaders: [EmailAddress('uploader@example.com')],
+        uploadMessages: [],
+        githubRepository: 'dart-lang/browser_launcher',
+        githubCommitSha: 'a1b2c3d4e5f67890123456789012345678901234',
+        githubRunId: '123456789',
+      );
+      expect(
+        message.bodyText,
+        contains(
+          'GitHub Actions details:\n'
+          '- Repository: https://github.com/dart-lang/browser_launcher\n'
+          '- Commit: https://github.com/dart-lang/browser_launcher/commit/a1b2c3d4e5f67890123456789012345678901234\n'
+          '- Action run: https://github.com/dart-lang/browser_launcher/actions/runs/123456789',
+        ),
+      );
+      expect(
+        message.bodyHtml,
+        contains(
+          'GitHub Actions details:<br/>\n'
+          '- Repository: <a href="https://github.com/dart-lang/browser_launcher">dart-lang&#47;browser_launcher</a><br/>\n'
+          '- Commit: <a href="https://github.com/dart-lang/browser_launcher/commit/a1b2c3d4e5f67890123456789012345678901234"><code>a1b2c3d4e5f67890123456789012345678901234</code></a><br/>\n'
+          '- Action run: <a href="https://github.com/dart-lang/browser_launcher/actions/runs/123456789">#123456789</a>',
+        ),
+      );
+    });
   });
 }

--- a/app/test/service/email/email_templates_test.dart
+++ b/app/test/service/email/email_templates_test.dart
@@ -259,5 +259,35 @@ void main() {
         ),
       );
     });
+
+    test('with GitHub Actions details (without commit sha)', () {
+      final message = createPackageUploadedEmail(
+        packageName: 'pkg_foo',
+        packageVersion: '1.0.0',
+        displayId: 'service:github-actions',
+        authorizedUploaders: [EmailAddress('uploader@example.com')],
+        uploadMessages: [],
+        githubRepository: 'dart-lang/browser_launcher',
+        githubRunId: '123456789',
+      );
+      expect(
+        message.bodyText,
+        contains(
+          'GitHub Actions details:\n'
+          '- Repository: https://github.com/dart-lang/browser_launcher\n'
+          '- Action run: https://github.com/dart-lang/browser_launcher/actions/runs/123456789',
+        ),
+      );
+      expect(message.bodyText, isNot(contains('- Commit:')));
+      expect(
+        message.bodyHtml,
+        contains(
+          'GitHub Actions details:<br/>\n'
+          '- Repository: <a href="https://github.com/dart-lang/browser_launcher">dart-lang&#47;browser_launcher</a><br/>\n'
+          '- Action run: <a href="https://github.com/dart-lang/browser_launcher/actions/runs/123456789">#123456789</a>',
+        ),
+      );
+      expect(message.bodyHtml, isNot(contains('- Commit:')));
+    });
   });
 }

--- a/app/test/service/email/email_templates_test.dart
+++ b/app/test/service/email/email_templates_test.dart
@@ -239,12 +239,51 @@ void main() {
         githubRepository: 'dart-lang/browser_launcher',
         githubCommitSha: 'a1b2c3d4e5f67890123456789012345678901234',
         githubRunId: '123456789',
+        githubRef: 'refs/tags/1.0.0',
+        githubActor: 'octocat',
       );
       expect(
         message.bodyText,
         contains(
           'GitHub Actions details:\n'
           '- Repository: https://github.com/dart-lang/browser_launcher\n'
+          '- Tag: https://github.com/dart-lang/browser_launcher/releases/tag/1.0.0\n'
+          '- Commit: https://github.com/dart-lang/browser_launcher/commit/a1b2c3d4e5f67890123456789012345678901234\n'
+          '- Action run: https://github.com/dart-lang/browser_launcher/actions/runs/123456789\n'
+          '- Triggered by: https://github.com/octocat',
+        ),
+      );
+      expect(
+        message.bodyHtml,
+        contains(
+          'GitHub Actions details:<br/>\n'
+          '- Repository: <a href="https://github.com/dart-lang/browser_launcher">dart-lang&#47;browser_launcher</a><br/>\n'
+          '- Tag: <a href="https://github.com/dart-lang/browser_launcher/releases/tag/1.0.0"><code>1.0.0</code></a><br/>\n'
+          '- Commit: <a href="https://github.com/dart-lang/browser_launcher/commit/a1b2c3d4e5f67890123456789012345678901234"><code>a1b2c3d4e5f67890123456789012345678901234</code></a><br/>\n'
+          '- Action run: <a href="https://github.com/dart-lang/browser_launcher/actions/runs/123456789">#123456789</a><br/>\n'
+          '- Triggered by: <a href="https://github.com/octocat">@octocat</a>',
+        ),
+      );
+    });
+
+    test('with GitHub Actions details on branch', () {
+      final message = createPackageUploadedEmail(
+        packageName: 'pkg_foo',
+        packageVersion: '1.0.0',
+        displayId: 'service:github-actions',
+        authorizedUploaders: [EmailAddress('uploader@example.com')],
+        uploadMessages: [],
+        githubRepository: 'dart-lang/browser_launcher',
+        githubCommitSha: 'a1b2c3d4e5f67890123456789012345678901234',
+        githubRunId: '123456789',
+        githubRef: 'refs/heads/main',
+      );
+      expect(
+        message.bodyText,
+        contains(
+          'GitHub Actions details:\n'
+          '- Repository: https://github.com/dart-lang/browser_launcher\n'
+          '- Branch: https://github.com/dart-lang/browser_launcher/tree/main\n'
           '- Commit: https://github.com/dart-lang/browser_launcher/commit/a1b2c3d4e5f67890123456789012345678901234\n'
           '- Action run: https://github.com/dart-lang/browser_launcher/actions/runs/123456789',
         ),
@@ -254,6 +293,7 @@ void main() {
         contains(
           'GitHub Actions details:<br/>\n'
           '- Repository: <a href="https://github.com/dart-lang/browser_launcher">dart-lang&#47;browser_launcher</a><br/>\n'
+          '- Branch: <a href="https://github.com/dart-lang/browser_launcher/tree/main"><code>main</code></a><br/>\n'
           '- Commit: <a href="https://github.com/dart-lang/browser_launcher/commit/a1b2c3d4e5f67890123456789012345678901234"><code>a1b2c3d4e5f67890123456789012345678901234</code></a><br/>\n'
           '- Action run: <a href="https://github.com/dart-lang/browser_launcher/actions/runs/123456789">#123456789</a>',
         ),

--- a/app/test/shared/urls_test.dart
+++ b/app/test/shared/urls_test.dart
@@ -186,4 +186,33 @@ void main() {
       }
     });
   });
+
+  group('GitHub URLs', () {
+    test('repository URL', () {
+      expect(
+        githubRepositoryUrl('dart-lang/pub-dev').toString(),
+        'https://github.com/dart-lang/pub-dev',
+      );
+    });
+
+    test('commit URL', () {
+      expect(
+        githubCommitUrl(
+          repository: 'dart-lang/pub-dev',
+          commit: 'a1b2c3d4e5f6',
+        ).toString(),
+        'https://github.com/dart-lang/pub-dev/commit/a1b2c3d4e5f6',
+      );
+    });
+
+    test('workflow run URL', () {
+      expect(
+        githubWorkflowRunUrl(
+          repository: 'dart-lang/pub-dev',
+          runId: '123456789',
+        ).toString(),
+        'https://github.com/dart-lang/pub-dev/actions/runs/123456789',
+      );
+    });
+  });
 }

--- a/app/test/shared/urls_test.dart
+++ b/app/test/shared/urls_test.dart
@@ -214,5 +214,49 @@ void main() {
         'https://github.com/dart-lang/pub-dev/actions/runs/123456789',
       );
     });
+
+    test('ref URL', () {
+      expect(
+        githubRefUrl(
+          repository: 'dart-lang/pub-dev',
+          ref: 'refs/tags/v1.0.0',
+        ).toString(),
+        'https://github.com/dart-lang/pub-dev/releases/tag/v1.0.0',
+      );
+      expect(
+        githubRefUrl(
+          repository: 'dart-lang/pub-dev',
+          ref: 'v1.0.0',
+          refType: 'tag',
+        ).toString(),
+        'https://github.com/dart-lang/pub-dev/releases/tag/v1.0.0',
+      );
+      expect(
+        githubRefUrl(
+          repository: 'dart-lang/pub-dev',
+          ref: 'refs/heads/main',
+        ).toString(),
+        'https://github.com/dart-lang/pub-dev/tree/main',
+      );
+      expect(
+        githubRefUrl(
+          repository: 'dart-lang/pub-dev',
+          ref: 'refs/heads/feature/release',
+        ).toString(),
+        'https://github.com/dart-lang/pub-dev/tree/feature/release',
+      );
+      expect(
+        githubRefUrl(
+          repository: 'dart-lang/pub-dev',
+          ref: 'custom-branch',
+          refType: 'branch',
+        ).toString(),
+        'https://github.com/dart-lang/pub-dev/tree/custom-branch',
+      );
+    });
+
+    test('user URL', () {
+      expect(githubUserUrl('octocat').toString(), 'https://github.com/octocat');
+    });
   });
 }


### PR DESCRIPTION
When packages are published via automated GitHub Actions OIDC authentication, include actionable repository, git ref/tag, commit, workflow run, and actor links in maintainer notification emails.

* Add Uri-based GitHub URL helpers (githubRepositoryUrl, githubCommitUrl, githubWorkflowRunUrl, githubRefUrl, githubUserUrl) in app/lib/shared/urls.dart.
* Update createPackageUploadedEmail to format GitHub Actions repository, git ref/tag, commit, run, and actor details in both plain text and HTML emails.
* Pass GitHub Actions metadata from agent.payload in PackageBackend._performTarballUpload.
* Link commit revision hash in audit log summaries.
* Add and update unit test coverage across affected components.