### PR TITLE
Prepare for default branch migration to main

### DIFF
--- a/.github/workflows/sync_master.yaml
+++ b/.github/workflows/sync_master.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.repository_owner == 'dart-lang' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/sync_master.yaml
+++ b/.github/workflows/sync_master.yaml
@@ -1,0 +1,22 @@
+name: Sync master with main
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  sync-master:
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'dart-lang' }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fast-forward master to main
+        run: |
+          git push origin HEAD:refs/heads/master --force


### PR DESCRIPTION
This PR prepares the repository for migrating the default branch from `master` to `main`:

- Adds `.github/workflows/sync_master.yaml` to continuously fast-forward `master` to `main` on every push to `main`.