### PR TITLE
Migrate package download redirect to using V4 signed urls

### DIFF
--- a/app/config/dartlang-pub-dev.yaml
+++ b/app/config/dartlang-pub-dev.yaml
@@ -72,3 +72,5 @@ rateLimits:
     daily: 24
 imageProxyHmacKeyVersion: projects/dartlang-pub-dev/locations/us-central1/keyRings/image-proxy-key-ring/cryptoKeys/image-proxy-mac-key/cryptoKeyVersions/2
 imageProxyServiceBaseUrl: https://external-images-staging.pub.dev
+
+downloadSignerServiceAccount: package-download-signer@dartlang-pub-dev.iam.gserviceaccount.com

--- a/app/config/dartlang-pub.yaml
+++ b/app/config/dartlang-pub.yaml
@@ -152,3 +152,5 @@ rateLimits:
     daily: 200
 imageProxyHmacKeyVersion: projects/dartlang-pub/locations/us-central1/keyRings/image-proxy-key-ring/cryptoKeys/image-proxy-mac-key/cryptoKeyVersions/2
 imageProxyServiceBaseUrl: https://external-images.pub.dev
+
+downloadSignerServiceAccount: package-download-signer@dartlang-pub.iam.gserviceaccount.com

--- a/app/lib/frontend/handlers/pubapi.dart
+++ b/app/lib/frontend/handlers/pubapi.dart
@@ -84,9 +84,8 @@ class PubApi {
   ///
   /// This is the endpoint we link to from the version listing.
   ///
-  /// While this is here a redirect to a bucket, and will be done this way on
-  /// staging, on pub.dev we actually serve this endpoint directly from a bucket
-  /// via GCLB (load balancer), and will never trigger this handler.
+  /// This end-point is generally handled by GCLB which serves it directly from the bucket.
+  /// But when hitting the service directly or testing locally we need to redirect to the bucket.
   @EndPoint.get('/api/archives/<package|[^-/]+>-<version>.tar.gz')
   Future<Response> fetchPackage(
     Request request,

--- a/app/lib/package/backend.dart
+++ b/app/lib/package/backend.dart
@@ -47,6 +47,7 @@ import '../shared/redis_cache.dart' show cache;
 import '../shared/storage.dart';
 import '../shared/urls.dart' as urls;
 import '../shared/utils.dart';
+import 'download_signer_service.dart';
 import 'model_properties.dart';
 import 'models.dart';
 import 'name_tracker.dart';
@@ -410,7 +411,11 @@ class PackageBackend {
     InvalidInputException.checkSemanticVersion(version);
     final cv = canonicalizeVersion(version);
     final object = 'latest/api/archives/$package-$cv.tar.gz';
-    return Uri.parse(_exportedApiBucket.objectUrl(object));
+    return await downloadSigner.buildDownloadUrl(
+      _exportedApiBucket.bucketName,
+      object,
+      Duration(minutes: 15),
+    );
   }
 
   /// Updates the stable, prerelease and preview versions of [package].

--- a/app/lib/package/download_signer_service.dart
+++ b/app/lib/package/download_signer_service.dart
@@ -1,0 +1,150 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:_pub_shared/utils/http.dart';
+import 'package:clock/clock.dart';
+import 'package:collection/collection.dart';
+import 'package:convert/convert.dart';
+import 'package:crypto/crypto.dart';
+import 'package:gcloud/service_scope.dart' as ss;
+import 'package:googleapis/iam/v1.dart' as iam;
+import 'package:http/http.dart' as http;
+
+import '../shared/configuration.dart';
+import 'upload_signer_service.dart' show SigningResult;
+
+/// The registered [DownloadSignerService] object.
+DownloadSignerService get downloadSigner =>
+    ss.lookup(#_download_url_signer) as DownloadSignerService;
+
+/// Register a new [DownloadSignerService] object into the current service
+/// scope.
+void registerDownloadSigner(DownloadSignerService downloadSigner) =>
+    ss.register(#_download_url_signer, downloadSigner);
+
+/// Creates an download signer based on the current environment.
+Future<DownloadSignerService> createDownloadSigner(
+  http.Client authClient,
+) async {
+  final email = activeConfiguration.downloadSignerServiceAccount;
+  return _IamBasedDownloadSigner(
+    activeConfiguration.projectId,
+    email,
+    authClient,
+  );
+}
+
+/// Signs Google Cloud Storage URLs for downloading objects securely.
+abstract base class DownloadSignerService {
+  /// The Google Access ID (e.g. service account email) used for signing.
+  String get googleAccessId;
+
+  /// Google Cloud Storage V4 signatures require strict RFC 3986 encoding.
+  /// Dart's Uri.encodeComponent does not encode !, ', (, ), or *.
+  /// https://cloud.google.com/storage/docs/authentication/canonical-requests#about-resource-path
+  String _uriEncode(String input) {
+    return Uri.encodeComponent(input)
+        .replaceAll('!', '%21')
+        .replaceAll("'", '%27')
+        .replaceAll('(', '%28')
+        .replaceAll(')', '%29')
+        .replaceAll('*', '%2A');
+  }
+
+  /// Builds a V4 signed URL for downloading a Google Cloud Storage object.
+  Future<Uri> buildDownloadUrl(
+    String bucket,
+    String object,
+    Duration lifetime,
+  ) async {
+    final now = clock.now().toUtc();
+    final datetime = now
+        .toIso8601String()
+        .replaceAll('-', '')
+        .replaceAll(':', '')
+        .replaceAll(RegExp(r'\.\d+'), '');
+    final date = datetime.split('T').first;
+    final scope = '$date/auto/storage/goog4_request';
+
+    final canonicalQueryParameters = {
+      'X-Goog-Algorithm': 'GOOG4-RSA-SHA256',
+      'X-Goog-Credential': '$googleAccessId/$scope',
+      'X-Goog-Date': datetime,
+      'X-Goog-Expires': '${lifetime.inSeconds}',
+      'X-Goog-SignedHeaders': 'host',
+    };
+
+    final canonicalQueryString = canonicalQueryParameters.entries
+        .sortedBy((e) => e.key)
+        .map((e) => '${e.key}=${Uri.encodeComponent(e.value)}')
+        .join('&');
+
+    final canonicalUri =
+        '/$bucket/${object.split('/').map(_uriEncode).join('/')}';
+
+    final canonicalRequest = [
+      'GET',
+      canonicalUri,
+      canonicalQueryString,
+      'host:storage.googleapis.com',
+      '', // empty line separates headers and signed headers
+      'host',
+      'UNSIGNED-PAYLOAD', // 'GET' request has no payload
+    ].join('\n');
+
+    final canonicalRequestHash = hex.encode(
+      sha256.convert(utf8.encode(canonicalRequest)).bytes,
+    );
+
+    final stringToSign = [
+      'GOOG4-RSA-SHA256',
+      datetime,
+      scope,
+      canonicalRequestHash,
+    ].join('\n');
+
+    final result = await sign(utf8.encode(stringToSign));
+
+    return Uri(
+      scheme: 'https',
+      host: 'storage.googleapis.com',
+      path: canonicalUri,
+      queryParameters: {
+        ...canonicalQueryParameters,
+        'X-Goog-Signature': hex.encode(result.bytes),
+      },
+    );
+  }
+
+  Future<SigningResult> sign(List<int> bytes);
+}
+
+/// Uses the [iam.IamApi] to sign Google Cloud Storage download URLs.
+final class _IamBasedDownloadSigner extends DownloadSignerService {
+  final String projectId;
+  final String email;
+  final http.Client authClient;
+
+  _IamBasedDownloadSigner(this.projectId, this.email, this.authClient);
+
+  @override
+  String get googleAccessId => email;
+
+  @override
+  Future<SigningResult> sign(List<int> bytes) async {
+    final request = iam.SignBlobRequest()..bytesToSignAsBytes = bytes;
+    final name = 'projects/$projectId/serviceAccounts/$email';
+    return await withRetryHttpClient(client: authClient, (client) async {
+      final iamApi = iam.IamApi(client);
+      final response =
+          // TODO: figure out what new API we should use.
+          // ignore: deprecated_member_use
+          await iamApi.projects.serviceAccounts.signBlob(request, name);
+      return SigningResult(email, response.signatureAsBytes);
+    });
+  }
+}

--- a/app/lib/package/fake_download_signer_service.dart
+++ b/app/lib/package/fake_download_signer_service.dart
@@ -1,0 +1,33 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'download_signer_service.dart';
+import 'upload_signer_service.dart' show SigningResult;
+
+/// A fake implementation of DownloadSignerService for testing.
+final class FakeDownloadSignerService extends DownloadSignerService {
+  final String _storageBaseUrl;
+
+  FakeDownloadSignerService(this._storageBaseUrl);
+
+  @override
+  String get googleAccessId => 'fake-download-signer@example.com';
+
+  @override
+  Future<Uri> buildDownloadUrl(
+    String bucket,
+    String object,
+    Duration lifetime,
+  ) async {
+    return Uri.parse('$_storageBaseUrl/$bucket/$object');
+  }
+
+  @override
+  Future<SigningResult> sign(List<int> bytes) async {
+    return SigningResult(googleAccessId, Uint8List.fromList([1, 2, 3]));
+  }
+}

--- a/app/lib/service/services.dart
+++ b/app/lib/service/services.dart
@@ -38,6 +38,8 @@ import '../fake/server/fake_client_context.dart';
 import '../fake/server/fake_storage_server.dart';
 import '../frontend/handlers.dart';
 import '../package/backend.dart';
+import '../package/download_signer_service.dart';
+import '../package/fake_download_signer_service.dart';
 import '../package/name_tracker.dart';
 import '../package/screenshots/backend.dart';
 import '../package/search_adapter.dart';
@@ -109,6 +111,7 @@ Future<void> withServices(FutureOr<void> Function() fn) async {
             : loggingEmailSender,
       );
       registerUploadSigner(await createUploadSigner(authClient));
+      registerDownloadSigner(await createDownloadSigner(authClient));
       registerSecretBackend(GcpSecretBackend(authClient));
 
       // Configure a CloudCompute pool for later use in TaskBackend
@@ -197,6 +200,9 @@ Future<R> withFakeServices<R>({
         registerDomainVerifier(FakeDomainVerifier());
         registerEmailSender(
           FakeEmailSender(outputDir: envConfig.fakeEmailSenderOutputDir),
+        );
+        registerDownloadSigner(
+          FakeDownloadSignerService(configuration!.storageBaseUrl!),
         );
         registerUploadSigner(
           FakeUploadSignerService(configuration!.storageBaseUrl!),

--- a/app/lib/shared/configuration.dart
+++ b/app/lib/shared/configuration.dart
@@ -189,6 +189,9 @@ final class Configuration {
   /// https://cloud.google.com/iam/docs/reference/credentials/rest/v1/projects.serviceAccounts/signBlob
   final String? uploadSignerServiceAccount;
 
+  /// The service account used for signing download URLs.
+  final String downloadSignerServiceAccount;
+
   /// Whether indexing of the content by robots should be blocked.
   final bool blockRobots;
 
@@ -274,6 +277,7 @@ final class Configuration {
     required this.externalServiceAudience,
     required this.gmailRelayServiceAccount,
     required this.uploadSignerServiceAccount,
+    required this.downloadSignerServiceAccount,
     required this.blockRobots,
     required this.productionHosts,
     required this.primaryApiUri,
@@ -341,6 +345,7 @@ final class Configuration {
       defaultServiceBaseUrl: 'http://localhost:$frontendPort/',
       gmailRelayServiceAccount: null, // disable email sending
       uploadSignerServiceAccount: null,
+      downloadSignerServiceAccount: 'fake-download-signer@example.com',
       blockRobots: false,
       productionHosts: ['localhost'],
       primaryApiUri: Uri.parse('http://localhost:$frontendPort/'),
@@ -393,6 +398,7 @@ final class Configuration {
       defaultServiceBaseUrl: primaryApiUri?.toString() ?? 'http://localhost:0/',
       gmailRelayServiceAccount: null, // disable email sending
       uploadSignerServiceAccount: null,
+      downloadSignerServiceAccount: 'fake-download-signer@example.com',
       blockRobots: true,
       productionHosts: ['localhost'],
       primaryApiUri: primaryApiUri ?? Uri.parse('https://pub.dev/'),

--- a/app/lib/shared/configuration.g.dart
+++ b/app/lib/shared/configuration.g.dart
@@ -37,6 +37,7 @@ Configuration _$ConfigurationFromJson(
       'externalServiceAudience',
       'gmailRelayServiceAccount',
       'uploadSignerServiceAccount',
+      'downloadSignerServiceAccount',
       'blockRobots',
       'productionHosts',
       'primaryApiUri',
@@ -130,6 +131,10 @@ Configuration _$ConfigurationFromJson(
       'uploadSignerServiceAccount',
       (v) => v as String?,
     ),
+    downloadSignerServiceAccount: $checkedConvert(
+      'downloadSignerServiceAccount',
+      (v) => v as String,
+    ),
     blockRobots: $checkedConvert('blockRobots', (v) => v as bool),
     productionHosts: $checkedConvert(
       'productionHosts',
@@ -204,6 +209,7 @@ Map<String, dynamic> _$ConfigurationToJson(Configuration instance) =>
       'externalServiceAudience': instance.externalServiceAudience,
       'gmailRelayServiceAccount': instance.gmailRelayServiceAccount,
       'uploadSignerServiceAccount': instance.uploadSignerServiceAccount,
+      'downloadSignerServiceAccount': instance.downloadSignerServiceAccount,
       'blockRobots': instance.blockRobots,
       'productionHosts': instance.productionHosts,
       'primaryApiUri': instance.primaryApiUri?.toString(),

--- a/app/test/shared/test_data/foo_config.yaml
+++ b/app/test/shared/test_data/foo_config.yaml
@@ -28,3 +28,4 @@ admins:
   - removeUsers
   - manageAssignedTags
   - removePackage
+downloadSignerServiceAccount: foo@example.com


### PR DESCRIPTION
With this buckets do not have to be public anymore.

Granted we still need to change GCLB configuration.