### PR TITLE
Upgrade pana to 0.23.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Important changes to data models, configuration, and migrations between each
 AppEngine version, listed here to ease deployment and troubleshooting.
 
 ## Next Release (replace with git tag when deployed)
+ * Bump runtimeVersion to `2026.09.01`.
+ * Upgraded pana to `0.23.19`.
 
 ## `20260818t114400-all`
  * Bump runtimeVersion to `2026.08.18`.

--- a/app/lib/shared/versions.dart
+++ b/app/lib/shared/versions.dart
@@ -24,10 +24,10 @@ final RegExp runtimeVersionPattern = RegExp(r'^\d{4}\.\d{2}\.\d{2}$');
 /// when the version switch happens.
 const _acceptedRuntimeVersions = <String>[
   // The current [runtimeVersion].
-  '2026.08.18',
+  '2026.09.01',
   // Fallback runtime versions.
+  '2026.08.18',
   '2026.08.13',
-  '2026.08.12',
 ];
 
 /// Sets the current runtime versions.

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -48,7 +48,7 @@ dependencies:
   watcher: ^1.0.0
   yaml: ^3.1.0
   # pana version to be pinned
-  pana: '0.23.18'
+  pana: '0.23.19'
   # 3rd-party packages with pinned versions
   mailer: '6.6.0'
   postgres: '3.5.12'

--- a/pkg/pub_worker/pubspec.yaml
+++ b/pkg/pub_worker/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   appengine: ^0.13.13
   json_annotation: ^4.3.0
   jsontool: ^2.0.0
-  pana: ^0.23.18
+  pana: ^0.23.19
   path: ^1.8.0
   lints: ^6.0.0 # required for pana
   meta: ^1.7.0

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -613,10 +613,10 @@ packages:
     dependency: transitive
     description:
       name: pana
-      sha256: "27d218134d65896d4bdf9522cbc1924a7df7155867f2b27a0557536300d17329"
+      sha256: "0c76e89f3dea0398df0e13d61f733903c864a9f7fac58087d2c1cbfba9950c20"
       url: "https://pub.dev"
     source: hosted
-    version: "0.23.18"
+    version: "0.23.19"
   path:
     dependency: transitive
     description:


### PR DESCRIPTION
Upgrades `pana` to `0.23.19`, bumps `runtimeVersion` to `2026.09.01`, and updates `pubspec.lock` and `CHANGELOG.md`.