### PR TITLE
Render automated bot actors as plain text in publish emails

### DIFF
--- a/app/lib/service/email/email_templates.dart
+++ b/app/lib/service/email/email_templates.dart
@@ -285,7 +285,10 @@ EmailMessage createPackageUploadedEmail({
       if (refLabel != null && refUri != null) '- $refLabel: $refUri',
       if (commitUri != null) '- Commit: $commitUri',
       if (runUri != null) '- Action run: $runUri',
-      if (actor != null && actorUri != null) '- Triggered by: $actorUri',
+      if (actor != null)
+        actorUri != null
+            ? '- Triggered by: $actorUri'
+            : '- Triggered by: @$actor',
     ];
     githubInfoText = textLines.join('\n');
 
@@ -298,8 +301,10 @@ EmailMessage createPackageUploadedEmail({
         '- Commit: <a href="$commitUri"><code>${htmlEscape.convert(commitSha)}</code></a>',
       if (runUri != null && runId != null)
         '- Action run: <a href="$runUri">#${htmlEscape.convert(runId)}</a>',
-      if (actor != null && actorUri != null)
-        '- Triggered by: <a href="$actorUri">@${htmlEscape.convert(actor)}</a>',
+      if (actor != null)
+        actorUri != null
+            ? '- Triggered by: <a href="$actorUri">@${htmlEscape.convert(actor)}</a>'
+            : '- Triggered by: @${htmlEscape.convert(actor)}',
     ];
     githubInfoHtml = htmlLines.join('<br/>\n');
   }

--- a/app/lib/shared/urls.dart
+++ b/app/lib/shared/urls.dart
@@ -345,9 +345,19 @@ Uri githubRefUrl({
   );
 }
 
+final _githubUsernameRegExp = RegExp(
+  r'^[a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9])){0,38}$',
+);
+
 /// Returns the GitHub user profile URL for a given GitHub username.
-Uri githubUserUrl(String actor) =>
-    Uri(scheme: 'https', host: 'github.com', pathSegments: [actor]);
+///
+/// Returns `null` if [actor] is not a valid human GitHub username
+/// (for example, automated bot identities such as `github-actions[bot]`).
+Uri? githubUserUrl(String actor) {
+  if (actor.endsWith('[bot]')) return null;
+  if (!_githubUsernameRegExp.hasMatch(actor)) return null;
+  return Uri(scheme: 'https', host: 'github.com', pathSegments: [actor]);
+}
 
 /// Returns the consent URL that will be sent to the invited user.
 String consentUrl(String consentId) => '$siteRoot/consent?id=$consentId';

--- a/app/test/service/email/email_templates_test.dart
+++ b/app/test/service/email/email_templates_test.dart
@@ -329,5 +329,42 @@ void main() {
       );
       expect(message.bodyHtml, isNot(contains('- Commit:')));
     });
+
+    test('with GitHub Actions details (bot actor)', () {
+      final message = createPackageUploadedEmail(
+        packageName: 'pkg_foo',
+        packageVersion: '1.0.0',
+        displayId: 'service:github-actions',
+        authorizedUploaders: [EmailAddress('uploader@example.com')],
+        uploadMessages: [],
+        githubRepository: 'dart-lang/browser_launcher',
+        githubCommitSha: 'a1b2c3d4e5f67890123456789012345678901234',
+        githubRunId: '123456789',
+        githubRef: 'refs/tags/1.0.0',
+        githubActor: 'github-actions[bot]',
+      );
+      expect(
+        message.bodyText,
+        contains(
+          'GitHub Actions details:\n'
+          '- Repository: https://github.com/dart-lang/browser_launcher\n'
+          '- Tag: https://github.com/dart-lang/browser_launcher/releases/tag/1.0.0\n'
+          '- Commit: https://github.com/dart-lang/browser_launcher/commit/a1b2c3d4e5f67890123456789012345678901234\n'
+          '- Action run: https://github.com/dart-lang/browser_launcher/actions/runs/123456789\n'
+          '- Triggered by: @github-actions[bot]',
+        ),
+      );
+      expect(
+        message.bodyHtml,
+        contains(
+          'GitHub Actions details:<br/>\n'
+          '- Repository: <a href="https://github.com/dart-lang/browser_launcher">dart-lang&#47;browser_launcher</a><br/>\n'
+          '- Tag: <a href="https://github.com/dart-lang/browser_launcher/releases/tag/1.0.0"><code>1.0.0</code></a><br/>\n'
+          '- Commit: <a href="https://github.com/dart-lang/browser_launcher/commit/a1b2c3d4e5f67890123456789012345678901234"><code>a1b2c3d4e5f67890123456789012345678901234</code></a><br/>\n'
+          '- Action run: <a href="https://github.com/dart-lang/browser_launcher/actions/runs/123456789">#123456789</a><br/>\n'
+          '- Triggered by: @github-actions[bot]',
+        ),
+      );
+    });
   });
 }

--- a/app/test/shared/urls_test.dart
+++ b/app/test/shared/urls_test.dart
@@ -257,6 +257,12 @@ void main() {
 
     test('user URL', () {
       expect(githubUserUrl('octocat').toString(), 'https://github.com/octocat');
+      expect(githubUserUrl('github-actions[bot]'), isNull);
+      expect(githubUserUrl('dependabot[bot]'), isNull);
+      expect(githubUserUrl('-invalid'), isNull);
+      expect(githubUserUrl('invalid-'), isNull);
+      expect(githubUserUrl('in--valid'), isNull);
+      expect(githubUserUrl(''), isNull);
     });
   });
 }


### PR DESCRIPTION
When packages are published via automated GitHub Actions OIDC authentication, automated bots such as `github-actions[bot]` do not have standard user profiles at `github.com/<actor>`. Generating profile links for them produces broken URLs like `https://github.com/github-actions%5Bbot%5D` which return 404.

* Update `githubUserUrl` in `app/lib/shared/urls.dart` to return `null` for bot identities (e.g. `[bot]` suffix) or invalid usernames.
* Update `createPackageUploadedEmail` in `app/lib/service/email/email_templates.dart` to display unlinked `@actor` in plain text and HTML emails when `actorUri` is `null`.
* Add unit tests in `urls_test.dart` and `email_templates_test.dart`.
