### PR TITLE
Remove canonical bucket domain access check

### DIFF
--- a/app/bin/tools/check_domain_access.dart
+++ b/app/bin/tools/check_domain_access.dart
@@ -33,7 +33,6 @@ final urls = <String>[
   // package archive
   'https://pub.dev/packages/http/versions/0.13.1.tar.gz',
   'https://pub.dartlang.org/packages/http/versions/0.13.1.tar.gz',
-  'https://storage.googleapis.com/pub-packages/packages/http-0.13.1.tar.gz',
 ];
 final uris = urls.map((u) => Uri.parse(u)).toList();
 final hosts = uris.map((u) => u.host).toSet().toList();


### PR DESCRIPTION
The canonical packages bucket is no longer publicly accessible since we rely on GCLB/CDN. This direct check would fail when access is restricted, so it has been removed.
